### PR TITLE
test: fix flaky inspector-stop-profile-after-done

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -13,7 +13,6 @@ test-inspector-debug-end              : PASS, FLAKY
 test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
 test-http2-ping-flood                 : PASS, FLAKY
 test-http2-settings-flood             : PASS, FLAKY
-test-inspector-stop-profile-after-done: PASS, FLAKY
 
 [$system==linux]
 

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -25,7 +25,7 @@ async function runTests() {
 
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
-    // { 'method': 'Profiler.enable' },
+    { 'method': 'Profiler.enable' },
     // { 'method': 'Runtime.runIfWaitingForDebugger' },
     // { 'method': 'Profiler.start' }
   ]);

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -27,15 +27,15 @@ async function runTests() {
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
-    // { 'method': 'Profiler.start' }
+    { 'method': 'Profiler.start' }
   ]);
 
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Debugger attached.')
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, '');
-  // stderrString = await child.nextStderrString();
-  // assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
 
   // await session.send({ 'method': 'Profiler.stop' });
   // session.disconnect();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -26,7 +26,7 @@ async function runTests() {
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
     { 'method': 'Profiler.enable' },
-    // { 'method': 'Runtime.runIfWaitingForDebugger' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' },
     // { 'method': 'Profiler.start' }
   ]);
 

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -33,11 +33,10 @@ async function runTests() {
   assert.strictEqual(stderrString, 'Debugger attached.')
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, '');
-
-  session.send({ 'method': 'Profiler.start' });
-
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
+
+  session.send({ 'method': 'Profiler.start' });
 
   // await session.send({ 'method': 'Profiler.stop' });
   // session.disconnect();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -11,7 +11,7 @@ async function runTests() {
   const child = new NodeInstance(['--inspect-brk=0'],
                                  `const interval = setInterval(() => {
                                     console.log(new Object());
-                                  }, 70);
+                                  }, 140);
                                   process.stdin.on('data', (msg) => {
                                     if (msg.toString() === 'fhqwhgads') {
                                       clearInterval(interval);
@@ -31,7 +31,7 @@ async function runTests() {
   const session = await child.connectInspectorSession();
 
   session.send([
-    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 700 } },
+    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 1400 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
@@ -43,7 +43,7 @@ async function runTests() {
   assert.strictEqual(stderrString, 'Debugger attached.');
 
   session.send({ 'method': 'Profiler.start' })
-  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 1400);
+  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 2800);
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -15,7 +15,7 @@ async function runTests() {
                                  }, 10);`);
   const session = await child.connectInspectorSession();
 
-  // let stderrString = await child.nextStderrString();
+  let stderrString = await child.nextStderrString();
   // assert(stderrString.includes('Debugger listening on'), stderrString);
   // stderrString = await child.nextStderrString();
   // assert.strictEqual(stderrString,

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -11,7 +11,7 @@ async function runTests() {
   const child = new NodeInstance(['--inspect-brk=0'],
                                  `const interval = setInterval(() => {
                                     console.log(new Object());
-                                  }, 10);
+                                  }, 70);
                                   process.stdin.on('data', (msg) => {
                                     if (msg.toString() === 'fhqwhgads') {
                                       clearInterval(interval);
@@ -23,7 +23,7 @@ async function runTests() {
     const message = data.toString();
     stderrMessages.push(message);
     if (message.trim() === 'Waiting for the debugger to disconnect...') {
-      // await session.send({ 'method': 'Profiler.stop' });
+      await session.send({ 'method': 'Profiler.stop' });
       session.disconnect();
       assert.strictEqual(0, (await child.expectShutdown()).exitCode);
     }
@@ -31,7 +31,7 @@ async function runTests() {
   const session = await child.connectInspectorSession();
 
   session.send([
-    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
+    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 700 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
@@ -42,8 +42,8 @@ async function runTests() {
   const stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Debugger attached.');
 
-  // session.send({ 'method': 'Profiler.start' })
-  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 200);
+  session.send({ 'method': 'Profiler.start' })
+  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 1400);
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -27,13 +27,15 @@ async function runTests() {
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
-    // { 'method': 'Profiler.start' }
   ]);
 
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Debugger attached.')
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, '');
+
+  session.send({ 'method': 'Profiler.start' });
+
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
 

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -5,6 +5,8 @@ common.skipIfInspectorDisabled();
 const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
 
+const stderrMessages = [];
+
 async function runTests() {
   const child = new NodeInstance(['--inspect-brk=0'],
                                  `let c = 0;
@@ -13,36 +15,24 @@ async function runTests() {
                                    if (c++ === 10)
                                      clearInterval(interval);
                                  }, 10);`);
-  const session = await child.connectInspectorSession();
 
-  let stderrString = await child.nextStderrString();
-  assert(stderrString.includes('Debugger listening on'), stderrString);
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString,
-                     'For help see https://nodejs.org/en/docs/inspector');
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, '');
+  child._process.stderr.on('data', async (data) => {
+    const message = data.toString();
+    stderrMessages.push(message);
+    if (message.trim() === 'Waiting for the debugger to disconnect...') {
+      await session.send({ 'method': 'Profiler.stop' });
+      session.disconnect();
+      assert.strictEqual(0, (await child.expectShutdown()).exitCode);
+    }
+  })
+  const session = await child.connectInspectorSession();
 
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
-  ]);
-
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, 'Debugger attached.')
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, '');
-
-  await session.send({ 'method': 'Profiler.start' });
-
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
-
-  // await session.send({ 'method': 'Profiler.stop' });
-  // session.disconnect();
-  // assert.strictEqual(0, (await child.expectShutdown()).exitCode);
-  child.kill();
+    { 'method': 'Profiler.start' }
+  ]);  
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -16,9 +16,10 @@ async function runTests() {
   const session = await child.connectInspectorSession();
 
   let stderrString = await child.nextStderrString();
-  while (!stderrString.includes('Debugger listening on')) {
-    stderrString += await child.nextStderrString();
-  }
+  assert(stderrString.includes('Debugger listening on'), stderrString);
+  // if (!stderrString.includes('Debugger listening on')) {
+  //   stderrString += await child.nextStderrString();
+  // }
 
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
@@ -27,8 +28,11 @@ async function runTests() {
     { 'method': 'Profiler.start' }
   ]);
 
+  let limit = 0;
   while (!stderrString.includes('Waiting for the debugger to disconnect...')) {
     stderrString += await child.nextStderrString();
+    if (limit++ > 10)
+      throw new Error('no!');
   }
 
   await session.send({ 'method': 'Profiler.stop' });

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -13,7 +13,7 @@ async function runTests() {
                                    if (c++ === 10)
                                      clearInterval(interval);
                                  }, 10);`);
-  // const session = await child.connectInspectorSession();
+  const session = await child.connectInspectorSession();
 
   // let stderrString = await child.nextStderrString();
   // assert(stderrString.includes('Debugger listening on'), stderrString);

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -13,33 +13,34 @@ async function runTests() {
                                    if (c++ === 10)
                                      clearInterval(interval);
                                  }, 10);`);
-  const session = await child.connectInspectorSession();
+  // const session = await child.connectInspectorSession();
 
-  let stderrString = await child.nextStderrString();
-  assert(stderrString.includes('Debugger listening on'), stderrString);
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString,
-                     'For help see https://nodejs.org/en/docs/inspector');
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, '');
+  // let stderrString = await child.nextStderrString();
+  // assert(stderrString.includes('Debugger listening on'), stderrString);
+  // stderrString = await child.nextStderrString();
+  // assert.strictEqual(stderrString,
+  //                    'For help see https://nodejs.org/en/docs/inspector');
+  // stderrString = await child.nextStderrString();
+  // assert.strictEqual(stderrString, '');
 
-  session.send([
-    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
-    { 'method': 'Profiler.enable' },
-    { 'method': 'Runtime.runIfWaitingForDebugger' },
-    { 'method': 'Profiler.start' }
-  ]);
+  // session.send([
+  //   { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
+  //   { 'method': 'Profiler.enable' },
+  //   { 'method': 'Runtime.runIfWaitingForDebugger' },
+  //   { 'method': 'Profiler.start' }
+  // ]);
 
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, 'Debugger attached.')
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, '');
-  stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
+  // stderrString = await child.nextStderrString();
+  // assert.strictEqual(stderrString, 'Debugger attached.')
+  // stderrString = await child.nextStderrString();
+  // assert.strictEqual(stderrString, '');
+  // stderrString = await child.nextStderrString();
+  // assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
 
-  await session.send({ 'method': 'Profiler.stop' });
-  session.disconnect();
-  assert.strictEqual(0, (await child.expectShutdown()).exitCode);
+  // await session.send({ 'method': 'Profiler.stop' });
+  // session.disconnect();
+  // assert.strictEqual(0, (await child.expectShutdown()).exitCode);
+  child.kill();
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -33,10 +33,11 @@ async function runTests() {
   assert.strictEqual(stderrString, 'Debugger attached.')
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, '');
+
+  await session.send({ 'method': 'Profiler.start' });
+
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
-
-  session.send({ 'method': 'Profiler.start' });
 
   // await session.send({ 'method': 'Profiler.stop' });
   // session.disconnect();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -23,12 +23,12 @@ async function runTests() {
   stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, '');
 
-  // session.send([
-  //   { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
-  //   { 'method': 'Profiler.enable' },
-  //   { 'method': 'Runtime.runIfWaitingForDebugger' },
-  //   { 'method': 'Profiler.start' }
-  // ]);
+  session.send([
+    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
+    { 'method': 'Profiler.enable' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' },
+    { 'method': 'Profiler.start' }
+  ]);
 
   // stderrString = await child.nextStderrString();
   // assert.strictEqual(stderrString, 'Debugger attached.')

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -16,8 +16,8 @@ async function runTests() {
   const session = await child.connectInspectorSession();
 
   let stderrString = await child.nextStderrString();
-  // assert(stderrString.includes('Debugger listening on'), stderrString);
-  // stderrString = await child.nextStderrString();
+  assert(stderrString.includes('Debugger listening on'), stderrString);
+  stderrString = await child.nextStderrString();
   // assert.strictEqual(stderrString,
   //                    'For help see https://nodejs.org/en/docs/inspector');
   // stderrString = await child.nextStderrString();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -5,45 +5,27 @@ common.skipIfInspectorDisabled();
 const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
 
-const stderrMessages = [];
-
 async function runTests() {
   const child = new NodeInstance(['--inspect-brk=0'],
-                                 `const interval = setInterval(() => {
-                                    console.log(new Object());
-                                  }, 200);
-                                  process.stdin.on('data', (msg) => {
-                                    if (msg.toString() === 'fhqwhgads') {
-                                      clearInterval(interval);
-                                      process.exit();
-                                    }
-                                  });`);
-
-  child._process.stderr.on('data', async (data) => {
-    const message = data.toString();
-    stderrMessages.push(message);
-    if (message.trim() === 'Waiting for the debugger to disconnect...') {
-      await session.send({ 'method': 'Profiler.stop' });
-      session.disconnect();
-      assert.strictEqual(0, (await child.expectShutdown()).exitCode);
-    }
-  })
+                                 `let c = 0;
+                                  const interval = setInterval(() => {
+                                   console.log(new Object());
+                                   if (c++ === 10)
+                                     clearInterval(interval);
+                                 }, ${common.platformTimeout(30)});`);
   const session = await child.connectInspectorSession();
 
   session.send([
-    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 2000 } },
-    { 'method': 'Profiler.enable' },
-    { 'method': 'Runtime.runIfWaitingForDebugger' }
-  ]);
-
-  await child.nextStderrString();
-  await child.nextStderrString();
-  await child.nextStderrString();
-  const stderrString = await child.nextStderrString();
-  assert.strictEqual(stderrString, 'Debugger attached.');
-
-  session.send({ 'method': 'Profiler.start' })
-  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 4000);
+    { method: 'Profiler.setSamplingInterval',
+      params: { interval: common.platformTimeout(300) } },
+    { method: 'Profiler.enable' },
+    { method: 'Runtime.runIfWaitingForDebugger' },
+    { method: 'Profiler.start' }]);
+  while (await child.nextStderrString() !==
+         'Waiting for the debugger to disconnect...');
+  await session.send({ method: 'Profiler.stop' });
+  session.disconnect();
+  assert.strictEqual(0, (await child.expectShutdown()).exitCode);
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -11,7 +11,7 @@ async function runTests() {
   const child = new NodeInstance(['--inspect-brk=0'],
                                  `const interval = setInterval(() => {
                                     console.log(new Object());
-                                  }, 140);
+                                  }, 200);
                                   process.stdin.on('data', (msg) => {
                                     if (msg.toString() === 'fhqwhgads') {
                                       clearInterval(interval);
@@ -31,7 +31,7 @@ async function runTests() {
   const session = await child.connectInspectorSession();
 
   session.send([
-    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 1400 } },
+    { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 2000 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
@@ -43,7 +43,7 @@ async function runTests() {
   assert.strictEqual(stderrString, 'Debugger attached.');
 
   session.send({ 'method': 'Profiler.start' })
-  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 2800);
+  setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 4000);
 }
 
 common.crashOnUnhandledRejection();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -25,9 +25,9 @@ async function runTests() {
 
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
-    { 'method': 'Profiler.enable' },
-    { 'method': 'Runtime.runIfWaitingForDebugger' },
-    { 'method': 'Profiler.start' }
+    // { 'method': 'Profiler.enable' },
+    // { 'method': 'Runtime.runIfWaitingForDebugger' },
+    // { 'method': 'Profiler.start' }
   ]);
 
   // stderrString = await child.nextStderrString();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -30,10 +30,10 @@ async function runTests() {
     // { 'method': 'Profiler.start' }
   ]);
 
-  // stderrString = await child.nextStderrString();
-  // assert.strictEqual(stderrString, 'Debugger attached.')
-  // stderrString = await child.nextStderrString();
-  // assert.strictEqual(stderrString, '');
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, 'Debugger attached.')
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, '');
   // stderrString = await child.nextStderrString();
   // assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
 

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -17,9 +17,11 @@ async function runTests() {
 
   let stderrString = await child.nextStderrString();
   assert(stderrString.includes('Debugger listening on'), stderrString);
-  // if (!stderrString.includes('Debugger listening on')) {
-  //   stderrString += await child.nextStderrString();
-  // }
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString,
+                     'For help see https://nodejs.org/en/docs/inspector');
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, '');
 
   session.send([
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
@@ -28,12 +30,12 @@ async function runTests() {
     { 'method': 'Profiler.start' }
   ]);
 
-  let limit = 0;
-  while (!stderrString.includes('Waiting for the debugger to disconnect...')) {
-    stderrString += await child.nextStderrString();
-    if (limit++ > 10)
-      throw new Error('no!');
-  }
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, 'Debugger attached.')
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, '');
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, 'Waiting for the debugger to disconnect...');
 
   await session.send({ 'method': 'Profiler.stop' });
   session.disconnect();

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -18,10 +18,10 @@ async function runTests() {
   let stderrString = await child.nextStderrString();
   assert(stderrString.includes('Debugger listening on'), stderrString);
   stderrString = await child.nextStderrString();
-  // assert.strictEqual(stderrString,
-  //                    'For help see https://nodejs.org/en/docs/inspector');
-  // stderrString = await child.nextStderrString();
-  // assert.strictEqual(stderrString, '');
+  assert.strictEqual(stderrString,
+                     'For help see https://nodejs.org/en/docs/inspector');
+  stderrString = await child.nextStderrString();
+  assert.strictEqual(stderrString, '');
 
   // session.send([
   //   { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -23,7 +23,7 @@ async function runTests() {
     const message = data.toString();
     stderrMessages.push(message);
     if (message.trim() === 'Waiting for the debugger to disconnect...') {
-      await session.send({ 'method': 'Profiler.stop' });
+      // await session.send({ 'method': 'Profiler.stop' });
       session.disconnect();
       assert.strictEqual(0, (await child.expectShutdown()).exitCode);
     }
@@ -42,7 +42,7 @@ async function runTests() {
   const stderrString = await child.nextStderrString();
   assert.strictEqual(stderrString, 'Debugger attached.');
 
-  session.send({ 'method': 'Profiler.start' })
+  // session.send({ 'method': 'Profiler.start' })
   setTimeout(() => { child._process.stdin.write('fhqwhgads'); }, 200);
 }
 

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -27,7 +27,7 @@ async function runTests() {
     { 'method': 'Profiler.setSamplingInterval', 'params': { 'interval': 100 } },
     { 'method': 'Profiler.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
-    { 'method': 'Profiler.start' }
+    // { 'method': 'Profiler.start' }
   ]);
 
   stderrString = await child.nextStderrString();


### PR DESCRIPTION
In test/sequential/test-inspector-stop-profile-after-done.js, start the
profiler before running the code to avoid a race condition. If
`Profile.start` is received after the debugger is waiting to disconnect,
then the process will not terminate.

    
Fixes: https://github.com/nodejs/node/issues/16772


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test inspector