### PR TITLE
buffer: throw when filling with empty buffers

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -519,6 +519,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/17427
     description: Specifying an invalid string for `fill` triggers a thrown
                  exception.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18129
+    description: Attempting to fill a non-zero length buffer with a zero length
+                 buffer triggers a thrown exception.
 -->
 
 * `size` {integer} The desired length of the new `Buffer`.
@@ -1231,6 +1235,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/17427
     description: Specifying an invalid string for `value` triggers a thrown
                  exception.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18129
+    description: Attempting to fill a non-zero length buffer with a zero length
+                 buffer triggers a thrown exception.
 -->
 
 * `value` {string|Buffer|integer} The value to fill `buf` with.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -511,18 +511,18 @@ console.log(buf2.toString());
 <!-- YAML
 added: v5.10.0
 changes:
-  - version: v8.9.3
-    pr-url: https://github.com/nodejs/node/pull/17428
-    description: Specifying an invalid string for `fill` now results in a
-                 zero-filled buffer.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17427
-    description: Specifying an invalid string for `fill` triggers a thrown
-                 exception.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/18129
     description: Attempting to fill a non-zero length buffer with a zero length
                  buffer triggers a thrown exception.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17427
+    description: Specifying an invalid string for `fill` triggers a thrown
+                 exception.
+  - version: v8.9.3
+    pr-url: https://github.com/nodejs/node/pull/17428
+    description: Specifying an invalid string for `fill` now results in a
+                 zero-filled buffer.
 -->
 
 * `size` {integer} The desired length of the new `Buffer`.
@@ -1228,17 +1228,17 @@ console.log(buf1.equals(buf3));
 <!-- YAML
 added: v0.5.0
 changes:
-  - version: v5.7.0
-    pr-url: https://github.com/nodejs/node/pull/4935
-    description: The `encoding` parameter is supported now.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17427
-    description: Specifying an invalid string for `value` triggers a thrown
-                 exception.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/18129
     description: Attempting to fill a non-zero length buffer with a zero length
                  buffer triggers a thrown exception.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17427
+    description: Specifying an invalid string for `value` triggers a thrown
+                 exception.
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4935
+    description: The `encoding` parameter is supported now.
 -->
 
 * `value` {string|Buffer|integer} The value to fill `buf` with.

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -642,13 +642,6 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
                                     str_obj,
                                     enc,
                                     nullptr);
-    // This check is also needed in case Write() returns that no bytes could
-    // be written. If no bytes could be written, then return -1 because the
-    // string is invalid. This will trigger a throw in JavaScript. Silently
-    // failing should be avoided because it can lead to buffers with unexpected
-    // contents.
-    if (str_length == 0)
-      return args.GetReturnValue().Set(-1);
   }
 
  start_fill:
@@ -656,6 +649,13 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   if (str_length >= fill_length)
     return;
 
+  // If str_length is zero, then either an empty buffer was provided, or Write()
+  // indicated that no bytes could be written. If no bytes could be written,
+  // then return -1 because the fill value is invalid. This will trigger a throw
+  // in JavaScript. Silently failing should be avoided because it can lead to
+  // buffers with unexpected contents.
+  if (str_length == 0)
+    return args.GetReturnValue().Set(-1);
 
   size_t in_there = str_length;
   char* ptr = ts_obj_data + start + str_length;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1024,3 +1024,10 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_VALUE',
   type: TypeError
 });
+
+common.expectsError(() => {
+  Buffer.alloc(1, Buffer.alloc(0));
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  type: TypeError
+});


### PR DESCRIPTION
Prior to this commit, Node would enter an infinite loop when attempting to fill a non-zero length buffer with a zero length buffer. This commit introduces a thrown exception in this scenario.

Fixes: https://github.com/nodejs/node/issues/18128

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
