### PR TITLE
deps: cherry-pick 3dfb90b from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/arm64/macro-assembler-arm64.cc
+++ b/deps/v8/src/arm64/macro-assembler-arm64.cc
@@ -1958,6 +1958,15 @@ void TurboAssembler::Call(Handle<Code> code, RelocInfo::Mode rmode) {
 #endif
 }
 
+void TurboAssembler::Call(ExternalReference target) {
+  UseScratchRegisterScope temps(this);
+  Register temp = temps.AcquireX();
+  // Immediate is in charge of setting the relocation mode to
+  // EXTERNAL_REFERENCE.
+  Ldr(temp, Immediate(target));
+  Call(temp);
+}
+
 int TurboAssembler::CallSize(Register target) {
   USE(target);
   return kInstructionSize;
@@ -3399,7 +3408,7 @@ void TurboAssembler::CallPrintf(int arg_count, const CPURegister* args) {
     dc32(arg_pattern_list);   // kPrintfArgPatternListOffset
   }
 #else
-  Call(FUNCTION_ADDR(printf), RelocInfo::EXTERNAL_REFERENCE);
+  Call(ExternalReference::printf_function(isolate()));
 #endif
 }
 

--- a/deps/v8/src/arm64/macro-assembler-arm64.h
+++ b/deps/v8/src/arm64/macro-assembler-arm64.h
@@ -884,6 +884,7 @@ class TurboAssembler : public Assembler {
   void Call(Label* target);
   void Call(Address target, RelocInfo::Mode rmode);
   void Call(Handle<Code> code, RelocInfo::Mode rmode = RelocInfo::CODE_TARGET);
+  void Call(ExternalReference target);
 
   void CallForDeoptimization(Address target, RelocInfo::Mode rmode) {
     Call(target, rmode);

--- a/deps/v8/src/assembler.cc
+++ b/deps/v8/src/assembler.cc
@@ -1397,6 +1397,10 @@ ExternalReference ExternalReference::libc_memset_function(Isolate* isolate) {
   return ExternalReference(Redirect(isolate, FUNCTION_ADDR(libc_memset)));
 }
 
+ExternalReference ExternalReference::printf_function(Isolate* isolate) {
+  return ExternalReference(Redirect(isolate, FUNCTION_ADDR(std::printf)));
+}
+
 template <typename SubjectChar, typename PatternChar>
 ExternalReference ExternalReference::search_string_raw(Isolate* isolate) {
   auto f = SearchStringRaw<SubjectChar, PatternChar>;

--- a/deps/v8/src/assembler.h
+++ b/deps/v8/src/assembler.h
@@ -969,6 +969,8 @@ class ExternalReference BASE_EMBEDDED {
   static ExternalReference libc_memmove_function(Isolate* isolate);
   static ExternalReference libc_memset_function(Isolate* isolate);
 
+  static ExternalReference printf_function(Isolate* isolate);
+
   static ExternalReference try_internalize_string_function(Isolate* isolate);
 
   static ExternalReference check_object_type(Isolate* isolate);

--- a/deps/v8/src/external-reference-table.cc
+++ b/deps/v8/src/external-reference-table.cc
@@ -241,6 +241,7 @@ void ExternalReferenceTable::AddReferences(Isolate* isolate) {
       "libc_memmove");
   Add(ExternalReference::libc_memset_function(isolate).address(),
       "libc_memset");
+  Add(ExternalReference::printf_function(isolate).address(), "printf");
   Add(ExternalReference::try_internalize_string_function(isolate).address(),
       "try_internalize_string_function");
   Add(ExternalReference::check_object_type(isolate).address(),


### PR DESCRIPTION
Original commit message:

    [arm64] Mark std::printf as an external reference

    Arm64's implementation of `TurboAssembler::Abort()` supports printing the
    bailout reason to the standard output without calling to the runtime. For this
    to work, we need access to the host's printf function so we can call it
    directly. In the general case, `Abort` does call the runtime, however, we cannot
    do it if we want to abort from inside CEntryStub.

    Bug: v8:6939
    Change-Id: I2a57603cdc182a45cf770f405bd6ae449f40a047
    Reviewed-on: https://chromium-review.googlesource.com/730746
    Reviewed-by: Benedikt Meurer <bmeurer@chromium.org>
    Commit-Queue: Pierre Langlois <pierre.langlois@arm.com>
    Cr-Commit-Position: refs/heads/master@{#48790}

Refs: https://github.com/v8/v8/commit/3dfb90b6698f10fadc108a06356135d5ea1f3222

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/nodejs/node/issues/15395

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps/v8