### PR TITLE
timers: allow Immediates to be unrefed

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -18,6 +18,38 @@ This object is created internally and is returned from [`setImmediate()`][]. It
 can be passed to [`clearImmediate()`][] in order to cancel the scheduled
 actions.
 
+By default, when an immediate is scheduled, the Node.js event loop will continue
+running as long as the immediate is active. The `Immediate` object returned by
+[`setImmediate()`][] exports both `immediate.ref()` and `immediate.unref()`
+functions that can be used to control this default behavior.
+
+### immediate.ref()
+<!-- YAML
+added: REPLACEME
+-->
+
+When called, requests that the Node.js event loop *not* exit so long as the
+`Immediate` is active. Calling `immediate.ref()` multiple times will have no
+effect.
+
+*Note*: By default, all `Immediate` objects are "ref'd", making it normally
+unnecessary to call `immediate.ref()` unless `immediate.unref()` had been called
+previously.
+
+Returns a reference to the `Immediate`.
+
+### immediate.unref()
+<!-- YAML
+added: REPLACEME
+-->
+
+When called, the active `Immediate` object will not require the Node.js event
+loop to remain active. If there is no other activity keeping the event loop
+running, the process may exit before the `Immediate` object's callback is
+invoked. Calling `immediate.unref()` multiple times will have no effect.
+
+Returns a reference to the `Immediate`.
+
 ## Class: Timeout
 
 This object is created internally and is returned from [`setTimeout()`][] and

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -53,10 +53,13 @@ const trigger_async_id_symbol = timerInternals.trigger_async_id_symbol;
 
 // *Must* match Environment::ImmediateInfo::Fields in src/env.h.
 const kCount = 0;
-const kHasOutstanding = 1;
+const kRefCount = 1;
+const kHasOutstanding = 2;
 
-const [activateImmediateCheck, immediateInfo] =
+const [immediateInfo, toggleImmediateRef] =
   setImmediateCallback(processImmediate);
+
+const kRefed = Symbol('refed');
 
 // The Timeout class
 const Timeout = timerInternals.Timeout;
@@ -656,7 +659,7 @@ function processImmediate() {
   const queue = outstandingQueue.head !== null ?
     outstandingQueue : immediateQueue;
   var immediate = queue.head;
-  var tail = queue.tail;
+  const tail = queue.tail;
 
   // Clear the linked list early in case new `setImmediate()` calls occur while
   // immediate callbacks are executed
@@ -668,22 +671,16 @@ function processImmediate() {
       continue;
     }
 
-    // Save next in case `clearImmediate(immediate)` is called from callback
-    const next = immediate._idleNext;
+    immediate._destroyed = true;
 
     const asyncId = immediate[async_id_symbol];
     emitBefore(asyncId, immediate[trigger_async_id_symbol]);
 
-    tryOnImmediate(immediate, next, tail);
+    tryOnImmediate(immediate, tail);
 
     emitAfter(asyncId);
 
-    // If `clearImmediate(immediate)` wasn't called from the callback, use the
-    // `immediate`'s next item
-    if (immediate._idleNext !== null)
-      immediate = immediate._idleNext;
-    else
-      immediate = next;
+    immediate = immediate._idleNext;
   }
 
   immediateInfo[kHasOutstanding] = 0;
@@ -691,7 +688,7 @@ function processImmediate() {
 
 // An optimization so that the try/finally only de-optimizes (since at least v8
 // 4.7) what is in this smaller function.
-function tryOnImmediate(immediate, next, oldTail) {
+function tryOnImmediate(immediate, oldTail) {
   var threw = true;
   try {
     // make the actual call outside the try/finally to allow it to be optimized
@@ -700,19 +697,21 @@ function tryOnImmediate(immediate, next, oldTail) {
   } finally {
     immediate._onImmediate = null;
 
-    if (!immediate._destroyed) {
-      immediate._destroyed = true;
-      immediateInfo[kCount]--;
+    immediateInfo[kCount]--;
 
-      if (async_hook_fields[kDestroy] > 0) {
-        emitDestroy(immediate[async_id_symbol]);
-      }
+    if (immediate[kRefed]) {
+      immediate[kRefed] = false;
+      immediateInfo[kRefCount]--;
     }
 
-    if (threw && (immediate._idleNext !== null || next !== null)) {
+    if (async_hook_fields[kDestroy] > 0) {
+      emitDestroy(immediate[async_id_symbol]);
+    }
+
+    if (threw && immediate._idleNext !== null) {
       // Handle any remaining Immediates after error handling has resolved,
       // assuming we're still alive to do so.
-      outstandingQueue.head = immediate._idleNext || next;
+      outstandingQueue.head = immediate._idleNext;
       outstandingQueue.tail = oldTail;
       immediateInfo[kHasOutstanding] = 1;
     }
@@ -729,31 +728,51 @@ function runCallback(timer) {
 }
 
 
-function Immediate(callback, args) {
-  this._idleNext = null;
-  this._idlePrev = null;
-  // this must be set to null first to avoid function tracking
-  // on the hidden class, revisit in V8 versions after 6.2
-  this._onImmediate = null;
-  this._onImmediate = callback;
-  this._argv = args;
-  this._destroyed = false;
+const Immediate = class Immediate {
+  constructor(callback, args) {
+    this._idleNext = null;
+    this._idlePrev = null;
+    // this must be set to null first to avoid function tracking
+    // on the hidden class, revisit in V8 versions after 6.2
+    this._onImmediate = null;
+    this._onImmediate = callback;
+    this._argv = args;
+    this._destroyed = false;
+    this[kRefed] = false;
 
-  this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
-  this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
-  if (async_hook_fields[kInit] > 0) {
-    emitInit(this[async_id_symbol],
-             'Immediate',
-             this[trigger_async_id_symbol],
-             this);
+    this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
+    this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
+    if (async_hook_fields[kInit] > 0) {
+      emitInit(this[async_id_symbol],
+               'Immediate',
+               this[trigger_async_id_symbol],
+               this);
+    }
+
+    this.ref();
+    immediateInfo[kCount]++;
+
+    immediateQueue.append(this);
   }
 
-  if (immediateInfo[kCount] === 0)
-    activateImmediateCheck();
-  immediateInfo[kCount]++;
+  ref() {
+    if (!this[kRefed]) {
+      this[kRefed] = true;
+      if (immediateInfo[kRefCount]++ === 0)
+        toggleImmediateRef(true);
+    }
+    return this;
+  }
 
-  immediateQueue.append(this);
-}
+  unref() {
+    if (this[kRefed]) {
+      this[kRefed] = false;
+      if (--immediateInfo[kRefCount] === 0)
+        toggleImmediateRef(false);
+    }
+    return this;
+  }
+};
 
 function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
@@ -793,15 +812,16 @@ exports.setImmediate = setImmediate;
 
 
 exports.clearImmediate = function(immediate) {
-  if (!immediate) return;
+  if (!immediate || immediate._destroyed)
+    return;
 
-  if (!immediate._destroyed) {
-    immediateInfo[kCount]--;
-    immediate._destroyed = true;
+  immediateInfo[kCount]--;
+  immediate._destroyed = true;
 
-    if (async_hook_fields[kDestroy] > 0) {
-      emitDestroy(immediate[async_id_symbol]);
-    }
+  immediate.unref();
+
+  if (async_hook_fields[kDestroy] > 0) {
+    emitDestroy(immediate[async_id_symbol]);
   }
 
   immediate._onImmediate = null;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -665,30 +665,36 @@ function processImmediate() {
   // immediate callbacks are executed
   queue.head = queue.tail = null;
 
-  while (immediate !== null) {
-    if (!immediate._onImmediate) {
-      immediate = immediate._idleNext;
-      continue;
-    }
+  let count = 0;
+  let refCount = 0;
 
+  while (immediate !== null) {
     immediate._destroyed = true;
 
     const asyncId = immediate[async_id_symbol];
     emitBefore(asyncId, immediate[trigger_async_id_symbol]);
 
-    tryOnImmediate(immediate, tail);
+    count++;
+    if (immediate[kRefed]) {
+      immediate[kRefed] = undefined;
+      refCount++;
+    }
+
+    tryOnImmediate(immediate, tail, count, refCount);
 
     emitAfter(asyncId);
 
     immediate = immediate._idleNext;
   }
 
+  immediateInfo[kCount] -= count;
+  immediateInfo[kRefCount] -= refCount;
   immediateInfo[kHasOutstanding] = 0;
 }
 
 // An optimization so that the try/finally only de-optimizes (since at least v8
 // 4.7) what is in this smaller function.
-function tryOnImmediate(immediate, oldTail) {
+function tryOnImmediate(immediate, oldTail, count, refCount) {
   var threw = true;
   try {
     // make the actual call outside the try/finally to allow it to be optimized
@@ -697,23 +703,21 @@ function tryOnImmediate(immediate, oldTail) {
   } finally {
     immediate._onImmediate = null;
 
-    immediateInfo[kCount]--;
-
-    if (immediate[kRefed]) {
-      immediate[kRefed] = false;
-      immediateInfo[kRefCount]--;
-    }
-
     if (async_hook_fields[kDestroy] > 0) {
       emitDestroy(immediate[async_id_symbol]);
     }
 
-    if (threw && immediate._idleNext !== null) {
-      // Handle any remaining Immediates after error handling has resolved,
-      // assuming we're still alive to do so.
-      outstandingQueue.head = immediate._idleNext;
-      outstandingQueue.tail = oldTail;
-      immediateInfo[kHasOutstanding] = 1;
+    if (threw) {
+      immediateInfo[kCount] -= count;
+      immediateInfo[kRefCount] -= refCount;
+
+      if (immediate._idleNext !== null) {
+        // Handle any remaining Immediates after error handling has resolved,
+        // assuming we're still alive to do so.
+        outstandingQueue.head = immediate._idleNext;
+        outstandingQueue.tail = oldTail;
+        immediateInfo[kHasOutstanding] = 1;
+      }
     }
   }
 }
@@ -756,7 +760,7 @@ const Immediate = class Immediate {
   }
 
   ref() {
-    if (!this[kRefed]) {
+    if (this[kRefed] === false) {
       this[kRefed] = true;
       if (immediateInfo[kRefCount]++ === 0)
         toggleImmediateRef(true);
@@ -765,7 +769,7 @@ const Immediate = class Immediate {
   }
 
   unref() {
-    if (this[kRefed]) {
+    if (this[kRefed] === true) {
       this[kRefed] = false;
       if (--immediateInfo[kRefCount] === 0)
         toggleImmediateRef(false);
@@ -818,7 +822,11 @@ exports.clearImmediate = function(immediate) {
   immediateInfo[kCount]--;
   immediate._destroyed = true;
 
-  immediate.unref();
+  if (immediate[kRefed]) {
+    immediate[kRefed] = undefined;
+    if (--immediateInfo[kRefCount] === 0)
+      toggleImmediateRef(false);
+  }
 
   if (async_hook_fields[kDestroy] > 0) {
     emitDestroy(immediate[async_id_symbol]);

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -675,10 +675,9 @@ function processImmediate() {
     emitBefore(asyncId, immediate[trigger_async_id_symbol]);
 
     count++;
-    if (immediate[kRefed]) {
-      immediate[kRefed] = undefined;
+    if (immediate[kRefed])
       refCount++;
-    }
+    immediate[kRefed] = undefined;
 
     tryOnImmediate(immediate, tail, count, refCount);
 
@@ -822,11 +821,9 @@ exports.clearImmediate = function(immediate) {
   immediateInfo[kCount]--;
   immediate._destroyed = true;
 
-  if (immediate[kRefed]) {
-    immediate[kRefed] = undefined;
-    if (--immediateInfo[kRefCount] === 0)
-      toggleImmediateRef(false);
-  }
+  if (immediate[kRefed] && --immediateInfo[kRefCount] === 0)
+    toggleImmediateRef(false);
+  immediate[kRefed] = undefined;
 
   if (async_hook_fields[kDestroy] > 0) {
     emitDestroy(immediate[async_id_symbol]);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -548,7 +548,7 @@ inline void Environment::set_fs_stats_field_array(double* fields) {
   fs_stats_field_array_ = fields;
 }
 
-void Environment::SetImmediate(native_immediate_callback cb,
+void Environment::CreateImmediate(native_immediate_callback cb,
                                void* data,
                                v8::Local<v8::Object> obj,
                                bool ref) {
@@ -560,17 +560,22 @@ void Environment::SetImmediate(native_immediate_callback cb,
     ref
   });
   immediate_info()->count_inc(1);
-  if (ref) {
-    if (immediate_info()->ref_count() == 0)
-      ToggleImmediateRef(true);
-    immediate_info()->ref_count_inc(1);
-  }
+}
+
+void Environment::SetImmediate(native_immediate_callback cb,
+                               void* data,
+                               v8::Local<v8::Object> obj) {
+  CreateImmediate(cb, data, obj, true);
+
+  if (immediate_info()->ref_count() == 0)
+    ToggleImmediateRef(true);
+  immediate_info()->ref_count_inc(1);
 }
 
 void Environment::SetUnrefImmediate(native_immediate_callback cb,
                                     void* data,
                                     v8::Local<v8::Object> obj) {
-  SetImmediate(cb, data, obj, false);
+  CreateImmediate(cb, data, obj, false);
 }
 
 inline performance::performance_state* Environment::performance_state() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -229,6 +229,10 @@ inline uint32_t Environment::ImmediateInfo::count() const {
   return fields_[kCount];
 }
 
+inline uint32_t Environment::ImmediateInfo::ref_count() const {
+  return fields_[kRefCount];
+}
+
 inline bool Environment::ImmediateInfo::has_outstanding() const {
   return fields_[kHasOutstanding] == 1;
 }
@@ -239,6 +243,14 @@ inline void Environment::ImmediateInfo::count_inc(uint32_t increment) {
 
 inline void Environment::ImmediateInfo::count_dec(uint32_t decrement) {
   fields_[kCount] = fields_[kCount] - decrement;
+}
+
+inline void Environment::ImmediateInfo::ref_count_inc(uint32_t increment) {
+  fields_[kRefCount] = fields_[kRefCount] + increment;
+}
+
+inline void Environment::ImmediateInfo::ref_count_dec(uint32_t decrement) {
+  fields_[kRefCount] = fields_[kRefCount] - decrement;
 }
 
 inline Environment::TickInfo::TickInfo(v8::Isolate* isolate)
@@ -538,16 +550,27 @@ inline void Environment::set_fs_stats_field_array(double* fields) {
 
 void Environment::SetImmediate(native_immediate_callback cb,
                                void* data,
-                               v8::Local<v8::Object> obj) {
+                               v8::Local<v8::Object> obj,
+                               bool ref) {
   native_immediate_callbacks_.push_back({
     cb,
     data,
-    std::unique_ptr<v8::Persistent<v8::Object>>(
-        obj.IsEmpty() ? nullptr : new v8::Persistent<v8::Object>(isolate_, obj))
+    std::unique_ptr<v8::Persistent<v8::Object>>(obj.IsEmpty() ?
+        nullptr : new v8::Persistent<v8::Object>(isolate_, obj)),
+    ref
   });
-  if (immediate_info()->count() == 0)
-    ActivateImmediateCheck();
   immediate_info()->count_inc(1);
+  if (ref) {
+    if (immediate_info()->ref_count() == 0)
+      ToggleImmediateRef(true);
+    immediate_info()->ref_count_inc(1);
+  }
+}
+
+void Environment::SetUnrefImmediate(native_immediate_callback cb,
+                                    void* data,
+                                    v8::Local<v8::Object> obj) {
+  SetImmediate(cb, data, obj, false);
 }
 
 inline performance::performance_state* Environment::performance_state() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -82,6 +82,8 @@ void Environment::Start(int argc,
 
   uv_idle_init(event_loop(), immediate_idle_handle());
 
+  uv_check_start(immediate_check_handle(), CheckImmediate);
+
   // Inform V8's CPU profiler when we're idle.  The profiler is sampling-based
   // but not all samples are created equal; mark the wall clock time spent in
   // epoll_wait() and friends so profiling tools can filter it out.  The samples
@@ -274,38 +276,34 @@ void Environment::EnvPromiseHook(v8::PromiseHookType type,
 void Environment::RunAndClearNativeImmediates() {
   size_t count = native_immediate_callbacks_.size();
   if (count > 0) {
+    size_t ref_count = 0;
     std::vector<NativeImmediateCallback> list;
     native_immediate_callbacks_.swap(list);
     for (const auto& cb : list) {
       cb.cb_(this, cb.data_);
       if (cb.keep_alive_)
         cb.keep_alive_->Reset();
+      if (cb.refed_)
+        ref_count++;
     }
 
 #ifdef DEBUG
     CHECK_GE(immediate_info()->count(), count);
 #endif
     immediate_info()->count_dec(count);
+    immediate_info()->ref_count_dec(ref_count);
   }
-}
-
-static bool MaybeStopImmediate(Environment* env) {
-  if (env->immediate_info()->count() == 0) {
-    uv_check_stop(env->immediate_check_handle());
-    uv_idle_stop(env->immediate_idle_handle());
-    return true;
-  }
-  return false;
 }
 
 
 void Environment::CheckImmediate(uv_check_t* handle) {
   Environment* env = Environment::from_immediate_check_handle(handle);
+
+  if (env->immediate_info()->count() == 0)
+    return;
+
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());
-
-  if (MaybeStopImmediate(env))
-    return;
 
   env->RunAndClearNativeImmediates();
 
@@ -318,13 +316,17 @@ void Environment::CheckImmediate(uv_check_t* handle) {
                  {0, 0}).ToLocalChecked();
   } while (env->immediate_info()->has_outstanding());
 
-  MaybeStopImmediate(env);
+  if (env->immediate_info()->ref_count() == 0)
+    env->ToggleImmediateRef(false);
 }
 
-void Environment::ActivateImmediateCheck() {
-  uv_check_start(&immediate_check_handle_, CheckImmediate);
-  // Idle handle is needed only to stop the event loop from blocking in poll.
-  uv_idle_start(&immediate_idle_handle_, [](uv_idle_t*){ });
+void Environment::ToggleImmediateRef(bool ref) {
+  if (ref) {
+    // Idle handle is needed only to stop the event loop from blocking in poll.
+    uv_idle_start(immediate_idle_handle(), [](uv_idle_t*){ });
+  } else {
+    uv_idle_stop(immediate_idle_handle());
+  }
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -702,8 +702,7 @@ class Environment {
   // obj will be kept alive between now and after the callback has run.
   inline void SetImmediate(native_immediate_callback cb,
                            void* data,
-                           v8::Local<v8::Object> obj = v8::Local<v8::Object>(),
-                           bool ref = true);
+                           v8::Local<v8::Object> obj = v8::Local<v8::Object>());
   inline void SetUnrefImmediate(native_immediate_callback cb,
                                 void* data,
                                 v8::Local<v8::Object> obj =
@@ -726,6 +725,11 @@ class Environment {
   static inline Environment* ForAsyncHooks(AsyncHooks* hooks);
 
  private:
+  inline void CreateImmediate(native_immediate_callback cb,
+                              void* data,
+                              v8::Local<v8::Object> obj,
+                              bool ref);
+
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
 

--- a/src/env.h
+++ b/src/env.h
@@ -457,10 +457,14 @@ class Environment {
    public:
     inline AliasedBuffer<uint32_t, v8::Uint32Array>& fields();
     inline uint32_t count() const;
+    inline uint32_t ref_count() const;
     inline bool has_outstanding() const;
 
     inline void count_inc(uint32_t increment);
     inline void count_dec(uint32_t decrement);
+
+    inline void ref_count_inc(uint32_t increment);
+    inline void ref_count_dec(uint32_t decrement);
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -468,6 +472,7 @@ class Environment {
 
     enum Fields {
       kCount,
+      kRefCount,
       kHasOutstanding,
       kFieldsCount
     };
@@ -697,9 +702,14 @@ class Environment {
   // obj will be kept alive between now and after the callback has run.
   inline void SetImmediate(native_immediate_callback cb,
                            void* data,
-                           v8::Local<v8::Object> obj = v8::Local<v8::Object>());
+                           v8::Local<v8::Object> obj = v8::Local<v8::Object>(),
+                           bool ref = true);
+  inline void SetUnrefImmediate(native_immediate_callback cb,
+                                void* data,
+                                v8::Local<v8::Object> obj =
+                                    v8::Local<v8::Object>());
   // This needs to be available for the JS-land setImmediate().
-  void ActivateImmediateCheck();
+  void ToggleImmediateRef(bool ref);
 
   class ShouldNotAbortOnUncaughtScope {
    public:
@@ -780,6 +790,7 @@ class Environment {
     native_immediate_callback cb_;
     void* data_;
     std::unique_ptr<v8::Persistent<v8::Object>> keep_alive_;
+    bool refed_;
   };
   std::vector<NativeImmediateCallback> native_immediate_callbacks_;
   void RunAndClearNativeImmediates();

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -182,9 +182,8 @@ void SetupPerformanceObservers(const FunctionCallbackInfo<Value>& args) {
 }
 
 // Creates a GC Performance Entry and passes it to observers
-void PerformanceGCCallback(uv_async_t* handle) {
-  GCPerformanceEntry* entry = static_cast<GCPerformanceEntry*>(handle->data);
-  Environment* env = entry->env();
+void PerformanceGCCallback(Environment* env, void* ptr) {
+  GCPerformanceEntry* entry = static_cast<GCPerformanceEntry*>(ptr);
   HandleScope scope(env->isolate());
   Local<Context> context = env->context();
 
@@ -201,10 +200,6 @@ void PerformanceGCCallback(uv_async_t* handle) {
   }
 
   delete entry;
-  auto closeCB = [](uv_handle_t* handle) {
-    delete reinterpret_cast<uv_async_t*>(handle);
-  };
-  uv_close(reinterpret_cast<uv_handle_t*>(handle), closeCB);
 }
 
 // Marks the start of a GC cycle
@@ -221,16 +216,13 @@ void MarkGarbageCollectionEnd(Isolate* isolate,
                               v8::GCCallbackFlags flags,
                               void* data) {
   Environment* env = static_cast<Environment*>(data);
-  uv_async_t* async = new uv_async_t();
-  if (uv_async_init(env->event_loop(), async, PerformanceGCCallback))
-    return delete async;
-  uv_unref(reinterpret_cast<uv_handle_t*>(async));
-  async->data =
+  GCPerformanceEntry* entry =
       new GCPerformanceEntry(env,
                              static_cast<PerformanceGCKind>(type),
                              performance_last_gc_start_mark_,
                              PERFORMANCE_NOW());
-  CHECK_EQ(0, uv_async_send(async));
+  env->SetUnrefImmediate(PerformanceGCCallback,
+                         entry);
 }
 
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -83,16 +83,16 @@ class TimerWrap : public HandleWrap {
     CHECK(args[0]->IsFunction());
     auto env = Environment::GetCurrent(args);
     env->set_immediate_callback_function(args[0].As<Function>());
-    auto activate_cb = [] (const FunctionCallbackInfo<Value>& args) {
-      Environment::GetCurrent(args)->ActivateImmediateCheck();
+    auto toggle_ref_cb = [] (const FunctionCallbackInfo<Value>& args) {
+      Environment::GetCurrent(args)->ToggleImmediateRef(args[0]->IsTrue());
     };
-    auto activate_function =
-        env->NewFunctionTemplate(activate_cb)->GetFunction(env->context())
+    auto toggle_ref_function =
+        env->NewFunctionTemplate(toggle_ref_cb)->GetFunction(env->context())
         .ToLocalChecked();
     auto result = Array::New(env->isolate(), 2);
-    result->Set(env->context(), 0, activate_function).FromJust();
-    result->Set(env->context(), 1,
+    result->Set(env->context(), 0,
                 env->immediate_info()->fields().GetJSArray()).FromJust();
+    result->Set(env->context(), 1, toggle_ref_function).FromJust();
     args.GetReturnValue().Set(result);
   }
 

--- a/test/addons-napi/test_uv_loop/test_uv_loop.cc
+++ b/test/addons-napi/test_uv_loop/test_uv_loop.cc
@@ -24,6 +24,15 @@ void* SetImmediate(napi_env env, T&& cb) {
 
     assert(cb() != nullptr);
   });
+  // Idle handle is needed only to stop the event loop from blocking in poll.
+  uv_idle_t* idle = new uv_idle_t;
+  uv_idle_init(loop, idle);
+  uv_idle_start(idle, [](uv_idle_t* idle) {
+    uv_close(reinterpret_cast<uv_handle_t*>(idle), [](uv_handle_t* handle) {
+      delete reinterpret_cast<uv_check_t*>(handle);
+    });
+  });
+
   return nullptr;
 }
 

--- a/test/parallel/test-timers-immediate-unref-simple.js
+++ b/test/parallel/test-timers-immediate-unref-simple.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const common = require('../common');
+
+// This immediate should not execute as it was unrefed
+// and nothing else is keeping the event loop alive
+setImmediate(common.mustNotCall()).unref();

--- a/test/parallel/test-timers-immediate-unref.js
+++ b/test/parallel/test-timers-immediate-unref.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const Countdown = require('../common/countdown');
+
+// This immediate should execute as it was unrefed and refed again.
+// It also confirms that unref/ref are chainable.
+setImmediate(common.mustCall(firstStep)).ref().unref().unref().ref();
+
+function firstStep() {
+  const countdown = new Countdown(2, () => setImmediate(finalStep));
+  // Unrefed setImmediate executes if it was unrefed but something else keeps
+  // the loop open
+  setImmediate(common.mustCall(() => countdown.dec())).unref();
+  setTimeout(common.mustCall(() => countdown.dec()), 50);
+}
+
+function finalStep() {
+  // This immediate should not execute as it was unrefed
+  // and nothing else is keeping the event loop alive
+  setImmediate(common.mustNotCall()).unref();
+}


### PR DESCRIPTION
Slightly refactor the Immediates handling to allow for them to be unrefed, similar to setTimeout, but without extra handles. Adds `immediate.ref()` and `immediate.unref()`.

There's a roughly 5-10% performance regression on some of the immediate benchmarks, as well as a more substantial regression on `clearImmediate`. Both are a result of needing to track an extra property on the Immediate class. That said, since 9.0.0 got released we've seen the performance on `setImmediate` benchmarks grow by roughly 40-50%, so IMO we can afford this slight regression.

CI: https://ci.nodejs.org/job/node-test-pull-request/12523/
Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/96/
CitGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1202/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers