### PR TITLE
test: fix flaky interval test

### DIFF
--- a/test/sequential/test-timers-set-interval-excludes-callback-duration.js
+++ b/test/sequential/test-timers-set-interval-excludes-callback-duration.js
@@ -4,15 +4,14 @@ const Timer = process.binding('timer_wrap').Timer;
 const assert = require('assert');
 
 let cntr = 0;
-let first, second;
+let first;
 const t = setInterval(() => {
-  common.busyLoop(50);
   cntr++;
   if (cntr === 1) {
     first = Timer.now();
+    common.busyLoop(100);
   } else if (cntr === 2) {
-    second = Timer.now();
-    assert(Math.abs(second - first - 100) < 10);
+    assert(Timer.now() - first < 120);
     clearInterval(t);
   }
 }, 100);


### PR DESCRIPTION
A test was recently introduced that consistently fails on OS X & a few other machines. This PR reliably fixes it.

CI: https://ci.nodejs.org/job/node-test-pull-request/12522/
Stress test CI: https://ci.nodejs.org/job/node-stress-single-test/1686/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test