### PR TITLE
doc: fix typo in esm.md

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -34,7 +34,7 @@ node --experimental-modules my-app.mjs
 
 Only the CLI argument for the main entry point to the program can be an entry
 point into an ESM graph. Dynamic import can also be used with the flag
-`--harmony-dynamic-import` to create entry points into ESM graphs at run time.
+`--harmony-dynamic-import` to create entry points into ESM graphs at runtime.
 
 ### Unsupported
 


### PR DESCRIPTION
Change `run time` to `runtime` for both correctness and consistency with
every other instance of the expression in the docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc