### PR TITLE
async_hooks,test: Only use IPv6 in http test

### DIFF
--- a/test/async-hooks/test-graph.http.js
+++ b/test/async-hooks/test-graph.http.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasIPv6)
+  common.skip('IPv6 support required');
+
 const initHooks = require('./init-hooks');
 const verifyGraph = require('./verify-graph');
 const http = require('http');
@@ -13,7 +16,11 @@ const server = http.createServer(common.mustCall(function(req, res) {
   this.close(common.mustCall());
 }));
 server.listen(0, common.mustCall(function() {
-  http.get(`http://127.0.0.1:${server.address().port}`, common.mustCall());
+  http.get({
+    host: '::1',
+    family: 6,
+    port: server.address().port
+  }, common.mustCall());
 }));
 
 process.on('exit', function() {


### PR DESCRIPTION
If IPv6 is not supported on a machine, the IPv6 handle will first be
created, this will then fail and default to an IPv4 handle. This causes
the graph to change, as there now is an extra handle.

Fix: https://github.com/nodejs/node/pull/18003#issuecomment-357486485

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks
