### PR TITLE
stream: delete redundant code

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -657,11 +657,9 @@ function onCorkedFinish(corkReq, state, err) {
     cb(err);
     entry = entry.next;
   }
-  if (state.corkedRequestsFree) {
-    state.corkedRequestsFree.next = corkReq;
-  } else {
-    state.corkedRequestsFree = corkReq;
-  }
+
+  // reuse the free corkReq.
+  state.corkedRequestsFree.next = corkReq;
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -307,7 +307,6 @@ Writable.prototype.uncork = function() {
 
     if (!state.writing &&
         !state.corked &&
-        !state.finished &&
         !state.bufferProcessing &&
         state.bufferedRequest)
       clearBuffer(this, state);
@@ -579,7 +578,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   // ignore unnecessary end() calls.
-  if (!state.ending && !state.finished)
+  if (!state.ending)
     endWritable(this, state, cb);
 };
 


### PR DESCRIPTION
In `Writable.prototype.end()`, `state.ending` is true after calling
`endWritable()` and it doesn't reset to false.

In `Writable.prototype.uncork()`, `state.finished` must be false
if `state.bufferedRequest` is true.

In `onCorkedFinish()`, `state.corkedRequestsFree` of a writable
stream is never null.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream