### PR TITLE
src,doc,test: Fix common misspellings

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1505,7 +1505,7 @@ added: v8.0.0
   argument.
 
 The `_destroy()` method is called by [`writable.destroy()`][writable-destroy].
-It can be overriden by child classes but it **must not** be called directly.
+It can be overridden by child classes but it **must not** be called directly.
 
 #### writable.\_final(callback)
 <!-- YAML
@@ -1727,7 +1727,7 @@ added: v8.0.0
   argument.
 
 The `_destroy()` method is called by [`readable.destroy()`][readable-destroy].
-It can be overriden by child classes but it **must not** be called directly.
+It can be overridden by child classes but it **must not** be called directly.
 
 #### readable.push(chunk[, encoding])
 <!-- YAML

--- a/doc/guides/maintaining-the-build-files.md
+++ b/doc/guides/maintaining-the-build-files.md
@@ -15,7 +15,7 @@ There are three main build files that may be directly run when building Node.js:
   Makefile mentioned below is maintained separately by humans). For a detailed
   guide on this script, see [configure](#configure).
 - `vcbuild.bat`: A Windows Batch Script that locates build tools, provides a
-  subset of the targets avilable in the [Makefile](#makefile), and a few targets
+  subset of the targets available in the [Makefile](#makefile), and a few targets
   of its own. For a detailed guide on this script, see
   [vcbuild.bat](#vcbuild.bat).
 - `Makefile`: A Makefile that can be run with GNU Make. It provides a set of

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -831,7 +831,7 @@ inline int Http2Session::OnBeginHeadersCallback(nghttp2_session* handle,
 }
 
 // Called by nghttp2 for each header name/value pair in a HEADERS block.
-// This had to have been preceeded by a call to OnBeginHeadersCallback so
+// This had to have been preceded by a call to OnBeginHeadersCallback so
 // the Http2Stream is guaranteed to already exist.
 inline int Http2Session::OnHeaderCallback(nghttp2_session* handle,
                                           const nghttp2_frame* frame,
@@ -2731,7 +2731,7 @@ void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(false);
   }
 
-  // The Ping itself is an Async resource. When the acknowledgement is recieved,
+  // The Ping itself is an Async resource. When the acknowledgement is received,
   // the callback will be invoked and a notification sent out to JS land. The
   // notification will include the duration of the ping, allowing the round
   // trip to be measured.

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -94,7 +94,7 @@ assert.ok(!arg);
       assert.strictEqual(code, null);
       // most posix systems will show 'SIGABRT', but alpine34 does not
       if (signal !== 'SIGABRT') {
-        console.log(`parent recived signal ${signal}\nchild's stderr:`);
+        console.log(`parent received signal ${signal}\nchild's stderr:`);
         console.log(stderr);
         process.exit(1);
       }

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -652,7 +652,7 @@ internet-related tests.
 A set of addresses for internet-related tests. All properties are configurable
 via `NODE_TEST_*` environment variables. For example, to configure
 `internet.addresses.INET_HOST`, set the environment
-vairable `NODE_TEST_INET_HOST` to a specified host.
+variable `NODE_TEST_INET_HOST` to a specified host.
 
 ## WPT Module
 

--- a/test/fixtures/loop.js
+++ b/test/fixtures/loop.js
@@ -4,7 +4,7 @@ console.log('A message', 5);
 while (t > 0) {
   if (t++ === 1000) {
     t = 0;
-    console.log(`Outputed message #${k++}`);
+    console.log(`Outputted message #${k++}`);
   }
 }
 process.exit(55);

--- a/test/sequential/test-inspector-async-hook-setup-at-signal.js
+++ b/test/sequential/test-inspector-async-hook-setup-at-signal.js
@@ -17,7 +17,7 @@ function waitUntilDebugged() {
   // call stack depth is 0. We need a chance to call
   // Debugger.setAsyncCallStackDepth *before* activating the actual timer for
   // async stack traces to work. Directly using a debugger statement would be
-  // too brittle, and using a longer timeout would unnecesarily slow down the
+  // too brittle, and using a longer timeout would unnecessarily slow down the
   // test on most machines. Triggering a debugger break through an interval is
   // a faster and more reliable way.
   process._rawDebug('Signal received, waiting for debugger setup');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src, doc, test

Fixed a few common misspellings found across the codebase.