### PR TITLE
doc: V8 branch used in 8.x not active anymore

### DIFF
--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -144,9 +144,10 @@ includes the following branches<sup>1</sup>:
 </table>
 
 
-The versions of V8 used in Node.js v4.x and v6.x have already been abandoned by
-upstream V8. However, Node.js needs to continue supporting these branches for
-many months (Current branches) or several years (LTS branches).
+The versions of V8 used in Node.js v4.x, v6.x, and 8.x have already been
+abandoned by upstream V8. However, Node.js needs to continue supporting
+these branches for many months (Current branches) or several
+years (LTS branches).
 
 ## Maintenance Process
 


### PR DESCRIPTION
Add 8.x to the LTS versions that use a V8 branch that is
not active anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->


##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc