### PR TITLE
doc: fix typo in http2stream.close param default

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -919,7 +919,7 @@ added: v8.4.0
 -->
 
 * code {number} Unsigned 32-bit integer identifying the error code. **Default:**
-  `http2.constant.NGHTTP2_NO_ERROR` (`0x00`)
+  `http2.constants.NGHTTP2_NO_ERROR` (`0x00`)
 * `callback` {Function} An optional function registered to listen for the
   `'close'` event.
 * Returns: {undefined}


### PR DESCRIPTION
Just fixing a typo in the docs.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
