### PR TITLE
stream: use state.ending to see if stream called end()

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -283,7 +283,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   if (typeof cb !== 'function')
     cb = nop;
 
-  if (state.ended)
+  if (state.ending)
     writeAfterEnd(this, cb);
   else if (isBuf || validChunk(this, state, chunk, cb)) {
     state.pendingcb++;

--- a/test/parallel/test-stream-writable-write-writev-finish.js
+++ b/test/parallel/test-stream-writable-write-writev-finish.js
@@ -154,3 +154,27 @@ const stream = require('stream');
   };
   rs.pipe(ws);
 }
+
+{
+  const w = new stream.Writable();
+  w._write = (chunk, encoding, cb) => {
+    process.nextTick(cb);
+  };
+  w.on('error', common.mustCall());
+  w.on('prefinish', () => {
+    w.write("shouldn't write in prefinish listener");
+  });
+  w.end();
+}
+
+{
+  const w = new stream.Writable();
+  w._write = (chunk, encoding, cb) => {
+    process.nextTick(cb);
+  };
+  w.on('error', common.mustCall());
+  w.on('finish', () => {
+    w.write("should't write in finish listener");
+  });
+  w.end();
+}


### PR DESCRIPTION
Calling `writable.end()` will probably synchronously call
`writable.write()`, in such a situation the `state.ended`
is false and `writable.write()` doesn't trigger `writeAfterEnd()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

There is an example as below:
```
const { Writable } = require('stream');

let data = '';
const w = new Writable({
  write: function(chunk, encoding, cb) {
    process.nextTick(() => {
      data += chunk;
      cb();
    });
  },
});

w.on('prefinish', () => {
  // w.write('prefinish');
});
w.on('finish', () => {
  w.write('finish');
});

w.end(() => {
  console.log(data);
});
```
when 'prefinish' listener doesn't call `w.write()`, `w.end()` will synchronously emit 'finish' event. The console's output is: **finish**.
when 'prefinish' listener calls `w.write()`,  the 'finish' event will be asynchronously emitted. The `w.write()` that called by the 'finish' listener will trigger `writeAfterEnd()` and throw a Error.

I think using `state.ended` to decide whether to trigger `writeAfterEnd` is diffcult to understand and is somewhat unreasonable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream