### PR TITLE
http2: add a number of checks for server close callback

### DIFF
--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -38,6 +38,7 @@ function onStream(stream, headers) {
 function verifySecureSession(key, cert, ca, opts) {
   const server = h2.createSecureServer({ cert, key });
   server.on('stream', common.mustCall(onStream));
+  server.on('close', common.mustCall());
   server.listen(0, common.mustCall(() => {
     opts = opts || { };
     opts.secureContext = tls.createSecureContext({ ca });
@@ -72,7 +73,7 @@ function verifySecureSession(key, cert, ca, opts) {
       assert.strictEqual(jsonData.servername,
                          opts.servername || 'localhost');
       assert.strictEqual(jsonData.alpnProtocol, 'h2');
-      server.close();
+      server.close(common.mustCall());
       client[kSocket].destroy();
     }));
   }));

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -29,6 +29,8 @@ function onStream(stream, headers, flags) {
   stream.end(body.slice(20));
 }
 
+server.on('close', common.mustCall());
+
 server.listen(0);
 
 server.on('listening', common.mustCall(() => {
@@ -46,7 +48,7 @@ server.on('listening', common.mustCall(() => {
 
   const countdown = new Countdown(count, () => {
     client.close();
-    server.close();
+    server.close(common.mustCall());
   });
 
   for (let n = 0; n < count; n++) {

--- a/test/parallel/test-http2-createwritereq.js
+++ b/test/parallel/test-http2-createwritereq.js
@@ -60,7 +60,7 @@ server.listen(0, common.mustCall(function() {
       testsFinished++;
 
       if (testsFinished === testsToRun) {
-        server.close();
+        server.close(common.mustCall());
       }
     }));
 

--- a/test/parallel/test-http2-misbehaving-flow-control.js
+++ b/test/parallel/test-http2-misbehaving-flow-control.js
@@ -72,13 +72,15 @@ server.on('stream', (stream) => {
     message: 'Stream closed with error code 3'
   }));
   stream.on('close', common.mustCall(() => {
-    server.close();
+    server.close(common.mustCall());
     client.destroy();
   }));
   stream.resume();
   stream.respond();
   stream.end('ok');
 });
+
+server.on('close', common.mustCall());
 
 server.listen(0, () => {
   client = net.connect(server.address().port, () => {


### PR DESCRIPTION
Verify that server close callbacks are being called

Refs: https://github.com/nodejs/node/issues/18176

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2