### PR TITLE
doc: remove unnecessary Require

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3382,7 +3382,7 @@ napi_status napi_async_init(napi_env env,
 - `[in] env`: The environment that the API is invoked under.
 - `[in] async_resource`: An optional object associated with the async work
   that will be passed to possible `async_hooks` [`init` hooks][].
-- `[in] async_resource_name`: Required identifier for the kind of resource
+- `[in] async_resource_name`: Identifier for the kind of resource
   that is being provided for diagnostic information exposed by the
   `async_hooks` API.
 - `[out] result`: The initialized async context.


### PR DESCRIPTION
This was the only instance were we said a parameter
was required.  It is assumed parameters are required unless
the doc says they are option.  Remove `Required` to make
consistent with the rest of the doc

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api