### PR TITLE
util: implement util.getSystemErrorName()

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -257,7 +257,7 @@ intended as a debugging tool. Some input values can have a significant
 performance overhead that can block the event loop. Use this function
 with care and never in a hot code path.
 
-## util.getErrorName(code)
+## util.getSystemErrorName(code)
 <!-- YAML
 added: REPLACEME
 -->
@@ -271,7 +271,7 @@ See [Common System Errors][] for the names of common errors.
 
 ```js
 fs.access('file/that/does/not/exist', (err) => {
-  const name = util.getErrorName(err.errno);
+  const name = util.getSystemErrorName(err.errno);
   console.log(name);  // ENOENT
 });
 ```

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -257,12 +257,12 @@ intended as a debugging tool. Some input values can have a significant
 performance overhead that can block the event loop. Use this function
 with care and never in a hot code path.
 
-## util.getSystemErrorName(code)
+## util.getSystemErrorName(err)
 <!-- YAML
 added: REPLACEME
 -->
 
-* `code` {number}
+* `err` {number}
 * Returns: {string}
 
 Returns the string name for a numeric error code that comes from a Node.js API.
@@ -272,7 +272,7 @@ See [Common System Errors][] for the names of common errors.
 ```js
 fs.access('file/that/does/not/exist', (err) => {
   const name = util.getSystemErrorName(err.errno);
-  console.log(name);  // ENOENT
+  console.error(name);  // ENOENT
 });
 ```
 
@@ -1381,7 +1381,7 @@ Deprecated predecessor of `console.log`.
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [Internationalization]: intl.html
 [WHATWG Encoding Standard]: https://encoding.spec.whatwg.org/
-[Common System Errors]: errors.html#common_system_errors
+[Common System Errors]: errors.html#errors_common_system_errors
 [constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [list of deprecated APIS]: deprecations.html#deprecations_list_of_deprecated_apis
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -257,6 +257,25 @@ intended as a debugging tool. Some input values can have a significant
 performance overhead that can block the event loop. Use this function
 with care and never in a hot code path.
 
+## util.getErrorName(code)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {number}
+* Returns: {string}
+
+Returns the string name for a numeric error code that comes from a Node.js API.
+The mapping between error codes and error names is platform-dependent.
+See [Common System Errors][] for the names of common errors.
+
+```js
+fs.access('file/that/does/not/exist', (err) => {
+  const name = util.getErrorName(err.errno);
+  console.log(name);  // ENOENT
+});
+```
+
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
@@ -1362,6 +1381,7 @@ Deprecated predecessor of `console.log`.
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [Internationalization]: intl.html
 [WHATWG Encoding Standard]: https://encoding.spec.whatwg.org/
+[Common System Errors]: errors.html#common_system_errors
 [constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [list of deprecated APIS]: deprecations.html#deprecations_list_of_deprecated_apis
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,7 +22,9 @@
 'use strict';
 
 const util = require('util');
-const { deprecate, convertToValidSignal } = require('internal/util');
+const {
+  deprecate, convertToValidSignal, getErrorName
+} = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const { createPromise,
         promiseResolve, promiseReject } = process.binding('util');
@@ -30,7 +32,6 @@ const debug = util.debuglog('child_process');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 const errors = require('internal/errors');
-const { errname } = process.binding('uv');
 const child_process = require('internal/child_process');
 const {
   _validateStdio,
@@ -275,7 +276,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (!ex) {
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
       ex.killed = child.killed || killed;
-      ex.code = code < 0 ? errname(code) : code;
+      ex.code = code < 0 ? getErrorName(code) : code;
       ex.signal = signal;
     }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -23,7 +23,7 @@
 
 const util = require('util');
 const {
-  deprecate, convertToValidSignal, getErrorName
+  deprecate, convertToValidSignal, getSystemErrorName
 } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const { createPromise,
@@ -276,7 +276,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (!ex) {
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
       ex.killed = child.killed || killed;
-      ex.code = code < 0 ? getErrorName(code) : code;
+      ex.code = code < 0 ? getSystemErrorName(code) : code;
       ex.signal = signal;
     }
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -215,11 +215,8 @@ function getConstructorOf(obj) {
 }
 
 function getSystemErrorName(code) {
-  if (errmap.has(code)) {
-    return errmap.get(code)[0];
-  } else {
-    return `Unknown system error ${code}`;
-  }
+  const entry = errmap.get(code);
+  return entry ? entry[0] : `Unknown system error ${code}`;
 }
 
 // getConstructorOf is wrapped into this to save iterations

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -214,7 +214,7 @@ function getConstructorOf(obj) {
   return null;
 }
 
-function getErrorName(code) {
+function getSystemErrorName(code) {
   if (errmap.has(code)) {
     return errmap.get(code)[0];
   } else {
@@ -349,7 +349,7 @@ module.exports = {
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,
-  getErrorName,
+  getSystemErrorName,
   getIdentificationOf,
   isError,
   join,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -214,9 +214,17 @@ function getConstructorOf(obj) {
   return null;
 }
 
-function getSystemErrorName(code) {
-  const entry = errmap.get(code);
-  return entry ? entry[0] : `Unknown system error ${code}`;
+function getSystemErrorName(err) {
+  if (typeof err !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err', 'number', err);
+  }
+  if (err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'err',
+                                'a negative integer', err);
+  }
+
+  const entry = errmap.get(err);
+  return entry ? entry[0] : `Unknown system error ${err}`;
 }
 
 // getConstructorOf is wrapped into this to save iterations

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -12,6 +12,7 @@ const {
   arrow_message_private_symbol: kArrowMessagePrivateSymbolIndex,
   decorated_private_symbol: kDecoratedPrivateSymbolIndex
 } = process.binding('util');
+const { errmap } = process.binding('uv');
 
 const noCrypto = !process.versions.openssl;
 
@@ -213,6 +214,14 @@ function getConstructorOf(obj) {
   return null;
 }
 
+function getErrorName(code) {
+  if (errmap.has(code)) {
+    return errmap.get(code)[0];
+  } else {
+    return `Unknown system error ${code}`;
+  }
+}
+
 // getConstructorOf is wrapped into this to save iterations
 function getIdentificationOf(obj) {
   const original = obj;
@@ -340,6 +349,7 @@ module.exports = {
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,
+  getErrorName,
   getIdentificationOf,
   isError,
   join,

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,7 +25,6 @@ const errors = require('internal/errors');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 
-const { errname } = process.binding('uv');
 const { previewMapIterator, previewSetIterator } = require('internal/v8');
 
 const {
@@ -56,6 +55,7 @@ const {
 const {
   customInspectSymbol,
   deprecate,
+  getErrorName,
   getIdentificationOf,
   isError,
   promisify,
@@ -1062,7 +1062,7 @@ function _errnoException(err, syscall, original) {
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'err',
                                 'a negative integer', err);
   }
-  const name = errname(err);
+  const name = getErrorName(err);
   var message = `${syscall} ${name}`;
   if (original)
     message += ` ${original}`;
@@ -1151,6 +1151,7 @@ module.exports = exports = {
   debuglog,
   deprecate,
   format,
+  getErrorName,
   inherits,
   inspect,
   isArray: Array.isArray,

--- a/lib/util.js
+++ b/lib/util.js
@@ -55,7 +55,7 @@ const {
 const {
   customInspectSymbol,
   deprecate,
-  getErrorName,
+  getSystemErrorName,
   getIdentificationOf,
   isError,
   promisify,
@@ -1062,7 +1062,7 @@ function _errnoException(err, syscall, original) {
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'err',
                                 'a negative integer', err);
   }
-  const name = getErrorName(err);
+  const name = getSystemErrorName(err);
   var message = `${syscall} ${name}`;
   if (original)
     message += ` ${original}`;
@@ -1151,7 +1151,7 @@ module.exports = exports = {
   debuglog,
   deprecate,
   format,
-  getErrorName,
+  getSystemErrorName,
   inherits,
   inspect,
   isArray: Array.isArray,

--- a/lib/util.js
+++ b/lib/util.js
@@ -1055,13 +1055,6 @@ function error(...args) {
 }
 
 function _errnoException(err, syscall, original) {
-  if (typeof err !== 'number') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err', 'number', err);
-  }
-  if (err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'err',
-                                'a negative integer', err);
-  }
   const name = getSystemErrorName(err);
   var message = `${syscall} ${name}`;
   if (original)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -40,7 +40,7 @@ using v8::Value;
 
 
 // TODO(joyeecheung): deprecate this function in favor of
-// lib/util.getErrorName()
+// lib/util.getSystemErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int err = args[0]->Int32Value();

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -39,6 +39,8 @@ using v8::String;
 using v8::Value;
 
 
+// TODO(joyeecheung): deprecate this function in favor of
+// lib/util.getErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int err = args[0]->Int32Value();

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -1,8 +1,9 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const uv = process.binding('uv');
+const { getErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
@@ -26,7 +27,7 @@ const fixture = fixtures.path('exit.js');
   const code = -1;
   const callback = common.mustCall((err, stdout, stderr) => {
     assert.strictEqual(err.toString().trim(), errorString);
-    assert.strictEqual(err.code, uv.errname(code));
+    assert.strictEqual(err.code, getErrorName(code));
     assert.strictEqual(err.killed, true);
     assert.strictEqual(err.signal, null);
     assert.strictEqual(err.cmd, process.execPath);

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const { getErrorName } = require('util');
+const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
@@ -27,7 +27,7 @@ const fixture = fixtures.path('exit.js');
   const code = -1;
   const callback = common.mustCall((err, stdout, stderr) => {
     assert.strictEqual(err.toString().trim(), errorString);
-    assert.strictEqual(err.code, getErrorName(code));
+    assert.strictEqual(err.code, getSystemErrorName(code));
     assert.strictEqual(err.killed, true);
     assert.strictEqual(err.signal, null);
     assert.strictEqual(err.cmd, process.execPath);

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const fs = require('fs');
-const uv = process.binding('uv');
+const { getErrorName } = require('util');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
@@ -46,9 +46,10 @@ function randomHandle(type) {
     handleName = `pipe ${path}`;
   }
 
-  if (errno < 0) {  // uv.errname requires err < 0
-    assert(errno >= 0, `unable to bind ${handleName}: ${uv.errname(errno)}`);
+  if (errno < 0) {
+    assert.fail(`unable to bind ${handleName}: ${getErrorName(errno)}`);
   }
+
   if (!common.isWindows) {  // fd doesn't work on windows
     // err >= 0 but fd = -1, should not happen
     assert.notStrictEqual(handle.fd, -1,

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const fs = require('fs');
-const { getErrorName } = require('util');
+const { getSystemErrorName } = require('util');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
@@ -47,7 +47,7 @@ function randomHandle(type) {
   }
 
   if (errno < 0) {
-    assert.fail(`unable to bind ${handleName}: ${getErrorName(errno)}`);
+    assert.fail(`unable to bind ${handleName}: ${getSystemErrorName(errno)}`);
   }
 
   if (!common.isWindows) {  // fd doesn't work on windows

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -2,9 +2,12 @@
 
 const common = require('../common');
 const assert = require('assert');
-const util = require('util');
-const uv = process.binding('uv');
+const {
+  getErrorName,
+  _errnoException
+} = require('util');
 
+const uv = process.binding('uv');
 const keys = Object.keys(uv);
 
 keys.forEach((key) => {
@@ -12,17 +15,18 @@ keys.forEach((key) => {
     return;
 
   assert.doesNotThrow(() => {
-    const err = util._errnoException(uv[key], 'test');
+    const err = _errnoException(uv[key], 'test');
     const name = uv.errname(uv[key]);
-    assert.strictEqual(err.code, err.errno);
+    assert.strictEqual(getErrorName(uv[key]), name);
     assert.strictEqual(err.code, name);
+    assert.strictEqual(err.code, err.errno);
     assert.strictEqual(err.message, `test ${name}`);
   });
 });
 
 ['test', {}, []].forEach((key) => {
   common.expectsError(
-    () => util._errnoException(key),
+    () => _errnoException(key),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -33,7 +37,7 @@ keys.forEach((key) => {
 
 [0, 1, Infinity, -Infinity, NaN].forEach((key) => {
   common.expectsError(
-    () => util._errnoException(key),
+    () => _errnoException(key),
     {
       code: 'ERR_OUT_OF_RANGE',
       type: RangeError,

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -24,25 +24,30 @@ keys.forEach((key) => {
   });
 });
 
-['test', {}, []].forEach((key) => {
-  common.expectsError(
-    () => _errnoException(key),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "err" argument must be of type number. ' +
-               `Received type ${typeof key}`
-    });
-});
+function runTest(fn) {
+  ['test', {}, []].forEach((err) => {
+    common.expectsError(
+      () => fn(err),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "err" argument must be of type number. ' +
+                 `Received type ${typeof err}`
+      });
+  });
 
-[0, 1, Infinity, -Infinity, NaN].forEach((key) => {
-  common.expectsError(
-    () => _errnoException(key),
-    {
-      code: 'ERR_OUT_OF_RANGE',
-      type: RangeError,
-      message: 'The value of "err" is out of range. ' +
-               'It must be a negative integer. ' +
-               `Received ${key}`
-    });
-});
+  [0, 1, Infinity, -Infinity, NaN].forEach((err) => {
+    common.expectsError(
+      () => fn(err),
+      {
+        code: 'ERR_OUT_OF_RANGE',
+        type: RangeError,
+        message: 'The value of "err" is out of range. ' +
+                 'It must be a negative integer. ' +
+                 `Received ${err}`
+      });
+  });
+}
+
+runTest(_errnoException);
+runTest(getSystemErrorName);

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const {
-  getErrorName,
+  getSystemErrorName,
   _errnoException
 } = require('util');
 
@@ -17,7 +17,7 @@ keys.forEach((key) => {
   assert.doesNotThrow(() => {
     const err = _errnoException(uv[key], 'test');
     const name = uv.errname(uv[key]);
-    assert.strictEqual(getErrorName(uv[key]), name);
+    assert.strictEqual(getSystemErrorName(uv[key]), name);
     assert.strictEqual(err.code, name);
     assert.strictEqual(err.code, err.errno);
     assert.strictEqual(err.message, `test ${name}`);

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
+const { getErrorName } = require('util');
 
 // Make sure that all Providers are tested.
 {
@@ -204,7 +205,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
       // Use a long string to make sure the write happens asynchronously.
       const err = handle.writeLatin1String(wreq, 'hi'.repeat(100000));
       if (err)
-        throw new Error(`write failed: ${process.binding('uv').errname(err)}`);
+        throw new Error(`write failed: ${getErrorName(err)}`);
       testInitialized(wreq, 'WriteWrap');
     });
     req.address = common.localhostIPv4;

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
-const { getErrorName } = require('util');
+const { getSystemErrorName } = require('util');
 
 // Make sure that all Providers are tested.
 {
@@ -205,7 +205,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
       // Use a long string to make sure the write happens asynchronously.
       const err = handle.writeLatin1String(wreq, 'hi'.repeat(100000));
       if (err)
-        throw new Error(`write failed: ${getErrorName(err)}`);
+        throw new Error(`write failed: ${getSystemErrorName(err)}`);
       testInitialized(wreq, 'WriteWrap');
     });
     req.address = common.localhostIPv4;


### PR DESCRIPTION
Reimplement uv.errname() as internal/util.getErrorName() to
avoid the memory leaks caused by unknown error codes
and avoid calling into C++ for the error names. Also
expose it as a public API for external use.

The next step would be to deprecate `uv.errname()` (since the binding seems to be used in the user land, e.g. [execa](https://github.com/sindresorhus/execa/blob/80a059d/lib/errname.js)), remove the C++ code and monkey patch the binding to `internal/util.getErrorName()` during bootstrapping, although I am not sure when during the bootstrapping process is the best time to do that.

Refs: http://docs.libuv.org/en/v1.x/errors.html#c.uv_err_name

> const char* uv_err_name(int err)
>   Returns the error name for the given error code. Leaks a few bytes of memory when you call it with an unknown error code
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util, child_process, test