### PR TITLE
Add Node Slack community to support options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ search these unofficial resources:
 * [Questions tagged 'node.js' on StackOverflow][]
 * [#node.js channel on chat.freenode.net][]. See <http://nodeirc.info/> for more
   information.
-* [Node.js Slack Community](http://node-js.slack.com): Visit
+* [Node.js Slack Community](https://node-js.slack.com/): Visit
   [nodeslackers.com](http://www.nodeslackers.com/) to register.
 
 GitHub issues are meant for tracking enhancements and bugs, not general support.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ search these unofficial resources:
 * [Questions tagged 'node.js' on StackOverflow][]
 * [#node.js channel on chat.freenode.net][]. See <http://nodeirc.info/> for more
   information.
+* [Node.js Slack Community](http://node-js.slack.com): Visit
+  [nodeslackers.com](http://www.nodeslackers.com/) to register.
 
 GitHub issues are meant for tracking enhancements and bugs, not general support.
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

Adds the Node.js Slack Community to the list of support resources. Admins from the Slack community have agreed to posting and upholding the CoC and collaborating with the Moderation Team to uphold the guidelines. cc @alextes @ljharb

To note: would like to try this as well with `#nodejs` on Freenode IRC, but it takes a bit more work. So it stays listed in unofficial until/if we're able to confirm the same and have an admin team with bandwidth to support the existing community.
