### PR TITLE
Use uv_hrtime as tracing timestamp

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.7',
+    'v8_embedder_string': '-node.8',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/libplatform/v8-tracing.h
+++ b/deps/v8/include/libplatform/v8-tracing.h
@@ -43,8 +43,8 @@ class V8_PLATFORM_EXPORT TraceObject {
       const char** arg_names, const uint8_t* arg_types,
       const uint64_t* arg_values,
       std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
-      unsigned int flags);
-  void UpdateDuration();
+      unsigned int flags, int64_t timestamp, int64_t cpu_timestamp);
+  void UpdateDuration(int64_t timestamp, int64_t cpu_timestamp);
   void InitializeForTesting(
       char phase, const uint8_t* category_enabled_flag, const char* name,
       const char* scope, uint64_t id, uint64_t bind_id, int num_args,
@@ -258,6 +258,10 @@ class V8_PLATFORM_EXPORT TracingController
   void StopTracing();
 
   static const char* GetCategoryGroupName(const uint8_t* category_enabled_flag);
+
+ protected:
+  virtual int64_t CurrentTimestampMicroseconds();
+  virtual int64_t CurrentCpuTimestampMicroseconds();
 
  private:
   const uint8_t* GetCategoryGroupEnabledInternal(const char* category_group);

--- a/deps/v8/include/libplatform/v8-tracing.h
+++ b/deps/v8/include/libplatform/v8-tracing.h
@@ -247,6 +247,13 @@ class V8_PLATFORM_EXPORT TracingController
       const uint64_t* arg_values,
       std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
       unsigned int flags) override;
+  uint64_t AddTraceEventWithTimestamp(
+      char phase, const uint8_t* category_enabled_flag, const char* name,
+      const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
+      const char** arg_names, const uint8_t* arg_types,
+      const uint64_t* arg_values,
+      std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+      unsigned int flags, int64_t timestamp) override;
   void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
                                 const char* name, uint64_t handle) override;
   void AddTraceStateObserver(

--- a/deps/v8/include/v8-platform.h
+++ b/deps/v8/include/v8-platform.h
@@ -119,11 +119,11 @@ class TracingController {
   }
 
   /**
-   * Adds a trace event to the platform tracing system. This function call is
+   * Adds a trace event to the platform tracing system. These function calls are
    * usually the result of a TRACE_* macro from trace_event_common.h when
    * tracing and the category of the particular trace are enabled. It is not
-   * advisable to call this function on its own; it is really only meant to be
-   * used by the trace macros. The returned handle can be used by
+   * advisable to call these functions on their own; they are really only meant
+   * to be used by the trace macros. The returned handle can be used by
    * UpdateTraceEventDuration to update the duration of COMPLETE events.
    */
   virtual uint64_t AddTraceEvent(
@@ -133,6 +133,15 @@ class TracingController {
       const uint64_t* arg_values,
       std::unique_ptr<ConvertableToTraceFormat>* arg_convertables,
       unsigned int flags) {
+    return 0;
+  }
+  virtual uint64_t AddTraceEventWithTimestamp(
+      char phase, const uint8_t* category_enabled_flag, const char* name,
+      const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
+      const char** arg_names, const uint8_t* arg_types,
+      const uint64_t* arg_values,
+      std::unique_ptr<ConvertableToTraceFormat>* arg_convertables,
+      unsigned int flags, int64_t timestamp) {
     return 0;
   }
 

--- a/deps/v8/src/libplatform/tracing/trace-object.cc
+++ b/deps/v8/src/libplatform/tracing/trace-object.cc
@@ -37,7 +37,7 @@ void TraceObject::Initialize(
     const char** arg_names, const uint8_t* arg_types,
     const uint64_t* arg_values,
     std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
-    unsigned int flags) {
+    unsigned int flags, int64_t timestamp, int64_t cpu_timestamp) {
   pid_ = base::OS::GetCurrentProcessId();
   tid_ = base::OS::GetCurrentThreadId();
   phase_ = phase;
@@ -47,8 +47,8 @@ void TraceObject::Initialize(
   id_ = id;
   bind_id_ = bind_id;
   flags_ = flags;
-  ts_ = base::TimeTicks::HighResolutionNow().ToInternalValue();
-  tts_ = base::ThreadTicks::Now().ToInternalValue();
+  ts_ = timestamp;
+  tts_ = cpu_timestamp;
   duration_ = 0;
   cpu_duration_ = 0;
 
@@ -103,9 +103,9 @@ void TraceObject::Initialize(
 
 TraceObject::~TraceObject() { delete[] parameter_copy_storage_; }
 
-void TraceObject::UpdateDuration() {
-  duration_ = base::TimeTicks::HighResolutionNow().ToInternalValue() - ts_;
-  cpu_duration_ = base::ThreadTicks::Now().ToInternalValue() - tts_;
+void TraceObject::UpdateDuration(int64_t timestamp, int64_t cpu_timestamp) {
+  duration_ = timestamp - ts_;
+  cpu_duration_ = cpu_timestamp - tts_;
 }
 
 void TraceObject::InitializeForTesting(

--- a/deps/v8/src/libplatform/tracing/tracing-controller.cc
+++ b/deps/v8/src/libplatform/tracing/tracing-controller.cc
@@ -75,6 +75,24 @@ uint64_t TracingController::AddTraceEvent(
   return handle;
 }
 
+uint64_t TracingController::AddTraceEventWithTimestamp(
+    char phase, const uint8_t* category_enabled_flag, const char* name,
+    const char* scope, uint64_t id, uint64_t bind_id, int num_args,
+    const char** arg_names, const uint8_t* arg_types,
+    const uint64_t* arg_values,
+    std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+    unsigned int flags, int64_t timestamp) {
+  uint64_t handle;
+  TraceObject* trace_object = trace_buffer_->AddTraceEvent(&handle);
+  if (trace_object) {
+    trace_object->Initialize(phase, category_enabled_flag, name, scope, id,
+                             bind_id, num_args, arg_names, arg_types,
+                             arg_values, arg_convertables, flags, timestamp,
+                             CurrentCpuTimestampMicroseconds());
+  }
+  return handle;
+}
+
 void TracingController::UpdateTraceEventDuration(
     const uint8_t* category_enabled_flag, const char* name, uint64_t handle) {
   TraceObject* trace_object = trace_buffer_->GetEventByHandle(handle);

--- a/deps/v8/src/tracing/trace-event.h
+++ b/deps/v8/src/tracing/trace-event.h
@@ -96,6 +96,23 @@ enum CategoryGroupEnabledFlags {
 //                    unsigned int flags)
 #define TRACE_EVENT_API_ADD_TRACE_EVENT v8::internal::tracing::AddTraceEventImpl
 
+// Add a trace event to the platform tracing system.
+// uint64_t TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_TIMESTAMP(
+//                    char phase,
+//                    const uint8_t* category_group_enabled,
+//                    const char* name,
+//                    const char* scope,
+//                    uint64_t id,
+//                    uint64_t bind_id,
+//                    int num_args,
+//                    const char** arg_names,
+//                    const uint8_t* arg_types,
+//                    const uint64_t* arg_values,
+//                    unsigned int flags,
+//                    int64_t timestamp)
+#define TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_TIMESTAMP \
+  v8::internal::tracing::AddTraceEventWithTimestampImpl
+
 // Set the duration field of a COMPLETE trace event.
 // void TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION(
 //     const uint8_t* category_group_enabled,
@@ -212,10 +229,18 @@ enum CategoryGroupEnabledFlags {
     }                                                                          \
   } while (0)
 
-// Adds a trace event with a given timestamp. Not Implemented.
+// Adds a trace event with a given timestamp.
 #define INTERNAL_TRACE_EVENT_ADD_WITH_TIMESTAMP(phase, category_group, name, \
                                                 timestamp, flags, ...)       \
-  UNIMPLEMENTED()
+  do {                                                                       \
+    INTERNAL_TRACE_EVENT_GET_CATEGORY_INFO(category_group);                  \
+    if (INTERNAL_TRACE_EVENT_CATEGORY_GROUP_ENABLED_FOR_RECORDING_MODE()) {  \
+      v8::internal::tracing::AddTraceEventWithTimestamp(                     \
+          phase, INTERNAL_TRACE_EVENT_UID(category_group_enabled), name,     \
+          v8::internal::tracing::kGlobalScope, v8::internal::tracing::kNoId, \
+          v8::internal::tracing::kNoId, flags, timestamp, ##__VA_ARGS__);    \
+    }                                                                        \
+  } while (0)
 
 // Adds a trace event with a given id and timestamp. Not Implemented.
 #define INTERNAL_TRACE_EVENT_ADD_WITH_ID_AND_TIMESTAMP(     \
@@ -431,6 +456,28 @@ static V8_INLINE uint64_t AddTraceEventImpl(
                                    arg_values, arg_convertables, flags);
 }
 
+static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
+    char phase, const uint8_t* category_group_enabled, const char* name,
+    const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
+    const char** arg_names, const uint8_t* arg_types,
+    const uint64_t* arg_values, unsigned int flags, int64_t timestamp) {
+  std::unique_ptr<ConvertableToTraceFormat> arg_convertables[2];
+  if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
+    arg_convertables[0].reset(reinterpret_cast<ConvertableToTraceFormat*>(
+        static_cast<intptr_t>(arg_values[0])));
+  }
+  if (num_args > 1 && arg_types[1] == TRACE_VALUE_TYPE_CONVERTABLE) {
+    arg_convertables[1].reset(reinterpret_cast<ConvertableToTraceFormat*>(
+        static_cast<intptr_t>(arg_values[1])));
+  }
+  DCHECK_LE(num_args, 2);
+  v8::TracingController* controller =
+      v8::internal::tracing::TraceEventHelper::GetTracingController();
+  return controller->AddTraceEventWithTimestamp(
+      phase, category_group_enabled, name, scope, id, bind_id, num_args,
+      arg_names, arg_types, arg_values, arg_convertables, flags, timestamp);
+}
+
 // Define SetTraceValue for each allowed type. It stores the type and
 // value in the return arguments. This allows this API to avoid declaring any
 // structures so that it is portable to third_party libraries.
@@ -531,6 +578,48 @@ static V8_INLINE uint64_t AddTraceEvent(
   return TRACE_EVENT_API_ADD_TRACE_EVENT(
       phase, category_group_enabled, name, scope, id, bind_id, num_args,
       arg_names, arg_types, arg_values, flags);
+}
+
+static V8_INLINE uint64_t AddTraceEventWithTimestamp(
+    char phase, const uint8_t* category_group_enabled, const char* name,
+    const char* scope, uint64_t id, uint64_t bind_id, unsigned int flags,
+    int64_t timestamp) {
+  return TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_TIMESTAMP(
+      phase, category_group_enabled, name, scope, id, bind_id, kZeroNumArgs,
+      nullptr, nullptr, nullptr, flags, timestamp);
+}
+
+template <class ARG1_TYPE>
+static V8_INLINE uint64_t AddTraceEventWithTimestamp(
+    char phase, const uint8_t* category_group_enabled, const char* name,
+    const char* scope, uint64_t id, uint64_t bind_id, unsigned int flags,
+    int64_t timestamp, const char* arg1_name, ARG1_TYPE&& arg1_val) {
+  const int num_args = 1;
+  uint8_t arg_type;
+  uint64_t arg_value;
+  SetTraceValue(std::forward<ARG1_TYPE>(arg1_val), &arg_type, &arg_value);
+  return TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_TIMESTAMP(
+      phase, category_group_enabled, name, scope, id, bind_id, num_args,
+      &arg1_name, &arg_type, &arg_value, flags, timestamp);
+}
+
+template <class ARG1_TYPE, class ARG2_TYPE>
+static V8_INLINE uint64_t AddTraceEventWithTimestamp(
+    char phase, const uint8_t* category_group_enabled, const char* name,
+    const char* scope, uint64_t id, uint64_t bind_id, unsigned int flags,
+    int64_t timestamp, const char* arg1_name, ARG1_TYPE&& arg1_val,
+    const char* arg2_name, ARG2_TYPE&& arg2_val) {
+  const int num_args = 2;
+  const char* arg_names[2] = {arg1_name, arg2_name};
+  unsigned char arg_types[2];
+  uint64_t arg_values[2];
+  SetTraceValue(std::forward<ARG1_TYPE>(arg1_val), &arg_types[0],
+                &arg_values[0]);
+  SetTraceValue(std::forward<ARG2_TYPE>(arg2_val), &arg_types[1],
+                &arg_values[1]);
+  return TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_TIMESTAMP(
+      phase, category_group_enabled, name, scope, id, bind_id, num_args,
+      arg_names, arg_types, arg_values, flags, timestamp);
 }
 
 // Used by TRACE_EVENTx macros. Do not use directly.

--- a/deps/v8/test/cctest/libplatform/test-tracing.cc
+++ b/deps/v8/test/cctest/libplatform/test-tracing.cc
@@ -42,7 +42,7 @@ TEST(TestTraceObject) {
   uint8_t category_enabled_flag = 41;
   trace_object.Initialize('X', &category_enabled_flag, "Test.Trace",
                           "Test.Scope", 42, 123, 0, nullptr, nullptr, nullptr,
-                          nullptr, 0);
+                          nullptr, 0, 1729, 4104);
   CHECK_EQ('X', trace_object.phase());
   CHECK_EQ(category_enabled_flag, *trace_object.category_enabled_flag());
   CHECK_EQ(std::string("Test.Trace"), std::string(trace_object.name()));
@@ -96,7 +96,7 @@ TEST(TestTraceBufferRingBuffer) {
     CHECK_NOT_NULL(trace_object);
     trace_object->Initialize('X', &category_enabled_flag, names[i].c_str(),
                              "Test.Scope", 42, 123, 0, nullptr, nullptr,
-                             nullptr, nullptr, 0);
+                             nullptr, nullptr, 0, 1729, 4104);
     trace_object = ring_buffer->GetEventByHandle(handles[i]);
     CHECK_NOT_NULL(trace_object);
     CHECK_EQ('X', trace_object->phase());

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -19,3 +19,7 @@ node --trace-events-enabled --trace-event-categories v8,node,node.async_hooks se
 Running Node.js with tracing enabled will produce log files that can be opened
 in the [`chrome://tracing`](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
 tab of Chrome.
+
+Starting with Node 10.0.0, the tracing system uses the same time source as the
+one used by `process.hrtime()` however the trace-event timestamps are expressed
+in microseconds, unlike `process.hrtime()` which returns nanoseconds.

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -8,7 +8,14 @@
 namespace node {
 namespace tracing {
 
-using v8::platform::tracing::TracingController;
+class TracingController : public v8::platform::tracing::TracingController {
+ public:
+  TracingController() : v8::platform::tracing::TracingController() {}
+
+  int64_t CurrentTimestampMicroseconds() override {
+    return uv_hrtime() / 1000;
+  }
+};
 
 class Agent {
  public:


### PR DESCRIPTION
Use `uv_hrtime` as the time source for tracing. The PR also includes two API changing cherry-picks from upstream that allow us to override the time source.

Fixes: https://github.com/nodejs/node/issues/17349

/cc @AndreasMadsen @jasnell @nodejs/v8 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tracing

CI: ~https://ci.nodejs.org/job/node-test-pull-request/12574/~ https://ci.nodejs.org/job/node-test-pull-request/12662/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1164/