### PR TITLE
src: remove unused variable in node_file

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -539,7 +539,6 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Local<Context> context = env->context();
 
   CHECK_GE(args.Length(), 1);
 
@@ -563,7 +562,6 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Local<Context> context = env->context();
 
   CHECK_GE(args.Length(), 1);
 


### PR DESCRIPTION
Currently the following warning is reported when building:
```console
../src/node_file.cc:542:18:
warning: unused variable 'context' [-Wunused-variable]
  Local<Context> context = env->context();
                 ^
../src/node_file.cc:566:18:
warning: unused variable 'context' [-Wunused-variable]
  Local<Context> context = env->context();
                 ^
2 warnings generated.
```
The commit removes the unused variables.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src