### PR TITLE
src: validate args length in Access and Close

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -426,6 +426,7 @@ void Access(const FunctionCallbackInfo<Value>& args) {
     AsyncCall(env, args, "access", UTF8, AfterNoArgs,
               uv_fs_access, *path, mode);
   } else {  // access(path, mode, undefined, ctx)
+    CHECK_EQ(args.Length(), 4);
     fs_req_wrap req_wrap;
     SyncCall(env, args[3], &req_wrap, "access", uv_fs_access, *path, mode);
   }
@@ -447,6 +448,7 @@ void Close(const FunctionCallbackInfo<Value>& args) {
     AsyncCall(env, args, "close", UTF8, AfterNoArgs,
               uv_fs_close, fd);
   } else {  // close(fd, undefined, ctx)
+    CHECK_EQ(args.Length(), 3);
     fs_req_wrap req_wrap;
     SyncCall(env, args[2], &req_wrap, "close", uv_fs_close, fd);
   }


### PR DESCRIPTION
This is a follow-up of https://github.com/nodejs/node/pull/17914. When
Access and Close functions are called in Sync mode, the number of items
in args is validated. These are the only two places in this file where
this validation doesn't take place.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src fs
