### PR TITLE
http: free the parser before emitting 'upgrade'

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -420,6 +420,7 @@ function socketOnData(d) {
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
     parser.finish();
+    freeParser(parser, req, socket);
 
     var bodyHead = d.slice(bytesParsed, d.length);
 
@@ -440,7 +441,6 @@ function socketOnData(d) {
       // Got Upgrade header or CONNECT method, but have no handler.
       socket.destroy();
     }
-    freeParser(parser, req, socket);
   } else if (parser.incoming && parser.incoming.complete &&
              // When the status code is 100 (Continue), the server will
              // send a final response after this client sends a request

--- a/test/parallel/test-http-parser-freed-before-upgrade.js
+++ b/test/parallel/test-http-parser-freed-before-upgrade.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+
+server.on('upgrade', common.mustCall((request, socket) => {
+  assert.strictEqual(socket.parser, null);
+  socket.write([
+    'HTTP/1.1 101 Switching Protocols',
+    'Connection: Upgrade',
+    'Upgrade: WebSocket',
+    '\r\n'
+  ].join('\r\n'));
+}));
+
+server.listen(common.mustCall(() => {
+  const request = http.get({
+    port: server.address().port,
+    headers: {
+      Connection: 'Upgrade',
+      Upgrade: 'WebSocket'
+    }
+  });
+
+  request.on('upgrade', common.mustCall((response, socket) => {
+    assert.strictEqual(socket.parser, null);
+    socket.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
The reason for this change is mainly to be consistent with the server but also to prevent an error from being thrown in the unlikely case where the user assigns something to the `parser` property when the `'upgrade'` event is emitted.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http