### PR TITLE
child_process: do not ignore proto values of env

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -504,7 +504,7 @@ function normalizeSpawnArguments(file, args, options) {
   var env = options.env || process.env;
   var envPairs = [];
 
-  for (const key of Object.keys(env)) {
+  for (var key in env) {
     const value = env[key];
     if (value !== undefined) {
       envPairs.push(`${key}=${value}`);

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -57,7 +57,7 @@ child.stdout.on('data', function(chunk) {
 
 process.on('exit', function() {
   assert.ok(response.includes('HELLO=WORLD'));
-  assert.ok(!response.includes('FOO='));
+  assert.ok(response.includes('FOO=BAR'));
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
   assert.ok(response.includes(`EMPTY=${os.EOL}`));


### PR DESCRIPTION
This reverts part of the behaviour introduced in a recent PR, and updates the test. Without this change, CitGM and other packages are broken. I would like to have this fast-tracked (like, land within an hour or less) because as things are, CitGM is completely broken.

Also, I would like to propose, that going forward all changes that are labeled as semver-minor/major/patch MUST have a CitGM run to land. If any issues are found, collaborators & TSC should decide whether those are blocking or not. In either case, an effort should be made to fix the impacted modules before the PR lands — or at the very least in cases where those modules are integral to the Node.js core project.

Refs: https://github.com/nodejs/node/commit/85739b6c5b5d12204a81de18ceddf2d357effb8b
Fixes: https://github.com/nodejs/citgm/issues/536

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process, test