### PR TITLE
deps: cherry-pick 0bcb1d6f from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.3',
+    'v8_embedder_string': '-node.4',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -5475,6 +5475,11 @@ Genesis::Genesis(
     if (!InstallDebuggerNatives()) return;
   }
 
+  if (FLAG_disallow_code_generation_from_strings) {
+    native_context()->set_allow_code_gen_from_strings(
+        isolate->heap()->false_value());
+  }
+
   ConfigureUtilsObject(context_type);
 
   // Check that the script context table is empty except for the 'this' binding.

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -766,6 +766,8 @@ DEFINE_BOOL(builtins_in_stack_traces, false,
             "show built-in functions in stack traces")
 DEFINE_BOOL(enable_experimental_builtins, true,
             "enable new csa-based experimental builtins")
+DEFINE_BOOL(disallow_code_generation_from_strings, false,
+            "disallow eval and friends")
 
 // builtins.cc
 DEFINE_BOOL(allow_unsafe_function_constructor, false,

--- a/deps/v8/test/mjsunit/disallow-codegen-from-strings.js
+++ b/deps/v8/test/mjsunit/disallow-codegen-from-strings.js
@@ -1,0 +1,9 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --disallow-code-generation-from-strings
+
+assertThrows("1 + 1", EvalError);
+assertThrows(() => eval("1 + 1"), EvalError);
+assertThrows(() => Function("x", "return x + 1"), EvalError);


### PR DESCRIPTION
This has landed in 6.5, but we shouldn't have to wait!

Original commit message:

    Introduce --disallow-code-generation-from-strings

    Exposing the existing Context::AllowCodeGenerationFromStrings(false) API
    to the command line.

    Bug: v8:7134
    Change-Id: I062ccff0b03c5bcf6878c41c455c0ded37a1d743
    Reviewed-on: https://chromium-review.googlesource.com/809631
    Reviewed-by: Michael Starzinger <mstarzinger@chromium.org>
    Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#49911}

Refs: https://github.com/v8/v8/commit/0bcb1d6f2de9b278b1de7de1b5333e7f47fdce8e