### PR TITLE
tty: fix console printing on Windows

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -24,7 +24,6 @@
 const util = require('util');
 const net = require('net');
 const { TTY, isTTY } = process.binding('tty_wrap');
-const { makeSyncWrite } = require('internal/net');
 const { inherits } = util;
 const errnoException = util._errnoException;
 const errors = require('internal/errors');
@@ -92,8 +91,6 @@ function WriteStream(fd) {
   // even though it was originally intended to change in v1.0.2 (Libuv 1.2.1).
   // Ref: https://github.com/nodejs/node/pull/1771#issuecomment-119351671
   this._handle.setBlocking(true);
-  this._writev = null;
-  this._write = makeSyncWrite(fd);
 
   var winSize = new Array(2);
   var err = this._handle.getWindowSize(winSize);


### PR DESCRIPTION
This broke writing non-ASCII data to the console on Windows because the result would be codepage-dependent.

This partially reverts 8b751f7eb7b05a0b27f52e2288a636fdd78e9ecb.

Fixes: https://github.com/nodejs/node/issues/18189
Refs: https://github.com/nodejs/node/pull/18019

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

/cc @vsemozhetbyt 