### PR TITLE
buffer: coerce offset to integer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1272,6 +1272,7 @@ function toFloat(x) {
 
 
 Buffer.prototype.readDoubleBE = function(offset, noAssert) {
+  offset = offset >>> 0;
   const x1 = this.readUInt32BE(offset + 0, noAssert);
   const x0 = this.readUInt32BE(offset + 4, noAssert);
   return toDouble(x0, x1);
@@ -1279,6 +1280,7 @@ Buffer.prototype.readDoubleBE = function(offset, noAssert) {
 
 
 Buffer.prototype.readDoubleLE = function(offset, noAssert) {
+  offset = offset >>> 0;
   const x0 = this.readUInt32LE(offset + 0, noAssert);
   const x1 = this.readUInt32LE(offset + 4, noAssert);
   return toDouble(x0, x1);
@@ -1286,11 +1288,13 @@ Buffer.prototype.readDoubleLE = function(offset, noAssert) {
 
 
 Buffer.prototype.readFloatBE = function(offset, noAssert) {
+  offset = offset >>> 0;
   return toFloat(this.readUInt32BE(offset, noAssert));
 };
 
 
 Buffer.prototype.readFloatLE = function(offset, noAssert) {
+  offset = offset >>> 0;
   return toFloat(this.readUInt32LE(offset, noAssert));
 };
 

--- a/test/parallel/test-readdouble.js
+++ b/test/parallel/test-readdouble.js
@@ -29,102 +29,101 @@ const assert = require('assert');
 /*
  * Test (64 bit) double
  */
-function test(clazz) {
-  const buffer = new clazz(8);
+const buffer = Buffer.allocUnsafe(8);
 
-  buffer[0] = 0x55;
-  buffer[1] = 0x55;
-  buffer[2] = 0x55;
-  buffer[3] = 0x55;
-  buffer[4] = 0x55;
-  buffer[5] = 0x55;
-  buffer[6] = 0xd5;
-  buffer[7] = 0x3f;
-  assert.strictEqual(1.1945305291680097e+103, buffer.readDoubleBE(0));
-  assert.strictEqual(0.3333333333333333, buffer.readDoubleLE(0));
+buffer[0] = 0x55;
+buffer[1] = 0x55;
+buffer[2] = 0x55;
+buffer[3] = 0x55;
+buffer[4] = 0x55;
+buffer[5] = 0x55;
+buffer[6] = 0xd5;
+buffer[7] = 0x3f;
+assert.strictEqual(1.1945305291680097e+103, buffer.readDoubleBE(0));
+assert.strictEqual(0.3333333333333333, buffer.readDoubleLE(0));
 
-  buffer[0] = 1;
-  buffer[1] = 0;
-  buffer[2] = 0;
-  buffer[3] = 0;
-  buffer[4] = 0;
-  buffer[5] = 0;
-  buffer[6] = 0xf0;
-  buffer[7] = 0x3f;
-  assert.strictEqual(7.291122019655968e-304, buffer.readDoubleBE(0));
-  assert.strictEqual(1.0000000000000002, buffer.readDoubleLE(0));
+buffer[0] = 1;
+buffer[1] = 0;
+buffer[2] = 0;
+buffer[3] = 0;
+buffer[4] = 0;
+buffer[5] = 0;
+buffer[6] = 0xf0;
+buffer[7] = 0x3f;
+assert.strictEqual(7.291122019655968e-304, buffer.readDoubleBE(0));
+assert.strictEqual(1.0000000000000002, buffer.readDoubleLE(0));
 
-  buffer[0] = 2;
-  assert.strictEqual(4.778309726801735e-299, buffer.readDoubleBE(0));
-  assert.strictEqual(1.0000000000000004, buffer.readDoubleLE(0));
+buffer[0] = 2;
+assert.strictEqual(4.778309726801735e-299, buffer.readDoubleBE(0));
+assert.strictEqual(1.0000000000000004, buffer.readDoubleLE(0));
 
-  buffer[0] = 1;
-  buffer[6] = 0;
-  buffer[7] = 0;
-  assert.strictEqual(7.291122019556398e-304, buffer.readDoubleBE(0));
-  assert.strictEqual(5e-324, buffer.readDoubleLE(0));
+buffer[0] = 1;
+buffer[6] = 0;
+buffer[7] = 0;
+assert.strictEqual(7.291122019556398e-304, buffer.readDoubleBE(0));
+assert.strictEqual(5e-324, buffer.readDoubleLE(0));
 
-  buffer[0] = 0xff;
-  buffer[1] = 0xff;
-  buffer[2] = 0xff;
-  buffer[3] = 0xff;
-  buffer[4] = 0xff;
-  buffer[5] = 0xff;
-  buffer[6] = 0x0f;
-  buffer[7] = 0x00;
-  assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
-  assert.strictEqual(2.225073858507201e-308, buffer.readDoubleLE(0));
+buffer[0] = 0xff;
+buffer[1] = 0xff;
+buffer[2] = 0xff;
+buffer[3] = 0xff;
+buffer[4] = 0xff;
+buffer[5] = 0xff;
+buffer[6] = 0x0f;
+buffer[7] = 0x00;
+assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
+assert.strictEqual(2.225073858507201e-308, buffer.readDoubleLE(0));
 
-  buffer[6] = 0xef;
-  buffer[7] = 0x7f;
-  assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
-  assert.strictEqual(1.7976931348623157e+308, buffer.readDoubleLE(0));
+buffer[6] = 0xef;
+buffer[7] = 0x7f;
+assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
+assert.strictEqual(1.7976931348623157e+308, buffer.readDoubleLE(0));
 
-  buffer[0] = 0;
-  buffer[1] = 0;
-  buffer[2] = 0;
-  buffer[3] = 0;
-  buffer[4] = 0;
-  buffer[5] = 0;
-  buffer[6] = 0xf0;
-  buffer[7] = 0x3f;
-  assert.strictEqual(3.03865e-319, buffer.readDoubleBE(0));
-  assert.strictEqual(1, buffer.readDoubleLE(0));
+buffer[0] = 0;
+buffer[1] = 0;
+buffer[2] = 0;
+buffer[3] = 0;
+buffer[4] = 0;
+buffer[5] = 0;
+buffer[6] = 0xf0;
+buffer[7] = 0x3f;
+assert.strictEqual(3.03865e-319, buffer.readDoubleBE(0));
+assert.strictEqual(1, buffer.readDoubleLE(0));
 
-  buffer[6] = 0;
-  buffer[7] = 0x40;
-  assert.strictEqual(3.16e-322, buffer.readDoubleBE(0));
-  assert.strictEqual(2, buffer.readDoubleLE(0));
+buffer[6] = 0;
+buffer[7] = 0x40;
+assert.strictEqual(3.16e-322, buffer.readDoubleBE(0));
+assert.strictEqual(2, buffer.readDoubleLE(0));
 
-  buffer[7] = 0xc0;
-  assert.strictEqual(9.5e-322, buffer.readDoubleBE(0));
-  assert.strictEqual(-2, buffer.readDoubleLE(0));
+buffer[7] = 0xc0;
+assert.strictEqual(9.5e-322, buffer.readDoubleBE(0));
+assert.strictEqual(-2, buffer.readDoubleLE(0));
 
-  buffer[6] = 0x10;
-  buffer[7] = 0;
-  assert.strictEqual(2.0237e-320, buffer.readDoubleBE(0));
-  assert.strictEqual(2.2250738585072014e-308, buffer.readDoubleLE(0));
+buffer[6] = 0x10;
+buffer[7] = 0;
+assert.strictEqual(2.0237e-320, buffer.readDoubleBE(0));
+assert.strictEqual(2.2250738585072014e-308, buffer.readDoubleLE(0));
 
-  buffer[6] = 0;
-  assert.strictEqual(0, buffer.readDoubleBE(0));
-  assert.strictEqual(0, buffer.readDoubleLE(0));
-  assert.strictEqual(false, 1 / buffer.readDoubleLE(0) < 0);
+buffer[6] = 0;
+assert.strictEqual(0, buffer.readDoubleBE(0));
+assert.strictEqual(0, buffer.readDoubleLE(0));
+assert.strictEqual(false, 1 / buffer.readDoubleLE(0) < 0);
 
-  buffer[7] = 0x80;
-  assert.strictEqual(6.3e-322, buffer.readDoubleBE(0));
-  assert.strictEqual(-0, buffer.readDoubleLE(0));
-  assert.strictEqual(true, 1 / buffer.readDoubleLE(0) < 0);
+buffer[7] = 0x80;
+assert.strictEqual(6.3e-322, buffer.readDoubleBE(0));
+assert.strictEqual(-0, buffer.readDoubleLE(0));
+assert.strictEqual(true, 1 / buffer.readDoubleLE(0) < 0);
 
-  buffer[6] = 0xf0;
-  buffer[7] = 0x7f;
-  assert.strictEqual(3.0418e-319, buffer.readDoubleBE(0));
-  assert.strictEqual(Infinity, buffer.readDoubleLE(0));
+buffer[6] = 0xf0;
+buffer[7] = 0x7f;
+assert.strictEqual(3.0418e-319, buffer.readDoubleBE(0));
+assert.strictEqual(Infinity, buffer.readDoubleLE(0));
 
-  buffer[6] = 0xf0;
-  buffer[7] = 0xff;
-  assert.strictEqual(3.04814e-319, buffer.readDoubleBE(0));
-  assert.strictEqual(-Infinity, buffer.readDoubleLE(0));
-}
+buffer[7] = 0xff;
+assert.strictEqual(3.04814e-319, buffer.readDoubleBE(0));
+assert.strictEqual(-Infinity, buffer.readDoubleLE(0));
 
-
-test(Buffer);
+buffer.writeDoubleBE(246800);
+assert.strictEqual(buffer.readDoubleBE(), 246800);
+assert.strictEqual(buffer.readDoubleBE(0.7), 246800);
+assert.strictEqual(buffer.readDoubleBE(NaN), 246800);


### PR DESCRIPTION
The offset was formerly coerced to a integer and this reimplements
that.

Fixes #18208

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer