### PR TITLE
test: added input validation test for fchmod

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1294,7 +1294,8 @@ fs.fchmod = function(fd, mode, callback) {
   mode = modeNum(mode);
   validateUint32(fd, 'fd');
   validateUint32(mode, 'mode');
-  if (mode < 0 || mode > 0o777)
+  // values for mode < 0 are already checked via the validateUint32 function
+  if (mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
 
   const req = new FSReqWrap();

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -44,8 +44,8 @@ const fs = require('fs');
 
 // Check for mode values range
 const modeUpperBoundaryValue = 0o777;
-common.mustCall(() => fs.fchmod(1, modeUpperBoundaryValue);
-common.mustCall(() => fs.fchmodSync(1, modeUpperBoundaryValue);
+common.mustCall(() => fs.fchmod(1, modeUpperBoundaryValue));
+common.mustCall(() => fs.fchmodSync(1, modeUpperBoundaryValue));
 
 // umask of 0o777 is equal to 775
 const modeOutsideUpperBoundValue = 776;

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -1,0 +1,67 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+// This test ensures that input for fchmod is valid, testing for valid
+// inputs for fd and mode
+
+// Check input type
+['', false, null, undefined, {}, [], Infinity, -1].forEach((i) => {
+  common.expectsError(
+    () => fs.fchmod(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type integer'
+    }
+  );
+  common.expectsError(
+    () => fs.fchmodSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type integer'
+    }
+  );
+
+  common.expectsError(
+    () => fs.fchmod(1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "mode" argument must be of type integer'
+    }
+  );
+  common.expectsError(
+    () => fs.fchmodSync(1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "mode" argument must be of type integer'
+    }
+  );
+});
+
+// Check for mode values range
+const modeUpperBoundaryValue = 0o777;
+common.mustCall(() => fs.fchmod(1, modeUpperBoundaryValue);
+common.mustCall(() => fs.fchmodSync(1, modeUpperBoundaryValue);
+
+// umask of 0o777 is equal to 775
+const modeOutsideUpperBoundValue = 776;
+common.expectsError(
+  () => fs.fchmod(1, i),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The value of "mode" is out of range.'
+  }
+);
+common.expectsError(
+  () => fs.fchmodSync(1, i),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The value of "mode" is out of range.'
+  }
+);

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -44,13 +44,13 @@ const fs = require('fs');
 
 // Check for mode values range
 const modeUpperBoundaryValue = 0o777;
-common.mustCall(() => fs.fchmod(1, modeUpperBoundaryValue));
-common.mustCall(() => fs.fchmodSync(1, modeUpperBoundaryValue));
+fs.fchmod(1, modeUpperBoundaryValue);
+fs.fchmodSync(1, modeUpperBoundaryValue);
 
 // umask of 0o777 is equal to 775
 const modeOutsideUpperBoundValue = 776;
 common.expectsError(
-  () => fs.fchmod(1, i),
+  () => fs.fchmod(1, modeOutsideUpperBoundValue),
   {
     code: 'ERR_OUT_OF_RANGE',
     type: RangeError,
@@ -58,7 +58,7 @@ common.expectsError(
   }
 );
 common.expectsError(
-  () => fs.fchmodSync(1, i),
+  () => fs.fchmodSync(1, modeOutsideUpperBoundValue),
   {
     code: 'ERR_OUT_OF_RANGE',
     type: RangeError,

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fs = require('fs');
 
-['', false, null, undefined, {}, []].forEach((i) => {
+['', false, null, undefined, {}, [], Infinity, -1].forEach((i) => {
   common.expectsError(
     () => fs.fchown(i),
     {


### PR DESCRIPTION
Added a test to ensure input validation for FD and mode for fs.fchmod.
Removed check for values lower than 0 for `mode` as it's already checked
by `validateUint32`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, fs
