### PR TITLE
util: isDeepStrictEqual always returns false to compare WeakMap/WeakSet

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -80,6 +80,12 @@ function strictDeepEqual(val1, val2, memos) {
   if (Object.getPrototypeOf(val1) !== Object.getPrototypeOf(val2)) {
     return false;
   }
+  if (val1Tag === '[object WeakMap]' || val1Tag === '[object WeakSet]') {
+    // Note: Weak Reference Collection is not designed to check the equivalence.
+    // They are depends on Garbage Collection implementation.
+    // see: https://tc39.github.io/ecma262/#sec-weakmap-objects
+    return false;
+  }
   if (val1Tag === '[object Array]') {
     // Check for sparse arrays and general fast path
     if (val1.length !== val2.length)

--- a/test/parallel/test-util-isDeepStrictEqual.js
+++ b/test/parallel/test-util-isDeepStrictEqual.js
@@ -481,3 +481,22 @@ utilIsDeepStrict(-0, -0);
   boxedStringA[symbol1] = true;
   utilIsDeepStrict(a, b);
 }
+
+// Handle WeakMap and WeakSet
+{
+  const wm1 = new WeakMap();
+  const wm2 = new WeakMap();
+  const key = {};
+  wm1.set(key, 1);
+  wm2.set(key, 1);
+  // seems to be equal but WeakMap is always false
+  notUtilIsDeepStrict(wm1, wm2);
+
+  const ws1 = new WeakSet();
+  const ws2 = new WeakSet();
+  const obj = {};
+  ws1.add(obj);
+  ws2.add(obj);
+  // seems to be equal but WeakSet is always false
+  notUtilIsDeepStrict(ws1, ws2);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
solve https://github.com/nodejs/node/issues/18227

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util