### PR TITLE
Add example of null to assert.ifError

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -442,6 +442,8 @@ argument in callbacks.
 ```js
 const assert = require('assert').strict;
 
+assert.ifError(null);
+// OK
 assert.ifError(0);
 // OK
 assert.ifError(1);


### PR DESCRIPTION
> This is useful when testing the error argument in callbacks.
>
> &mdash; [Assert | Node.js v9.4.0 Documentation](https://nodejs.org/api/assert.html#assert_assert_iferror_value)

`error argument` would be `null` or `Error`.
I think need to add example case of `null` to help understanding `assert.ifError`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
