### PR TITLE
 stream: remove unreachable code 

### DIFF
--- a/lib/internal/streams/BufferList.js
+++ b/lib/internal/streams/BufferList.js
@@ -62,8 +62,6 @@ module.exports = class BufferList {
   concat(n) {
     if (this.length === 0)
       return Buffer.alloc(0);
-    if (this.length === 1)
-      return this.head.data;
     const ret = Buffer.allocUnsafe(n >>> 0);
     var p = this.head;
     var i = 0;

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -15,16 +15,21 @@ assert.strictEqual(emptyList.join(','), '');
 
 assert.deepStrictEqual(emptyList.concat(0), Buffer.alloc(0));
 
+const buf = Buffer.from('foo');
+
 // Test buffer list with one element.
 const list = new BufferList();
-list.push('foo');
+list.push(buf);
 
-assert.strictEqual(list.concat(1), 'foo');
+const copy = list.concat(3);
+
+assert.notStrictEqual(copy, buf);
+assert.deepStrictEqual(copy, buf);
 
 assert.strictEqual(list.join(','), 'foo');
 
 const shifted = list.shift();
-assert.strictEqual(shifted, 'foo');
+assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());
 
 const tmp = util.inspect.defaultOptions.colors;


### PR DESCRIPTION
First commit remove some unreachable code. `BufferList.prototype.concat()` is [not called](https://github.com/nodejs/node/blob/7809f386b03d6f2f570fe41060a7ef6e158f5cdb/lib/_stream_readable.js#L997-L998) when there is only a buffer in the list.

Second commit fixes a test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream, test