### PR TITLE
test: make test-async-wrap-getasyncid parallelizable

### DIFF
--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -139,6 +139,8 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 }
 
 {
+  common.refreshTmpDir();
+
   const server = net.createServer(common.mustCall((socket) => {
     server.close();
   })).listen(common.PIPE, common.mustCall(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Previously this test cannot be run with the node-stress-single-test job because the tmp dir is not created before `common.PIPE` is listened. See https://ci.nodejs.org/job/node-stress-single-test/1712/nodes=alpine34-container-x64/console

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test