### PR TITLE
doc: document asserts Weak(Map|Set) behavior

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -213,6 +213,7 @@ are recursively evaluated also by the following rules.
 * Map keys and Set items are compared unordered.
 * Recursion stops when both sides differ or both sides encounter a circular
   reference.
+* `WeakMap` and `WeakSet` will return true, no matter what values they contain.
 
 ```js
 const assert = require('assert').strict;
@@ -254,6 +255,16 @@ assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol1]: 1 });
 // OK, because it is the same symbol on both objects.
 assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol2]: 1 });
 // Fails because symbol1 !== symbol2!
+
+const weakMap1 = new WeakMap();
+const weakMap2 = new WeakMap([1, 1]);
+const weakMap3 = new WeakMap();
+weakMap3.unequal = true;
+
+assert.deepStrictEqual(weakMap1, weakMap2);
+// OK, because it is impossible to compare the entries
+assert.deepStrictEqual(weakMap1, weakMap3);
+// Fails because weakMap3 has a property that weakMap1 does not contain!
 ```
 
 If the values are not equal, an `AssertionError` is thrown with a `message`
@@ -870,6 +881,8 @@ second argument. This might lead to difficult-to-spot errors.
 [`Set`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Set
 [`Symbol`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 [`TypeError`]: errors.html#errors_class_typeerror
+[`WeakMap`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeapMap
+[`WeakSet`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
 [`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message
 [`assert.notDeepStrictEqual()`]: #assert_assert_notdeepstrictequal_actual_expected_message

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -213,7 +213,8 @@ are recursively evaluated also by the following rules.
 * Map keys and Set items are compared unordered.
 * Recursion stops when both sides differ or both sides encounter a circular
   reference.
-* `WeakMap` and `WeakSet` will return true, no matter what values they contain.
+* [`WeakMap`][] and [`WeakSet`][] will return true, no matter what values they
+  contain.
 
 ```js
 const assert = require('assert').strict;
@@ -257,7 +258,7 @@ assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol2]: 1 });
 // Fails because symbol1 !== symbol2!
 
 const weakMap1 = new WeakMap();
-const weakMap2 = new WeakMap([1, 1]);
+const weakMap2 = new WeakMap([[{}, {}]]);
 const weakMap3 = new WeakMap();
 weakMap3.unequal = true;
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -213,7 +213,7 @@ are recursively evaluated also by the following rules.
 * Map keys and Set items are compared unordered.
 * Recursion stops when both sides differ or both sides encounter a circular
   reference.
-* ['WeakMap'][] and ['WeakSet'][] comparison does not rely on their values. See
+* [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values. See
   below for further details.
 
 ```js

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -882,7 +882,7 @@ second argument. This might lead to difficult-to-spot errors.
 [`Set`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Set
 [`Symbol`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol
 [`TypeError`]: errors.html#errors_class_typeerror
-[`WeakMap`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeapMap
+[`WeakMap`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [`WeakSet`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
 [`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -213,8 +213,8 @@ are recursively evaluated also by the following rules.
 * Map keys and Set items are compared unordered.
 * Recursion stops when both sides differ or both sides encounter a circular
   reference.
-* [`WeakMap`][] and [`WeakSet`][] will return true, no matter what values they
-  contain.
+* ['WeakMap'][] and ['WeakSet'][] comparison does not rely on their values. See
+  below for further details.
 
 ```js
 const assert = require('assert').strict;


### PR DESCRIPTION
Right now it is not documentated that WeakMap entries are not
compared. This might result in some confusion. This adds a note
about the behavior in `assert.deepStrictEqual`. This documentation
is also references in `util.isDeepStrictEqual`, so we do not have
to document it again for that function as the underlying algorithm
is the same.

Refs: #18228 
Closes: #18228

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc