### PR TITLE
benchmark: use destructuring and more

### DIFF
--- a/benchmark/arrays/var-int.js
+++ b/benchmark/arrays/var-int.js
@@ -17,10 +17,8 @@ const bench = common.createBenchmark(main, {
   n: [25]
 });
 
-function main(conf) {
-  const type = conf.type;
+function main({ type, n }) {
   const clazz = global[type];
-  const n = +conf.n;
 
   bench.start();
   const arr = new clazz(n * 1e6);

--- a/benchmark/arrays/zero-float.js
+++ b/benchmark/arrays/zero-float.js
@@ -17,10 +17,8 @@ const bench = common.createBenchmark(main, {
   n: [25]
 });
 
-function main(conf) {
-  const type = conf.type;
+function main({ type, n }) {
   const clazz = global[type];
-  const n = +conf.n;
 
   bench.start();
   const arr = new clazz(n * 1e6);

--- a/benchmark/arrays/zero-int.js
+++ b/benchmark/arrays/zero-int.js
@@ -17,10 +17,8 @@ const bench = common.createBenchmark(main, {
   n: [25]
 });
 
-function main(conf) {
-  const type = conf.type;
+function main({ type, n }) {
   const clazz = global[type];
-  const n = +conf.n;
 
   bench.start();
   const arr = new clazz(n * 1e6);

--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -13,9 +13,7 @@ const bench = common.createBenchmark(main, {
   ]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const len = +conf.len;
+function main({ len, n, method }) {
   var i;
 
   const data = Buffer.allocUnsafe(len + 1);
@@ -26,7 +24,7 @@ function main(conf) {
   data.copy(expected);
   data.copy(expectedWrong);
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -38,14 +38,11 @@ function benchmark(method, n, values, values2) {
   bench.end(n);
 }
 
-function main(conf) {
-  const n = +conf.n;
-  const len = +conf.len;
-
+function main({ n, len, method }) {
   const array = Array(len).fill(1);
   var values, values2;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly':

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -25,10 +25,9 @@ function createObj(source, add = '') {
   }));
 }
 
-function main(conf) {
-  const size = conf.size;
-  // TODO: Fix this "hack"
-  const n = conf.n / size;
+function main({ size, n, method }) {
+  // TODO: Fix this "hack". `n` should not be manipulated.
+  n = n / size;
   var i;
 
   const source = Array.apply(null, Array(size));
@@ -36,7 +35,7 @@ function main(conf) {
   const expected = createObj(source);
   const expectedWrong = createObj(source, '4');
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -15,7 +15,7 @@ const primValues = {
 };
 
 const bench = common.createBenchmark(main, {
-  prim: Object.keys(primValues),
+  primitive: Object.keys(primValues),
   n: [25],
   len: [1e5],
   method: [
@@ -30,10 +30,8 @@ const bench = common.createBenchmark(main, {
   ]
 });
 
-function main(conf) {
-  const prim = primValues[conf.prim];
-  const n = +conf.n;
-  const len = +conf.len;
+function main({ n, len, primitive, method }) {
+  const prim = primValues[primitive];
   const actual = [];
   const expected = [];
   const expectedWrong = [];
@@ -52,7 +50,7 @@ function main(conf) {
   const expectedSet = new Set(expected);
   const expectedWrongSet = new Set(expectedWrong);
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_Array':

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -14,7 +14,7 @@ const primValues = {
 };
 
 const bench = common.createBenchmark(main, {
-  prim: Object.keys(primValues),
+  primitive: Object.keys(primValues),
   n: [1e6],
   method: [
     'deepEqual',
@@ -24,16 +24,15 @@ const bench = common.createBenchmark(main, {
   ]
 });
 
-function main(conf) {
-  const prim = primValues[conf.prim];
-  const n = +conf.n;
+function main({ n, primitive, method }) {
+  const prim = primValues[primitive];
   const actual = prim;
   const expected = prim;
   const expectedWrong = 'b';
   var i;
 
   // Creates new array to avoid loop invariant code motion
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -38,15 +38,12 @@ function benchmark(method, n, values, values2) {
   bench.end(n);
 }
 
-function main(conf) {
-  const n = +conf.n;
-  const len = +conf.len;
-
+function main({ n, len, method }) {
   const array = Array(len).fill(1);
 
   var values, values2;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly':

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -24,12 +24,8 @@ const bench = common.createBenchmark(main, {
   len: [1e6]
 });
 
-function main(conf) {
-  const type = conf.type;
+function main({ type, n, len, method }) {
   const clazz = global[type];
-  const n = +conf.n;
-  const len = +conf.len;
-
   const actual = new clazz(len);
   const expected = new clazz(len);
   const expectedWrong = Buffer.alloc(len);
@@ -37,7 +33,7 @@ function main(conf) {
   expectedWrong[wrongIndex] = 123;
   var i;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -13,15 +13,14 @@ const bench = common.createBenchmark(main, {
   ]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n, method }) {
   const throws = () => { throw new TypeError('foobar'); };
   const doesNotThrow = () => { return 'foobar'; };
   const regExp = /foobar/;
   const message = 'failure';
   var i;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'doesNotThrow':
@@ -54,6 +53,6 @@ function main(conf) {
       bench.end(n);
       break;
     default:
-      throw new Error(`Unsupported method ${conf.method}`);
+      throw new Error(`Unsupported method ${method}`);
   }
 }

--- a/benchmark/async_hooks/gc-tracking.js
+++ b/benchmark/async_hooks/gc-tracking.js
@@ -21,10 +21,8 @@ function endAfterGC(n) {
   });
 }
 
-function main(conf) {
-  const n = +conf.n;
-
-  switch (conf.method) {
+function main({ n, method }) {
+  switch (method) {
     case 'trackingEnabled':
       bench.start();
       for (let i = 0; i < n; i++) {

--- a/benchmark/buffers/buffer-base64-decode-wrapped.js
+++ b/benchmark/buffers/buffer-base64-decode-wrapped.js
@@ -6,8 +6,7 @@ const bench = common.createBenchmark(main, {
   n: [32],
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const charsPerLine = 76;
   const linesCount = 8 << 16;
   const bytesCount = charsPerLine * linesCount / 4 * 3;

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -6,8 +6,7 @@ const bench = common.createBenchmark(main, {
   n: [32],
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const s = 'abcd'.repeat(8 << 20);
   // eslint-disable-next-line no-unescaped-regexp-dot
   s.match(/./);  // Flatten string.

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -27,9 +27,7 @@ const bench = common.createBenchmark(main, {
   n: [32]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const len = +conf.len;
+function main({ n, len }) {
   const b = Buffer.allocUnsafe(len);
   let s = '';
   let i;

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -15,11 +15,7 @@ const chars = [
   '𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷𠺝𠺢' // 4 bytes
 ];
 
-function main(conf) {
-  const n = conf.n | 0;
-  const len = conf.len | 0;
-  const encoding = conf.encoding;
-
+function main({ n, len, encoding }) {
   var strings = [];
   var results;
   if (encoding === 'buffer') {

--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -7,10 +7,8 @@ const bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-function main(conf) {
-  const iter = (conf.millions >>> 0) * 1e6;
-  const size = (conf.size >>> 0);
-  const args = (conf.args >>> 0);
+function main({ millions, size, args }) {
+  const iter = millions * 1e6;
   const b0 = Buffer.alloc(size, 'a');
   const b1 = Buffer.alloc(size, 'a');
   const b0Len = b0.length;

--- a/benchmark/buffers/buffer-compare-offset.js
+++ b/benchmark/buffers/buffer-compare-offset.js
@@ -23,13 +23,11 @@ function compareUsingOffset(b0, b1, len, iter) {
   bench.end(iter / 1e6);
 }
 
-function main(conf) {
-  const iter = (conf.millions >>> 0) * 1e6;
-  const size = (conf.size >>> 0);
-  const method =
-    conf.method === 'slice' ? compareUsingSlice : compareUsingOffset;
-  method(Buffer.alloc(size, 'a'),
-         Buffer.alloc(size, 'b'),
-         size >> 1,
-         iter);
+function main({ millions, size, method }) {
+  const iter = millions * 1e6;
+  const fn = method === 'slice' ? compareUsingSlice : compareUsingOffset;
+  fn(Buffer.alloc(size, 'a'),
+     Buffer.alloc(size, 'b'),
+     size >> 1,
+     iter);
 }

--- a/benchmark/buffers/buffer-compare.js
+++ b/benchmark/buffers/buffer-compare.js
@@ -27,9 +27,8 @@ const bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-function main(conf) {
-  const iter = (conf.millions >>> 0) * 1e6;
-  const size = (conf.size >>> 0);
+function main({ millions, size }) {
+  const iter = millions * 1e6;
   const b0 = Buffer.alloc(size, 'a');
   const b1 = Buffer.alloc(size, 'a');
 

--- a/benchmark/buffers/buffer-concat.js
+++ b/benchmark/buffers/buffer-concat.js
@@ -8,15 +8,11 @@ const bench = common.createBenchmark(main, {
   n: [1024]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const size = +conf.pieceSize;
-  const pieces = +conf.pieces;
-
+function main({ n, pieces, pieceSize, withTotalLength }) {
   const list = new Array(pieces);
-  list.fill(Buffer.allocUnsafe(size));
+  list.fill(Buffer.allocUnsafe(pieceSize));
 
-  const totalLength = conf.withTotalLength ? pieces * size : undefined;
+  const totalLength = withTotalLength ? pieces * pieceSize : undefined;
 
   bench.start();
   for (var i = 0; i < n * 1024; i++) {

--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -15,10 +15,8 @@ const bench = common.createBenchmark(main, {
   n: [1024]
 });
 
-function main(conf) {
-  const len = +conf.len;
-  const n = +conf.n;
-  switch (conf.type) {
+function main({ len, n, type }) {
+  switch (type) {
     case '':
     case 'fast-alloc':
       bench.start();

--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -18,10 +18,7 @@ const bench = common.createBenchmark(main, {
   n: [2048]
 });
 
-function main(conf) {
-  const len = +conf.len;
-  const n = +conf.n;
-
+function main({ len, n, source }) {
   const array = new Array(len).fill(42);
   const arrayBuf = new ArrayBuffer(len);
   const str = 'a'.repeat(len);
@@ -31,7 +28,7 @@ function main(conf) {
 
   var i;
 
-  switch (conf.source) {
+  switch (source) {
     case 'array':
       bench.start();
       for (i = 0; i < n * 1024; i++) {

--- a/benchmark/buffers/buffer-hex.js
+++ b/benchmark/buffers/buffer-hex.js
@@ -7,9 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  const len = conf.len | 0;
-  const n = conf.n | 0;
+function main({ len, n }) {
   const buf = Buffer.alloc(len);
 
   for (let i = 0; i < buf.length; i++)

--- a/benchmark/buffers/buffer-indexof-number.js
+++ b/benchmark/buffers/buffer-indexof-number.js
@@ -8,16 +8,14 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const search = +conf.value;
+function main({ n, value }) {
   const aliceBuffer = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/alice.html')
   );
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    aliceBuffer.indexOf(search, 0, undefined);
+    aliceBuffer.indexOf(value, 0, undefined);
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -25,16 +25,13 @@ const bench = common.createBenchmark(main, {
   search: searchStrings,
   encoding: ['undefined', 'utf8', 'ucs2', 'binary'],
   type: ['buffer', 'string'],
-  iter: [1]
+  iter: [100000]
 });
 
-function main(conf) {
-  const iter = (conf.iter) * 100000;
+function main({ iter, search, encoding, type }) {
   var aliceBuffer = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/alice.html')
   );
-  var search = conf.search;
-  var encoding = conf.encoding;
 
   if (encoding === 'undefined') {
     encoding = undefined;
@@ -44,7 +41,7 @@ function main(conf) {
     aliceBuffer = Buffer.from(aliceBuffer.toString(), encoding);
   }
 
-  if (conf.type === 'buffer') {
+  if (type === 'buffer') {
     search = Buffer.from(Buffer.from(search).toString(), encoding);
   }
 

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -16,14 +16,11 @@ const methods = {
   'iterator': benchIterator
 };
 
-function main(conf) {
-  const len = +conf.size;
-  const clazz = conf.type === 'fast' ? Buffer : SlowBuffer;
-  const buffer = new clazz(len);
+function main({ size, type, method, n }) {
+  const clazz = type === 'fast' ? Buffer : SlowBuffer;
+  const buffer = new clazz(size);
   buffer.fill(0);
-
-  const method = conf.method || 'for';
-  methods[method](buffer, conf.n);
+  methods[method || 'for'](buffer, n);
 }
 
 

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -25,13 +25,12 @@ const bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-function main(conf) {
-  const noAssert = conf.noAssert === 'true';
-  const len = +conf.millions * 1e6;
-  const clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
+function main({ noAssert, millions, buf, type }) {
+  noAssert = noAssert === 'true';
+  const len = millions * 1e6;
+  const clazz = buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
   const buff = new clazz(8);
-  const type = conf.type || 'UInt8';
-  const fn = `read${type}`;
+  const fn = `read${type || 'UInt8'}`;
 
   buff.writeDoubleLE(0, 0, noAssert);
   const testFunction = new Function('buff', `

--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -10,9 +10,8 @@ const bench = common.createBenchmark(main, {
 const buf = Buffer.allocUnsafe(1024);
 const slowBuf = new SlowBuffer(1024);
 
-function main(conf) {
-  const n = +conf.n;
-  const b = conf.type === 'fast' ? buf : slowBuf;
+function main({ n, type }) {
+  const b = type === 'fast' ? buf : slowBuf;
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
     b.slice(10, 256);

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -72,13 +72,9 @@ function genMethod(method) {
   return (new Function(fnString))();
 }
 
-function main(conf) {
-  const method = conf.method || 'swap16';
-  const len = conf.len | 0;
-  const n = conf.n | 0;
-  const aligned = conf.aligned || 'true';
+function main({ method, len, n, aligned = 'true' }) {
   const buf = createBuffer(len, aligned === 'true');
-  const bufferSwap = genMethod(method);
+  const bufferSwap = genMethod(method || 'swap16');
 
   bufferSwap(n, buf);
   bench.start();

--- a/benchmark/buffers/buffer-tojson.js
+++ b/benchmark/buffers/buffer-tojson.js
@@ -7,9 +7,8 @@ const bench = common.createBenchmark(main, {
   len: [0, 10, 256, 4 * 1024]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const buf = Buffer.allocUnsafe(+conf.len);
+function main({ n, len }) {
+  const buf = Buffer.allocUnsafe(len);
 
   bench.start();
   for (var i = 0; i < n; ++i)

--- a/benchmark/buffers/buffer-tostring.js
+++ b/benchmark/buffers/buffer-tostring.js
@@ -9,11 +9,7 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  var encoding = conf.encoding;
-  const args = conf.args | 0;
-  const len = conf.len | 0;
-  const n = conf.n | 0;
+function main({ encoding, args, len, n }) {
   const buf = Buffer.alloc(len, 42);
 
   if (encoding.length === 0)

--- a/benchmark/buffers/buffer-write-string.js
+++ b/benchmark/buffers/buffer-write-string.js
@@ -10,12 +10,7 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  const len = +conf.len;
-  const n = +conf.n;
-  const encoding = conf.encoding;
-  const args = conf.args;
-
+function main({ len, n, encoding, args }) {
   const string = 'a'.repeat(len);
   const buf = Buffer.allocUnsafe(len);
 

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -45,13 +45,11 @@ const mod = {
   writeUInt32LE: UINT32
 };
 
-function main(conf) {
-  const noAssert = conf.noAssert === 'true';
-  const len = +conf.millions * 1e6;
-  const clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
+function main({ noAssert, millions, buf, type }) {
+  const len = millions * 1e6;
+  const clazz = buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
   const buff = new clazz(8);
-  const type = conf.type || 'UInt8';
-  const fn = `write${type}`;
+  const fn = `write${type || 'UInt8'}`;
 
   if (/Int/.test(fn))
     benchInt(buff, fn, len, noAssert);
@@ -63,7 +61,7 @@ function benchInt(buff, fn, len, noAssert) {
   const m = mod[fn];
   const testFunction = new Function('buff', `
     for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(i & ${m}, 0, ${JSON.stringify(noAssert)});
+      buff.${fn}(i & ${m}, 0, ${noAssert});
     }
   `);
   bench.start();
@@ -74,7 +72,7 @@ function benchInt(buff, fn, len, noAssert) {
 function benchFloat(buff, fn, len, noAssert) {
   const testFunction = new Function('buff', `
     for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(i, 0, ${JSON.stringify(noAssert)});
+      buff.${fn}(i, 0, ${noAssert});
     }
   `);
   bench.start();

--- a/benchmark/buffers/buffer_zero.js
+++ b/benchmark/buffers/buffer_zero.js
@@ -10,13 +10,12 @@ const bench = common.createBenchmark(main, {
 const zeroBuffer = Buffer.alloc(0);
 const zeroString = '';
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n, type }) {
   bench.start();
 
-  if (conf.type === 'buffer')
+  if (type === 'buffer')
     for (let i = 0; i < n * 1024; i++) Buffer.from(zeroBuffer);
-  else if (conf.type === 'string')
+  else if (type === 'string')
     for (let i = 0; i < n * 1024; i++) Buffer.from(zeroString);
 
   bench.end(n);

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -39,11 +39,11 @@ const mod = {
   setUint32: UINT32
 };
 
-function main(conf) {
-  const len = +conf.millions * 1e6;
+function main({ millions, type }) {
+  type = type || 'Uint8';
+  const len = millions * 1e6;
   const ab = new ArrayBuffer(8);
   const dv = new DataView(ab, 0, 8);
-  const type = conf.type || 'Uint8';
   const le = /LE$/.test(type);
   const fn = `set${type.replace(/[LB]E$/, '')}`;
 

--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -12,12 +12,10 @@ const bench = common.createBenchmark(childProcessExecStdout, {
   dur: [5]
 });
 
-function childProcessExecStdout(conf) {
+function childProcessExecStdout({ dur, len }) {
   bench.start();
 
-  const maxDuration = conf.dur * 1000;
-  const len = +conf.len;
-
+  const maxDuration = dur * 1000;
   const cmd = `yes "${'.'.repeat(len)}"`;
   const child = exec(cmd, { 'stdio': ['ignore', 'pipe', 'ignore'] });
 

--- a/benchmark/child_process/child-process-params.js
+++ b/benchmark/child_process/child-process-params.js
@@ -20,11 +20,7 @@ const configs = {
 
 const bench = common.createBenchmark(main, configs);
 
-function main(conf) {
-  const n = +conf.n;
-  const methodName = conf.methodName;
-  const params = +conf.params;
-
+function main({ n, methodName, params }) {
   const method = cp[methodName];
 
   switch (methodName) {

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -18,11 +18,9 @@ if (process.argv[2] === 'child') {
     dur: [5]
   });
   const spawn = require('child_process').spawn;
-  function main(conf) {
-    bench.start();
 
-    const dur = +conf.dur;
-    const len = +conf.len;
+  function main({ dur, len }) {
+    bench.start();
 
     const options = { 'stdio': ['ignore', 1, 2, 'ipc'] };
     const child = spawn(process.argv[0],

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -17,11 +17,8 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-function main(conf) {
+function main({ dur, len }) {
   bench.start();
-
-  const dur = +conf.dur;
-  const len = +conf.len;
 
   const msg = `"${'.'.repeat(len)}"`;
   const options = { 'stdio': ['ignore', 'pipe', 'ignore'] };

--- a/benchmark/child_process/spawn-echo.js
+++ b/benchmark/child_process/spawn-echo.js
@@ -5,9 +5,7 @@ const bench = common.createBenchmark(main, {
 });
 
 const spawn = require('child_process').spawn;
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   go(n, n);
 }

--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -10,22 +10,19 @@ if (cluster.isMaster) {
     n: [1e5]
   });
 
-  function main(conf) {
-    const n = +conf.n;
-    const workers = +conf.workers;
-    const sends = +conf.sendsPerBroadcast;
-    const expectedPerBroadcast = sends * workers;
-    var payload;
+  function main({ n, workers, sendsPerBroadcast, payload }) {
+    const expectedPerBroadcast = sendsPerBroadcast * workers;
     var readies = 0;
     var broadcasts = 0;
     var msgCount = 0;
+    var data;
 
-    switch (conf.payload) {
+    switch (payload) {
       case 'string':
-        payload = 'hello world!';
+        data = 'hello world!';
         break;
       case 'object':
-        payload = { action: 'pewpewpew', powerLevel: 9001 };
+        data = { action: 'pewpewpew', powerLevel: 9001 };
         break;
       default:
         throw new Error('Unsupported payload type');
@@ -51,8 +48,8 @@ if (cluster.isMaster) {
       }
       for (id in cluster.workers) {
         const worker = cluster.workers[id];
-        for (var i = 0; i < sends; ++i)
-          worker.send(payload);
+        for (var i = 0; i < sendsPerBroadcast; ++i)
+          worker.send(data);
       }
     }
 

--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const dgram = require('dgram');
 const PORT = common.PORT;
 
 // `num` is the number of send requests to queue up each time.
@@ -15,34 +16,15 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var dur;
-var len;
-var num;
-var type;
-var chunk;
-var chunks;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  num = +conf.num;
-  type = conf.type;
-  chunks = +conf.chunks;
-
-  chunk = [];
+function main({ dur, len, num, type, chunks }) {
+  const chunk = [];
   for (var i = 0; i < chunks; i++) {
     chunk.push(Buffer.allocUnsafe(Math.round(len / chunks)));
   }
 
-  server();
-}
-
-const dgram = require('dgram');
-
-function server() {
+  // Server
   var sent = 0;
   const socket = dgram.createSocket('udp4');
-
   const onsend = type === 'concat' ? onsendConcat : onsendMulti;
 
   function onsendConcat() {

--- a/benchmark/dgram/bind-params.js
+++ b/benchmark/dgram/bind-params.js
@@ -12,10 +12,9 @@ const configs = {
 const bench = common.createBenchmark(main, configs);
 const noop = () => {};
 
-function main(conf) {
-  const n = +conf.n;
-  const port = conf.port === 'true' ? 0 : undefined;
-  const address = conf.address === 'true' ? '0.0.0.0' : undefined;
+function main({ n, port, address }) {
+  port = port === 'true' ? 0 : undefined;
+  address = address === 'true' ? '0.0.0.0' : undefined;
 
   if (port !== undefined && address !== undefined) {
     bench.start();

--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const dgram = require('dgram');
 const PORT = common.PORT;
 
 // `num` is the number of send requests to queue up each time.
@@ -15,31 +16,11 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var dur;
-var len;
-var num;
-var type;
-var chunk;
-var chunks;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  num = +conf.num;
-  type = conf.type;
-  chunks = +conf.chunks;
-
-  chunk = [];
+function main({ dur, len, num, type, chunks }) {
+  const chunk = [];
   for (var i = 0; i < chunks; i++) {
     chunk.push(Buffer.allocUnsafe(Math.round(len / chunks)));
   }
-
-  server();
-}
-
-const dgram = require('dgram');
-
-function server() {
   var sent = 0;
   var received = 0;
   const socket = dgram.createSocket('udp4');

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const dgram = require('dgram');
 const PORT = common.PORT;
 
 // `num` is the number of send requests to queue up each time.
@@ -14,24 +15,8 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var dur;
-var len;
-var num;
-var type;
-var chunk;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  num = +conf.num;
-  type = conf.type;
-  chunk = Buffer.allocUnsafe(len);
-  server();
-}
-
-const dgram = require('dgram');
-
-function server() {
+function main({ dur, len, num, type }) {
+  const chunk = Buffer.allocUnsafe(len);
   var sent = 0;
   var received = 0;
   const socket = dgram.createSocket('udp4');

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const dgram = require('dgram');
 const PORT = common.PORT;
 
 // `num` is the number of send requests to queue up each time.
@@ -14,24 +15,8 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var dur;
-var len;
-var num;
-var type;
-var chunk;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  num = +conf.num;
-  type = conf.type;
-  chunk = Buffer.allocUnsafe(len);
-  server();
-}
-
-const dgram = require('dgram');
-
-function server() {
+function main({ dur, len, num, type }) {
+  const chunk = Buffer.allocUnsafe(len);
   var sent = 0;
   var received = 0;
   const socket = dgram.createSocket('udp4');

--- a/benchmark/dns/lookup.js
+++ b/benchmark/dns/lookup.js
@@ -9,13 +9,10 @@ const bench = common.createBenchmark(main, {
   n: [5e6]
 });
 
-function main(conf) {
-  const name = conf.name;
-  const n = +conf.n;
-  const all = conf.all === 'true' ? true : false;
+function main({ name, n, all }) {
   var i = 0;
 
-  if (all) {
+  if (all === 'true') {
     const opts = { all: true };
     bench.start();
     (function cb() {

--- a/benchmark/domain/domain-fn-args.js
+++ b/benchmark/domain/domain-fn-args.js
@@ -3,17 +3,15 @@ const common = require('../common.js');
 const domain = require('domain');
 
 const bench = common.createBenchmark(main, {
-  arguments: [0, 1, 2, 3],
+  args: [0, 1, 2, 3],
   n: [10]
 });
 
 const bdomain = domain.create();
 const gargs = [1, 2, 3];
 
-function main(conf) {
-
-  const n = +conf.n;
-  const myArguments = gargs.slice(0, conf.arguments);
+function main({ n, args }) {
+  const myArguments = gargs.slice(0, args);
   bench.start();
 
   bdomain.enter();

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -38,10 +38,10 @@ function runDefaultParams(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'withoutdefaults':

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -34,10 +34,10 @@ function runSwapDestructured(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'swap':

--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -33,10 +33,10 @@ function runDestructured(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'normal':

--- a/benchmark/es/foreach-bench.js
+++ b/benchmark/es/foreach-bench.js
@@ -52,17 +52,15 @@ function useForEach(n, items) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
-  const count = +conf.count;
-
+function main({ millions, count, method }) {
+  const n = millions * 1e6;
   const items = new Array(count);
   var i;
   var fn;
   for (i = 0; i < count; i++)
     items[i] = i;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'for':

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -108,10 +108,10 @@ function runMap(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'object':

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -60,10 +60,10 @@ function runUseArguments(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'copy':

--- a/benchmark/es/spread-bench.js
+++ b/benchmark/es/spread-bench.js
@@ -23,16 +23,16 @@ function makeTest(count, rest) {
   }
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
-  const ctx = conf.context === 'context' ? {} : null;
-  var fn = makeTest(conf.count, conf.rest);
-  const args = new Array(conf.count);
+function main({ millions, context, count, rest, method }) {
+  const n = millions * 1e6;
+  const ctx = context === 'context' ? {} : null;
+  var fn = makeTest(count, rest);
+  const args = new Array(count);
   var i;
-  for (i = 0; i < conf.count; i++)
+  for (i = 0; i < count; i++)
     args[i] = i;
 
-  switch (conf.method) {
+  switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'apply':

--- a/benchmark/es/string-concatenations.js
+++ b/benchmark/es/string-concatenations.js
@@ -17,15 +17,13 @@ const configs = {
 const bench = common.createBenchmark(main, configs);
 
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n, mode }) {
   const str = 'abc';
   const num = 123;
 
   let string;
 
-  switch (conf.mode) {
+  switch (mode) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'multi-concat':

--- a/benchmark/es/string-repeat.js
+++ b/benchmark/es/string-repeat.js
@@ -12,14 +12,12 @@ const configs = {
 
 const bench = common.createBenchmark(main, configs);
 
-function main(conf) {
-  const n = +conf.n;
-  const size = +conf.size;
-  const character = conf.encoding === 'ascii' ? 'a' : '\ud83d\udc0e'; // '🐎'
+function main({ n, size, encoding, mode }) {
+  const character = encoding === 'ascii' ? 'a' : '\ud83d\udc0e'; // '🐎'
 
   let str;
 
-  switch (conf.mode) {
+  switch (mode) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'Array':

--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -4,9 +4,7 @@ const events = require('events');
 
 const bench = common.createBenchmark(main, { n: [25e4] });
 
-function main(conf) {
-  const n = conf.n | 0;
-
+function main({ n }) {
   const ee = new events.EventEmitter();
   const listeners = [];
 

--- a/benchmark/events/ee-emit.js
+++ b/benchmark/events/ee-emit.js
@@ -8,11 +8,7 @@ const bench = common.createBenchmark(main, {
   listeners: [1, 5, 10],
 });
 
-function main(conf) {
-  const n = conf.n | 0;
-  const argc = conf.argc | 0;
-  const listeners = Math.max(conf.listeners | 0, 1);
-
+function main({ n, argc, listeners }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < listeners; k += 1)

--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -4,9 +4,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const bench = common.createBenchmark(main, { n: [5e7] });
 
-function main(conf) {
-  const n = conf.n | 0;
-
+function main({ n }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -4,9 +4,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const bench = common.createBenchmark(main, { n: [5e6] });
 
-function main(conf) {
-  const n = conf.n | 0;
-
+function main({ n }) {
   const ee = new EventEmitter();
   ee.setMaxListeners(101);
 

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -4,9 +4,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const bench = common.createBenchmark(main, { n: [5e6] });
 
-function main(conf) {
-  const n = conf.n | 0;
-
+function main({ n }) {
   const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {

--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -4,9 +4,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const bench = common.createBenchmark(main, { n: [2e7] });
 
-function main(conf) {
-  const n = conf.n | 0;
-
+function main({ n }) {
   const ee = new EventEmitter();
 
   function listener() {}

--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -9,9 +9,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-
+function main({ n }) {
   bench.start();
   (function r(cntr) {
     if (cntr-- <= 0)

--- a/benchmark/fs/bench-readdirSync.js
+++ b/benchmark/fs/bench-readdirSync.js
@@ -9,9 +9,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; i++) {
     fs.readdirSync(path.resolve(__dirname, '../../lib/'));

--- a/benchmark/fs/bench-realpath.js
+++ b/benchmark/fs/bench-realpath.js
@@ -12,10 +12,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-  const pathType = conf.pathType;
-
+function main({ n, pathType }) {
   bench.start();
   if (pathType === 'relative')
     relativePath(n);

--- a/benchmark/fs/bench-realpathSync.js
+++ b/benchmark/fs/bench-realpathSync.js
@@ -14,10 +14,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-  const pathType = conf.pathType;
-
+function main({ n, pathType }) {
   bench.start();
   if (pathType === 'relative')
     relativePath(n);

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -9,9 +9,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-  const statType = conf.statType;
+function main({ n, statType }) {
   var arg;
   if (statType === 'fstat')
     arg = fs.openSync(__filename, 'r');

--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -9,9 +9,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
-  const statSyncType = conf.statSyncType;
+function main({ n, statSyncType }) {
   const arg = (statSyncType === 'fstatSync' ?
     fs.openSync(__filename, 'r') :
     __dirname);

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -18,7 +18,7 @@ const bench = common.createBenchmark(main, {
 
 function main(conf) {
   encodingType = conf.encodingType;
-  size = +conf.size;
+  size = conf.size;
   filesize = conf.filesize;
 
   switch (encodingType) {

--- a/benchmark/fs/readFileSync.js
+++ b/benchmark/fs/readFileSync.js
@@ -7,9 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [60e4]
 });
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; ++i)
     fs.readFileSync(__filename);

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -15,8 +15,7 @@ const bench = common.createBenchmark(main, {
   concurrent: [1, 10]
 });
 
-function main(conf) {
-  const len = +conf.len;
+function main({ len, dur, concurrent }) {
   try { fs.unlinkSync(filename); } catch (e) {}
   var data = Buffer.alloc(len, 'x');
   fs.writeFileSync(filename, data);
@@ -30,7 +29,7 @@ function main(conf) {
     bench.end(reads);
     try { fs.unlinkSync(filename); } catch (e) {}
     process.exit(0);
-  }, +conf.dur * 1000);
+  }, dur * 1000);
 
   function read() {
     fs.readFile(filename, afterRead);
@@ -48,6 +47,5 @@ function main(conf) {
       read();
   }
 
-  var cur = +conf.concurrent;
-  while (cur--) read();
+  while (concurrent--) read();
 }

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -13,10 +13,7 @@ const bench = common.createBenchmark(main, {
   size: [2, 1024, 65535, 1024 * 1024]
 });
 
-function main(conf) {
-  const dur = +conf.dur;
-  const encodingType = conf.encodingType;
-  const size = +conf.size;
+function main({ dur, encodingType, size }) {
   var encoding;
 
   var chunk;

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -11,9 +11,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const len = +conf.len;
-  const num = +conf.n;
+function main({ len, n }) {
   var todo = [];
   const headers = [];
   // Chose 7 because 9 showed "Connection error" / "Connection closed"
@@ -78,7 +76,7 @@ function main(conf) {
       size = (size * mult + add) % mod;
       if (did) {
         count += 1;
-        if (count === num) {
+        if (count === n) {
           bench.end(count);
           process.exit(0);
         } else {

--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -15,9 +15,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const len = conf.len >>> 0;
-  const n = conf.n >>> 0;
+function main({ len, n }) {
   var header = `GET /hello HTTP/1.1${CRLF}Content-Type: text/plain${CRLF}`;
 
   for (var i = 0; i < len; i++) {

--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -30,10 +30,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6],
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const key = conf.key;
-
+function main({ n, key }) {
   bench.start();
   for (var i = 0; i < n; i++) {
     _checkInvalidHeaderChar(key);

--- a/benchmark/http/check_is_http_token.js
+++ b/benchmark/http/check_is_http_token.js
@@ -40,10 +40,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6],
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const key = conf.key;
-
+function main({ n, key }) {
   bench.start();
   for (var i = 0; i < n; i++) {
     _checkIsHttpToken(key);

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -16,9 +16,9 @@ const bench = common.createBenchmark(main, {
   c: [100]
 });
 
-function main(conf) {
+function main({ len, n, c }) {
   const http = require('http');
-  const chunk = Buffer.alloc(conf.len, '8');
+  const chunk = Buffer.alloc(len, '8');
 
   const server = http.createServer(function(req, res) {
     function send(left) {
@@ -28,12 +28,12 @@ function main(conf) {
         send(left - 1);
       }, 0);
     }
-    send(conf.n);
+    send(n);
   });
 
   server.listen(common.PORT, function() {
     bench.http({
-      connections: conf.c
+      connections: c
     }, function() {
       server.close();
     });

--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -11,13 +11,10 @@ const bench = common.createBenchmark(main, {
   method: ['write', 'end']
 });
 
-function main(conf) {
-  const dur = +conf.dur;
-  const len = +conf.len;
-
+function main({ dur, len, type, method }) {
   var encoding;
   var chunk;
-  switch (conf.type) {
+  switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
       break;
@@ -55,7 +52,7 @@ function main(conf) {
       pummel();  // Line up next request.
       res.resume();
     });
-    if (conf.method === 'write') {
+    if (method === 'write') {
       req.write(chunk, encoding);
       req.end();
     } else {

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -15,7 +15,7 @@ if (cluster.isMaster) {
   require('../fixtures/simple-http-server.js').listen(port);
 }
 
-function main(conf) {
+function main({ type, len, c }) {
   process.env.PORT = PORT;
   var workers = 0;
   const w1 = cluster.fork();
@@ -27,11 +27,11 @@ function main(conf) {
       return;
 
     setTimeout(function() {
-      const path = `/${conf.type}/${conf.len}`;
+      const path = `/${type}/${len}`;
 
       bench.http({
         path: path,
-        connections: conf.c
+        connections: c
       }, function() {
         w1.destroy();
         w2.destroy();

--- a/benchmark/http/create-clientrequest.js
+++ b/benchmark/http/create-clientrequest.js
@@ -8,10 +8,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const len = +conf.len;
-  const n = +conf.n;
-
+function main({ len, n }) {
   const path = '/'.repeat(len);
   const opts = { path: path, createConnection: function() {} };
 

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -17,11 +17,10 @@ const bench = common.createBenchmark(main, {
   method: ['write', 'end']
 });
 
-function main(conf) {
+function main({ len, type, method, c }) {
   const http = require('http');
   var chunk;
-  const len = conf.len;
-  switch (conf.type) {
+  switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
       break;
@@ -42,15 +41,15 @@ function main(conf) {
     res.end(chunk);
   }
 
-  const method = conf.method === 'write' ? write : end;
+  const fn = method === 'write' ? write : end;
 
   const server = http.createServer(function(req, res) {
-    method(res);
+    fn(res);
   });
 
   server.listen(common.PORT, function() {
     bench.http({
-      connections: conf.c
+      connections: c
     }, function() {
       server.close();
     });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -12,17 +12,16 @@ const bench = common.createBenchmark(main, {
   res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
-function main(conf) {
+function main({ type, len, chunks, c, chunkedEnc, res }) {
   process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
   .listen(PORT)
   .on('listening', function() {
-    const path =
-      `/${conf.type}/${conf.len}/${conf.chunks}/${conf.res}/${conf.chunkedEnc}`;
+    const path = `/${type}/${len}/${chunks}/${res}/${chunkedEnc}`;
 
     bench.http({
       path: path,
-      connections: conf.c
+      connections: c
     }, function() {
       server.close();
     });

--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -9,9 +9,7 @@ const bench = common.createBenchmark(main, {
   benchmarker: ['h2load']
 }, { flags: ['--no-warnings', '--expose-http2'] });
 
-function main(conf) {
-  const n = +conf.n;
-  const nheaders = +conf.nheaders;
+function main({ n, nheaders }) {
   const http2 = require('http2');
   const server = http2.createServer({
     maxHeaderListPairs: 20000

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -14,15 +14,11 @@ const bench = common.createBenchmark(main, {
   benchmarker: ['h2load']
 }, { flags: ['--no-warnings', '--expose-http2'] });
 
-function main(conf) {
-
+function main({ requests, streams, clients }) {
   fs.open(file, 'r', (err, fd) => {
     if (err)
       throw err;
 
-    const n = +conf.requests;
-    const m = +conf.streams;
-    const c = +conf.clients;
     const http2 = require('http2');
     const server = http2.createServer();
     server.on('stream', (stream) => {
@@ -32,10 +28,10 @@ function main(conf) {
     server.listen(PORT, () => {
       bench.http({
         path: '/',
-        requests: n,
-        maxConcurrentStreams: m,
-        clients: c,
-        threads: c
+        requests,
+        maxConcurrentStreams: streams,
+        clients,
+        threads: clients
       }, () => server.close());
     });
 

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -15,10 +15,7 @@ const bench = common.createBenchmark(main, {
   benchmarker: ['h2load']
 }, { flags: ['--no-warnings', '--expose-http2'] });
 
-function main(conf) {
-  const n = +conf.requests;
-  const m = +conf.streams;
-  const c = +conf.clients;
+function main({ requests, streams, clients }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
@@ -30,10 +27,10 @@ function main(conf) {
   server.listen(PORT, () => {
     bench.http({
       path: '/',
-      requests: n,
-      maxConcurrentStreams: m,
-      clients: c,
-      threads: c
+      requests,
+      maxConcurrentStreams: streams,
+      clients,
+      threads: clients
     }, () => { server.close(); });
   });
 }

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -10,19 +10,16 @@ const bench = common.createBenchmark(main, {
   benchmarker: ['h2load']
 }, { flags: ['--no-warnings', '--expose-http2'] });
 
-function main(conf) {
-  const m = +conf.streams;
-  const l = +conf.length;
-  const s = +conf.size;
+function main({ streams, length, size }) {
   const http2 = require('http2');
   const server = http2.createServer();
   server.on('stream', (stream) => {
     stream.respond();
     let written = 0;
     function write() {
-      stream.write('ü'.repeat(s));
-      written += s;
-      if (written < l)
+      stream.write('ü'.repeat(size));
+      written += size;
+      if (written < length)
         setImmediate(write);
       else
         stream.end();
@@ -33,7 +30,7 @@ function main(conf) {
     bench.http({
       path: '/',
       requests: 10000,
-      maxConcurrentStreams: m,
+      maxConcurrentStreams: streams,
     }, () => { server.close(); });
   });
 }

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -8,9 +8,8 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals']
 });
 
-function main(conf) {
+function main({ n }) {
   const FreeList = require('internal/freelist');
-  const n = conf.n;
   const poolSize = 1000;
   const list = new FreeList('test', poolSize, Object);
   var i;

--- a/benchmark/misc/function_call/index.js
+++ b/benchmark/misc/function_call/index.js
@@ -31,13 +31,13 @@ const bench = common.createBenchmark(main, {
   millions: [1, 10, 50]
 });
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, type }) {
+  const n = millions * 1e6;
 
-  const fn = conf.type === 'cxx' ? cxx : js;
+  const fn = type === 'cxx' ? cxx : js;
   bench.start();
   for (var i = 0; i < n; i++) {
     fn();
   }
-  bench.end(+conf.millions);
+  bench.end(millions);
 }

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -59,10 +59,10 @@ function runSymbol(n) {
   bench.end(n / 1e6);
 }
 
-function main(conf) {
-  const n = +conf.millions * 1e6;
+function main({ millions, method }) {
+  const n = millions * 1e6;
 
-  switch (conf.method) {
+  switch (method) {
     // '' is a default case for tests
     case '':
     case 'property':

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -62,10 +62,8 @@ function runICU(n, val) {
   bench.end(n);
 }
 
-function main(conf) {
-  const n = +conf.n;
-  const val = conf.val;
-  switch (conf.method) {
+function main({ n, val, method }) {
+  switch (method) {
     // '' is a default case for tests
     case '':
     case 'punycode':

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -8,8 +8,7 @@ const bench = common.createBenchmark(startNode, {
   dur: [1]
 });
 
-function startNode(conf) {
-  const dur = +conf.dur;
+function startNode({ dur }) {
   var go = true;
   var starts = 0;
 

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -8,19 +8,17 @@ const bench = common.createBenchmark(main, {
   n: [10e4]
 });
 
-function main(conf) {
+function main({ n, type }) {
   let fn;
-  const n = conf.n | 0;
-
-  if (conf.type === 'extend') {
+  if (type === 'extend') {
     fn = util._extend;
-  } else if (conf.type === 'assign') {
+  } else if (type === 'assign') {
     fn = Object.assign;
   }
 
   // Force-optimize the method to test so that the benchmark doesn't
   // get disrupted by the optimizer kicking in halfway through.
-  for (var i = 0; i < conf.type.length * 10; i += 1)
+  for (var i = 0; i < type.length * 10; i += 1)
     fn({}, process.env);
 
   const obj = new Proxy({}, { set: function(a, b, c) { return true; } });

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -12,8 +12,8 @@ const bench = common.createBenchmark(main, {
   useCache: ['true', 'false']
 });
 
-function main(conf) {
-  const n = +conf.thousands * 1e3;
+function main({ thousands, fullPath, useCache }) {
+  const n = thousands * 1e3;
 
   refreshTmpDir();
   try { fs.mkdirSync(benchmarkDirectory); } catch (e) {}
@@ -30,10 +30,10 @@ function main(conf) {
     );
   }
 
-  if (conf.fullPath === 'true')
-    measureFull(n, conf.useCache === 'true');
+  if (fullPath === 'true')
+    measureFull(n, useCache === 'true');
   else
-    measureDir(n, conf.useCache === 'true');
+    measureDir(n, useCache === 'true');
 
   refreshTmpDir();
 }

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
@@ -10,17 +11,10 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var dur;
-var len;
-var type;
 var chunk;
 var encoding;
 
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-
+function main({ dur, len, type }) {
   switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -37,34 +31,6 @@ function main(conf) {
       throw new Error(`invalid type: ${type}`);
   }
 
-  server();
-}
-
-const net = require('net');
-
-function Writer() {
-  this.received = 0;
-  this.writable = true;
-}
-
-Writer.prototype.write = function(chunk, encoding, cb) {
-  this.received += chunk.length;
-
-  if (typeof encoding === 'function')
-    encoding();
-  else if (typeof cb === 'function')
-    cb();
-
-  return true;
-};
-
-// doesn't matter, never emits anything.
-Writer.prototype.on = function() {};
-Writer.prototype.once = function() {};
-Writer.prototype.emit = function() {};
-Writer.prototype.prependListener = function() {};
-
-function server() {
   const writer = new Writer();
 
   // the actual benchmark.
@@ -95,3 +61,25 @@ function server() {
     });
   });
 }
+
+function Writer() {
+  this.received = 0;
+  this.writable = true;
+}
+
+Writer.prototype.write = function(chunk, encoding, cb) {
+  this.received += chunk.length;
+
+  if (typeof encoding === 'function')
+    encoding();
+  else if (typeof cb === 'function')
+    cb();
+
+  return true;
+};
+
+// doesn't matter, never emits anything.
+Writer.prototype.on = function() {};
+Writer.prototype.once = function() {};
+Writer.prototype.emit = function() {};
+Writer.prototype.prependListener = function() {};

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
@@ -10,17 +11,10 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var dur;
-var len;
-var type;
 var chunk;
 var encoding;
 
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-
+function main({ dur, len, type }) {
   switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -37,10 +31,30 @@ function main(conf) {
       throw new Error(`invalid type: ${type}`);
   }
 
-  server();
-}
+  const reader = new Reader();
+  const writer = new Writer();
 
-const net = require('net');
+  // the actual benchmark.
+  const server = net.createServer(function(socket) {
+    socket.pipe(writer);
+  });
+
+  server.listen(PORT, function() {
+    const socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      reader.pipe(socket);
+
+      setTimeout(function() {
+        const bytes = writer.received;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+        process.exit(0);
+      }, dur * 1000);
+    });
+  });
+}
 
 function Writer() {
   this.received = 0;
@@ -84,30 +98,3 @@ Reader.prototype.pipe = function(dest) {
   this.flow();
   return dest;
 };
-
-
-function server() {
-  const reader = new Reader();
-  const writer = new Writer();
-
-  // the actual benchmark.
-  const server = net.createServer(function(socket) {
-    socket.pipe(writer);
-  });
-
-  server.listen(PORT, function() {
-    const socket = net.connect(PORT);
-    socket.on('connect', function() {
-      bench.start();
-
-      reader.pipe(socket);
-
-      setTimeout(function() {
-        const bytes = writer.received;
-        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
-        bench.end(gbits);
-        process.exit(0);
-      }, dur * 1000);
-    });
-  });
-}

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common.js');
+const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
@@ -10,17 +11,10 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-var dur;
-var len;
-var type;
 var chunk;
 var encoding;
 
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-
+function main({ dur, len, type }) {
   switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -37,10 +31,33 @@ function main(conf) {
       throw new Error(`invalid type: ${type}`);
   }
 
-  server();
-}
+  const reader = new Reader();
+  const writer = new Writer();
 
-const net = require('net');
+  // the actual benchmark.
+  const server = net.createServer(function(socket) {
+    socket.pipe(socket);
+  });
+
+  server.listen(PORT, function() {
+    const socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      reader.pipe(socket);
+      socket.pipe(writer);
+
+      setTimeout(function() {
+        // multiply by 2 since we're sending it first one way
+        // then then back again.
+        const bytes = writer.received * 2;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+        process.exit(0);
+      }, dur * 1000);
+    });
+  });
+}
 
 function Writer() {
   this.received = 0;
@@ -84,33 +101,3 @@ Reader.prototype.pipe = function(dest) {
   this.flow();
   return dest;
 };
-
-
-function server() {
-  const reader = new Reader();
-  const writer = new Writer();
-
-  // the actual benchmark.
-  const server = net.createServer(function(socket) {
-    socket.pipe(socket);
-  });
-
-  server.listen(PORT, function() {
-    const socket = net.connect(PORT);
-    socket.on('connect', function() {
-      bench.start();
-
-      reader.pipe(socket);
-      socket.pipe(writer);
-
-      setTimeout(function() {
-        // multiply by 2 since we're sending it first one way
-        // then then back again.
-        const bytes = writer.received * 2;
-        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
-        bench.end(gbits);
-        process.exit(0);
-      }, dur * 1000);
-    });
-  });
-}

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -10,17 +10,10 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-var dur;
-var len;
-var type;
 var chunk;
 var encoding;
 
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-
+function main({ dur, len, type }) {
   switch (type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -37,7 +30,29 @@ function main(conf) {
       throw new Error(`invalid type: ${type}`);
   }
 
-  server();
+  const reader = new Reader();
+  const writer = new Writer();
+
+  // the actual benchmark.
+  const server = net.createServer(function(socket) {
+    reader.pipe(socket);
+  });
+
+  server.listen(PORT, function() {
+    const socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      socket.pipe(writer);
+
+      setTimeout(function() {
+        const bytes = writer.received;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+        process.exit(0);
+      }, dur * 1000);
+    });
+  });
 }
 
 const net = require('net');
@@ -84,30 +99,3 @@ Reader.prototype.pipe = function(dest) {
   this.flow();
   return dest;
 };
-
-
-function server() {
-  const reader = new Reader();
-  const writer = new Writer();
-
-  // the actual benchmark.
-  const server = net.createServer(function(socket) {
-    reader.pipe(socket);
-  });
-
-  server.listen(PORT, function() {
-    const socket = net.connect(PORT);
-    socket.on('connect', function() {
-      bench.start();
-
-      socket.pipe(writer);
-
-      setTimeout(function() {
-        const bytes = writer.received;
-        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
-        bench.end(gbits);
-        process.exit(0);
-      }, dur * 1000);
-    });
-  });
-}

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -19,23 +19,7 @@ const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
 const WriteWrap = process.binding('stream_wrap').WriteWrap;
 const PORT = common.PORT;
 
-var dur;
-var len;
-var type;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-  server();
-}
-
-
-function fail(err, syscall) {
-  throw util._errnoException(err, syscall);
-}
-
-function server() {
+function main({ dur, len, type }) {
   const serverHandle = new TCP(TCPConstants.SERVER);
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
@@ -73,10 +57,15 @@ function server() {
     clientHandle.readStart();
   };
 
-  client();
+  client(type, len);
 }
 
-function client() {
+
+function fail(err, syscall) {
+  throw util._errnoException(err, syscall);
+}
+
+function client(type, len) {
   var chunk;
   switch (type) {
     case 'buf':

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -14,27 +14,17 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
+function fail(err, syscall) {
+  throw util._errnoException(err, syscall);
+}
+
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
 const WriteWrap = process.binding('stream_wrap').WriteWrap;
 const PORT = common.PORT;
 
-var dur;
-var len;
-var type;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-  server();
-}
-
-function fail(err, syscall) {
-  throw util._errnoException(err, syscall);
-}
-
-function server() {
+function main({ dur, len, type }) {
+  // Server
   const serverHandle = new TCP(TCPConstants.SERVER);
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
@@ -70,10 +60,7 @@ function server() {
     clientHandle.readStart();
   };
 
-  client();
-}
-
-function client() {
+  // Client
   var chunk;
   switch (type) {
     case 'buf':
@@ -91,9 +78,9 @@ function client() {
 
   const clientHandle = new TCP(TCPConstants.SOCKET);
   const connectReq = new TCPConnectWrap();
-  const err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
   var bytes = 0;
 
+  err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
   if (err)
     fail(err, 'connect');
 

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -19,22 +19,7 @@ const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
 const WriteWrap = process.binding('stream_wrap').WriteWrap;
 const PORT = common.PORT;
 
-var dur;
-var len;
-var type;
-
-function main(conf) {
-  dur = +conf.dur;
-  len = +conf.len;
-  type = conf.type;
-  server();
-}
-
-function fail(err, syscall) {
-  throw util._errnoException(err, syscall);
-}
-
-function server() {
+function main({ dur, len, type }) {
   const serverHandle = new TCP(TCPConstants.SERVER);
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
@@ -103,10 +88,14 @@ function server() {
     }
   };
 
-  client();
+  client(dur);
 }
 
-function client() {
+function fail(err, syscall) {
+  throw util._errnoException(err, syscall);
+}
+
+function client(dur) {
   const clientHandle = new TCP(TCPConstants.SOCKET);
   const connectReq = new TCPConnectWrap();
   const err = clientHandle.connect(connectReq, '127.0.0.1', PORT);

--- a/benchmark/os/cpus.js
+++ b/benchmark/os/cpus.js
@@ -7,9 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [3e4]
 });
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; ++i)
     cpus();

--- a/benchmark/os/loadavg.js
+++ b/benchmark/os/loadavg.js
@@ -7,9 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [5e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; ++i)
     loadavg();

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   pathext: [
@@ -18,20 +18,17 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  var input = String(conf.pathext);
+function main({ n, pathext }) {
   var ext;
-  const extIdx = input.indexOf('|');
+  const extIdx = pathext.indexOf('|');
   if (extIdx !== -1) {
-    ext = input.slice(extIdx + 1);
-    input = input.slice(0, extIdx);
+    ext = pathext.slice(extIdx + 1);
+    pathext = pathext.slice(0, extIdx);
   }
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.basename(input, ext);
+    posix.basename(pathext, ext);
   }
   bench.end(n);
 }

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   pathext: [
@@ -18,20 +18,17 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  var input = String(conf.pathext);
+function main({ n, pathext }) {
   var ext;
-  const extIdx = input.indexOf('|');
+  const extIdx = pathext.indexOf('|');
   if (extIdx !== -1) {
-    ext = input.slice(extIdx + 1);
-    input = input.slice(0, extIdx);
+    ext = pathext.slice(extIdx + 1);
+    pathext = pathext.slice(0, extIdx);
   }
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.basename(input, ext);
+    posix.basename(pathext, ext);
   }
   bench.end(n);
 }

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -15,14 +15,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.dirname(input);
+    posix.dirname(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -15,14 +15,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.dirname(input);
+    win32.dirname(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -18,14 +18,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.extname(input);
+    posix.extname(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -18,14 +18,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.extname(input);
+    win32.extname(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   props: [
@@ -9,10 +9,8 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const props = String(conf.props).split('|');
+function main({ n, props }) {
+  props = props.split('|');
   const obj = {
     root: props[0] || '',
     dir: props[1] || '',
@@ -23,7 +21,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.format(obj);
+    posix.format(obj);
   }
   bench.end(n);
 }

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   props: [
@@ -9,10 +9,8 @@ const bench = common.createBenchmark(main, {
   n: [1e7]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const props = String(conf.props).split('|');
+function main({ n, props }) {
+  props = props.split('|');
   const obj = {
     root: props[0] || '',
     dir: props[1] || '',
@@ -23,7 +21,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.format(obj);
+    win32.format(obj);
   }
   bench.end(n);
 }

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -13,14 +13,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.isAbsolute(input);
+    posix.isAbsolute(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -14,14 +14,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.isAbsolute(input);
+    win32.isAbsolute(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -9,14 +9,12 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const args = String(conf.paths).split('|');
+function main({ n, paths }) {
+  const args = paths.split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.join.apply(null, args);
+    posix.join.apply(null, args);
   }
   bench.end(n);
 }

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -9,14 +9,12 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const args = String(conf.paths).split('|');
+function main({ n, paths }) {
+  const args = paths.split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.join.apply(null, args);
+    win32.join.apply(null, args);
   }
   bench.end(n);
 }

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -12,14 +12,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p._makeLong(input);
+    win32._makeLong(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -14,14 +14,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.normalize(input);
+    posix.normalize(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -14,14 +14,10 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.normalize(input);
+    win32.normalize(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/parse-posix.js
+++ b/benchmark/path/parse-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -15,17 +15,13 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   for (var i = 0; i < n; i++) {
-    p.parse(input);
+    posix.parse(path);
   }
   bench.start();
   for (i = 0; i < n; i++) {
-    p.parse(input);
+    posix.parse(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/parse-win32.js
+++ b/benchmark/path/parse-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   path: [
@@ -16,17 +16,13 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const input = String(conf.path);
-
+function main({ n, path }) {
   for (var i = 0; i < n; i++) {
-    p.parse(input);
+    win32.parse(path);
   }
   bench.start();
   for (i = 0; i < n; i++) {
-    p.parse(input);
+    win32.parse(path);
   }
   bench.end(n);
 }

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -15,23 +15,20 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  var from = String(conf.paths);
+function main({ n, paths }) {
   var to = '';
-  const delimIdx = from.indexOf('|');
+  const delimIdx = paths.indexOf('|');
   if (delimIdx > -1) {
-    to = from.slice(delimIdx + 1);
-    from = from.slice(0, delimIdx);
+    to = paths.slice(delimIdx + 1);
+    paths = paths.slice(0, delimIdx);
   }
   for (var i = 0; i < n; i++) {
-    p.relative(from, to);
+    posix.relative(paths, to);
   }
 
   bench.start();
   for (i = 0; i < n; i++) {
-    p.relative(from, to);
+    posix.relative(paths, to);
   }
   bench.end(n);
 }

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -13,25 +13,22 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  var from = String(conf.paths);
+function main({ n, paths }) {
   var to = '';
-  const delimIdx = from.indexOf('|');
+  const delimIdx = paths.indexOf('|');
   if (delimIdx > -1) {
-    to = from.slice(delimIdx + 1);
-    from = from.slice(0, delimIdx);
+    to = paths.slice(delimIdx + 1);
+    paths = paths.slice(0, delimIdx);
   }
 
   // Warmup
   for (var i = 0; i < n; i++) {
-    p.relative(from, to);
+    win32.relative(paths, to);
   }
 
   bench.start();
   for (i = 0; i < n; i++) {
-    p.relative(from, to);
+    win32.relative(paths, to);
   }
   bench.end(n);
 }

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { posix } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -12,14 +12,12 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.posix;
-  const args = String(conf.paths).split('|');
+function main({ n, paths }) {
+  const args = paths.split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve.apply(null, args);
+    posix.resolve.apply(null, args);
   }
   bench.end(n);
 }

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const path = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   paths: [
@@ -12,14 +12,12 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const p = path.win32;
-  const args = String(conf.paths).split('|');
+function main({ n, paths }) {
+  const args = paths.split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve.apply(null, args);
+    win32.resolve.apply(null, args);
   }
   bench.end(n);
 }

--- a/benchmark/process/bench-env.js
+++ b/benchmark/process/bench-env.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
 });
 
 
-function main(conf) {
-  const n = conf.n >>> 0;
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; i++) {
     // Access every item in object to process values.

--- a/benchmark/process/bench-hrtime.js
+++ b/benchmark/process/bench-hrtime.js
@@ -8,13 +8,12 @@ const bench = common.createBenchmark(main, {
   type: ['raw', 'diff']
 });
 
-function main(conf) {
-  const n = conf.n | 0;
+function main({ n, type }) {
   const hrtime = process.hrtime;
   var noDead = hrtime();
   var i;
 
-  if (conf.type === 'raw') {
+  if (type === 'raw') {
     bench.start();
     for (i = 0; i < n; i++) {
       noDead = hrtime();

--- a/benchmark/process/memoryUsage.js
+++ b/benchmark/process/memoryUsage.js
@@ -5,9 +5,7 @@ const bench = common.createBenchmark(main, {
   n: [1e5]
 });
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; i++) {
     process.memoryUsage();

--- a/benchmark/process/next-tick-breadth-args.js
+++ b/benchmark/process/next-tick-breadth-args.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [4]
 });
 
-function main(conf) {
-  const N = +conf.millions * 1e6;
+function main({ millions }) {
+  const N = millions * 1e6;
   var n = 0;
 
   function cb1(arg1) {

--- a/benchmark/process/next-tick-breadth.js
+++ b/benchmark/process/next-tick-breadth.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [4]
 });
 
-function main(conf) {
-  const N = +conf.millions * 1e6;
+function main({ millions }) {
+  const N = millions * 1e6;
   var n = 0;
 
   function cb() {

--- a/benchmark/process/next-tick-depth-args.js
+++ b/benchmark/process/next-tick-depth-args.js
@@ -7,8 +7,8 @@ const bench = common.createBenchmark(main, {
 
 process.maxTickDepth = Infinity;
 
-function main(conf) {
-  var n = +conf.millions * 1e6;
+function main({ millions }) {
+  var n = millions * 1e6;
 
   function cb4(arg1, arg2, arg3, arg4) {
     if (--n) {
@@ -21,7 +21,7 @@ function main(conf) {
       else
         process.nextTick(cb1, 0);
     } else
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
   function cb3(arg1, arg2, arg3) {
     if (--n) {
@@ -34,7 +34,7 @@ function main(conf) {
       else
         process.nextTick(cb1, 0);
     } else
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
   function cb2(arg1, arg2) {
     if (--n) {
@@ -47,7 +47,7 @@ function main(conf) {
       else
         process.nextTick(cb1, 0);
     } else
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
   function cb1(arg1) {
     if (--n) {
@@ -60,7 +60,7 @@ function main(conf) {
       else
         process.nextTick(cb1, 0);
     } else
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
   bench.start();
   process.nextTick(cb1, true);

--- a/benchmark/process/next-tick-depth.js
+++ b/benchmark/process/next-tick-depth.js
@@ -6,8 +6,8 @@ const bench = common.createBenchmark(main, {
 
 process.maxTickDepth = Infinity;
 
-function main(conf) {
-  var n = +conf.millions * 1e6;
+function main({ millions }) {
+  var n = millions * 1e6;
 
   bench.start();
   process.nextTick(onNextTick);
@@ -15,6 +15,6 @@ function main(conf) {
     if (--n)
       process.nextTick(onNextTick);
     else
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
 }

--- a/benchmark/process/next-tick-exec-args.js
+++ b/benchmark/process/next-tick-exec-args.js
@@ -4,8 +4,8 @@ const bench = common.createBenchmark(main, {
   millions: [5]
 });
 
-function main(conf) {
-  var n = +conf.millions * 1e6;
+function main({ millions }) {
+  var n = millions * 1e6;
 
   bench.start();
   for (var i = 0; i < n; i++) {
@@ -20,6 +20,6 @@ function main(conf) {
   }
   function onNextTick(i) {
     if (i + 1 === n)
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
 }

--- a/benchmark/process/next-tick-exec.js
+++ b/benchmark/process/next-tick-exec.js
@@ -4,8 +4,8 @@ const bench = common.createBenchmark(main, {
   millions: [5]
 });
 
-function main(conf) {
-  var n = +conf.millions * 1e6;
+function main({ millions }) {
+  var n = millions * 1e6;
 
   bench.start();
   for (var i = 0; i < n; i++) {
@@ -13,6 +13,6 @@ function main(conf) {
   }
   function onNextTick(i) {
     if (i + 1 === n)
-      bench.end(+conf.millions);
+      bench.end(millions);
   }
 }

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -8,9 +8,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6],
 });
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
+function main({ type, n }) {
   const input = inputs[type];
   var i;
   // Execute the function a "sufficient" number of times before the timed

--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -7,10 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [1e7],
 });
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-
+function main({ type, n }) {
   const inputs = {
     noencode: {
       foo: 'bar',

--- a/benchmark/querystring/querystring-unescapebuffer.js
+++ b/benchmark/querystring/querystring-unescapebuffer.js
@@ -12,10 +12,7 @@ const bench = common.createBenchmark(main, {
   n: [10e6],
 });
 
-function main(conf) {
-  const input = conf.input;
-  const n = conf.n | 0;
-
+function main({ input, n }) {
   bench.start();
   for (var i = 0; i < n; i += 1)
     querystring.unescapeBuffer(input);

--- a/benchmark/streams/readable-bigread.js
+++ b/benchmark/streams/readable-bigread.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [100e1]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const b = new Buffer(32);
   const s = new Readable();
   function noop() {}

--- a/benchmark/streams/readable-bigunevenread.js
+++ b/benchmark/streams/readable-bigunevenread.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [100e1]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const b = new Buffer(32);
   const s = new Readable();
   function noop() {}

--- a/benchmark/streams/readable-boundaryread.js
+++ b/benchmark/streams/readable-boundaryread.js
@@ -8,11 +8,10 @@ const bench = common.createBenchmark(main, {
   type: ['string', 'buffer']
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n, type }) {
   const s = new Readable();
   var data = 'a'.repeat(32);
-  if (conf.type === 'buffer')
+  if (type === 'buffer')
     data = Buffer.from(data);
   s._read = function() {};
 

--- a/benchmark/streams/readable-readall.js
+++ b/benchmark/streams/readable-readall.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [50e2]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const b = new Buffer(32);
   const s = new Readable();
   function noop() {}

--- a/benchmark/streams/readable-unevenread.js
+++ b/benchmark/streams/readable-unevenread.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [100e1]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const b = new Buffer(32);
   const s = new Readable();
   function noop() {}

--- a/benchmark/streams/transform-creation.js
+++ b/benchmark/streams/transform-creation.js
@@ -13,9 +13,7 @@ function MyTransform() {
 inherits(MyTransform, Transform);
 MyTransform.prototype._transform = function() {};
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   bench.start();
   for (var i = 0; i < n; ++i)
     new MyTransform();

--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -7,8 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [2e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
+function main({ n }) {
   const b = Buffer.allocUnsafe(1024);
   const s = new Writable();
   s._write = function(chunk, encoding, cb) {

--- a/benchmark/string_decoder/string-decoder-create.js
+++ b/benchmark/string_decoder/string-decoder-create.js
@@ -9,10 +9,7 @@ const bench = common.createBenchmark(main, {
   n: [25e6]
 });
 
-function main(conf) {
-  const encoding = conf.encoding;
-  const n = conf.n | 0;
-
+function main({ encoding, n }) {
   bench.start();
   for (var i = 0; i < n; ++i) {
     const sd = new StringDecoder(encoding);

--- a/benchmark/string_decoder/string-decoder.js
+++ b/benchmark/string_decoder/string-decoder.js
@@ -4,8 +4,8 @@ const StringDecoder = require('string_decoder').StringDecoder;
 
 const bench = common.createBenchmark(main, {
   encoding: ['ascii', 'utf8', 'base64-utf8', 'base64-ascii', 'utf16le'],
-  inlen: [32, 128, 1024, 4096],
-  chunk: [16, 64, 256, 1024],
+  inLen: [32, 128, 1024, 4096],
+  chunkLen: [16, 64, 256, 1024],
   n: [25e5]
 });
 
@@ -13,12 +13,7 @@ const UTF8_ALPHA = 'Blåbærsyltetøy';
 const ASC_ALPHA = 'Blueberry jam';
 const UTF16_BUF = Buffer.from('Blåbærsyltetøy', 'utf16le');
 
-function main(conf) {
-  const encoding = conf.encoding;
-  const inLen = conf.inlen | 0;
-  const chunkLen = conf.chunk | 0;
-  const n = conf.n | 0;
-
+function main({ encoding, inLen, chunkLen, n }) {
   var alpha;
   var buf;
   const chunks = [];

--- a/benchmark/timers/immediate.js
+++ b/benchmark/timers/immediate.js
@@ -6,9 +6,9 @@ const bench = common.createBenchmark(main, {
   type: ['depth', 'depth1', 'breadth', 'breadth1', 'breadth4', 'clear']
 });
 
-function main(conf) {
-  const N = +conf.thousands * 1e3;
-  switch (conf.type) {
+function main({ thousands, type }) {
+  const N = thousands * 1e3;
+  switch (type) {
     case 'depth':
       depth(N);
       break;

--- a/benchmark/timers/set-immediate-breadth-args.js
+++ b/benchmark/timers/set-immediate-breadth-args.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [5]
 });
 
-function main(conf) {
-  const N = +conf.millions * 1e6;
+function main({ millions }) {
+  const N = millions * 1e6;
 
   process.on('exit', function() {
     bench.end(N / 1e6);

--- a/benchmark/timers/set-immediate-breadth.js
+++ b/benchmark/timers/set-immediate-breadth.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [10]
 });
 
-function main(conf) {
-  const N = +conf.millions * 1e6;
+function main({ millions }) {
+  const N = millions * 1e6;
 
   process.on('exit', function() {
     bench.end(N / 1e6);

--- a/benchmark/timers/set-immediate-depth-args.js
+++ b/benchmark/timers/set-immediate-depth-args.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [5]
 });
 
-function main(conf) {
-  const N = +conf.millions * 1e6;
+function main({ millions }) {
+  const N = millions * 1e6;
 
   process.on('exit', function() {
     bench.end(N / 1e6);

--- a/benchmark/timers/timers-breadth.js
+++ b/benchmark/timers/timers-breadth.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   thousands: [5000],
 });
 
-function main(conf) {
-  const N = +conf.thousands * 1e3;
+function main({ thousands }) {
+  const N = thousands * 1e3;
   var n = 0;
   bench.start();
   function cb() {

--- a/benchmark/timers/timers-cancel-pooled.js
+++ b/benchmark/timers/timers-cancel-pooled.js
@@ -6,8 +6,8 @@ const bench = common.createBenchmark(main, {
   millions: [5],
 });
 
-function main(conf) {
-  const iterations = +conf.millions * 1e6;
+function main({ millions }) {
+  const iterations = millions * 1e6;
 
   var timer = setTimeout(() => {}, 1);
   for (var i = 0; i < iterations; i++) {

--- a/benchmark/timers/timers-cancel-unpooled.js
+++ b/benchmark/timers/timers-cancel-unpooled.js
@@ -6,8 +6,8 @@ const bench = common.createBenchmark(main, {
   millions: [1],
 });
 
-function main(conf) {
-  const iterations = +conf.millions * 1e6;
+function main({ millions }) {
+  const iterations = millions * 1e6;
 
   const timersList = [];
   for (var i = 0; i < iterations; i++) {

--- a/benchmark/timers/timers-depth.js
+++ b/benchmark/timers/timers-depth.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   thousands: [1],
 });
 
-function main(conf) {
-  const N = +conf.thousands * 1e3;
+function main({ thousands }) {
+  const N = thousands * 1e3;
   var n = 0;
   bench.start();
   setTimeout(cb, 1);

--- a/benchmark/timers/timers-insert-pooled.js
+++ b/benchmark/timers/timers-insert-pooled.js
@@ -5,8 +5,8 @@ const bench = common.createBenchmark(main, {
   millions: [5],
 });
 
-function main(conf) {
-  const iterations = +conf.millions * 1e6;
+function main({ millions }) {
+  const iterations = millions * 1e6;
 
   bench.start();
 

--- a/benchmark/timers/timers-insert-unpooled.js
+++ b/benchmark/timers/timers-insert-unpooled.js
@@ -6,8 +6,8 @@ const bench = common.createBenchmark(main, {
   millions: [1],
 });
 
-function main(conf) {
-  const iterations = +conf.millions * 1e6;
+function main({ millions }) {
+  const iterations = millions * 1e6;
 
   const timersList = [];
 

--- a/benchmark/timers/timers-timeout-pooled.js
+++ b/benchmark/timers/timers-timeout-pooled.js
@@ -8,8 +8,8 @@ const bench = common.createBenchmark(main, {
   millions: [10],
 });
 
-function main(conf) {
-  const iterations = +conf.millions * 1e6;
+function main({ millions }) {
+  const iterations = millions * 1e6;
   let count = 0;
 
   // Function tracking on the hidden class in V8 can cause misleading

--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -7,9 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [1, 50000]
 });
 
-function main(conf) {
-  const n = +conf.n;
-
+function main({ n }) {
   var i = 0;
   var m = {};
   // First call dominates results

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -6,20 +6,15 @@ const bench = common.createBenchmark(main, {
   size: [2, 1024, 1024 * 1024]
 });
 
-var dur, type, encoding, size;
-var server;
-
 const path = require('path');
 const fs = require('fs');
 const cert_dir = path.resolve(__dirname, '../../test/fixtures');
 var options;
 const tls = require('tls');
 
-function main(conf) {
-  dur = +conf.dur;
-  type = conf.type;
-  size = +conf.size;
-
+function main({ dur, type, size }) {
+  var encoding;
+  var server;
   var chunk;
   switch (type) {
     case 'buf':

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -16,10 +16,7 @@ var dur;
 var concurrency;
 var running = true;
 
-function main(conf) {
-  dur = +conf.dur;
-  concurrency = +conf.concurrency;
-
+function main({ dur, concurrency }) {
   const cert_dir = path.resolve(__dirname, '../../test/fixtures');
   const options = {
     key: fs.readFileSync(`${cert_dir}/test_key.pem`),

--- a/benchmark/url/legacy-vs-whatwg-url-get-prop.js
+++ b/benchmark/url/legacy-vs-whatwg-url-get-prop.js
@@ -71,11 +71,7 @@ function useWHATWG(n, input) {
   return noDead;
 }
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-  const method = conf.method;
-
+function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
     throw new Error('Unknown input type');

--- a/benchmark/url/legacy-vs-whatwg-url-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-parse.js
@@ -31,11 +31,7 @@ function useWHATWG(n, input) {
   return noDead;
 }
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-  const method = conf.method;
-
+function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
     throw new Error('Unknown input type');

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
@@ -28,11 +28,7 @@ function useWHATWG(n, input) {
   bench.end(n);
 }
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-  const method = conf.method;
-
+function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
     throw new Error('Unknown input type');

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -30,11 +30,7 @@ function useWHATWG(n, input, prop) {
   bench.end(n);
 }
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-  const method = conf.method;
-
+function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
     throw new Error('Unknown input type');

--- a/benchmark/url/legacy-vs-whatwg-url-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-serialize.js
@@ -33,11 +33,7 @@ function useWHATWG(n, input, prop) {
   return noDead;
 }
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-  const method = conf.method;
-
+function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
     throw new Error('Unknown input type');

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -12,10 +12,7 @@ const bench = common.createBenchmark(main, {
   n: [25e6]
 });
 
-function main(conf) {
-  const type = conf.type;
-  const n = conf.n | 0;
-
+function main({ type, n }) {
   const input = inputs[type] || '';
 
   // Force-optimize url.format() so that the benchmark doesn't get

--- a/benchmark/url/url-resolve.js
+++ b/benchmark/url/url-resolve.js
@@ -18,13 +18,12 @@ const bench = common.createBenchmark(main, {
   n: [1e5]
 });
 
-function main(conf) {
-  const n = conf.n | 0;
-  const href = hrefs[conf.href];
-  const path = paths[conf.path];
+function main({ n, href, path }) {
+  const h = hrefs[href];
+  const p = paths[path];
 
   bench.start();
   for (var i = 0; i < n; i += 1)
-    url.resolve(href, path);
+    url.resolve(h, p);
   bench.end(n);
 }

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -44,10 +44,7 @@ function iterator(n) {
   assert.strictEqual(noDead[1], '3rd');
 }
 
-function main(conf) {
-  const method = conf.method;
-  const n = conf.n | 0;
-
+function main({ method, n }) {
   switch (method) {
     case 'forEach':
       forEach(n);

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -37,11 +37,7 @@ function has(n, param) {
   bench.end(n);
 }
 
-function main(conf) {
-  const method = conf.method;
-  const param = conf.param;
-  const n = conf.n | 0;
-
+function main({ method, param, n }) {
   switch (method) {
     case 'get':
       get(n, param);

--- a/benchmark/url/url-searchparams-sort.js
+++ b/benchmark/url/url-searchparams-sort.js
@@ -31,10 +31,9 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals']
 });
 
-function main(conf) {
+function main({ type, n }) {
   const searchParams = require('internal/url').searchParamsSymbol;
-  const input = inputs[conf.type];
-  const n = conf.n | 0;
+  const input = inputs[type];
   const params = new URLSearchParams();
   const array = getParams(input);
 

--- a/benchmark/url/usvstring.js
+++ b/benchmark/url/usvstring.js
@@ -16,10 +16,9 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals']
 });
 
-function main(conf) {
+function main({ input, n }) {
   const { toUSVString } = require('internal/url');
-  const str = inputs[conf.input];
-  const n = conf.n | 0;
+  const str = inputs[input];
 
   bench.start();
   for (var i = 0; i < n; i++)

--- a/benchmark/url/whatwg-url-idna.js
+++ b/benchmark/url/whatwg-url-idna.js
@@ -31,15 +31,13 @@ const bench = common.createBenchmark(main, {
   n: [5e6]
 });
 
-function main(conf) {
-  const n = conf.n | 0;
-  const to = conf.to;
-  const input = inputs[conf.input][to];
+function main({ n, to, input }) {
+  const value = inputs[input][to];
   const method = to === 'ascii' ? domainToASCII : domainToUnicode;
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    method(input);
+    method(value);
   }
   bench.end(n);
 }

--- a/benchmark/url/whatwg-url-properties.js
+++ b/benchmark/url/whatwg-url-properties.js
@@ -46,11 +46,9 @@ function getAlternative(prop) {
   return alternatives[prop];
 }
 
-function main(conf) {
-  const n = conf.n | 0;
-  const input = inputs[conf.input];
-  const url = new URL(input);
-  const prop = conf.prop;
+function main({ n, input, prop }) {
+  const value = inputs[input];
+  const url = new URL(value);
 
   switch (prop) {
     case 'protocol':

--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -47,11 +47,9 @@ function getInput(input) {
   }
 }
 
-function main(conf) {
-  const normalizeEncoding = require('internal/util').normalizeEncoding;
-
-  const n = conf.n | 0;
-  const inputs = getInput(conf.input);
+function main({ input, n }) {
+  const { normalizeEncoding } = require('internal/util');
+  const inputs = getInput(input);
   var noDead = '';
 
   bench.start();

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -34,16 +34,15 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals']
 });
 
-function main(conf) {
+function main({ type, argument, version, n }) {
   // For testing, if supplied with an empty type, default to ArrayBufferView.
-  conf.type = conf.type || 'ArrayBufferView';
+  type = type || 'ArrayBufferView';
 
   const util = process.binding('util');
   const types = require('internal/util/types');
 
-  const n = (+conf.n) | 0;
-  const func = { native: util, js: types }[conf.version][`is${conf.type}`];
-  const arg = args[conf.type][conf.argument];
+  const func = { native: util, js: types }[version][`is${type}`];
+  const arg = args[type][argument];
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -11,9 +11,7 @@ const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const method = conf.method;
+function main({ method, n }) {
   var i = 0;
   bench.start();
   for (; i < n; i++)

--- a/benchmark/vm/run-in-context.js
+++ b/benchmark/vm/run-in-context.js
@@ -10,10 +10,8 @@ const bench = common.createBenchmark(main, {
 
 const vm = require('vm');
 
-function main(conf) {
-  const n = +conf.n;
-  const options = conf.breakOnSigint ? { breakOnSigint: true } : {};
-  const withSigintListener = !!conf.withSigintListener;
+function main({ n, breakOnSigint, withSigintListener }) {
+  const options = breakOnSigint ? { breakOnSigint: true } : {};
 
   process.removeAllListeners('SIGINT');
   if (withSigintListener)

--- a/benchmark/vm/run-in-this-context.js
+++ b/benchmark/vm/run-in-this-context.js
@@ -10,10 +10,8 @@ const bench = common.createBenchmark(main, {
 
 const vm = require('vm');
 
-function main(conf) {
-  const n = +conf.n;
-  const options = conf.breakOnSigint ? { breakOnSigint: true } : {};
-  const withSigintListener = !!conf.withSigintListener;
+function main({ n, breakOnSigint, withSigintListener }) {
+  const options = breakOnSigint ? { breakOnSigint: true } : {};
 
   process.removeAllListeners('SIGINT');
   if (withSigintListener)

--- a/benchmark/zlib/creation.js
+++ b/benchmark/zlib/creation.js
@@ -10,14 +10,13 @@ const bench = common.createBenchmark(main, {
   n: [5e5]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const fn = zlib[`create${conf.type}`];
+function main({ n, type, options }) {
+  const fn = zlib[`create${type}`];
   if (typeof fn !== 'function')
     throw new Error('Invalid zlib type');
   var i = 0;
 
-  if (conf.options === 'true') {
+  if (options === 'true') {
     const opts = {};
     bench.start();
     for (; i < n; ++i)

--- a/benchmark/zlib/deflate.js
+++ b/benchmark/zlib/deflate.js
@@ -8,10 +8,8 @@ const bench = common.createBenchmark(main, {
   n: [4e5]
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const method = conf.method;
-  const chunk = Buffer.alloc(+conf.inputLen, 'a');
+function main({ n, method, inputLen }) {
+  const chunk = Buffer.alloc(inputLen, 'a');
 
   var i = 0;
   switch (method) {


### PR DESCRIPTION
There is often confusion about using e.g. `+conf.n` in the bench due to historical reasons.

This cleans this up in all benchmark files and I switched to use destructuring to reduce the code size. It actually reducing the overall changed lines significantly.

While going through the benchmark files I also found a couple other things that would be nice to refactor but I would like to get this in first (if it is going to be accepted due to the churn).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark