### PR TITLE
fix flaky net-connect-handle-econnrefused

### DIFF
--- a/test/parallel/test-net-connect-handle-econnrefused.js
+++ b/test/parallel/test-net-connect-handle-econnrefused.js
@@ -27,11 +27,10 @@ const assert = require('assert');
 const server = net.createServer();
 server.listen(0);
 const port = server.address().port;
-const c = net.createConnection(port);
-
-c.on('connect', common.mustNotCall());
-
-c.on('error', common.mustCall((e) => {
-  assert.strictEqual('ECONNREFUSED', e.code);
-}));
-server.close();
+server.close(() => {
+  const c = net.createConnection(port);
+  c.on('connect', common.mustNotCall());
+  c.on('error', common.mustCall((e) => {
+    assert.strictEqual('ECONNREFUSED', e.code);
+  }));
+});


### PR DESCRIPTION
This PR closes #18164

I changed timing of connecting to server.
It connects to server after server.close called certainly.

Does that solve this issue?
I'd appreciate any feedback or suggestions.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test