### PR TITLE
test: change assert message to default

### DIFF
--- a/test/known_issues/test-http-path-contains-unicode.js
+++ b/test/known_issues/test-http-path-contains-unicode.js
@@ -11,10 +11,7 @@ const http = require('http');
 const expected = '/café🐶';
 
 //Sanity check for café🐶 is café🐶
-assert.strictEqual(
-  expected,
-  '/caf\u{e9}\u{1f436}'
-);
+assert.strictEqual('/caf\u{e9}\u{1f436}', expected);
 
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(req.url, expected);

--- a/test/known_issues/test-http-path-contains-unicode.js
+++ b/test/known_issues/test-http-path-contains-unicode.js
@@ -10,10 +10,10 @@ const http = require('http');
 
 const expected = '/café🐶';
 
+//Sanity check for café🐶 is café🐶
 assert.strictEqual(
   expected,
-  '/caf\u{e9}\u{1f436}',
-  'Sanity check that string literal produced the expected string'
+  '/caf\u{e9}\u{1f436}'
 );
 
 const server = http.createServer(common.mustCall(function(req, res) {


### PR DESCRIPTION
assert.strictEqual message argument removed to replace
with default assert message to show the expected vs
actual values

Refs: https://github.com/nodejs/node/issues/13296

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
