### PR TITLE
test: fix flaky cluster unix socket test

### DIFF
--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -20,6 +20,7 @@ assert.strictEqual(path.resolve(socketDir, socketName).length > 100, true,
 
 if (cluster.isMaster) {
   // ensure that the worker exits peacefully
+  common.refreshTmpDir();
   process.chdir(common.tmpDir);
   fs.mkdirSync(socketDir);
   cluster.fork().on('exit', common.mustCall(function(statusCode) {


### PR DESCRIPTION
Ensure `common.tmpDir` exists before trying to chdir into it.  Fixes a
"ENOENT: no such file or directory, uv_chdir" error when the temporary
directory is removed before running the test.