### PR TITLE
stream: fix not calling cleanup() when unpiping all streams.

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -759,7 +759,7 @@ Readable.prototype.unpipe = function(dest) {
     state.flowing = false;
 
     for (var i = 0; i < len; i++)
-      dests[i].emit('unpipe', this, unpipeInfo);
+      dests[i].emit('unpipe', this, { hasUnpiped: false });
     return this;
   }
 

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -50,7 +50,7 @@ assert.strictEqual(source._readableState.pipes, null);
     srcCheckEventNames.forEach((eventName) => {
       assert.strictEqual(
         source.listenerCount(eventName), 0,
-        `source's '${eventName}' event listeners don't be cleaned up`
+        `source's '${eventName}' event listeners not removed`
       );
     });
   });
@@ -60,8 +60,8 @@ assert.strictEqual(source._readableState.pipes, null);
     source.pipe(dest);
 
     const unpipeChecker = common.mustCall(() => {
-      assert.strictEqual(
-        dest.listenerCount('unpipe'), 1,
+      assert.deepStrictEqual(
+        dest.listeners('unpipe'), [unpipeChecker],
         `destination{${currentDestId}} should have a 'unpipe' event ` +
         'listener which is `unpipeChecker`'
       );
@@ -70,7 +70,7 @@ assert.strictEqual(source._readableState.pipes, null);
         assert.strictEqual(
           dest.listenerCount(eventName), 0,
           `destination{${currentDestId}}'s '${eventName}' event ` +
-          "listeners don't be cleaned up"
+          'listeners not removed'
         );
       });
 

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -33,7 +33,7 @@ source.unpipe(dest1);
 assert.strictEqual(source._readableState.pipes, null);
 
 {
-  // test `cleanup()` if we unpipe all streams. 
+  // test `cleanup()` if we unpipe all streams.
   const source = Readable({ read: () => {} });
   const dest1 = Writable({ write: () => {} });
   const dest2 = Writable({ write: () => {} });
@@ -47,7 +47,7 @@ assert.strictEqual(source._readableState.pipes, null);
     assert.strictEqual(source._readableState.pipesCount, 0);
     assert.strictEqual(source._readableState.flowing, false);
 
-    srcCheckEventNames.forEach(eventName => {
+    srcCheckEventNames.forEach((eventName) => {
       assert.strictEqual(
         source.listenerCount(eventName), 0,
         `source's '${eventName}' event listeners don't be cleaned up`
@@ -62,13 +62,15 @@ assert.strictEqual(source._readableState.pipes, null);
     const unpipeChecker = common.mustCall(() => {
       assert.strictEqual(
         dest.listenerCount('unpipe'), 1,
-        `destination{${currentDestId}} should have a 'unpipe' event listener which is \`unpipeChecker\``
+        `destination{${currentDestId}} should have a 'unpipe' event ` +
+        'listener which is `unpipeChecker`'
       );
       dest.removeListener('unpipe', unpipeChecker);
-      destCheckEventNames.forEach(eventName => {
+      destCheckEventNames.forEach((eventName) => {
         assert.strictEqual(
           dest.listenerCount(eventName), 0,
-          `destination{${currentDestId}}'s '${eventName}' event listeners don't be cleaned up`
+          `destination{${currentDestId}}'s '${eventName}' event ` +
+          "listeners don't be cleaned up"
         );
       });
 

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -31,3 +31,26 @@ source.unpipe(dest2);
 source.unpipe(dest1);
 
 assert.strictEqual(source._readableState.pipes, null);
+
+{
+  // unpipe all
+  const source = Readable({ read: () => {} });
+  const dest1 = Writable({ write: () => {} });
+  const dest2 = Writable({ write: () => {} });
+
+  source.pipe(dest1);
+  source.pipe(dest2);
+
+  checkDestCleanup(dest1);
+  checkDestCleanup(dest2);
+
+  source.unpipe();
+
+  function checkDestCleanup(dest) {
+    const unpipeChecker = common.mustCall(() => {
+      dest.removeListener('unpipe', unpipeChecker);
+      assert.strictEqual(dest.listenerCount('unpipe'), 0);
+    });
+    dest.on('unpipe', unpipeChecker);
+  }
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/12746

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

After a readable stream pipes more than one writable streams, I calls `readable.unpipe()` to remove all piped writable stream. I find that only the first piped writable stream calls the `cleanup()`, the others don't call `cleanup()`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream