### PR TITLE
test: improve fs error message test

### DIFF
--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -24,276 +24,395 @@ const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
-const fn = fixtures.path('non-existent');
+const nonexistentFile = fixtures.path('non-existent');
 const existingFile = fixtures.path('exit.js');
 const existingFile2 = fixtures.path('create-file.js');
 const existingDir = fixtures.path('empty');
 const existingDir2 = fixtures.path('keys');
 const uv = process.binding('uv');
 
-// ASYNC_CALL
-
-fs.stat(fn, common.mustCall((err) => {
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, stat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'stat');
-}));
-
-fs.lstat(fn, common.mustCall((err) => {
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, lstat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'lstat');
-}));
-
+// stat
 {
-  const fd = fs.openSync(existingFile, 'r');
-  fs.closeSync(fd);
-  fs.fstat(fd, common.mustCall((err) => {
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, stat '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'stat');
+    return true;
+  }
+  
+  fs.stat(nonexistentFile, common.mustCall(validateError));
+  
+  assert.throws(
+    () => fs.statSync(nonexistentFile),
+    validateError
+  );
+}
+
+// lstat
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, lstat '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'lstat');
+    return true;
+  };
+
+  fs.lstat(nonexistentFile, common.mustCall(validateError));
+  assert.throws(
+    () => fs.lstatSync(nonexistentFile),
+    validateError
+  );
+}
+
+// fstat
+{
+  const validateError = (err) => {
     assert.strictEqual(err.message, 'EBADF: bad file descriptor, fstat');
     assert.strictEqual(err.errno, uv.UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fstat');
-  }));
-}
+    return true;
+  };
 
-fs.realpath(fn, common.mustCall((err) => {
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, lstat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'lstat');
-}));
-
-fs.readlink(fn, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.link(fn, 'foo', common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.link(existingFile, existingFile2, common.mustCall((err) => {
-  assert.ok(err.message.includes(existingFile));
-  assert.ok(err.message.includes(existingFile2));
-}));
-
-fs.symlink(existingFile, existingFile2, common.mustCall((err) => {
-  assert.ok(err.message.includes(existingFile));
-  assert.ok(err.message.includes(existingFile2));
-}));
-
-fs.unlink(fn, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.rename(fn, 'foo', common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.rename(existingDir, existingDir2, common.mustCall((err) => {
-  assert.ok(err.message.includes(existingDir));
-  assert.ok(err.message.includes(existingDir2));
-}));
-
-fs.rmdir(fn, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.mkdir(existingFile, 0o666, common.mustCall((err) => {
-  assert.ok(err.message.includes(existingFile));
-}));
-
-fs.rmdir(existingFile, common.mustCall((err) => {
-  assert.ok(err.message.includes(existingFile));
-}));
-
-fs.chmod(fn, 0o666, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.open(fn, 'r', 0o666, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-fs.readFile(fn, common.mustCall((err) => {
-  assert.ok(err.message.includes(fn));
-}));
-
-// Sync
-
-const errors = [];
-let expected = 0;
-
-try {
-  ++expected;
-  fs.statSync(fn);
-} catch (err) {
-  errors.push('stat');
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, stat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'stat');
-}
-
-try {
-  ++expected;
-  fs.mkdirSync(existingFile, 0o666);
-} catch (err) {
-  errors.push('mkdir');
-  assert.ok(err.message.includes(existingFile));
-}
-
-try {
-  ++expected;
-  fs.chmodSync(fn, 0o666);
-} catch (err) {
-  errors.push('chmod');
-  assert.ok(err.message.includes(fn));
-}
-
-try {
-  ++expected;
-  fs.lstatSync(fn);
-} catch (err) {
-  errors.push('lstat');
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, lstat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'lstat');
-}
-
-try {
-  ++expected;
   const fd = fs.openSync(existingFile, 'r');
   fs.closeSync(fd);
-  fs.fstatSync(fd);
-} catch (err) {
-  errors.push('fstat');
-  assert.strictEqual(err.message, 'EBADF: bad file descriptor, fstat');
-  assert.strictEqual(err.errno, uv.UV_EBADF);
-  assert.strictEqual(err.code, 'EBADF');
-  assert.strictEqual(err.syscall, 'fstat');
+
+  fs.fstat(fd, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.fstatSync(fd),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.realpathSync(fn);
-} catch (err) {
-  errors.push('realpath');
-  assert.strictEqual(fn, err.path);
-  assert.strictEqual(
-    err.message,
-    `ENOENT: no such file or directory, lstat '${fn}'`);
-  assert.strictEqual(err.errno, uv.UV_ENOENT);
-  assert.strictEqual(err.code, 'ENOENT');
-  assert.strictEqual(err.syscall, 'lstat');
+// realpath
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, lstat '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'lstat');
+    return true;
+  };
+
+  fs.realpath(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.realpathSync(nonexistentFile),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.readlinkSync(fn);
-} catch (err) {
-  errors.push('readlink');
-  assert.ok(err.message.includes(fn));
+// readlink
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, readlink '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'readlink');
+    return true;
+  };
+
+  fs.readlink(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.readlinkSync(nonexistentFile),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.linkSync(fn, 'foo');
-} catch (err) {
-  errors.push('link');
-  assert.ok(err.message.includes(fn));
+// link nonexistent file
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual('foo', err.dest);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, link '${nonexistentFile}' -> 'foo'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'link');
+    return true;
+  };
+
+  fs.link(nonexistentFile, 'foo', common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.linkSync(nonexistentFile, 'foo'),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.linkSync(existingFile, existingFile2);
-} catch (err) {
-  errors.push('link');
-  assert.ok(err.message.includes(existingFile));
-  assert.ok(err.message.includes(existingFile2));
+// link existing file
+{
+  const validateError = (err) => {
+    assert.strictEqual(existingFile, err.path);
+    assert.strictEqual(existingFile2, err.dest);
+    assert.strictEqual(
+      err.message,
+      `EEXIST: file already exists, link '${existingFile}' -> ` +
+      `'${existingFile2}'`);
+    assert.strictEqual(err.errno, uv.UV_EEXIST);
+    assert.strictEqual(err.code, 'EEXIST');
+    assert.strictEqual(err.syscall, 'link');
+    return true;
+  };
+
+  fs.link(existingFile, existingFile2, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.linkSync(existingFile, existingFile2),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.symlinkSync(existingFile, existingFile2);
-} catch (err) {
-  errors.push('symlink');
-  assert.ok(err.message.includes(existingFile));
-  assert.ok(err.message.includes(existingFile2));
+// symlink
+{
+  const validateError = (err) => {
+    assert.strictEqual(existingFile, err.path);
+    assert.strictEqual(existingFile2, err.dest);
+    assert.strictEqual(
+      err.message,
+      `EEXIST: file already exists, symlink '${existingFile}' -> ` +
+      `'${existingFile2}'`);
+    assert.strictEqual(err.errno, uv.UV_EEXIST);
+    assert.strictEqual(err.code, 'EEXIST');
+    assert.strictEqual(err.syscall, 'symlink');
+    return true;
+  };
+
+  fs.symlink(existingFile, existingFile2, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.symlinkSync(existingFile, existingFile2),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.unlinkSync(fn);
-} catch (err) {
-  errors.push('unlink');
-  assert.ok(err.message.includes(fn));
+// unlink
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, unlink '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'unlink');
+    return true;
+  };
+
+  fs.unlink(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.unlinkSync(nonexistentFile),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.rmdirSync(fn);
-} catch (err) {
-  errors.push('rmdir');
-  assert.ok(err.message.includes(fn));
+// rename
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual('foo', err.dest);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, rename '${nonexistentFile}' ` +
+      '-> \'foo\'');
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'rename');
+    return true;
+  };
+
+  fs.rename(nonexistentFile, 'foo', common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.renameSync(nonexistentFile, 'foo'),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.rmdirSync(existingFile);
-} catch (err) {
-  errors.push('rmdir');
-  assert.ok(err.message.includes(existingFile));
+// rename non-empty directory
+{
+  const validateError = (err) => {
+    assert.strictEqual(existingDir, err.path);
+    assert.strictEqual(existingDir2, err.dest);
+    assert.strictEqual(
+      err.message,
+      `ENOTEMPTY: directory not empty, rename '${existingDir}' -> ` +
+      `'${existingDir2}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOTEMPTY);
+    assert.strictEqual(err.code, 'ENOTEMPTY');
+    assert.strictEqual(err.syscall, 'rename');
+    return true;
+  };
+
+  fs.rename(existingDir, existingDir2, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.renameSync(existingDir, existingDir2),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.openSync(fn, 'r');
-} catch (err) {
-  errors.push('opens');
-  assert.ok(err.message.includes(fn));
+// rmdir
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, rmdir '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'rmdir');
+    return true;
+  };
+
+  fs.rmdir(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.rmdirSync(nonexistentFile),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.renameSync(fn, 'foo');
-} catch (err) {
-  errors.push('rename');
-  assert.ok(err.message.includes(fn));
+// mkdir
+{
+  const validateError = (err) => {
+    assert.strictEqual(existingFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `EEXIST: file already exists, mkdir '${existingFile}'`);
+    assert.strictEqual(err.errno, uv.UV_EEXIST);
+    assert.strictEqual(err.code, 'EEXIST');
+    assert.strictEqual(err.syscall, 'mkdir');
+    return true;
+  };
+
+  fs.mkdir(existingFile, 0o666, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.mkdirSync(existingFile, 0o666),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.renameSync(existingDir, existingDir2);
-} catch (err) {
-  errors.push('rename');
-  assert.ok(err.message.includes(existingDir));
-  assert.ok(err.message.includes(existingDir2));
+// rmdir
+{
+  const validateError = (err) => {
+    assert.strictEqual(existingFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOTDIR: not a directory, rmdir '${existingFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOTDIR);
+    assert.strictEqual(err.code, 'ENOTDIR');
+    assert.strictEqual(err.syscall, 'rmdir');
+    return true;
+  };
+
+  fs.rmdir(existingFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.rmdirSync(existingFile),
+    validateError
+  );
 }
 
-try {
-  ++expected;
-  fs.readdirSync(fn);
-} catch (err) {
-  errors.push('readdir');
-  assert.ok(err.message.includes(fn));
+// chmod
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, chmod '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'chmod');
+    return true;
+  };
+
+  fs.chmod(nonexistentFile, 0o666, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.chmodSync(nonexistentFile, 0o666),
+    validateError
+  );
 }
 
-assert.strictEqual(expected, errors.length);
+// open
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, open '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'open');
+    return true;
+  };
+
+  fs.open(nonexistentFile, 'r', 0o666, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.openSync(nonexistentFile, 'r', 0o666),
+    validateError
+  );
+}
+
+// read
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, open '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'open');
+    return true;
+  };
+
+  fs.readFile(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.readFileSync(nonexistentFile),
+    validateError
+  );
+}
+
+// readdir
+{
+  const validateError = (err) => {
+    assert.strictEqual(nonexistentFile, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, scandir '${nonexistentFile}'`);
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'scandir');
+    return true;
+  };
+
+  fs.readdir(nonexistentFile, common.mustCall(validateError));
+
+  assert.throws(
+    () => fs.readdirSync(nonexistentFile),
+    validateError
+  );
+}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -327,12 +327,19 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(existingFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOTDIR: not a directory, rmdir '${existingFile}'`);
-    assert.strictEqual(err.errno, uv.UV_ENOTDIR);
-    assert.strictEqual(err.code, 'ENOTDIR');
     assert.strictEqual(err.syscall, 'rmdir');
+    if (err.code === 'ENOTDIR') {
+      assert.strictEqual(
+        err.message,
+        `ENOTDIR: not a directory, rmdir '${existingFile}'`);
+      assert.strictEqual(err.errno, uv.UV_ENOTDIR);
+    } else {  // windows
+      assert.strictEqual(
+        err.message,
+        `ENOENT: no such file or directory, rmdir '${existingFile}'`);
+      assert.strictEqual(err.errno, uv.UV_ENOENT);
+      assert.strictEqual(err.code, 'ENOENT');
+    }
     return true;
   };
 


### PR DESCRIPTION
In preparation for more fs error migrations..

- Reuse error validators for sync and async tests
- Validate properties of the errors

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, fs