### PR TITLE
stream: delete unused code

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -180,7 +180,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 Transform.prototype._read = function(n) {
   var ts = this._transformState;
 
-  if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
+  if (ts.writechunk !== null && !ts.transforming) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {


### PR DESCRIPTION
In implementation of `stream.Writable`, `writable._write()` is always called with a callback that is `_writableState.onwrite()`. And In `afterTransform()`, `ts.writechunk` and `ts.writecb` are assigned to null.  So, `ts.writecb` is a true value if `ts.writechunk` isn't null.

From the view of `stream.Writable`, only `ts.writecb` can inform it about the end of writing chunk to the underlying. So a callback is essential to call `writable._write()`. So, `ts.writecb` is a true value if `ts.writechunk` isn't null.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream