### PR TITLE
doc: `readable.push()` supports `undefined` in non-object mode

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1798,6 +1798,10 @@ class SourceWrapper extends Readable {
 The `readable.push()` method is intended be called only by Readable
 Implementers, and only from within the `readable._read()` method.
 
+For streams not operating in object mode, if the `chunk` parameter of
+`readable.push()` is `undefined`, it will be treated as empty string or
+buffer. See [`readable.push('')`][] for more information.
+
 #### Errors While Reading
 
 It is recommended that errors occurring during the processing of the
@@ -2313,6 +2317,7 @@ contain multi-byte characters.
 [`stream.uncork()`]: #stream_writable_uncork
 [`stream.unpipe()`]: #stream_readable_unpipe_destination
 [`stream.wrap()`]: #stream_readable_wrap_stream
+[`readable.push('')`]: #stream_readable_push
 [`writable.cork()`]: #stream_writable_cork
 [`writable.uncork()`]: #stream_writable_uncork
 [`zlib.createDeflate()`]: zlib.html#zlib_zlib_createdeflate_options


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
I found that the readable stream that isn't in object mode supports `undefined` [long ago](https://github.com/nodejs/node/commit/7764b84297432ffb3535a9fe26ec386b315d499d#diff-ba6a0df0f5212f5cba5ca5179e209a17L270), and it's original idea is to [express EOF](https://github.com/nodejs/node/commit/7764b84297432ffb3535a9fe26ec386b315d499d#diff-ba6a0df0f5212f5cba5ca5179e209a17L288). Now it is just treated as a empty string or buffer. But the doc and [code](https://github.com/nodejs/node/blob/master/lib/_stream_readable.js#L292) aren't clear for it **although it is not important**.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, stream