### PR TITLE
Fix: Typo in in async_hooks.triggerAsyncId explanation

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -492,7 +492,7 @@ fs.open(path, 'r', (err, fd) => {
 });
 ```
 
-The ID returned fom `executionAsyncId()` is related to execution timing, not
+The ID returned from `executionAsyncId()` is related to execution timing, not
 causality (which is covered by `triggerAsyncId()`). For example:
 
 ```js


### PR DESCRIPTION
Tiny typo I found whilst reading through the async hooks documentation. 
`fom` -> `from`