### PR TITLE
[v9.x] async_hooks: use typed array stack as fast path

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -19,6 +19,12 @@ const async_wrap = process.binding('async_wrap');
  *    retrieving the triggerAsyncId value is passing directly to the
  *    constructor -> value set in kDefaultTriggerAsyncId -> executionAsyncId of
  *    the current resource.
+ *
+ * async_ids_fast_stack is a Float64Array that contains part of the async ID
+ * stack. Each pushAsyncIds() call adds two doubles to it, and each
+ * popAsyncIds() call removes two doubles from it.
+ * It has a fixed size, so if that is exceeded, calls to the native
+ * side are used instead in pushAsyncIds() and popAsyncIds().
  */
 const { async_hook_fields, async_id_fields } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a std::stack on
@@ -26,7 +32,7 @@ const { async_hook_fields, async_id_fields } = async_wrap;
 // current execution stack. This is unwound as each resource exits. In the case
 // of a fatal exception this stack is emptied after calling each hook's after()
 // callback.
-const { pushAsyncIds, popAsyncIds } = async_wrap;
+const { pushAsyncIds: pushAsyncIds_, popAsyncIds: popAsyncIds_ } = async_wrap;
 // For performance reasons, only track Proimses when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;
 // Properties in active_hooks are used to keep track of the set of hooks being
@@ -60,8 +66,8 @@ const active_hooks = {
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
 const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
-        kCheck, kExecutionAsyncId, kAsyncIdCounter,
-        kDefaultTriggerAsyncId } = async_wrap.constants;
+        kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
+        kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
 // Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
@@ -326,6 +332,38 @@ function emitDestroyScript(asyncId) {
   if (async_hook_fields[kDestroy] === 0 || asyncId <= 0)
     return;
   async_wrap.queueDestroyAsyncId(asyncId);
+}
+
+
+// This is the equivalent of the native push_async_ids() call.
+function pushAsyncIds(asyncId, triggerAsyncId) {
+  const offset = async_hook_fields[kStackLength];
+  if (offset * 2 >= async_wrap.async_ids_stack.length)
+    return pushAsyncIds_(asyncId, triggerAsyncId);
+  async_wrap.async_ids_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
+  async_wrap.async_ids_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
+  async_hook_fields[kStackLength]++;
+  async_id_fields[kExecutionAsyncId] = asyncId;
+  async_id_fields[kTriggerAsyncId] = triggerAsyncId;
+}
+
+
+// This is the equivalent of the native pop_async_ids() call.
+function popAsyncIds(asyncId) {
+  if (async_hook_fields[kStackLength] === 0) return false;
+  const stackLength = async_hook_fields[kStackLength];
+
+  if (async_hook_fields[kCheck] > 0 &&
+      async_id_fields[kExecutionAsyncId] !== asyncId) {
+    // Do the same thing as the native code (i.e. crash hard).
+    return popAsyncIds_(asyncId);
+  }
+
+  const offset = stackLength - 1;
+  async_id_fields[kExecutionAsyncId] = async_wrap.async_ids_stack[2 * offset];
+  async_id_fields[kTriggerAsyncId] = async_wrap.async_ids_stack[2 * offset + 1];
+  async_hook_fields[kStackLength] = offset;
+  return offset > 0;
 }
 
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -366,9 +366,9 @@
     // Arrays containing hook flags and ids for async_hook calls.
     const { async_hook_fields, async_id_fields } = async_wrap;
     // Internal functions needed to manipulate the stack.
-    const { clearAsyncIdStack, asyncIdStackSize } = async_wrap;
+    const { clearAsyncIdStack } = async_wrap;
     const { kAfter, kExecutionAsyncId,
-            kDefaultTriggerAsyncId } = async_wrap.constants;
+            kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
     process._fatalException = function(er) {
       var caught;
@@ -406,7 +406,7 @@
           do {
             NativeModule.require('internal/async_hooks').emitAfter(
               async_id_fields[kExecutionAsyncId]);
-          } while (asyncIdStackSize() > 0);
+          } while (async_hook_fields[kStackLength] > 0);
         // Or completely empty the id stack.
         } else {
           clearAsyncIdStack();

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -95,6 +95,21 @@ class AliasedBuffer {
     js_array_.Reset();
   }
 
+  AliasedBuffer& operator=(AliasedBuffer&& that) {
+    this->~AliasedBuffer();
+    isolate_ = that.isolate_;
+    count_ = that.count_;
+    byte_offset_ = that.byte_offset_;
+    buffer_ = that.buffer_;
+    free_buffer_ = that.free_buffer_;
+
+    js_array_.Reset(isolate_, that.js_array_.Get(isolate_));
+
+    that.buffer_ = nullptr;
+    that.js_array_.Reset();
+    return *this;
+  }
+
   /**
    * Helper class that is returned from operator[] to support assignment into
    * a specified location.
@@ -111,9 +126,15 @@ class AliasedBuffer {
           index_(that.index_) {
     }
 
-    inline Reference& operator=(const NativeT &val) {
+    template <typename T>
+    inline Reference& operator=(const T& val) {
       aliased_buffer_->SetValue(index_, val);
       return *this;
+    }
+
+    // This is not caught by the template operator= above.
+    inline Reference& operator=(const Reference& val) {
+      return *this = static_cast<NativeT>(val);
     }
 
     operator NativeT() const {
@@ -186,8 +207,12 @@ class AliasedBuffer {
     return GetValue(index);
   }
 
+  size_t Length() const {
+    return count_;
+  }
+
  private:
-  v8::Isolate* const isolate_;
+  v8::Isolate* isolate_;
   size_t count_;
   size_t byte_offset_;
   NativeT* buffer_;

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -467,13 +467,6 @@ void AsyncWrap::PopAsyncIds(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void AsyncWrap::AsyncIdStackSize(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  args.GetReturnValue().Set(
-      static_cast<double>(env->async_hooks()->stack_size()));
-}
-
-
 void AsyncWrap::ClearAsyncIdStack(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   env->async_hooks()->clear_async_id_stack();
@@ -512,7 +505,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "setupHooks", SetupHooks);
   env->SetMethod(target, "pushAsyncIds", PushAsyncIds);
   env->SetMethod(target, "popAsyncIds", PopAsyncIds);
-  env->SetMethod(target, "asyncIdStackSize", AsyncIdStackSize);
   env->SetMethod(target, "clearAsyncIdStack", ClearAsyncIdStack);
   env->SetMethod(target, "queueDestroyAsyncId", QueueDestroyAsyncId);
   env->SetMethod(target, "enablePromiseHook", EnablePromiseHook);
@@ -550,6 +542,10 @@ void AsyncWrap::Initialize(Local<Object> target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());
 
+  target->Set(context,
+              env->async_ids_stack_string(),
+              env->async_hooks()->async_ids_stack().GetJSArray()).FromJust();
+
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \
   FORCE_SET_TARGET_FIELD(                                                     \
@@ -566,6 +562,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kTriggerAsyncId);
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
   SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
+  SET_HOOKS_CONSTANT(kStackLength);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);
 
@@ -595,6 +592,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->set_async_hooks_after_function(Local<Function>());
   env->set_async_hooks_destroy_function(Local<Function>());
   env->set_async_hooks_promise_resolve_function(Local<Function>());
+  env->set_async_hooks_binding(target);
 }
 
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -123,7 +123,6 @@ class AsyncWrap : public BaseObject {
   static void GetAsyncId(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PushAsyncIds(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PopAsyncIds(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void AsyncIdStackSize(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ClearAsyncIdStack(
     const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AsyncReset(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/env.cc
+++ b/src/env.cc
@@ -323,4 +323,20 @@ void Environment::ActivateImmediateCheck() {
   uv_idle_start(&immediate_idle_handle_, [](uv_idle_t*){ });
 }
 
+void Environment::AsyncHooks::grow_async_ids_stack() {
+  const uint32_t old_capacity = async_ids_stack_.Length() / 2;
+  const uint32_t new_capacity = old_capacity * 1.5;
+  AliasedBuffer<double, v8::Float64Array> new_buffer(
+      env()->isolate(), new_capacity * 2);
+
+  for (uint32_t i = 0; i < old_capacity * 2; ++i)
+    new_buffer[i] = async_ids_stack_[i];
+  async_ids_stack_ = std::move(new_buffer);
+
+  env()->async_hooks_binding()->Set(
+      env()->context(),
+      env()->async_ids_stack_string(),
+      async_ids_stack_.GetJSArray()).FromJust();
+}
+
 }  // namespace node

--- a/src/env.h
+++ b/src/env.h
@@ -41,7 +41,6 @@
 #include <map>
 #include <stdint.h>
 #include <vector>
-#include <stack>
 #include <unordered_map>
 
 struct nghttp2_rcbuf;
@@ -100,6 +99,7 @@ class ModuleWrap;
   V(address_string, "address")                                                \
   V(args_string, "args")                                                      \
   V(async, "async")                                                           \
+  V(async_ids_stack_string, "async_ids_stack")                                \
   V(buffer_string, "buffer")                                                  \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
@@ -282,6 +282,7 @@ class ModuleWrap;
   V(async_hooks_before_function, v8::Function)                                \
   V(async_hooks_after_function, v8::Function)                                 \
   V(async_hooks_promise_resolve_function, v8::Function)                       \
+  V(async_hooks_binding, v8::Object)                                          \
   V(binding_cache_object, v8::Object)                                         \
   V(internal_binding_cache_object, v8::Object)                                \
   V(buffer_prototype_object, v8::Object)                                      \
@@ -313,11 +314,6 @@ class ModuleWrap;
   V(write_wrap_constructor_function, v8::Function)                            \
 
 class Environment;
-
-struct node_async_ids {
-  double async_id;
-  double trigger_async_id;
-};
 
 class IsolateData {
  public:
@@ -382,6 +378,7 @@ class Environment {
       kPromiseResolve,
       kTotals,
       kCheck,
+      kStackLength,
       kFieldsCount,
     };
 
@@ -393,18 +390,17 @@ class Environment {
       kUidFieldsCount,
     };
 
-    AsyncHooks() = delete;
-
     inline AliasedBuffer<uint32_t, v8::Uint32Array>& fields();
     inline AliasedBuffer<double, v8::Float64Array>& async_id_fields();
+    inline AliasedBuffer<double, v8::Float64Array>& async_ids_stack();
 
     inline v8::Local<v8::String> provider_string(int idx);
 
     inline void no_force_checks();
+    inline Environment* env();
 
     inline void push_async_ids(double async_id, double trigger_async_id);
     inline bool pop_async_id(double async_id);
-    inline size_t stack_size();
     inline void clear_async_id_stack();  // Used in fatal exceptions.
 
     // Used to set the kDefaultTriggerAsyncId in a scope. This is instead of
@@ -426,18 +422,20 @@ class Environment {
 
    private:
     friend class Environment;  // So we can call the constructor.
-    inline explicit AsyncHooks(v8::Isolate* isolate);
+    inline AsyncHooks();
     // Keep a list of all Persistent strings used for Provider types.
     v8::Eternal<v8::String> providers_[AsyncWrap::PROVIDERS_LENGTH];
-    // Used by provider_string().
-    v8::Isolate* isolate_;
+    // Keep track of the environment copy itself.
+    Environment* env_;
     // Stores the ids of the current execution context stack.
-    std::stack<struct node_async_ids> async_ids_stack_;
+    AliasedBuffer<double, v8::Float64Array> async_ids_stack_;
     // Attached to a Uint32Array that tracks the number of active hooks for
     // each type.
     AliasedBuffer<uint32_t, v8::Uint32Array> fields_;
     // Attached to a Float64Array that tracks the state of async resources.
     AliasedBuffer<double, v8::Float64Array> async_id_fields_;
+
+    void grow_async_ids_stack();
 
     DISALLOW_COPY_AND_ASSIGN(AsyncHooks);
   };
@@ -682,6 +680,8 @@ class Environment {
   };
 
   inline bool inside_should_not_abort_on_uncaught_scope() const;
+
+  static inline Environment* ForAsyncHooks(AsyncHooks* hooks);
 
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),

--- a/test/parallel/test-async-hooks-recursive-stack.js
+++ b/test/parallel/test-async-hooks-recursive-stack.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// This test verifies that the async ID stack can grow indefinitely.
+
+function recurse(n) {
+  const a = new async_hooks.AsyncResource('foobar');
+  a.emitBefore();
+  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  if (n >= 0)
+    recurse(n - 1);
+  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  a.emitAfter();
+}
+
+recurse(1000);


### PR DESCRIPTION
Backport https://github.com/nodejs/node/pull/17780 to v9.x

CI: https://ci.nodejs.org/job/node-test-commit/15582/

@evanlucas 