### PR TITLE
domain, src: clean up domain-related code

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -94,7 +94,7 @@ process.setUncaughtExceptionCaptureCallback = function(fn) {
   throw err;
 };
 
-function topLevelDomainCallback(cb, args) {
+function topLevelDomainCallback(cb, ...args) {
   const domain = this.domain;
   if (domain)
     domain.enter();

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -94,11 +94,21 @@ process.setUncaughtExceptionCaptureCallback = function(fn) {
   throw err;
 };
 
+function topLevelDomainCallback(cb, args) {
+  const domain = this.domain;
+  if (domain)
+    domain.enter();
+  const ret = Reflect.apply(cb, this, args);
+  if (domain)
+    domain.exit();
+  return ret;
+}
+
 // It's possible to enter one domain while already inside
 // another one. The stack is each entered domain.
 const stack = [];
 exports._stack = stack;
-process._setupDomainUse();
+internalBinding('domain').enable(topLevelDomainCallback);
 
 function updateExceptionCapture() {
   if (stack.every((domain) => domain.listenerCount('error') === 0)) {

--- a/node.gyp
+++ b/node.gyp
@@ -299,6 +299,7 @@
         'src/node_constants.cc',
         'src/node_contextify.cc',
         'src/node_debug_options.cc',
+        'src/node_domain.cc',
         'src/node_file.cc',
         'src/node_http2.cc',
         'src/node_http_parser.cc',

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -310,7 +310,6 @@ inline Environment::Environment(IsolateData* isolate_data,
       immediate_info_(context->GetIsolate()),
       tick_info_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
-      using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
       abort_on_uncaught_exception_(false),
@@ -425,14 +424,6 @@ inline Environment::TickInfo* Environment::tick_info() {
 
 inline uint64_t Environment::timer_base() const {
   return timer_base_;
-}
-
-inline bool Environment::using_domains() const {
-  return using_domains_;
-}
-
-inline void Environment::set_using_domains(bool value) {
-  using_domains_ = value;
 }
 
 inline bool Environment::printed_error() const {

--- a/src/env.h
+++ b/src/env.h
@@ -91,7 +91,6 @@ class ModuleWrap;
   V(decorated_private_symbol, "node:decorated")                               \
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(selected_npn_buffer_private_symbol, "node:selectedNpnBuffer")             \
-  V(domain_private_symbol, "node:domain")                                     \
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.
@@ -128,7 +127,6 @@ class ModuleWrap;
   V(dns_soa_string, "SOA")                                                    \
   V(dns_srv_string, "SRV")                                                    \
   V(dns_txt_string, "TXT")                                                    \
-  V(domain_string, "domain")                                                  \
   V(emit_warning_string, "emitWarning")                                       \
   V(exchange_string, "exchange")                                              \
   V(encoding_string, "encoding")                                              \
@@ -280,6 +278,7 @@ class ModuleWrap;
   V(internal_binding_cache_object, v8::Object)                                \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
+  V(domain_callback, v8::Function)                                            \
   V(host_import_module_dynamically_callback, v8::Function)                    \
   V(http2ping_constructor_template, v8::ObjectTemplate)                       \
   V(http2stream_constructor_template, v8::ObjectTemplate)                     \
@@ -567,9 +566,6 @@ class Environment {
 
   inline IsolateData* isolate_data() const;
 
-  inline bool using_domains() const;
-  inline void set_using_domains(bool value);
-
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
@@ -746,7 +742,6 @@ class Environment {
   ImmediateInfo immediate_info_;
   TickInfo tick_info_;
   const uint64_t timer_base_;
-  bool using_domains_;
   bool printed_error_;
   bool trace_sync_io_;
   bool abort_on_uncaught_exception_;

--- a/src/env.h
+++ b/src/env.h
@@ -244,7 +244,6 @@ class ModuleWrap;
   V(subject_string, "subject")                                                \
   V(subjectaltname_string, "subjectaltname")                                  \
   V(syscall_string, "syscall")                                                \
-  V(tick_domain_cb_string, "_tickDomainCallback")                             \
   V(ticketkeycallback_string, "onticketkeycallback")                          \
   V(timeout_string, "timeout")                                                \
   V(tls_ticket_string, "tlsTicket")                                           \

--- a/src/node.cc
+++ b/src/node.cc
@@ -1066,17 +1066,13 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
     return Undefined(env->isolate());
   }
 
-  MaybeLocal<Value> ret;
+  MaybeLocal<Value> ret = callback->Call(env->context(), recv, argc, argv);
 
-  {
-    ret = callback->Call(env->context(), recv, argc, argv);
-
-    if (ret.IsEmpty()) {
-      // NOTE: For backwards compatibility with public API we return Undefined()
-      // if the top level call threw.
-      scope.MarkAsFailed();
-      return scope.IsInnerMakeCallback() ? ret : Undefined(env->isolate());
-    }
+  if (ret.IsEmpty()) {
+    // NOTE: For backwards compatibility with public API we return Undefined()
+    // if the top level call threw.
+    scope.MarkAsFailed();
+    return scope.IsInnerMakeCallback() ? ret : Undefined(env->isolate());
   }
 
   scope.Close();

--- a/src/node.cc
+++ b/src/node.cc
@@ -1000,12 +1000,10 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
   if (asyncContext.async_id != 0 || domain_cb.IsEmpty() || recv.IsEmpty()) {
     ret = callback->Call(env->context(), recv, argc, argv);
   } else {
-    Local<Array> argv_array = Array::New(env->isolate(), argc);
-    for (int i = 0; i < argc; i++) {
-      argv_array->Set(env->context(), i, argv[i]).FromJust();
-    }
-    Local<Value> domain_argv[] = { callback, argv_array };
-    ret = domain_cb->Call(env->context(), recv, 2, domain_argv);
+    std::vector<Local<Value>> args(1 + argc);
+    args[0] = callback;
+    std::copy(&argv[0], &argv[argc], &args[1]);
+    ret = domain_cb->Call(env->context(), recv, args.size(), &args[0]);
   }
 
   if (ret.IsEmpty()) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1042,11 +1042,6 @@ void InternalCallbackScope::Close() {
     return;
   }
 
-  if (env_->async_hooks()->fields()[AsyncHooks::kTotals]) {
-    CHECK_EQ(env_->execution_async_id(), 0);
-    CHECK_EQ(env_->trigger_async_id(), 0);
-  }
-
   Local<Object> process = env_->process_object();
 
   if (env_->tick_callback_function()->Call(process, 0, nullptr).IsEmpty()) {

--- a/src/node_domain.cc
+++ b/src/node_domain.cc
@@ -1,0 +1,34 @@
+#include "v8.h"
+#include "node_internals.h"
+
+namespace node {
+namespace domain {
+
+using v8::Context;
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+
+void Enable(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  CHECK(args[0]->IsFunction());
+
+  env->set_domain_callback(args[0].As<Function>());
+}
+
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+
+  env->SetMethod(target, "enable", Enable);
+}
+
+}  // namespace domain
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(domain, node::domain::Initialize)

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -104,6 +104,7 @@ struct sockaddr;
     V(cares_wrap)                                                             \
     V(config)                                                                 \
     V(contextify)                                                             \
+    V(domain)                                                                 \
     V(fs)                                                                     \
     V(fs_event_wrap)                                                          \
     V(http2)                                                                  \

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -22,6 +22,7 @@
 #include <node.h>
 #include <v8.h>
 
+using v8::Boolean;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Local;
@@ -31,11 +32,15 @@ using v8::Value;
 
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Value> params[] = {
+    Boolean::New(isolate, true),
+    Boolean::New(isolate, false)
+  };
   Local<Value> ret = node::MakeCallback(isolate,
                                         isolate->GetCurrentContext()->Global(),
                                         args[0].As<Function>(),
-                                        0,
-                                        nullptr);
+                                        2,
+                                        params);
   assert(ret->IsTrue());
 }
 

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -31,11 +31,12 @@ using v8::Value;
 
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  node::MakeCallback(isolate,
-                     isolate->GetCurrentContext()->Global(),
-                     args[0].As<Function>(),
-                     0,
-                     nullptr);
+  Local<Value> ret = node::MakeCallback(isolate,
+                                        isolate->GetCurrentContext()->Global(),
+                                        args[0].As<Function>(),
+                                        0,
+                                        nullptr);
+  assert(ret->IsTrue());
 }
 
 void init(Local<Object> exports) {

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -40,7 +40,8 @@ const lines = [
   // This line shouldn't cause an assertion error.
   `require('${buildPath}')` +
   // Log output to double check callback ran.
-  '.method(function() { console.log(\'cb_ran\'); return true; });',
+  '.method(function(v1, v2) {' +
+  'console.log(\'cb_ran\'); return v1 === true && v2 === false; });',
 ];
 
 const dInput = new stream.Readable();

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -40,7 +40,7 @@ const lines = [
   // This line shouldn't cause an assertion error.
   `require('${buildPath}')` +
   // Log output to double check callback ran.
-  '.method(function() { console.log(\'cb_ran\'); });',
+  '.method(function() { console.log(\'cb_ran\'); return true; });',
 ];
 
 const dInput = new stream.Readable();

--- a/test/cctest/node_module_reg.cc
+++ b/test/cctest/node_module_reg.cc
@@ -5,6 +5,7 @@
 void _register_cares_wrap() {}
 void _register_config() {}
 void _register_contextify() {}
+void _register_domain() {}
 void _register_fs() {}
 void _register_fs_event_wrap() {}
 void _register_http2() {}


### PR DESCRIPTION
Move the majority of C++ domain-related code into JS land by introducing a top level domain callback which handles entering & exiting the domain.

Move the rest of the domain necessities into their own file that creates an internal binding, to avoid exposing domain-related code on the process object.

Also a bit of other assorted domain-related cleanup.

(This happens to boost the performance of top-level domain code by roughly 33% but mostly I just wanted to have less domain-related code scattered all over.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
domain, src