### PR TITLE
build: fix building addons in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,10 @@ $(1)build/Release/.buildstamp: $(1)build/Makefile $(2) $(ADDON_PREREQS)
 	$(NODE_GYP) --directory=$(1) build
 	@touch $$@
 $(1)build/Release/binding.node: $(1)build/Release/.buildstamp
+$(1)build/Debug/.buildstamp: $(1)build/Makefile $(2) $(ADDON_PREREQS)
+	$(NODE_GYP) --directory=$(1) --debug build
+	@touch $$@
+$(1)build/Debug/binding.node: $(1)build/Debug/.buildstamp
 endef
 
 $(foreach x, $(ADDON_DIRS), \


### PR DESCRIPTION
After cleaning addons, running `make build-addons` failed
when Node was configured for debug mode,
because the Makefile was expecting `build/Release/` addon paths,
not `build/Debug/` addon paths.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

build