### PR TITLE
src: schedule unref immediate for uv_close in destructors

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -521,6 +521,9 @@ ChannelWrap::~ChannelWrap() {
   }
 
   ares_destroy(channel_);
+
+  if (timer_handle_ == nullptr)
+    return;
   uv_timer_stop(timer_handle_);
   auto close_cb = [](Environment* env, void* data) {
     uv_close(reinterpret_cast<uv_handle_t*>(data), [](uv_handle_t* handle) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -149,7 +149,6 @@ class ChannelWrap : public AsyncWrap {
 
   void Setup();
   void EnsureServers();
-  void CleanupTimer();
 
   void ModifyActivityQueryCount(int count);
 
@@ -503,7 +502,12 @@ void ChannelWrap::Setup() {
 
   /* Initialize the timeout timer. The timer won't be started until the */
   /* first socket is opened. */
-  CleanupTimer();
+  if (timer_handle_ != nullptr) {
+    auto close_cb = [](uv_handle_t* handle) {
+      delete reinterpret_cast<uv_timer_t*>(handle);
+    };
+    uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_), close_cb);
+  }
   timer_handle_ = new uv_timer_t();
   timer_handle_->data = static_cast<void*>(this);
   uv_timer_init(env()->event_loop(), timer_handle_);
@@ -517,19 +521,16 @@ ChannelWrap::~ChannelWrap() {
   }
 
   ares_destroy(channel_);
-  CleanupTimer();
-}
-
-
-void ChannelWrap::CleanupTimer() {
-  if (timer_handle_ == nullptr) return;
-
-  uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
-           [](uv_handle_t* handle) {
-    delete reinterpret_cast<uv_timer_t*>(handle);
-  });
+  uv_timer_stop(timer_handle_);
+  auto close_cb = [](Environment* env, void* data) {
+    uv_close(reinterpret_cast<uv_handle_t*>(data), [](uv_handle_t* handle) {
+      delete reinterpret_cast<uv_timer_t*>(handle);
+    });
+  };
+  env()->SetUnrefImmediate(close_cb, timer_handle_);
   timer_handle_ = nullptr;
 }
+
 
 void ChannelWrap::ModifyActivityQueryCount(int count) {
   active_query_count_ += count;


### PR DESCRIPTION
Calling `uv_close` directly in destructors seems to be problematic as it can bring a loop back alive after `EmitBeforeExit`. The problem is that this only happens sometimes as it depends on GC timing, making the behaviour of these two classes unpredictable.

This PR should fix that behaviour and also (I think?) fix the flaky `sequential/test-async-wrap-getasyncid.js` test.

Fixes: https://github.com/nodejs/node/issues/18190

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src