### PR TITLE
doc: add missing URL argument types in fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -843,7 +843,7 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {string|Buffer|number} filename or file descriptor
+* `file` {string|Buffer|URL|number} filename or file descriptor
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
@@ -898,7 +898,7 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {string|Buffer|number} filename or file descriptor
+* `file` {string|Buffer|URL|number} filename or file descriptor
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
@@ -1709,7 +1709,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `mode` {integer}
 * `callback` {Function}
   * `err` {Error}
@@ -1724,7 +1724,7 @@ Only available on macOS.
 deprecated: v0.4.7
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `mode` {integer}
 
 Synchronous lchmod(2). Returns `undefined`.
@@ -1739,7 +1739,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `uid` {integer}
 * `gid` {integer}
 * `callback` {Function}
@@ -1753,7 +1753,7 @@ to the completion callback.
 deprecated: v0.4.7
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `uid` {integer}
 * `gid` {integer}
 
@@ -2694,7 +2694,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `len` {integer} **Default:** `0`
 * `callback` {Function}
   * `err` {Error}
@@ -2711,7 +2711,7 @@ being thrown in the future.
 added: v0.8.6
 -->
 
-* `path` {string|Buffer}
+* `path` {string|Buffer|URL}
 * `len` {integer} **Default:** `0`
 
 Synchronous truncate(2). Returns `undefined`. A file descriptor can also be
@@ -2760,7 +2760,7 @@ Synchronous unlink(2). Returns `undefined`.
 added: v0.1.31
 -->
 
-* `filename` {string|Buffer}
+* `filename` {string|Buffer|URL}
 * `listener` {Function} Optional, a listener previously attached using
   `fs.watchFile()`
 
@@ -3120,7 +3120,7 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {string|Buffer|integer} filename or file descriptor
+* `file` {string|Buffer|URL|integer} filename or file descriptor
 * `data` {string|Buffer|Uint8Array}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
@@ -3171,7 +3171,7 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {string|Buffer|integer} filename or file descriptor
+* `file` {string|Buffer|URL|integer} filename or file descriptor
 * `data` {string|Buffer|Uint8Array}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, fs

##### Refs:

`fs.appendFile()` -> [`fs.writeFile()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1595) -> [`fs.open()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1540) -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L756)

`fs.lchmod()` ->[`fs.open()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1317) -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L756)

`fs.lchown()` ->[`fs.open()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1379) -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L756)

`fs.truncate()` ->[`fs.open()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L944) -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L756)

`fs.writeFile()`-> [`fs.open()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1540) -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L756)

`fs.unwatchFile()` -> [`getPathFromURL()`](https://github.com/nodejs/node/blob/f5d9169dedb053946c7b71f146b6b757dccbe61b/lib/fs.js#L1781)

