### PR TITLE
doc: remove confusing signature in fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2761,9 +2761,8 @@ added: v0.1.31
 -->
 
 * `filename` {string|Buffer}
-* `listener` {Function|undefined} **Default:** `undefined`
-  * `eventType` {string}
-  * `filename` {string|Buffer}
+* `listener` {Function} Optional, a listener previously attached using
+  `fs.watchFile()`
 
 Stop watching for changes on `filename`. If `listener` is specified, only that
 particular listener is removed. Otherwise, *all* listeners are removed,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, fs

Fixes: https://github.com/nodejs/node/issues/18305

This signature has been added in https://github.com/nodejs/node/pull/13424. It seems to be erroneous as it can make an inattentive reader (me at least) think that `listener` is not a previously defined listener for `fs.watchFile()`, but a new callback for ` fs.unwatchFile()`. Sorry if I am wrong and doubly confusing.
