### PR TITLE
test: force context allocation in test module

### DIFF
--- a/test/fixtures/es-modules/loop.mjs
+++ b/test/fixtures/es-modules/loop.mjs
@@ -9,4 +9,5 @@ while (t > 0) {
 }
 process.exit(55);
 
+// test/parallel/test-inspector-esm.js expects t and k to be context-allocated.
 (function force_context_allocation() { return t + k; })

--- a/test/fixtures/es-modules/loop.mjs
+++ b/test/fixtures/es-modules/loop.mjs
@@ -8,3 +8,5 @@ while (t > 0) {
   }
 }
 process.exit(55);
+
+(function force_context_allocation() { return t + k; })


### PR DESCRIPTION
This is to anticipate `test/parallel/test-inspector-esm.js` failing due to V8's behavior changing in [c3bd741efd](https://github.com/v8/v8/commit/c3bd741efd29b8c6b322cea62f045e971cd7d183).

Top-level variables in a module are then no longer context-allocated by default. That however is expected in the test. This change forces context allocation by closing over top-level variables.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
