### PR TITLE
doc: Fix typos in async_hooks

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -244,10 +244,10 @@ RANDOMBYTESREQUEST, TLSWRAP, Timeout, Immediate, TickObject
 There is also the `PROMISE` resource type, which is used to track `Promise`
 instances and asynchronous work scheduled by them.
 
-Users are be able to define their own `type` when using the public embedder API.
+Users are able to define their own `type` when using the public embedder API.
 
 *Note:* It is possible to have type name collisions. Embedders are encouraged
-to use a unique prefixes, such as the npm package name, to prevent collisions
+to use unique prefixes, such as the npm package name, to prevent collisions
 when listening to the hooks.
 
 ###### `triggerId`


### PR DESCRIPTION
Corrected two small typos found in the async_hook documentation. 👍 