### PR TITLE
assert: use a default message in assert

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -692,9 +692,8 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17581
-    description: assert.ok() will throw a `ERR_MISSING_ARGS` error.
-                 Use assert.fail() instead.
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: assert.ok() (no arguments) will now use a predefined error msg.
 -->
 * `value` {any}
 * `message` {any}
@@ -707,6 +706,8 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is `undefined`, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
 `AssertionError`.
+If no arguments are passed in at all `message` will be set to the string:
+"No value argument passed to assert.ok".
 
 Be aware that in the `repl` the error message will be different to the one
 thrown in a file! See below for further details.
@@ -718,6 +719,10 @@ assert.ok(true);
 // OK
 assert.ok(1);
 // OK
+
+assert.ok();
+// throws:
+// "AssertionError: No value argument passed to `assert.ok`.
 
 assert.ok(false, 'it\'s false');
 // throws "AssertionError: it's false"

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -137,11 +137,10 @@ function getBuffer(fd, assertLine) {
 function innerOk(args, fn) {
   var [value, message] = args;
 
-  if (args.length === 0)
-    throw new TypeError('ERR_MISSING_ARGS', 'value');
-
   if (!value) {
-    if (message == null) {
+    if (args.length === 0) {
+      message = 'No value argument passed to `assert.ok()`';
+    } else if (message == null) {
       // Use the call as error message if possible.
       // This does not work with e.g. the repl.
       const err = new Error();

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -733,18 +733,18 @@ common.expectsError(
   assert.equal(assert.notDeepEqual, assert.notDeepStrictEqual);
   assert.equal(Object.keys(assert).length, Object.keys(a).length);
   assert(7);
-  common.expectsError(
+  assert.throws(
     () => assert(),
     {
-      code: 'ERR_MISSING_ARGS',
-      type: TypeError
+      message: 'No value argument passed to `assert.ok()`',
+      name: 'AssertionError [ERR_ASSERTION]'
     }
   );
-  common.expectsError(
+  assert.throws(
     () => a(),
     {
-      code: 'ERR_MISSING_ARGS',
-      type: TypeError
+      message: 'No value argument passed to `assert.ok()`',
+      name: 'AssertionError [ERR_ASSERTION]'
     }
   );
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -734,7 +734,7 @@ common.expectsError(
   assert.equal(Object.keys(assert).length, Object.keys(a).length);
   assert(7);
   assert.throws(
-    () => assert(),
+    () => assert(...[]),
     {
       message: 'No value argument passed to `assert.ok()`',
       name: 'AssertionError [ERR_ASSERTION]'


### PR DESCRIPTION
In case no arguments are passed to `assert.ok` it should just
use a default message. Otherwise `assert.ok` can not be used as
a callback.

The PR that changed the behavior before is `semver-major` and has not yet been released. 
So I just changed the original changed entry.

The reason for the change is something like this:

```js
const assert = require('assert');
const EventEmitter = require('events');

const e = new EventEmitter();
e.once('hello', assert);
e.emit('hello');
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert