### PR TITLE
benchmarks: improve code base

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -14,8 +14,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ len, n, method }) {
-  var i;
-
   const data = Buffer.allocUnsafe(len + 1);
   const actual = Buffer.alloc(len);
   const expected = Buffer.alloc(len);
@@ -24,40 +22,13 @@ function main({ len, n, method }) {
   data.copy(expected);
   data.copy(expectedWrong);
 
-  switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'deepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    default:
-      throw new Error('Unsupported method');
+  // eslint-disable-next-line no-restricted-properties
+  const fn = method !== '' ? assert[method] : assert.deepEqual;
+  const value2 = method.includes('not') ? expectedWrong : expected;
+
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    fn(actual, value2);
   }
+  bench.end(n);
 }

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -117,6 +117,6 @@ function main({ n, len, method }) {
       benchmark(assert.notDeepEqual, n, values, values2);
       break;
     default:
-      throw new Error('Unsupported method');
+      throw new Error(`Unsupported method ${method}`);
   }
 }

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -28,47 +28,19 @@ function createObj(source, add = '') {
 function main({ size, n, method }) {
   // TODO: Fix this "hack". `n` should not be manipulated.
   n = n / size;
-  var i;
 
   const source = Array.apply(null, Array(size));
   const actual = createObj(source);
   const expected = createObj(source);
   const expectedWrong = createObj(source, '4');
 
-  switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'deepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    default:
-      throw new Error('Unsupported method');
+  // eslint-disable-next-line no-restricted-properties
+  const fn = method !== '' ? assert[method] : assert.deepEqual;
+  const value2 = method.includes('not') ? expectedWrong : expected;
+
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    fn(actual, value2);
   }
+  bench.end(n);
 }

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -30,12 +30,19 @@ const bench = common.createBenchmark(main, {
   ]
 });
 
+function run(fn, n, actual, expected) {
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    fn(actual, expected);
+  }
+  bench.end(n);
+}
+
 function main({ n, len, primitive, method }) {
   const prim = primValues[primitive];
   const actual = [];
   const expected = [];
   const expectedWrong = [];
-  var i;
 
   for (var x = 0; x < len; x++) {
     actual.push(prim);
@@ -51,69 +58,37 @@ function main({ n, len, primitive, method }) {
   const expectedWrongSet = new Set(expectedWrong);
 
   switch (method) {
+    // Empty string falls through to next line as default, mostly for tests.
     case '':
-      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_Array':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual(actual, expected);
-      }
-      bench.end(n);
+      // eslint-disable-next-line no-restricted-properties
+      run(assert.deepEqual, n, actual, expected);
       break;
     case 'deepStrictEqual_Array':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual(actual, expected);
-      }
-      bench.end(n);
+      run(assert.deepStrictEqual, n, actual, expected);
       break;
     case 'notDeepEqual_Array':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual(actual, expectedWrong);
-      }
-      bench.end(n);
+      // eslint-disable-next-line no-restricted-properties
+      run(assert.notDeepEqual, n, actual, expectedWrong);
       break;
     case 'notDeepStrictEqual_Array':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual(actual, expectedWrong);
-      }
-      bench.end(n);
+      run(assert.notDeepStrictEqual, n, actual, expectedWrong);
       break;
     case 'deepEqual_Set':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual(actualSet, expectedSet);
-      }
-      bench.end(n);
+      // eslint-disable-next-line no-restricted-properties
+      run(assert.deepEqual, n, actualSet, expectedSet);
       break;
     case 'deepStrictEqual_Set':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual(actualSet, expectedSet);
-      }
-      bench.end(n);
+      run(assert.deepStrictEqual, n, actualSet, expectedSet);
       break;
     case 'notDeepEqual_Set':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual(actualSet, expectedWrongSet);
-      }
-      bench.end(n);
+      // eslint-disable-next-line no-restricted-properties
+      run(assert.notDeepEqual, n, actualSet, expectedWrongSet);
       break;
     case 'notDeepStrictEqual_Set':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual(actualSet, expectedWrongSet);
-      }
-      bench.end(n);
+      run(assert.notDeepStrictEqual, n, actualSet, expectedWrongSet);
       break;
     default:
-      throw new Error('Unsupported method');
+      throw new Error(`Unsupported method "${method}"`);
   }
 }

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -29,43 +29,14 @@ function main({ n, primitive, method }) {
   const actual = prim;
   const expected = prim;
   const expectedWrong = 'b';
-  var i;
 
-  // Creates new array to avoid loop invariant code motion
-  switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual([actual], [expected]);
-      }
-      bench.end(n);
-      break;
-    case 'deepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual([actual], [expected]);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual([actual], [expectedWrong]);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual([actual], [expectedWrong]);
-      }
-      bench.end(n);
-      break;
-    default:
-      throw new Error('Unsupported method');
+  // eslint-disable-next-line no-restricted-properties
+  const fn = method !== '' ? assert[method] : assert.deepEqual;
+  const value2 = method.includes('not') ? expectedWrong : expected;
+
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    fn([actual], [value2]);
   }
+  bench.end(n);
 }

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -126,6 +126,6 @@ function main({ n, len, method }) {
       benchmark(assert.notDeepEqual, n, values, values2);
       break;
     default:
-      throw new Error('Unsupported method');
+      throw new Error(`Unsupported method "${method}"`);
   }
 }

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -31,42 +31,14 @@ function main({ type, n, len, method }) {
   const expectedWrong = Buffer.alloc(len);
   const wrongIndex = Math.floor(len / 2);
   expectedWrong[wrongIndex] = 123;
-  var i;
 
-  switch (method) {
-    case '':
-      // Empty string falls through to next line as default, mostly for tests.
-    case 'deepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.deepEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'deepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.deepStrictEqual(actual, expected);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        // eslint-disable-next-line no-restricted-properties
-        assert.notDeepEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    case 'notDeepStrictEqual':
-      bench.start();
-      for (i = 0; i < n; ++i) {
-        assert.notDeepStrictEqual(actual, expectedWrong);
-      }
-      bench.end(n);
-      break;
-    default:
-      throw new Error('Unsupported method');
+  // eslint-disable-next-line no-restricted-properties
+  const fn = method !== '' ? assert[method] : assert.deepEqual;
+  const value2 = method.includes('not') ? expectedWrong : expected;
+
+  bench.start();
+  for (var i = 0; i < n; ++i) {
+    fn(actual, value2);
   }
+  bench.end(n);
 }

--- a/benchmark/async_hooks/gc-tracking.js
+++ b/benchmark/async_hooks/gc-tracking.js
@@ -22,22 +22,23 @@ function endAfterGC(n) {
 }
 
 function main({ n, method }) {
+  var i;
   switch (method) {
     case 'trackingEnabled':
       bench.start();
-      for (let i = 0; i < n; i++) {
+      for (i = 0; i < n; i++) {
         new AsyncResource('foobar');
       }
       endAfterGC(n);
       break;
     case 'trackingDisabled':
       bench.start();
-      for (let i = 0; i < n; i++) {
+      for (i = 0; i < n; i++) {
         new AsyncResource('foobar', { requireManualDestroy: true });
       }
       endAfterGC(n);
       break;
     default:
-      throw new Error('Unsupported method');
+      throw new Error(`Unsupported method "${method}"`);
   }
 }

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -17,10 +17,9 @@ const chars = [
 
 function main({ n, len, encoding }) {
   var strings = [];
-  var results;
+  var results = [ len * 16 ];
   if (encoding === 'buffer') {
     strings = [ Buffer.alloc(len * 16, 'a') ];
-    results = [ len * 16 ];
   } else {
     for (const string of chars) {
       // Strings must be built differently, depending on encoding

--- a/benchmark/buffers/buffer-compare-offset.js
+++ b/benchmark/buffers/buffer-compare-offset.js
@@ -8,26 +8,22 @@ const bench = common.createBenchmark(main, {
 });
 
 function compareUsingSlice(b0, b1, len, iter) {
-  var i;
-  bench.start();
-  for (i = 0; i < iter; i++)
+  for (var i = 0; i < iter; i++)
     Buffer.compare(b0.slice(1, len), b1.slice(1, len));
-  bench.end(iter / 1e6);
 }
 
 function compareUsingOffset(b0, b1, len, iter) {
-  var i;
-  bench.start();
-  for (i = 0; i < iter; i++)
+  for (var i = 0; i < iter; i++)
     b0.compare(b1, 1, len, 1, len);
-  bench.end(iter / 1e6);
 }
 
 function main({ millions, size, method }) {
   const iter = millions * 1e6;
   const fn = method === 'slice' ? compareUsingSlice : compareUsingOffset;
+  bench.start();
   fn(Buffer.alloc(size, 'a'),
      Buffer.alloc(size, 'b'),
      size >> 1,
      iter);
+  bench.end(millions);
 }

--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -16,51 +16,38 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ len, n, type }) {
+  let fn, i;
   switch (type) {
     case '':
     case 'fast-alloc':
-      bench.start();
-      for (let i = 0; i < n * 1024; i++) {
-        Buffer.alloc(len);
-      }
-      bench.end(n);
+      fn = Buffer.alloc;
       break;
     case 'fast-alloc-fill':
       bench.start();
-      for (let i = 0; i < n * 1024; i++) {
+      for (i = 0; i < n * 1024; i++) {
         Buffer.alloc(len, 0);
       }
       bench.end(n);
-      break;
+      return;
     case 'fast-allocUnsafe':
-      bench.start();
-      for (let i = 0; i < n * 1024; i++) {
-        Buffer.allocUnsafe(len);
-      }
-      bench.end(n);
+      fn = Buffer.allocUnsafe;
       break;
     case 'slow-allocUnsafe':
-      bench.start();
-      for (let i = 0; i < n * 1024; i++) {
-        Buffer.allocUnsafeSlow(len);
-      }
-      bench.end(n);
+      fn = Buffer.allocUnsafeSlow;
       break;
     case 'slow':
-      bench.start();
-      for (let i = 0; i < n * 1024; i++) {
-        SlowBuffer(len);
-      }
-      bench.end(n);
+      fn = SlowBuffer;
       break;
     case 'buffer()':
-      bench.start();
-      for (let i = 0; i < n * 1024; i++) {
-        Buffer(len);
-      }
-      bench.end(n);
+      fn = Buffer;
       break;
     default:
-      assert.fail(null, null, 'Should not get here');
+      assert.fail('Should not get here');
   }
+
+  bench.start();
+  for (i = 0; i < n * 1024; i++) {
+    fn(len);
+  }
+  bench.end(n);
 }

--- a/benchmark/buffers/buffer-hex.js
+++ b/benchmark/buffers/buffer-hex.js
@@ -9,15 +9,16 @@ const bench = common.createBenchmark(main, {
 
 function main({ len, n }) {
   const buf = Buffer.alloc(len);
+  var i;
 
-  for (let i = 0; i < buf.length; i++)
+  for (i = 0; i < buf.length; i++)
     buf[i] = i & 0xff;
 
   const hex = buf.toString('hex');
 
   bench.start();
 
-  for (let i = 0; i < n; i += 1)
+  for (i = 0; i < n; i += 1)
     Buffer.from(hex, 'hex');
 
   bench.end(n);

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -20,36 +20,30 @@ function main({ size, type, method, n }) {
   const clazz = type === 'fast' ? Buffer : SlowBuffer;
   const buffer = new clazz(size);
   buffer.fill(0);
-  methods[method || 'for'](buffer, n);
+  const fn = methods[method || 'for'];
+
+  bench.start();
+  fn(buffer, n);
+  bench.end(n);
 }
 
-
 function benchFor(buffer, n) {
-  bench.start();
-
   for (var k = 0; k < n; k++) {
     for (var i = 0; i < buffer.length; i++) {
       assert(buffer[i] === 0);
     }
   }
-
-  bench.end(n);
 }
 
 function benchForOf(buffer, n) {
-  bench.start();
-
   for (var k = 0; k < n; k++) {
     for (const b of buffer) {
       assert(b === 0);
     }
   }
-  bench.end(n);
 }
 
 function benchIterator(buffer, n) {
-  bench.start();
-
   for (var k = 0; k < n; k++) {
     const iter = buffer[Symbol.iterator]();
     var cur = iter.next();
@@ -60,6 +54,4 @@ function benchIterator(buffer, n) {
     }
 
   }
-
-  bench.end(n);
 }

--- a/benchmark/buffers/buffer-read-float.js
+++ b/benchmark/buffers/buffer-read-float.js
@@ -9,12 +9,10 @@ const bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-function main(conf) {
-  const noAssert = conf.noAssert === 'true';
-  const len = +conf.millions * 1e6;
+function main({ noAssert, millions, type, endian, value }) {
+  noAssert = noAssert === 'true';
+  type = type || 'Double';
   const buff = Buffer.alloc(8);
-  const type = conf.type || 'Double';
-  const endian = conf.endian;
   const fn = `read${type}${endian}`;
   const values = {
     Double: {
@@ -32,15 +30,12 @@ function main(conf) {
       nan: NaN,
     },
   };
-  const value = values[type][conf.value];
 
-  buff[`write${type}${endian}`](value, 0, noAssert);
-  const testFunction = new Function('buff', `
-    for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(0, ${JSON.stringify(noAssert)});
-    }
-  `);
+  buff[`write${type}${endian}`](values[type][value], 0, noAssert);
+
   bench.start();
-  testFunction(buff);
-  bench.end(len / 1e6);
+  for (var i = 0; i !== millions * 1e6; i++) {
+    buff[fn](0, noAssert);
+  }
+  bench.end(millions);
 }

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -16,21 +16,17 @@ const bench = common.createBenchmark(main, {
   byteLength: [1, 2, 4, 6]
 });
 
-function main(conf) {
-  const noAssert = conf.noAssert === 'true';
-  const len = conf.millions * 1e6;
-  const clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
+function main({ millions, noAssert, buf, type, byteLength }) {
+  noAssert = noAssert === 'true';
+  type = type || 'UInt8';
+  const clazz = buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
   const buff = new clazz(8);
-  const type = conf.type || 'UInt8';
   const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0, noAssert);
-  const testFunction = new Function('buff', `
-    for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(0, ${conf.byteLength}, ${JSON.stringify(noAssert)});
-    }
-  `);
   bench.start();
-  testFunction(buff);
-  bench.end(len / 1e6);
+  for (var i = 0; i !== millions * 1e6; i++) {
+    buff[fn](0, byteLength, noAssert);
+  }
+  bench.end(millions);
 }

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -27,18 +27,14 @@ const bench = common.createBenchmark(main, {
 
 function main({ noAssert, millions, buf, type }) {
   noAssert = noAssert === 'true';
-  const len = millions * 1e6;
   const clazz = buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
   const buff = new clazz(8);
   const fn = `read${type || 'UInt8'}`;
 
   buff.writeDoubleLE(0, 0, noAssert);
-  const testFunction = new Function('buff', `
-    for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(0, ${JSON.stringify(noAssert)});
-    }
-  `);
   bench.start();
-  testFunction(buff);
-  bench.end(len / 1e6);
+  for (var i = 0; i !== millions * 1e6; i++) {
+    buff[fn](0, noAssert);
+  }
+  bench.end(millions);
 }

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -46,36 +46,29 @@ const mod = {
 };
 
 function main({ noAssert, millions, buf, type }) {
-  const len = millions * 1e6;
   const clazz = buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
   const buff = new clazz(8);
   const fn = `write${type || 'UInt8'}`;
 
   if (/Int/.test(fn))
-    benchInt(buff, fn, len, noAssert);
+    benchInt(buff, fn, millions, noAssert);
   else
-    benchFloat(buff, fn, len, noAssert);
+    benchFloat(buff, fn, millions, noAssert);
 }
 
-function benchInt(buff, fn, len, noAssert) {
+function benchInt(buff, fn, millions, noAssert) {
   const m = mod[fn];
-  const testFunction = new Function('buff', `
-    for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(i & ${m}, 0, ${noAssert});
-    }
-  `);
   bench.start();
-  testFunction(buff);
-  bench.end(len / 1e6);
+  for (var i = 0; i !== millions * 1e6; i++) {
+    buff[fn](i & m, 0, noAssert);
+  }
+  bench.end(millions);
 }
 
-function benchFloat(buff, fn, len, noAssert) {
-  const testFunction = new Function('buff', `
-    for (var i = 0; i !== ${len}; i++) {
-      buff.${fn}(i, 0, ${noAssert});
-    }
-  `);
+function benchFloat(buff, fn, millions, noAssert) {
   bench.start();
-  testFunction(buff);
-  bench.end(len / 1e6);
+  for (var i = 0; i !== millions * 1e6; i++) {
+    buff[fn](i, 0, noAssert);
+  }
+  bench.end(millions);
 }

--- a/benchmark/buffers/buffer_zero.js
+++ b/benchmark/buffers/buffer_zero.js
@@ -11,12 +11,9 @@ const zeroBuffer = Buffer.alloc(0);
 const zeroString = '';
 
 function main({ n, type }) {
+  const data = type === 'buffer' ? zeroBuffer : zeroString;
+
   bench.start();
-
-  if (type === 'buffer')
-    for (let i = 0; i < n * 1024; i++) Buffer.from(zeroBuffer);
-  else if (type === 'string')
-    for (let i = 0; i < n * 1024; i++) Buffer.from(zeroString);
-
+  for (var i = 0; i < n * 1024; i++) Buffer.from(data);
   bench.end(n);
 }

--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -8,13 +8,13 @@ const bench = common.createBenchmark(main, {
   len: [1024, 4 * 1024, 16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024]
 });
 
-function main(conf) {
-  const message = Buffer.alloc(conf.len, 'b');
-  const key = crypto.randomBytes(keylen[conf.cipher]);
+function main({ n, len, cipher }) {
+  const message = Buffer.alloc(len, 'b');
+  const key = crypto.randomBytes(keylen[cipher]);
   const iv = crypto.randomBytes(12);
   const associate_data = Buffer.alloc(16, 'z');
   bench.start();
-  AEAD_Bench(conf.cipher, message, associate_data, key, iv, conf.n, conf.len);
+  AEAD_Bench(cipher, message, associate_data, key, iv, n, len);
 }
 
 function AEAD_Bench(cipher, message, associate_data, key, iv, n, len) {

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -9,8 +9,7 @@ const bench = common.createBenchmark(main, {
   api: ['legacy', 'stream']
 });
 
-function main(conf) {
-  var api = conf.api;
+function main({ api, cipher, type, len, writes }) {
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
@@ -33,25 +32,25 @@ function main(conf) {
   // alice_secret and bob_secret should be the same
   assert(alice_secret === bob_secret);
 
-  const alice_cipher = crypto.createCipher(conf.cipher, alice_secret);
-  const bob_cipher = crypto.createDecipher(conf.cipher, bob_secret);
+  const alice_cipher = crypto.createCipher(cipher, alice_secret);
+  const bob_cipher = crypto.createDecipher(cipher, bob_secret);
 
   var message;
   var encoding;
-  switch (conf.type) {
+  switch (type) {
     case 'asc':
-      message = 'a'.repeat(conf.len);
+      message = 'a'.repeat(len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = 'ü'.repeat(conf.len / 2);
+      message = 'ü'.repeat(len / 2);
       encoding = 'utf8';
       break;
     case 'buf':
-      message = Buffer.alloc(conf.len, 'b');
+      message = Buffer.alloc(len, 'b');
       break;
     default:
-      throw new Error(`unknown message type: ${conf.type}`);
+      throw new Error(`unknown message type: ${type}`);
   }
 
   const fn = api === 'stream' ? streamWrite : legacyWrite;
@@ -59,7 +58,7 @@ function main(conf) {
   // write data as fast as possible to alice, and have bob decrypt.
   // use old API for comparison to v0.8
   bench.start();
-  fn(alice_cipher, bob_cipher, message, encoding, conf.writes);
+  fn(alice_cipher, bob_cipher, message, encoding, writes);
 }
 
 function streamWrite(alice, bob, message, encoding, writes) {

--- a/benchmark/crypto/get-ciphers.js
+++ b/benchmark/crypto/get-ciphers.js
@@ -7,12 +7,10 @@ const bench = common.createBenchmark(main, {
   v: ['crypto', 'tls']
 });
 
-function main(conf) {
-  const n = +conf.n;
-  const v = conf.v;
+function main({ n, v }) {
   const method = require(v).getCiphers;
   var i = 0;
-  // first call to getChipers will dominate the results
+  // First call to getChipers will dominate the results
   if (n > 1) {
     for (; i < n; i++)
       method();

--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -13,8 +13,7 @@ const bench = common.createBenchmark(main, {
   api: ['legacy', 'stream']
 });
 
-function main(conf) {
-  var api = conf.api;
+function main({ api, type, len, out, writes, algo }) {
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
@@ -23,26 +22,26 @@ function main(conf) {
 
   var message;
   var encoding;
-  switch (conf.type) {
+  switch (type) {
     case 'asc':
-      message = 'a'.repeat(conf.len);
+      message = 'a'.repeat(len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = 'ü'.repeat(conf.len / 2);
+      message = 'ü'.repeat(len / 2);
       encoding = 'utf8';
       break;
     case 'buf':
-      message = Buffer.alloc(conf.len, 'b');
+      message = Buffer.alloc(len, 'b');
       break;
     default:
-      throw new Error(`unknown message type: ${conf.type}`);
+      throw new Error(`unknown message type: ${type}`);
   }
 
   const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
-  fn(conf.algo, message, encoding, conf.writes, conf.len, conf.out);
+  fn(algo, message, encoding, writes, len, out);
 }
 
 function legacyWrite(algo, message, encoding, writes, len, outEnc) {

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -12,8 +12,7 @@ const bench = common.createBenchmark(main, {
   api: ['legacy', 'stream']
 });
 
-function main(conf) {
-  var api = conf.api;
+function main({ api, type, len, algo, writes }) {
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
@@ -22,26 +21,26 @@ function main(conf) {
 
   var message;
   var encoding;
-  switch (conf.type) {
+  switch (type) {
     case 'asc':
-      message = 'a'.repeat(conf.len);
+      message = 'a'.repeat(len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = 'ü'.repeat(conf.len / 2);
+      message = 'ü'.repeat(len / 2);
       encoding = 'utf8';
       break;
     case 'buf':
-      message = Buffer.alloc(conf.len, 'b');
+      message = Buffer.alloc(len, 'b');
       break;
     default:
-      throw new Error(`unknown message type: ${conf.type}`);
+      throw new Error(`unknown message type: ${type}`);
   }
 
   const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
-  fn(conf.algo, message, encoding, conf.writes, conf.len);
+  fn(algo, message, encoding, writes, len);
 }
 
 function legacyWrite(algo, message, encoding, writes, len) {

--- a/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
+++ b/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
@@ -22,10 +22,10 @@ const bench = common.createBenchmark(main, {
   len: [16, 32, 64]
 });
 
-function main(conf) {
-  const message = Buffer.alloc(conf.len, 'b');
+function main({ len, algo, keylen, n }) {
+  const message = Buffer.alloc(len, 'b');
   bench.start();
-  StreamWrite(conf.algo, conf.keylen, message, conf.n, conf.len);
+  StreamWrite(algo, keylen, message, n, len);
 }
 
 function StreamWrite(algo, keylen, message, n, len) {

--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -23,10 +23,10 @@ const bench = common.createBenchmark(main, {
   len: [1024, 102400, 2 * 102400, 3 * 102400, 1024 * 1024]
 });
 
-function main(conf) {
-  const message = Buffer.alloc(conf.len, 'b');
+function main({ len, algo, keylen, writes }) {
+  const message = Buffer.alloc(len, 'b');
   bench.start();
-  StreamWrite(conf.algo, conf.keylen, message, conf.writes, conf.len);
+  StreamWrite(algo, keylen, message, writes, len);
 }
 
 function StreamWrite(algo, keylen, message, writes, len) {

--- a/benchmark/dgram/bind-params.js
+++ b/benchmark/dgram/bind-params.js
@@ -15,10 +15,11 @@ const noop = () => {};
 function main({ n, port, address }) {
   port = port === 'true' ? 0 : undefined;
   address = address === 'true' ? '0.0.0.0' : undefined;
+  var i;
 
   if (port !== undefined && address !== undefined) {
     bench.start();
-    for (let i = 0; i < n; i++) {
+    for (i = 0; i < n; i++) {
       dgram.createSocket('udp4').bind(port, address)
         .on('error', noop)
         .unref();
@@ -26,7 +27,7 @@ function main({ n, port, address }) {
     bench.end(n);
   } else if (port !== undefined) {
     bench.start();
-    for (let i = 0; i < n; i++) {
+    for (i = 0; i < n; i++) {
       dgram.createSocket('udp4')
         .bind(port)
         .on('error', noop)
@@ -35,7 +36,7 @@ function main({ n, port, address }) {
     bench.end(n);
   } else if (port === undefined && address === undefined) {
     bench.start();
-    for (let i = 0; i < n; i++) {
+    for (i = 0; i < n; i++) {
       dgram.createSocket('udp4')
         .bind()
         .on('error', noop)

--- a/benchmark/domain/domain-fn-args.js
+++ b/benchmark/domain/domain-fn-args.js
@@ -28,15 +28,6 @@ function main({ n, args }) {
   bench.end(n);
 }
 
-function fn(a, b, c) {
-  if (!a)
-    a = 1;
-
-  if (!b)
-    b = 2;
-
-  if (!c)
-    c = 3;
-
+function fn(a = 1, b = 2, c = 3) {
   return a + b + c;
 }

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -20,37 +20,31 @@ function defaultParams(x = 1, y = 2) {
   assert.strictEqual(y, 2);
 }
 
-function runOldStyleDefaults(n) {
-
-  var i = 0;
+function runOldStyleDefaults(millions) {
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < millions * 1e6; i++)
     oldStyleDefaults();
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runDefaultParams(n) {
-
-  var i = 0;
+function runDefaultParams(millions) {
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < millions * 1e6; i++)
     defaultParams();
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function main({ millions, method }) {
-  const n = millions * 1e6;
-
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'withoutdefaults':
-      runOldStyleDefaults(n);
+      runOldStyleDefaults(millions);
       break;
     case 'withdefaults':
-      runDefaultParams(n);
+      runDefaultParams(millions);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -8,10 +8,10 @@ const bench = common.createBenchmark(main, {
   millions: [100]
 });
 
-function runSwapManual(n) {
+function runSwapManual(millions) {
   var x, y, r;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     x = 1, y = 2;
     r = x;
     x = y;
@@ -19,34 +19,32 @@ function runSwapManual(n) {
     assert.strictEqual(x, 2);
     assert.strictEqual(y, 1);
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runSwapDestructured(n) {
+function runSwapDestructured(millions) {
   var x, y;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     x = 1, y = 2;
     [x, y] = [y, x];
     assert.strictEqual(x, 2);
     assert.strictEqual(y, 1);
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function main({ millions, method }) {
-  const n = millions * 1e6;
-
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'swap':
-      runSwapManual(n);
+      runSwapManual(millions);
       break;
     case 'destructure':
-      runSwapDestructured(n);
+      runSwapDestructured(millions);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -7,45 +7,43 @@ const bench = common.createBenchmark(main, {
   millions: [100]
 });
 
-function runNormal(n) {
+function runNormal(millions) {
   var i = 0;
   const o = { x: 0, y: 1 };
   bench.start();
-  for (; i < n; i++) {
+  for (; i < millions * 1e6; i++) {
     /* eslint-disable no-unused-vars */
     const x = o.x;
     const y = o.y;
     const r = o.r || 2;
     /* eslint-enable no-unused-vars */
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runDestructured(n) {
+function runDestructured(millions) {
   var i = 0;
   const o = { x: 0, y: 1 };
   bench.start();
-  for (; i < n; i++) {
+  for (; i < millions * 1e6; i++) {
     /* eslint-disable no-unused-vars */
     const { x, y, r = 2 } = o;
     /* eslint-enable no-unused-vars */
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function main({ millions, method }) {
-  const n = millions * 1e6;
-
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'normal':
-      runNormal(n);
+      runNormal(millions);
       break;
     case 'destructureObject':
-      runDestructured(n);
+      runDestructured(millions);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/es/foreach-bench.js
+++ b/benchmark/es/foreach-bench.js
@@ -8,56 +8,51 @@ const bench = common.createBenchmark(main, {
   millions: [5]
 });
 
-function useFor(n, items, count) {
-  var i, j;
+function useFor(millions, items, count) {
   bench.start();
-  for (i = 0; i < n; i++) {
-    for (j = 0; j < count; j++) {
+  for (var i = 0; i < millions * 1e6; i++) {
+    for (var j = 0; j < count; j++) {
       /* eslint-disable no-unused-vars */
       const item = items[j];
       /* esline-enable no-unused-vars */
     }
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function useForOf(n, items) {
-  var i, item;
+function useForOf(millions, items) {
+  var item;
   bench.start();
-  for (i = 0; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     for (item of items) {}
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function useForIn(n, items) {
-  var i, j, item;
+function useForIn(millions, items) {
   bench.start();
-  for (i = 0; i < n; i++) {
-    for (j in items) {
+  for (var i = 0; i < millions * 1e6; i++) {
+    for (var j in items) {
       /* eslint-disable no-unused-vars */
-      item = items[j];
+      const item = items[j];
       /* esline-enable no-unused-vars */
     }
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function useForEach(n, items) {
-  var i;
+function useForEach(millions, items) {
   bench.start();
-  for (i = 0; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     items.forEach((item) => {});
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function main({ millions, count, method }) {
-  const n = millions * 1e6;
   const items = new Array(count);
-  var i;
   var fn;
-  for (i = 0; i < count; i++)
+  for (var i = 0; i < count; i++)
     items[i] = i;
 
   switch (method) {
@@ -76,7 +71,7 @@ function main({ millions, count, method }) {
       fn = useForEach;
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
-  fn(n, items, count);
+  fn(millions, items, count);
 }

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -11,63 +11,59 @@ const bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-function runObject(n) {
+function runObject(millions) {
   const m = {};
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m[`i${i}`] = i;
     m[`s${i}`] = String(i);
     assert.strictEqual(String(m[`i${i}`]), m[`s${i}`]);
     m[`i${i}`] = undefined;
     m[`s${i}`] = undefined;
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runNullProtoObject(n) {
+function runNullProtoObject(millions) {
   const m = Object.create(null);
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m[`i${i}`] = i;
     m[`s${i}`] = String(i);
     assert.strictEqual(String(m[`i${i}`]), m[`s${i}`]);
     m[`i${i}`] = undefined;
     m[`s${i}`] = undefined;
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runNullProtoLiteralObject(n) {
+function runNullProtoLiteralObject(millions) {
   const m = { __proto__: null };
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m[`i${i}`] = i;
     m[`s${i}`] = String(i);
     assert.strictEqual(String(m[`i${i}`]), m[`s${i}`]);
     m[`i${i}`] = undefined;
     m[`s${i}`] = undefined;
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function StorageObject() {}
 StorageObject.prototype = Object.create(null);
 
-function runStorageObject(n) {
+function runStorageObject(millions) {
   const m = new StorageObject();
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m[`i${i}`] = i;
     m[`s${i}`] = String(i);
     assert.strictEqual(String(m[`i${i}`]), m[`s${i}`]);
     m[`i${i}`] = undefined;
     m[`s${i}`] = undefined;
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function fakeMap() {
@@ -80,59 +76,55 @@ function fakeMap() {
   };
 }
 
-function runFakeMap(n) {
+function runFakeMap(millions) {
   const m = fakeMap();
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m.set(`i${i}`, i);
     m.set(`s${i}`, String(i));
     assert.strictEqual(String(m.get(`i${i}`)), m.get(`s${i}`));
     m.set(`i${i}`, undefined);
     m.set(`s${i}`, undefined);
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
-function runMap(n) {
+function runMap(millions) {
   const m = new Map();
-  var i = 0;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     m.set(`i${i}`, i);
     m.set(`s${i}`, String(i));
     assert.strictEqual(String(m.get(`i${i}`)), m.get(`s${i}`));
     m.set(`i${i}`, undefined);
     m.set(`s${i}`, undefined);
   }
-  bench.end(n / 1e6);
+  bench.end(millions);
 }
 
 function main({ millions, method }) {
-  const n = millions * 1e6;
-
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'object':
-      runObject(n);
+      runObject(millions);
       break;
     case 'nullProtoObject':
-      runNullProtoObject(n);
+      runNullProtoObject(millions);
       break;
     case 'nullProtoLiteralObject':
-      runNullProtoLiteralObject(n);
+      runNullProtoLiteralObject(millions);
       break;
     case 'storageObject':
-      runStorageObject(n);
+      runStorageObject(millions);
       break;
     case 'fakeMap':
-      runFakeMap(n);
+      runFakeMap(millions);
       break;
     case 'map':
-      runMap(n);
+      runMap(millions);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -33,49 +33,39 @@ function useArguments() {
   assert.strictEqual(arguments[3], 'b');
 }
 
-function runCopyArguments(n) {
-
-  var i = 0;
-  bench.start();
-  for (; i < n; i++)
+function runCopyArguments(millions) {
+  for (var i = 0; i < millions * 1e6; i++)
     copyArguments(1, 2, 'a', 'b');
-  bench.end(n / 1e6);
 }
 
-function runRestArguments(n) {
-
-  var i = 0;
-  bench.start();
-  for (; i < n; i++)
+function runRestArguments(millions) {
+  for (var i = 0; i < millions * 1e6; i++)
     restArguments(1, 2, 'a', 'b');
-  bench.end(n / 1e6);
 }
 
-function runUseArguments(n) {
-
-  var i = 0;
-  bench.start();
-  for (; i < n; i++)
+function runUseArguments(millions) {
+  for (var i = 0; i < millions * 1e6; i++)
     useArguments(1, 2, 'a', 'b');
-  bench.end(n / 1e6);
 }
 
 function main({ millions, method }) {
-  const n = millions * 1e6;
-
+  var fn;
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
     case 'copy':
-      runCopyArguments(n);
+      fn = runCopyArguments;
       break;
     case 'rest':
-      runRestArguments(n);
+      fn = runRestArguments;
       break;
     case 'arguments':
-      runUseArguments(n);
+      fn = runUseArguments;
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
+  bench.start();
+  fn(millions);
+  bench.end(millions);
 }

--- a/benchmark/es/spread-bench.js
+++ b/benchmark/es/spread-bench.js
@@ -24,7 +24,6 @@ function makeTest(count, rest) {
 }
 
 function main({ millions, context, count, rest, method }) {
-  const n = millions * 1e6;
   const ctx = context === 'context' ? {} : null;
   var fn = makeTest(count, rest);
   const args = new Array(count);
@@ -37,25 +36,25 @@ function main({ millions, context, count, rest, method }) {
       // Empty string falls through to next line as default, mostly for tests.
     case 'apply':
       bench.start();
-      for (i = 0; i < n; i++)
+      for (i = 0; i < millions * 1e6; i++)
         fn.apply(ctx, args);
-      bench.end(n / 1e6);
+      bench.end(millions);
       break;
     case 'spread':
       if (ctx !== null)
         fn = fn.bind(ctx);
       bench.start();
-      for (i = 0; i < n; i++)
+      for (i = 0; i < millions * 1e6; i++)
         fn(...args);
-      bench.end(n / 1e6);
+      bench.end(millions);
       break;
     case 'call-spread':
       bench.start();
-      for (i = 0; i < n; i++)
+      for (i = 0; i < millions * 1e6; i++)
         fn.call(ctx, ...args);
-      bench.end(n / 1e6);
+      bench.end(millions);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/es/string-concatenations.js
+++ b/benchmark/es/string-concatenations.js
@@ -16,7 +16,6 @@ const configs = {
 
 const bench = common.createBenchmark(main, configs);
 
-
 function main({ n, mode }) {
   const str = 'abc';
   const num = 123;
@@ -63,7 +62,7 @@ function main({ n, mode }) {
       bench.end(n);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${mode}"`);
   }
 
   return string;

--- a/benchmark/es/string-repeat.js
+++ b/benchmark/es/string-repeat.js
@@ -33,7 +33,7 @@ function main({ n, size, encoding, mode }) {
       bench.end(n);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${mode}"`);
   }
 
   assert.strictEqual([...str].length, size);

--- a/benchmark/fs/bench-realpath.js
+++ b/benchmark/fs/bench-realpath.js
@@ -16,10 +16,8 @@ function main({ n, pathType }) {
   bench.start();
   if (pathType === 'relative')
     relativePath(n);
-  else if (pathType === 'resolved')
-    resolvedPath(n);
   else
-    throw new Error(`unknown "pathType": ${pathType}`);
+    resolvedPath(n);
 }
 
 function relativePath(n) {

--- a/benchmark/fs/bench-realpathSync.js
+++ b/benchmark/fs/bench-realpathSync.js
@@ -15,24 +15,10 @@ const bench = common.createBenchmark(main, {
 
 
 function main({ n, pathType }) {
+  const path = pathType === 'relative' ? relative_path : resolved_path;
   bench.start();
-  if (pathType === 'relative')
-    relativePath(n);
-  else if (pathType === 'resolved')
-    resolvedPath(n);
-  else
-    throw new Error(`unknown "pathType": ${pathType}`);
+  for (var i = 0; i < n; i++) {
+    fs.realpathSync(path);
+  }
   bench.end(n);
-}
-
-function relativePath(n) {
-  for (var i = 0; i < n; i++) {
-    fs.realpathSync(relative_path);
-  }
-}
-
-function resolvedPath(n) {
-  for (var i = 0; i < n; i++) {
-    fs.realpathSync(resolved_path);
-  }
 }

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -36,7 +36,6 @@ function main({ dur, encodingType, size }) {
   try { fs.unlinkSync(filename); } catch (e) {}
 
   var started = false;
-  var ending = false;
   var ended = false;
 
   var f = fs.createWriteStream(filename);
@@ -52,15 +51,9 @@ function main({ dur, encodingType, size }) {
 
 
   function write() {
-    // don't try to write after we end, even if a 'drain' event comes.
-    // v0.8 streams are so sloppy!
-    if (ending)
-      return;
-
     if (!started) {
       started = true;
       setTimeout(function() {
-        ending = true;
         f.end();
       }, dur * 1000);
       bench.start();

--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -14,7 +14,6 @@ const bench = common.createBenchmark(main, {
   n: [1e5],
 });
 
-
 function main({ len, n }) {
   var header = `GET /hello HTTP/1.1${CRLF}Content-Type: text/plain${CRLF}`;
 
@@ -26,7 +25,6 @@ function main({ len, n }) {
   processHeader(Buffer.from(header), n);
 }
 
-
 function processHeader(header, n) {
   const parser = newParser(REQUEST);
 
@@ -37,7 +35,6 @@ function processHeader(header, n) {
   }
   bench.end(n);
 }
-
 
 function newParser(type) {
   const parser = new HTTPParser(type);

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
   // unicode confuses ab on os x.
@@ -13,9 +12,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ type, len, chunks, c, chunkedEnc, res }) {
-  process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
-  .listen(PORT)
+  .listen(common.PORT)
   .on('listening', function() {
     const path = `/${type}/${len}/${chunks}/${res}/${chunkedEnc}`;
 

--- a/benchmark/http/upgrade.js
+++ b/benchmark/http/upgrade.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common.js');
-const PORT = common.PORT;
 const net = require('net');
 
 const bench = common.createBenchmark(main, {
@@ -20,7 +19,6 @@ const resData = 'HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
                 '\r\n\r\n';
 
 function main({ n }) {
-  process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
     .listen(common.PORT)
     .on('listening', function() {

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common.js');
-const PORT = common.PORT;
 const path = require('path');
 const fs = require('fs');
 
@@ -25,7 +24,7 @@ function main({ requests, streams, clients }) {
       stream.respondWithFD(fd);
       stream.on('error', (err) => {});
     });
-    server.listen(PORT, () => {
+    server.listen(common.PORT, () => {
       bench.http({
         path: '/',
         requests,

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const common = require('../common.js');
-const PORT = common.PORT;
-
 const path = require('path');
 const fs = require('fs');
-
 const file = path.join(path.resolve(__dirname, '../fixtures'), 'alice.html');
 
 const bench = common.createBenchmark(main, {
@@ -24,7 +21,7 @@ function main({ requests, streams, clients }) {
     out.pipe(stream);
     stream.on('error', (err) => {});
   });
-  server.listen(PORT, () => {
+  server.listen(common.PORT, () => {
     bench.http({
       path: '/',
       requests,

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common.js');
-const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
@@ -26,7 +25,7 @@ function main({ streams, length, size }) {
     }
     write();
   });
-  server.listen(PORT, () => {
+  server.listen(common.PORT, () => {
     bench.http({
       path: '/',
       requests: 10000,

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -12,7 +12,6 @@ function main({ n }) {
   const FreeList = require('internal/freelist');
   const poolSize = 1000;
   const list = new FreeList('test', poolSize, Object);
-  var i;
   var j;
   const used = [];
 
@@ -23,7 +22,7 @@ function main({ n }) {
 
   bench.start();
 
-  for (i = 0; i < n; i++) {
+  for (var i = 0; i < n; i++) {
     // Return all the items to the pool
     for (j = 0; j < poolSize; j++) {
       list.free(used[j]);

--- a/benchmark/misc/function_call/index.js
+++ b/benchmark/misc/function_call/index.js
@@ -32,11 +32,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ millions, type }) {
-  const n = millions * 1e6;
-
   const fn = type === 'cxx' ? cxx : js;
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (var i = 0; i < millions * 1e6; i++) {
     fn();
   }
   bench.end(millions);

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -78,6 +78,6 @@ function main({ millions, method }) {
       runSymbol(n);
       break;
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -55,9 +55,8 @@ function runPunycode(n, val) {
 }
 
 function runICU(n, val) {
-  var i = 0;
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < n; i++)
     usingICU(val);
   bench.end(n);
 }
@@ -76,6 +75,6 @@ function main({ n, val, method }) {
       }
       // fallthrough
     default:
-      throw new Error('Unexpected method');
+      throw new Error(`Unexpected method "${method}"`);
   }
 }

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -13,12 +13,10 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ thousands, fullPath, useCache }) {
-  const n = thousands * 1e3;
-
   tmpdir.refresh();
   try { fs.mkdirSync(benchmarkDirectory); } catch (e) {}
 
-  for (var i = 0; i <= n; i++) {
+  for (var i = 0; i <= thousands * 1e3; i++) {
     fs.mkdirSync(`${benchmarkDirectory}${i}`);
     fs.writeFileSync(
       `${benchmarkDirectory}${i}/package.json`,
@@ -31,37 +29,37 @@ function main({ thousands, fullPath, useCache }) {
   }
 
   if (fullPath === 'true')
-    measureFull(n, useCache === 'true');
+    measureFull(thousands, useCache === 'true');
   else
-    measureDir(n, useCache === 'true');
+    measureDir(thousands, useCache === 'true');
 
   tmpdir.refresh();
 }
 
-function measureFull(n, useCache) {
+function measureFull(thousands, useCache) {
   var i;
   if (useCache) {
-    for (i = 0; i <= n; i++) {
+    for (i = 0; i <= thousands * 1e3; i++) {
       require(`${benchmarkDirectory}${i}/index.js`);
     }
   }
   bench.start();
-  for (i = 0; i <= n; i++) {
+  for (i = 0; i <= thousands * 1e3; i++) {
     require(`${benchmarkDirectory}${i}/index.js`);
   }
-  bench.end(n / 1e3);
+  bench.end(thousands);
 }
 
-function measureDir(n, useCache) {
+function measureDir(thousands, useCache) {
   var i;
   if (useCache) {
-    for (i = 0; i <= n; i++) {
+    for (i = 0; i <= thousands * 1e3; i++) {
       require(`${benchmarkDirectory}${i}`);
     }
   }
   bench.start();
-  for (i = 0; i <= n; i++) {
+  for (i = 0; i <= thousands * 1e3; i++) {
     require(`${benchmarkDirectory}${i}`);
   }
-  bench.end(n / 1e3);
+  bench.end(thousands);
 }

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const { posix } = require('path');
+const { win32 } = require('path');
 
 const bench = common.createBenchmark(main, {
   pathext: [
@@ -28,7 +28,7 @@ function main({ n, pathext }) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    posix.basename(pathext, ext);
+    win32.basename(pathext, ext);
   }
   bench.end(n);
 }

--- a/benchmark/timers/set-immediate-breadth.js
+++ b/benchmark/timers/set-immediate-breadth.js
@@ -9,7 +9,7 @@ function main({ millions }) {
   const N = millions * 1e6;
 
   process.on('exit', function() {
-    bench.end(N / 1e6);
+    bench.end(millions);
   });
 
   function cb() {}

--- a/benchmark/timers/set-immediate-depth-args.js
+++ b/benchmark/timers/set-immediate-depth-args.js
@@ -9,7 +9,7 @@ function main({ millions }) {
   const N = millions * 1e6;
 
   process.on('exit', function() {
-    bench.end(N / 1e6);
+    bench.end(millions);
   });
 
   function cb3(n, arg2, arg3) {

--- a/benchmark/timers/timers-cancel-pooled.js
+++ b/benchmark/timers/timers-cancel-pooled.js
@@ -28,5 +28,5 @@ function main({ millions }) {
 }
 
 function cb() {
-  assert(false, 'Timer should not call callback');
+  assert.fail('Timer should not call callback');
 }

--- a/benchmark/timers/timers-cancel-unpooled.js
+++ b/benchmark/timers/timers-cancel-unpooled.js
@@ -22,5 +22,5 @@ function main({ millions }) {
 }
 
 function cb() {
-  assert(false, `Timer ${this._idleTimeout} should not call callback`);
+  assert.fail(`Timer ${this._idleTimeout} should not call callback`);
 }

--- a/benchmark/timers/timers-insert-unpooled.js
+++ b/benchmark/timers/timers-insert-unpooled.js
@@ -23,5 +23,5 @@ function main({ millions }) {
 }
 
 function cb() {
-  assert(false, `Timer ${this._idleTimeout} should not call callback`);
+  assert.fail(`Timer ${this._idleTimeout} should not call callback`);
 }

--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -8,14 +8,15 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  var i = 0;
+  const input = ['ABC', 'XYZ123', 'FOO'];
   var m = {};
   // First call dominates results
   if (n > 1) {
-    tls.convertNPNProtocols(['ABC', 'XYZ123', 'FOO'], m);
+    tls.convertNPNProtocols(input, m);
     m = {};
   }
   bench.start();
-  for (; i < n; i++) tls.convertNPNProtocols(['ABC', 'XYZ123', 'FOO'], m);
+  for (var i = 0; i < n; i++)
+    tls.convertNPNProtocols(input, m);
   bench.end(n);
 }

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -11,12 +11,13 @@ const bench = common.createBenchmark(main, {
 
 var clientConn = 0;
 var serverConn = 0;
-var server;
 var dur;
 var concurrency;
 var running = true;
 
-function main({ dur, concurrency }) {
+function main(conf) {
+  dur = conf.dur;
+  concurrency = conf.concurrency;
   const cert_dir = path.resolve(__dirname, '../../test/fixtures');
   const options = {
     key: fs.readFileSync(`${cert_dir}/test_key.pem`),
@@ -25,7 +26,7 @@ function main({ dur, concurrency }) {
     ciphers: 'AES256-GCM-SHA384'
   };
 
-  server = tls.createServer(options, onConnection);
+  const server = tls.createServer(options, onConnection);
   server.listen(common.PORT, onListening);
 }
 

--- a/benchmark/url/legacy-vs-whatwg-url-get-prop.js
+++ b/benchmark/url/legacy-vs-whatwg-url-get-prop.js
@@ -74,7 +74,7 @@ function useWHATWG(n, input) {
 function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
-    throw new Error('Unknown input type');
+    throw new Error(`Unknown input type "${type}"`);
   }
 
   var noDead;  // Avoid dead code elimination.
@@ -86,7 +86,7 @@ function main({ type, n, method }) {
       noDead = useWHATWG(n, input);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method "${method}"`);
   }
 
   assert.ok(noDead);

--- a/benchmark/url/legacy-vs-whatwg-url-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-parse.js
@@ -34,7 +34,7 @@ function useWHATWG(n, input) {
 function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
-    throw new Error('Unknown input type');
+    throw new Error(`Unknown input type "${type}"`);
   }
 
   var noDead;  // Avoid dead code elimination.
@@ -46,7 +46,7 @@ function main({ type, n, method }) {
       noDead = useWHATWG(n, input);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method ${method}`);
   }
 
   assert.ok(noDead);

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
@@ -31,7 +31,7 @@ function useWHATWG(n, input) {
 function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
-    throw new Error('Unknown input type');
+    throw new Error(`Unknown input type "${type}"`);
   }
 
   switch (method) {
@@ -42,6 +42,6 @@ function main({ type, n, method }) {
       useWHATWG(n, input);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method ${method}`);
   }
 }

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -33,7 +33,7 @@ function useWHATWG(n, input, prop) {
 function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
-    throw new Error('Unknown input type');
+    throw new Error(`Unknown input type "${type}"`);
   }
 
   switch (method) {
@@ -44,6 +44,6 @@ function main({ type, n, method }) {
       useWHATWG(n, input);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method ${method}`);
   }
 }

--- a/benchmark/url/legacy-vs-whatwg-url-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-serialize.js
@@ -36,7 +36,7 @@ function useWHATWG(n, input, prop) {
 function main({ type, n, method }) {
   const input = inputs[type];
   if (!input) {
-    throw new Error('Unknown input type');
+    throw new Error(`Unknown input type "${type}"`);
   }
 
   var noDead;  // Avoid dead code elimination.
@@ -48,7 +48,7 @@ function main({ type, n, method }) {
       noDead = useWHATWG(n, input);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method ${method}`);
   }
 
   assert.ok(noDead);

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -53,6 +53,6 @@ function main({ method, n }) {
       iterator(n);
       break;
     default:
-      throw new Error('Unknown method');
+      throw new Error(`Unknown method ${method}`);
   }
 }

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -10,45 +10,14 @@ const bench = common.createBenchmark(main, {
 
 const str = 'one=single&two=first&three=first&two=2nd&three=2nd&three=3rd';
 
-function get(n, param) {
-  const params = new URLSearchParams(str);
-
-  bench.start();
-  for (var i = 0; i < n; i += 1)
-    params.get(param);
-  bench.end(n);
-}
-
-function getAll(n, param) {
-  const params = new URLSearchParams(str);
-
-  bench.start();
-  for (var i = 0; i < n; i += 1)
-    params.getAll(param);
-  bench.end(n);
-}
-
-function has(n, param) {
-  const params = new URLSearchParams(str);
-
-  bench.start();
-  for (var i = 0; i < n; i += 1)
-    params.has(param);
-  bench.end(n);
-}
-
 function main({ method, param, n }) {
-  switch (method) {
-    case 'get':
-      get(n, param);
-      break;
-    case 'getAll':
-      getAll(n, param);
-      break;
-    case 'has':
-      has(n, param);
-      break;
-    default:
-      throw new Error('Unknown method');
-  }
+  const params = new URLSearchParams(str);
+  const fn = params[method];
+  if (!fn)
+    throw new Error(`Unknown method ${method}`);
+
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    fn(param);
+  bench.end(n);
 }

--- a/benchmark/url/url-searchparams-sort.js
+++ b/benchmark/url/url-searchparams-sort.js
@@ -37,9 +37,8 @@ function main({ type, n }) {
   const params = new URLSearchParams();
   const array = getParams(input);
 
-  var i;
   bench.start();
-  for (i = 0; i < n; i++) {
+  for (var i = 0; i < n; i++) {
     params[searchParams] = array.slice();
     params.sort();
   }

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -22,9 +22,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, type }) {
   // For testing, if supplied with an empty type, default to string.
-  type = type || 'string';
-
-  const [first, second] = inputs[type];
+  const [first, second] = inputs[type || 'string'];
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -18,14 +18,13 @@ function main({ n, len, type }) {
   var arr = Array(len);
   var i, opts;
 
-  // For testing, if supplied with an empty type, default to denseArray.
-  type = type || 'denseArray';
-
   switch (type) {
     case 'denseArray_showHidden':
       opts = { showHidden: true };
       arr = arr.fill('denseArray');
       break;
+      // For testing, if supplied with an empty type, default to denseArray.
+    case '':
     case 'denseArray':
       arr = arr.fill('denseArray');
       break;

--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -12,9 +12,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ method, n }) {
-  var i = 0;
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < n; i++)
     v8[method]();
   bench.end(n);
 }

--- a/benchmark/vm/run-in-context.js
+++ b/benchmark/vm/run-in-context.js
@@ -17,12 +17,10 @@ function main({ n, breakOnSigint, withSigintListener }) {
   if (withSigintListener)
     process.on('SIGINT', () => {});
 
-  var i = 0;
-
   const contextifiedSandbox = vm.createContext();
 
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < n; i++)
     vm.runInContext('0', contextifiedSandbox, options);
   bench.end(n);
 }

--- a/benchmark/vm/run-in-this-context.js
+++ b/benchmark/vm/run-in-this-context.js
@@ -17,10 +17,8 @@ function main({ n, breakOnSigint, withSigintListener }) {
   if (withSigintListener)
     process.on('SIGINT', () => {});
 
-  var i = 0;
-
   bench.start();
-  for (; i < n; i++)
+  for (var i = 0; i < n; i++)
     vm.runInThisContext('0', options);
   bench.end(n);
 }


### PR DESCRIPTION
Just some refactoring of some benchmarks to reduce code overhead and improve readability.

I some times changed `let` in a loop to `var` because it may theoretically still lead to a deopt / prevent a opt.

I fixed two benchmarks that regressed before and what I realized when going over all files again.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark