### PR TITLE
process: small improvements to internals

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -227,14 +227,7 @@ function setupChannel() {
     // Make sure it's not accidentally inherited by child processes.
     delete process.env.NODE_CHANNEL_FD;
 
-    const cp = require('child_process');
-
-    // Load tcp_wrap to avoid situation where we might immediately receive
-    // a message.
-    // FIXME is this really necessary?
-    process.binding('tcp_wrap');
-
-    cp._forkChild(fd);
+    require('child_process')._forkChild(fd);
     assert(process.send);
   }
 }

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -178,24 +178,23 @@ function setupKillAndExit() {
 
 
 function setupSignalHandlers() {
-  // Load events module in order to access prototype elements on process like
-  // process.addListener.
-  const signalWraps = {};
+  const signalWraps = Object.create(null);
+  let Signal;
 
   function isSignal(event) {
     return typeof event === 'string' && constants[event] !== undefined;
   }
 
   // Detect presence of a listener for the special signal types
-  process.on('newListener', function(type, listener) {
-    if (isSignal(type) &&
-        !signalWraps.hasOwnProperty(type)) {
-      const Signal = process.binding('signal_wrap').Signal;
+  process.on('newListener', function(type) {
+    if (isSignal(type) && signalWraps[type] === undefined) {
+      if (Signal === undefined)
+        Signal = process.binding('signal_wrap').Signal;
       const wrap = new Signal();
 
       wrap.unref();
 
-      wrap.onsignal = function() { process.emit(type, type); };
+      wrap.onsignal = process.emit.bind(process, type, type);
 
       const signum = constants[type];
       const err = wrap.start(signum);
@@ -208,8 +207,8 @@ function setupSignalHandlers() {
     }
   });
 
-  process.on('removeListener', function(type, listener) {
-    if (signalWraps.hasOwnProperty(type) && this.listenerCount(type) === 0) {
+  process.on('removeListener', function(type) {
+    if (signalWraps[type] !== undefined && this.listenerCount(type) === 0) {
       signalWraps[type].close();
       delete signalWraps[type];
     }


### PR DESCRIPTION
Some small tweaks:

1. Remove unnecessary call to a binding which is already guaranteed to be loaded via requiring `child_process` (and that's even if calling that binding was necessary in the first place)

2. Cleanup `setupSignalHandlers`, including removing an outdated comment, using null prototype Object, not calling C++ repeatedly to get the binding, etc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process