### PR TITLE
doc: Add doc for performance.clearGC()

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -37,6 +37,14 @@ added: REPLACEME
 Remove all performance entry objects with `entryType` equal to `name` from the
 Performance Timeline.
 
+### performance.clearGC()
+<!-- YAML
+added: v8.5.0
+-->
+
+Remove all performance entry objects with `entryType` equal to `gc` from the
+Performance Timeline.
+
 ### performance.clearFunctions([name])
 <!-- YAML
 added: v8.5.0

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -37,14 +37,6 @@ added: REPLACEME
 Remove all performance entry objects with `entryType` equal to `name` from the
 Performance Timeline.
 
-### performance.clearGC()
-<!-- YAML
-added: v8.5.0
--->
-
-Remove all performance entry objects with `entryType` equal to `gc` from the
-Performance Timeline.
-
 ### performance.clearFunctions([name])
 <!-- YAML
 added: v8.5.0
@@ -54,6 +46,14 @@ added: v8.5.0
 
 If `name` is not provided, removes all `PerformanceFunction` objects from the
 Performance Timeline. If `name` is provided, removes entries with `name`.
+
+### performance.clearGC()
+<!-- YAML
+added: v8.5.0
+-->
+
+Remove all performance entry objects with `entryType` equal to `gc` from the
+Performance Timeline.
 
 ### performance.clearMarks([name])
 <!-- YAML


### PR DESCRIPTION
`performance.clearGC` seems to have been available since the [original implementation](https://github.com/nodejs/node/pull/14680) of `perf_hooks` but it was missing from the docs. This PR adds documentation for it.

Open to wording changes if something could be improved.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
