### PR TITLE
src: refactor stream callbacks and ownership

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -666,7 +666,7 @@ function onSocketPause() {
 function unconsume(parser, socket) {
   if (socket._handle) {
     if (parser._consumed)
-      parser.unconsume(socket._handle._externalStream);
+      parser.unconsume();
     parser._consumed = false;
     socket.removeListener('pause', onSocketPause);
     socket.removeListener('resume', onSocketResume);

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -465,7 +465,10 @@ function setupChannel(target, channel) {
   var jsonBuffer = '';
   var pendingHandle = null;
   channel.buffering = false;
-  channel.onread = function(nread, pool, recvHandle) {
+  channel.pendingHandle = null;
+  channel.onread = function(nread, pool) {
+    const recvHandle = channel.pendingHandle;
+    channel.pendingHandle = null;
     // TODO(bnoordhuis) Check that nread > 0.
     if (pool) {
       if (recvHandle)

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -3,6 +3,7 @@
 #include "connect_wrap.h"
 #include "env-inl.h"
 #include "pipe_wrap.h"
+#include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "tcp_wrap.h"
 #include "util-inl.h"

--- a/src/env.h
+++ b/src/env.h
@@ -210,6 +210,7 @@ class ModuleWrap;
   V(owner_string, "owner")                                                    \
   V(parse_error_string, "Parse Error")                                        \
   V(path_string, "path")                                                      \
+  V(pending_handle_string, "pendingHandle")                                   \
   V(pbkdf2_error_string, "PBKDF2 Error")                                      \
   V(pid_string, "pid")                                                        \
   V(pipe_string, "pipe")                                                      \

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -25,52 +25,10 @@ JSStream::JSStream(Environment* env, Local<Object> obj)
       StreamBase(env) {
   node::Wrap(obj, this);
   MakeWeak<JSStream>(this);
-
-  set_alloc_cb({ OnAllocImpl, this });
-  set_read_cb({ OnReadImpl, this });
 }
 
 
 JSStream::~JSStream() {
-}
-
-
-void JSStream::OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx) {
-  buf->base = Malloc(size);
-  buf->len = size;
-}
-
-
-void JSStream::OnReadImpl(ssize_t nread,
-                          const uv_buf_t* buf,
-                          uv_handle_type pending,
-                          void* ctx) {
-  JSStream* wrap = static_cast<JSStream*>(ctx);
-  CHECK_NE(wrap, nullptr);
-  Environment* env = wrap->env();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-
-  if (nread < 0)  {
-    if (buf != nullptr && buf->base != nullptr)
-      free(buf->base);
-    wrap->EmitData(nread, Local<Object>(), Local<Object>());
-    return;
-  }
-
-  if (nread == 0) {
-    if (buf->base != nullptr)
-      free(buf->base);
-    return;
-  }
-
-  CHECK_LE(static_cast<size_t>(nread), buf->len);
-  char* base = node::Realloc(buf->base, nread);
-
-  CHECK_EQ(pending, UV_UNKNOWN_HANDLE);
-
-  Local<Object> obj = Buffer::New(env, base, nread).ToLocalChecked();
-  wrap->EmitData(nread, obj, Local<Object>());
 }
 
 
@@ -212,18 +170,19 @@ void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   int len = Buffer::Length(args[0]);
 
-  do {
-    uv_buf_t buf;
+  // Repeatedly ask the stream's owner for memory, copy the data that we
+  // just read from JS into those buffers and emit them as reads.
+  while (len != 0) {
+    uv_buf_t buf = wrap->EmitAlloc(len);
     ssize_t avail = len;
-    wrap->EmitAlloc(len, &buf);
     if (static_cast<ssize_t>(buf.len) < avail)
       avail = buf.len;
 
     memcpy(buf.base, data, avail);
     data += avail;
     len -= avail;
-    wrap->EmitRead(avail, &buf);
-  } while (len != 0);
+    wrap->EmitRead(avail, buf);
+  }
 }
 
 
@@ -231,7 +190,7 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
   JSStream* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
-  wrap->EmitRead(UV_EOF, nullptr);
+  wrap->EmitRead(UV_EOF);
 }
 
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -535,6 +535,12 @@ class Http2Priority {
   nghttp2_priority_spec spec;
 };
 
+class Http2StreamListener : public StreamListener {
+ public:
+  uv_buf_t OnStreamAlloc(size_t suggested_size) override;
+  void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
+};
+
 class Http2Stream : public AsyncWrap,
                     public StreamBase {
  public:
@@ -747,6 +753,8 @@ class Http2Stream : public AsyncWrap,
   int64_t fd_offset_ = 0;
   int64_t fd_length_ = -1;
 
+  Http2StreamListener stream_listener_;
+
   friend class Http2Session;
 };
 
@@ -798,7 +806,7 @@ class Http2Stream::Provider::Stream : public Http2Stream::Provider {
 };
 
 
-class Http2Session : public AsyncWrap {
+class Http2Session : public AsyncWrap, public StreamListener {
  public:
   Http2Session(Environment* env,
                Local<Object> wrap,
@@ -872,21 +880,11 @@ class Http2Session : public AsyncWrap {
 
   size_t self_size() const override { return sizeof(*this); }
 
-  char* stream_alloc() {
-    return stream_buf_;
-  }
-
   inline void GetTrailers(Http2Stream* stream, uint32_t* flags);
 
-  static void OnStreamAllocImpl(size_t suggested_size,
-                                uv_buf_t* buf,
-                                void* ctx);
-  static void OnStreamReadImpl(ssize_t nread,
-                               const uv_buf_t* bufs,
-                               uv_handle_type pending,
-                               void* ctx);
-  static void OnStreamAfterWriteImpl(WriteWrap* w, int status, void* ctx);
-  static void OnStreamDestructImpl(void* ctx);
+  // Handle reads/writes from the underlying network transport.
+  void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
+  void OnStreamAfterWrite(WriteWrap* w, int status) override;
 
   // The JavaScript API
   static void New(const FunctionCallbackInfo<Value>& args);
@@ -1074,16 +1072,12 @@ class Http2Session : public AsyncWrap {
   int flags_ = SESSION_STATE_NONE;
 
   // The StreamBase instance being used for i/o
-  StreamBase* stream_;
-  StreamResource::Callback<StreamResource::AllocCb> prev_alloc_cb_;
-  StreamResource::Callback<StreamResource::ReadCb> prev_read_cb_;
   padding_strategy_type padding_strategy_ = PADDING_STRATEGY_NONE;
 
   // use this to allow timeout tracking during long-lasting writes
   uint32_t chunks_sent_since_last_write_ = 0;
 
-  char* stream_buf_ = nullptr;
-  size_t stream_buf_size_ = 0;
+  uv_buf_t stream_buf_ = uv_buf_init(nullptr, 0);
   v8::Local<v8::ArrayBuffer> stream_buf_ab_;
 
   size_t max_outstanding_pings_ = DEFAULT_MAX_PINGS;
@@ -1099,6 +1093,7 @@ class Http2Session : public AsyncWrap {
   void ClearOutgoing(int status);
 
   friend class Http2Scope;
+  friend class Http2StreamListener;
 };
 
 class Http2SessionPerformanceEntry : public PerformanceEntry {

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -29,6 +29,7 @@
 #include "node_buffer.h"
 #include "node_wrap.h"
 #include "connect_wrap.h"
+#include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -22,6 +22,7 @@
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_wrap.h"
+#include "stream_base-inl.h"
 #include "util-inl.h"
 
 #include <string.h>

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -33,9 +33,7 @@ inline StreamListener::~StreamListener() {
 
 inline void StreamListener::PassReadErrorToPreviousListener(ssize_t nread) {
   CHECK_NE(previous_listener_, nullptr);
-  previous_listener_->OnStreamRead(nread,
-                                   uv_buf_init(nullptr, 0),
-                                   UV_UNKNOWN_HANDLE);
+  previous_listener_->OnStreamRead(nread, uv_buf_init(nullptr, 0));
 }
 
 
@@ -85,12 +83,10 @@ inline uv_buf_t StreamResource::EmitAlloc(size_t suggested_size) {
   return listener_->OnStreamAlloc(suggested_size);
 }
 
-inline void StreamResource::EmitRead(ssize_t nread,
-                                     const uv_buf_t& buf,
-                                     uv_handle_type pending) {
+inline void StreamResource::EmitRead(ssize_t nread, const uv_buf_t& buf) {
   if (nread > 0)
     bytes_read_ += static_cast<uint64_t>(nread);
-  listener_->OnStreamRead(nread, buf, pending);
+  listener_->OnStreamRead(nread, buf);
 }
 
 inline void StreamResource::EmitAfterWrite(WriteWrap* w, int status) {

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -437,22 +437,16 @@ void StreamBase::AfterWrite(WriteWrap* req_wrap, int status) {
 }
 
 
-void StreamBase::CallJSOnreadMethod(ssize_t nread,
-                                    Local<Object> buf,
-                                    Local<Object> handle) {
+void StreamBase::CallJSOnreadMethod(ssize_t nread, Local<Object> buf) {
   Environment* env = env_;
 
   Local<Value> argv[] = {
     Integer::New(env->isolate(), nread),
-    buf,
-    handle
+    buf
   };
 
   if (argv[1].IsEmpty())
     argv[1] = Undefined(env->isolate());
-
-  if (argv[2].IsEmpty())
-    argv[2] = Undefined(env->isolate());
 
   AsyncWrap* wrap = GetAsyncWrap();
   CHECK_NE(wrap, nullptr);
@@ -493,19 +487,6 @@ void StreamResource::ClearError() {
 
 uv_buf_t StreamListener::OnStreamAlloc(size_t suggested_size) {
   return uv_buf_init(Malloc(suggested_size), suggested_size);
-}
-
-void StreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
-  // This cannot be virtual because it is just as valid to override the other
-  // OnStreamRead() callback.
-  CHECK(0 && "OnStreamRead() needs to be implemented");
-}
-
-void StreamListener::OnStreamRead(ssize_t nread,
-                                  const uv_buf_t& buf,
-                                  uv_handle_type pending) {
-  CHECK_EQ(pending, UV_UNKNOWN_HANDLE);
-  OnStreamRead(nread, buf);
 }
 
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -34,12 +34,12 @@ template int StreamBase::WriteString<LATIN1>(
     const FunctionCallbackInfo<Value>& args);
 
 
-int StreamBase::ReadStart(const FunctionCallbackInfo<Value>& args) {
+int StreamBase::ReadStartJS(const FunctionCallbackInfo<Value>& args) {
   return ReadStart();
 }
 
 
-int StreamBase::ReadStop(const FunctionCallbackInfo<Value>& args) {
+int StreamBase::ReadStopJS(const FunctionCallbackInfo<Value>& args) {
   return ReadStop();
 }
 
@@ -437,9 +437,9 @@ void StreamBase::AfterWrite(WriteWrap* req_wrap, int status) {
 }
 
 
-void StreamBase::EmitData(ssize_t nread,
-                          Local<Object> buf,
-                          Local<Object> handle) {
+void StreamBase::CallJSOnreadMethod(ssize_t nread,
+                                    Local<Object> buf,
+                                    Local<Object> handle) {
   Environment* env = env_;
 
   Local<Value> argv[] = {
@@ -488,6 +488,45 @@ const char* StreamResource::Error() const {
 
 void StreamResource::ClearError() {
   // No-op
+}
+
+
+uv_buf_t StreamListener::OnStreamAlloc(size_t suggested_size) {
+  return uv_buf_init(Malloc(suggested_size), suggested_size);
+}
+
+void StreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
+  // This cannot be virtual because it is just as valid to override the other
+  // OnStreamRead() callback.
+  CHECK(0 && "OnStreamRead() needs to be implemented");
+}
+
+void StreamListener::OnStreamRead(ssize_t nread,
+                                  const uv_buf_t& buf,
+                                  uv_handle_type pending) {
+  CHECK_EQ(pending, UV_UNKNOWN_HANDLE);
+  OnStreamRead(nread, buf);
+}
+
+
+void EmitToJSStreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
+  CHECK_NE(stream_, nullptr);
+  StreamBase* stream = static_cast<StreamBase*>(stream_);
+  Environment* env = stream->stream_env();
+  HandleScope handle_scope(env->isolate());
+  Context::Scope context_scope(env->context());
+
+  if (nread <= 0)  {
+    free(buf.base);
+    if (nread < 0)
+      stream->CallJSOnreadMethod(nread, Local<Object>());
+    return;
+  }
+
+  CHECK_LE(static_cast<size_t>(nread), buf.len);
+
+  Local<Object> obj = Buffer::New(env, buf.base, nread).ToLocalChecked();
+  stream->CallJSOnreadMethod(nread, obj);
 }
 
 }  // namespace node

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -15,6 +15,7 @@ namespace node {
 
 // Forward declarations
 class StreamBase;
+class StreamResource;
 
 template<typename Base>
 class StreamReq {
@@ -123,38 +124,78 @@ class WriteWrap : public ReqWrap<uv_write_t>,
   const size_t storage_size_;
 };
 
+
+// This is the generic interface for objects that control Node.js' C++ streams.
+// For example, the default `EmitToJSStreamListener` emits a stream's data
+// as Buffers in JS, or `TLSWrap` reads and decrypts data from a stream.
+class StreamListener {
+ public:
+  virtual ~StreamListener();
+
+  // This is called when a stream wants to allocate memory immediately before
+  // reading data into the freshly allocated buffer (i.e. it is always followed
+  // by a `OnStreamRead()` call).
+  // This memory may be statically or dynamically allocated; for example,
+  // a protocol parser may want to read data into a static buffer if it knows
+  // that all data is going to be fully handled during the next
+  // `OnStreamRead()` call.
+  // The returned buffer does not need to contain `suggested_size` bytes.
+  // The default implementation of this method returns a buffer that has exactly
+  // the suggested size and is allocated using malloc().
+  virtual uv_buf_t OnStreamAlloc(size_t suggested_size);
+
+  // `OnStreamRead()` is called when data is available on the socket and has
+  // been read into the buffer provided by `OnStreamAlloc()`.
+  // The `buf` argument is the return value of `uv_buf_t`, or may be a buffer
+  // with base nullpptr in case of an error.
+  // `nread` is the number of read bytes (which is at most the buffer length),
+  // or, if negative, a libuv error code.
+  // The variant with a `uv_handle_type` argument is used by libuv-backed
+  // streams for handle transfers (e.g. passing net.Socket instances between
+  // cluster workers). For all other streams, overriding the simple variant
+  // should be sufficient.
+  // By default, the second variant crashes if `pending` is set and otherwise
+  // calls the simple variant.
+  virtual void OnStreamRead(ssize_t nread,
+                            const uv_buf_t& buf) = 0;
+  virtual void OnStreamRead(ssize_t nread,
+                            const uv_buf_t& buf,
+                            uv_handle_type pending);
+
+  // This is called once a Write has finished. `status` may be 0 or,
+  // if negative, a libuv error code.
+  virtual void OnStreamAfterWrite(WriteWrap* w, int status) {}
+
+  // This is called immediately before the stream is destroyed.
+  virtual void OnStreamDestroy() {}
+
+ protected:
+  // Pass along a read error to the `StreamListener` instance that was active
+  // before this one. For example, a protocol parser does not care about read
+  // errors and may instead want to let the original handler
+  // (e.g. the JS handler) take care of the situation.
+  void PassReadErrorToPreviousListener(ssize_t nread);
+
+  StreamResource* stream_ = nullptr;
+  StreamListener* previous_listener_ = nullptr;
+
+  friend class StreamResource;
+};
+
+
+// A default emitter that just pushes data chunks as Buffer instances to
+// JS land via the handle’s .ondata method.
+class EmitToJSStreamListener : public StreamListener {
+ public:
+  void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
+};
+
+
+// A generic stream, comparable to JS land’s `Duplex` streams.
+// A stream is always controlled through one `StreamListener` instance.
 class StreamResource {
  public:
-  template <class T>
-  struct Callback {
-    Callback() : fn(nullptr), ctx(nullptr) {}
-    Callback(T fn, void* ctx) : fn(fn), ctx(ctx) {}
-    Callback(const Callback&) = default;
-
-    inline bool is_empty() { return fn == nullptr; }
-    inline void clear() {
-      fn = nullptr;
-      ctx = nullptr;
-    }
-
-    T fn;
-    void* ctx;
-  };
-
-  typedef void (*AfterWriteCb)(WriteWrap* w, int status, void* ctx);
-  typedef void (*AllocCb)(size_t size, uv_buf_t* buf, void* ctx);
-  typedef void (*ReadCb)(ssize_t nread,
-                         const uv_buf_t* buf,
-                         uv_handle_type pending,
-                         void* ctx);
-  typedef void (*DestructCb)(void* ctx);
-
-  StreamResource() : bytes_read_(0) {
-  }
-  virtual ~StreamResource() {
-    if (!destruct_cb_.is_empty())
-      destruct_cb_.fn(destruct_cb_.ctx);
-  }
+  virtual ~StreamResource();
 
   virtual int DoShutdown(ShutdownWrap* req_wrap) = 0;
   virtual int DoTryWrite(uv_buf_t** bufs, size_t* count);
@@ -162,49 +203,44 @@ class StreamResource {
                       uv_buf_t* bufs,
                       size_t count,
                       uv_stream_t* send_handle) = 0;
+
+  // Start reading from the underlying resource. This is called by the consumer
+  // when more data is desired.
+  virtual int ReadStart() = 0;
+  // Stop reading from the underlying resource. This is called by the
+  // consumer when its buffers are full and no more data can be handled.
+  virtual int ReadStop() = 0;
+
+  // Optionally, this may provide an error message to be used for
+  // failing writes.
   virtual const char* Error() const;
+  // Clear the current error (i.e. that would be returned by Error()).
   virtual void ClearError();
 
-  // Events
-  inline void EmitAfterWrite(WriteWrap* w, int status) {
-    if (!after_write_cb_.is_empty())
-      after_write_cb_.fn(w, status, after_write_cb_.ctx);
-  }
-
-  inline void EmitAlloc(size_t size, uv_buf_t* buf) {
-    if (!alloc_cb_.is_empty())
-      alloc_cb_.fn(size, buf, alloc_cb_.ctx);
-  }
-
-  inline void EmitRead(ssize_t nread,
-                       const uv_buf_t* buf,
-                       uv_handle_type pending = UV_UNKNOWN_HANDLE) {
-    if (nread > 0)
-      bytes_read_ += static_cast<uint64_t>(nread);
-    if (!read_cb_.is_empty())
-      read_cb_.fn(nread, buf, pending, read_cb_.ctx);
-  }
-
-  inline void set_after_write_cb(Callback<AfterWriteCb> c) {
-    after_write_cb_ = c;
-  }
-
-  inline void set_alloc_cb(Callback<AllocCb> c) { alloc_cb_ = c; }
-  inline void set_read_cb(Callback<ReadCb> c) { read_cb_ = c; }
-  inline void set_destruct_cb(Callback<DestructCb> c) { destruct_cb_ = c; }
-
-  inline Callback<AfterWriteCb> after_write_cb() { return after_write_cb_; }
-  inline Callback<AllocCb> alloc_cb() { return alloc_cb_; }
-  inline Callback<ReadCb> read_cb() { return read_cb_; }
-  inline Callback<DestructCb> destruct_cb() { return destruct_cb_; }
+  // Transfer ownership of this tream to `listener`. The previous listener
+  // will not receive any more callbacks while the new listener was active.
+  void PushStreamListener(StreamListener* listener);
+  // Remove a listener, and, if this was the currently active one,
+  // transfer ownership back to the previous listener.
+  void RemoveStreamListener(StreamListener* listener);
 
  protected:
-  Callback<AfterWriteCb> after_write_cb_;
-  Callback<AllocCb> alloc_cb_;
-  Callback<ReadCb> read_cb_;
-  Callback<DestructCb> destruct_cb_;
-  uint64_t bytes_read_;
+  // Call the current listener's OnStreamAlloc() method.
+  uv_buf_t EmitAlloc(size_t suggested_size);
+  // Call the current listener's OnStreamRead() method and update the
+  // stream's read byte counter.
+  void EmitRead(ssize_t nread,
+                const uv_buf_t& buf = uv_buf_init(nullptr, 0),
+                uv_handle_type pending = UV_UNKNOWN_HANDLE);
+  // Call the current listener's OnStreamAfterWrite() method.
+  void EmitAfterWrite(WriteWrap* w, int status);
+
+  StreamListener* listener_ = nullptr;
+  uint64_t bytes_read_ = 0;
+
+  friend class StreamListener;
 };
+
 
 class StreamBase : public StreamResource {
  public:
@@ -224,40 +260,29 @@ class StreamBase : public StreamResource {
   virtual bool IsIPCPipe();
   virtual int GetFD();
 
-  virtual int ReadStart() = 0;
-  virtual int ReadStop() = 0;
-
-  inline void Consume() {
-    CHECK_EQ(consumed_, false);
-    consumed_ = true;
-  }
-
-  inline void Unconsume() {
-    CHECK_EQ(consumed_, true);
-    consumed_ = false;
-  }
-
-  void EmitData(ssize_t nread,
-                v8::Local<v8::Object> buf,
-                v8::Local<v8::Object> handle);
+  void CallJSOnreadMethod(
+      ssize_t nread,
+      v8::Local<v8::Object> buf,
+      v8::Local<v8::Object> handle = v8::Local<v8::Object>());
 
   // These are called by the respective {Write,Shutdown}Wrap class.
   virtual void AfterShutdown(ShutdownWrap* req, int status);
   virtual void AfterWrite(WriteWrap* req, int status);
 
- protected:
-  explicit StreamBase(Environment* env) : env_(env), consumed_(false) {
-  }
+  // This is named `stream_env` to avoid name clashes, because a lot of
+  // subclasses are also `BaseObject`s.
+  Environment* stream_env() const;
 
-  virtual ~StreamBase() = default;
+ protected:
+  explicit StreamBase(Environment* env);
 
   // One of these must be implemented
   virtual AsyncWrap* GetAsyncWrap() = 0;
   virtual v8::Local<v8::Object> GetObject();
 
   // JS Methods
-  int ReadStart(const v8::FunctionCallbackInfo<v8::Value>& args);
-  int ReadStop(const v8::FunctionCallbackInfo<v8::Value>& args);
+  int ReadStartJS(const v8::FunctionCallbackInfo<v8::Value>& args);
+  int ReadStopJS(const v8::FunctionCallbackInfo<v8::Value>& args);
   int Shutdown(const v8::FunctionCallbackInfo<v8::Value>& args);
   int Writev(const v8::FunctionCallbackInfo<v8::Value>& args);
   int WriteBuffer(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -280,7 +305,7 @@ class StreamBase : public StreamResource {
 
  private:
   Environment* env_;
-  bool consumed_;
+  EmitToJSStreamListener default_listener_;
 };
 
 }  // namespace node

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -150,17 +150,8 @@ class StreamListener {
   // with base nullpptr in case of an error.
   // `nread` is the number of read bytes (which is at most the buffer length),
   // or, if negative, a libuv error code.
-  // The variant with a `uv_handle_type` argument is used by libuv-backed
-  // streams for handle transfers (e.g. passing net.Socket instances between
-  // cluster workers). For all other streams, overriding the simple variant
-  // should be sufficient.
-  // By default, the second variant crashes if `pending` is set and otherwise
-  // calls the simple variant.
   virtual void OnStreamRead(ssize_t nread,
                             const uv_buf_t& buf) = 0;
-  virtual void OnStreamRead(ssize_t nread,
-                            const uv_buf_t& buf,
-                            uv_handle_type pending);
 
   // This is called once a Write has finished. `status` may be 0 or,
   // if negative, a libuv error code.
@@ -229,9 +220,7 @@ class StreamResource {
   uv_buf_t EmitAlloc(size_t suggested_size);
   // Call the current listener's OnStreamRead() method and update the
   // stream's read byte counter.
-  void EmitRead(ssize_t nread,
-                const uv_buf_t& buf = uv_buf_init(nullptr, 0),
-                uv_handle_type pending = UV_UNKNOWN_HANDLE);
+  void EmitRead(ssize_t nread, const uv_buf_t& buf = uv_buf_init(nullptr, 0));
   // Call the current listener's OnStreamAfterWrite() method.
   void EmitAfterWrite(WriteWrap* w, int status);
 
@@ -260,10 +249,7 @@ class StreamBase : public StreamResource {
   virtual bool IsIPCPipe();
   virtual int GetFD();
 
-  void CallJSOnreadMethod(
-      ssize_t nread,
-      v8::Local<v8::Object> buf,
-      v8::Local<v8::Object> handle = v8::Local<v8::Object>());
+  void CallJSOnreadMethod(ssize_t nread, v8::Local<v8::Object> buf);
 
   // These are called by the respective {Write,Shutdown}Wrap class.
   virtual void AfterShutdown(ShutdownWrap* req, int status);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -93,7 +93,6 @@ LibuvStreamWrap::LibuvStreamWrap(Environment* env,
                  provider),
       StreamBase(env),
       stream_(stream) {
-  PushStreamListener(this);
 }
 
 
@@ -146,7 +145,13 @@ bool LibuvStreamWrap::IsIPCPipe() {
 
 
 int LibuvStreamWrap::ReadStart() {
-  return uv_read_start(stream(), OnAlloc, OnRead);
+  return uv_read_start(stream(), [](uv_handle_t* handle,
+                                    size_t suggested_size,
+                                    uv_buf_t* buf) {
+    static_cast<LibuvStreamWrap*>(handle->data)->OnUvAlloc(suggested_size, buf);
+  }, [](uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
+    static_cast<LibuvStreamWrap*>(stream->data)->OnUvRead(nread, buf);
+  });
 }
 
 
@@ -155,16 +160,11 @@ int LibuvStreamWrap::ReadStop() {
 }
 
 
-void LibuvStreamWrap::OnAlloc(uv_handle_t* handle,
-                              size_t suggested_size,
-                              uv_buf_t* buf) {
-  LibuvStreamWrap* wrap = static_cast<LibuvStreamWrap*>(handle->data);
-  HandleScope scope(wrap->env()->isolate());
-  Context::Scope context_scope(wrap->env()->context());
+void LibuvStreamWrap::OnUvAlloc(size_t suggested_size, uv_buf_t* buf) {
+  HandleScope scope(env()->isolate());
+  Context::Scope context_scope(env()->context());
 
-  CHECK_EQ(wrap->stream(), reinterpret_cast<uv_stream_t*>(handle));
-
-  *buf = wrap->EmitAlloc(suggested_size);
+  *buf = EmitAlloc(suggested_size);
 }
 
 
@@ -190,64 +190,47 @@ static Local<Object> AcceptHandle(Environment* env, LibuvStreamWrap* parent) {
 }
 
 
-void LibuvStreamWrap::OnStreamRead(ssize_t nread,
-                                   const uv_buf_t& buf,
-                                   uv_handle_type pending) {
-  HandleScope handle_scope(env()->isolate());
+void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
+  HandleScope scope(env()->isolate());
   Context::Scope context_scope(env()->context());
-
-  if (nread <= 0) {
-    free(buf.base);
-    if (nread < 0)
-      CallJSOnreadMethod(nread, Local<Object>());
-    return;
-  }
-
-  CHECK_LE(static_cast<size_t>(nread), buf.len);
-
-  Local<Object> pending_obj;
-
-  if (pending == UV_TCP) {
-    pending_obj = AcceptHandle<TCPWrap, uv_tcp_t>(env(), this);
-  } else if (pending == UV_NAMED_PIPE) {
-    pending_obj = AcceptHandle<PipeWrap, uv_pipe_t>(env(), this);
-  } else if (pending == UV_UDP) {
-    pending_obj = AcceptHandle<UDPWrap, uv_udp_t>(env(), this);
-  } else {
-    CHECK_EQ(pending, UV_UNKNOWN_HANDLE);
-  }
-
-  Local<Object> obj = Buffer::New(env(), buf.base, nread).ToLocalChecked();
-  CallJSOnreadMethod(nread, obj, pending_obj);
-}
-
-
-void LibuvStreamWrap::OnRead(uv_stream_t* handle,
-                             ssize_t nread,
-                             const uv_buf_t* buf) {
-  LibuvStreamWrap* wrap = static_cast<LibuvStreamWrap*>(handle->data);
-  HandleScope scope(wrap->env()->isolate());
-  Context::Scope context_scope(wrap->env()->context());
   uv_handle_type type = UV_UNKNOWN_HANDLE;
 
-  if (wrap->is_named_pipe_ipc() &&
-      uv_pipe_pending_count(reinterpret_cast<uv_pipe_t*>(handle)) > 0) {
-    type = uv_pipe_pending_type(reinterpret_cast<uv_pipe_t*>(handle));
+  if (is_named_pipe_ipc() &&
+      uv_pipe_pending_count(reinterpret_cast<uv_pipe_t*>(stream())) > 0) {
+    type = uv_pipe_pending_type(reinterpret_cast<uv_pipe_t*>(stream()));
   }
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
-  CHECK_EQ(wrap->persistent().IsEmpty(), false);
+  CHECK_EQ(persistent().IsEmpty(), false);
 
   if (nread > 0) {
-    if (wrap->is_tcp()) {
+    if (is_tcp()) {
       NODE_COUNT_NET_BYTES_RECV(nread);
-    } else if (wrap->is_named_pipe()) {
+    } else if (is_named_pipe()) {
       NODE_COUNT_PIPE_BYTES_RECV(nread);
+    }
+
+    Local<Object> pending_obj;
+
+    if (type == UV_TCP) {
+      pending_obj = AcceptHandle<TCPWrap, uv_tcp_t>(env(), this);
+    } else if (type == UV_NAMED_PIPE) {
+      pending_obj = AcceptHandle<PipeWrap, uv_pipe_t>(env(), this);
+    } else if (type == UV_UDP) {
+      pending_obj = AcceptHandle<UDPWrap, uv_udp_t>(env(), this);
+    } else {
+      CHECK_EQ(type, UV_UNKNOWN_HANDLE);
+    }
+
+    if (!pending_obj.IsEmpty()) {
+      object()->Set(env()->context(),
+                    env()->pending_handle_string(),
+                    pending_obj).FromJust();
     }
   }
 
-  wrap->EmitRead(nread, *buf, type);
+  EmitRead(nread, *buf);
 }
 
 
@@ -371,11 +354,6 @@ void LibuvStreamWrap::AfterUvWrite(uv_write_t* req, int status) {
   HandleScope scope(req_wrap->env()->isolate());
   Context::Scope context_scope(req_wrap->env()->context());
   req_wrap->Done(status);
-}
-
-
-void LibuvStreamWrap::AfterWrite(WriteWrap* w, int status) {
-  StreamBase::AfterWrite(w, status);
 }
 
 }  // namespace node

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -33,7 +33,9 @@
 
 namespace node {
 
-class LibuvStreamWrap : public HandleWrap, public StreamBase {
+class LibuvStreamWrap : public HandleWrap,
+                        public StreamListener,
+                        public StreamBase {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
@@ -79,9 +81,6 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
                   uv_stream_t* stream,
                   AsyncWrap::ProviderType provider);
 
-  ~LibuvStreamWrap() {
-  }
-
   AsyncWrap* GetAsyncWrap() override;
 
   static void AddMethods(Environment* env,
@@ -105,11 +104,16 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   static void AfterUvShutdown(uv_shutdown_t* req, int status);
 
   // Resource interface implementation
-  static void OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx);
-  static void OnReadImpl(ssize_t nread,
-                         const uv_buf_t* buf,
-                         uv_handle_type pending,
-                         void* ctx);
+  void OnStreamRead(ssize_t nread,
+                    const uv_buf_t& buf) override {
+    CHECK(0 && "must not be called");
+  }
+  void OnStreamRead(ssize_t nread,
+                    const uv_buf_t& buf,
+                    uv_handle_type pending) override;
+  void OnStreamAfterWrite(WriteWrap* w, int status) override {
+    previous_listener_->OnStreamAfterWrite(w, status);
+  }
 
   void AfterWrite(WriteWrap* req_wrap, int status) override;
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -33,9 +33,7 @@
 
 namespace node {
 
-class LibuvStreamWrap : public HandleWrap,
-                        public StreamListener,
-                        public StreamBase {
+class LibuvStreamWrap : public HandleWrap, public StreamBase {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
@@ -93,29 +91,11 @@ class LibuvStreamWrap : public HandleWrap,
   static void SetBlocking(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   // Callbacks for libuv
-  static void OnAlloc(uv_handle_t* handle,
-                      size_t suggested_size,
-                      uv_buf_t* buf);
+  void OnUvAlloc(size_t suggested_size, uv_buf_t* buf);
+  void OnUvRead(ssize_t nread, const uv_buf_t* buf);
 
-  static void OnRead(uv_stream_t* handle,
-                     ssize_t nread,
-                     const uv_buf_t* buf);
   static void AfterUvWrite(uv_write_t* req, int status);
   static void AfterUvShutdown(uv_shutdown_t* req, int status);
-
-  // Resource interface implementation
-  void OnStreamRead(ssize_t nread,
-                    const uv_buf_t& buf) override {
-    CHECK(0 && "must not be called");
-  }
-  void OnStreamRead(ssize_t nread,
-                    const uv_buf_t& buf,
-                    uv_handle_type pending) override;
-  void OnStreamAfterWrite(WriteWrap* w, int status) override {
-    previous_listener_->OnStreamAfterWrite(w, status);
-  }
-
-  void AfterWrite(WriteWrap* req_wrap, int status) override;
 
   uv_stream_t* const stream_;
 };

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -27,6 +27,7 @@
 #include "node_buffer.h"
 #include "node_wrap.h"
 #include "connect_wrap.h"
+#include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -59,7 +59,6 @@ TLSWrap::TLSWrap(Environment* env,
       SSLWrap<TLSWrap>(env, sc, kind),
       StreamBase(env),
       sc_(sc),
-      stream_(stream),
       enc_in_(nullptr),
       enc_out_(nullptr),
       write_size_(0),
@@ -78,14 +77,7 @@ TLSWrap::TLSWrap(Environment* env,
   SSL_CTX_sess_set_get_cb(sc_->ctx_, SSLWrap<TLSWrap>::GetSessionCallback);
   SSL_CTX_sess_set_new_cb(sc_->ctx_, SSLWrap<TLSWrap>::NewSessionCallback);
 
-  stream_->Consume();
-  stream_->set_after_write_cb({ OnAfterWriteImpl, this });
-  stream_->set_alloc_cb({ OnAllocImpl, this });
-  stream_->set_read_cb({ OnReadImpl, this });
-  stream_->set_destruct_cb({ OnDestructImpl, this });
-
-  set_alloc_cb({ OnAllocSelf, this });
-  set_read_cb({ OnReadSelf, this });
+  stream->PushStreamListener(this);
 
   InitSSL();
 }
@@ -100,19 +92,6 @@ TLSWrap::~TLSWrap() {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   sni_context_.Reset();
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-
-  // See test/parallel/test-tls-transport-destroy-after-own-gc.js:
-  // If this TLSWrap is garbage collected, we cannot allow callbacks to be
-  // called on this stream.
-
-  if (stream_ == nullptr)
-    return;
-  stream_->set_destruct_cb({ nullptr, nullptr });
-  stream_->set_after_write_cb({ nullptr, nullptr });
-  stream_->set_alloc_cb({ nullptr, nullptr });
-  stream_->set_read_cb({ nullptr, nullptr });
-  stream_->set_destruct_cb({ nullptr, nullptr });
-  stream_->Unconsume();
 }
 
 
@@ -208,15 +187,13 @@ void TLSWrap::Receive(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   size_t len = Buffer::Length(args[0]);
 
-  uv_buf_t buf;
-
   // Copy given buffer entirely or partiall if handle becomes closed
   while (len > 0 && wrap->IsAlive() && !wrap->IsClosing()) {
-    wrap->stream_->EmitAlloc(len, &buf);
+    uv_buf_t buf = wrap->OnStreamAlloc(len);
     size_t copy = buf.len > len ? len : buf.len;
     memcpy(buf.base, data, copy);
     buf.len = copy;
-    wrap->stream_->EmitRead(buf.len, &buf);
+    wrap->OnStreamRead(copy, buf);
 
     data += copy;
     len -= copy;
@@ -307,7 +284,7 @@ void TLSWrap::EncOut() {
           ->NewInstance(env()->context()).ToLocalChecked();
   WriteWrap* write_req = WriteWrap::New(env(),
                                         req_wrap_obj,
-                                        stream_);
+                                        static_cast<StreamBase*>(stream_));
 
   uv_buf_t buf[arraysize(data)];
   for (size_t i = 0; i < count; i++)
@@ -324,7 +301,7 @@ void TLSWrap::EncOut() {
 }
 
 
-void TLSWrap::EncOutAfterWrite(WriteWrap* req_wrap, int status) {
+void TLSWrap::OnStreamAfterWrite(WriteWrap* req_wrap, int status) {
   // We should not be getting here after `DestroySSL`, because all queued writes
   // must be invoked with UV_ECANCELED
   CHECK_NE(ssl_, nullptr);
@@ -421,12 +398,11 @@ void TLSWrap::ClearOut() {
     while (read > 0) {
       int avail = read;
 
-      uv_buf_t buf;
-      EmitAlloc(avail, &buf);
+      uv_buf_t buf = EmitAlloc(avail);
       if (static_cast<int>(buf.len) < avail)
         avail = buf.len;
       memcpy(buf.base, current, avail);
-      EmitRead(avail, &buf);
+      EmitRead(avail, buf);
 
       // Caveat emptor: OnRead() calls into JS land which can result in
       // the SSL context object being destroyed.  We have to carefully
@@ -442,7 +418,7 @@ void TLSWrap::ClearOut() {
   int flags = SSL_get_shutdown(ssl_);
   if (!eof_ && flags & SSL_RECEIVED_SHUTDOWN) {
     eof_ = true;
-    EmitRead(UV_EOF, nullptr);
+    EmitRead(UV_EOF);
   }
 
   // We need to check whether an error occurred or the connection was
@@ -524,22 +500,24 @@ AsyncWrap* TLSWrap::GetAsyncWrap() {
 
 
 bool TLSWrap::IsIPCPipe() {
-  return stream_->IsIPCPipe();
+  return static_cast<StreamBase*>(stream_)->IsIPCPipe();
 }
 
 
 int TLSWrap::GetFD() {
-  return stream_->GetFD();
+  return static_cast<StreamBase*>(stream_)->GetFD();
 }
 
 
 bool TLSWrap::IsAlive() {
-  return ssl_ != nullptr && stream_ != nullptr && stream_->IsAlive();
+  return ssl_ != nullptr &&
+      stream_ != nullptr &&
+      static_cast<StreamBase*>(stream_)->IsAlive();
 }
 
 
 bool TLSWrap::IsClosing() {
-  return stream_->IsClosing();
+  return static_cast<StreamBase*>(stream_)->IsClosing();
 }
 
 
@@ -638,62 +616,16 @@ int TLSWrap::DoWrite(WriteWrap* w,
 }
 
 
-void TLSWrap::OnAfterWriteImpl(WriteWrap* w, int status, void* ctx) {
-  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
-  wrap->EncOutAfterWrite(w, status);
+uv_buf_t TLSWrap::OnStreamAlloc(size_t suggested_size) {
+  CHECK_NE(ssl_, nullptr);
+
+  size_t size = suggested_size;
+  char* base = crypto::NodeBIO::FromBIO(enc_in_)->PeekWritable(&size);
+  return uv_buf_init(base, size);
 }
 
 
-void TLSWrap::OnAllocImpl(size_t suggested_size, uv_buf_t* buf, void* ctx) {
-  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
-
-  if (wrap->ssl_ == nullptr) {
-    *buf = uv_buf_init(nullptr, 0);
-    return;
-  }
-
-  size_t size = 0;
-  buf->base = crypto::NodeBIO::FromBIO(wrap->enc_in_)->PeekWritable(&size);
-  buf->len = size;
-}
-
-
-void TLSWrap::OnReadImpl(ssize_t nread,
-                         const uv_buf_t* buf,
-                         uv_handle_type pending,
-                         void* ctx) {
-  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
-  wrap->DoRead(nread, buf, pending);
-}
-
-
-void TLSWrap::OnDestructImpl(void* ctx) {
-  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
-  wrap->clear_stream();
-}
-
-
-void TLSWrap::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
-  buf->base = node::Malloc(suggested_size);
-  buf->len = suggested_size;
-}
-
-
-void TLSWrap::OnReadSelf(ssize_t nread,
-                         const uv_buf_t* buf,
-                         uv_handle_type pending,
-                         void* ctx) {
-  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
-  Local<Object> buf_obj;
-  if (buf != nullptr)
-    buf_obj = Buffer::New(wrap->env(), buf->base, buf->len).ToLocalChecked();
-  wrap->EmitData(nread, buf_obj, Local<Object>());
-}
-
-
-void TLSWrap::DoRead(ssize_t nread,
-                     const uv_buf_t* buf,
-                     uv_handle_type pending) {
+void TLSWrap::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   if (nread < 0)  {
     // Error should be emitted only after all data was read
     ClearOut();
@@ -705,13 +637,13 @@ void TLSWrap::DoRead(ssize_t nread,
       eof_ = true;
     }
 
-    EmitRead(nread, nullptr);
+    EmitRead(nread);
     return;
   }
 
   // Only client connections can receive data
   if (ssl_ == nullptr) {
-    EmitRead(UV_EPROTO, nullptr);
+    EmitRead(UV_EPROTO);
     return;
   }
 
@@ -800,6 +732,9 @@ void TLSWrap::DestroySSL(const FunctionCallbackInfo<Value>& args) {
 
   // Destroy the SSL structure and friends
   wrap->SSLWrap<TLSWrap>::DestroySSL();
+
+  if (wrap->stream_ != nullptr)
+    wrap->stream_->RemoveStreamListener(wrap);
 }
 
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -26,6 +26,7 @@
 #include "node_buffer.h"
 #include "node_wrap.h"
 #include "req_wrap-inl.h"
+#include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
 

--- a/test/parallel/test-tls-socket-destroy.js
+++ b/test/parallel/test-tls-socket-destroy.js
@@ -19,6 +19,7 @@ const server = net.createServer(common.mustCall((conn) => {
   const socket = new tls.TLSSocket(conn, options);
   socket.once('data', common.mustCall(() => {
     socket._destroySSL();  // Should not crash.
+    socket.destroy();
     server.close();
   }));
 }));


### PR DESCRIPTION
Instead of setting individual callbacks on streams and tracking
stream ownership through a boolean `consume_` flag, always have
one specific listener object in charge of a stream, and call
methods on that object rather than generic C-style callbacks.


<details><summary>
Benchmark results show no significant changes:</summary>


    $ ./node benchmark/compare.js --runs 5 --new ./node --old ./node-master net | Rscript benchmark/compare.R
    [00:43:05|% 100| 8/8 files | 10/10 runs | 6/6 configs]: Done
                                                                          improvement confidence     p.value
     net/net-c2s-cork.js dur=5 type="buf" len=1024                           -0.80 %            0.720985414
     net/net-c2s-cork.js dur=5 type="buf" len=128                            -3.50 %            0.278786279
     net/net-c2s-cork.js dur=5 type="buf" len=16                             -4.44 %          * 0.010458284
     net/net-c2s-cork.js dur=5 type="buf" len=32                             -0.51 %            0.445313528
     net/net-c2s-cork.js dur=5 type="buf" len=4                              -1.57 %            0.074816557
     net/net-c2s-cork.js dur=5 type="buf" len=512                            -0.25 %            0.926451422
     net/net-c2s-cork.js dur=5 type="buf" len=64                              1.66 %          * 0.020469582
     net/net-c2s-cork.js dur=5 type="buf" len=8                              -0.18 %            0.739524856
     net/net-c2s.js dur=5 type="asc" len=102400                              -0.22 %            0.904819514
     net/net-c2s.js dur=5 type="asc" len=16777216                             0.34 %            0.862222556
     net/net-c2s.js dur=5 type="buf" len=102400                              -0.45 %            0.755593966
     net/net-c2s.js dur=5 type="buf" len=16777216                             1.87 %            0.477896886
     net/net-c2s.js dur=5 type="utf" len=102400                              -0.30 %            0.572739665
     net/net-c2s.js dur=5 type="utf" len=16777216                             1.18 %            0.369268245
     net/net-pipe.js dur=5 type="asc" len=102400                              1.18 %            0.368102481
     net/net-pipe.js dur=5 type="asc" len=16777216                            0.41 %            0.659646192
     net/net-pipe.js dur=5 type="buf" len=102400                              1.65 %            0.148484290
     net/net-pipe.js dur=5 type="buf" len=16777216                            0.05 %            0.949649889
     net/net-pipe.js dur=5 type="utf" len=102400                              0.65 %            0.463140117
     net/net-pipe.js dur=5 type="utf" len=16777216                            0.57 %            0.531757174
     net/net-s2c.js dur=5 type="asc" len=102400                               0.01 %            0.994663657
     net/net-s2c.js dur=5 type="asc" len=16777216                             0.55 %            0.690648594
     net/net-s2c.js dur=5 type="buf" len=102400                               1.06 %            0.162661878
     net/net-s2c.js dur=5 type="buf" len=16777216                             2.21 %            0.458328732
     net/net-s2c.js dur=5 type="utf" len=102400                               0.47 %            0.346382821
     net/net-s2c.js dur=5 type="utf" len=16777216                            -1.19 %            0.075676276
     net/net-wrap-js-stream-passthrough.js dur=5 type="asc" len=102400       -5.01 %            0.566507367
     net/net-wrap-js-stream-passthrough.js dur=5 type="asc" len=16777216      1.81 %            0.382296906
     net/net-wrap-js-stream-passthrough.js dur=5 type="buf" len=102400       -4.32 %            0.543143575
     net/net-wrap-js-stream-passthrough.js dur=5 type="buf" len=16777216      0.12 %            0.774690856
     net/net-wrap-js-stream-passthrough.js dur=5 type="utf" len=102400        2.33 %            0.152586683
     net/net-wrap-js-stream-passthrough.js dur=5 type="utf" len=16777216      0.50 %            0.687525683
     net/tcp-raw-c2s.js dur=5 type="asc" len=102400                           0.05 %            0.917082371
     net/tcp-raw-c2s.js dur=5 type="asc" len=16777216                         4.17 %         ** 0.005564067
     net/tcp-raw-c2s.js dur=5 type="buf" len=102400                           0.56 %          * 0.037673166
     net/tcp-raw-c2s.js dur=5 type="buf" len=16777216                         0.77 %         ** 0.006890503
     net/tcp-raw-c2s.js dur=5 type="utf" len=102400                          -0.50 %            0.397862701
     net/tcp-raw-c2s.js dur=5 type="utf" len=16777216                         1.00 %            0.300638263
     net/tcp-raw-pipe.js dur=5 type="asc" len=102400                          0.82 %            0.722353484
     net/tcp-raw-pipe.js dur=5 type="asc" len=16777216                       15.00 %            0.070918075
     net/tcp-raw-pipe.js dur=5 type="buf" len=102400                         -1.03 %            0.819639125
     net/tcp-raw-pipe.js dur=5 type="buf" len=16777216                       18.35 %            0.329069149
     net/tcp-raw-pipe.js dur=5 type="utf" len=102400                         -0.27 %            0.984576346
     net/tcp-raw-pipe.js dur=5 type="utf" len=16777216                        2.78 %            0.362840470
     net/tcp-raw-s2c.js dur=5 type="asc" len=102400                          -0.15 %            0.820491736
     net/tcp-raw-s2c.js dur=5 type="asc" len=16777216                        -0.42 %            0.813160796
     net/tcp-raw-s2c.js dur=5 type="buf" len=102400                           0.26 %            0.615102013
     net/tcp-raw-s2c.js dur=5 type="buf" len=16777216                        -2.16 %            0.464289164
     net/tcp-raw-s2c.js dur=5 type="utf" len=102400                          -0.33 %            0.383964275
     net/tcp-raw-s2c.js dur=5 type="utf" len=16777216                         1.08 %            0.224603980

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

</details>

---

As a heads up, after this I’d like to also refactor the writable side a bit more by removing `WriteWrap` and `ShutdownWrap` as explicit classes; I have some WIP work but haven’t gotten that to pass all TLS tests yet…

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

src