### PR TITLE
[v9.x] deps: cherry-pick 55b4879 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.26',
+    'v8_embedder_string': '-node.27',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/profiler/heap-snapshot-generator.cc
+++ b/deps/v8/src/profiler/heap-snapshot-generator.cc
@@ -1137,8 +1137,6 @@ void V8HeapExplorer::ExtractMapReferences(int entry, Map* map) {
                          constructor_or_backpointer,
                          Map::kConstructorOrBackPointerOffset);
   } else {
-    DCHECK(constructor_or_backpointer->IsJSFunction() ||
-           constructor_or_backpointer->IsNull(map->GetIsolate()));
     SetInternalReference(map, entry, "constructor", constructor_or_backpointer,
                          Map::kConstructorOrBackPointerOffset);
   }


### PR DESCRIPTION
Original commit message:

    [heap-profiler] remove bogus DCHECK

    A map’s `constructor_or_backpointer` can be any kind of value,
    because `fn.prototype = foo` sets that field to `foo` if the
    latter is not a `JSReceiver`; so the `DCHECK` that is being
    removed here was invalid.

    Refs: https://github.com/nodejs/node/issues/18223
    Bug: node:18223
    Change-Id: Ia6449c07bb724e515d73b162369ab36ab1d89c6b
    Reviewed-on: https://chromium-review.googlesource.com/874472
    Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#50735}

Refs: https://github.com/v8/v8/commit/55b48798eb3f443b9d04f7d43c55b3dada4f9de7
Fixes: https://github.com/nodejs/node/issues/18223

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
