### PR TITLE
(v6.x backport) crypto: warn on invalid authentication tag length

### DIFF
--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -314,6 +314,14 @@ const errMessages = {
 
 const ciphers = crypto.getCiphers();
 
+common.expectWarning('Warning', (common.hasFipsCrypto ? [] : [
+  'Use Cipheriv for counter mode of aes-192-gcm'
+]).concat(
+  [0, 1, 2, 6, 9, 10, 11, 17]
+  .map((i) => `Permitting authentication tag lengths of ${i} bytes is ` +
+            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.')
+));
+
 for (const i in TEST_CASES) {
   const test = TEST_CASES[i];
 
@@ -454,4 +462,15 @@ for (const i in TEST_CASES) {
   assert.throws(() => encrypt.getAuthTag(), errMessages.state);
   assert.throws(() => encrypt.setAAD(Buffer.from('123', 'ascii')),
                 errMessages.state);
+}
+
+// GCM only supports specific authentication tag lengths, invalid lengths should
+// produce warnings.
+{
+  for (const length of [0, 1, 2, 4, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]) {
+    const decrypt = crypto.createDecipheriv('aes-256-gcm',
+                                            'FxLKsqdmv0E9xrQhp0b1ZgI0K7JFZJM8',
+                                            'qkuZpJWCewa6Szih');
+    decrypt.setAuthTag(Buffer.from('1'.repeat(length)));
+  }
 }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -141,7 +141,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
 // setAutoPadding/setAuthTag/setAAD should return `this`
 {
   const key = '0123456789';
-  const tagbuf = Buffer.from('tagbuf');
+  const tagbuf = Buffer.from('auth_tag');
   const aadbuf = Buffer.from('aadbuf');
   const decipher = crypto.createDecipher('aes-256-gcm', key);
   assert.strictEqual(decipher.setAutoPadding(), decipher);


### PR DESCRIPTION
Manual backport of https://github.com/nodejs/node/pull/17566 to v6.x.