### PR TITLE
doc: include null as a return value for require.resolve.paths()

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -626,9 +626,11 @@ added: v8.9.0
 -->
 
 * `request` {string} The module path whose lookup paths are being retrieved.
-* Returns: {Array}
+* Returns: {Array|null}
 
-Returns an array containing the paths searched during resolution of `request`.
+Returns an array containing the paths searched during resolution of `request` or
+null if the `request` string references a core module, for example `http` or
+`fs`.
 
 ## The `module` Object
 <!-- YAML


### PR DESCRIPTION
Update documentation of modules.md for require.resolve.paths()
to include the possibillity of null as a return value if
the request string given matches a core module name.

Fixes: https://github.com/nodejs/node/issues/18230

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc