### PR TITLE
http: switch on string values

### DIFF
--- a/benchmark/http/set_header.js
+++ b/benchmark/http/set_header.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common.js');
+const { OutgoingMessage } = require('_http_outgoing');
+
+const bench = common.createBenchmark(main, {
+  value: [
+    'X-Powered-By',
+    'Vary',
+    'Set-Cookie',
+    'Content-Type',
+    'Content-Length',
+    'Connection',
+    'Transfer-Encoding'
+  ],
+  n: [1e6],
+});
+
+function main(conf) {
+  const n = +conf.n;
+  const value = conf.value;
+
+  const og = new OutgoingMessage();
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    og.setHeader(value, '');
+  }
+  bench.end(n);
+}

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -510,18 +510,15 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   const key = name.toLowerCase();
   this[outHeadersKey][key] = [name, value];
 
-  switch (key.length) {
-    case 10:
-      if (key === 'connection')
-        this._removedConnection = false;
+  switch (key) {
+    case 'connection':
+      this._removedConnection = false;
       break;
-    case 14:
-      if (key === 'content-length')
-        this._removedContLen = false;
+    case 'content-length':
+      this._removedContLen = false;
       break;
-    case 17:
-      if (key === 'transfer-encoding')
-        this._removedTE = false;
+    case 'transfer-encoding':
+      this._removedTE = false;
       break;
   }
 };
@@ -583,22 +580,18 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
 
   var key = name.toLowerCase();
 
-  switch (key.length) {
-    case 10:
-      if (key === 'connection')
-        this._removedConnection = true;
+  switch (key) {
+    case 'connection':
+      this._removedConnection = true;
       break;
-    case 14:
-      if (key === 'content-length')
-        this._removedContLen = true;
+    case 'content-length':
+      this._removedContLen = true;
       break;
-    case 17:
-      if (key === 'transfer-encoding')
-        this._removedTE = true;
+    case 'transfer-encoding':
+      this._removedTE = true;
       break;
-    case 4:
-      if (key === 'date')
-        this.sendDate = false;
+    case 'date':
+      this.sendDate = false;
       break;
   }
 


### PR DESCRIPTION
Long ago, V8 was much faster switching on string lengths than values. That is no longer the case, so we can simplify a couple of methods.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes _(sort of, see detail below)_
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

* http

##### Test results


I ran the test suite and found the following errors on Windows, which were consistent with or without this change. A couple of other errors also showed up inconsistently. Two of them seem to be covered by [18251](https://github.com/nodejs/node/issues/18251), but I didn't see any active issue for test-assert.

```
=== release test-assert ===
Path: parallel/test-assert
assert.js:68
  throw new errors.AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: 'The expression evaluated to a falsy value:\r\n\r\n  assert((() => \'string\')()\n      // eslint-disable-next-line\n      ===\n strictEqual 'The expression evaluated to a falsy value:\r\n\r\n  assert((() => \'string\')()\r\n      // eslint-disable-next-line\r\n      =
    at Object.innerFn (D:\repos\node\test\common\index.js:762:16)
    at expectedException (assert.js:374:19)
    at Function.throws (assert.js:419:16)
    at Object.expectsError (D:\repos\node\test\common\index.js:784:12)
    at Object.<anonymous> (D:\repos\node\test\parallel\test-assert.js:842:8)
    at Module._compile (module.js:661:30)
    at Object.Module._extensions..js (module.js:672:10)
    at Module.load (module.js:578:32)
    at tryModuleLoad (module.js:518:12)
    at Function.Module._load (module.js:510:3)
Command: D:\repos\node\Release\node.exe D:\repos\node\test\parallel\test-assert.js
=== release test-http2-ping-flood ===
Path: sequential/test-http2-ping-flood
(node:23136) ExperimentalWarning: The http2 module is an experimental API.
Command: D:\repos\node\Release\node.exe D:\repos\node\test\sequential\test-http2-ping-flood.js
--- TIMEOUT ---
=== release test-http2-settings-flood ===
Path: sequential/test-http2-settings-flood
(node:30612) ExperimentalWarning: The http2 module is an experimental API.
Command: D:\repos\node\Release\node.exe D:\repos\node\test\sequential\test-http2-settings-flood.js
--- TIMEOUT ---
```

##### Benchmark results

```
>Release\node.exe benchmark\compare.js --old Release_old\node.exe --new Release\node.exe --filter set_header http | rscript benchmark\compare.R
[00:05:25|% 100| 1/1 files | 60/60 runs | 7/7 configs]: Done
                                                          improvement confidence      p.value
 http\\set_header.js n=1000000 value="Connection"            22.61 %        *** 5.803813e-14
 http\\set_header.js n=1000000 value="Content-Length"        20.64 %        *** 9.065010e-19
 http\\set_header.js n=1000000 value="Content-Type"          23.51 %        *** 6.291114e-26
 http\\set_header.js n=1000000 value="Set-Cookie"            26.20 %        *** 8.024882e-29
 http\\set_header.js n=1000000 value="Transfer-Encoding"     15.54 %        *** 6.562425e-14
 http\\set_header.js n=1000000 value="Vary"                  20.31 %        *** 1.390219e-17
 http\\set_header.js n=1000000 value="X-Powered-By"          21.68 %        *** 7.662119e-17
```
