### PR TITLE
errors: improve the description of ERR_INVALID_ARG_VALUE

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -23,8 +23,15 @@ const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
 
 // Lazily loaded
-var util = null;
+var util_ = null;
 var buffer;
+
+function lazyUtil() {
+  if (!util_) {
+    util_ = require('util');
+  }
+  return util_;
+}
 
 function makeNodeError(Base) {
   return class NodeError extends Base {
@@ -142,6 +149,7 @@ function createErrDiff(actual, expected, operator) {
   var lastPos = 0;
   var end = '';
   var skipped = false;
+  const util = lazyUtil();
   const actualLines = util
     .inspect(actual, { compact: false }).split('\n');
   const expectedLines = util
@@ -262,13 +270,11 @@ class AssertionError extends Error {
     if (message != null) {
       super(message);
     } else {
-      if (util === null) {
-        util = require('util');
-        if (process.stdout.isTTY && process.stdout.getColorDepth() !== 1) {
-          green = '\u001b[32m';
-          white = '\u001b[39m';
-          red = '\u001b[31m';
-        }
+      const util = lazyUtil();
+      if (process.stdout.isTTY && process.stdout.getColorDepth() !== 1) {
+        green = '\u001b[32m';
+        white = '\u001b[39m';
+        red = '\u001b[31m';
       }
 
       if (actual && actual.stack && actual instanceof Error)
@@ -333,7 +339,7 @@ function message(key, args) {
   if (typeof msg === 'function') {
     fmt = msg;
   } else {
-    if (util === null) util = require('util');
+    const util = lazyUtil();
     fmt = util.format;
     if (args === undefined || args.length === 0)
       return msg;
@@ -537,8 +543,14 @@ E('ERR_INSPECTOR_CLOSED', 'Session was closed');
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
-E('ERR_INVALID_ARG_VALUE', (name, value) =>
-  `The value "${String(value)}" is invalid for argument "${name}"`);
+E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
+  const util = lazyUtil();
+  let inspected = util.inspect(value);
+  if (inspected.length > 128) {
+    inspected = inspected.slice(0, 128) + '...';
+  }
+  return `The argument '${name}' ${reason}. Received ${inspected}`;
+}),
 E('ERR_INVALID_ARRAY_LENGTH',
   (name, len, actual) => {
     internalAssert(typeof actual === 'number', 'actual must be a number');

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -351,10 +351,20 @@ assert.strictEqual(
 }
 
 {
-  const error = new errors.Error('ERR_INVALID_ARG_VALUE', 'foo', 'bar');
+  const error = new errors.Error('ERR_INVALID_ARG_VALUE', 'foo', '\u0000bar');
   assert.strictEqual(
     error.message,
-    'The value "bar" is invalid for argument "foo"'
+    'The argument \'foo\' is invalid. Received \'\\u0000bar\''
+  );
+}
+
+{
+  const error = new errors.Error(
+    'ERR_INVALID_ARG_VALUE',
+    'foo', { a: 1 }, 'must have property \'b\'');
+  assert.strictEqual(
+    error.message,
+    'The argument \'foo\' must have property \'b\'. Received { a: 1 }'
   );
 }
 


### PR DESCRIPTION
- Allow user to customize why the argument is invalid
- Display the argument with util.inspect so null bytes can be
  displayed properly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Spinning off from https://github.com/nodejs/node/pull/18308 , but I think this can be submitted alone since that one needs a bit more reviews to land and that's semver-major. The current formatter does not allow users to explain why the argument is invalid and it displays the argument with `${String(value)}` which cannot display null bytes properly.  This patch makes the error message more debuggable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors