### PR TITLE
process: js fast path for cached bindings

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -243,6 +243,14 @@
     perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
   }
 
+  const moduleLoadList = [];
+  Object.defineProperty(process, 'moduleLoadList', {
+    value: moduleLoadList,
+    configurable: true,
+    enumerable: true,
+    writable: false
+  });
+
   {
     const bindingObj = Object.create(null);
 
@@ -250,8 +258,10 @@
     process.binding = function binding(module) {
       module = String(module);
       let mod = bindingObj[module];
-      if (typeof mod !== 'object')
+      if (typeof mod !== 'object') {
         mod = bindingObj[module] = getBinding(module);
+        moduleLoadList.push(`Binding ${module}`);
+      }
       return mod;
     };
 
@@ -273,8 +283,10 @@
 
     internalBinding = function internalBinding(module) {
       let mod = bindingObj[module];
-      if (typeof mod !== 'object')
+      if (typeof mod !== 'object') {
         mod = bindingObj[module] = getInternalBinding(module);
+        moduleLoadList.push(`Internal Binding ${module}`);
+      }
       return mod;
     };
   }
@@ -583,7 +595,7 @@
       throw err;
     }
 
-    process.moduleLoadList.push(`NativeModule ${id}`);
+    moduleLoadList.push(`NativeModule ${id}`);
 
     const nativeModule = new NativeModule(id);
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -243,44 +243,49 @@
     perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
   }
 
-  function pushValueToArray() {
-    for (var i = 0; i < arguments.length; i++)
-      this.push(arguments[i]);
-  }
+  {
+    const bindingObj = Object.create(null);
 
-  function setupProcessBinding(bindingObj) {
-    const _binding = process.binding;
-
+    const getBinding = process.binding;
     process.binding = function binding(module) {
-      if (!module || typeof module !== 'string')
-        return;
+      module = String(module);
       if (typeof bindingObj[module] === 'object')
         return bindingObj[module];
-      return _binding(module);
+      bindingObj[module] = getBinding(module);
+      return bindingObj[module];
+    };
+
+    const getLinkedBinding = process._linkedBinding;
+    process._linkedBinding = function _linkedBinding(module) {
+      module = String(module);
+      if (typeof bindingObj[module] === 'object')
+        return bindingObj[module];
+      bindingObj[module] = getLinkedBinding(module);
+      return bindingObj[module];
     };
   }
 
-  function setupInternalBinding(bindingObj) {
-    const _internalBinding = process._internalBinding;
+  {
+    const bindingObj = Object.create(null);
+
+    const getInternalBinding = process._internalBinding;
     delete process._internalBinding;
 
     internalBinding = function internalBinding(module) {
-      if (!module || typeof module !== 'string')
-        return;
       if (typeof bindingObj[module] === 'object')
         return bindingObj[module];
-      return _internalBinding(module);
+      bindingObj[module] = getInternalBinding(module);
+      return bindingObj[module];
     };
   }
 
   function setupProcessObject() {
-    const [
-      bindingObj,
-      internalBindingObj
-    ] = process._setupProcessObject(pushValueToArray);
+    process._setupProcessObject(pushValueToArray);
 
-    setupProcessBinding(bindingObj);
-    setupInternalBinding(internalBindingObj);
+    function pushValueToArray() {
+      for (var i = 0; i < arguments.length; i++)
+        this.push(arguments[i]);
+    }
   }
 
   function setupGlobalVariables() {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -249,19 +249,19 @@
     const getBinding = process.binding;
     process.binding = function binding(module) {
       module = String(module);
-      if (typeof bindingObj[module] === 'object')
-        return bindingObj[module];
-      bindingObj[module] = getBinding(module);
-      return bindingObj[module];
+      let mod = bindingObj[module];
+      if (typeof mod !== 'object')
+        mod = bindingObj[module] = getBinding(module);
+      return mod;
     };
 
     const getLinkedBinding = process._linkedBinding;
     process._linkedBinding = function _linkedBinding(module) {
       module = String(module);
-      if (typeof bindingObj[module] === 'object')
-        return bindingObj[module];
-      bindingObj[module] = getLinkedBinding(module);
-      return bindingObj[module];
+      let mod = bindingObj[module];
+      if (typeof mod !== 'object')
+        mod = bindingObj[module] = getLinkedBinding(module);
+      return mod;
     };
   }
 
@@ -272,10 +272,10 @@
     delete process._internalBinding;
 
     internalBinding = function internalBinding(module) {
-      if (typeof bindingObj[module] === 'object')
-        return bindingObj[module];
-      bindingObj[module] = getInternalBinding(module);
-      return bindingObj[module];
+      let mod = bindingObj[module];
+      if (typeof mod !== 'object')
+        mod = bindingObj[module] = getInternalBinding(module);
+      return mod;
     };
   }
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -21,9 +21,6 @@
 
     setupProcessObject();
 
-    internalBinding = process._internalBinding;
-    delete process._internalBinding;
-
     // do this good and early, since it handles errors.
     setupProcessFatal();
 
@@ -246,13 +243,44 @@
     perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
   }
 
-  function setupProcessObject() {
-    process._setupProcessObject(pushValueToArray);
+  function pushValueToArray() {
+    for (var i = 0; i < arguments.length; i++)
+      this.push(arguments[i]);
+  }
 
-    function pushValueToArray() {
-      for (var i = 0; i < arguments.length; i++)
-        this.push(arguments[i]);
-    }
+  function setupProcessBinding(bindingObj) {
+    const _binding = process.binding;
+
+    process.binding = function binding(module) {
+      if (!module || typeof module !== 'string')
+        return;
+      if (typeof bindingObj[module] === 'object')
+        return bindingObj[module];
+      return _binding(module);
+    };
+  }
+
+  function setupInternalBinding(bindingObj) {
+    const _internalBinding = process._internalBinding;
+    delete process._internalBinding;
+
+    internalBinding = function internalBinding(module) {
+      if (!module || typeof module !== 'string')
+        return;
+      if (typeof bindingObj[module] === 'object')
+        return bindingObj[module];
+      return _internalBinding(module);
+    };
+  }
+
+  function setupProcessObject() {
+    const [
+      bindingObj,
+      internalBindingObj
+    ] = process._setupProcessObject(pushValueToArray);
+
+    setupProcessBinding(bindingObj);
+    setupInternalBinding(internalBindingObj);
   }
 
   function setupGlobalVariables() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -329,16 +329,6 @@ inline Environment::Environment(IsolateData* isolate_data,
   v8::Context::Scope context_scope(context);
   set_as_external(v8::External::New(isolate(), this));
 
-  v8::Local<v8::Primitive> null = v8::Null(isolate());
-  v8::Local<v8::Object> binding_cache_object = v8::Object::New(isolate());
-  CHECK(binding_cache_object->SetPrototype(context, null).FromJust());
-  set_binding_cache_object(binding_cache_object);
-
-  v8::Local<v8::Object> internal_binding_cache_object =
-      v8::Object::New(isolate());
-  CHECK(internal_binding_cache_object->SetPrototype(context, null).FromJust());
-  set_internal_binding_cache_object(internal_binding_cache_object);
-
   set_module_load_list_array(v8::Array::New(isolate()));
 
   AssignToContext(context, ContextInfo(""));

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -329,8 +329,6 @@ inline Environment::Environment(IsolateData* isolate_data,
   v8::Context::Scope context_scope(context);
   set_as_external(v8::External::New(isolate(), this));
 
-  set_module_load_list_array(v8::Array::New(isolate()));
-
   AssignToContext(context, ContextInfo(""));
 
   destroy_async_id_list_.reserve(512);

--- a/src/env.h
+++ b/src/env.h
@@ -277,8 +277,6 @@ class ModuleWrap;
   V(async_hooks_after_function, v8::Function)                                 \
   V(async_hooks_promise_resolve_function, v8::Function)                       \
   V(async_hooks_binding, v8::Object)                                          \
-  V(binding_cache_object, v8::Object)                                         \
-  V(internal_binding_cache_object, v8::Object)                                \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
   V(host_import_module_dynamically_callback, v8::Function)                    \

--- a/src/env.h
+++ b/src/env.h
@@ -285,7 +285,6 @@ class ModuleWrap;
   V(http2settings_constructor_template, v8::ObjectTemplate)                   \
   V(immediate_callback_function, v8::Function)                                \
   V(inspector_console_api_object, v8::Object)                                 \
-  V(module_load_list_array, v8::Array)                                        \
   V(pbkdf2_constructor_template, v8::ObjectTemplate)                          \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(performance_entry_callback, v8::Function)                                 \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2556,15 +2556,7 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   Local<String> module = args[0].As<String>();
-
-  // Append a string to process.moduleLoadList
-  char buf[1024];
   node::Utf8Value module_v(env->isolate(), module);
-  snprintf(buf, sizeof(buf), "Binding %s", *module_v);
-
-  Local<Array> modules = env->module_load_list_array();
-  uint32_t l = modules->Length();
-  modules->Set(l, OneByteString(env->isolate(), buf));
 
   node_module* mod = get_builtin_module(*module_v);
   Local<Object> exports;
@@ -2591,15 +2583,7 @@ static void InternalBinding(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   Local<String> module = args[0].As<String>();
-
-  // Append a string to process.moduleLoadList
-  char buf[1024];
   node::Utf8Value module_v(env->isolate(), module);
-  snprintf(buf, sizeof(buf), "Internal Binding %s", *module_v);
-
-  Local<Array> modules = env->module_load_list_array();
-  uint32_t l = modules->Length();
-  modules->Set(l, OneByteString(env->isolate(), buf));
 
   node_module* mod = get_internal_module(*module_v);
   if (mod == nullptr) return ThrowIfNoSuchModule(env, *module_v);
@@ -2970,11 +2954,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(process,
                     "version",
                     FIXED_ONE_BYTE_STRING(env->isolate(), NODE_VERSION));
-
-  // process.moduleLoadList
-  READONLY_PROPERTY(process,
-                    "moduleLoadList",
-                    env->module_load_list_array());
 
   // process.versions
   Local<Object> versions = Object::New(env->isolate());


### PR DESCRIPTION
Currently, both `process.binding` and `internalBinding` have to call into C++ regardless of whether the module has been cached or not. This creates significant overhead to all binding calls and unfortunately the rest of the codebase doesn't really optimize the amount of times that bindings are required (as an example: 12 files require the async_wrap binding).

Changing all the usage of this function throughout the codebase would introduce a lot of churn (and is kind of a hassle) so instead this PR introduces a JS fast path for both functions for cases where the binding has already been cached. While micro benchmarks are not super meaningful here (it's not like we call `binding` that often...), this does speed up the cached call by 400%.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process, src