### PR TITLE
src,lib: implement import.meta

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -36,12 +36,17 @@ Only the CLI argument for the main entry point to the program can be an entry
 point into an ESM graph. Dynamic import can also be used to create entry points
 into ESM graphs at runtime.
 
+#### `import.meta`
+
+The `import.meta` metaproperty is an `Object` that contains the following
+property:
+* `url` {string} The absolute `file:` URL of the module
+
 ### Unsupported
 
 | Feature | Reason |
 | --- | --- |
 | `require('./foo.mjs')` | ES Modules have differing resolution and timing, use dynamic import |
-| `import.meta` | pending V8 implementation |
 
 ## Notable differences between `import` and `require`
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -104,6 +104,7 @@
       process.emitWarning(
         'The ESM module loader is experimental.',
         'ExperimentalWarning', undefined);
+      NativeModule.require('internal/process/modules').setup();
     }
 
 

--- a/lib/internal/process/modules.js
+++ b/lib/internal/process/modules.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const {
+  setInitializeImportMetaObjectCallback
+} = internalBinding('module_wrap');
+
+function initializeImportMetaObject(wrap, meta) {
+  meta.url = wrap.url;
+}
+
+function setupModules() {
+  setInitializeImportMetaObjectCallback(initializeImportMetaObject);
+}
+
+module.exports = {
+  setup: setupModules
+};

--- a/node.gyp
+++ b/node.gyp
@@ -112,6 +112,7 @@
       'lib/internal/net.js',
       'lib/internal/module.js',
       'lib/internal/os.js',
+      'lib/internal/process/modules.js',
       'lib/internal/process/next_tick.js',
       'lib/internal/process/promises.js',
       'lib/internal/process/stdio.js',

--- a/src/env.h
+++ b/src/env.h
@@ -249,6 +249,7 @@ class ModuleWrap;
   V(type_string, "type")                                                      \
   V(uid_string, "uid")                                                        \
   V(unknown_string, "<unknown>")                                              \
+  V(url_string, "url")                                                        \
   V(user_string, "user")                                                      \
   V(username_string, "username")                                              \
   V(valid_from_string, "valid_from")                                          \
@@ -278,6 +279,7 @@ class ModuleWrap;
   V(context, v8::Context)                                                     \
   V(domain_callback, v8::Function)                                            \
   V(host_import_module_dynamically_callback, v8::Function)                    \
+  V(host_initialize_import_meta_object_callback, v8::Function)                \
   V(http2ping_constructor_template, v8::ObjectTemplate)                       \
   V(http2stream_constructor_template, v8::ObjectTemplate)                     \
   V(http2settings_constructor_template, v8::ObjectTemplate)                   \

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -23,6 +23,10 @@ class ModuleWrap : public BaseObject {
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context);
+  static void HostInitializeImportMetaObjectCallback(
+      v8::Local<v8::Context> context,
+      v8::Local<v8::Module> module,
+      v8::Local<v8::Object> meta);
 
  private:
   ModuleWrap(Environment* env,
@@ -44,10 +48,14 @@ class ModuleWrap : public BaseObject {
   static void Resolve(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetImportModuleDynamicallyCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetInitializeImportMetaObjectCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static v8::MaybeLocal<v8::Module> ResolveCallback(
       v8::Local<v8::Context> context,
       v8::Local<v8::String> specifier,
       v8::Local<v8::Module> referrer);
+  static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
+
 
   v8::Persistent<v8::Module> module_;
   v8::Persistent<v8::String> url_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3680,6 +3680,8 @@ static void ParseArgs(int* argc,
       config_experimental_modules = true;
       new_v8_argv[new_v8_argc] = "--harmony-dynamic-import";
       new_v8_argc += 1;
+      new_v8_argv[new_v8_argc] = "--harmony-import-meta";
+      new_v8_argc += 1;
     } else if (strcmp(arg, "--experimental-vm-modules") == 0) {
       config_experimental_vm_modules = true;
     }  else if (strcmp(arg, "--loader") == 0) {

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -1,0 +1,22 @@
+// Flags: --experimental-modules
+
+import '../common';
+import assert from 'assert';
+
+assert.strictEqual(Object.getPrototypeOf(import.meta), null);
+
+const keys = ['url'];
+assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
+
+const descriptors = Object.getOwnPropertyDescriptors(import.meta);
+for (const descriptor of Object.values(descriptors)) {
+  delete descriptor.value; // Values are verified below.
+  assert.deepStrictEqual(descriptor, {
+    enumerable: true,
+    writable: true,
+    configurable: true
+  });
+}
+
+const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
+assert(import.meta.url.match(urlReg));


### PR DESCRIPTION
The feature is still behind the --harmony-import-meta V8 flag.
This commit implements the C++ callback that is required to configure
the `import.meta` object and adds ~two properties~ one property:
- url: absolute URL of the module
~- require: CommonJS `require` function~

/cc @nodejs/esm @MylesBorins @nodejs/tsc 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
ESM