### PR TITLE
stream: fix readable being emitted when nothing to do

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -520,7 +520,9 @@ function emitReadable(stream) {
 function emitReadable_(stream) {
   var state = stream._readableState;
   debug('emit readable');
-  stream.emit('readable');
+  if (!state.destroyed && (state.length || state.ended)) {
+    stream.emit('readable');
+  }
   state.needReadable = !state.flowing && !state.ended;
   flow(stream);
 }

--- a/test/parallel/test-stream-readable-no-unneeded-readable.js
+++ b/test/parallel/test-stream-readable-no-unneeded-readable.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const { Readable, PassThrough } = require('stream');
+
+const source = new Readable({
+  read: () => {}
+});
+
+source.push('foo');
+source.push('bar');
+source.push(null);
+
+const pt = source.pipe(new PassThrough());
+
+const wrapper = new Readable({
+  read: () => {
+    let data = pt.read();
+
+    if (data) {
+      wrapper.push(data);
+      return;
+    }
+
+    pt.once('readable', function() {
+      data = pt.read();
+      if (data) {
+        wrapper.push(data);
+      }
+      // else the end event should fire
+    });
+  }
+});
+
+pt.once('end', function() {
+  wrapper.push(null);
+});
+
+wrapper.resume();
+wrapper.once('end', common.mustCall());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream

This fixes an issue introduced by https://github.com/nodejs/node/pull/17979 where the readable event are sometimes emitted when the stream is neither readable nor has it ended.