### PR TITLE
benchmark: cut down http benchmark run time

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -182,7 +182,7 @@ exports.run = function(options, callback) {
     port: exports.PORT,
     path: '/',
     connections: 100,
-    duration: 10,
+    duration: 5,
     benchmarker: exports.default_http_benchmarker
   }, options);
   if (!options.benchmarker) {

--- a/benchmark/http/set-header.js
+++ b/benchmark/http/set-header.js
@@ -3,15 +3,19 @@ const common = require('../common.js');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  // unicode confuses ab on os x.
-  type: ['bytes', 'buffer'],
-  len: [4, 1024, 102400],
-  chunks: [1, 4],
-  c: [50, 500],
-  chunkedEnc: [1, 0]
+  res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
-function main({ type, len, chunks, c, chunkedEnc, res }) {
+const type = 'bytes';
+const len = 4;
+const chunks = 0;
+const chunkedEnc = 0;
+const c = 50;
+
+// normal: writeHead(status, {...})
+// setHeader: statusCode = status, setHeader(...) x2
+// setHeaderWH: setHeader(...), writeHead(status, ...)
+function main({ res }) {
   process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
   .listen(PORT)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This split the http/simple.js benchmark so the header settings can be benchmarked differently to reduce the time spent on this benchmark. IIUC other parameters do not have an impact on the results, see the OP of https://github.com/nodejs/node/pull/10558

Also cut the default duration to 5 seconds, on the benchmark CI we have about 20k req/sec for most types of scenarios so the results from 100k reqs should be representative enough.

cc @mscdex 

Refs: https://github.com/nodejs/node/pull/18003#issuecomment-355923135

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark