### PR TITLE
benchmark: implement duration in http test double

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -89,11 +89,14 @@ class TestDoubleBenchmarker {
   }
 
   create(options) {
+    const env = Object.assign({
+      duration: options.duration,
+      test_url: `http://127.0.0.1:${options.port}${options.path}`,
+    }, process.env);
+
     const child = child_process.fork(this.executable, {
       silent: true,
-      env: Object.assign({}, process.env, {
-        test_url: `http://127.0.0.1:${options.port}${options.path}`
-      })
+      env
     });
     return child;
   }

--- a/benchmark/_test-double-benchmarker.js
+++ b/benchmark/_test-double-benchmarker.js
@@ -2,6 +2,28 @@
 
 const http = require('http');
 
-http.get(process.env.test_url, function() {
-  console.log(JSON.stringify({ throughput: 1 }));
-});
+const duration = process.env.duration || 0;
+const url = process.env.test_url;
+
+const start = process.hrtime();
+let throughput = 0;
+
+function request(res) {
+  res.on('data', () => {});
+  res.on('error', () => {});
+  res.on('end', () => {
+    throughput++;
+    const diff = process.hrtime(start);
+    if (duration > 0 && diff[0] < duration) {
+      run();
+    } else {
+      console.log(JSON.stringify({ throughput }));
+    }
+  });
+}
+
+function run() {
+  http.get(url, request);
+}
+
+run();

--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -25,4 +25,7 @@ runBenchmark('http',
                'res=normal',
                'type=asc'
              ],
-             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

When using the test double benchmarker the throughput would always be 1, which breaks the R script - that is fine, but it would be helpful to make it less dumb so we can start digging into the profile of our http benchmarks using this simplified benchmarker.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->