### PR TITLE
http: simplify checkInvalidHeaderChar

### DIFF
--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -3,43 +3,66 @@
 const common = require('../common.js');
 const _checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
 
-// Put it here so the benchmark result lines will not be super long.
-const LONG_AND_INVALID = 'Here is a value that is really a folded header ' +
-  'value\r\n  this should be supported, but it is not currently';
+const groupedInputs = {
+  // Representative set of inputs from an AcmeAir benchmark run:
+  // all valid strings, average length 14.4, stdev 13.0
+  group_acmeair: [
+    'W/"2-d4cbb29"', 'OK', 'Express', 'X-HTTP-Method-Override', 'Express',
+    'application/json', 'application/json; charset=utf-8', '206', 'OK',
+    'sessionid=; Path=/', 'text/html; charset=utf-8',
+    'text/html; charset=utf-8', '10', 'W/"a-eda64de5"', 'OK', 'Express',
+    'application/json', 'application/json; charset=utf-8', '2', 'W/"2-d4cbb29"',
+    'OK', 'Express', 'X-HTTP-Method-Override', 'sessionid=; Path=/', 'Express',
+    'sessionid=; Path=/,sessionid=6b059402-d62f-4e6f-b3dd-ce5b9e487c39; Path=/',
+    'text/html; charset=utf-8', 'text/html; charset=utf-8', '9', 'OK',
+    'sessionid=; Path=/', 'text/html; charset=utf-8',
+    'text/html; charset=utf-8', '10', 'W/"a-eda64de5"', 'OK', 'Express',
+    'Express', 'X-HTTP-Method-Override', 'sessionid=; Path=/',
+    'application/json'
+  ],
+
+  // Put it here so the benchmark result lines will not be super long.
+  LONG_AND_INVALID: ['Here is a value that is really a folded header ' +
+    'value\r\n  this should be supported, but it is not currently']
+};
+
+const inputs = [
+  // Valid
+  '',
+  '1',
+  '\t\t\t\t\t\t\t\t\t\tFoo bar baz',
+  'keep-alive',
+  'close',
+  'gzip',
+  '20091',
+  'private',
+  'text/html; charset=utf-8',
+  'text/plain',
+  'Sat, 07 May 2016 16:54:48 GMT',
+  'SAMEORIGIN',
+  'en-US',
+
+  // Invalid
+  '中文呢', // unicode
+  'foo\nbar',
+  '\x7F'
+];
 
 const bench = common.createBenchmark(main, {
-  key: [
-    // Valid
-    '',
-    '1',
-    '\t\t\t\t\t\t\t\t\t\tFoo bar baz',
-    'keep-alive',
-    'close',
-    'gzip',
-    '20091',
-    'private',
-    'text/html; charset=utf-8',
-    'text/plain',
-    'Sat, 07 May 2016 16:54:48 GMT',
-    'SAMEORIGIN',
-    'en-US',
-
-    // Invalid
-    'LONG_AND_INVALID',
-    '中文呢', // unicode
-    'foo\nbar',
-    '\x7F'
-  ],
+  input: inputs.concat(Object.keys(groupedInputs)),
   n: [1e6],
 });
 
-function main({ n, key }) {
-  if (key === 'LONG_AND_INVALID') {
-    key = LONG_AND_INVALID;
+function main({ n, input }) {
+  let inputs = [input];
+  if (groupedInputs.hasOwnProperty(input)) {
+    inputs = groupedInputs[input];
   }
+
+  const len = inputs.length;
   bench.start();
   for (var i = 0; i < n; i++) {
-    _checkInvalidHeaderChar(key);
+    _checkInvalidHeaderChar(inputs[i % len]);
   }
   bench.end(n);
 }

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -242,57 +242,15 @@ function checkIsHttpToken(val) {
   return tokenRegExp.test(val);
 }
 
+const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
 /**
  * True if val contains an invalid field-vchar
  *  field-value    = *( field-content / obs-fold )
  *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
  *  field-vchar    = VCHAR / obs-text
- *
- * checkInvalidHeaderChar() is currently designed to be inlinable by v8,
- * so take care when making changes to the implementation so that the source
- * code size does not exceed v8's default max_inlined_source_size setting.
  **/
-var validHdrChars = [
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, // 0 - 15
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 - 31
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 32 - 47
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 48 - 63
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 64 - 79
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 80 - 95
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 96 - 111
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, // 112 - 127
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 128 ...
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1  // ... 255
-];
 function checkInvalidHeaderChar(val) {
-  val += '';
-  if (val.length < 1)
-    return false;
-  if (!validHdrChars[val.charCodeAt(0)])
-    return true;
-  if (val.length < 2)
-    return false;
-  if (!validHdrChars[val.charCodeAt(1)])
-    return true;
-  if (val.length < 3)
-    return false;
-  if (!validHdrChars[val.charCodeAt(2)])
-    return true;
-  if (val.length < 4)
-    return false;
-  if (!validHdrChars[val.charCodeAt(3)])
-    return true;
-  for (var i = 4; i < val.length; ++i) {
-    if (!validHdrChars[val.charCodeAt(i)])
-      return true;
-  }
-  return false;
+  return headerCharRegex.test(val);
 }
 
 module.exports = {


### PR DESCRIPTION
In the spirit of [17399](https://github.com/nodejs/node/pull/17399), we can also simplify checkInvalidHeaderChar to use regex matching instead of a loop. This makes it faster on long matches and slower on short matches or non-matches. This change also includes some sample data from an AcmeAir benchmark run, as a rough proxy for real-world data.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

* http

##### Benchmark results

```
                                                                                                improvement confidence      p.value
 http\\check_invalid_header_char.js n=1000000 input="\177"                                        -56.65 %        *** 1.320705e-40
 http\\check_invalid_header_char.js n=1000000 input=""                                            -70.08 %        *** 1.329603e-60
 http\\check_invalid_header_char.js n=1000000 input="\\t\\t\\t\\t\\t\\t\\t\\t\\t\\tFoo bar baz"   198.82 %        *** 1.052799e-76
 http\\check_invalid_header_char.js n=1000000 input="1"                                           -50.00 %        *** 7.800619e-22
 http\\check_invalid_header_char.js n=1000000 input="20091"                                        -6.44 %        *** 7.491287e-04
 http\\check_invalid_header_char.js n=1000000 input="ä,-æ-╪å`¢"                                   -33.16 %        *** 5.648190e-21
 http\\check_invalid_header_char.js n=1000000 input="close"                                        22.88 %        *** 1.497247e-25
 http\\check_invalid_header_char.js n=1000000 input="en-US"                                        24.31 %        *** 4.582121e-46
 http\\check_invalid_header_char.js n=1000000 input="foo\\nbar"                                    -5.84 %        *** 2.581802e-08
 http\\check_invalid_header_char.js n=1000000 input="group_acmeair"                                19.81 %        *** 2.764867e-37
 http\\check_invalid_header_char.js n=1000000 input="gzip"                                          4.54 %          * 1.921983e-02
 http\\check_invalid_header_char.js n=1000000 input="Here is a value that is real..."(truncated)  280.31 %        *** 8.462204e-37
 http\\check_invalid_header_char.js n=1000000 input="keep-alive"                                   80.49 %        *** 4.132616e-53
 http\\check_invalid_header_char.js n=1000000 input="private"                                      41.84 %        *** 1.856953e-15
 http\\check_invalid_header_char.js n=1000000 input="SAMEORIGIN"                                   82.00 %        *** 2.317592e-50
 http\\check_invalid_header_char.js n=1000000 input="Sat, 07 May 2016 16:54:48 GMT"               199.94 %        *** 2.698766e-29
 http\\check_invalid_header_char.js n=1000000 input="text/html; charset=utf-8"                    176.87 %        *** 1.854601e-33
 http\\check_invalid_header_char.js n=1000000 input="text/plain"                                   75.47 %        *** 1.241438e-24
```
