### PR TITLE
 test: fix test/parallel/test-tls-server-verify.js on Windows CI

### DIFF
--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -327,7 +327,7 @@ function runTest(port, testIndex) {
     } else {
       server.close();
       successfulTests++;
-      runTest(port, nextTest++);
+      runTest(0, nextTest++);
     }
   }
 
@@ -345,7 +345,7 @@ function runTest(port, testIndex) {
           if (clientsCompleted === tcase.clients.length) {
             server.close();
             successfulTests++;
-            runTest(port, nextTest++);
+            runTest(0, nextTest++);
           }
         });
       }
@@ -355,7 +355,6 @@ function runTest(port, testIndex) {
 
 
 let nextTest = 0;
-runTest(0, nextTest++);
 runTest(0, nextTest++);
 
 


### PR DESCRIPTION
The test runs two test cases at a time. This is not relevant to what the
test is actually testing. Not sure why doing it that way causes a
deadlock on some Windows servers, but running one at a time fixes it.
    
Fixes: https://github.com/nodejs/node/issues/18269

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test