### PR TITLE
test: Verify the shell option works properly on execFile

### DIFF
--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -7,7 +7,7 @@ const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
-const execOpts = { encoding: 'utf8', shell: process.env.SHELL };
+const execOpts = { encoding: 'utf8', shell: true };
 
 {
   execFile(

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -7,6 +7,7 @@ const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
+const execOpts = { encoding: 'utf8', shell: process.env.SHELL };
 
 {
   execFile(
@@ -38,4 +39,11 @@ const fixture = fixtures.path('exit.js');
 
   child.kill();
   child.emit('close', code, null);
+}
+
+{
+  // Verify the shell option works properly
+  execFile('ls', [process.execPath, '*'], execOpts, common.mustCall((err) => {
+    assert.strictEqual(err, null);
+  }));
 }

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -43,7 +43,7 @@ const execOpts = { encoding: 'utf8', shell: process.env.SHELL };
 
 {
   // Verify the shell option works properly
-  execFile('ls', [process.execPath, '*'], execOpts, common.mustCall((err) => {
+  execFile(process.execPath, [fixture, 0], execOpts, common.mustCall((err) => {
     assert.strictEqual(err, null);
   }));
 }

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -29,6 +29,7 @@ const TIMER = 200;
 const SLEEP = 2000;
 
 const start = Date.now();
+const execOpts = { encoding: 'utf8', shell: process.env.SHELL };
 let err;
 let caught = false;
 
@@ -141,3 +142,8 @@ assert.strictEqual(ret, `${msg}\n`);
     return true;
   });
 }
+
+// Verify the shell option works properly
+assert.doesNotThrow(() => {
+  execFileSync('ls', [process.execPath, '*'], execOpts);
+});

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -29,7 +29,7 @@ const TIMER = 200;
 const SLEEP = 2000;
 
 const start = Date.now();
-const execOpts = { encoding: 'utf8', shell: process.env.SHELL };
+const execOpts = { encoding: 'utf8', shell: true };
 let err;
 let caught = false;
 

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -145,5 +145,5 @@ assert.strictEqual(ret, `${msg}\n`);
 
 // Verify the shell option works properly
 assert.doesNotThrow(() => {
-  execFileSync('ls', [process.execPath, '*'], execOpts);
+  execFileSync(process.execPath, [], execOpts);
 });


### PR DESCRIPTION
Useful for executing in a shell because it accepts arguments as
an array instead of a string as exec does.
Depending on the circumstances,
that can prove to be useful if the arguments are already prepared.

This are test for this https://github.com/nodejs/node/issues/18199 
documented here https://github.com/nodejs/node/pull/18237

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
