### PR TITLE
buffer: simplify isNaN checks

### DIFF
--- a/benchmark/buffers/adjust-offset.js
+++ b/benchmark/buffers/adjust-offset.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common.js');
+const { adjustOffset } = require('buffer');
+
+const inputs = {
+  zero: 0,
+  one: 1,
+  float: 1.3,
+  medium: 600,
+  large: 2 ** 35,
+  inf: Infinity,
+  nan: NaN
+};
+
+const bench = common.createBenchmark(main, {
+  input: Object.keys(inputs),
+  n: [1e6]
+});
+
+function main(conf) {
+  const input = inputs[conf.input];
+  const n = conf.n | 0;
+
+  bench.start();
+
+  for (let i = 0; i < n; i += 1)
+    adjustOffset(input, 700);
+
+  bench.end(n);
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -365,8 +365,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
     byteOffset = 0;
   } else {
     byteOffset = +byteOffset;
-    // check for NaN
-    if (byteOffset !== byteOffset)
+    if (isNaN(byteOffset))
       byteOffset = 0;
   }
 
@@ -380,8 +379,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
   } else {
     // convert length to non-negative integer
     length = +length;
-    // Check for NaN
-    if (length !== length) {
+    if (isNaN(length)) {
       length = 0;
     } else if (length > 0) {
       if (length > maxLength)
@@ -765,8 +763,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   // Coerce to Number. Values like null and [] become 0.
   byteOffset = +byteOffset;
   // If the offset is undefined, "foo", {}, coerces to NaN, search whole buffer.
-  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
-  if (byteOffset !== byteOffset) {
+  if (isNaN(byteOffset)) {
     byteOffset = dir ? 0 : buffer.length;
   }
   dir = !!dir;  // Cast to bool.
@@ -1001,8 +998,7 @@ function adjustOffset(offset, length) {
   // Use Math.trunc() to convert offset to an integer value that can be larger
   // than an Int32. Hence, don't use offset | 0 or similar techniques.
   offset = Math.trunc(offset);
-  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
-  if (offset === 0 || offset !== offset) {
+  if (offset === 0 || isNaN(offset)) {
     return 0;
   } else if (offset < 0) {
     offset += length;
@@ -1658,6 +1654,7 @@ module.exports = exports = {
   SlowBuffer,
   transcode,
   INSPECT_MAX_BYTES: 50,
+  adjustOffset,
 
   // Legacy
   kMaxLength,


### PR DESCRIPTION
In modern versions of V8, calling isNaN is not substantially slower than the more cumbersome `x !== x`, so we can use the simpler style.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

* buffer

##### Benchmark results

```
                                                     improvement confidence   p.value
 buffers\\adjust-offset.js n=1000000 input="float"      -1.71 %            0.3660126
 buffers\\adjust-offset.js n=1000000 input="inf"         3.19 %            0.2990196
 buffers\\adjust-offset.js n=1000000 input="large"       2.07 %            0.6073530
 buffers\\adjust-offset.js n=1000000 input="medium"     -5.21 %          * 0.0116013
 buffers\\adjust-offset.js n=1000000 input="nan"         1.14 %            0.5428374
 buffers\\adjust-offset.js n=1000000 input="one"        -2.29 %            0.3348872
 buffers\\adjust-offset.js n=1000000 input="zero"        1.38 %            0.5324238
```