### PR TITLE
module: enable dynamic import flag for esmodules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -33,7 +33,8 @@ node --experimental-modules my-app.mjs
 ### Supported
 
 Only the CLI argument for the main entry point to the program can be an entry
-point into an ESM graph.
+point into an ESM graph. Dynamic import can also be used to create entry points
+into ESM graphs at runtime.
 
 ### Unsupported
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -33,8 +33,7 @@ node --experimental-modules my-app.mjs
 ### Supported
 
 Only the CLI argument for the main entry point to the program can be an entry
-point into an ESM graph. Dynamic import can also be used with the flag
-`--harmony-dynamic-import` to create entry points into ESM graphs at runtime.
+point into an ESM graph.
 
 ### Unsupported
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3678,6 +3678,8 @@ static void ParseArgs(int* argc,
       config_preserve_symlinks = true;
     } else if (strcmp(arg, "--experimental-modules") == 0) {
       config_experimental_modules = true;
+      new_v8_argv[new_v8_argc] = "--harmony-dynamic-import";
+      new_v8_argc += 1;
     } else if (strcmp(arg, "--experimental-vm-modules") == 0) {
       config_experimental_vm_modules = true;
     }  else if (strcmp(arg, "--loader") == 0) {

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-modules --harmony-dynamic-import
+// Flags: --experimental-modules
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
currently if you want to use dynamic import you must use both the
`--experimental-modules` and the `--harmony-dynamic-imports` flags.
Chrome is currently shipping dynamic import unflagged, the flag
only remains in V8 to guard embedders who have not set the appropriate
callback from throwing an unhandled rejection when the feature is used.

As such it is reasonable to enable the flag by default for
`--experimental-modules`