### PR TITLE
timers: attach listOnTimeout function to TimerWrap

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -218,11 +218,11 @@ function TimersList(msecs, unrefed) {
   if (unrefed === true)
     timer.unref();
   timer.start(msecs);
-
-  timer[kOnTimeout] = listOnTimeout;
 }
 
-function listOnTimeout() {
+// adds listOnTimeout to the C++ object prototype, as
+// V8 would not inline it otherwise.
+TimerWrap.prototype[kOnTimeout] = function listOnTimeout() {
   var list = this._list;
   var msecs = list.msecs;
 
@@ -291,7 +291,7 @@ function listOnTimeout() {
     return;
 
   this.close();
-}
+};
 
 
 // An optimization so that the try/finally only de-optimizes (since at least v8


### PR DESCRIPTION
This avoid continuous deoptimizations cycles in V8 for the listOnTimeout function by attaching it to the TimeWrap prototype.
It improves insertion and cancellation time of unpooled timers by 18% and 28% respectively.

```
$ cat timewrap.csv | Rscript benchmark/compare.R
                                                    improvement confidence      p.value
 timers/immediate.js type="breadth" thousands=5000      -1.23 %            6.471883e-01
 timers/immediate.js type="breadth1" thousands=5000      6.23 %          * 4.589025e-02
 timers/immediate.js type="breadth4" thousands=5000     -0.28 %            8.716988e-01
 timers/immediate.js type="clear" thousands=5000         1.61 %            2.157496e-01
 timers/immediate.js type="depth" thousands=5000         0.68 %            2.223863e-01
 timers/immediate.js type="depth1" thousands=5000       -0.26 %            7.391597e-01
 timers/set-immediate-breadth-args.js millions=5        -1.31 %            4.186285e-01
 timers/set-immediate-breadth.js millions=10             3.01 %            2.234333e-01
 timers/set-immediate-depth-args.js millions=5           0.92 %            6.154973e-01
 timers/timers-breadth.js thousands=5000                 1.78 %            4.422721e-01
 timers/timers-cancel-pooled.js millions=5               0.78 %            5.467502e-01
 timers/timers-cancel-unpooled.js millions=1            27.60 %        *** 1.806596e-59
 timers/timers-depth.js thousands=1                      0.32 %            5.568216e-01
 timers/timers-insert-pooled.js millions=5               0.47 %            7.908426e-01
 timers/timers-insert-unpooled.js millions=1            18.19 %        *** 4.666303e-46
 timers/timers-timeout-pooled.js millions=10            -0.69 %            4.534725e-01
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

timers