### PR TITLE
src: fix compiler warning about deprecated api

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -152,12 +152,14 @@ void Environment::CleanupHandles() {
 void Environment::StartProfilerIdleNotifier() {
   uv_prepare_start(&idle_prepare_handle_, [](uv_prepare_t* handle) {
     Environment* env = ContainerOf(&Environment::idle_prepare_handle_, handle);
-    env->isolate()->GetCpuProfiler()->SetIdle(true);
+    v8::CpuProfiler* cpu_profiler = v8::CpuProfiler::New(env->isolate());
+    cpu_profiler->SetIdle(true);
   });
 
   uv_check_start(&idle_check_handle_, [](uv_check_t* handle) {
     Environment* env = ContainerOf(&Environment::idle_check_handle_, handle);
-    env->isolate()->GetCpuProfiler()->SetIdle(false);
+    v8::CpuProfiler* cpu_profiler = v8::CpuProfiler::New(env->isolate());
+    cpu_profiler->SetIdle(false);
   });
 }
 


### PR DESCRIPTION
The `GetCpuProfiler()` api has been deprecated and it is advised to
use the `CpuProfiler::New` call instead. This PR refactors to code
causing the warning using a pattern found within in the V8 codebase.