### PR TITLE
src, loader: return promises from link

### DIFF
--- a/lib/internal/loader/ModuleJob.js
+++ b/lib/internal/loader/ModuleJob.js
@@ -6,9 +6,6 @@ const { decorateErrorStack } = require('internal/util');
 const assert = require('assert');
 const resolvedPromise = SafePromise.resolve();
 
-const enableDebug = (process.env.NODE_DEBUG || '').match(/\besm\b/) ||
-    process.features.debug;
-
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
 class ModuleJob {
@@ -27,7 +24,6 @@ class ModuleJob {
 
     // Wait for the ModuleWrap instance being linked with all dependencies.
     const link = async () => {
-      const dependencyJobs = [];
       ({ module: this.module,
          reflect: this.reflect } = await this.modulePromise);
       if (inspectBrk) {
@@ -35,19 +31,17 @@ class ModuleJob {
         initWrapper(this.module.instantiate, this.module);
       }
       assert(this.module instanceof ModuleWrap);
-      const promises = this.module.link(async (dependencySpecifier) => {
-        const dependencyJobPromise =
-            this.loader.getModuleJob(dependencySpecifier, url);
-        dependencyJobs.push(dependencyJobPromise);
-        const dependencyJob = await dependencyJobPromise;
-        return (await dependencyJob.modulePromise).module;
+
+      const dependencyJobs = [];
+      const promises = this.module.link(async (specifier) => {
+        const jobPromise = this.loader.getModuleJob(specifier, url);
+        dependencyJobs.push(jobPromise);
+        return (await (await jobPromise).modulePromise).module;
       });
-      if (enableDebug) {
-        // Make sure all dependencies are entered into the list synchronously.
-        Object.freeze(dependencyJobs);
-      }
+
       if (promises !== undefined)
-        await Promise.all(promises);
+        await SafePromise.all(promises);
+
       return SafePromise.all(dependencyJobs);
     };
     // Promise for the list of all dependencyJobs.

--- a/lib/internal/loader/ModuleJob.js
+++ b/lib/internal/loader/ModuleJob.js
@@ -35,7 +35,7 @@ class ModuleJob {
         initWrapper(this.module.instantiate, this.module);
       }
       assert(this.module instanceof ModuleWrap);
-      this.module.link(async (dependencySpecifier) => {
+      const promises = this.module.link(async (dependencySpecifier) => {
         const dependencyJobPromise =
             this.loader.getModuleJob(dependencySpecifier, url);
         dependencyJobs.push(dependencyJobPromise);
@@ -46,6 +46,8 @@ class ModuleJob {
         // Make sure all dependencies are entered into the list synchronously.
         Object.freeze(dependencyJobs);
       }
+      if (promises !== undefined)
+        await Promise.all(promises);
       return SafePromise.all(dependencyJobs);
     };
     // Promise for the list of all dependencyJobs.

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -178,7 +178,7 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
     Local<Promise> resolve_promise = resolve_return_value.As<Promise>();
     obj->resolve_cache_[specifier_std].Reset(env->isolate(), resolve_promise);
 
-    USE(promises->Set(mod_context, specifier, resolve_promise));
+    promises->Set(mod_context, specifier, resolve_promise).FromJust();
   }
 
   args.GetReturnValue().Set(promises);


### PR DESCRIPTION
Returns the promises created by link so that they can be awaited to get
rid of race conditions while resolving and loading modules.

closes #18249

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
loader, src
