### PR TITLE
V8: Replace forLoop for forLoop reverse in getHeapSpaceStatistics

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -94,7 +94,7 @@ function getHeapSpaceStatistics() {
   const buffer = heapSpaceStatisticsBuffer;
   updateHeapSpaceStatisticsArrayBuffer();
 
-  for (var i = 0; i < kNumberOfHeapSpaces; i++) {
+  for (var i = kNumberOfHeapSpaces - 1; i >= 0; --i) {
     const propertyOffset = i * kHeapSpaceStatisticsPropertiesCount;
     heapSpaceStatistics[i] = {
       space_name: kHeapSpaces[i],


### PR DESCRIPTION
Replace forLoop for forLoop reverse, pre-decrement to improve
the performance.

After running V8 benchmark this is the result:
##### With the actual `for loop`:
```
v8/get-stats.js
v8/get-stats.js n=1000000 method="getHeapStatistics": 3,925,281.1737783994
v8/get-stats.js n=1000000 method="getHeapSpaceStatistics": 3,079,267.8209353415
```
##### With `for loop, reverse, pre-decrement`:
```
v8/get-stats.js
v8/get-stats.js n=1000000 method="getHeapStatistics": 3,414,352.1774798837
v8/get-stats.js n=1000000 method="getHeapSpaceStatistics": 2,875,818.4633268225
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
##### Affected core subsystem(s)
V8
