### PR TITLE
cluster: add cwd to cluster.settings

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -711,6 +711,8 @@ changes:
   * `exec` {string} File path to worker file. **Default:** `process.argv[1]`
   * `args` {Array} String arguments passed to worker.
     **Default:** `process.argv.slice(2)`
+  * `cwd` {string} Current working directory of the worker process. **Default:**
+    `undefined` (inherits from parent process)
   * `silent` {boolean} Whether or not to send output to parent's stdio.
     **Default:** `false`
   * `stdio` {Array} Configures the stdio of forked processes. Because the

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -126,6 +126,7 @@ function createWorkerProcess(id, env) {
   }
 
   return fork(cluster.settings.exec, cluster.settings.args, {
+    cwd: cluster.settings.cwd,
     env: workerEnv,
     silent: cluster.settings.silent,
     windowsHide: cluster.settings.windowsHide,

--- a/test/parallel/test-cluster-cwd.js
+++ b/test/parallel/test-cluster-cwd.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  common.refreshTmpDir();
+
+  assert.strictEqual(cluster.settings.cwd, undefined);
+  cluster.fork().on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, process.cwd());
+  }));
+
+  cluster.setupMaster({ cwd: common.tmpDir });
+  assert.strictEqual(cluster.settings.cwd, common.tmpDir);
+  cluster.fork().on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, common.tmpDir);
+  }));
+} else {
+  process.send(process.cwd());
+  process.disconnect();
+}


### PR DESCRIPTION
This commit allows cluster workers to be created with configurable working directories.

Closes #16388

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
cluster