### PR TITLE
build: fix coverage build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,9 @@ coverage-test: coverage-build
 	$(RM) out/$(BUILDTYPE)/obj.target/node/gen/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/tracing/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/gen/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node_lib/src/tracing/*.gcda
 	-$(MAKE) $(COVTESTS)
 	mv lib lib__
 	mv lib_ lib
@@ -201,7 +204,7 @@ coverage-test: coverage-build
 		--temp-directory "$(CURDIR)/.cov_tmp" \
 		--report-dir "../coverage")
 	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \
-		--gcov-exclude='.*usr' -v -r Release/obj.target/node \
+		--gcov-exclude='.*usr' -v -r Release/obj.target \
 		--html --html-detail -o ../coverage/cxxcoverage.html \
 		--gcov-executable="$(GCOV)")
 	mv lib lib_

--- a/node.gypi
+++ b/node.gypi
@@ -184,25 +184,20 @@
       ],
     }],
     [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
-        ' and coverage=="false" and force_load=="true"', {
+        ' and force_load=="true"', {
       'ldflags': [ '-Wl,-z,noexecstack',
                    '-Wl,--whole-archive <(v8_base)',
                    '-Wl,--no-whole-archive' ]
     }],
-    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
-        ' and coverage=="true" and force_load=="true"', {
-      'ldflags': [ '-Wl,-z,noexecstack',
-                   '-Wl,--whole-archive <(v8_base)',
-                   '-Wl,--no-whole-archive',
-                   '--coverage',
+    [ 'OS in "mac freebsd linux" and node_shared=="false"'
+        ' and coverage=="true"', {
+      'ldflags': [ '--coverage',
                    '-g',
                    '-O0' ],
-       'cflags': [ '--coverage',
+      'cflags': [ '--coverage',
                    '-g',
                    '-O0' ],
-       'cflags!': [ '-O3' ]
-    }],
-    [ 'OS=="mac" and node_shared=="false" and coverage=="true"', {
+      'cflags!': [ '-O3' ],
       'xcode_settings': {
         'OTHER_LDFLAGS': [
           '--coverage',


### PR DESCRIPTION
After adding the node_lib target in node.gyp, most of the node source
files are moved to that target. When coverage option is enabled,
corresponding cflags and ldflags are needed in that target as well.
gcovr also needs to check .gcda data for both node and node_lib.

Fixes: https://github.com/nodejs/node/issues/18402

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
