### PR TITLE
doc: fix error in "http.request" example code

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1808,8 +1808,8 @@ upload a file with a POST request, then write to the `ClientRequest` object.
 Example:
 
 ```js
-const postData = querystring.stringify({
-  'msg': 'Hello World!'
+const postData = JSON.stringify({
+  msg: 'Hello World!'
 });
 
 const options = {


### PR DESCRIPTION
The code example of the "http.request(options[, callback])" section
in the "api/http.md" file, had a:
"querystring.stringify({'msg': 'Hello World'})"
statement at the top.

I corrected this by:
* Replacing the "querystring.stringify" with "JSON.stringify".
* Removing the reduntant single quotes from the "'msg'" key.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
