### PR TITLE
util: add bigint formatting to util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -342,6 +342,7 @@ inspect.colors = Object.assign(Object.create(null), {
 inspect.styles = Object.assign(Object.create(null), {
   'special': 'cyan',
   'number': 'yellow',
+  'bigint': 'yellow',
   'boolean': 'yellow',
   'undefined': 'grey',
   'null': 'bold',
@@ -650,6 +651,9 @@ function formatPrimitive(fn, value, ctx) {
   }
   if (typeof value === 'number')
     return formatNumber(fn, value);
+  // eslint-disable-next-line valid-typeof
+  if (typeof value === 'bigint')
+    return fn(`${value}n`, 'bigint');
   if (typeof value === 'boolean')
     return fn(`${value}`, 'boolean');
   if (typeof value === 'undefined')

--- a/test/parallel/test-util-inspect-bigint.js
+++ b/test/parallel/test-util-inspect-bigint.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Flags: --harmony-bigint
+
+require('../common');
+const assert = require('assert');
+
+const { inspect } = require('util');
+
+assert.strictEqual(inspect(1n), '1n');


### PR DESCRIPTION
bigints found their way into node master at some point and as i've been experimenting with them i got increasingly annoyed at not being able to tell the difference between them and numbers in the repl, so i made this.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
util