### PR TITLE
test: show pending exception error in napi tests

### DIFF
--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -20,9 +20,10 @@ const theError = new Error('Some error');
 
   // Test that the exception thrown above was marked as pending
   // before it was handled on the JS side
-  assert.strictEqual(test_exception.wasPending(), true,
-                     'VM was marked as having an exception pending' +
-                     ' when it was allowed through');
+  const exception_pending = test_exception.wasPending();
+  assert.strictEqual(exception_pending, true,
+                     'Expected exception to be pending, but' +
+                     `it was marked as ${exception_pending}`);
 
   // Test that the native side does not capture a non-existing exception
   returnedError = test_exception.returnException(common.mustCall());
@@ -44,7 +45,8 @@ const theError = new Error('Some error');
                      ` ${caughtError} was passed`);
 
   // Test that the exception state remains clear when no exception is thrown
-  assert.strictEqual(test_exception.wasPending(), false,
-                     'VM was not marked as having an exception pending' +
-                     ' when none was allowed through');
+  const exception_pending = test_exception.wasPending();
+  assert.strictEqual(exception_pending, false,
+                     'Expected no exception to be pending, but' +
+                     ` it was marked as ${exception_pending}`);
 }

--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -22,8 +22,8 @@ const theError = new Error('Some error');
   // before it was handled on the JS side
   const exception_pending = test_exception.wasPending();
   assert.strictEqual(exception_pending, true,
-                     'Expected exception to be pending, but' +
-                     `it was marked as ${exception_pending}`);
+                     'Exception not pending as expected,' +
+                     ` .wasPending() returned ${exception_pending}`);
 
   // Test that the native side does not capture a non-existing exception
   returnedError = test_exception.returnException(common.mustCall());
@@ -47,6 +47,6 @@ const theError = new Error('Some error');
   // Test that the exception state remains clear when no exception is thrown
   const exception_pending = test_exception.wasPending();
   assert.strictEqual(exception_pending, false,
-                     'Expected no exception to be pending, but' +
-                     ` it was marked as ${exception_pending}`);
+                     'Exception state did not remain clear as expected,' +
+                     ` .wasPending() returned ${exception_pending}`);
 }


### PR DESCRIPTION
Shows the result of the wasPending in the error message if the
assertion fails.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
