### PR TITLE
test: refactor test assertions and comments in napi tests

### DIFF
--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -28,7 +28,7 @@ assert.strictEqual(test_general.testGetPrototype(baseObject),
                    Object.getPrototypeOf(baseObject));
 assert.strictEqual(test_general.testGetPrototype(extendedObject),
                    Object.getPrototypeOf(extendedObject));
-//Prototypes for base and extended should be different.
+// Prototypes for base and extended should be different.
 assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -30,7 +30,7 @@ assert.strictEqual(test_general.testGetPrototype(extendedObject),
                    Object.getPrototypeOf(extendedObject));
 //Prototypes for base and extended should be different.
 assert.notStrictEqual(test_general.testGetPrototype(baseObject),
-          test_general.testGetPrototype(extendedObject));
+                      test_general.testGetPrototype(extendedObject));
 
 // test version management functions
 // expected version is currently 1
@@ -76,8 +76,9 @@ assert.throws(() => test_general.wrap(x), Error);
 const y = {};
 test_general.wrap(y);
 test_general.removeWrap(y);
-assert.doesNotThrow(() => test_general.wrap(y), Error, 
-					'Wrapping twice succeeds if a remove_wrap() separates the instances');
+assert.doesNotThrow(() => test_general.wrap(y), Error,
+                    'Wrapping twice succeeds if a remove_wrap()' +
+                    ' separates the instances');
 
 // Ensure that removing a wrap and garbage collecting does not fire the
 // finalize callback.

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -28,9 +28,9 @@ assert.strictEqual(test_general.testGetPrototype(baseObject),
                    Object.getPrototypeOf(baseObject));
 assert.strictEqual(test_general.testGetPrototype(extendedObject),
                    Object.getPrototypeOf(extendedObject));
-assert.ok(test_general.testGetPrototype(baseObject) !==
-          test_general.testGetPrototype(extendedObject),
-          'Prototypes for base and extended should be different');
+//Prototypes for base and extended should be different.
+assert.notStrictEqual(test_general.testGetPrototype(baseObject),
+          test_general.testGetPrototype(extendedObject));
 
 // test version management functions
 // expected version is currently 1

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -70,17 +70,14 @@ assert.strictEqual(test_general.derefItemWasCalled(), true,
 // Assert that wrapping twice fails.
 const x = {};
 test_general.wrap(x);
-assert.throws(function() {
-  test_general.wrap(x);
-}, Error);
+assert.throws(() => test_general.wrap(x), Error);
 
 // Ensure that wrapping, removing the wrap, and then wrapping again works.
 const y = {};
 test_general.wrap(y);
 test_general.removeWrap(y);
-assert.doesNotThrow(function() {
-  test_general.wrap(y);
-}, Error, 'Wrapping twice succeeds if a remove_wrap() separates the instances');
+assert.doesNotThrow(() => test_general.wrap(y), Error, 
+					'Wrapping twice succeeds if a remove_wrap() separates the instances');
 
 // Ensure that removing a wrap and garbage collecting does not fire the
 // finalize callback.


### PR DESCRIPTION
Change `assert.ok()` to `assert.notStrictEquals()` where appropriate and change some functions to arrow functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
