### PR TITLE
test: speed up parallel/test-tls-session-cache

### DIFF
--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -69,11 +69,11 @@ function doTest(testOptions, callback) {
   server.on('newSession', function(id, data, cb) {
     ++newSessionCount;
     // Emulate asynchronous store
-    setTimeout(function() {
+    setImmediate(() => {
       assert.ok(!session);
       session = { id, data };
       cb();
-    }, 1000);
+    });
   });
   server.on('resumeSession', function(id, callback) {
     ++resumeCount;
@@ -89,9 +89,9 @@ function doTest(testOptions, callback) {
     }
 
     // Just to check that async really works there
-    setTimeout(function() {
+    setImmediate(() => {
       callback(null, data);
-    }, 100);
+    });
   });
 
   server.listen(0, function() {
@@ -132,7 +132,7 @@ function doTest(testOptions, callback) {
         }
         assert.strictEqual(code, 0);
         server.close(common.mustCall(function() {
-          setTimeout(callback, 100);
+          setImmediate(callback);
         }));
       }));
     }


### PR DESCRIPTION
This test had some unnecessary timeouts that made it run for a
much longer time than necessary (about 9 s rather than 0.2 s).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/tls