### PR TITLE
lib: remove debugger dead code

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -64,11 +64,7 @@
     NativeModule.require('internal/trace_events_async_hooks').setup();
     NativeModule.require('internal/inspector_async_hook').setup();
 
-    // Do not initialize channel in debugger agent, it deletes env variable
-    // and the main thread won't see it.
-    if (process.argv[1] !== '--debug-agent')
-      _process.setupChannel();
-
+    _process.setupChannel();
     _process.setupRawDebug();
 
     const browserGlobals = !process._noBrowserGlobals;


### PR DESCRIPTION
The only one that use `--debug-agent` has been remove since 719247f, so `process.argv[1] !== '--debug-agent'` is always true.

See commit 719247f
@targos 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
