### PR TITLE
net: remove redundant code from _writeGeneric()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -783,13 +783,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     // Retain chunks
     if (err === 0) req._chunks = chunks;
   } else {
-    var enc;
-    if (data instanceof Buffer) {
-      enc = 'buffer';
-    } else {
-      enc = encoding;
-    }
-    err = createWriteReq(req, this._handle, data, enc);
+    err = createWriteReq(req, this._handle, data, encoding);
   }
 
   if (err)


### PR DESCRIPTION
The encoding is already handled by `Writable.prototype.write()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net