### PR TITLE
doc: improve `--pending-deprecation` documentation

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -368,7 +368,10 @@ Node.js uses three Deprecation levels:
   being staged for deprecation in a future Node.js major release. An explicit
   notice indicating the deprecated status is added to the API documentation
   but no functional changes are implemented in the code. There will be no
-  runtime deprecation warnings emitted for such deprecations.
+  runtime deprecation warnings emitted for such deprecations by default.
+  Documentation-only deprecations may trigger a runtime warning when launched
+  with [`--pending-deprecation`][] flag (or its alternative,
+  `NODE_PENDING_DEPRECATION=1` environment variable).
 
 * *Runtime Deprecation* refers to the use of process warnings emitted at
   runtime the first time that a deprecated API is used. A command-line
@@ -744,6 +747,7 @@ LTS working group and the Release team.
 [backporting guide]: doc/guides/backporting-to-release-lines.md
 [Stability Index]: doc/api/documentation.md#stability-index
 [Enhancement Proposal]: https://github.com/nodejs/node-eps
+[`--pending-deprecation`]: doc/api/cli.md#--pending-deprecation
 [git-username]: https://help.github.com/articles/setting-your-username-in-git/
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils
 [TSC]: https://github.com/nodejs/TSC

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -14,6 +14,12 @@ Node.js utilizes three kinds of Deprecations:
 
 A Documentation-only deprecation is one that is expressed only within the
 Node.js API docs. These generate no side-effects while running Node.js.
+Some Documentation-only deprecations trigger a runtime warning when launched
+with [`--pending-deprecation`][] flag (or its alternative,
+`NODE_PENDING_DEPRECATION=1` environment variable), similarly to Runtime
+deprecations below. Documentation-only deprecations that support that flag
+are explicitly labeled as such in the
+[list of Deprecated APIs](#deprecations_list_of_deprecated_apis).
 
 A Runtime deprecation will, by default, generate a process warning that will
 be printed to `stderr` the first time the deprecated API is used. When the
@@ -66,7 +72,7 @@ be used.
 <a id="DEP0005"></a>
 ### DEP0005: Buffer() constructor
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The `Buffer()` function and `new Buffer()` constructor are deprecated due to
 API usability issues that can potentially lead to accidental security issues.
@@ -818,6 +824,7 @@ a future version at which point only authentication tag lengths of 128, 120,
 is not included in this list will be considered invalid in compliance with
 [NIST SP 800-38D][].
 
+[`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer


### PR DESCRIPTION
This implements steps 1-2 from #18417:

1. `--pending-deprecation` is being mentioned in [COLLABORATOR_GUIDE.md#deprecations](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#deprecations) as a subset of doc-deprecation.
2. `--pending-deprecation` is being mentioned in  [doc/api/deprecations.md](https://github.com/nodejs/node/blob/master/doc/api/deprecations.md), and the deprecations that support it are explicitly labeled as such (currently, there is only one).

##### Checklist
- [x] `make lint-md` passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
