### PR TITLE
doc: remove removed apis from http2 docs

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -476,7 +476,6 @@ added: v8.4.0
 Used to set a callback function that is called when there is no activity on
 the `Http2Session` after `msecs` milliseconds. The given `callback` is
 registered as a listener on the `'timeout'` event.
-```
 
 #### http2session.socket
 <!-- YAML


### PR DESCRIPTION
* Removed references to removed `socketError` event
* Removed second definition of `Http2Session#close` (as far as I could tell in the implementation, `close` no longer accepts an `options` object)
* Add parameter types for `ClientHttp2Session` `'altsvc'` event
* Re-ordered event names in `Http2SecureServer` to be alphabetical and added `'session'` event (from `Http2Server`)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
