### PR TITLE
doc: fix manpage warnings

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -37,9 +37,9 @@ node \- Server-side JavaScript runtime
 .RI [ script.js \ |
 .B -e
 .RI \&" script \&"
-.R |
+.RI |
 .B -
-.R ]
+.RI ]
 .B [--]
 .RI [ arguments ]
 .br


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added

##### Affected core subsystem(s)
doc

Fixes: https://github.com/nodejs/node/issues/18434 which was introduced in https://github.com/nodejs/node/commit/594b5d7b8970a68d9cd66f629cf1862cfca68412. The textual output is the same for me, before and after this fix:

````
node [options] [v8 options] [script.js | -e "script" | - ] [--] [arguments]
````
