### PR TITLE
benchmark: rest operator benchmark

### DIFF
--- a/benchmark/es/rest-assign.js
+++ b/benchmark/es/rest-assign.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+const util = require('util');
+
+const bench = common.createBenchmark(main, {
+  method: ['rest', 'assign', '_extend'],
+  count: [5, 10, 20],
+  millions: [1]
+});
+
+function main({ millions, context, count, rest, method }) {
+  const n = millions * 1e6;
+
+  const src = {};
+  for (let n = 0; n < count; n++)
+    src[`p${n}`] = n;
+
+  let obj;
+  let i;
+
+  switch (method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
+    case 'extend':
+      bench.start();
+      for (i = 0; i < n; i++)
+        obj = util._extend({}, src);
+      bench.end(n);
+      break;
+    case 'assign':
+      bench.start();
+      for (i = 0; i < n; i++)
+        obj = Object.assign({}, src);
+      bench.end(n);
+      break;
+    case 'rest':
+      bench.start();
+      for (i = 0; i < n; i++)
+        obj = { ...src };
+      bench.end(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}

--- a/benchmark/es/spread-assign.js
+++ b/benchmark/es/spread-assign.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const util = require('util');
 
 const bench = common.createBenchmark(main, {
-  method: ['rest', 'assign', '_extend'],
+  method: ['spread', 'assign', '_extend'],
   count: [5, 10, 20],
   millions: [1]
 });
@@ -23,7 +23,7 @@ function main({ millions, context, count, rest, method }) {
   switch (method) {
     case '':
       // Empty string falls through to next line as default, mostly for tests.
-    case 'extend':
+    case '_extend':
       bench.start();
       for (i = 0; i < n; i++)
         obj = util._extend({}, src);
@@ -35,7 +35,7 @@ function main({ millions, context, count, rest, method }) {
         obj = Object.assign({}, src);
       bench.end(n);
       break;
-    case 'rest':
+    case 'spread':
       bench.start();
       for (i = 0; i < n; i++)
         obj = { ...src };


### PR DESCRIPTION
Benchmark comparing `util._extend()`, `Object.assign()`, and the rest operator for object assignment (e.g. `{ ...src }`).

`util._extend()` still wins currently.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
benchmarks