### PR TITLE
tools: fix icu README lint error

### DIFF
--- a/tools/icu/README.md
+++ b/tools/icu/README.md
@@ -24,7 +24,7 @@ make
 ```
 
 > _Note_ in theory, the equivalent `vcbuild.bat` commands should work also,
-but the commands below are makefile-centric.
+> but the commands below are makefile-centric.
 
 - If there are ICU version-specific changes needed, you may need to make changes in `icu-generic.gyp` or add patch files to `tools/icu/patches`.
   - Specifically, look for the lists in `sources!` in the `icu-generic.gyp` for files to exclude.


### PR DESCRIPTION
When https://github.com/nodejs/node/pull/16939 landed it broke the linter on master. This fixes that issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools