### PR TITLE
v8: add missing ',' in OpenBSD's 'sources' section

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -288,7 +288,7 @@
         ],
       }],
       [ 'OS in "linux freebsd openbsd solaris aix"', {
-        'cflags': [ '-pthread', ],
+        'cflags': [ '-pthread' ],
         'ldflags': [ '-pthread' ],
       }],
       [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
@@ -301,6 +301,7 @@
             'standalone_static_library': 1,
           }],
           ['OS=="openbsd"', {
+            'cflags': [ '-I/usr/local/include' ],
             'ldflags': [ '-Wl,-z,wxneeded' ],
           }],
         ],

--- a/deps/v8/src/v8.gyp
+++ b/deps/v8/src/v8.gyp
@@ -2068,9 +2068,10 @@
                 '-L/usr/local/lib -lexecinfo',
             ]},
             'sources': [
+              'base/debug/stack_trace_posix.cc',
               'base/platform/platform-openbsd.cc',
               'base/platform/platform-posix.h',
-              'base/platform/platform-posix.cc'
+              'base/platform/platform-posix.cc',
               'base/platform/platform-posix-time.h',
               'base/platform/platform-posix-time.cc',
             ],


### PR DESCRIPTION

Fix issues #15784 and https://github.com/nodejs/help/issues/992

##### Checklist

- [X] `make` (OpenBSD)


##### Affected core subsystem(s)
v8

---

I can run a diff [upstream](https://github.com/v8/v8/blob/master/gypfiles/v8.gyp#L2066) as well - but IMO it would be better if someone like @bnoordhuis did, as I don't know who does the reviews in v8 :D