### PR TITLE
test: add unexpected value to dgram socket type assertion

### DIFF
--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -52,10 +52,12 @@ validTypes.forEach((validType) => {
     // note: linux will double the buffer size
     assert.ok(socket.getRecvBufferSize() === 10000 ||
               socket.getRecvBufferSize() === 20000,
-              'SO_RCVBUF not 1300 or 2600');
+              'SO_RCVBUF not 10000 or 20000, ' +
+              `was ${socket.getRecvBufferSize()}`);
     assert.ok(socket.getSendBufferSize() === 15000 ||
               socket.getSendBufferSize() === 30000,
-              'SO_SNDBUF not 1800 or 3600');
+              'SO_SNDBUF not 15000 or 30000, ' +
+              `was ${socket.getRecvBufferSize()}`);
     socket.close();
   }));
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/dgram
