### PR TITLE
util: move flagged deprecation to internal/util

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -43,6 +43,7 @@ const {
 } = process.binding('buffer');
 const { isAnyArrayBuffer } = process.binding('util');
 const {
+  deprecator,
   customInspectSymbol,
   normalizeEncoding,
   kIsEncodingSymbol
@@ -51,9 +52,6 @@ const {
   isArrayBufferView,
   isUint8Array
 } = require('internal/util/types');
-const {
-  pendingDeprecation
-} = process.binding('config');
 const errors = require('internal/errors');
 
 const internalBuffer = require('internal/buffer');
@@ -124,27 +122,12 @@ function alignPool() {
   }
 }
 
-var bufferWarn = true;
 const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'recommended for use due to security and usability ' +
                       'concerns. Please use the new Buffer.alloc(), ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
-
-function showFlaggedDeprecation() {
-  if (bufferWarn) {
-    // This is a *pending* deprecation warning. It is not emitted by
-    // default unless the --pending-deprecation command-line flag is
-    // used or the NODE_PENDING_DEPRECATION=1 env var is set.
-    process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
-    bufferWarn = false;
-  }
-}
-
-const doFlaggedDeprecation =
-  pendingDeprecation ?
-    showFlaggedDeprecation :
-    function() {};
+const deprecation0005 = deprecator(bufferWarning, 'DEP0005', { pending: true });
 
 /**
  * The Buffer() constructor is deprecated in documentation and should not be
@@ -157,7 +140,7 @@ const doFlaggedDeprecation =
  * Deprecation Code: DEP0005
  **/
 function Buffer(arg, encodingOrOffset, length) {
-  doFlaggedDeprecation();
+  deprecation0005(Buffer);
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -2,6 +2,7 @@
 
 const errors = require('internal/errors');
 const { signals } = process.binding('constants').os;
+const { pendingDeprecation } = process.binding('config');
 
 const {
   createPromise,
@@ -35,6 +36,35 @@ function objectToString(o) {
 // Keep a list of deprecation codes that have been warned on so we only warn on
 // each one once.
 const codesWarned = {};
+
+// Returns a function that emits a deprecation on first run
+// For internal use only. `code` is a required argument.
+// If --no-deprecation is set, then it is a no-op.
+// { pending: true } are visible only when pendingDeprecation is on
+function deprecator(msg, code, options = {}) {
+  if (process.noDeprecation === true) {
+    return () => {};
+  }
+  if (options.pending && !pendingDeprecation) {
+    return () => {};
+  }
+
+  // code should be set
+  if (typeof code !== 'string' || code === '')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'string');
+
+  let warned = false;
+
+  function deprecation(caller) {
+    if (warned) return;
+    warned = true;
+    if (codesWarned[code]) return;
+    codesWarned[code] = true;
+    process.emitWarning(msg, 'DeprecationWarning', code, caller || deprecation);
+  }
+
+  return deprecation;
+}
 
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
@@ -357,6 +387,7 @@ module.exports = {
   createClassWrapper,
   decorateErrorStack,
   deprecate,
+  deprecator,
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,


### PR DESCRIPTION
Two changes in this commit:

1. Deprecation-related logic is moved from buffer.js to internal/util.js
   That is the new deprecator() method that generates either a
   deprecation function or a noop, depending on the deprecation type and
   runtime flags.

2. Buffer pending deprecation stack trace is fixed, so that internal
   logic does not appear in there, and the first line of the stack
   should now point at userland code where the deprecated method was
   called.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer, util
