### PR TITLE
benchmark: shorten config name in http benchmark

### DIFF
--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -34,7 +34,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, key }) {
-  if (key == 'LONG_AND_INVALID') {
+  if (key === 'LONG_AND_INVALID') {
     key = LONG_AND_INVALID;
   }
   bench.start();

--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -3,6 +3,10 @@
 const common = require('../common.js');
 const _checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
 
+// Put it here so the benchmark result lines will not be super long.
+const LONG_AND_INVALID = 'Here is a value that is really a folded header ' +
+  'value\r\n  this should be \supported, but it is not currently';
+
 const bench = common.createBenchmark(main, {
   key: [
     // Valid
@@ -21,8 +25,7 @@ const bench = common.createBenchmark(main, {
     'en-US',
 
     // Invalid
-    'Here is a value that is really a folded header value\r\n  this should be \
-     supported, but it is not currently',
+    'LONG_AND_INVALID',
     '中文呢', // unicode
     'foo\nbar',
     '\x7F'
@@ -31,6 +34,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, key }) {
+  if (key == 'LONG_AND_INVALID') {
+    key = LONG_AND_INVALID;
+  }
   bench.start();
   for (var i = 0; i < n; i++) {
     _checkInvalidHeaderChar(key);


### PR DESCRIPTION
Before the output of `compare.R` run on http benchmarks contains a line like this

```
 http/check_invalid_header_char.js n=1000000 key="Here is a value that is really a folded header value\\r\\n  this should be      supported, but it is not currently"       ±4.32%  ±5.75%  ±7.49%
```

which force every line to align with it so the results are hard to read (both from a console and from the benchmark CI) due to wrapping. (For example, see the end of https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/107/console)

After this patch the line would look like this

```
 http/check_invalid_header_char.js n=1000000 key="LONG_AND_INVALID"       ±4.32%  ±5.75%  ±7.49%
```

and the results won't be as wide and will not usually be wrapped anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark