### PR TITLE
lib: include missing profiler file

### DIFF
--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -8,6 +8,7 @@ const scriptFiles = [
   'internal/deps/v8/tools/profile',
   'internal/deps/v8/tools/profile_view',
   'internal/deps/v8/tools/logreader',
+  'internal/deps/v8/tools/arguments',
   'internal/deps/v8/tools/tickprocessor',
   'internal/deps/v8/tools/SourceMap',
   'internal/deps/v8/tools/tickprocessor-driver'

--- a/node.gyp
+++ b/node.gyp
@@ -153,6 +153,7 @@
       'deps/v8/tools/profile.js',
       'deps/v8/tools/profile_view.js',
       'deps/v8/tools/logreader.js',
+      'deps/v8/tools/arguments.js',
       'deps/v8/tools/tickprocessor.js',
       'deps/v8/tools/SourceMap.js',
       'deps/v8/tools/tickprocessor-driver.js',


### PR DESCRIPTION
This commit includes `deps/v8/tools/arguments.js`, which is needed by the profiler.

Fixes: https://github.com/nodejs/node/issues/18451

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
lib