### PR TITLE
buffer: Buffer.concat upgrade in performance

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -454,12 +454,13 @@ Buffer.concat = function concat(list, length) {
     );
   }
 
-  if (list.length === 0)
+  const listLength = list.length;
+  if (listLength === 0)
     return new FastBuffer();
 
   if (length === undefined) {
     length = 0;
-    for (i = 0; i < list.length; i++)
+    for (i = 0; i < listLength; i++)
       length += list[i].length;
   } else {
     length = length >>> 0;
@@ -467,7 +468,7 @@ Buffer.concat = function concat(list, length) {
 
   var buffer = Buffer.allocUnsafe(length);
   var pos = 0;
-  for (i = 0; i < list.length; i++) {
+  for (i = 0; i < listLength; i++) {
     var buf = list[i];
     if (!isUint8Array(buf)) {
       throw new errors.TypeError(


### PR DESCRIPTION
Check for list length only once ant not every time the loop increments its value, this way we can have an improvement in performance.
_(If this PR gets approved i would be happy to collaborated and do the same process over the `/lib/buffer.js` file and others as well 👍)_

Here are the benchmark i ran in my local, before:
![image](https://user-images.githubusercontent.com/1050904/35581716-a9268150-05ba-11e8-825f-d0f22f5eeb27.png)

After:
![image](https://user-images.githubusercontent.com/1050904/35581749-bfddf82e-05ba-11e8-85f9-becdfd6d412c.png)


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer
