### PR TITLE
process: fix reading zero-length env vars on win32

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2598,6 +2598,7 @@ static void EnvGetter(Local<Name> property,
 #else  // _WIN32
   node::TwoByteValue key(isolate, property);
   WCHAR buffer[32767];  // The maximum size allowed for environment variables.
+  SetLastError(ERROR_SUCCESS);
   DWORD result = GetEnvironmentVariableW(reinterpret_cast<WCHAR*>(*key),
                                          buffer,
                                          arraysize(buffer));
@@ -2646,6 +2647,7 @@ static void EnvQuery(Local<Name> property,
 #else  // _WIN32
     node::TwoByteValue key(info.GetIsolate(), property);
     WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
+    SetLastError(ERROR_SUCCESS);
     if (GetEnvironmentVariableW(key_ptr, nullptr, 0) > 0 ||
         GetLastError() == ERROR_SUCCESS) {
       rc = 0;

--- a/test/parallel/test-process-env-windows-error-reset.js
+++ b/test/parallel/test-process-env-windows-error-reset.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// This checks that after accessing a missing env var, a subsequent
+// env read will succeed even for empty variables.
+
+{
+  process.env.FOO = '';
+  process.env.NONEXISTENT_ENV_VAR;
+  const foo = process.env.FOO;
+
+  assert.strictEqual(foo, '');
+}
+
+{
+  process.env.FOO = '';
+  process.env.NONEXISTENT_ENV_VAR;
+  const hasFoo = 'FOO' in process.env;
+
+  assert.strictEqual(hasFoo, true);
+}


### PR DESCRIPTION
Up until now, Node did not clear the current error code
attempting to read environment variables on Windows.
Since checking the error code is the way we distinguish between
missing and zero-length environment variables, this could lead to a
false positive when the error code was still tainted.

In the simplest case, accessing a missing variable and then a
zero-length one would lead Node to believe that both calls yielded
an error.

Before:

    > process.env.I=''; process.env.Q; process.env.I
    undefined
    > process.env.I=''; /*process.env.Q;*/ process.env.I
    ''

After:

    > process.env.I=''; process.env.Q; process.env.I
    ''
    > process.env.I=''; /*process.env.Q;*/ process.env.I
    ''

This only affects Node 8 and above, since before
1aa595e5bd64241451b3884d3029b9b9aa97c42d we always constructed a
`v8::String::Value` instance for passing the lookup key to the OS,
which in in turn always made a heap allocation and therefore
reset the error code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

process