### PR TITLE
[v9.x backport] doc: capitalize non-primitive types

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -308,7 +308,7 @@ added: v0.1.21
 * `expected` {any}
 * `message` {any} **Default:** `'Failed'`
 * `operator` {string} **Default:** '!='
-* `stackStartFunction` {function} **Default:** `assert.fail`
+* `stackStartFunction` {Function} **Default:** `assert.fail`
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`. If

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -718,7 +718,7 @@ changes:
     `'ipc'` entry. When this option is provided, it overrides `silent`.
   * `uid` {number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {number} Sets the group identity of the process. (See setgid(2).)
-  * `inspectPort` {number|function} Sets inspector port of worker.
+  * `inspectPort` {number|Function} Sets inspector port of worker.
     This can be a number, or a function that takes no arguments and returns a
     number. By default each worker gets its own port, incremented from the
     master's `process.debugPort`.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1183,7 +1183,7 @@ added: v8.4.0
 * `options` {Object}
   * `endStream` {boolean} Set to `true` to indicate that the response will not
     include payload data.
-  * `getTrailers` {function} Callback function invoked to collect trailer
+  * `getTrailers` {Function} Callback function invoked to collect trailer
     headers.
 * Returns: {undefined}
 


### PR DESCRIPTION
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

Backport of #18111