### PR TITLE
async_hooks: clean up comments

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -11,16 +11,17 @@ const async_wrap = process.binding('async_wrap');
  * the various asynchronous states of the application. These are:
  *  kExecutionAsyncId: The async_id assigned to the resource responsible for the
  *    current execution stack.
- *  kTriggerAsyncId: The trigger_async_id of the resource responsible for
- *    the current execution stack.
+ *  kTriggerAsyncId: The async_id of the resource that caused (or 'triggered')
+ *    the resource corresponding to the current execution stack.
  *  kAsyncIdCounter: Incremental counter tracking the next assigned async_id.
  *  kDefaultTriggerAsyncId: Written immediately before a resource's constructor
- *    that sets the value of the init()'s triggerAsyncId. The order of
- *    retrieving the triggerAsyncId value is passing directly to the
- *    constructor -> value set in kDefaultTriggerAsyncId -> executionAsyncId of
- *    the current resource.
+ *    that sets the value of the init()'s triggerAsyncId. The precedence order
+ *    of retrieving the triggerAsyncId value is:
+ *    1. the value passed directly to the constructor
+ *    2. value set in kDefaultTriggerAsyncId
+ *    3. executionAsyncId of the current resource.
  *
- * async_ids_fast_stack is a Float64Array that contains part of the async ID
+ * async_ids_stack is a Float64Array that contains part of the async ID
  * stack. Each pushAsyncIds() call adds two doubles to it, and each
  * popAsyncIds() call removes two doubles from it.
  * It has a fixed size, so if that is exceeded, calls to the native
@@ -28,10 +29,10 @@ const async_wrap = process.binding('async_wrap');
  */
 const { async_id_symbol, async_hook_fields, async_id_fields } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a std::stack on
-// Environment::AsyncHooks::ids_stack_ tracks the resource responsible for the
-// current execution stack. This is unwound as each resource exits. In the case
-// of a fatal exception this stack is emptied after calling each hook's after()
-// callback.
+// Environment::AsyncHooks::async_ids_stack_ tracks the resource responsible for
+// the current execution stack. This is unwound as each resource exits. In the
+// case of a fatal exception this stack is emptied after calling each hook's
+// after() callback.
 const { pushAsyncIds: pushAsyncIds_, popAsyncIds: popAsyncIds_ } = async_wrap;
 // For performance reasons, only track Promises when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -540,12 +540,12 @@ void AsyncWrap::Initialize(Local<Object> target,
   // this way to allow JS and C++ to read/write each value as quickly as
   // possible. The fields are represented as follows:
   //
-  // kAsyncUid: Maintains the state of the next unique id to be assigned.
+  // kAsyncIdCounter: Maintains the state of the next unique id to be assigned.
   //
   // kDefaultTriggerAsyncId: Write the id of the resource responsible for a
   //   handle's creation just before calling the new handle's constructor.
   //   After the new handle is constructed kDefaultTriggerAsyncId is set back
-  //   to 0.
+  //   to -1.
   FORCE_SET_TARGET_FIELD(target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());


### PR DESCRIPTION
With some of the recent work, some of the comments were no longer
representative of the code, or were otherwise unclear. This commit
fixes some obvious issues I found.

Ref: https://github.com/nodejs/node/commit/83e5215a4e8438a43b9f0002b7a43e2fd2dd37a4
Ref: https://github.com/nodejs/node/commit/0784b0440c05464f79b857f7d8698fcc953d3fb3


##### Checklist

- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_hooks