### PR TITLE
build: added doc linting when runnning `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1183,6 +1183,7 @@ lint: ## Run JS, C++, MD and doc linters.
 	$(MAKE) lint-js || EXIT_STATUS=$$? ; \
 	$(MAKE) lint-cpp || EXIT_STATUS=$$? ; \
 	$(MAKE) lint-addon-docs || EXIT_STATUS=$$? ; \
+	$(MAKE) lint-md || EXIT_STATUS=$$? ; \
 	exit $$EXIT_STATUS
 CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/18466

Lint docs when running `make lint`. Added a call to `lint-md` inside the `lint` command in the Makefiile

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
build
