### PR TITLE
http, timers: remove domain specific code

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -458,12 +458,6 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   var socket = this.socket;
   var req = socket._httpMessage;
 
-  // propagate "domain" setting...
-  if (req.domain && !res.domain) {
-    debug('setting "res.domain"');
-    res.domain = req.domain;
-  }
-
   debug('AGENT incoming response!');
 
   if (req.res) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -576,7 +576,6 @@ Timeout.prototype.unref = function() {
     this._handle.owner = this;
     this._handle[kOnTimeout] = unrefdHandle;
     this._handle.start(delay);
-    this._handle.domain = this.domain;
     this._handle.unref();
   }
   return this;

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -30,13 +30,19 @@ timeoutd.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.message, 'Timeout UNREFd',
                      'Domain should catch timer error');
   clearTimeout(timeout);
-}));
+}, 2));
 
+let t;
 timeoutd.run(function() {
   setTimeout(function() {
     throw new Error('Timeout UNREFd');
   }, 0).unref();
+
+  t = setTimeout(function() {
+    throw new Error('Timeout UNREFd');
+  }, 0);
 });
+t.unref();
 
 const immediated = domain.create();
 


### PR DESCRIPTION
This PR removes some domain specific code that is no longer necessary due to the changes in semantics of how domains are tracked.

This will need a CitGM run to make sure no one is relying on the current behaviour but the interaction with the actual `domain` module remains the same, so hopefully this should be fine.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http, timers