### PR TITLE
test: fix test-tty-get-color-depth

### DIFF
--- a/test/parallel/test-tty-get-color-depth.js
+++ b/test/parallel/test-tty-get-color-depth.js
@@ -10,7 +10,7 @@ const { WriteStream } = require('tty');
 
 // Do our best to grab a tty fd.
 function getTTYfd() {
-  const ttyFd = [0, 1, 2, 4, 5].find(tty.isatty);
+  const ttyFd = [1, 2, 4, 5].find(tty.isatty);
   if (ttyFd === undefined) {
     try {
       return openSync('/dev/tty');


### PR DESCRIPTION
If `getTTYfd()` returns 0, and stdin is not writable (like on Windows), trying to create `WriteStream` will fail. This commit fixes that by skipping fd 0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

