### PR TITLE
test: add tls benchmark test

### DIFF
--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -40,11 +40,11 @@ function main({ dur, type, size }) {
   };
 
   server = tls.createServer(options, onConnection);
-  setTimeout(done, dur * 1000);
   var conn;
   server.listen(common.PORT, function() {
     const opt = { port: common.PORT, rejectUnauthorized: false };
     conn = tls.connect(opt, function() {
+      setTimeout(done, dur * 1000);
       bench.start();
       conn.on('drain', write);
       write();

--- a/test/sequential/test-benchmark-tls.js
+++ b/test/sequential/test-benchmark-tls.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.enoughTestMem)
+  common.skip('Insufficient memory for TLS benchmark test');
+
+// Because the TLS benchmarks use hardcoded ports, this should be in sequential
+// rather than parallel to make sure it does not conflict with tests that choose
+// random available ports.
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('tls',
+             [
+               'concurrency=0',
+               'dur=0.1',
+               'n=1',
+               'size=2',
+               'type=asc'
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });


### PR DESCRIPTION
A recent change to benchmarks broke one of the TLS benchmarks and since we have no tests for these it went undetected. This ~~fixes the issue and also~~ introduces a test for TLS benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark, test