### PR TITLE
test: mark test-inspector-stop-profile-after-done flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -13,6 +13,7 @@ test-inspector-debug-end              : PASS, FLAKY
 test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
 test-http2-ping-flood                 : PASS, FLAKY
 test-http2-settings-flood             : PASS, FLAKY
+test-inspector-stop-profile-after-done: PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
This test is consistently failing and making CI red.

Refs: https://github.com/nodejs/node/issues/16772