### PR TITLE
doc: fix unassigned deprecation codes

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -824,8 +824,8 @@ a future version at which point only authentication tag lengths of 128, 120,
 is not included in this list will be considered invalid in compliance with
 [NIST SP 800-38D][].
 
-<a id="DEP00XX"></a>
-### DEP00XX: crypto.DEFAULT_ENCODING
+<a id="DEP0091"></a>
+### DEP0091: crypto.DEFAULT_ENCODING
 
 Type: Runtime
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -831,8 +831,8 @@ Type: Runtime
 
 The [`crypto.DEFAULT_ENCODING`][] property is deprecated.
 
-<a id="DEP00XX"></a>
-### DEP00XX: Top-level `this` bound to `module.exports`
+<a id="DEP0092"></a>
+### DEP0092: Top-level `this` bound to `module.exports`
 
 Type: Documentation-only
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -206,9 +206,9 @@ Object.defineProperties(exports, {
     enumerable: true,
     configurable: true,
     get: deprecate(getDefaultEncoding,
-                   'crypto.DEFAULT_ENCODING is deprecated.', 'DEP00XX'),
+                   'crypto.DEFAULT_ENCODING is deprecated.', 'DEP0091'),
     set: deprecate(setDefaultEncoding,
-                   'crypto.DEFAULT_ENCODING is deprecated.', 'DEP00XX')
+                   'crypto.DEFAULT_ENCODING is deprecated.', 'DEP0091')
   },
   constants: {
     configurable: false,


### PR DESCRIPTION
Oopsie... Forgot to assign the deprecation code when landing https://github.com/nodejs/node/pull/18333

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto, docs