### PR TITLE
test: refactor test-http-abort-before-end

### DIFF
--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -22,25 +22,22 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const assert = require('assert');
 
 const server = http.createServer(common.mustNotCall());
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(() => {
   const req = http.request({
     method: 'GET',
     host: '127.0.0.1',
-    port: this.address().port
+    port: server.address().port
   });
 
-  req.on('error', function(ex) {
-    // https://github.com/joyent/node/issues/1399#issuecomment-2597359
-    // abort() should emit an Error, not the net.Socket object
-    assert(ex instanceof Error);
-  });
+  req.on('abort', common.mustCall(() => {
+    server.close();
+  }));
+
+  req.on('error', common.mustNotCall());
 
   req.abort();
   req.end();
-
-  server.close();
-});
+}));


### PR DESCRIPTION
This test was added over six years ago, and the behavior seems to have changed since then. When the test was originally written, `common.mustCall()` did not exist. The only assertion in this test was not actually executing. Instead of an `'error'` event being emitted as expected, an `'abort'` event was emitted.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test