### PR TITLE
stream: defer readable when sync

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -486,11 +486,18 @@ function onEofChunk(stream, state) {
   }
   state.ended = true;
 
-  // emit 'readable' now to make sure it gets picked up.
-  state.needReadable = false;
-  if (!state.emittedReadable) {
-    state.emittedReadable = true;
-    emitReadable_(stream);
+  if (state.sync && state.length) {
+    // if we are sync and have data in the buffer, wait until next tick
+    // to emit the data. otherwise we risk emitting data in the flow()
+    // the readable code triggers during a read() call
+    emitReadable(stream);
+  } else {
+    // emit 'readable' now to make sure it gets picked up.
+    state.needReadable = false;
+    if (!state.emittedReadable) {
+      state.emittedReadable = true;
+      emitReadable_(stream);
+    }
   }
 }
 

--- a/test/parallel/test-stream-pipe-flow.js
+++ b/test/parallel/test-stream-pipe-flow.js
@@ -1,0 +1,67 @@
+'use strict';
+const common = require('../common');
+const { Readable, Writable, PassThrough } = require('stream');
+
+{
+  let ticks = 17;
+
+  const rs = new Readable({
+    objectMode: true,
+    read: () => {
+      if (ticks-- > 0)
+        return process.nextTick(() => rs.push({}));
+      rs.push({});
+      rs.push(null);
+    }
+  });
+
+  const ws = new Writable({
+    highWaterMark: 0,
+    objectMode: true,
+    write: (data, end, cb) => setImmediate(cb)
+  });
+
+  rs.on('end', common.mustCall());
+  ws.on('finish', common.mustCall());
+  rs.pipe(ws);
+}
+
+{
+  let missing = 8;
+
+  const rs = new Readable({
+    objectMode: true,
+    read: () => {
+      if (missing--) rs.push({});
+      else rs.push(null);
+    }
+  });
+
+  const pt = rs
+    .pipe(new PassThrough({ objectMode: true, highWaterMark: 2 }))
+    .pipe(new PassThrough({ objectMode: true, highWaterMark: 2 }));
+
+  pt.on('end', function() {
+    wrapper.push(null);
+  });
+
+  const wrapper = new Readable({
+    objectMode: true,
+    read: () => {
+      process.nextTick(function() {
+        let data = pt.read();
+        if (data === null) {
+          pt.once('readable', function() {
+            data = pt.read();
+            if (data !== null) wrapper.push(data);
+          });
+        } else {
+          wrapper.push(data);
+        }
+      });
+    }
+  });
+
+  wrapper.resume();
+  wrapper.on('end', common.mustCall());
+}

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { Readable } = require('stream');
+const common = require('../common');
+
+let ticks = 18;
+let expectedData = 19;
+
+const rs = new Readable({
+  objectMode: true,
+  read: () => {
+    if (ticks-- > 0)
+      return process.nextTick(() => rs.push({}));
+    rs.push({});
+    rs.push(null);
+  }
+});
+
+rs.on('end', common.mustCall());
+readAndPause();
+
+function readAndPause() {
+  // Does a on(data) -> pause -> wait -> resume -> on(data) ... loop.
+  // Expects on(data) to never fire if the stream is paused.
+  const ondata = common.mustCall((data) => {
+    rs.pause();
+
+    expectedData--;
+    if (expectedData <= 0)
+      return;
+
+    setImmediate(function() {
+      rs.removeListener('data', ondata);
+      readAndPause();
+      rs.resume();
+    });
+  }, 1); // only call ondata once
+
+  rs.on('data', ondata);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream

Fixes #18484 by not calling `flow()` when `state.sync` is set