### PR TITLE
test: remove destructor from node_test_fixture

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -64,10 +64,6 @@ class NodeTestFixture : public ::testing::Test {
  protected:
   v8::Isolate* isolate_;
 
-  ~NodeTestFixture() {
-    TearDown();
-  }
-
   virtual void SetUp() {
     CHECK_EQ(0, uv_loop_init(&current_loop));
     platform_ = new node::NodePlatform(8, nullptr);
@@ -86,7 +82,6 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void TearDown() {
-    if (platform_ == nullptr) return;
     platform_->Shutdown();
     while (uv_loop_alive(&current_loop)) {
       uv_run(&current_loop, UV_RUN_ONCE);

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -5,16 +5,7 @@
 
 using node::AliasedBuffer;
 
-class AliasBufferTest : public NodeTestFixture {
- protected:
-  void SetUp() override {
-    NodeTestFixture::SetUp();
-  }
-
-  void TearDown() override {
-    NodeTestFixture::TearDown();
-  }
-};
+class AliasBufferTest : public NodeTestFixture {};
 
 template<class NativeT>
 void CreateOracleValues(NativeT* buf, size_t count) {


### PR DESCRIPTION
This commit removes the destructor from node_test_fixture.h which calls
the TearDown function causing TearDown to be called twice. This also
allows us to remove the check of the platform_ in TearDown.

Also the Setup/TearDown functions in AliasBufferTest are removed as they
are not necessary.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test