### PR TITLE
doc: remove usage of you in n-api doc

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3146,11 +3146,8 @@ required in order to enable correct proper of the reference.
 Afterward, additional manipulation of the wrapper's prototype chain may cause
 `napi_unwrap()` to fail.
 
-*Note*: Calling `napi_wrap()` a second time on an object that already has a
-native instance associated with it by virtue of a previous call to
-`napi_wrap()` will cause an error to be returned. In order to associate
-another native instance with the given object, call `napi_remove_wrap()` on it
-first.
+Calling napi_wrap() a second time on an object will return an error. To associate
+another native instance with the object, use napi_remove_wrap() first.
 
 ### napi_unwrap
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3148,7 +3148,7 @@ Afterward, additional manipulation of the wrapper's prototype chain may cause
 
 *Note*: Calling `napi_wrap()` a second time on an object that already has a
 native instance associated with it by virtue of a previous call to
-`napi_wrap()` will cause an error to be returned. If you wish to associate
+`napi_wrap()` will cause an error to be returned. In order to associate
 another native instance with the given object, call `napi_remove_wrap()` on it
 first.
 


### PR DESCRIPTION
We avoid using 'you' in the documentation based on our
guidelines. Remove usage in the n-api doc.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api