### PR TITLE
test: add env undefined regression test

### DIFF
--- a/test/parallel/test-child-process-exec-node-env-undefined.js
+++ b/test/parallel/test-child-process-exec-node-env-undefined.js
@@ -1,0 +1,31 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var exec = require('child_process').exec
+var readFileSync = require('fs').readFileSync
+
+process.env.test = ''
+try { readFileSync('file-does-not-exist') } catch (e) {}
+
+exec(process.execPath + ' -p "process.env.test === \'undefined\' ? \'BUG\' : \'OK\'"', function (err, stdout) {
+  if (err) throw err
+  if (stdout.indexOf('BUG') != -1) throw new Error('BUG')
+})


### PR DESCRIPTION
This test is intended to trigger a bug in process.env on Windows.
process.env may return the string 'undefined' for not existing or empty environment variables in some corner cases.

Please run this test in CI on Windows x86.

Original issue: https://github.com/nodejs/node/issues/14593#issuecomment-361111588
