### PR TITLE
n-api: wrap control flow macro in do/while

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -66,10 +66,12 @@ struct napi_env__ {
     }                                                                   \
   } while (0)
 
-#define CHECK_ENV(env)        \
-  if ((env) == nullptr) {     \
-    return napi_invalid_arg;  \
-  }
+#define CHECK_ENV(env)          \
+  do {                          \
+    if ((env) == nullptr) {     \
+      return napi_invalid_arg;  \
+    }                           \
+  } while (0)
 
 #define CHECK_ARG(env, arg) \
   RETURN_STATUS_IF_FALSE((env), ((arg) != nullptr), napi_invalid_arg)


### PR DESCRIPTION
Make CHECK_ENV() safe to use in the following context:

    if (condition)
      CHECK_ENV(env);
    else
      something_else();