### PR TITLE
test: add useful info to error msg and refactor

### DIFF
--- a/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
+++ b/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
@@ -6,15 +6,18 @@ const assert = require('assert');
 
 const d = domain.create();
 
-process.on('uncaughtException', common.mustCall(function onUncaught() {
+process.once('uncaughtException', common.mustCall(function onUncaught() {
   assert.strictEqual(
     process.domain, null,
-    'domains stack should be empty in uncaughtException handler');
+    'Domains stack should be empty in uncaughtException handler ' +
+    `but the value of process.domain is ${JSON.stringify(process.domain)}`);
 }));
 
 process.on('beforeExit', common.mustCall(function onBeforeExit() {
-  assert.strictEqual(process.domain, null,
-                     'domains stack should be empty in beforeExit handler');
+  assert.strictEqual(
+    process.domain, null,
+    'Domains stack should be empty in beforeExit handler ' +
+    `but the value of process.domain is ${JSON.stringify(process.domain)}`);
 }));
 
 d.run(function() {


### PR DESCRIPTION
Add useful info about process.domain to error meesages in the
uncaughtException event listener and the beforeExit event listener.

Refactor code such as using template literals, and also make sure
uncaughtException listner is detached after firing once to avoid
endless loop in case of exception throw in the beforeExit event
listner.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
