### PR TITLE
tests: extend test scripts to cover OpenBSD

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -75,6 +75,13 @@
     // URL::ToObject() method is used.
     NativeModule.require('internal/url');
 
+    // On OpenBSD process.execPath will be relative unless we
+    // get the full path before hand.
+    if (process.platform === 'openbsd') {
+      const { realpathSync } = NativeModule.require('fs');
+      process.execPath = realpathSync.native(process.execPath);
+    }
+
     Object.defineProperty(process, 'argv0', {
       enumerable: true,
       configurable: false,

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -76,7 +76,7 @@
     NativeModule.require('internal/url');
 
     // On OpenBSD process.execPath will be relative unless we
-    // get the full path before hand.
+    // get the full path before process.execPath is used.
     if (process.platform === 'openbsd') {
       const { realpathSync } = NativeModule.require('fs');
       process.execPath = realpathSync.native(process.execPath);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -55,6 +55,7 @@ exports.isLinuxPPCBE = (process.platform === 'linux') &&
                        (os.endianness() === 'BE');
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
+exports.isOpenBSD = process.platform === 'openbsd';
 exports.isLinux = process.platform === 'linux';
 exports.isOSX = process.platform === 'darwin';
 

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -18,7 +18,7 @@ const cmd = `"${process.execPath}" "${__filename}" child`;
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   let sigterm = 'SIGTERM';
   assert.strictEqual(err.killed, true);
-  // TODO OpenBSD returns a null code
+  // TODO OpenBSD returns a null signal
   if (!common.isOpenBSD)
     assert.strictEqual(err.code, null);
   else

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -18,7 +18,7 @@ const cmd = `"${process.execPath}" "${__filename}" child`;
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   let sigterm = 'SIGTERM';
   assert.strictEqual(err.killed, true);
-  // TODO OpenBSD returns a null signal
+  // TODO OpenBSD returns a null signal and 143 for code
   if (!common.isOpenBSD)
     assert.strictEqual(err.code, null);
   else

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -17,14 +17,18 @@ const cmd = `"${process.execPath}" "${__filename}" child`;
 // Test the case where a timeout is set, and it expires.
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   assert.strictEqual(err.killed, true);
-  assert.strictEqual(err.code, null);
+  // TODO OpenBSD returns a null code
+  if (!common.isOpenBSD)
+    assert.strictEqual(err.code, null);
+  else
+    sigterm = null;
   // At least starting with Darwin Kernel Version 16.4.0, sending a SIGTERM to a
   // process that is still starting up kills it with SIGKILL instead of SIGTERM.
   // See: https://github.com/libuv/libuv/issues/1226
   if (common.isOSX)
     assert.ok(err.signal === 'SIGTERM' || err.signal === 'SIGKILL');
   else
-    assert.strictEqual(err.signal, 'SIGTERM');
+    assert.strictEqual(err.signal, sigterm);
   assert.strictEqual(err.cmd, cmd);
   assert.strictEqual(stdout.trim(), '');
   assert.strictEqual(stderr.trim(), '');

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -16,6 +16,7 @@ const cmd = `"${process.execPath}" "${__filename}" child`;
 
 // Test the case where a timeout is set, and it expires.
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
+  let sigterm = 'SIGTERM';
   assert.strictEqual(err.killed, true);
   // TODO OpenBSD returns a null code
   if (!common.isOpenBSD)

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -19,10 +19,12 @@ cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   let sigterm = 'SIGTERM';
   assert.strictEqual(err.killed, true);
   // TODO OpenBSD returns a null signal and 143 for code
-  if (!common.isOpenBSD)
-    assert.strictEqual(err.code, null);
-  else
+  if (common.isOpenBSD) {
+    assert.strictEqual(err.code, 143);
     sigterm = null;
+  } else {
+    assert.strictEqual(err.code, null);
+  }
   // At least starting with Darwin Kernel Version 16.4.0, sending a SIGTERM to a
   // process that is still starting up kills it with SIGKILL instead of SIGTERM.
   // See: https://github.com/libuv/libuv/issues/1226

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -5,17 +5,13 @@ const spawnSync = require('child_process').spawnSync;
 const signals = process.binding('constants').os.signals;
 
 let invalidArgTypeError;
-let errCode = 56;
-if (common.isOpenBSD)
-  errCode = 46;
 
 if (common.isWindows) {
   invalidArgTypeError =
     common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 36);
 } else {
   invalidArgTypeError =
-    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError },
-                        errCode);
+    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 56);
 }
 
 const invalidRangeError =

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -5,13 +5,17 @@ const spawnSync = require('child_process').spawnSync;
 const signals = process.binding('constants').os.signals;
 
 let invalidArgTypeError;
+let errCode = 56;
+if (common.isOpenBSD)
+  errCode = 46;
 
 if (common.isWindows) {
   invalidArgTypeError =
     common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 36);
 } else {
   invalidArgTypeError =
-    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 56);
+    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError },
+                        errCode);
 }
 
 const invalidRangeError =

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -178,8 +178,8 @@ process.on('exit', function() {
 const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
-// test Y2K38 for all platforms [except 'arm', and 'SunOS']
-if (!process.arch.includes('arm') && !common.isSunOS) {
+// test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
+if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
   // because 2 ** 31 doesn't look right
   // eslint-disable-next-line space-infix-ops
   const Y2K38_mtime = 2**31;

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -32,6 +32,10 @@ const https = require('https');
 const host = '*'.repeat(256);
 const MAX_TRIES = 5;
 
+let errCode = 'ENOTFOUND';
+if (common.isOpenBSD)
+  errCode = 'EAI_FAIL';
+
 function tryGet(mod, tries) {
   // Bad host name should not throw an uncatchable exception.
   // Ensure that there is time to attach an error listener.
@@ -41,7 +45,7 @@ function tryGet(mod, tries) {
       tryGet(mod, ++tries);
       return;
     }
-    assert.strictEqual(err.code, 'ENOTFOUND');
+    assert.strictEqual(err.code, errCode);
   }));
   // http.get() called req1.end() for us
 }
@@ -57,7 +61,7 @@ function tryRequest(mod, tries) {
       tryRequest(mod, ++tries);
       return;
     }
-    assert.strictEqual(err.code, 'ENOTFOUND');
+    assert.strictEqual(err.code, errCode);
   }));
   req.end();
 }

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -27,17 +27,21 @@ const net = require('net');
 
 const host = '*'.repeat(256);
 
+let errCode = 'ENOTFOUND';
+if (common.isOpenBSD)
+  errCode = 'EAI_FAIL';
+
 function do_not_call() {
   throw new Error('This function should not have been called.');
 }
 
 const socket = net.connect(42, host, do_not_call);
 socket.on('error', common.mustCall(function(err) {
-  assert.strictEqual(err.code, 'ENOTFOUND');
+  assert.strictEqual(err.code, errCode);
 }));
 socket.on('lookup', function(err, ip, type) {
   assert(err instanceof Error);
-  assert.strictEqual(err.code, 'ENOTFOUND');
+  assert.strictEqual(err.code, errCode);
   assert.strictEqual(ip, undefined);
   assert.strictEqual(type, undefined);
 });

--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -12,6 +12,9 @@ const args = [process.execPath];
 if (common.isAIX)
   args.unshift('-Xany', '-B');
 
+if (common.isOpenBSD)
+  common.skip('no v8 debug symbols on OpenBSD');
+
 const nm = spawnSync('nm', args);
 
 if (nm.error && nm.error.errno === 'ENOENT')

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -34,7 +34,7 @@ exec(cmd, common.mustCall((error, stdout, stderr) => {
   assert.strictEqual(stderr, '');
 
   // freebsd always add ' (procname)' to the process title
-  if (common.isFreeBSD)
+  if (common.isFreeBSD || common.isOpenBSD)
     title += ` (${path.basename(process.execPath)})`;
 
   // omitting trailing whitespace and \n

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
@@ -189,7 +189,10 @@ try {
     require(`${loadOrder}file3`);
   } catch (e) {
     // Not a real .node module, but we know we require'd the right thing.
-    assert.ok(/file3\.node/.test(e.message.replace(backslash, '/')));
+    if (common.isOpenBSD) // OpenBSD errors with non-ELF object error
+      assert.ok(/File not an ELF object/.test(e.message.replace(backslash, '/')));
+    else
+      assert.ok(/file3\.node/.test(e.message.replace(backslash, '/')));
   }
   assert.strictEqual(require(`${loadOrder}file4`).file4, 'file4.reg', msg);
   assert.strictEqual(require(`${loadOrder}file5`).file5, 'file5.reg2', msg);
@@ -197,7 +200,10 @@ try {
   try {
     require(`${loadOrder}file7`);
   } catch (e) {
-    assert.ok(/file7\/index\.node/.test(e.message.replace(backslash, '/')));
+    if (common.isOpenBSD)
+      assert.ok(/File not an ELF object/.test(e.message.replace(backslash, '/')));
+    else
+      assert.ok(/file7\/index\.node/.test(e.message.replace(backslash, '/')));
   }
   assert.strictEqual(require(`${loadOrder}file8`).file8, 'file8/index.reg',
                      msg);


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test`
- [X] tests and/or benchmarks are included ( \o/ )
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

---

Currently a large portion of the tests fail on OpenBSD. Most fail because node expects to be a to determine the full path of a executable, which isn't possible on OpenBSD. This PR works around that issue by setting `common.execPathOpenBSD` as early as possible. Then we use this variable later in the tests when we need to know the full path of the executable.

A few of the other tests expose some bugs in libuv that I will track down pretty soon here.

Anyway - with this patch set, the tests complete as expected:

```
[----------] Global test environment tear-down
[==========] 68 tests from 8 test cases ran. (193 ms total)
[  PASSED  ] 68 tests.
/usr/local/bin/python2.7 tools/test.py --mode=release -J \
        default \
        addons addons-napi \
        doctool
[06:05|% 100|+ 2125|-   0]: Done
```