### PR TITLE
doc: nodejs/modules team now exists

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -31,7 +31,7 @@
 | `test/*`                                 | @nodejs/testing                                                       |
 | `tools/node_modules/eslint`, `.eslintrc` | @not-an-aardvark, @silverwind, @trott                                 |
 | build                                    | @nodejs/build                                                         |
-| ES Modules                               | @bmeck, @Fishrock123, @guybedford, @MylesBorins, @targos              |
+| `src/module_wrap.*`, `lib/internal/loader/*`, `lib/internal/vm/Module.js` | @nodejs/modules                      |
 | GYP                                      | @nodejs/gyp                                                           |
 | performance                              | @nodejs/performance                                                   |
 | platform specific                        | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |


### PR DESCRIPTION
the nodejs/modules team has been created, changes who to ping for es modules

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)