### PR TITLE
test: do not check TXT content in test-dns-any

### DIFF
--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -59,9 +59,6 @@ const checkers = {
   checkTXT(r) {
     assert.ok(Array.isArray(r.entries));
     assert.ok(r.entries.length > 0);
-    r.entries.forEach((txt) => {
-      assert(txt.startsWith('v=spf1'));
-    });
     assert.strictEqual(r.type, 'TXT');
   },
   checkSOA(r) {


### PR DESCRIPTION
google.com added another TXT record which broke this test.
This removes the check on the content of the TXT record
since that depends on an external state subject to change.

Note: this is a test under `test/internet` which is not normally run, that's why this has been broken without being noticed.

```
> nslookup -type=TXT google.com
Server:		8.8.8.8
Address:	8.8.8.8#53

Non-authoritative answer:
google.com	text = "docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e"
google.com	text = "v=spf1 include:_spf.google.com ~all"

```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @XadillaX 

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
