### PR TITLE
fs: fix misplaced errors in fs.symlinkSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1161,6 +1161,11 @@ fs.readlinkSync = function(path, options) {
                                   options.encoding, undefined, ctx);
   if (ctx.errno !== undefined) {
     throw errors.uvException(ctx);
+  } else if (ctx.error) {
+    // TODO(joyeecheung): this is an encoding error usually caused by memory
+    // problems. We need to figure out proper error code(s) for this.
+    Error.captureStackTrace(ctx.error);
+    throw ctx.error;
   }
   return result;
 };
@@ -1232,11 +1237,6 @@ fs.symlinkSync = function(target, path, type) {
 
   if (ctx.errno !== undefined) {
     throw errors.uvException(ctx);
-  } else if (ctx.error) {
-    // TODO(joyeecheung): this is an encoding error usually caused by memory
-    // problems. We need to figure out proper error code(s) for this.
-    Error.captureStackTrace(ctx.error);
-    throw ctx.error;
   }
 };
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -886,7 +886,7 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
     fs_req_wrap req;
     int err = SyncCall(env, args[3], &req, "readlink",
                        uv_fs_readlink, *path);
-    if (err) {
+    if (err < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
     }
     const char* link_path = static_cast<const char*>(req.req.ptr);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

The ctx.error is supposed to be handled in fs.readlinkSync,
but was handled in fs.symlinkSync by mistake.

Also fix the error number check in readlink to be consistent
with SYNC_CALL.

Refs: https://github.com/nodejs/node/pull/18348

This is an oversight of https://github.com/nodejs/node/pull/18348, the error handling was supposed to be in `fs.readlinkSync` instead of `fs.symlinkSync`. I couldn't come up with a test because these errors cannot be triggered easily:

https://github.com/nodejs/node/blob/1286923cc05e3e7a726fc682be54212ccfc66812/src/string_bytes.cc#L41-L51

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs