### PR TITLE
http: Separate constant variable for TypeError & error

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -43,7 +43,7 @@ const errors = require('internal/errors');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
-//TypeError and error constants
+// Error types
 const ERR_INVALID_ARG_TYPE = 'ERR_INVALID_ARG_TYPE';
 const ERR_INVALID_DOMAIN_NAME = 'ERR_INVALID_DOMAIN_NAME';
 const ERR_INVALID_PROTOCOL = 'ERR_INVALID_PROTOCOL';

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -43,9 +43,17 @@ const errors = require('internal/errors');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
+//TypeError and error constants
+const ERR_INVALID_ARG_TYPE = 'ERR_INVALID_ARG_TYPE';
+const ERR_INVALID_DOMAIN_NAME = 'ERR_INVALID_DOMAIN_NAME';
+const ERR_INVALID_PROTOCOL = 'ERR_INVALID_PROTOCOL';
+const ERR_INVALID_HTTP_TOKEN = 'ERR_INVALID_HTTP_TOKEN';
+const ERR_UNESCAPED_CHARACTERS = 'ERR_UNESCAPED_CHARACTERS';
+const ERR_HTTP_HEADERS_SENT = 'ERR_HTTP_HEADERS_SENT';
+
 function validateHost(host, name) {
   if (host !== null && host !== undefined && typeof host !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', `options.${name}`,
+    throw new errors.TypeError(ERR_INVALID_ARG_TYPE, `options.${name}`,
                                ['string', 'undefined', 'null'], host);
   }
   return host;
@@ -57,7 +65,7 @@ function ClientRequest(options, cb) {
   if (typeof options === 'string') {
     options = url.parse(options);
     if (!options.hostname) {
-      throw new errors.Error('ERR_INVALID_DOMAIN_NAME');
+      throw new errors.Error(ERR_INVALID_DOMAIN_NAME);
     }
   } else if (options && options[searchParamsSymbol] &&
              options[searchParamsSymbol][searchParamsSymbol]) {
@@ -78,7 +86,7 @@ function ClientRequest(options, cb) {
     // Explicitly pass through this statement as agent will not be used
     // when createConnection is provided.
   } else if (typeof agent.addRequest !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'Agent option',
+    throw new errors.TypeError(ERR_INVALID_ARG_TYPE, 'Agent option',
                                ['Agent-like Object', 'undefined', 'false']);
   }
   this.agent = agent;
@@ -92,11 +100,11 @@ function ClientRequest(options, cb) {
   if (options.path) {
     path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
-      throw new errors.TypeError('ERR_UNESCAPED_CHARACTERS', 'Request path');
+      throw new errors.TypeError(ERR_UNESCAPED_CHARACTERS, 'Request path');
   }
 
   if (protocol !== expectedProtocol) {
-    throw new errors.Error('ERR_INVALID_PROTOCOL', protocol, expectedProtocol);
+    throw new errors.Error(ERR_INVALID_PROTOCOL, protocol, expectedProtocol);
   }
 
   var defaultPort = options.defaultPort ||
@@ -114,13 +122,13 @@ function ClientRequest(options, cb) {
   var method = options.method;
   var methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'method',
+    throw new errors.TypeError(ERR_INVALID_ARG_TYPE, 'method',
                                'string', method);
   }
 
   if (methodIsString && method) {
     if (!checkIsHttpToken(method)) {
-      throw new errors.TypeError('ERR_INVALID_HTTP_TOKEN', 'Method', method);
+      throw new errors.TypeError(ERR_INVALID_HTTP_TOKEN, 'Method', method);
     }
     method = this.method = method.toUpperCase();
   } else {
@@ -202,7 +210,7 @@ function ClientRequest(options, cb) {
 
     if (this.getHeader('expect')) {
       if (this._header) {
-        throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'render');
+        throw new errors.Error(ERR_HTTP_HEADERS_SENT, 'render');
       }
 
       this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
@@ -261,7 +269,7 @@ ClientRequest.prototype._finish = function _finish() {
 
 ClientRequest.prototype._implicitHeader = function _implicitHeader() {
   if (this._header) {
-    throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'render');
+    throw new errors.Error(ERR_HTTP_HEADERS_SENT, 'render');
   }
   this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
                     this[outHeadersKey]);


### PR DESCRIPTION
Using constants is more a way of defensive programming, also it improves performance optimization. Most importantly, it is for human reader.

Since I have made a nice cleanup to make a separate constant variable for `ErrorType` and `error` in `lib/_http_client.js`.

##### Checklist

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


##### Affected core subsystem(s)
_http_client.js