### PR TITLE
test: suppress unused warning postmortem_metadata

### DIFF
--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -130,7 +130,7 @@ TEST_F(DebugSymbolsTest, ReqWrapList) {
   // NOTE (mmarchini): Workaround to fix failing tests on ARM64 machines with
   // older GCC. Should be removed once we upgrade the GCC version used on our
   // ARM64 CI machinies.
-  for (auto it : *(*env)->req_wrap_queue()) {}
+  for (auto it : *(*env)->req_wrap_queue()) { (void) it; }
 
   auto queue = reinterpret_cast<uintptr_t>((*env)->req_wrap_queue());
   auto head = queue +


### PR DESCRIPTION
Currently the following warning is generated by when building the
cctests:
```console
../test/cctest/test_node_postmortem_metadata.cc:133:13:
warning: unused variable 'it' [-Wunused-variable]
  for (auto it : *(*env)->req_wrap_queue()) {}
            ^
1 warning generated.
```
This commmit adds a cast to void to suppres the warning.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test