### PR TITLE
test: introduce SetUpTestCase/TearDownTestCase

### DIFF
--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -1,3 +1,7 @@
 #include "node_test_fixture.h"
 
-uv_loop_t current_loop;
+uv_loop_t NodeTestFixture::current_loop;
+std::unique_ptr<node::NodePlatform> NodeTestFixture::platform;
+std::unique_ptr<v8::ArrayBuffer::Allocator> NodeTestFixture::allocator;
+std::unique_ptr<v8::TracingController> NodeTestFixture::tracing_controller;
+v8::Isolate::CreateParams NodeTestFixture::params;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -99,9 +99,7 @@ class EnvironmentTestFixture : public NodeTestFixture {
  public:
   class Env {
    public:
-    Env(const v8::HandleScope& handle_scope,
-        const Argv& argv,
-        NodeTestFixture* test_fixture) {
+    Env(const v8::HandleScope& handle_scope, const Argv& argv) {
       auto isolate = handle_scope.GetIsolate();
       context_ = node::NewContext(isolate);
       CHECK(!context_.IsEmpty());

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -53,49 +53,45 @@ struct Argv {
   int nr_args_;
 };
 
-extern uv_loop_t current_loop;
 
 class NodeTestFixture : public ::testing::Test {
- public:
-  static uv_loop_t* CurrentLoop() { return &current_loop; }
-
-  node::MultiIsolatePlatform* Platform() const { return platform_; }
-
  protected:
+  static std::unique_ptr<v8::ArrayBuffer::Allocator> allocator;
+  static std::unique_ptr<v8::TracingController> tracing_controller;
+  static std::unique_ptr<node::NodePlatform> platform;
+  static v8::Isolate::CreateParams params;
+  static uv_loop_t current_loop;
   v8::Isolate* isolate_;
 
-  virtual void SetUp() {
+  static void SetUpTestCase() {
+    platform.reset(new node::NodePlatform(8, nullptr));
+    tracing_controller.reset(new v8::TracingController());
+    allocator.reset(v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+    params.array_buffer_allocator = allocator.get();
+    node::tracing::TraceEventHelper::SetTracingController(
+        tracing_controller.get());
     CHECK_EQ(0, uv_loop_init(&current_loop));
-    platform_ = new node::NodePlatform(8, nullptr);
-    v8::V8::InitializePlatform(platform_);
+    v8::V8::InitializePlatform(platform.get());
     v8::V8::Initialize();
-    v8::Isolate::CreateParams params_;
-    params_.array_buffer_allocator = allocator_.get();
-    isolate_ = v8::Isolate::New(params_);
-
-    // As the TracingController is stored globally, we only need to create it
-    // one time for all tests.
-    if (node::tracing::TraceEventHelper::GetTracingController() == nullptr) {
-      node::tracing::TraceEventHelper::SetTracingController(
-          new v8::TracingController());
-    }
   }
 
-  virtual void TearDown() {
-    platform_->Shutdown();
+  static void TearDownTestCase() {
+    platform->Shutdown();
     while (uv_loop_alive(&current_loop)) {
       uv_run(&current_loop, UV_RUN_ONCE);
     }
     v8::V8::ShutdownPlatform();
-    delete platform_;
-    platform_ = nullptr;
     CHECK_EQ(0, uv_loop_close(&current_loop));
   }
 
- private:
-  node::NodePlatform* platform_ = nullptr;
-  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_{
-      v8::ArrayBuffer::Allocator::NewDefaultAllocator()};
+  virtual void SetUp() {
+    isolate_ = v8::Isolate::New(params);
+  }
+
+  virtual void TearDown() {
+    isolate_->Dispose();
+    isolate_ = nullptr;
+  }
 };
 
 
@@ -112,8 +108,8 @@ class EnvironmentTestFixture : public NodeTestFixture {
       context_->Enter();
 
       isolate_data_ = node::CreateIsolateData(isolate,
-                                              NodeTestFixture::CurrentLoop(),
-                                              test_fixture->Platform());
+                                              &NodeTestFixture::current_loop,
+                                              platform.get());
       CHECK_NE(nullptr, isolate_data_);
       environment_ = node::CreateEnvironment(isolate_data_,
                                              context_,

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -64,7 +64,7 @@ class NodeTestFixture : public ::testing::Test {
   v8::Isolate* isolate_;
 
   static void SetUpTestCase() {
-    platform.reset(new node::NodePlatform(8, nullptr));
+    platform.reset(new node::NodePlatform(4, nullptr));
     tracing_controller.reset(new v8::TracingController());
     allocator.reset(v8::ArrayBuffer::Allocator::NewDefaultAllocator());
     params.array_buffer_allocator = allocator.get();

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -86,6 +86,7 @@ class NodeTestFixture : public ::testing::Test {
 
   virtual void SetUp() {
     isolate_ = v8::Isolate::New(params);
+    CHECK_NE(isolate_, nullptr);
   }
 
   virtual void TearDown() {

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -32,7 +32,7 @@ class EnvironmentTest : public EnvironmentTestFixture {
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, argv, this};
+  Env env {handle_scope, argv};
 
   AtExit(*env, at_exit_callback1);
   RunAtExit(*env);
@@ -42,7 +42,7 @@ TEST_F(EnvironmentTest, AtExitWithEnvironment) {
 TEST_F(EnvironmentTest, AtExitWithArgument) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, argv, this};
+  Env env {handle_scope, argv};
 
   std::string arg{"some args"};
   AtExit(*env, at_exit_callback1, static_cast<void*>(&arg));
@@ -53,8 +53,8 @@ TEST_F(EnvironmentTest, AtExitWithArgument) {
 TEST_F(EnvironmentTest, MultipleEnvironmentsPerIsolate) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env1 {handle_scope, argv, this};
-  Env env2 {handle_scope, argv, this};
+  Env env1 {handle_scope, argv};
+  Env env2 {handle_scope, argv};
 
   AtExit(*env1, at_exit_callback1);
   AtExit(*env2, at_exit_callback2);

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -50,7 +50,7 @@ TEST_F(DebugSymbolsTest, ExternalStringDataOffset) {
 TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   v8::Local<v8::Object> object = v8::Object::New(isolate_);
   node::BaseObject obj(*env, object);
@@ -67,7 +67,7 @@ TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
 TEST_F(DebugSymbolsTest, EnvironmentHandleWrapQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto expected = reinterpret_cast<uintptr_t>((*env)->handle_wrap_queue());
   auto calculated = reinterpret_cast<uintptr_t>(*env) +
@@ -78,7 +78,7 @@ TEST_F(DebugSymbolsTest, EnvironmentHandleWrapQueue) {
 TEST_F(DebugSymbolsTest, EnvironmentReqWrapQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto expected = reinterpret_cast<uintptr_t>((*env)->req_wrap_queue());
   auto calculated = reinterpret_cast<uintptr_t>(*env) +
@@ -89,7 +89,7 @@ TEST_F(DebugSymbolsTest, EnvironmentReqWrapQueue) {
 TEST_F(DebugSymbolsTest, HandleWrapList) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   uv_tcp_t handle;
 
@@ -118,7 +118,7 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
 TEST_F(DebugSymbolsTest, ReqWrapList) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
   obj_template->InstanceTemplate()->SetInternalFieldCount(1);


### PR DESCRIPTION
This commit add SetUpTestCase and TearDownTestCase functions that will
be called once per test case. Currently we only have SetUp/TearDown
which are called for each test.

This commit moves the initialization and configuration of Node and V8 to
be done on a per test case basis, but gives each test a new Isolate.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test