### PR TITLE
doc: fix `REPLACEME` in changelog PR URLs

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -18,7 +18,7 @@ For more information about the used equality comparisons see
 added: REPLACEME
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17615
     description: Added error diffs to the strict mode
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/17002
@@ -445,7 +445,7 @@ See below for further details.
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18418
     description: Calling `assert.fail` with more than one argument is deprecated
                  and emits a warning.
 -->
@@ -728,7 +728,7 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18319
     description: assert.ok() (no arguments) will now use a predefined error msg.
 -->
 * `value` {any}
@@ -834,7 +834,7 @@ instead of the `AssertionError`.
 added: v0.1.21
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17584
     description: The `error` parameter can now be an object as well.
   - version: v4.2.0
     pr-url: https://github.com/nodejs/node/pull/3276

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -108,7 +108,7 @@ new Console(process.stdout, process.stderr);
 added: v0.1.101
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17706
     description: The implementation is now spec compliant and does not throw
                  anymore.
 -->

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -352,7 +352,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/17907
     description: The `depth` default changed to Infinity.
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17576
     description: The `compact` option is supported now.
   - version: v6.6.0
     pr-url: https://github.com/nodejs/node/pull/8174


### PR DESCRIPTION
These were mistakenly not replaced while landing the PRs.

/cc @BridgeAR 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc