### PR TITLE
tls: pass in Timer.now() value straight from C++

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -32,7 +32,6 @@ const common = require('_tls_common');
 const { StreamWrap } = require('_stream_wrap');
 const { Buffer } = require('buffer');
 const debug = util.debuglog('tls');
-const { Timer } = process.binding('timer_wrap');
 const tls_wrap = process.binding('tls_wrap');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
@@ -49,13 +48,12 @@ const kSNICallback = Symbol('snicallback');
 
 const noop = () => {};
 
-function onhandshakestart() {
+function onhandshakestart(now) {
   debug('onhandshakestart');
 
-  const owner = this.owner;
-  const now = Timer.now();
-
   assert(now >= this.lastHandshakeTime);
+
+  const owner = this.owner;
 
   if ((now - this.lastHandshakeTime) >= tls.CLIENT_RENEG_WINDOW * 1000) {
     this.handshakes = 0;

--- a/src/env.cc
+++ b/src/env.cc
@@ -347,7 +347,7 @@ void Environment::ToggleImmediateRef(bool ref) {
 Local<Value> Environment::GetNow() {
   uv_update_time(event_loop());
   uint64_t now = uv_now(event_loop());
-  CHECK(now >= timer_base());
+  CHECK_GE(now, timer_base());
   now -= timer_base();
   if (now <= 0xffffffff)
     return Integer::New(isolate(), static_cast<uint32_t>(now));

--- a/src/env.cc
+++ b/src/env.cc
@@ -349,7 +349,7 @@ Local<Value> Environment::GetNow() {
   uint64_t now = uv_now(event_loop());
   CHECK(now >= timer_base());
   now -= timer_base();
-  if (now <= 0xfffffff)
+  if (now <= 0xffffffff)
     return Integer::New(isolate(), static_cast<uint32_t>(now));
   else
     return Number::New(isolate(), static_cast<double>(now));

--- a/src/env.cc
+++ b/src/env.cc
@@ -12,13 +12,16 @@ namespace node {
 using v8::Context;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Message;
+using v8::Number;
 using v8::Private;
 using v8::StackFrame;
 using v8::StackTrace;
 using v8::String;
+using v8::Value;
 
 IsolateData::IsolateData(Isolate* isolate,
                          uv_loop_t* event_loop,
@@ -338,6 +341,18 @@ void Environment::ToggleImmediateRef(bool ref) {
   } else {
     uv_idle_stop(immediate_idle_handle());
   }
+}
+
+
+Local<Value> Environment::GetNow() {
+  uv_update_time(event_loop());
+  uint64_t now = uv_now(event_loop());
+  CHECK(now >= timer_base());
+  now -= timer_base();
+  if (now <= 0xfffffff)
+    return Integer::New(isolate(), static_cast<uint32_t>(now));
+  else
+    return Number::New(isolate(), static_cast<double>(now));
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -726,6 +726,8 @@ class Environment {
 
   static inline Environment* ForAsyncHooks(AsyncHooks* hooks);
 
+  v8::Local<v8::Value> GetNow();
+
  private:
   inline void CreateImmediate(native_immediate_callback cb,
                               void* data,

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -37,7 +37,6 @@ using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
-using v8::Number;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -142,7 +141,7 @@ class TimerWrap : public HandleWrap {
     Local<Value> ret;
     Local<Value> args[1];
     do {
-      args[0] = GetNow(env);
+      args[0] = env->GetNow();
       ret = wrap->MakeCallback(kOnTimeout, 1, args).ToLocalChecked();
     } while (ret->IsUndefined() &&
              !env->tick_info()->has_thrown() &&
@@ -153,18 +152,7 @@ class TimerWrap : public HandleWrap {
 
   static void Now(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
-    args.GetReturnValue().Set(GetNow(env));
-  }
-
-  static Local<Value> GetNow(Environment* env) {
-    uv_update_time(env->event_loop());
-    uint64_t now = uv_now(env->event_loop());
-    CHECK(now >= env->timer_base());
-    now -= env->timer_base();
-    if (now <= 0xfffffff)
-      return Integer::New(env->isolate(), static_cast<uint32_t>(now));
-    else
-      return Number::New(env->isolate(), static_cast<double>(now));
+    args.GetReturnValue().Set(env->GetNow());
   }
 
   uv_timer_t handle_;

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -230,7 +230,8 @@ void TLSWrap::SSLInfoCallback(const SSL* ssl_, int where, int ret) {
   if (where & SSL_CB_HANDSHAKE_START) {
     Local<Value> callback = object->Get(env->onhandshakestart_string());
     if (callback->IsFunction()) {
-      c->MakeCallback(callback.As<Function>(), 0, nullptr);
+      Local<Value> argv[] = { env->GetNow() };
+      c->MakeCallback(callback.As<Function>(), arraysize(argv), argv);
     }
   }
 


### PR DESCRIPTION
Instead of separately calling into C++ from JS to retrieve the `Timer.now()` value, pass it in as an argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls, src