### PR TITLE
doc,assert,timers: assign deprecation codes

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -840,15 +840,16 @@ Assigning properties to the top-level `this` as an alternative
 to `module.exports` is deprecated. Developers should use `exports`
 or `module.exports` instead.
 
-### DEP00XX: crypto.fips is deprecated and replaced.
+<a id="DEP0093"></a>
+### DEP0093: crypto.fips is deprecated and replaced.
 
 Type: Documentation-only
 
 The [`crypto.fips`][] property is deprecated. Please use `crypto.setFips()`
 and `crypto.getFips()` instead.
 
-<a id="DEP0XX"></a>
-### DEP0XXX: Using `assert.fail()` with more than one argument.
+<a id="DEP0094"></a>
+### DEP0094: Using `assert.fail()` with more than one argument.
 
 Type: Runtime
 
@@ -856,15 +857,15 @@ Using `assert.fail()` with more than one argument has no benefit over writing an
 individual error message. Either use `assert.fail()` with one argument or switch
 to one of the other assert methods.
 
-<a id="DEP00XX"></a>
-### DEP00XX: timers.enroll()
+<a id="DEP0095"></a>
+### DEP0095: timers.enroll()
 
 Type: Runtime
 
 `timers.enroll()` is deprecated. Please use the publicly documented [`setTimeout()`][] or [`setInterval()`][] instead.
 
-<a id="DEP00XX"></a>
-### DEP00XX: timers.unenroll()
+<a id="DEP0096"></a>
+### DEP0096: timers.unenroll()
 
 Type: Runtime
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -89,7 +89,7 @@ function fail(actual, expected, message, operator, stackStartFn) {
         'assert.fail() with more than one argument is deprecated. ' +
           'Please use assert.strictEqual() instead or only pass a message.',
         'DeprecationWarning',
-        'DEP00XXX'
+        'DEP0094'
       );
     }
     if (argsLen === 2)

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -358,7 +358,7 @@ function unenroll(item) {
 exports.unenroll = util.deprecate(unenroll,
                                   'timers.unenroll() is deprecated. ' +
                                   'Please use clearTimeout instead.',
-                                  'DEP00XX');
+                                  'DEP0096');
 
 
 // Make a regular object able to act as a timer by setting some properties.
@@ -377,7 +377,7 @@ function enroll(item, msecs) {
 exports.enroll = util.deprecate(enroll,
                                 'timers.unenroll() is deprecated. ' +
                                 'Please use clearTimeout instead.',
-                                'DEP00XX');
+                                'DEP0095');
 
 
 /*

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -375,7 +375,7 @@ function enroll(item, msecs) {
 }
 
 exports.enroll = util.deprecate(enroll,
-                                'timers.unenroll() is deprecated. ' +
+                                'timers.enroll() is deprecated. ' +
                                 'Please use clearTimeout instead.',
                                 'DEP0095');
 

--- a/test/parallel/test-timers-max-duration-warning.js
+++ b/test/parallel/test-timers-max-duration-warning.js
@@ -19,7 +19,7 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(lines[0], `${OVERFLOW} does not fit into a 32-bit signed` +
                                ' integer.');
   assert.strictEqual(lines.length, 2);
-}, 4));
+}, 5));
 
 
 {


### PR DESCRIPTION
Overlooked when landing the respective PRs.

/cc @Fishrock123 @BridgeAR @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc,assert,timers