### PR TITLE
deps,src: align ssize_t ABI between Node & nghttp2

### DIFF
--- a/deps/nghttp2/lib/includes/config.h
+++ b/deps/nghttp2/lib/includes/config.h
@@ -1,8 +1,18 @@
 /* Hint to the compiler that a function never returns */
 #define NGHTTP2_NORETURN
 
-/* Define to `int' if <sys/types.h> does not define. */
-#define ssize_t int
+/* Edited to match src/node.h. */
+#include <stdint.h>
+
+#ifdef _WIN32
+#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+typedef intptr_t ssize_t;
+# define _SSIZE_T_
+# define _SSIZE_T_DEFINED
+#endif
+#else  // !_WIN32
+# include <sys/types.h>  // size_t, ssize_t
+#endif  // _WIN32
 
 /* Define to 1 if you have the `std::map::emplace`. */
 #define HAVE_STD_MAP_EMPLACE 1

--- a/src/node.h
+++ b/src/node.h
@@ -184,7 +184,6 @@ NODE_EXTERN v8::Local<v8::Value> MakeCallback(
 #endif
 
 #ifdef _WIN32
-// TODO(tjfontaine) consider changing the usage of ssize_t to ptrdiff_t
 #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
 typedef intptr_t ssize_t;
 # define _SSIZE_T_

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -764,13 +764,7 @@ inline ssize_t Http2Session::Write(const uv_buf_t* bufs, size_t nbufs) {
                                bufs[n].len);
     CHECK_NE(ret, NGHTTP2_ERR_NOMEM);
 
-    // If there is an error calling any of the callbacks, ret will be a
-    // negative number identifying the error code. This can happen, for
-    // instance, if the session is destroyed during any of the JS callbacks
-    // Note: if ssize_t is not defined (e.g. on Win32), nghttp2 will typedef
-    // ssize_t to int. Cast here so that the < 0 check actually works on
-    // Windows.
-    if (static_cast<int>(ret) < 0)
+    if (ret < 0)
       return ret;
 
     total += ret;
@@ -1709,10 +1703,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
     statistics_.data_received += nread;
     ssize_t ret = Write(&stream_buf_, 1);
 
-    // Note: if ssize_t is not defined (e.g. on Win32), nghttp2 will typedef
-    // ssize_t to int. Cast here so that the < 0 check actually works on
-    // Windows.
-    if (static_cast<int>(ret) < 0) {
+    if (ret < 0) {
       DEBUG_HTTP2SESSION2(this, "fatal error receiving data: %d", ret);
 
       Local<Value> argv[] = {


### PR DESCRIPTION
Previously, we performed casts that are considered undefined behavior.
Instead, just define `ssize_t` for nghttp2 the same way we define it
for the rest of Node.

Also, remove a TODO comment that would probably also be *technically*
correct but shouldn’t matter as long as nobody is complaining.
(And is therefore unlikely to ever be implemented.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/http2

CI: https://ci.nodejs.org/job/node-test-commit/15932/