### PR TITLE
test: fix flaky timers-block-eventloop test

### DIFF
--- a/test/sequential/test-timers-block-eventloop.js
+++ b/test/sequential/test-timers-block-eventloop.js
@@ -1,24 +1,18 @@
 'use strict';
 
 const common = require('../common');
-const fs = require('fs');
-const platformTimeout = common.platformTimeout;
+const assert = require('assert');
 
+let called = false;
 const t1 = setInterval(() => {
-  common.busyLoop(platformTimeout(12));
-}, platformTimeout(10));
-
-const t2 = setInterval(() => {
-  common.busyLoop(platformTimeout(15));
-}, platformTimeout(10));
-
-const t3 =
-  setTimeout(common.mustNotCall('eventloop blocked!'), platformTimeout(200));
-
-setTimeout(function() {
-  fs.stat('/dev/nonexistent', () => {
+  assert(!called);
+  called = true;
+  setImmediate(common.mustCall(() => {
     clearInterval(t1);
     clearInterval(t2);
-    clearTimeout(t3);
-  });
-}, platformTimeout(50));
+  }));
+}, 10);
+
+const t2 = setInterval(() => {
+  common.busyLoop(20);
+}, 10);


### PR DESCRIPTION
Due to extensive reliance on timings and the fs module, this test
is currently inherently flaky. Refactor it to simply use setImmediate
and only one busy loop.

CI: https://ci.nodejs.org/job/node-test-pull-request/12934/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test