### PR TITLE
net: remove Socket.prototoype.read

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -397,15 +397,6 @@ function writeAfterFIN(chunk, encoding, cb) {
   }
 }
 
-Socket.prototype.read = function(n) {
-  if (n === 0)
-    return stream.Readable.prototype.read.call(this, n);
-
-  this.read = stream.Readable.prototype.read;
-  this._consuming = true;
-  return this.read(n);
-};
-
 Socket.prototype.setTimeout = function(msecs, callback) {
   // Type checking identical to timers.enroll()
   msecs = validateTimerDuration(msecs);


### PR DESCRIPTION
Unused since 34b535f4caba366789d949211e4369b1e1d01152.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

net

CI: https://ci.nodejs.org/job/node-test-commit/15943/