### PR TITLE
tools: add .mjs linting for Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -509,7 +509,7 @@ if defined lint_js_ci goto lint-js-ci
 if not defined lint_js goto exit
 if not exist tools\node_modules\eslint goto no-lint
 echo running lint-js
-%config%\node tools\node_modules\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.md benchmark doc lib test tools
+%config%\node tools\node_modules\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.mjs,.md benchmark doc lib test tools
 goto exit
 
 :lint-js-ci


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools, modules

Sync Windows linting with https://github.com/nodejs/node/blob/05e702d9f16f6808e83f6a47cfa4294dea3f7343/Makefile#L1104

This seems to be slipped in https://github.com/nodejs/node/commit/c8a389e19f172edbada83f59944cad7cc802d9d5
