### PR TITLE
src: set thread local env in CreateEnvironment

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -373,11 +373,6 @@ inline Environment::~Environment() {
   ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
 #undef V
 
-  auto tl_env = static_cast<Environment*>(uv_key_get(&thread_local_env));
-  if (tl_env == this) {
-    uv_key_delete(&Environment::thread_local_env);
-  }
-
   delete[] heap_statistics_buffer_;
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;

--- a/src/env.cc
+++ b/src/env.cc
@@ -80,6 +80,11 @@ v8::CpuProfiler* IsolateData::GetCpuProfiler() {
   return cpu_profiler_;
 }
 
+
+void InitThreadLocalOnce() {
+  CHECK_EQ(0, uv_key_create(&Environment::thread_local_env));
+}
+
 void Environment::Start(int argc,
                         const char* const* argv,
                         int exec_argc,
@@ -148,7 +153,8 @@ void Environment::Start(int argc,
   SetupProcessObject(this, argc, argv, exec_argc, exec_argv);
   LoadAsyncWrapperInfo(this);
 
-  CHECK_EQ(0, uv_key_create(&thread_local_env));
+  static uv_once_t init_once = UV_ONCE_INIT;
+  uv_once(&init_once, InitThreadLocalOnce);
   uv_key_set(&thread_local_env, this);
 }
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -147,6 +147,9 @@ void Environment::Start(int argc,
 
   SetupProcessObject(this, argc, argv, exec_argc, exec_argv);
   LoadAsyncWrapperInfo(this);
+
+  CHECK_EQ(0, uv_key_create(&thread_local_env));
+  uv_key_set(&thread_local_env, this);
 }
 
 void Environment::CleanupHandles() {
@@ -470,5 +473,7 @@ void Environment::AsyncHooks::grow_async_ids_stack() {
       env()->async_ids_stack_string(),
       async_ids_stack_.GetJSArray()).FromJust();
 }
+
+uv_key_t Environment::thread_local_env = {};
 
 }  // namespace node

--- a/src/env.h
+++ b/src/env.h
@@ -371,6 +371,7 @@ struct ContextInfo {
   bool is_default = false;
 };
 
+
 class Environment {
  public:
   class AsyncHooks {
@@ -543,6 +544,8 @@ class Environment {
   template <typename T>
   static inline Environment* GetCurrent(
       const v8::PropertyCallbackInfo<T>& info);
+
+  static inline Environment* GetThreadLocalEnv();
 
   inline Environment(IsolateData* isolate_data, v8::Local<v8::Context> context);
   inline ~Environment();
@@ -831,6 +834,8 @@ class Environment {
   static void EnvPromiseHook(v8::PromiseHookType type,
                              v8::Local<v8::Promise> promise,
                              v8::Local<v8::Value> parent);
+
+  static uv_key_t thread_local_env;
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/env.h
+++ b/src/env.h
@@ -545,6 +545,7 @@ class Environment {
   static inline Environment* GetCurrent(
       const v8::PropertyCallbackInfo<T>& info);
 
+  static uv_key_t thread_local_env;
   static inline Environment* GetThreadLocalEnv();
 
   inline Environment(IsolateData* isolate_data, v8::Local<v8::Context> context);
@@ -835,7 +836,6 @@ class Environment {
                              v8::Local<v8::Promise> promise,
                              v8::Local<v8::Value> parent);
 
-  static uv_key_t thread_local_env;
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/env.h
+++ b/src/env.h
@@ -371,7 +371,6 @@ struct ContextInfo {
   bool is_default = false;
 };
 
-
 class Environment {
  public:
   class AsyncHooks {
@@ -835,7 +834,6 @@ class Environment {
   static void EnvPromiseHook(v8::PromiseHookType type,
                              v8::Local<v8::Promise> promise,
                              v8::Local<v8::Value> parent);
-
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/node.cc
+++ b/src/node.cc
@@ -4296,12 +4296,18 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
   HandleScope handle_scope(isolate);
   Context::Scope context_scope(context);
   auto env = new Environment(isolate_data, context);
+  CHECK_EQ(0, uv_key_create(&thread_local_env));
+  uv_key_set(&thread_local_env, env);
   env->Start(argc, argv, exec_argc, exec_argv, v8_is_profiling);
   return env;
 }
 
 
 void FreeEnvironment(Environment* env) {
+  auto tl_env = static_cast<Environment*>(uv_key_get(&thread_local_env));
+  if (tl_env == env) {
+    uv_key_delete(&thread_local_env);
+  }
   delete env;
 }
 

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -33,6 +33,16 @@ TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   EXPECT_TRUE(called_cb_1);
 }
 
+TEST_F(EnvironmentTest, AtExitWithoutEnvironment) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env {handle_scope, argv, this};
+
+  AtExit(at_exit_callback1);  // No Environment is passed to AtExit.
+  RunAtExit(*env);
+  EXPECT_TRUE(called_cb_1);
+}
+
 TEST_F(EnvironmentTest, AtExitWithArgument) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -36,7 +36,7 @@ TEST_F(EnvironmentTest, AtExitWithEnvironment) {
 TEST_F(EnvironmentTest, AtExitWithoutEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, argv, this};
+  Env env {handle_scope, argv};
 
   AtExit(at_exit_callback1);  // No Environment is passed to AtExit.
   RunAtExit(*env);


### PR DESCRIPTION
This commit set the Environment as a thread local when CreateEnvironment
is called which is currently not being done. This would lead to a
segment fault if later node::AtExit is called without specifying the
environment parameter. This specific issue was reported by Electron.

If I recall correctly, back when this was implemented the motivation was
that if embedders have multiple environments per isolate they should be
using the AtExit functions that take an environment. This is not the
case with Electron which only create a single environment (as far as I
know), and if a native module calls AtExit this would lead to the
segment fault.

I was able to reproduce Electron issue and the provided test simulates
it. I was also able to use this patch and verify that it works for the
Electron issue as well.

Refs: https://github.com/nodejs/node/pull/9163
Refs: https://github.com/electron/electron/issues/11299


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src