### PR TITLE
timers: clean up, async integration for unref, simplify clearTimeout

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -260,7 +260,7 @@ TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
       continue;
     }
 
-    tryOnTimeout(timer, list);
+    tryOnTimeout(timer);
   }
 
   // If `L.peek(list)` returned nothing, the list was either empty or we have
@@ -289,7 +289,7 @@ TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
 
 // An optimization so that the try/finally only de-optimizes (since at least v8
 // 4.7) what is in this smaller function.
-function tryOnTimeout(timer, list) {
+function tryOnTimeout(timer) {
   timer._called = true;
   const timerAsyncId = (typeof timer[async_id_symbol] === 'number') ?
     timer[async_id_symbol] : null;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -465,8 +465,8 @@ function rearm(timer, start = TimerWrap.now()) {
 
 
 const clearTimeout = exports.clearTimeout = function(timer) {
-  if (timer && (timer[kOnTimeout] || timer._onTimeout)) {
-    timer[kOnTimeout] = timer._onTimeout = null;
+  if (timer && timer._onTimeout) {
+    timer._onTimeout = null;
     if (timer instanceof Timeout) {
       timer.close(); // for after === 0
     } else {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -442,8 +442,7 @@ function ontimeout(timer, start) {
     rearm(timer, start);
 }
 
-
-function rearm(timer, start) {
+function rearm(timer, start = TimerWrap.now()) {
   // // Do not re-arm unenroll'd or closed timers.
   if (timer._idleTimeout === -1) return;
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -289,7 +289,7 @@ TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
 
 // An optimization so that the try/finally only de-optimizes (since at least v8
 // 4.7) what is in this smaller function.
-function tryOnTimeout(timer) {
+function tryOnTimeout(timer, start) {
   timer._called = true;
   const timerAsyncId = (typeof timer[async_id_symbol] === 'number') ?
     timer[async_id_symbol] : null;
@@ -297,7 +297,7 @@ function tryOnTimeout(timer) {
   if (timerAsyncId !== null)
     emitBefore(timerAsyncId, timer[trigger_async_id_symbol]);
   try {
-    ontimeout(timer);
+    ontimeout(timer, start);
     threw = false;
   } finally {
     if (timerAsyncId !== null) {
@@ -520,7 +520,7 @@ function unrefdHandle(now) {
   try {
     // Don't attempt to call the callback if it is not a function.
     if (typeof this.owner._onTimeout === 'function') {
-      ontimeout(this.owner, now);
+      tryOnTimeout(this.owner, now);
     }
   } finally {
     // Make sure we clean up if the callback is no longer a function

--- a/test/async-hooks/test-timers.setTimeout.js
+++ b/test/async-hooks/test-timers.setTimeout.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const tick = require('./tick');
+const initHooks = require('./init-hooks');
+const { checkInvocations } = require('./hook-checks');
+const TIMEOUT = common.platformTimeout(100);
+
+const hooks = initHooks();
+hooks.enable();
+
+// install first timeout
+setTimeout(common.mustCall(ontimeout), TIMEOUT);
+const as = hooks.activitiesOfTypes('Timeout');
+assert.strictEqual(as.length, 1);
+const t1 = as[0];
+assert.strictEqual(t1.type, 'Timeout');
+assert.strictEqual(typeof t1.uid, 'number');
+assert.strictEqual(typeof t1.triggerAsyncId, 'number');
+checkInvocations(t1, { init: 1 }, 't1: when first timer installed');
+
+let timer;
+let t2;
+function ontimeout() {
+  checkInvocations(t1, { init: 1, before: 1 }, 't1: when first timer fired');
+
+  setTimeout(onSecondTimeout, TIMEOUT).unref();
+  const as = hooks.activitiesOfTypes('Timeout');
+  t2 = as[1];
+  assert.strictEqual(as.length, 2);
+  checkInvocations(t1, { init: 1, before: 1 },
+                   't1: when second timer installed');
+  checkInvocations(t2, { init: 1 },
+                   't2: when second timer installed');
+
+  timer = setTimeout(common.mustNotCall(), 2 ** 31 - 1);
+}
+
+function onSecondTimeout() {
+  const as = hooks.activitiesOfTypes('Timeout');
+  assert.strictEqual(as.length, 3);
+  checkInvocations(t1, { init: 1, before: 1, after: 1 },
+                   't1: when second timer fired');
+  checkInvocations(t2, { init: 1, before: 1 },
+                   't2: when second timer fired');
+  clearTimeout(timer);
+  tick(2);
+}
+
+process.on('exit', onexit);
+
+function onexit() {
+  hooks.disable();
+  hooks.sanityCheck('Timeout');
+
+  checkInvocations(t1, { init: 1, before: 1, after: 1, destroy: 1 },
+                   't1: when process exits');
+  checkInvocations(t2, { init: 1, before: 1, after: 1, destroy: 1 },
+                   't2: when process exits');
+}

--- a/test/parallel/test-timers-timeout-to-interval.js
+++ b/test/parallel/test-timers-timeout-to-interval.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../common');
+
+// This isn't officially supported but nonetheless is something that is
+// currently possible and as such it shouldn't cause the process to crash
+
+const t = setTimeout(common.mustCall(() => {
+  if (t._repeat) {
+    clearInterval(t);
+  }
+  t._repeat = true;
+}, 2), 1);


### PR DESCRIPTION
Assorted, small changes to timers:

1. A recent commit removed the usage of the second argument of `tryOnTimeout` but left the definition in place. Remove it.

2. It's possible for user-code to flip an existing timeout to be an interval during its execution, in which case the current code would crash due to `start` being undefined. Fix this by providing a default `start` value within `rearm`.

3. When async hooks integration for Timers was introduced, it was not included in the code for unref'd or subsequently ref'd timers which means those timers only have TIMERWRAP hooks.

4. Remove dead code from timeout & interval clearing — `timer[kOnTimeout]` is not something that can exist, as `kOnTimeout` only exists on `TimerWrap`.

The first two commits are semver-major as they rely on several prior semver-major PRs, the other two can both go into 8.x & 9.x and I will handle back-porting these sometime later this month.

Benchmark results:

```
 timers/timers-breadth.js thousands=5000                    -0.49 %       ±3.13%   ±4.13%   ±5.31%
 timers/timers-cancel-pooled.js millions=5          ***   1643.69 %      ±84.28% ±111.55% ±144.05%
 timers/timers-cancel-unpooled.js millions=1        ***    101.54 %       ±9.13%  ±12.06%  ±15.51%
 timers/timers-depth.js thousands=1                         -0.01 %       ±0.09%   ±0.12%   ±0.15%
 timers/timers-insert-pooled.js millions=5                   0.43 %       ±2.05%   ±2.71%   ±3.48%
 timers/timers-insert-unpooled.js millions=1                 0.80 %       ±3.13%   ±4.13%   ±5.30%
 timers/timers-timeout-pooled.js millions=10                -2.38 %       ±4.92%   ±6.49%   ±8.34%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers, test