### PR TITLE
test: convert new tests to use error types

### DIFF
--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -60,7 +60,7 @@ arrayTypes.forEach((currentType) => {
   const template = Reflect.construct(currentType, buffer);
   assert.throws(() => {
     test_typedarray.CreateTypedArray(template, buffer, 0, 136);
-  }, /Invalid typed array length/);
+  }, RangeError);
 });
 
 const nonByteArrayTypes = [ Int16Array, Uint16Array, Int32Array, Uint32Array,
@@ -71,5 +71,5 @@ nonByteArrayTypes.forEach((currentType) => {
     test_typedarray.CreateTypedArray(template, buffer,
                                      currentType.BYTES_PER_ELEMENT + 1, 1);
     console.log(`start of offset ${currentType}`);
-  }, /start offset of/);
+  }, RangeError);
 });

--- a/test/parallel/test-console-assign-undefined.js
+++ b/test/parallel/test-console-assign-undefined.js
@@ -17,8 +17,7 @@ assert.strictEqual(global.console, 42);
 common.expectsError(
   () => console.log('foo'),
   {
-    type: TypeError,
-    message: 'console.log is not a function'
+    type: TypeError
   }
 );
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

Some new tests were added recently that rely on error messages that are incompatible with Node-ChakraCore. This PR simply reverts the test to only relying on error type, rather than error message. `vcbuild test` is actually failing for me on an unrelated test, sequential/test-inspector-port-cluster, but I might make a new issue for that separately.
