### PR TITLE
timers: refactor timer list processing

### DIFF
--- a/benchmark/timers/timers-timeout-unpooled.js
+++ b/benchmark/timers/timers-timeout-unpooled.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common.js');
+
+// The following benchmark sets up n * 1e6 unpooled timeouts,
+// then measures their execution on the next uv tick
+
+const bench = common.createBenchmark(main, {
+  millions: [1],
+});
+
+function main({ millions }) {
+  const iterations = millions * 1e6;
+  let count = 0;
+
+  // Function tracking on the hidden class in V8 can cause misleading
+  // results in this benchmark if only a single function is used —
+  // alternate between two functions for a fairer benchmark
+
+  function cb() {
+    count++;
+    if (count === iterations)
+      bench.end(iterations / 1e6);
+  }
+  function cb2() {
+    count++;
+    if (count === iterations)
+      bench.end(iterations / 1e6);
+  }
+
+  for (var i = 0; i < iterations; i++) {
+    // unref().ref() will cause each of these timers to
+    // allocate their own handle
+    setTimeout(i % 2 ? cb : cb2, 1).unref().ref();
+  }
+
+  bench.start();
+}

--- a/benchmark/timers/timers-timeout-unpooled.js
+++ b/benchmark/timers/timers-timeout-unpooled.js
@@ -5,11 +5,10 @@ const common = require('../common.js');
 // then measures their execution on the next uv tick
 
 const bench = common.createBenchmark(main, {
-  millions: [1],
+  n: [1e6],
 });
 
-function main({ millions }) {
-  const iterations = millions * 1e6;
+function main({ n }) {
   let count = 0;
 
   // Function tracking on the hidden class in V8 can cause misleading
@@ -18,16 +17,16 @@ function main({ millions }) {
 
   function cb() {
     count++;
-    if (count === iterations)
-      bench.end(iterations / 1e6);
+    if (count === n)
+      bench.end(n);
   }
   function cb2() {
     count++;
-    if (count === iterations)
-      bench.end(iterations / 1e6);
+    if (count === n)
+      bench.end(n);
   }
 
-  for (var i = 0; i < iterations; i++) {
+  for (var i = 0; i < n; i++) {
     // unref().ref() will cause each of these timers to
     // allocate their own handle
     setTimeout(i % 2 ? cb : cb2, 1).unref().ref();

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -24,7 +24,7 @@
 const async_wrap = process.binding('async_wrap');
 const {
   Timer: TimerWrap,
-  setImmediateCallback,
+  setupTimers,
 } = process.binding('timer_wrap');
 const L = require('internal/linkedlist');
 const timerInternals = require('internal/timers');
@@ -34,7 +34,6 @@ const assert = require('assert');
 const util = require('util');
 const errors = require('internal/errors');
 const debug = util.debuglog('timer');
-const kOnTimeout = TimerWrap.kOnTimeout | 0;
 // Two arrays that share state between C++ and JS.
 const { async_hook_fields, async_id_fields } = async_wrap;
 const {
@@ -57,7 +56,7 @@ const kRefCount = 1;
 const kHasOutstanding = 2;
 
 const [immediateInfo, toggleImmediateRef] =
-  setImmediateCallback(processImmediate);
+  setupTimers(processImmediate, processTimers);
 
 const kRefed = Symbol('refed');
 
@@ -221,10 +220,14 @@ function TimersList(msecs, unrefed) {
   timer.start(msecs);
 }
 
-// adds listOnTimeout to the C++ object prototype, as
-// V8 would not inline it otherwise.
-TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
-  const list = this._list;
+function processTimers(now) {
+  if (this.owner)
+    return unrefdHandle(this.owner, now);
+  return listOnTimeout(this, now);
+}
+
+function listOnTimeout(handle, now) {
+  const list = handle._list;
   const msecs = list.msecs;
 
   debug('timeout callback %d', msecs);
@@ -241,7 +244,7 @@ TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
       if (timeRemaining <= 0) {
         timeRemaining = 1;
       }
-      this.start(timeRemaining);
+      handle.start(timeRemaining);
       debug('%d list wait because diff is %d', msecs, diff);
       return true;
     }
@@ -280,11 +283,11 @@ TimerWrap.prototype[kOnTimeout] = function listOnTimeout(now) {
 
   // Do not close the underlying handle if its ownership has changed
   // (e.g it was unrefed in its callback).
-  if (!this.owner)
-    this.close();
+  if (!handle.owner)
+    handle.close();
 
   return true;
-};
+}
 
 
 // An optimization so that the try/finally only de-optimizes (since at least v8
@@ -516,18 +519,17 @@ exports.clearInterval = function(timer) {
 };
 
 
-function unrefdHandle(now) {
+function unrefdHandle(timer, now) {
   try {
     // Don't attempt to call the callback if it is not a function.
-    if (typeof this.owner._onTimeout === 'function') {
-      tryOnTimeout(this.owner, now);
+    if (typeof timer._onTimeout === 'function') {
+      tryOnTimeout(timer, now);
     }
   } finally {
     // Make sure we clean up if the callback is no longer a function
     // even if the timer is an interval.
-    if (!this.owner._repeat ||
-        typeof this.owner._onTimeout !== 'function') {
-      this.owner.close();
+    if (!timer._repeat || typeof timer._onTimeout !== 'function') {
+      timer.close();
     }
   }
 
@@ -557,7 +559,6 @@ Timeout.prototype.unref = function() {
 
     this._handle = handle || new TimerWrap();
     this._handle.owner = this;
-    this._handle[kOnTimeout] = unrefdHandle;
     this._handle.start(delay);
     this._handle.unref();
   }
@@ -581,7 +582,6 @@ Timeout.prototype.close = function() {
     }
 
     this._idleTimeout = -1;
-    this._handle[kOnTimeout] = null;
     this._handle.close();
   } else {
     unenroll(this);

--- a/src/env.h
+++ b/src/env.h
@@ -308,6 +308,7 @@ class ModuleWrap;
   V(secure_context_constructor_template, v8::FunctionTemplate)                \
   V(tcp_constructor_template, v8::FunctionTemplate)                           \
   V(tick_callback_function, v8::Function)                                     \
+  V(timers_callback_function, v8::Function)                                   \
   V(tls_wrap_constructor_function, v8::Function)                              \
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \

--- a/test/message/timeout_throw.out
+++ b/test/message/timeout_throw.out
@@ -5,4 +5,5 @@ ReferenceError: undefined_reference_error_maker is not defined
     at Timeout._onTimeout (*test*message*timeout_throw.js:*:*)
     at ontimeout (timers.js:*:*)
     at tryOnTimeout (timers.js:*:*)
-    at Timer.listOnTimeout (timers.js:*:*)
+    at listOnTimeout (timers.js:*:*)
+    at Timer.processTimers (timers.js:*:*)


### PR DESCRIPTION
(~~The first commit is from https://github.com/nodejs/node/pull/18579. I will rebase once that PR lands.~~ Rebased.)

Currently timer handles have their processing function stored at `kOnTimeout` (which is an index = 0). This isn't actually completely efficient, even if the function is declared on the `prototype`, as it requires replacing when `unref` is called and un-assigning it when clearing timeouts. It also requires a property lookup in C++ which is a tad slow.

Instead, it's possible to pass in a function from JS to C++ at startup, similar to how Immediates work currently, which is then called from C++ and that function then decides what to do further (that is, whether to call `listOnTimeout` or `unrefdHandle`).

Locally, this change yields a roughly 10% improvement on the newly introduced benchmark for unpooled execution.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark, timers