### PR TITLE
test: properly tag anonymous namespaces

### DIFF
--- a/test/addons-napi/test_make_callback/binding.cc
+++ b/test/addons-napi/test_make_callback/binding.cc
@@ -54,6 +54,6 @@ napi_value Init(napi_env env, napi_value exports) {
   return exports;
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_make_callback_recurse/binding.cc
+++ b/test/addons-napi/test_make_callback_recurse/binding.cc
@@ -28,6 +28,6 @@ napi_value Init(napi_env env, napi_value exports) {
   return exports;
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons/async-hooks-id/binding.cc
+++ b/test/addons/async-hooks-id/binding.cc
@@ -22,6 +22,6 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "getTriggerAsyncId", GetTriggerAsyncId);
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -109,6 +109,6 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "getResource", GetResource);
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -69,6 +69,6 @@ void Initialize(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "testResolveAsync", TestResolveAsync);
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -26,6 +26,6 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "makeCallback", MakeCallback);
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -34,6 +34,6 @@ void Initialize(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "makeCallback", MakeCallback);
 }
 
-}  // namespace
+}  // anonymous namespace
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -398,7 +398,7 @@ static const std::string WsHandshakeRequest(const std::string& target_id) {
          "Sec-WebSocket-Key: aaa==\r\n"
          "Sec-WebSocket-Version: 13\r\n\r\n";
 }
-}  // namespace
+}  // anonymous namespace
 
 
 TEST_F(InspectorSocketServerTest, InspectorSessions) {


### PR DESCRIPTION
For tests that use anonymous namespaces, some tagged the close
of the namespace with 'namespace' while others used
'anonymous namespace'. It was suggested I should use
'anonymous namespace' in a recent PR review so make all of the
tests consistent with this.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test