### PR TITLE
test: fix flaky test-http2-session-unref

### DIFF
--- a/test/parallel/test-http2-session-unref.js
+++ b/test/parallel/test-http2-session-unref.js
@@ -49,5 +49,3 @@ server.listen(0, common.mustCall(() => {
 }));
 server.emit('connection', serverSide);
 server.unref();
-
-setTimeout(common.mustNotCall(() => {}), 1000).unref();


### PR DESCRIPTION
This test should exit naturally or will timeout on its own, a separate unrefed timer is not necessary.

Fixes: https://github.com/nodejs/node/issues/18587

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test