### PR TITLE
doc: fix typo in n-api.md

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3449,7 +3449,7 @@ invoking the callback. This should be a value previously obtained
 from [`napi_async_init`][].
 - `[out] result`: The newly created scope.
 
-There are cases(for example resolving promises) where it is
+There are cases (for example resolving promises) where it is
 necessary to have the equivalent of the scope associated with a callback
 in place when making certain N-API calls.  If there is no other script on
 the stack the [`napi_open_callback_scope`][] and


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api
