### PR TITLE
fs: make URL paths no longer experimental

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -164,9 +164,6 @@ example `fs.readdirSync('c:\\')` can potentially return a different result than
 <!-- YAML
 added: v7.6.0
 -->
-
-> Stability: 1 - Experimental
-
 For most `fs` module functions, the `path` or `filename` argument may be passed
 as a WHATWG [`URL`][] object. Only [`URL`][] objects using the `file:` protocol
 are supported.


### PR DESCRIPTION
Specifying fs paths as URLs isn't really experimental any more.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs