### PR TITLE
module: use undefined if no main

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -652,9 +652,8 @@ void Close(const FunctionCallbackInfo<Value>& args) {
 
 
 // Used to speed up module loading.  Returns the contents of the file as
-// a string or undefined when the file cannot be opened.  Returns an empty
-// string when the file does not contain the substring '"main"' because that
-// is the property we care about.
+// a string or undefined when the file cannot be opened or "main" is not found
+// in the file.
 static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   uv_loop_t* loop = env->event_loop();
@@ -704,7 +703,7 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
 
   const size_t size = offset - start;
   if (size == 0 || size == SearchString(&chars[start], size, "\"main\"")) {
-    args.GetReturnValue().SetEmptyString();
+    return;
   } else {
     Local<String> chars_string =
         String::NewFromUtf8(env->isolate(),

--- a/test/parallel/test-module-binding.js
+++ b/test/parallel/test-module-binding.js
@@ -6,8 +6,9 @@ const { readFileSync } = require('fs');
 const { strictEqual } = require('assert');
 
 strictEqual(internalModuleReadJSON('nosuchfile'), undefined);
-strictEqual(internalModuleReadJSON(fixtures.path('empty.txt')), '');
-strictEqual(internalModuleReadJSON(fixtures.path('empty-with-bom.txt')), '');
+strictEqual(internalModuleReadJSON(fixtures.path('empty.txt')), undefined);
+strictEqual(internalModuleReadJSON(fixtures.path('empty-with-bom.txt')),
+            undefined);
 {
   const filename = fixtures.path('require-bin/package.json');
   strictEqual(internalModuleReadJSON(filename), readFileSync(filename, 'utf8'));


### PR DESCRIPTION
If the package.json file does not have a "main" entry, return undefined
rather than an empty string. This is to make more consistent behavior.
For example, when package.json is a directory, "main" is undefined
rather than an empty string.

@bmeck @bnoordhuis Is this an acceptable resolution of the "package.json as a directory leaves `main` undefined if we land https://github.com/nodejs/node/pull/18270, but package.json as a file without a `main` sets `main` to an empty string" disagreement? Opening a PR because I figure it would be easier to determine "yes" or "no" with an actual proposal to look at. I *believe* @bmeck would prefer the empty string for both scenarios, but I also believe that `undefined` is acceptable to them too as long as it applies to both scenarios. But I could be wrong...

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
module