### PR TITLE
path: refactor to reduce duplicated codes

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -29,89 +29,26 @@ function assertPath(path) {
   }
 }
 
-// Resolves . and .. elements in a path with directory names
-function normalizeStringWin32(path, allowAboveRoot) {
-  var res = '';
-  var lastSegmentLength = 0;
-  var lastSlash = -1;
-  var dots = 0;
-  var code;
-  for (var i = 0; i <= path.length; ++i) {
-    if (i < path.length)
-      code = path.charCodeAt(i);
-    else if (code === 47/*/*/ || code === 92/*\*/)
-      break;
-    else
-      code = 47/*/*/;
-    if (code === 47/*/*/ || code === 92/*\*/) {
-      if (lastSlash === i - 1 || dots === 1) {
-        // NOOP
-      } else if (lastSlash !== i - 1 && dots === 2) {
-        if (res.length < 2 || lastSegmentLength !== 2 ||
-            res.charCodeAt(res.length - 1) !== 46/*.*/ ||
-            res.charCodeAt(res.length - 2) !== 46/*.*/) {
-          if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('\\');
-            if (lastSlashIndex !== res.length - 1) {
-              if (lastSlashIndex === -1) {
-                res = '';
-                lastSegmentLength = 0;
-              } else {
-                res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('\\');
-              }
-              lastSlash = i;
-              dots = 0;
-              continue;
-            }
-          } else if (res.length === 2 || res.length === 1) {
-            res = '';
-            lastSegmentLength = 0;
-            lastSlash = i;
-            dots = 0;
-            continue;
-          }
-        }
-        if (allowAboveRoot) {
-          if (res.length > 0)
-            res += '\\..';
-          else
-            res = '..';
-          lastSegmentLength = 2;
-        }
-      } else {
-        if (res.length > 0)
-          res += '\\' + path.slice(lastSlash + 1, i);
-        else
-          res = path.slice(lastSlash + 1, i);
-        lastSegmentLength = i - lastSlash - 1;
-      }
-      lastSlash = i;
-      dots = 0;
-    } else if (code === 46/*.*/ && dots !== -1) {
-      ++dots;
-    } else {
-      dots = -1;
-    }
-  }
-  return res;
+function isSlash(code, win32) {
+  return code === 47/*/*/ || (win32 && code === 92/*\*/);
 }
 
 // Resolves . and .. elements in a path with directory names
-function normalizeStringPosix(path, allowAboveRoot) {
+function _normalizeString(path, allowAboveRoot, win32) {
   var res = '';
   var lastSegmentLength = 0;
   var lastSlash = -1;
   var dots = 0;
   var code;
+  var slashChar = win32 ? '\\' : '/';
   for (var i = 0; i <= path.length; ++i) {
     if (i < path.length)
       code = path.charCodeAt(i);
-    else if (code === 47/*/*/)
+    else if (isSlash(code, win32))
       break;
     else
       code = 47/*/*/;
-    if (code === 47/*/*/) {
+    if (isSlash(code, win32)) {
       if (lastSlash === i - 1 || dots === 1) {
         // NOOP
       } else if (lastSlash !== i - 1 && dots === 2) {
@@ -119,14 +56,14 @@ function normalizeStringPosix(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== 46/*.*/ ||
             res.charCodeAt(res.length - 2) !== 46/*.*/) {
           if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('/');
+            const lastSlashIndex = res.lastIndexOf(slashChar);
             if (lastSlashIndex !== res.length - 1) {
               if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
                 res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('/');
+                lastSegmentLength = res.length - 1 - res.lastIndexOf(slashChar);
               }
               lastSlash = i;
               dots = 0;
@@ -142,14 +79,14 @@ function normalizeStringPosix(path, allowAboveRoot) {
         }
         if (allowAboveRoot) {
           if (res.length > 0)
-            res += '/..';
+            res += slashChar + '..';
           else
             res = '..';
           lastSegmentLength = 2;
         }
       } else {
         if (res.length > 0)
-          res += '/' + path.slice(lastSlash + 1, i);
+          res += slashChar + path.slice(lastSlash + 1, i);
         else
           res = path.slice(lastSlash + 1, i);
         lastSegmentLength = i - lastSlash - 1;
@@ -176,6 +113,162 @@ function _format(sep, pathObject) {
     return dir + base;
   }
   return dir + sep + base;
+}
+
+function _extname(path, win32) {
+  assertPath(path);
+  var start = 0;
+  var startDot = -1;
+  var startPart = 0;
+  var end = -1;
+  var matchedSlash = true;
+  // Track the state of characters (if any) we see before our first dot and
+  // after any path separator we find
+  var preDotState = 0;
+
+  // Check for a drive letter prefix so as not to mistake the following
+  // path separator as an extra separator at the end of the path that can be
+  // disregarded
+  if (win32 && path.length >= 2) {
+    const code = path.charCodeAt(0);
+    if (path.charCodeAt(1) === 58/*:*/ &&
+        ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+         (code >= 97/*a*/ && code <= 122/*z*/))) {
+      start = startPart = 2;
+    }
+  }
+
+  for (var i = path.length - 1; i >= start; --i) {
+    const code = path.charCodeAt(i);
+    if (isSlash(code, win32)) {
+      // If we reached a path separator that was not part of a set of path
+      // separators at the end of the string, stop now
+      if (!matchedSlash) {
+        startPart = i + 1;
+        break;
+      }
+      continue;
+    }
+    if (end === -1) {
+      // We saw the first non-path separator, mark this as the end of our
+      // extension
+      matchedSlash = false;
+      end = i + 1;
+    }
+    if (code === 46/*.*/) {
+      // If this is our first dot, mark it as the start of our extension
+      if (startDot === -1)
+        startDot = i;
+      else if (preDotState !== 1)
+        preDotState = 1;
+    } else if (startDot !== -1) {
+      // We saw a non-dot and non-path separator before our dot, so we should
+      // have a good chance at having a non-empty extension
+      preDotState = -1;
+    }
+  }
+
+  if (startDot === -1 ||
+      end === -1 ||
+      // We saw a non-dot character immediately before the dot
+      preDotState === 0 ||
+      // The (right-most) trimmed path component is exactly '..'
+      (preDotState === 1 &&
+       startDot === end - 1 &&
+       startDot === startPart + 1)) {
+    return '';
+  }
+  return path.slice(startDot, end);
+}
+
+function _basename(path, ext, win32) {
+  if (ext !== undefined && typeof ext !== 'string')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
+  assertPath(path);
+
+  var start = 0;
+  var end = -1;
+  var matchedSlash = true;
+  var i;
+
+  // Check for a drive letter prefix so as not to mistake the following
+  // path separator as an extra separator at the end of the path that can be
+  // disregarded
+  if (win32 && path.length >= 2) {
+    const drive = path.charCodeAt(0);
+    if ((drive >= 65/*A*/ && drive <= 90/*Z*/) ||
+        (drive >= 97/*a*/ && drive <= 122/*z*/)) {
+      if (path.charCodeAt(1) === 58/*:*/)
+        start = 2;
+    }
+  }
+
+  if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+    if (ext.length === path.length && ext === path)
+      return '';
+    var extIdx = ext.length - 1;
+    var firstNonSlashEnd = -1;
+    for (i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (isSlash(code, win32)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else {
+        if (firstNonSlashEnd === -1) {
+          // We saw the first non-path separator, remember this index in case
+          // we need it if the extension ends up not matching
+          matchedSlash = false;
+          firstNonSlashEnd = i + 1;
+        }
+        if (extIdx >= 0) {
+          // Try to match the explicit extension
+          if (code === ext.charCodeAt(extIdx)) {
+            if (--extIdx === -1) {
+              // We matched the extension, so mark this as the end of our path
+              // component
+              end = i;
+            }
+          } else {
+            // Extension does not match, so our result is the entire path
+            // component
+            extIdx = -1;
+            end = firstNonSlashEnd;
+          }
+        }
+      }
+    }
+
+    if (start === end)
+      end = firstNonSlashEnd;
+    else if (end === -1)
+      end = path.length;
+    return path.slice(start, end);
+  } else {
+    for (i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (isSlash(code, win32)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1)
+      return '';
+    return path.slice(start, end);
+  }
 }
 
 const win32 = {
@@ -325,7 +418,7 @@ const win32 = {
     // fails)
 
     // Normalize the tail path
-    resolvedTail = normalizeStringWin32(resolvedTail, !resolvedAbsolute);
+    resolvedTail = _normalizeString(resolvedTail, !resolvedAbsolute, true);
 
     return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
            '.';
@@ -425,7 +518,7 @@ const win32 = {
     var trailingSeparator = (code === 47/*/*/ || code === 92/*\*/);
     var tail;
     if (rootEnd < len)
-      tail = normalizeStringWin32(path.slice(rootEnd), !isAbsolute);
+      tail = _normalizeString(path.slice(rootEnd), !isAbsolute, true);
     else
       tail = '';
     if (tail.length === 0 && !isAbsolute)
@@ -814,159 +907,12 @@ const win32 = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
-    assertPath(path);
-    var start = 0;
-    var end = -1;
-    var matchedSlash = true;
-    var i;
-
-    // Check for a drive letter prefix so as not to mistake the following
-    // path separator as an extra separator at the end of the path that can be
-    // disregarded
-    if (path.length >= 2) {
-      const drive = path.charCodeAt(0);
-      if ((drive >= 65/*A*/ && drive <= 90/*Z*/) ||
-          (drive >= 97/*a*/ && drive <= 122/*z*/)) {
-        if (path.charCodeAt(1) === 58/*:*/)
-          start = 2;
-      }
-    }
-
-    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
-      if (ext.length === path.length && ext === path)
-        return '';
-      var extIdx = ext.length - 1;
-      var firstNonSlashEnd = -1;
-      for (i = path.length - 1; i >= start; --i) {
-        const code = path.charCodeAt(i);
-        if (code === 47/*/*/ || code === 92/*\*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else {
-          if (firstNonSlashEnd === -1) {
-            // We saw the first non-path separator, remember this index in case
-            // we need it if the extension ends up not matching
-            matchedSlash = false;
-            firstNonSlashEnd = i + 1;
-          }
-          if (extIdx >= 0) {
-            // Try to match the explicit extension
-            if (code === ext.charCodeAt(extIdx)) {
-              if (--extIdx === -1) {
-                // We matched the extension, so mark this as the end of our path
-                // component
-                end = i;
-              }
-            } else {
-              // Extension does not match, so our result is the entire path
-              // component
-              extIdx = -1;
-              end = firstNonSlashEnd;
-            }
-          }
-        }
-      }
-
-      if (start === end)
-        end = firstNonSlashEnd;
-      else if (end === -1)
-        end = path.length;
-      return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= start; --i) {
-        const code = path.charCodeAt(i);
-        if (code === 47/*/*/ || code === 92/*\*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
-    }
+    return _basename(path, ext, true);
   },
 
 
   extname: function extname(path) {
-    assertPath(path);
-    var start = 0;
-    var startDot = -1;
-    var startPart = 0;
-    var end = -1;
-    var matchedSlash = true;
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-    var preDotState = 0;
-
-    // Check for a drive letter prefix so as not to mistake the following
-    // path separator as an extra separator at the end of the path that can be
-    // disregarded
-    if (path.length >= 2) {
-      const code = path.charCodeAt(0);
-      if (path.charCodeAt(1) === 58/*:*/ &&
-          ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-           (code >= 97/*a*/ && code <= 122/*z*/))) {
-        start = startPart = 2;
-      }
-    }
-
-    for (var i = path.length - 1; i >= start; --i) {
-      const code = path.charCodeAt(i);
-      if (code === 47/*/*/ || code === 92/*\*/) {
-        // If we reached a path separator that was not part of a set of path
-        // separators at the end of the string, stop now
-        if (!matchedSlash) {
-          startPart = i + 1;
-          break;
-        }
-        continue;
-      }
-      if (end === -1) {
-        // We saw the first non-path separator, mark this as the end of our
-        // extension
-        matchedSlash = false;
-        end = i + 1;
-      }
-      if (code === 46/*.*/) {
-        // If this is our first dot, mark it as the start of our extension
-        if (startDot === -1)
-          startDot = i;
-        else if (preDotState !== 1)
-          preDotState = 1;
-      } else if (startDot !== -1) {
-        // We saw a non-dot and non-path separator before our dot, so we should
-        // have a good chance at having a non-empty extension
-        preDotState = -1;
-      }
-    }
-
-    if (startDot === -1 ||
-        end === -1 ||
-        // We saw a non-dot character immediately before the dot
-        preDotState === 0 ||
-        // The (right-most) trimmed path component is exactly '..'
-        (preDotState === 1 &&
-         startDot === end - 1 &&
-         startDot === startPart + 1)) {
-      return '';
-    }
-    return path.slice(startDot, end);
+    return _extname(path, true);
   },
 
 
@@ -1181,7 +1127,7 @@ const posix = {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeStringPosix(resolvedPath, !resolvedAbsolute);
+    resolvedPath = _normalizeString(resolvedPath, !resolvedAbsolute);
 
     if (resolvedAbsolute) {
       if (resolvedPath.length > 0)
@@ -1206,7 +1152,7 @@ const posix = {
     const trailingSeparator = path.charCodeAt(path.length - 1) === 47/*/*/;
 
     // Normalize the path
-    path = normalizeStringPosix(path, !isAbsolute);
+    path = _normalizeString(path, !isAbsolute);
 
     if (path.length === 0 && !isAbsolute)
       path = '.';
@@ -1373,133 +1319,12 @@ const posix = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
-    assertPath(path);
-
-    var start = 0;
-    var end = -1;
-    var matchedSlash = true;
-    var i;
-
-    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
-      if (ext.length === path.length && ext === path)
-        return '';
-      var extIdx = ext.length - 1;
-      var firstNonSlashEnd = -1;
-      for (i = path.length - 1; i >= 0; --i) {
-        const code = path.charCodeAt(i);
-        if (code === 47/*/*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else {
-          if (firstNonSlashEnd === -1) {
-            // We saw the first non-path separator, remember this index in case
-            // we need it if the extension ends up not matching
-            matchedSlash = false;
-            firstNonSlashEnd = i + 1;
-          }
-          if (extIdx >= 0) {
-            // Try to match the explicit extension
-            if (code === ext.charCodeAt(extIdx)) {
-              if (--extIdx === -1) {
-                // We matched the extension, so mark this as the end of our path
-                // component
-                end = i;
-              }
-            } else {
-              // Extension does not match, so our result is the entire path
-              // component
-              extIdx = -1;
-              end = firstNonSlashEnd;
-            }
-          }
-        }
-      }
-
-      if (start === end)
-        end = firstNonSlashEnd;
-      else if (end === -1)
-        end = path.length;
-      return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= 0; --i) {
-        if (path.charCodeAt(i) === 47/*/*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
-    }
+    return _basename(path, ext);
   },
 
 
   extname: function extname(path) {
-    assertPath(path);
-    var startDot = -1;
-    var startPart = 0;
-    var end = -1;
-    var matchedSlash = true;
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-    var preDotState = 0;
-    for (var i = path.length - 1; i >= 0; --i) {
-      const code = path.charCodeAt(i);
-      if (code === 47/*/*/) {
-        // If we reached a path separator that was not part of a set of path
-        // separators at the end of the string, stop now
-        if (!matchedSlash) {
-          startPart = i + 1;
-          break;
-        }
-        continue;
-      }
-      if (end === -1) {
-        // We saw the first non-path separator, mark this as the end of our
-        // extension
-        matchedSlash = false;
-        end = i + 1;
-      }
-      if (code === 46/*.*/) {
-        // If this is our first dot, mark it as the start of our extension
-        if (startDot === -1)
-          startDot = i;
-        else if (preDotState !== 1)
-          preDotState = 1;
-      } else if (startDot !== -1) {
-        // We saw a non-dot and non-path separator before our dot, so we should
-        // have a good chance at having a non-empty extension
-        preDotState = -1;
-      }
-    }
-
-    if (startDot === -1 ||
-        end === -1 ||
-        // We saw a non-dot character immediately before the dot
-        preDotState === 0 ||
-        // The (right-most) trimmed path component is exactly '..'
-        (preDotState === 1 &&
-         startDot === end - 1 &&
-         startDot === startPart + 1)) {
-      return '';
-    }
-    return path.slice(startDot, end);
+    return _extname(path);
   },
 
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -33,6 +33,11 @@ function isSlash(code, win32) {
   return code === 47/*/*/ || (win32 && code === 92/*\*/);
 }
 
+function isLetter(code) {
+  return (code >= 65/*A*/ && code <= 90/*Z*/) ||
+         (code >= 97/*a*/ && code <= 122/*z*/);
+}
+
 // Resolves . and .. elements in a path with directory names
 function _normalizeString(path, allowAboveRoot, win32) {
   var res = '';
@@ -132,8 +137,7 @@ function _extname(path, win32) {
   if (win32 && path.length >= 2) {
     const code = path.charCodeAt(0);
     if (path.charCodeAt(1) === 58/*:*/ &&
-        ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-         (code >= 97/*a*/ && code <= 122/*z*/))) {
+        (isLetter(code))) {
       start = startPart = 2;
     }
   }
@@ -196,8 +200,7 @@ function _basename(path, ext, win32) {
   // disregarded
   if (win32 && path.length >= 2) {
     const drive = path.charCodeAt(0);
-    if ((drive >= 65/*A*/ && drive <= 90/*Z*/) ||
-        (drive >= 97/*a*/ && drive <= 122/*z*/)) {
+    if (isLetter(drive)) {
       if (path.charCodeAt(1) === 58/*:*/)
         start = 2;
     }
@@ -369,8 +372,7 @@ const win32 = {
           } else {
             rootEnd = 1;
           }
-        } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                   (code >= 97/*a*/ && code <= 122/*z*/)) {
+        } else if (isLetter(code)) {
           // Possible device root
 
           if (path.charCodeAt(1) === 58/*:*/) {
@@ -490,8 +492,7 @@ const win32 = {
         } else {
           rootEnd = 1;
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if (isLetter(code)) {
         // Possible device root
 
         if (path.charCodeAt(1) === 58/*:*/) {
@@ -557,8 +558,7 @@ const win32 = {
     var code = path.charCodeAt(0);
     if (code === 47/*/*/ || code === 92/*\*/) {
       return true;
-    } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-               (code >= 97/*a*/ && code <= 122/*z*/)) {
+    } else if (isLetter(code)) {
       // Possible device root
 
       if (len > 2 && path.charCodeAt(1) === 58/*:*/) {
@@ -788,8 +788,7 @@ const win32 = {
             return '\\\\?\\UNC\\' + resolvedPath.slice(2);
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if (isLetter(code)) {
         // Possible device root
 
         if (resolvedPath.charCodeAt(1) === 58/*:*/ &&
@@ -864,8 +863,7 @@ const win32 = {
             }
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if (isLetter(code)) {
         // Possible device root
 
         if (path.charCodeAt(1) === 58/*:*/) {
@@ -983,8 +981,7 @@ const win32 = {
             }
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if (isLetter(code)) {
         // Possible device root
 
         if (path.charCodeAt(1) === 58/*:*/) {


### PR DESCRIPTION
There are many duplicated codes in methods such as `normalizeString`, `format`, `extname` and `basename`.

This change is to reduce them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
path