### PR TITLE
assert: fix throws trace

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -344,7 +344,7 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function compareKey(actual, expected, key, msg) {
+function compareExceptionKey(actual, expected, key, msg) {
   if (!isDeepStrictEqual(actual[key], expected[key])) {
     innerFail({
       actual: actual[key],
@@ -369,13 +369,13 @@ function expectedException(actual, expected, msg) {
     // The name and message could be non enumerable. Therefore test them
     // explicitly.
     if ('name' in expected) {
-      compareKey(actual, expected, 'name', msg);
+      compareExceptionKey(actual, expected, 'name', msg);
     }
     if ('message' in expected) {
-      compareKey(actual, expected, 'message', msg);
+      compareExceptionKey(actual, expected, 'message', msg);
     }
     for (const key of Object.keys(expected)) {
-      compareKey(actual, expected, key, msg);
+      compareExceptionKey(actual, expected, key, msg);
     }
     return true;
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -344,11 +344,17 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function createMsg(msg, key, actual, expected) {
-  if (msg)
-    return msg;
-  return `${key}: expected ${inspect(expected[key])}, ` +
-    `not ${inspect(actual[key])}`;
+function compareKey(actual, expected, key, msg) {
+  if (!isDeepStrictEqual(actual[key], expected[key])) {
+    innerFail({
+      actual: actual[key],
+      expected: expected[key],
+      message: msg || `${key}: expected ${inspect(expected[key])}, ` +
+                      `not ${inspect(actual[key])}`,
+      operator: 'throws',
+      stackStartFn: assert.throws
+    });
+  }
 }
 
 function expectedException(actual, expected, msg) {
@@ -363,23 +369,13 @@ function expectedException(actual, expected, msg) {
     // The name and message could be non enumerable. Therefore test them
     // explicitly.
     if ('name' in expected) {
-      assert.strictEqual(
-        actual.name,
-        expected.name,
-        createMsg(msg, 'name', actual, expected));
+      compareKey(actual, expected, 'name', msg);
     }
     if ('message' in expected) {
-      assert.strictEqual(
-        actual.message,
-        expected.message,
-        createMsg(msg, 'message', actual, expected));
+      compareKey(actual, expected, 'message', msg);
     }
-    const keys = Object.keys(expected);
-    for (const key of keys) {
-      assert.deepStrictEqual(
-        actual[key],
-        expected[key],
-        createMsg(msg, key, actual, expected));
+    for (const key of Object.keys(expected)) {
+      compareKey(actual, expected, key, msg);
     }
     return true;
   }

--- a/test/message/assert_throws_stack.js
+++ b/test/message/assert_throws_stack.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert').strict;
+
+assert.throws(() => { throw new Error('foo'); }, { bar: true });

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -1,0 +1,14 @@
+assert.js:*
+  throw new AssertionError(obj);
+  ^
+
+AssertionError [ERR_ASSERTION]: bar: expected true, not undefined
+    at Object.<anonymous> (*assert_throws_stack.js:*:*)
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *


### PR DESCRIPTION
The current stack trace thrown in case `assert.throws(fn, object)`
is used did not filter the stack trace. This fixes it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert