### PR TITLE
esm: revert format name to "cjs" over "commonjs"

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -137,7 +137,7 @@ module. This can be one of the following:
 | `format` | Description |
 | --- | --- |
 | `"esm"` | Load a standard JavaScript module |
-| `"commonjs"` | Load a node-style CommonJS module |
+| `"cjs"` | Load a node-style CommonJS module |
 | `"builtin"` | Load a node builtin CommonJS module |
 | `"json"` | Load a JSON file |
 | `"addon"` | Load a [C++ Addon][addons] |

--- a/lib/internal/loader/DefaultResolve.js
+++ b/lib/internal/loader/DefaultResolve.js
@@ -44,7 +44,7 @@ const extensionFormatMap = {
   '.mjs': 'esm',
   '.json': 'json',
   '.node': 'addon',
-  '.js': 'commonjs'
+  '.js': 'cjs'
 };
 
 function resolve(specifier, parentURL) {

--- a/lib/internal/loader/Translators.js
+++ b/lib/internal/loader/Translators.js
@@ -32,7 +32,7 @@ translators.set('esm', async (url) => {
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
-translators.set('commonjs', async (url) => {
+translators.set('cjs', async (url) => {
   debug(`Translating CJSModule ${url}`);
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const module = CJSModule._cache[


### PR DESCRIPTION
This reverts the change originally made in https://github.com/nodejs/node/pull/16874, returning the "format" name to `"cjs"` instead of `"commonjs"`.

There was some complaint over consistency of the new name form, so if we do want to change this should aim to get it in before that gets released.

Note the documentation change has already been released here, while the code change hasn't yet.

//cc @devsnek @MylesBorins @targos @jdalton 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
esm