### PR TITLE
benchmark: improve compare output

### DIFF
--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -80,6 +80,8 @@ if (showProgress) {
         conf += ` ${key}=${inspect(data.conf[key])}`;
       }
       conf = conf.slice(1);
+      // Escape quotes (") for correct csv formatting
+      conf = conf.replace(/"/g, '""');
 
       console.log(`"${job.binary}", "${job.filename}", "${conf}", ` +
                   `${data.rate}, ${data.time}`);

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const fork = require('child_process').fork;
+const { fork } = require('child_process');
+const { inspect } = require('util');
 const path = require('path');
 const CLI = require('./_cli.js');
 const BenchmarkProgress = require('./_benchmark_progress.js');
@@ -76,11 +77,9 @@ if (showProgress) {
       // Construct configuration string, " A=a, B=b, ..."
       let conf = '';
       for (const key of Object.keys(data.conf)) {
-        conf += ` ${key}=${JSON.stringify(data.conf[key])}`;
+        conf += ` ${key}=${inspect(data.conf[key])}`;
       }
       conf = conf.slice(1);
-      // Escape quotes (") for correct csv formatting
-      conf = conf.replace(/"/g, '""');
 
       console.log(`"${job.binary}", "${job.filename}", "${conf}", ` +
                   `${data.rate}, ${data.time}`);


### PR DESCRIPTION
The current output uses JSON.stringify to escape the config values.
This switches to util.inspect to have a better readable output.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark