### PR TITLE
stream: fix misleading error message

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -541,7 +541,7 @@ function clearBuffer(stream, state) {
 }
 
 Writable.prototype._write = function(chunk, encoding, cb) {
-  cb(new errors.Error('ERR_METHOD_NOT_IMPLEMENTED', '_transform'));
+  cb(new errors.Error('ERR_METHOD_NOT_IMPLEMENTED', '_write'));
 };
 
 Writable.prototype._writev = null;

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const Writable = require('stream').Writable;
@@ -25,6 +25,16 @@ w2.cork();
 w2.write(Buffer.from('blerg'));
 w2.write(Buffer.from('blerg'));
 w2.end();
+
+const w3 = new Writable();
+
+w3.on('error', common.expectsError({
+  type: Error,
+  code: 'ERR_METHOD_NOT_IMPLEMENTED',
+  message: 'The _write method is not implemented'
+}));
+
+w3.end(Buffer.from('blerg'));
 
 process.on('exit', function() {
   assert.strictEqual(w._write, _write);


### PR DESCRIPTION
The method to implement is `_write` not `_transform`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream