### PR TITLE
doc: add missing "changes" key in YAML comment

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1666,6 +1666,7 @@ Found'`.
 ## http.createServer([options][, requestListener])
 <!-- YAML
 added: v0.1.13
+changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/15752
     description: The `options` argument is supported now.


### PR DESCRIPTION
Fixes a YAML parse issue introduces in commit a899576c977aef32d85074ac09d511e4590e28d7.

It should unbreak CI.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc