### PR TITLE
assert: fix infinite loop

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -171,6 +171,8 @@ function createErrDiff(actual, expected, operator) {
     }
     actualLines.pop();
     expectedLines.pop();
+    if (actualLines.length === 0 || expectedLines.length === 0)
+      break;
     a = actualLines[actualLines.length - 1];
     b = expectedLines[expectedLines.length - 1];
   }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -297,8 +297,10 @@ class AssertionError extends Error {
       } else if (errorDiff === 1) {
         // In case the objects are equal but the operator requires unequal, show
         // the first object and say A equals B
-        const res = util
-          .inspect(actual, { compact: false }).split('\n');
+        const res = util.inspect(
+          actual,
+          { compact: false, customInspect: false }
+        ).split('\n');
 
         if (res.length > 20) {
           res[19] = '...';

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -151,9 +151,9 @@ function createErrDiff(actual, expected, operator) {
   var skipped = false;
   const util = lazyUtil();
   const actualLines = util
-    .inspect(actual, { compact: false }).split('\n');
+    .inspect(actual, { compact: false, customInspect: false }).split('\n');
   const expectedLines = util
-    .inspect(expected, { compact: false }).split('\n');
+    .inspect(expected, { compact: false, customInspect: false }).split('\n');
   const msg = `Input A expected to ${operator} input B:\n` +
         `${green}+ expected${white} ${red}- actual${white}`;
   const skippedMsg = ' ... Lines skipped';

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -908,7 +908,11 @@ common.expectsError(
     message: `${start}\n` +
     `${actExp}\n` +
     '\n' +
-    '  {}'
+    `${minus} {}\n` +
+    `${plus} {\n` +
+    `${plus}   loop: 'forever',\n` +
+    `${plus}   [Symbol(util.inspect.custom)]: [Function]\n` +
+    `${plus} }`
   });
 
   // notDeepEqual tests

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -31,6 +31,7 @@ const { EOL } = require('os');
 const EventEmitter = require('events');
 const { errorCache } = require('internal/errors');
 const { writeFileSync, unlinkSync } = require('fs');
+const { inspect } = require('util');
 const a = assert;
 
 function makeBlock(f) {
@@ -898,6 +899,17 @@ common.expectsError(
   assert.throws(
     () => assert.deepEqual(Array(12).fill(1), Array(12).fill(2)),
     { message });
+
+  const obj1 = {};
+  const obj2 = { loop: 'forever' };
+  obj2[inspect.custom] = () => '{}';
+  // No infinite loop and no custom inspect.
+  assert.throws(() => assert.deepEqual(obj1, obj2), {
+    message: `${start}\n` +
+    `${actExp}\n` +
+    '\n' +
+    '  {}'
+  });
 
   // notDeepEqual tests
   message = 'Identical input passed to notDeepStrictEqual:\n[\n  1\n]';


### PR DESCRIPTION
If an object has a custom inspect function set and it returns the same output for different objects and those objects are compared using strict assert, an infinite loop is triggered because a loop is not well defined.

Commit 1 fixes that. The second commit changes the output for strict assert to deactivate custom inspect functions. Showing identical output would be very confusing for users. This fixes that edge case.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert