### PR TITLE
stream: always defer readable in EOF when sync

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -489,8 +489,8 @@ function onEofChunk(stream, state) {
   state.ended = true;
 
   if (state.sync) {
-    // if we are sync and have data in the buffer, wait until next tick
-    // to emit the data. otherwise we risk emitting data in the flow()
+    // if we are sync, wait until next tick to emit the data.
+    // Otherwise we risk emitting data in the flow()
     // the readable code triggers during a read() call
     emitReadable(stream);
   } else {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -488,7 +488,7 @@ function onEofChunk(stream, state) {
   }
   state.ended = true;
 
-  if (state.sync && state.length) {
+  if (state.sync) {
     // if we are sync and have data in the buffer, wait until next tick
     // to emit the data. otherwise we risk emitting data in the flow()
     // the readable code triggers during a read() call

--- a/test/parallel/test-stream-readable-object-multi-push-async.js
+++ b/test/parallel/test-stream-readable-object-multi-push-async.js
@@ -160,7 +160,7 @@ const BATCH = 10;
   });
 
   readable.on('end', common.mustCall(() => {
-    assert.strictEqual(nextTickPassed, false);
+    assert.strictEqual(nextTickPassed, true);
   }));
 }
 


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/18612

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
stream