### PR TITLE
process: faster next tick

### DIFF
--- a/benchmark/streams/pipe-object-mode.js
+++ b/benchmark/streams/pipe-object-mode.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, Writable } = require('stream');
+
+const bench = common.createBenchmark(main, {
+  n: [5e6]
+});
+
+function main({ n }) {
+  const b = {};
+  const r = new Readable({ objectMode: true });
+  const w = new Writable({ objectMode: true });
+
+  var i = 0;
+
+  r._read = () => r.push(i++ === n ? null : b);
+  w._write = (data, enc, cb) => cb();
+
+  bench.start();
+
+  r.pipe(w);
+  w.on('finish', () => bench.end(n));
+}

--- a/benchmark/streams/pipe.js
+++ b/benchmark/streams/pipe.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, Writable } = require('stream');
+
+const bench = common.createBenchmark(main, {
+  n: [5e6]
+});
+
+function main({ n }) {
+  const b = new Buffer(1024);
+  const r = new Readable();
+  const w = new Writable();
+
+  var i = 0;
+
+  r._read = () => r.push(i++ === n ? null : b);
+  w._write = (data, enc, cb) => cb();
+
+  bench.start();
+
+  r.pipe(w);
+  w.on('finish', () => bench.end(n));
+}

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -32,32 +32,55 @@ function setupNextTick() {
   const kHasScheduled = 0;
   const kHasPromiseRejections = 1;
 
-  const nextTickQueue = {
-    head: null,
-    tail: null,
-    push(data) {
-      const entry = { data, next: null };
-      if (this.tail !== null) {
-        this.tail.next = entry;
-      } else {
-        this.head = entry;
-        tickInfo[kHasScheduled] = 1;
-      }
-      this.tail = entry;
-    },
-    shift() {
-      if (this.head === null)
-        return;
-      const ret = this.head.data;
-      if (this.head === this.tail) {
-        this.head = this.tail = null;
-        tickInfo[kHasScheduled] = 0;
-      } else {
-        this.head = this.head.next;
-      }
-      return ret;
+  // Queue size for each tick array. Must be a factor of two.
+  const kQueueSize = 2048;
+  const kQueueMask = kQueueSize - 1;
+
+  class FixedQueue {
+    constructor() {
+      this.bottom = 0;
+      this.top = 0;
+      this.list = new Array(kQueueSize);
+      this.next = null;
     }
-  };
+
+    push(data) {
+      this.list[this.top] = data;
+      this.top = (this.top + 1) & kQueueMask;
+    }
+
+    shift() {
+      const next = this.list[this.bottom];
+      if (next === undefined) return null;
+      this.list[this.bottom] = undefined;
+      this.bottom = (this.bottom + 1) & kQueueMask;
+      return next;
+    }
+  }
+
+  var head = new FixedQueue();
+  var tail = head;
+
+  function push(data) {
+    if (head.bottom === head.top) {
+      if (head.list[head.top] !== undefined)
+        head = head.next = new FixedQueue();
+      else
+        tickInfo[kHasScheduled] = 1;
+    }
+    head.push(data);
+  }
+
+  function shift() {
+    const next = tail.shift();
+    if (tail.top === tail.bottom) {
+      if (tail.next)
+        tail = tail.next;
+      else
+        tickInfo[kHasScheduled] = 0;
+    }
+    return next;
+  }
 
   process.nextTick = nextTick;
   // Needs to be accessible from beyond this scope.
@@ -69,7 +92,7 @@ function setupNextTick() {
   function _tickCallback() {
     let tock;
     do {
-      while (tock = nextTickQueue.shift()) {
+      while (tock = shift()) {
         const asyncId = tock[async_id_symbol];
         emitBefore(asyncId, tock[trigger_async_id_symbol]);
         // emitDestroy() places the async_id_symbol into an asynchronous queue
@@ -93,7 +116,7 @@ function setupNextTick() {
         emitAfter(asyncId);
       }
       runMicrotasks();
-    } while (nextTickQueue.head !== null || emitPromiseRejectionWarnings());
+    } while (head.top !== head.bottom || emitPromiseRejectionWarnings());
     tickInfo[kHasPromiseRejections] = 0;
   }
 
@@ -139,8 +162,7 @@ function setupNextTick() {
           args[i - 1] = arguments[i];
     }
 
-    nextTickQueue.push(new TickObject(callback, args,
-                                      getDefaultTriggerAsyncId()));
+    push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
   }
 
   // `internalNextTick()` will not enqueue any callback when the process is
@@ -168,6 +190,6 @@ function setupNextTick() {
 
     if (triggerAsyncId === null)
       triggerAsyncId = getDefaultTriggerAsyncId();
-    nextTickQueue.push(new TickObject(callback, args, triggerAsyncId));
+    push(new TickObject(callback, args, triggerAsyncId));
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process

Moves the nextTick implementation to a series of fixed size circular arrays instead of the linked list. The size for each array is fixed at 2048, which seems to provide the best perf.

Since streams are big nextTick users these days, I added a pipe benchmark also to see the impact.

##### NextTick benchmark

``` sh
node benchmark/compare.js --old ./node-master --new ./out/Release/node --filter next-tick process > next-tick.csv
cat next-tick.csv | Rscript benchmark/compare.R
```

```
                                              confidence improvement accuracy (*)   (**)  (***)
 process/next-tick-breadth-args.js millions=4        ***     40.11 %       ±1.23% ±1.64% ±2.14%
 process/next-tick-breadth.js millions=4             ***      7.16 %       ±3.50% ±4.67% ±6.11%
 process/next-tick-depth-args.js millions=12         ***      5.46 %       ±0.91% ±1.22% ±1.59%
 process/next-tick-depth.js millions=12              ***     23.26 %       ±2.51% ±3.36% ±4.40%
 process/next-tick-exec-args.js millions=5           ***     38.64 %       ±1.16% ±1.55% ±2.01%
 process/next-tick-exec.js millions=5                ***     77.20 %       ±1.63% ±2.18% ±2.88%

Be aware that when doing many comparisions the risk of a false-positive
result increases. In this case there are 6 comparisions, you can thus
expect the following amount of false-positive results:
  0.30 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.06 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

##### Streams benchmark

``` sh
node benchmark/compare.js --old ./node-master --new ./out/Release/node stream > stream.csv
cat stream.csv | Rscript benchmark/compare.R
```

```
                                                       confidence improvement accuracy (*)   (**)  (***)
 streams/pipe-object-mode.js n=5000000                        ***     21.85 %       ±0.76% ±1.01% ±1.32%
 streams/pipe.js n=5000000                                    ***     20.30 %       ±0.59% ±0.79% ±1.02%
 streams/readable-bigread.js n=1000                                    0.00 %       ±0.67% ±0.89% ±1.16%
 streams/readable-bigunevenread.js n=1000                             -0.10 %       ±0.69% ±0.92% ±1.20%
 streams/readable-boundaryread.js type="buffer" n=2000                -0.71 %       ±0.87% ±1.15% ±1.50%
 streams/readable-boundaryread.js type="string" n=2000                 0.04 %       ±0.91% ±1.21% ±1.58%
 streams/readable-readall.js n=5000                                   -0.21 %       ±1.86% ±2.48% ±3.22%
 streams/readable-unevenread.js n=1000                                -0.18 %       ±0.47% ±0.63% ±0.81%
 streams/transform-creation.js n=1000000                               0.21 %       ±0.59% ±0.79% ±1.02%
 streams/writable-manywrites.js n=2000000                     ***     55.44 %       ±2.41% ±3.21% ±4.20%

Be aware that when doing many comparisions the risk of a false-positive
result increases. In this case there are 10 comparisions, you can thus
expect the following amount of false-positive results:
  0.50 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.10 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```