### PR TITLE
fs: use fs.access in fs.exists

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -427,14 +427,10 @@ fs.exists = function(path, callback) {
   }
 
   try {
-    path = getPathFromURL(path);
-    validatePath(path);
+    fs.access(path, fs.FS_OK, suppressedCallback);
   } catch (err) {
     return callback(false);
   }
-  var req = new FSReqWrap();
-  req.oncomplete = suppressedCallback;
-  binding.stat(pathModule.toNamespacedPath(path), req);
 };
 
 Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
@@ -453,13 +449,7 @@ Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
 // TODO(joyeecheung): deprecate the never-throw-on-invalid-arguments behavior
 fs.existsSync = function(path) {
   try {
-    path = getPathFromURL(path);
-    validatePath(path);
-    const ctx = { path };
-    binding.stat(pathModule.toNamespacedPath(path), undefined, ctx);
-    if (ctx.errno !== undefined) {
-      return false;
-    }
+    fs.accessSync(path, fs.FS_OK);
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
Uses `fs.access()` to implement `fs.exists()` functionality. Fixes a issue, when a file exists but user does not have privileges to do stat on the file. 

Fixes: https://github.com/nodejs/node/issues/17921

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs