### PR TITLE
build,win: replace run-python subroutine with single find_python call

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -165,6 +165,9 @@ if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
+call tools\msvs\find_python.cmd
+if errorlevel 1 echo Could not find python2 & goto :exit
+
 call :getnodeversion || exit /b 1
 
 if defined TAG set configure_flags=%configure_flags% --tag=%TAG%
@@ -234,7 +237,8 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-call :run-python configure %configure_flags%
+echo configure %configure_flags%
+python configure %configure_flags%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -426,7 +430,7 @@ if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
 :node-check-deopts
-call :run-python tools\test.py --mode=release --check-deopts parallel sequential -J
+python tools\test.py --mode=release --check-deopts parallel sequential -J
 if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
@@ -450,7 +454,8 @@ if defined no_cctest echo Skipping cctest because no-cctest was specified && got
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
 :run-test-py
-call :run-python tools\test.py %test_args%
+echo running 'python tools\test.py %test_args%'
+python tools\test.py %test_args%
 goto test-v8
 
 :test-v8
@@ -462,7 +467,7 @@ goto lint-cpp
 :lint-cpp
 if not defined lint_cpp goto lint-js
 call :run-lint-cpp src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\addons-napi\*.cc test\addons-napi\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
-call :run-python tools/check-imports.py
+python tools/check-imports.py
 goto lint-js
 
 :run-lint-cpp
@@ -478,7 +483,7 @@ for /f "tokens=*" %%G in ('dir /b /s /a %*') do (
 ( endlocal
   set cppfilelist=%localcppfilelist%
 )
-call :run-python tools/cpplint.py %cppfilelist% > nul
+python tools/cpplint.py %cppfilelist% > nul
 goto exit
 
 :add-to-list
@@ -540,14 +545,6 @@ echo   vcbuild.bat lint                     : runs the C++ and JavaScript linter
 echo   vcbuild.bat no-cctest                : skip building cctest.exe
 goto exit
 
-:run-python
-call tools\msvs\find_python.cmd
-if errorlevel 1 echo Could not find python2 & goto :exit
-set cmd1="%VCBUILD_PYTHON_LOCATION%" %*
-echo %cmd1%
-%cmd1%
-exit /b %ERRORLEVEL%
-
 :exit
 goto :EOF
 
@@ -560,9 +557,8 @@ rem ***************
 set NODE_VERSION=
 set TAG=
 set FULLVERSION=
-:: Call as subroutine for validation of python
-call :run-python tools\getnodeversion.py > nul
-for /F "tokens=*" %%i in ('"%VCBUILD_PYTHON_LOCATION%" tools\getnodeversion.py') do set NODE_VERSION=%%i
+
+for /F "usebackq tokens=*" %%i in (`python "%~dp0tools\getnodeversion.py"`) do set NODE_VERSION=%%i
 if not defined NODE_VERSION (
   echo Cannot determine current version of Node.js
   exit /b 1


### PR DESCRIPTION
A subroutine does not work as a replacement for the `python` command
since one cannot use a subroutine call in a `for /F` loop.

This is an alternative to https://github.com/nodejs/node/pull/17293 and https://github.com/nodejs/node/pull/17804. I realized that `find_python.cmd` adds Python to `PATH`, so there is no need to introduce a variable.

I still slightly prefer https://github.com/nodejs/node/pull/17293 for the reasons outlined in https://github.com/nodejs/node/pull/17804 (basically, extra maintenance), but I prefer this PR to https://github.com/nodejs/node/pull/17804 since it doesn't introduce an extra variable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build