### PR TITLE
test: add lib path env when node_shared=true

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -260,6 +260,11 @@
             }],
           ],
         }],
+        [ 'node_shared=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
+          },
+        }],
         [ 'node_intermediate_lib_type=="shared_library" and OS=="win"', {
           # On Windows, having the same name for both executable and shared
           # lib causes filename collision. Need a different PRODUCT_NAME for
@@ -416,6 +421,10 @@
       'conditions': [
         [ 'node_shared=="true" and node_module_version!="" and OS!="win"', {
           'product_extension': '<(shlib_suffix)',
+          'xcode_settings': {
+            'LD_DYLIB_INSTALL_NAME':
+              '@rpath/lib<(node_core_target_name).<(shlib_suffix)'
+          },
         }],
         ['node_shared=="true" and OS=="aix"', {
           'product_name': 'node_base',
@@ -1130,6 +1139,9 @@
             '<@(library_files)',
             'common.gypi',
           ],
+          'direct_dependent_settings': {
+            'ldflags': [ '-Wl,-brtl' ],
+          },
         },
       ]
     }], # end aix section

--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -1,0 +1,29 @@
+/* eslint-disable required-modules */
+'use strict';
+const path = require('path');
+
+// If node executable is linked to shared lib, need to take care about the
+// shared lib path.
+exports.addLibraryPath = function(env) {
+  if (!process.config.variables.node_shared) {
+    return;
+  }
+
+  env = env || process.env;
+
+  env.LD_LIBRARY_PATH =
+    (env.LD_LIBRARY_PATH ? env.LD_LIBRARY_PATH + path.delimiter : '') +
+    path.join(path.dirname(process.execPath), 'lib.target');
+  // For AIX.
+  env.LIBPATH =
+    (env.LIBPATH ? env.LIBPATH + path.delimiter : '') +
+    path.join(path.dirname(process.execPath), 'lib.target');
+  // For Mac OSX.
+  env.DYLD_LIBRARY_PATH =
+    (env.DYLD_LIBRARY_PATH ? env.DYLD_LIBRARY_PATH + path.delimiter : '') +
+    path.dirname(process.execPath);
+  // For Windows.
+  env.PATH =
+    (env.PATH ? env.PATH + path.delimiter : '') +
+    path.dirname(process.execPath);
+};

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -28,6 +28,9 @@ const tmpdir = require('../common/tmpdir');
 const msg = { test: 'this' };
 const nodePath = process.execPath;
 const copyPath = path.join(tmpdir.path, 'node-copy.exe');
+const { addLibraryPath } = require('../common/shared-lib-util');
+
+addLibraryPath(process.env);
 
 if (process.env.FORK) {
   assert(process.send);

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -6,6 +6,9 @@ const path = require('path');
 const fs = require('fs');
 const child_process = require('child_process');
 const pkgName = 'foo';
+const { addLibraryPath } = require('../common/shared-lib-util');
+
+addLibraryPath(process.env);
 
 if (process.argv[2] === 'child') {
   console.log(require(pkgName).string);


### PR DESCRIPTION
When building the node with `--shared` option, the major output is the
shared library. However, we still build a node executable which links
to the shared lib. It's for testing purpose. When testing with the
executable, some test cases move/copy the executable, change the relative
path to the shared library and fail. Using lib path env would solve the
issue. However, in macOS, need to modify the dependency in the
executable by using the install_name_tool utility. In AIX, `-brtl`
linker option rebinds the symbols in the executable and addon modules
could use them.

Refs: https://github.com/nodejs/node/issues/18535

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, build