### PR TITLE
src: resolve issues reported by coverity

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1188,13 +1188,9 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
     req_wrap->SetReturnValue(args);
   } else {
     SYNC_CALL(open, *path, *path, flags, mode)
-    if (SYNC_RESULT < 0) {
-      args.GetReturnValue().Set(SYNC_RESULT);
-    } else {
-      HandleScope scope(env->isolate());
-      FileHandle* fd = new FileHandle(env, SYNC_RESULT);
-      args.GetReturnValue().Set(fd->object());
-    }
+    HandleScope scope(env->isolate());
+    FileHandle* fd = new FileHandle(env, SYNC_RESULT);
+    args.GetReturnValue().Set(fd->object());
   }
 }
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -62,7 +62,7 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
 
  private:
   enum encoding encoding_ = UTF8;
-  const char* syscall_;
+  const char* syscall_ = nullptr;
 
   const char* data_ = nullptr;
   MaybeStackBuffer<char> buffer_;


### PR DESCRIPTION
The specific issues raised by Coverity are:

```
** CID 182716:  Control flow issues  (DEADCODE)
/src/node_file.cc: 1192
>>> CID 182716:  Control flow issues  (DEADCODE)
>>> Execution cannot reach this statement:
    "args->GetReturnValue().Set(...".

** CID 182715:  Uninitialized members  (UNINIT_CTOR)
/src/node_file.h: 29
>>> CID 182715:  Uninitialized members  (UNINIT_CTOR)
>>> Non-static class member "syscall_" is not initialized in this
    constructor nor in any functions that it calls.
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
src