### PR TITLE
src: deprecate legacy node::MakeCallback

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -893,6 +893,15 @@ Use [`asyncResource.runInAsyncScope()`][] API instead which provides a much
 safer, and more convenient, alternative. See
 https://github.com/nodejs/node/pull/18513 for more details.
 
+<a id="DEP0098"></a>
+### DEP0098: async context-unaware node::MakeCallback C++ APIs
+
+Type: Compile-time
+
+Certain versions of `node::MakeCallback` APIs available to native modules are
+deprecated. Please use the versions of the API that accept an `async_context`
+parameter.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/src/node.h
+++ b/src/node.h
@@ -151,27 +151,30 @@ inline v8::Local<v8::Value> UVException(int errorno,
  * These methods need to be called in a HandleScope.
  *
  * It is preferred that you use the `MakeCallback` overloads taking
- * `async_id` arguments.
+ * `async_context` arguments.
  */
 
-NODE_EXTERN v8::Local<v8::Value> MakeCallback(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> recv,
-    const char* method,
-    int argc,
-    v8::Local<v8::Value>* argv);
-NODE_EXTERN v8::Local<v8::Value> MakeCallback(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> recv,
-    v8::Local<v8::String> symbol,
-    int argc,
-    v8::Local<v8::Value>* argv);
-NODE_EXTERN v8::Local<v8::Value> MakeCallback(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> recv,
-    v8::Local<v8::Function> callback,
-    int argc,
-    v8::Local<v8::Value>* argv);
+NODE_DEPRECATED("Use MakeCallback(..., async_context)",
+                NODE_EXTERN v8::Local<v8::Value> MakeCallback(
+                    v8::Isolate* isolate,
+                    v8::Local<v8::Object> recv,
+                    const char* method,
+                    int argc,
+                    v8::Local<v8::Value>* argv));
+NODE_DEPRECATED("Use MakeCallback(..., async_context)",
+                NODE_EXTERN v8::Local<v8::Value> MakeCallback(
+                    v8::Isolate* isolate,
+                    v8::Local<v8::Object> recv,
+                    v8::Local<v8::String> symbol,
+                    int argc,
+                    v8::Local<v8::Value>* argv));
+NODE_DEPRECATED("Use MakeCallback(..., async_context)",
+                NODE_EXTERN v8::Local<v8::Value> MakeCallback(
+                    v8::Isolate* isolate,
+                    v8::Local<v8::Object> recv,
+                    v8::Local<v8::Function> callback,
+                    int argc,
+                    v8::Local<v8::Value>* argv));
 
 }  // namespace node
 


### PR DESCRIPTION
The legacy `MakeCallback` functions do not provide a mechanism to
propagate async context. This means that any native modules using these
directly is likely breaking async debugging & tracing tools. For
example it is possible that such a module will cause incorrect async
stack traces to be reported (even when the module is not on the stack).

We've had context preserving versions of `MakeCallback` available since Node 8.x.

Ref: https://github.com/nodejs/node/issues/13254, specifically https://github.com/nodejs/node/issues/13254#issuecomment-363212661.
Related: https://github.com/nodejs/nan/pull/729

This doesn't fit into any of the categories of deprecations as defined in our [Deprecation policy](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#deprecations). This is an API available to native modules via `node.h`. It is not otherwise documented. Chances are high that any given native module would be using this API. The migration path is fairly easy though.

We will now give a compile time warning when a module using the deprecated API is being compiled against Node 10. There is no runtime impact at this point. From this point of view, I guess this is closest to a `Documentation-only` deprecation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, async_hooks

/cc @nodejs/async_hooks @nodejs/addon-api @nodejs/diagnostics 

CI: https://ci.nodejs.org/job/node-test-pull-request/13042/