### PR TITLE
doc: fix internal links in http2.md

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3072,47 +3072,47 @@ following additional properties:
   `Http2Session`.
 
 
-[ALPN negotiation]: #http2_alpn_negotiation
+[ALPN negotiation]: #alpn-negotiation
 [ALPN Protocol ID]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
-[Compatibility API]: #http2_compatibility_api
+[Compatibility API]: #compatibility-api
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
-[HTTP2 Headers Object]: #http2_headers_object
-[HTTP2 Settings Object]: #http2_settings_object
+[HTTP2 Headers Object]: #headers-object
+[HTTP2 Settings Object]: #settings-object
 [HTTPS]: https.html
-[Http2Session and Sockets]: #http2_http2session_and_sockets
+[Http2Session and Sockets]: #http2session-and-sockets
 [Performance Observer]: perf_hooks.html
 [Readable Stream]: stream.html#stream_class_stream_readable
 [RFC 7838]: https://tools.ietf.org/html/rfc7838
-[Using options.selectPadding]: #http2_using_options_selectpadding
+[Using options.selectPadding]: #using-optionsselectpadding
 [Writable Stream]: stream.html#stream_writable_streams
-[`'checkContinue'`]: #http2_event_checkcontinue
-[`'request'`]: #http2_event_request
-[`'unknownProtocol'`]: #http2_event_unknownprotocol
-[`ClientHttp2Stream`]: #http2_class_clienthttp2stream
+[`'checkContinue'`]: #event-checkcontinue
+[`'request'`]: #event-request
+[`'unknownProtocol'`]: #event-unknownprotocol
+[`ClientHttp2Stream`]: #class-clienthttp2stream
 [`Duplex`]: stream.html#stream_class_stream_duplex
 [`EventEmitter`]: events.html#events_class_eventemitter
-[`Http2ServerRequest`]: #http2_class_http2_http2serverrequest
-[`Http2Stream`]: #http2_class_http2stream
-[`ServerHttp2Stream`]: #http2_class_serverhttp2stream
+[`Http2ServerRequest`]: #class-http2http2serverrequest
+[`Http2Stream`]: #class-http2stream
+[`ServerHttp2Stream`]: #class-serverhttp2stream
 [`TypeError`]: errors.html#errors_class_typeerror
-[`http2.SecureServer`]: #http2_class_http2secureserver
-[`http2.createSecureServer()`]: #http2_http2_createsecureserver_options_onrequesthandler
-[`http2.Server`]: #http2_class_http2server
-[`http2.createServer()`]: #http2_http2_createserver_options_onrequesthandler
-[`http2stream.pushStream()`]: #http2_http2stream_pushstream_headers_options_callback
+[`http2.SecureServer`]: #class-http2secureserver
+[`http2.createSecureServer()`]: #http2createsecureserveroptions-onrequesthandler
+[`http2.Server`]: #class-http2server
+[`http2.createServer()`]: #http2createserveroptions-onrequesthandler
+[`http2stream.pushStream()`]: #http2streampushstreamheaders-options-callback
 [`net.Socket`]: net.html#net_class_net_socket
 [`net.Socket.prototype.ref`]: net.html#net_socket_ref
 [`net.Socket.prototype.unref`]: net.html#net_socket_unref
 [`net.connect()`]: net.html#net_net_connect
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
-[`response.end()`]: #http2_response_end_data_encoding_callback
-[`response.setHeader()`]: #http2_response_setheader_name_value
-[`response.socket`]: #http2_response_socket
-[`response.write()`]: #http2_response_write_chunk_encoding_callback
+[`response.end()`]: #responseenddata-encoding-callback
+[`response.setHeader()`]: #responsesetheadername-value
+[`response.socket`]: #responsesocket
+[`response.write()`]: #responsewritechunk-encoding-callback
 [`response.write(data, encoding)`]: http.html#http_response_write_chunk_encoding_callback
-[`response.writeContinue()`]: #http2_response_writecontinue
-[`response.writeHead()`]: #http2_response_writehead_statuscode_statusmessage_headers
+[`response.writeContinue()`]: #responsewritecontinue
+[`response.writeHead()`]: #responsewriteheadstatuscode-statusmessage-headers
 [`tls.TLSSocket`]: tls.html#tls_class_tls_tlssocket
 [`tls.connect()`]: tls.html#tls_tls_connect_options_callback
 [`tls.createServer()`]: tls.html#tls_tls_createserver_options_secureconnectionlistener


### PR DESCRIPTION
The current links #http2_name_fullName are incorrect
Correcting them to #name-fullName or ones used by markdown

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
