### PR TITLE
tools: fix prof polyfill readline

### DIFF
--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -96,6 +96,13 @@ function readline() {
     if (line.length === 0) {
       return '';
     }
+    if (bytes === 0) {
+      process.emitWarning('profile file is broken', {
+        code: 'BROKEN_PROFILE_FILE',
+        detail: `${JSON.stringify(line)} at the file end is broken`
+      });
+      return '';
+    }
   }
 }
 

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -97,7 +97,7 @@ function readline() {
       return '';
     }
     if (bytes === 0) {
-      process.emitWarning('profile file is broken', {
+      process.emitWarning(`Profile file ${logFile} is broken`, {
         code: 'BROKEN_PROFILE_FILE',
         detail: `${JSON.stringify(line)} at the file end is broken`
       });

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -246,7 +246,7 @@ Platform check for Windows 32-bit on Windows 64-bit.
 ### isCPPSymbolsNotMapped
 * [&lt;Boolean>]
 
-Platform check for c++ symbols are mapped or not.
+Platform check for C++ symbols are mapped or not.
 
 ### leakedGlobals()
 * return [&lt;Array>]

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -243,10 +243,10 @@ Platform check for Windows.
 
 Platform check for Windows 32-bit on Windows 64-bit.
 
-### isSymbolAvailable
+### isCPPSymbolsNotMapped
 * [&lt;Boolean>]
 
-Platform check for if symbol available.
+Platform check for c++ symbols are mapped or not.
 
 ### leakedGlobals()
 * return [&lt;Array>]

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -243,6 +243,11 @@ Platform check for Windows.
 
 Platform check for Windows 32-bit on Windows 64-bit.
 
+### isSymbolAvailable
+* [&lt;Boolean>]
+
+Platform check for if symbol available.
+
 ### leakedGlobals()
 * return [&lt;Array>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -803,7 +803,7 @@ exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');
 exports.restoreStderr = restoreWritable.bind(null, 'stderr');
 exports.isSymbolAvailable = exports.isWindows ||
-                           exports.isSunOS ||
-                           exports.isAIX ||
-                           exports.isLinuxPPCBE ||
-                           exports.isFreeBSD;
+                            exports.isSunOS ||
+                            exports.isAIX ||
+                            exports.isLinuxPPCBE ||
+                            exports.isFreeBSD;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -802,8 +802,8 @@ exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
 exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');
 exports.restoreStderr = restoreWritable.bind(null, 'stderr');
-exports.isSymbolAvailable = exports.isWindows ||
-                            exports.isSunOS ||
-                            exports.isAIX ||
-                            exports.isLinuxPPCBE ||
-                            exports.isFreeBSD;
+exports.isCPPSymbolsNotMapped = exports.isWindows ||
+                                exports.isSunOS ||
+                                exports.isAIX ||
+                                exports.isLinuxPPCBE ||
+                                exports.isFreeBSD;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -802,3 +802,8 @@ exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
 exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');
 exports.restoreStderr = restoreWritable.bind(null, 'stderr');
+exports.isSymbolAvailable = exports.isWindows ||
+                           exports.isSunOS ||
+                           exports.isAIX ||
+                           exports.isLinuxPPCBE ||
+                           exports.isFreeBSD;

--- a/test/tick-processor/test-tick-processor-builtin.js
+++ b/test/tick-processor/test-tick-processor-builtin.js
@@ -4,12 +4,15 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isWindows ||
-    common.isSunOS ||
-    common.isAIX ||
-    common.isLinuxPPCBE ||
-    common.isFreeBSD)
+if (
+  common.isWindows ||
+  common.isSunOS ||
+  common.isAIX ||
+  common.isLinuxPPCBE ||
+  common.isFreeBSD
+) {
   common.skip('C++ symbols are not mapped for this os.');
+}
 
 const base = require('./tick-processor-base.js');
 

--- a/test/tick-processor/test-tick-processor-builtin.js
+++ b/test/tick-processor/test-tick-processor-builtin.js
@@ -4,13 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (
-  common.isWindows ||
-  common.isSunOS ||
-  common.isAIX ||
-  common.isLinuxPPCBE ||
-  common.isFreeBSD
-) {
+if (common.isSymbolAvailable) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-builtin.js
+++ b/test/tick-processor/test-tick-processor-builtin.js
@@ -4,7 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isSymbolAvailable) {
+if (common.isCPPSymbolsNotMapped) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-cpp-core.js
+++ b/test/tick-processor/test-tick-processor-cpp-core.js
@@ -4,12 +4,15 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isWindows ||
-    common.isSunOS ||
-    common.isAIX ||
-    common.isLinuxPPCBE ||
-    common.isFreeBSD)
+if (
+  common.isWindows ||
+  common.isSunOS ||
+  common.isAIX ||
+  common.isLinuxPPCBE ||
+  common.isFreeBSD
+) {
   common.skip('C++ symbols are not mapped for this os.');
+}
 
 const base = require('./tick-processor-base.js');
 

--- a/test/tick-processor/test-tick-processor-cpp-core.js
+++ b/test/tick-processor/test-tick-processor-cpp-core.js
@@ -4,13 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (
-  common.isWindows ||
-  common.isSunOS ||
-  common.isAIX ||
-  common.isLinuxPPCBE ||
-  common.isFreeBSD
-) {
+if (common.isSymbolAvailable) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-cpp-core.js
+++ b/test/tick-processor/test-tick-processor-cpp-core.js
@@ -4,7 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isSymbolAvailable) {
+if (common.isCPPSymbolsNotMapped) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -6,13 +6,7 @@ tmpdir.refresh();
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (
-  common.isWindows ||
-  common.isSunOS ||
-  common.isAIX ||
-  common.isLinuxPPCBE ||
-  common.isFreeBSD
-) {
+if (common.isSymbolAvailable) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -1,0 +1,66 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+if (!common.enoughTestCpu)
+  common.skip('test is CPU-intensive');
+
+if (
+  common.isWindows ||
+  common.isSunOS ||
+  common.isAIX ||
+  common.isLinuxPPCBE ||
+  common.isFreeBSD
+) {
+  common.skip('C++ symbols are not mapped for this os.');
+}
+
+//This test will produce a broken profile log.
+//ensure prof-polyfill not stuck in infinite loop
+//and success process
+
+
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const LOG_FILE = path.join(tmpdir.path, 'tick-processor.log');
+const RETRY_TIMEOUT = 150;
+const BROKEN_PART = 'tick,';
+const WARN_REG_EXP = /\(node:\d+\) \[BROKEN_PROFILE_FILE\] Warning: profile file is broken[\r\n]+".*tick," at the file end is broken/;
+
+const code = `function f() {
+           this.ts = Date.now();
+           setImmediate(function() { new f(); });
+         };
+         f();`;
+
+const proc = cp.spawn(process.execPath, [
+  '--no_logfile_per_isolate',
+  '--logfile=-',
+  '--prof',
+  '-pe', code
+], {
+  stdio: ['ignore', 'pipe', 'inherit']
+});
+
+let ticks = '';
+proc.stdout.on('data', (chunk) => ticks += chunk);
+
+
+function runPolyfill(content) {
+  proc.kill();
+  content += BROKEN_PART;
+  fs.writeFileSync(LOG_FILE, content);
+  const child = cp.spawnSync(
+    `${process.execPath}`,
+    [
+      '--prof-process', LOG_FILE
+    ]);
+  assert(WARN_REG_EXP.test(child.stderr.toString()));
+  assert.strictEqual(child.status, 0, 'broken file should success too');
+}
+
+setTimeout(() => runPolyfill(ticks), RETRY_TIMEOUT);

--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -7,12 +7,12 @@ if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
 if (common.isCPPSymbolsNotMapped) {
-  common.skip('C++ symbols are not mapped for this os.');
+  common.skip('C++ symbols are not mapped for this OS.');
 }
 
-//This test will produce a broken profile log.
-//ensure prof-polyfill not stuck in infinite loop
-//and success process
+// This test will produce a broken profile log.
+// ensure prof-polyfill not stuck in infinite loop
+// and success process
 
 
 const assert = require('assert');
@@ -23,7 +23,8 @@ const fs = require('fs');
 const LOG_FILE = path.join(tmpdir.path, 'tick-processor.log');
 const RETRY_TIMEOUT = 150;
 const BROKEN_PART = 'tick,';
-const WARN_REG_EXP = /\(node:\d+\) \[BROKEN_PROFILE_FILE\] Warning: profile file is broken[\r\n]+".*tick," at the file end is broken/;
+const WARN_REG_EXP = /\(node:\d+\) \[BROKEN_PROFILE_FILE] Warning: Profile file .* is broken/;
+const WARN_DETAIL_REG_EXP = /".*tick," at the file end is broken/;
 
 const code = `function f() {
            this.ts = Date.now();
@@ -54,7 +55,8 @@ function runPolyfill(content) {
       '--prof-process', LOG_FILE
     ]);
   assert(WARN_REG_EXP.test(child.stderr.toString()));
-  assert.strictEqual(child.status, 0, 'broken file should success too');
+  assert(WARN_DETAIL_REG_EXP.test(child.stderr.toString()));
+  assert.strictEqual(child.status, 0);
 }
 
 setTimeout(() => runPolyfill(ticks), RETRY_TIMEOUT);

--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -6,7 +6,7 @@ tmpdir.refresh();
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isSymbolAvailable) {
+if (common.isCPPSymbolsNotMapped) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-preprocess-flag.js
+++ b/test/tick-processor/test-tick-processor-preprocess-flag.js
@@ -4,12 +4,15 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isWindows ||
-    common.isSunOS ||
-    common.isAIX ||
-    common.isLinuxPPCBE ||
-    common.isFreeBSD)
+if (
+  common.isWindows ||
+  common.isSunOS ||
+  common.isAIX ||
+  common.isLinuxPPCBE ||
+  common.isFreeBSD
+) {
   common.skip('C++ symbols are not mapped for this os.');
+}
 
 const base = require('./tick-processor-base.js');
 

--- a/test/tick-processor/test-tick-processor-preprocess-flag.js
+++ b/test/tick-processor/test-tick-processor-preprocess-flag.js
@@ -4,13 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (
-  common.isWindows ||
-  common.isSunOS ||
-  common.isAIX ||
-  common.isLinuxPPCBE ||
-  common.isFreeBSD
-) {
+if (common.isSymbolAvailable) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 

--- a/test/tick-processor/test-tick-processor-preprocess-flag.js
+++ b/test/tick-processor/test-tick-processor-preprocess-flag.js
@@ -4,7 +4,7 @@ const common = require('../common');
 if (!common.enoughTestCpu)
   common.skip('test is CPU-intensive');
 
-if (common.isSymbolAvailable) {
+if (common.isCPPSymbolsNotMapped) {
   common.skip('C++ symbols are not mapped for this os.');
 }
 


### PR DESCRIPTION
`node --prof foo.js` may not print the full profile log file,
the last line will broken like `tick,` and not more blank line.
`readline`will stuck in infinite loop, add `bytes < buf.length`
will fix it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

@bnoordhuis 