### PR TITLE
crypto: allow passing null as IV unless required

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1286,6 +1286,11 @@ Adversaries][] for details.
 ### crypto.createCipheriv(algorithm, key, iv[, options])
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18644
+    description: The `iv` parameter may now be `null` for ciphers which do not
+                 need an initialization vector.
 -->
 - `algorithm` {string}
 - `key` {string | Buffer | TypedArray | DataView}
@@ -1301,7 +1306,8 @@ available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
 [initialization vector][]. Both arguments must be `'utf8'` encoded strings,
-[Buffers][`Buffer`], `TypedArray`, or `DataView`s.
+[Buffers][`Buffer`], `TypedArray`, or `DataView`s. If the cipher does not need
+an initialization vector, `iv` may be `null`.
 
 ### crypto.createCredentials(details)
 <!-- YAML
@@ -1347,6 +1353,11 @@ to create the `Decipher` object.
 ### crypto.createDecipheriv(algorithm, key, iv[, options])
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18644
+    description: The `iv` parameter may now be `null` for ciphers which do not
+                 need an initialization vector.
 -->
 - `algorithm` {string}
 - `key` {string | Buffer | TypedArray | DataView}
@@ -1363,7 +1374,8 @@ available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
 [initialization vector][]. Both arguments must be `'utf8'` encoded strings,
-[Buffers][`Buffer`], `TypedArray`, or `DataView`s.
+[Buffers][`Buffer`], `TypedArray`, or `DataView`s. If the cipher does not need
+an initialization vector, `iv` may be `null`.
 
 ### crypto.createDiffieHellman(prime[, primeEncoding][, generator][, generatorEncoding])
 <!-- YAML

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -182,7 +182,7 @@ function Cipheriv(cipher, key, iv, options) {
   }
 
   iv = toBuf(iv);
-  if (!isArrayBufferView(iv)) {
+  if (iv !== null && !isArrayBufferView(iv)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'iv',
                                ['string', 'Buffer', 'TypedArray', 'DataView']);
   }
@@ -253,7 +253,7 @@ function Decipheriv(cipher, key, iv, options) {
   }
 
   iv = toBuf(iv);
-  if (!isArrayBufferView(iv)) {
+  if (iv !== null && !isArrayBufferView(iv)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'iv',
                                ['string', 'Buffer', 'TypedArray', 'DataView']);
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3090,8 +3090,17 @@ void CipherBase::InitIv(const char* cipher_type,
   const int expected_iv_len = EVP_CIPHER_iv_length(cipher);
   const int mode = EVP_CIPHER_mode(cipher);
   const bool is_gcm_mode = (EVP_CIPH_GCM_MODE == mode);
+  const bool has_iv = iv_len >= 0;
 
-  if (is_gcm_mode == false && iv_len != expected_iv_len) {
+  // Throw if no IV was passed and the cipher requires an IV
+  if (!has_iv && expected_iv_len != 0) {
+    char msg[128];
+    snprintf(msg, sizeof(msg), "Missing IV for cipher %s", cipher_type);
+    return env()->ThrowError(msg);
+  }
+
+  // Throw if an IV was passed which does not match the cipher's fixed IV length
+  if (is_gcm_mode == false && has_iv && iv_len != expected_iv_len) {
     return env()->ThrowError("Invalid IV length");
   }
 
@@ -3135,8 +3144,15 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   const node::Utf8Value cipher_type(env->isolate(), args[0]);
   ssize_t key_len = Buffer::Length(args[1]);
   const char* key_buf = Buffer::Data(args[1]);
-  ssize_t iv_len = Buffer::Length(args[2]);
-  const char* iv_buf = Buffer::Data(args[2]);
+  ssize_t iv_len;
+  const char* iv_buf;
+  if (args[2]->IsNull()) {
+    iv_buf = nullptr;
+    iv_len = -1;
+  } else {
+    iv_buf = Buffer::Data(args[2]);
+    iv_len = Buffer::Length(args[2]);
+  }
   cipher->InitIv(*cipher_type, key_buf, key_len, iv_buf, iv_len);
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3112,11 +3112,13 @@ void CipherBase::InitIv(const char* cipher_type,
   const bool encrypt = (kind_ == kCipher);
   EVP_CipherInit_ex(ctx_, cipher, nullptr, nullptr, nullptr, encrypt);
 
-  if (is_gcm_mode &&
-      !EVP_CIPHER_CTX_ctrl(ctx_, EVP_CTRL_GCM_SET_IVLEN, iv_len, nullptr)) {
-    EVP_CIPHER_CTX_free(ctx_);
-    ctx_ = nullptr;
-    return env()->ThrowError("Invalid IV length");
+  if (is_gcm_mode) {
+    CHECK(has_iv);
+    if (!EVP_CIPHER_CTX_ctrl(ctx_, EVP_CTRL_GCM_SET_IVLEN, iv_len, nullptr)) {
+      EVP_CIPHER_CTX_free(ctx_);
+      ctx_ = nullptr;
+      return env()->ThrowError("Invalid IV length");
+    }
   }
 
   if (!EVP_CIPHER_CTX_set_key_length(ctx_, key_len)) {

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -105,7 +105,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => crypto.createCipheriv('des-ede3-cbc', key, null),
+    () => crypto.createCipheriv('des-ede3-cbc', key, 10),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -141,7 +141,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => crypto.createDecipheriv('des-ede3-cbc', key, null),
+    () => crypto.createDecipheriv('des-ede3-cbc', key, 10),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -161,8 +161,9 @@ if (!common.hasFipsCrypto) {
               Buffer.from('A6A6A6A6A6A6A6A6', 'hex'));
 }
 
-// Zero-sized IV should be accepted in ECB mode.
+// Zero-sized IV or null should be accepted in ECB mode.
 crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16), Buffer.alloc(0));
+crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16), null);
 
 const errMessage = /Invalid IV length/;
 
@@ -185,6 +186,11 @@ for (let n = 0; n < 256; n += 1) {
                                 Buffer.alloc(n)),
     errMessage);
 }
+
+// And so should null be.
+assert.throws(() => {
+  crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16), null);
+}, /Missing IV for cipher aes-128-cbc/);
 
 // Zero-sized IV should be rejected in GCM mode.
 assert.throws(


### PR DESCRIPTION
There has been a lot of discussion around deprecating `create(Dec|C)ipher` in favor of `create(Dec|C)ipheriv`. This PR is a preparation which allows to pass `null` as the IV for ciphers that do not use an IV (e.g. ECB) instead of having to pass an empty buffer. Note that the parameter cannot currently be ommitted, which I think is fair considering that the IV is part of the name of the function.

This was separated from the actual deprecation of `create(Dec|C)ipher` to allow backporting and to make reviewing a little easier.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto