### PR TITLE
fs: fix stack overflow in fs.readdirSync

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1132,14 +1132,20 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
       name_v[name_idx++] = filename.ToLocalChecked();
 
       if (name_idx >= arraysize(name_v)) {
-        fn->Call(env->context(), names, name_idx, name_v)
-            .ToLocalChecked();
+        MaybeLocal<Value> ret = fn->Call(env->context(), names, name_idx,
+                                         name_v);
+        if (ret.IsEmpty()) {
+          return;
+        }
         name_idx = 0;
       }
     }
 
     if (name_idx > 0) {
-      fn->Call(env->context(), names, name_idx, name_v).ToLocalChecked();
+      MaybeLocal<Value> ret = fn->Call(env->context(), names, name_idx, name_v);
+      if (ret.IsEmpty()) {
+        return;
+      }
     }
 
     args.GetReturnValue().Set(names);

--- a/test/parallel/test-fs-readdir-stack-overflow.js
+++ b/test/parallel/test-fs-readdir-stack-overflow.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+
+const fs = require('fs');
+
+function recurse() {
+  fs.readdirSync('.');
+  recurse();
+}
+
+common.expectsError(
+  () => recurse(),
+  {
+    type: RangeError,
+    message: 'Maximum call stack size exceeded'
+  }
+);


### PR DESCRIPTION
Previously, fs.readdirSync calls the function returned by
env->push_values_to_array_function() in batch and check the returned
Maybe right away in C++, which can lead to assertions if the call stack
already reaches the maximum size. This patch fixes that by returning
early the call fails so the stack overflow error will be properly
thrown into JS land.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/nodejs/node/issues/18645

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs