### PR TITLE
doc: revised description of execFile to clarify usage

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -239,7 +239,7 @@ async function lsExample() {
 lsExample();
 ```
 
-### child_process.execFile(file[, args][, options][, callback])
+### child_process.execFile([command][, args][, options][, callback])
 <!-- YAML
 added: v0.1.91
 changes:
@@ -248,8 +248,8 @@ changes:
     description: The `windowsHide` option is supported now.
 -->
 
-* `file` {string} The name or path of the executable file to run.
-* `args` {string[]} List of string arguments.
+* `command` {string} The command to run.
+* `args` {string[]} The name of the executable file to run followed by a list of string arguments.
 * `options` {Object}
   * `cwd` {string} Current working directory of the child process.
   * `env` {Object} Environment key-value pairs.


### PR DESCRIPTION
I used child_process.execFile to execute a JS file. The docs state this:
child_process.execFile(file[, args][, options][, callback])
file: The name or path of the executable file to run.

This failed:
```js
execFile("node filename.js", { cwd: "path_to_file" })
```
This worked:
```js
execFile("node", ["filename.js"], { cwd: "path_to_file" })
```
The docs were confusing for me as it states the file to be executed should be passed as the first parameter. Rather, the command needed to be passed as the first parameter, with the file passed in as an arg. I believe the clarification I've submitted will be more clear and will help others avoid my confusion. Thanks for your consideration.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
