### PR TITLE
path: replace "magic" numbers by readable constants

### DIFF
--- a/lib/internal/constants.js
+++ b/lib/internal/constants.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  // Alphabet chars.
+  CHAR_UPPERCASE_A: 65, /*A*/
+  CHAR_LOWERCASE_A: 97, /*a*/
+  CHAR_UPPERCASE_Z: 90, /*Z*/
+  CHAR_LOWERCASE_Z: 122, /*z*/
+
+  // Non-alphabetic chars.
+  CHAR_DOT: 46, /*.*/
+  CHAR_FORWARD_SLASH: 47, /*/*/
+  CHAR_BACKWARD_SLASH: 92, /*\*/
+  CHAR_COLON: 58, /*:*/
+  CHAR_QUESTION_MARK: 63, /*?*/
+};

--- a/lib/path.js
+++ b/lib/path.js
@@ -22,6 +22,17 @@
 'use strict';
 
 const errors = require('internal/errors');
+const {
+  CHAR_UPPERCASE_A,
+  CHAR_LOWERCASE_A,
+  CHAR_UPPERCASE_Z,
+  CHAR_LOWERCASE_Z,
+  CHAR_DOT,
+  CHAR_FORWARD_SLASH,
+  CHAR_BACKWARD_SLASH,
+  CHAR_COLON,
+  CHAR_QUESTION_MARK,
+} = require('internal/constants');
 
 function assertPath(path) {
   if (typeof path !== 'string') {
@@ -39,17 +50,17 @@ function normalizeStringWin32(path, allowAboveRoot) {
   for (var i = 0; i <= path.length; ++i) {
     if (i < path.length)
       code = path.charCodeAt(i);
-    else if (code === 47/*/*/ || code === 92/*\*/)
+    else if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
       break;
     else
-      code = 47/*/*/;
-    if (code === 47/*/*/ || code === 92/*\*/) {
+      code = CHAR_FORWARD_SLASH;
+    if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       if (lastSlash === i - 1 || dots === 1) {
         // NOOP
       } else if (lastSlash !== i - 1 && dots === 2) {
         if (res.length < 2 || lastSegmentLength !== 2 ||
-            res.charCodeAt(res.length - 1) !== 46/*.*/ ||
-            res.charCodeAt(res.length - 2) !== 46/*.*/) {
+            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+            res.charCodeAt(res.length - 2) !== CHAR_DOT) {
           if (res.length > 2) {
             const lastSlashIndex = res.lastIndexOf('\\');
             if (lastSlashIndex !== res.length - 1) {
@@ -88,7 +99,7 @@ function normalizeStringWin32(path, allowAboveRoot) {
       }
       lastSlash = i;
       dots = 0;
-    } else if (code === 46/*.*/ && dots !== -1) {
+    } else if (code === CHAR_DOT && dots !== -1) {
       ++dots;
     } else {
       dots = -1;
@@ -107,17 +118,17 @@ function normalizeStringPosix(path, allowAboveRoot) {
   for (var i = 0; i <= path.length; ++i) {
     if (i < path.length)
       code = path.charCodeAt(i);
-    else if (code === 47/*/*/)
+    else if (code === CHAR_FORWARD_SLASH)
       break;
     else
-      code = 47/*/*/;
-    if (code === 47/*/*/) {
+      code = CHAR_FORWARD_SLASH;
+    if (code === CHAR_FORWARD_SLASH) {
       if (lastSlash === i - 1 || dots === 1) {
         // NOOP
       } else if (lastSlash !== i - 1 && dots === 2) {
         if (res.length < 2 || lastSegmentLength !== 2 ||
-            res.charCodeAt(res.length - 1) !== 46/*.*/ ||
-            res.charCodeAt(res.length - 2) !== 46/*.*/) {
+            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+            res.charCodeAt(res.length - 2) !== CHAR_DOT) {
           if (res.length > 2) {
             const lastSlashIndex = res.lastIndexOf('/');
             if (lastSlashIndex !== res.length - 1) {
@@ -156,7 +167,7 @@ function normalizeStringPosix(path, allowAboveRoot) {
       }
       lastSlash = i;
       dots = 0;
-    } else if (code === 46/*.*/ && dots !== -1) {
+    } else if (code === CHAR_DOT && dots !== -1) {
       ++dots;
     } else {
       dots = -1;
@@ -223,7 +234,7 @@ const win32 = {
 
       // Try to match a root
       if (len > 1) {
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // Possible UNC root
 
           // If we started with a separator, we know we at least have an
@@ -231,14 +242,14 @@ const win32 = {
           isAbsolute = true;
 
           code = path.charCodeAt(1);
-          if (code === 47/*/*/ || code === 92/*\*/) {
+          if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
             // Matched double path separator at beginning
             var j = 2;
             var last = j;
             // Match 1 or more non-path separators
             for (; j < len; ++j) {
               code = path.charCodeAt(j);
-              if (code === 47/*/*/ || code === 92/*\*/)
+              if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
                 break;
             }
             if (j < len && j !== last) {
@@ -248,7 +259,7 @@ const win32 = {
               // Match 1 or more path separators
               for (; j < len; ++j) {
                 code = path.charCodeAt(j);
-                if (code !== 47/*/*/ && code !== 92/*\*/)
+                if (code !== CHAR_FORWARD_SLASH && code !== CHAR_BACKWARD_SLASH)
                   break;
               }
               if (j < len && j !== last) {
@@ -257,7 +268,10 @@ const win32 = {
                 // Match 1 or more non-path separators
                 for (; j < len; ++j) {
                   code = path.charCodeAt(j);
-                  if (code === 47/*/*/ || code === 92/*\*/)
+                  const isPathSeparator =
+                    code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+
+                  if (isPathSeparator)
                     break;
                 }
                 if (j === len) {
@@ -276,16 +290,16 @@ const win32 = {
           } else {
             rootEnd = 1;
           }
-        } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                   (code >= 97/*a*/ && code <= 122/*z*/)) {
+        } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+                   (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
           // Possible device root
 
-          if (path.charCodeAt(1) === 58/*:*/) {
+          if (path.charCodeAt(1) === CHAR_COLON) {
             device = path.slice(0, 2);
             rootEnd = 2;
             if (len > 2) {
               code = path.charCodeAt(2);
-              if (code === 47/*/*/ || code === 92/*\*/) {
+              if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
                 // Treat separator following drive name as an absolute path
                 // indicator
                 isAbsolute = true;
@@ -294,7 +308,7 @@ const win32 = {
             }
           }
         }
-      } else if (code === 47/*/*/ || code === 92/*\*/) {
+      } else if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // `path` contains just a path separator
         rootEnd = 1;
         isAbsolute = true;
@@ -343,7 +357,7 @@ const win32 = {
 
     // Try to match a root
     if (len > 1) {
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // Possible UNC root
 
         // If we started with a separator, we know we at least have an absolute
@@ -351,14 +365,14 @@ const win32 = {
         isAbsolute = true;
 
         code = path.charCodeAt(1);
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // Matched double path separator at beginning
           var j = 2;
           var last = j;
           // Match 1 or more non-path separators
           for (; j < len; ++j) {
             code = path.charCodeAt(j);
-            if (code === 47/*/*/ || code === 92/*\*/)
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
               break;
           }
           if (j < len && j !== last) {
@@ -368,7 +382,7 @@ const win32 = {
             // Match 1 or more path separators
             for (; j < len; ++j) {
               code = path.charCodeAt(j);
-              if (code !== 47/*/*/ && code !== 92/*\*/)
+              if (code !== CHAR_FORWARD_SLASH && code !== CHAR_BACKWARD_SLASH)
                 break;
             }
             if (j < len && j !== last) {
@@ -377,7 +391,7 @@ const win32 = {
               // Match 1 or more non-path separators
               for (; j < len; ++j) {
                 code = path.charCodeAt(j);
-                if (code === 47/*/*/ || code === 92/*\*/)
+                if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
                   break;
               }
               if (j === len) {
@@ -397,16 +411,16 @@ const win32 = {
         } else {
           rootEnd = 1;
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+                 (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
         // Possible device root
 
-        if (path.charCodeAt(1) === 58/*:*/) {
+        if (path.charCodeAt(1) === CHAR_COLON) {
           device = path.slice(0, 2);
           rootEnd = 2;
           if (len > 2) {
             code = path.charCodeAt(2);
-            if (code === 47/*/*/ || code === 92/*\*/) {
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
               // Treat separator following drive name as an absolute path
               // indicator
               isAbsolute = true;
@@ -415,14 +429,15 @@ const win32 = {
           }
         }
       }
-    } else if (code === 47/*/*/ || code === 92/*\*/) {
+    } else if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       // `path` contains just a path separator, exit early to avoid unnecessary
       // work
       return '\\';
     }
 
     code = path.charCodeAt(len - 1);
-    var trailingSeparator = (code === 47/*/*/ || code === 92/*\*/);
+    var trailingSeparator =
+      (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH);
     var tail;
     if (rootEnd < len)
       tail = normalizeStringWin32(path.slice(rootEnd), !isAbsolute);
@@ -462,15 +477,15 @@ const win32 = {
     if (len === 0)
       return false;
     var code = path.charCodeAt(0);
-    if (code === 47/*/*/ || code === 92/*\*/) {
+    if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       return true;
-    } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-               (code >= 97/*a*/ && code <= 122/*z*/)) {
+    } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+               (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
       // Possible device root
 
-      if (len > 2 && path.charCodeAt(1) === 58/*:*/) {
+      if (len > 2 && path.charCodeAt(1) === CHAR_COLON) {
         code = path.charCodeAt(2);
-        if (code === 47/*/*/ || code === 92/*\*/)
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
           return true;
       }
     }
@@ -514,16 +529,16 @@ const win32 = {
     var needsReplace = true;
     var slashCount = 0;
     var code = firstPart.charCodeAt(0);
-    if (code === 47/*/*/ || code === 92/*\*/) {
+    if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       ++slashCount;
       const firstLen = firstPart.length;
       if (firstLen > 1) {
         code = firstPart.charCodeAt(1);
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           ++slashCount;
           if (firstLen > 2) {
             code = firstPart.charCodeAt(2);
-            if (code === 47/*/*/ || code === 92/*\*/)
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
               ++slashCount;
             else {
               // We matched a UNC path in the first part
@@ -537,7 +552,7 @@ const win32 = {
       // Find any more consecutive slashes we need to replace
       for (; slashCount < joined.length; ++slashCount) {
         code = joined.charCodeAt(slashCount);
-        if (code !== 47/*/*/ && code !== 92/*\*/)
+        if (code !== CHAR_FORWARD_SLASH && code !== CHAR_BACKWARD_SLASH)
           break;
       }
 
@@ -576,13 +591,13 @@ const win32 = {
     // Trim any leading backslashes
     var fromStart = 0;
     for (; fromStart < from.length; ++fromStart) {
-      if (from.charCodeAt(fromStart) !== 92/*\*/)
+      if (from.charCodeAt(fromStart) !== CHAR_BACKWARD_SLASH)
         break;
     }
     // Trim trailing backslashes (applicable to UNC paths only)
     var fromEnd = from.length;
     for (; fromEnd - 1 > fromStart; --fromEnd) {
-      if (from.charCodeAt(fromEnd - 1) !== 92/*\*/)
+      if (from.charCodeAt(fromEnd - 1) !== CHAR_BACKWARD_SLASH)
         break;
     }
     var fromLen = (fromEnd - fromStart);
@@ -590,13 +605,13 @@ const win32 = {
     // Trim any leading backslashes
     var toStart = 0;
     for (; toStart < to.length; ++toStart) {
-      if (to.charCodeAt(toStart) !== 92/*\*/)
+      if (to.charCodeAt(toStart) !== CHAR_BACKWARD_SLASH)
         break;
     }
     // Trim trailing backslashes (applicable to UNC paths only)
     var toEnd = to.length;
     for (; toEnd - 1 > toStart; --toEnd) {
-      if (to.charCodeAt(toEnd - 1) !== 92/*\*/)
+      if (to.charCodeAt(toEnd - 1) !== CHAR_BACKWARD_SLASH)
         break;
     }
     var toLen = (toEnd - toStart);
@@ -608,7 +623,7 @@ const win32 = {
     for (; i <= length; ++i) {
       if (i === length) {
         if (toLen > length) {
-          if (to.charCodeAt(toStart + i) === 92/*\*/) {
+          if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
             // We get here if `from` is the exact base path for `to`.
             // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
             return toOrig.slice(toStart + i + 1);
@@ -619,7 +634,7 @@ const win32 = {
           }
         }
         if (fromLen > length) {
-          if (from.charCodeAt(fromStart + i) === 92/*\*/) {
+          if (from.charCodeAt(fromStart + i) === CHAR_BACKWARD_SLASH) {
             // We get here if `to` is the exact base path for `from`.
             // For example: from='C:\\foo\\bar'; to='C:\\foo'
             lastCommonSep = i;
@@ -635,7 +650,7 @@ const win32 = {
       var toCode = to.charCodeAt(toStart + i);
       if (fromCode !== toCode)
         break;
-      else if (fromCode === 92/*\*/)
+      else if (fromCode === CHAR_BACKWARD_SLASH)
         lastCommonSep = i;
     }
 
@@ -651,7 +666,7 @@ const win32 = {
     // Generate the relative path based on the path difference between `to` and
     // `from`
     for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
-      if (i === fromEnd || from.charCodeAt(i) === 92/*\*/) {
+      if (i === fromEnd || from.charCodeAt(i) === CHAR_BACKWARD_SLASH) {
         if (out.length === 0)
           out += '..';
         else
@@ -665,7 +680,7 @@ const win32 = {
       return out + toOrig.slice(toStart + lastCommonSep, toEnd);
     else {
       toStart += lastCommonSep;
-      if (toOrig.charCodeAt(toStart) === 92/*\*/)
+      if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH)
         ++toStart;
       return toOrig.slice(toStart, toEnd);
     }
@@ -685,22 +700,22 @@ const win32 = {
 
     if (resolvedPath.length >= 3) {
       var code = resolvedPath.charCodeAt(0);
-      if (code === 92/*\*/) {
+      if (code === CHAR_BACKWARD_SLASH) {
         // Possible UNC root
 
-        if (resolvedPath.charCodeAt(1) === 92/*\*/) {
+        if (resolvedPath.charCodeAt(1) === CHAR_BACKWARD_SLASH) {
           code = resolvedPath.charCodeAt(2);
-          if (code !== 63/*?*/ && code !== 46/*.*/) {
+          if (code !== CHAR_QUESTION_MARK && code !== CHAR_DOT) {
             // Matched non-long UNC root, convert the path to a long UNC path
             return '\\\\?\\UNC\\' + resolvedPath.slice(2);
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+                 (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
         // Possible device root
 
-        if (resolvedPath.charCodeAt(1) === 58/*:*/ &&
-            resolvedPath.charCodeAt(2) === 92/*\*/) {
+        if (resolvedPath.charCodeAt(1) === CHAR_COLON &&
+            resolvedPath.charCodeAt(2) === CHAR_BACKWARD_SLASH) {
           // Matched device root, convert the path to a long UNC path
           return '\\\\?\\' + resolvedPath;
         }
@@ -723,20 +738,20 @@ const win32 = {
 
     // Try to match a root
     if (len > 1) {
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // Possible UNC root
 
         rootEnd = offset = 1;
 
         code = path.charCodeAt(1);
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // Matched double path separator at beginning
           var j = 2;
           var last = j;
           // Match 1 or more non-path separators
           for (; j < len; ++j) {
             code = path.charCodeAt(j);
-            if (code === 47/*/*/ || code === 92/*\*/)
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
               break;
           }
           if (j < len && j !== last) {
@@ -745,7 +760,7 @@ const win32 = {
             // Match 1 or more path separators
             for (; j < len; ++j) {
               code = path.charCodeAt(j);
-              if (code !== 47/*/*/ && code !== 92/*\*/)
+              if (code !== CHAR_FORWARD_SLASH && code !== CHAR_BACKWARD_SLASH)
                 break;
             }
             if (j < len && j !== last) {
@@ -754,7 +769,7 @@ const win32 = {
               // Match 1 or more non-path separators
               for (; j < len; ++j) {
                 code = path.charCodeAt(j);
-                if (code === 47/*/*/ || code === 92/*\*/)
+                if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
                   break;
               }
               if (j === len) {
@@ -771,20 +786,20 @@ const win32 = {
             }
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+                 (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
         // Possible device root
 
-        if (path.charCodeAt(1) === 58/*:*/) {
+        if (path.charCodeAt(1) === CHAR_COLON) {
           rootEnd = offset = 2;
           if (len > 2) {
             code = path.charCodeAt(2);
-            if (code === 47/*/*/ || code === 92/*\*/)
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
               rootEnd = offset = 3;
           }
         }
       }
-    } else if (code === 47/*/*/ || code === 92/*\*/) {
+    } else if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       // `path` contains just a path separator, exit early to avoid
       // unnecessary work
       return path;
@@ -792,7 +807,7 @@ const win32 = {
 
     for (var i = len - 1; i >= offset; --i) {
       code = path.charCodeAt(i);
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         if (!matchedSlash) {
           end = i;
           break;
@@ -827,9 +842,9 @@ const win32 = {
     // disregarded
     if (path.length >= 2) {
       const drive = path.charCodeAt(0);
-      if ((drive >= 65/*A*/ && drive <= 90/*Z*/) ||
-          (drive >= 97/*a*/ && drive <= 122/*z*/)) {
-        if (path.charCodeAt(1) === 58/*:*/)
+      if ((drive >= CHAR_UPPERCASE_A && drive <= CHAR_UPPERCASE_Z) ||
+          (drive >= CHAR_LOWERCASE_A && drive <= CHAR_LOWERCASE_Z)) {
+        if (path.charCodeAt(1) === CHAR_COLON)
           start = 2;
       }
     }
@@ -841,7 +856,7 @@ const win32 = {
       var firstNonSlashEnd = -1;
       for (i = path.length - 1; i >= start; --i) {
         const code = path.charCodeAt(i);
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // If we reached a path separator that was not part of a set of path
           // separators at the end of the string, stop now
           if (!matchedSlash) {
@@ -881,7 +896,7 @@ const win32 = {
     } else {
       for (i = path.length - 1; i >= start; --i) {
         const code = path.charCodeAt(i);
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // If we reached a path separator that was not part of a set of path
           // separators at the end of the string, stop now
           if (!matchedSlash) {
@@ -919,16 +934,16 @@ const win32 = {
     // disregarded
     if (path.length >= 2) {
       const code = path.charCodeAt(0);
-      if (path.charCodeAt(1) === 58/*:*/ &&
-          ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-           (code >= 97/*a*/ && code <= 122/*z*/))) {
+      if (path.charCodeAt(1) === CHAR_COLON &&
+          ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+           (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z))) {
         start = startPart = 2;
       }
     }
 
     for (var i = path.length - 1; i >= start; --i) {
       const code = path.charCodeAt(i);
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -943,7 +958,7 @@ const win32 = {
         matchedSlash = false;
         end = i + 1;
       }
-      if (code === 46/*.*/) {
+      if (code === CHAR_DOT) {
         // If this is our first dot, mark it as the start of our extension
         if (startDot === -1)
           startDot = i;
@@ -992,19 +1007,19 @@ const win32 = {
 
     // Try to match a root
     if (len > 1) {
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // Possible UNC root
 
         code = path.charCodeAt(1);
         rootEnd = 1;
-        if (code === 47/*/*/ || code === 92/*\*/) {
+        if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
           // Matched double path separator at beginning
           var j = 2;
           var last = j;
           // Match 1 or more non-path separators
           for (; j < len; ++j) {
             code = path.charCodeAt(j);
-            if (code === 47/*/*/ || code === 92/*\*/)
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
               break;
           }
           if (j < len && j !== last) {
@@ -1013,7 +1028,7 @@ const win32 = {
             // Match 1 or more path separators
             for (; j < len; ++j) {
               code = path.charCodeAt(j);
-              if (code !== 47/*/*/ && code !== 92/*\*/)
+              if (code !== CHAR_FORWARD_SLASH && code !== CHAR_BACKWARD_SLASH)
                 break;
             }
             if (j < len && j !== last) {
@@ -1022,7 +1037,7 @@ const win32 = {
               // Match 1 or more non-path separators
               for (; j < len; ++j) {
                 code = path.charCodeAt(j);
-                if (code === 47/*/*/ || code === 92/*\*/)
+                if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH)
                   break;
               }
               if (j === len) {
@@ -1037,15 +1052,15 @@ const win32 = {
             }
           }
         }
-      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+      } else if ((code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+                 (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)) {
         // Possible device root
 
-        if (path.charCodeAt(1) === 58/*:*/) {
+        if (path.charCodeAt(1) === CHAR_COLON) {
           rootEnd = 2;
           if (len > 2) {
             code = path.charCodeAt(2);
-            if (code === 47/*/*/ || code === 92/*\*/) {
+            if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
               if (len === 3) {
                 // `path` contains just a drive root, exit early to avoid
                 // unnecessary work
@@ -1062,7 +1077,7 @@ const win32 = {
           }
         }
       }
-    } else if (code === 47/*/*/ || code === 92/*\*/) {
+    } else if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
       // `path` contains just a path separator, exit early to avoid
       // unnecessary work
       ret.root = ret.dir = path;
@@ -1085,7 +1100,7 @@ const win32 = {
     // Get non-dir info
     for (; i >= rootEnd; --i) {
       code = path.charCodeAt(i);
-      if (code === 47/*/*/ || code === 92/*\*/) {
+      if (code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -1100,7 +1115,7 @@ const win32 = {
         matchedSlash = false;
         end = i + 1;
       }
-      if (code === 46/*.*/) {
+      if (code === CHAR_DOT) {
         // If this is our first dot, mark it as the start of our extension
         if (startDot === -1)
           startDot = i;
@@ -1174,7 +1189,7 @@ const posix = {
       }
 
       resolvedPath = path + '/' + resolvedPath;
-      resolvedAbsolute = path.charCodeAt(0) === 47/*/*/;
+      resolvedAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
     }
 
     // At this point the path should be resolved to a full absolute path, but
@@ -1202,8 +1217,9 @@ const posix = {
     if (path.length === 0)
       return '.';
 
-    const isAbsolute = path.charCodeAt(0) === 47/*/*/;
-    const trailingSeparator = path.charCodeAt(path.length - 1) === 47/*/*/;
+    const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    const trailingSeparator =
+      path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
 
     // Normalize the path
     path = normalizeStringPosix(path, !isAbsolute);
@@ -1221,7 +1237,7 @@ const posix = {
 
   isAbsolute: function isAbsolute(path) {
     assertPath(path);
-    return path.length > 0 && path.charCodeAt(0) === 47/*/*/;
+    return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
   },
 
 
@@ -1261,7 +1277,7 @@ const posix = {
     // Trim any leading backslashes
     var fromStart = 1;
     for (; fromStart < from.length; ++fromStart) {
-      if (from.charCodeAt(fromStart) !== 47/*/*/)
+      if (from.charCodeAt(fromStart) !== CHAR_FORWARD_SLASH)
         break;
     }
     var fromEnd = from.length;
@@ -1270,7 +1286,7 @@ const posix = {
     // Trim any leading backslashes
     var toStart = 1;
     for (; toStart < to.length; ++toStart) {
-      if (to.charCodeAt(toStart) !== 47/*/*/)
+      if (to.charCodeAt(toStart) !== CHAR_FORWARD_SLASH)
         break;
     }
     var toEnd = to.length;
@@ -1283,7 +1299,7 @@ const posix = {
     for (; i <= length; ++i) {
       if (i === length) {
         if (toLen > length) {
-          if (to.charCodeAt(toStart + i) === 47/*/*/) {
+          if (to.charCodeAt(toStart + i) === CHAR_FORWARD_SLASH) {
             // We get here if `from` is the exact base path for `to`.
             // For example: from='/foo/bar'; to='/foo/bar/baz'
             return to.slice(toStart + i + 1);
@@ -1293,7 +1309,7 @@ const posix = {
             return to.slice(toStart + i);
           }
         } else if (fromLen > length) {
-          if (from.charCodeAt(fromStart + i) === 47/*/*/) {
+          if (from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
             // We get here if `to` is the exact base path for `from`.
             // For example: from='/foo/bar/baz'; to='/foo/bar'
             lastCommonSep = i;
@@ -1309,7 +1325,7 @@ const posix = {
       var toCode = to.charCodeAt(toStart + i);
       if (fromCode !== toCode)
         break;
-      else if (fromCode === 47/*/*/)
+      else if (fromCode === CHAR_FORWARD_SLASH)
         lastCommonSep = i;
     }
 
@@ -1317,7 +1333,7 @@ const posix = {
     // Generate the relative path based on the path difference between `to`
     // and `from`
     for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
-      if (i === fromEnd || from.charCodeAt(i) === 47/*/*/) {
+      if (i === fromEnd || from.charCodeAt(i) === CHAR_FORWARD_SLASH) {
         if (out.length === 0)
           out += '..';
         else
@@ -1331,7 +1347,7 @@ const posix = {
       return out + to.slice(toStart + lastCommonSep);
     else {
       toStart += lastCommonSep;
-      if (to.charCodeAt(toStart) === 47/*/*/)
+      if (to.charCodeAt(toStart) === CHAR_FORWARD_SLASH)
         ++toStart;
       return to.slice(toStart);
     }
@@ -1348,12 +1364,12 @@ const posix = {
     if (path.length === 0)
       return '.';
     var code = path.charCodeAt(0);
-    var hasRoot = (code === 47/*/*/);
+    var hasRoot = (code === CHAR_FORWARD_SLASH);
     var end = -1;
     var matchedSlash = true;
     for (var i = path.length - 1; i >= 1; --i) {
       code = path.charCodeAt(i);
-      if (code === 47/*/*/) {
+      if (code === CHAR_FORWARD_SLASH) {
         if (!matchedSlash) {
           end = i;
           break;
@@ -1389,7 +1405,7 @@ const posix = {
       var firstNonSlashEnd = -1;
       for (i = path.length - 1; i >= 0; --i) {
         const code = path.charCodeAt(i);
-        if (code === 47/*/*/) {
+        if (code === CHAR_FORWARD_SLASH) {
           // If we reached a path separator that was not part of a set of path
           // separators at the end of the string, stop now
           if (!matchedSlash) {
@@ -1428,7 +1444,7 @@ const posix = {
       return path.slice(start, end);
     } else {
       for (i = path.length - 1; i >= 0; --i) {
-        if (path.charCodeAt(i) === 47/*/*/) {
+        if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
           // If we reached a path separator that was not part of a set of path
           // separators at the end of the string, stop now
           if (!matchedSlash) {
@@ -1461,7 +1477,7 @@ const posix = {
     var preDotState = 0;
     for (var i = path.length - 1; i >= 0; --i) {
       const code = path.charCodeAt(i);
-      if (code === 47/*/*/) {
+      if (code === CHAR_FORWARD_SLASH) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -1476,7 +1492,7 @@ const posix = {
         matchedSlash = false;
         end = i + 1;
       }
-      if (code === 46/*.*/) {
+      if (code === CHAR_DOT) {
         // If this is our first dot, mark it as the start of our extension
         if (startDot === -1)
           startDot = i;
@@ -1519,7 +1535,7 @@ const posix = {
     if (path.length === 0)
       return ret;
     var code = path.charCodeAt(0);
-    var isAbsolute = (code === 47/*/*/);
+    var isAbsolute = (code === CHAR_FORWARD_SLASH);
     var start;
     if (isAbsolute) {
       ret.root = '/';
@@ -1540,7 +1556,7 @@ const posix = {
     // Get non-dir info
     for (; i >= start; --i) {
       code = path.charCodeAt(i);
-      if (code === 47/*/*/) {
+      if (code === CHAR_FORWARD_SLASH) {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -1555,7 +1571,7 @@ const posix = {
         matchedSlash = false;
         end = i + 1;
       }
-      if (code === 46/*.*/) {
+      if (code === CHAR_DOT) {
         // If this is our first dot, mark it as the start of our extension
         if (startDot === -1)
           startDot = i;

--- a/node.gyp
+++ b/node.gyp
@@ -95,6 +95,7 @@
       'lib/internal/crypto/random.js',
       'lib/internal/crypto/sig.js',
       'lib/internal/crypto/util.js',
+      'lib/internal/constants.js',
       'lib/internal/encoding.js',
       'lib/internal/errors.js',
       'lib/internal/freelist.js',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- path

I replaced "magic" numbers from "path" module by well readable constants. I want to replace all "magic" numbers in whole project by constants like these, but I decided to start from only one module "path"