### PR TITLE
test: add url type check in Module options

### DIFF
--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -44,7 +44,7 @@ async function checkArgType() {
   });
 
   for (const invalidOptions of [
-    0, 1, null, true, 'str', () => {}, Symbol.iterator
+    0, 1, null, true, 'str', () => {}, { url: 0 }, Symbol.iterator
   ]) {
     common.expectsError(() => {
       new Module('', invalidOptions);


### PR DESCRIPTION
Hi. this is my first time contributing to an open source project. I'm a newbie here.
From the [Node.js Nightly Code Coverage](https://coverage.nodejs.org/), I noticed that
the code coverage in `root/internal/vm/Module.js` lacked some test coverage
for the url options parameter. The test just adds a check to ensure an error is thrown.

The change is a relatively small one. I took a look at the other lack of test areas for that
file, but perhaps I'm not familiar with the codebase to know how to test those.

Any help would be appreciated. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
