### PR TITLE
buffer: simplify check size in assertSize

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -238,9 +238,7 @@ function assertSize(size) {
 
   if (typeof size !== 'number') {
     err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number', size);
-  } else if (size < 0) {
-    err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
-  } else if (size > kMaxLength) {
+  } else if (size < 0 || size > kMaxLength) {
     err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
   }
 


### PR DESCRIPTION
Removed needless `else if`.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
