### PR TITLE
process: deprecate process assert

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -902,11 +902,21 @@ Certain versions of `node::MakeCallback` APIs available to native modules are
 deprecated. Please use the versions of the API that accept an `async_context`
 parameter.
 
+<a id="DEP00XX"></a>
+### DEP00XX: process.assert()
+
+Type: Runtime
+
+`process.assert()` is deprecated. Please use the [`assert`][] module instead.
+
+This was never a documented feature.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout
 [`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -3,11 +3,15 @@
 const errors = require('internal/errors');
 const util = require('util');
 const constants = process.binding('constants').os.signals;
+const assert = require('assert').strict;
+const { deprecate } = require('internal/util');
 
-const assert = process.assert = function(x, msg) {
-  if (!x) throw new errors.Error('ERR_ASSERTION', msg || 'assertion error');
-};
-
+process.assert = deprecate(
+  function(x, msg) {
+    if (!x) throw new errors.Error('ERR_ASSERTION', msg || 'assertion error');
+  },
+  'process.assert() is deprecated. Use the `assert` module instead.',
+  'DEP00XX');
 
 function setup_performance() {
   require('perf_hooks');

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -2,6 +2,11 @@
 const common = require('../common');
 const assert = require('assert');
 
+common.expectWarning(
+  'DeprecationWarning',
+  'process.assert() is deprecated. Use the `assert` module instead.'
+);
+
 assert.strictEqual(process.assert(1, 'error'), undefined);
 common.expectsError(() => {
   process.assert(undefined, 'errorMessage');
@@ -9,13 +14,11 @@ common.expectsError(() => {
   code: 'ERR_ASSERTION',
   type: Error,
   message: 'errorMessage'
-}
-);
+});
 common.expectsError(() => {
   process.assert(false);
 }, {
   code: 'ERR_ASSERTION',
   type: Error,
   message: 'assertion error'
-}
-);
+});


### PR DESCRIPTION
This was never documented and the `assert` module should be used instead. So let us just deprecate this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process