### PR TITLE
test: remove assert.doesNotThrow()

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -135,8 +135,11 @@ rules:
   no-mixed-spaces-and-tabs: error
   no-multiple-empty-lines: [error, {max: 2, maxEOF: 0, maxBOF: 0}]
   no-restricted-syntax: [error, {
+    selector: "CallExpression[callee.object.name='assert'][callee.property.name='doesNotThrow']",
+    message: "Please replace `assert.doesNotThrow()` and add a comment next to the code instead."
+  }, {
     selector: "CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.1.type='Literal']:not([arguments.1.regex])",
-    message: "use a regular expression for second argument of assert.throws()"
+    message: "Use a regular expression for second argument of assert.throws()"
   }, {
     selector: "CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.length<2]",
     message: "assert.throws() must be invoked with at least two arguments."

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -26,6 +26,7 @@ function main({ n, method }) {
     case 'doesNotThrow':
       bench.start();
       for (i = 0; i < n; ++i) {
+        // eslint-disable-next-line no-restricted-syntax
         assert.doesNotThrow(doesNotThrow);
       }
       bench.end(n);

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -341,6 +341,7 @@ to the caller.
 The following, for instance, will throw the [`TypeError`][] because there is no
 matching error type in the assertion:
 
+<!-- eslint-disable no-restricted-syntax -->
 ```js
 assert.doesNotThrow(
   () => {
@@ -353,6 +354,7 @@ assert.doesNotThrow(
 However, the following will result in an `AssertionError` with the message
 'Got unwanted exception (TypeError)..':
 
+<!-- eslint-disable no-restricted-syntax -->
 ```js
 assert.doesNotThrow(
   () => {
@@ -366,6 +368,7 @@ If an `AssertionError` is thrown and a value is provided for the `message`
 parameter, the value of `message` will be appended to the `AssertionError`
 message:
 
+<!-- eslint-disable no-restricted-syntax -->
 ```js
 assert.doesNotThrow(
   () => {

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -81,7 +81,7 @@ const y = {};
 test_general.wrap(y);
 test_general.removeWrap(y);
 // Wrapping twice succeeds if a remove_wrap() separates the instances
-assert.doesNotThrow(() => test_general.wrap(y));
+test_general.wrap(y);
 
 // Ensure that removing a wrap and garbage collecting does not fire the
 // finalize callback.

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -30,5 +30,5 @@ const sub = require('./submodule');
   const mod = require(path.join(i, 'binding.node'));
   assert.notStrictEqual(mod, null);
   assert.strictEqual(mod.hello(), 'world');
-  assert.doesNotThrow(() => sub.test(i));
+  sub.test(i);
 });

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -30,5 +30,5 @@ const sub = require('./submodule');
   const mod = require(path.join(i, 'binding.node'));
   assert.notStrictEqual(mod, null);
   assert.strictEqual(mod.hello(), 'world');
-  sub.test(i);
+  sub.test(i); // Should not throw.
 });

--- a/test/internet/test-dgram-membership.js
+++ b/test/internet/test-dgram-membership.js
@@ -10,7 +10,7 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 // addMembership() with valid socket and multicast address should not throw
 {
   const socket = setup();
-  assert.doesNotThrow(() => { socket.addMembership(multicastAddress); });
+  socket.addMembership(multicastAddress);
   socket.close();
 }
 
@@ -27,11 +27,7 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 // dropMembership() after addMembership() should not throw
 {
   const socket = setup();
-  assert.doesNotThrow(
-    () => {
-      socket.addMembership(multicastAddress);
-      socket.dropMembership(multicastAddress);
-    }
-  );
+  socket.addMembership(multicastAddress);
+  socket.dropMembership(multicastAddress);
   socket.close();
 }

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -580,14 +580,10 @@ process.on('exit', function() {
 });
 
 
-assert.doesNotThrow(() =>
-  dns.lookup(addresses.INET6_HOST, 6, common.mustCall()));
+dns.lookup(addresses.INET6_HOST, 6, common.mustCall());
 
-assert.doesNotThrow(() =>
-  dns.lookup(addresses.INET_HOST, {}, common.mustCall()));
+dns.lookup(addresses.INET_HOST, {}, common.mustCall());
 
-assert.doesNotThrow(() =>
-  dns.lookupService('0.0.0.0', '0', common.mustCall()));
+dns.lookupService('0.0.0.0', '0', common.mustCall());
 
-assert.doesNotThrow(() =>
-  dns.lookupService('0.0.0.0', 0, common.mustCall()));
+dns.lookupService('0.0.0.0', 0, common.mustCall());

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -579,11 +579,8 @@ process.on('exit', function() {
   assert.ok(getaddrinfoCallbackCalled);
 });
 
-
+// Should not throw.
 dns.lookup(addresses.INET6_HOST, 6, common.mustCall());
-
 dns.lookup(addresses.INET_HOST, {}, common.mustCall());
-
 dns.lookupService('0.0.0.0', '0', common.mustCall());
-
 dns.lookupService('0.0.0.0', 0, common.mustCall());

--- a/test/parallel/test-assert-checktag.js
+++ b/test/parallel/test-assert-checktag.js
@@ -30,8 +30,8 @@ function re(literals, ...values) {
   FakeDate.prototype = Date.prototype;
   const fake = new FakeDate();
 
-  assert.doesNotThrow(() => assert.deepEqual(date, fake));
-  assert.doesNotThrow(() => assert.deepEqual(fake, date));
+  assert.deepEqual(date, fake);
+  assert.deepEqual(fake, date);
 
   // For deepStrictEqual we check the runtime type,
   // then reveal the fakeness of the fake date
@@ -47,7 +47,7 @@ function re(literals, ...values) {
   for (const prop of Object.keys(global)) {
     fakeGlobal[prop] = global[prop];
   }
-  assert.doesNotThrow(() => assert.deepEqual(fakeGlobal, global));
+  assert.deepEqual(fakeGlobal, global);
   // Message will be truncated anyway, don't validate
   assert.throws(() => assert.deepStrictEqual(fakeGlobal, global),
                 assert.AssertionError);
@@ -59,7 +59,7 @@ function re(literals, ...values) {
   for (const prop of Object.keys(process)) {
     fakeProcess[prop] = process[prop];
   }
-  assert.doesNotThrow(() => assert.deepEqual(fakeProcess, process));
+  assert.deepEqual(fakeProcess, process);
   // Message will be truncated anyway, don't validate
   assert.throws(() => assert.deepStrictEqual(fakeProcess, process),
                 assert.AssertionError);

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -492,8 +492,8 @@ assertOnlyDeepEqual([1, , , 3], [1, , , 3, , , ]);
 
 // Handle NaN
 assert.throws(() => { assert.deepEqual(NaN, NaN); }, assert.AssertionError);
-{ assert.deepStrictEqual(NaN, NaN); }
-{ assert.deepStrictEqual({ a: NaN }, { a: NaN }); }
+assert.deepStrictEqual(NaN, NaN);
+assert.deepStrictEqual({ a: NaN }, { a: NaN });
 assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
 
 // Handle boxed primitives

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -34,7 +34,7 @@ const buf = Buffer.from(arr);
 // They have different [[Prototype]]
 assert.throws(() => assert.deepStrictEqual(arr, buf),
               re`${arr} deepStrictEqual ${buf}`);
-assert.doesNotThrow(() => assert.deepEqual(arr, buf));
+assert.deepEqual(arr, buf);
 
 {
   const buf2 = Buffer.from(arr);
@@ -42,7 +42,7 @@ assert.doesNotThrow(() => assert.deepEqual(arr, buf));
 
   assert.throws(() => assert.deepStrictEqual(buf2, buf),
                 re`${buf2} deepStrictEqual ${buf}`);
-  assert.doesNotThrow(() => assert.deepEqual(buf2, buf));
+  assert.deepEqual(buf2, buf);
 }
 
 {
@@ -50,7 +50,7 @@ assert.doesNotThrow(() => assert.deepEqual(arr, buf));
   arr2.prop = 5;
   assert.throws(() => assert.deepStrictEqual(arr, arr2),
                 re`${arr} deepStrictEqual ${arr2}`);
-  assert.doesNotThrow(() => assert.deepEqual(arr, arr2));
+  assert.deepEqual(arr, arr2);
 }
 
 const date = new Date('2016');
@@ -66,8 +66,8 @@ const date2 = new MyDate('2016');
 
 // deepEqual returns true as long as the time are the same,
 // but deepStrictEqual checks own properties
-assert.doesNotThrow(() => assert.deepEqual(date, date2));
-assert.doesNotThrow(() => assert.deepEqual(date2, date));
+assert.deepEqual(date, date2);
+assert.deepEqual(date2, date);
 assert.throws(() => assert.deepStrictEqual(date, date2),
               re`${date} deepStrictEqual ${date2}`);
 assert.throws(() => assert.deepStrictEqual(date2, date),
@@ -85,7 +85,7 @@ const re2 = new MyRegExp('test');
 
 // deepEqual returns true as long as the regexp-specific properties
 // are the same, but deepStrictEqual checks all properties
-assert.doesNotThrow(() => assert.deepEqual(re1, re2));
+assert.deepEqual(re1, re2);
 assert.throws(() => assert.deepStrictEqual(re1, re2),
               re`${re1} deepStrictEqual ${re2}`);
 
@@ -148,11 +148,11 @@ function assertNotDeepOrStrict(a, b, err) {
 }
 
 function assertOnlyDeepEqual(a, b, err) {
-  assert.doesNotThrow(() => assert.deepEqual(a, b));
+  assert.deepEqual(a, b);
   assert.throws(() => assert.deepStrictEqual(a, b), err ||
                 re`${a} deepStrictEqual ${b}`);
 
-  assert.doesNotThrow(() => assert.deepEqual(b, a));
+  assert.deepEqual(b, a);
   assert.throws(() => assert.deepStrictEqual(b, a), err ||
                 re`${b} deepStrictEqual ${a}`);
 }
@@ -492,10 +492,9 @@ assertOnlyDeepEqual([1, , , 3], [1, , , 3, , , ]);
 
 // Handle NaN
 assert.throws(() => { assert.deepEqual(NaN, NaN); }, assert.AssertionError);
-assert.doesNotThrow(() => { assert.deepStrictEqual(NaN, NaN); });
-assert.doesNotThrow(() => { assert.deepStrictEqual({ a: NaN }, { a: NaN }); });
-assert.doesNotThrow(
-  () => { assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]); });
+{ assert.deepStrictEqual(NaN, NaN); }
+{ assert.deepStrictEqual({ a: NaN }, { a: NaN }); }
+assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]);
 
 // Handle boxed primitives
 {
@@ -547,9 +546,7 @@ assertDeepAndStrictEqual(-0, -0);
   assertDeepAndStrictEqual(a, b);
 }
 
-assert.doesNotThrow(
-  () => assert.deepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)),
-  'deepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))');
+assert.deepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14));
 
 assert.throws(() => assert.deepEqual(new Date(), new Date(2000, 3, 14)),
               AssertionError,
@@ -561,16 +558,13 @@ assert.throws(
   'notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
 );
 
-assert.doesNotThrow(
-  () => assert.notDeepEqual(new Date(), new Date(2000, 3, 14)),
-  'notDeepEqual(new Date(), new Date(2000, 3, 14))'
-);
+assert.notDeepEqual(new Date(), new Date(2000, 3, 14));
 
-assert.doesNotThrow(() => assert.deepEqual(/a/, /a/));
-assert.doesNotThrow(() => assert.deepEqual(/a/g, /a/g));
-assert.doesNotThrow(() => assert.deepEqual(/a/i, /a/i));
-assert.doesNotThrow(() => assert.deepEqual(/a/m, /a/m));
-assert.doesNotThrow(() => assert.deepEqual(/a/igm, /a/igm));
+assert.deepEqual(/a/, /a/);
+assert.deepEqual(/a/g, /a/g);
+assert.deepEqual(/a/i, /a/i);
+assert.deepEqual(/a/m, /a/m);
+assert.deepEqual(/a/igm, /a/igm);
 assert.throws(() => assert.deepEqual(/ab/, /a/),
               {
                 code: 'ERR_ASSERTION',
@@ -605,23 +599,23 @@ assert.throws(() => assert.deepEqual(/a/igm, /a/im),
 {
   const re1 = /a/g;
   re1.lastIndex = 3;
-  assert.doesNotThrow(() => assert.deepEqual(re1, /a/g));
+  assert.deepEqual(re1, /a/g);
 }
 
-assert.doesNotThrow(() => assert.deepEqual(4, '4'), 'deepEqual(4, \'4\')');
-assert.doesNotThrow(() => assert.deepEqual(true, 1), 'deepEqual(true, 1)');
+assert.deepEqual(4, '4');
+assert.deepEqual(true, 1);
 assert.throws(() => assert.deepEqual(4, '5'),
               AssertionError,
               'deepEqual( 4, \'5\')');
 
 // Having the same number of owned properties && the same set of keys.
-assert.doesNotThrow(() => assert.deepEqual({ a: 4 }, { a: 4 }));
-assert.doesNotThrow(() => assert.deepEqual({ a: 4, b: '2' }, { a: 4, b: '2' }));
-assert.doesNotThrow(() => assert.deepEqual([4], ['4']));
+assert.deepEqual({ a: 4 }, { a: 4 });
+assert.deepEqual({ a: 4, b: '2' }, { a: 4, b: '2' });
+assert.deepEqual([4], ['4']);
 assert.throws(
   () => assert.deepEqual({ a: 4 }, { a: 4, b: true }), AssertionError);
-assert.doesNotThrow(() => assert.deepEqual(['a'], { 0: 'a' }));
-assert.doesNotThrow(() => assert.deepEqual({ a: 4, b: '1' }, { b: '1', a: 4 }));
+assert.deepEqual(['a'], { 0: 'a' });
+assert.deepEqual({ a: 4, b: '1' }, { b: '1', a: 4 });
 const a1 = [1, 2, 3];
 const a2 = [1, 2, 3];
 a1.a = 'test';
@@ -630,7 +624,7 @@ a2.b = true;
 a2.a = 'test';
 assert.throws(() => assert.deepEqual(Object.keys(a1), Object.keys(a2)),
               AssertionError);
-assert.doesNotThrow(() => assert.deepEqual(a1, a2));
+assert.deepEqual(a1, a2);
 
 // Having an identical prototype property.
 const nbRoot = {
@@ -654,11 +648,11 @@ nameBuilder2.prototype = nbRoot;
 const nb1 = new nameBuilder('Ryan', 'Dahl');
 let nb2 = new nameBuilder2('Ryan', 'Dahl');
 
-assert.doesNotThrow(() => assert.deepEqual(nb1, nb2));
+assert.deepEqual(nb1, nb2);
 
 nameBuilder2.prototype = Object;
 nb2 = new nameBuilder2('Ryan', 'Dahl');
-assert.doesNotThrow(() => assert.deepEqual(nb1, nb2));
+assert.deepEqual(nb1, nb2);
 
 // Primitives and object.
 assert.throws(() => assert.deepEqual(null, {}), AssertionError);
@@ -670,21 +664,15 @@ assert.throws(() => assert.deepEqual(true, {}), AssertionError);
 assert.throws(() => assert.deepEqual(Symbol(), {}), AssertionError);
 
 // Primitive wrappers and object.
-assert.doesNotThrow(() => assert.deepEqual(new String('a'), ['a']),
-                    AssertionError);
-assert.doesNotThrow(() => assert.deepEqual(new String('a'), { 0: 'a' }),
-                    AssertionError);
-assert.doesNotThrow(() => assert.deepEqual(new Number(1), {}), AssertionError);
-assert.doesNotThrow(() => assert.deepEqual(new Boolean(true), {}),
-                    AssertionError);
+assert.deepEqual(new String('a'), ['a']);
+assert.deepEqual(new String('a'), { 0: 'a' });
+assert.deepEqual(new Number(1), {});
+assert.deepEqual(new Boolean(true), {});
 
 // Same number of keys but different key names.
 assert.throws(() => assert.deepEqual({ a: 1 }, { b: 1 }), AssertionError);
 
-assert.doesNotThrow(
-  () => assert.deepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)),
-  'deepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
-);
+assert.deepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14));
 
 assert.throws(
   () => assert.deepStrictEqual(new Date(), new Date(2000, 3, 14)),
@@ -698,16 +686,13 @@ assert.throws(
   'notDeepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
 );
 
-assert.doesNotThrow(
-  () => assert.notDeepStrictEqual(new Date(), new Date(2000, 3, 14)),
-  'notDeepStrictEqual(new Date(), new Date(2000, 3, 14))'
-);
+assert.notDeepStrictEqual(new Date(), new Date(2000, 3, 14));
 
-assert.doesNotThrow(() => assert.deepStrictEqual(/a/, /a/));
-assert.doesNotThrow(() => assert.deepStrictEqual(/a/g, /a/g));
-assert.doesNotThrow(() => assert.deepStrictEqual(/a/i, /a/i));
-assert.doesNotThrow(() => assert.deepStrictEqual(/a/m, /a/m));
-assert.doesNotThrow(() => assert.deepStrictEqual(/a/igm, /a/igm));
+assert.deepStrictEqual(/a/, /a/);
+assert.deepStrictEqual(/a/g, /a/g);
+assert.deepStrictEqual(/a/i, /a/i);
+assert.deepStrictEqual(/a/m, /a/m);
+assert.deepStrictEqual(/a/igm, /a/igm);
 assert.throws(
   () => assert.deepStrictEqual(/ab/, /a/),
   {
@@ -747,7 +732,7 @@ assert.throws(
 {
   const re1 = /a/;
   re1.lastIndex = 3;
-  assert.doesNotThrow(() => assert.deepStrictEqual(re1, /a/));
+  assert.deepStrictEqual(re1, /a/);
 }
 
 assert.throws(() => assert.deepStrictEqual(4, '4'),
@@ -763,9 +748,8 @@ assert.throws(() => assert.deepStrictEqual(4, '5'),
               'deepStrictEqual(4, \'5\')');
 
 // Having the same number of owned properties && the same set of keys.
-assert.doesNotThrow(() => assert.deepStrictEqual({ a: 4 }, { a: 4 }));
-assert.doesNotThrow(
-  () => assert.deepStrictEqual({ a: 4, b: '2' }, { a: 4, b: '2' }));
+assert.deepStrictEqual({ a: 4 }, { a: 4 });
+assert.deepStrictEqual({ a: 4, b: '2' }, { a: 4, b: '2' });
 assert.throws(() => assert.deepStrictEqual([4], ['4']),
               {
                 code: 'ERR_ASSERTION',
@@ -787,14 +771,13 @@ assert.throws(() => assert.deepStrictEqual(['a'], { 0: 'a' }),
 
 /* eslint-enable */
 
-assert.doesNotThrow(
-  () => assert.deepStrictEqual({ a: 4, b: '1' }, { b: '1', a: 4 }));
+assert.deepStrictEqual({ a: 4, b: '1' }, { b: '1', a: 4 });
 
 assert.throws(
   () => assert.deepStrictEqual([0, 1, 2, 'a', 'b'], [0, 1, 2, 'b', 'a']),
   AssertionError);
 
-assert.doesNotThrow(() => assert.deepStrictEqual(a1, a2));
+assert.deepStrictEqual(a1, a2);
 
 // Prototype check.
 function Constructor1(first, last) {
@@ -815,7 +798,7 @@ assert.throws(() => assert.deepStrictEqual(obj1, obj2), AssertionError);
 Constructor2.prototype = Constructor1.prototype;
 obj2 = new Constructor2('Ryan', 'Dahl');
 
-assert.doesNotThrow(() => assert.deepStrictEqual(obj1, obj2));
+assert.deepStrictEqual(obj1, obj2);
 
 // primitives
 assert.throws(() => assert.deepStrictEqual(4, '4'), AssertionError);
@@ -824,7 +807,7 @@ assert.throws(() => assert.deepStrictEqual(Symbol(), Symbol()),
               AssertionError);
 
 const s = Symbol();
-assert.doesNotThrow(() => assert.deepStrictEqual(s, s));
+assert.deepStrictEqual(s, s);
 
 // Primitives and object.
 assert.throws(() => assert.deepStrictEqual(null, {}), AssertionError);

--- a/test/parallel/test-assert-if-error.js
+++ b/test/parallel/test-assert-if-error.js
@@ -67,9 +67,9 @@ assert.throws(
   }
 );
 
-assert.doesNotThrow(() => { assert.ifError(null); });
-assert.doesNotThrow(() => { assert.ifError(); });
-assert.doesNotThrow(() => { assert.ifError(undefined); });
+assert.ifError(null);
+assert.ifError();
+assert.ifError(undefined);
 
 // https://github.com/nodejs/node-v0.x-archive/issues/2893
 {

--- a/test/parallel/test-assert-if-error.js
+++ b/test/parallel/test-assert-if-error.js
@@ -67,6 +67,7 @@ assert.throws(
   }
 );
 
+// Should not throw.
 assert.ifError(null);
 assert.ifError();
 assert.ifError(undefined);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -38,32 +38,22 @@ assert.ok(a.AssertionError.prototype instanceof Error,
           'a.AssertionError instanceof Error');
 
 assert.throws(() => a(false), a.AssertionError, 'ok(false)');
-
-assert.doesNotThrow(() => a(true), a.AssertionError, 'ok(true)');
-
-assert.doesNotThrow(() => a('test', 'ok(\'test\')'));
-
 assert.throws(() => a.ok(false), a.AssertionError, 'ok(false)');
 
-assert.doesNotThrow(() => a.ok(true), a.AssertionError, 'ok(true)');
-
-assert.doesNotThrow(() => a.ok('test'), 'ok(\'test\')');
+a(true);
+a('test', 'ok(\'test\')');
+a.ok(true);
+a.ok('test');
 
 assert.throws(() => a.equal(true, false),
               a.AssertionError, 'equal(true, false)');
 
-assert.doesNotThrow(() => a.equal(null, null), 'equal(null, null)');
-
-assert.doesNotThrow(() => a.equal(undefined, undefined),
-                    'equal(undefined, undefined)');
-
-assert.doesNotThrow(() => a.equal(null, undefined), 'equal(null, undefined)');
-
-assert.doesNotThrow(() => a.equal(true, true), 'equal(true, true)');
-
-assert.doesNotThrow(() => a.equal(2, '2'), 'equal(2, \'2\')');
-
-assert.doesNotThrow(() => a.notEqual(true, false), 'notEqual(true, false)');
+a.equal(null, null);
+a.equal(undefined, undefined);
+a.equal(null, undefined);
+a.equal(true, true);
+a.equal(2, '2');
+a.notEqual(true, false);
 
 assert.throws(() => a.notEqual(true, true),
               a.AssertionError, 'notEqual(true, true)');
@@ -77,7 +67,7 @@ assert.throws(() => a.strictEqual(null, undefined),
 assert.throws(() => a.notStrictEqual(2, 2),
               a.AssertionError, 'notStrictEqual(2, 2)');
 
-assert.doesNotThrow(() => a.notStrictEqual(2, '2'), 'notStrictEqual(2, \'2\')');
+a.notStrictEqual(2, '2');
 
 // Testing the throwing.
 function thrower(errorConstructor) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -121,7 +121,7 @@ assert.throws(() => thrower(TypeError));
 }
 
 common.expectsError(
-  () => assert.doesNotThrow(() => thrower(Error), 'user message'),
+  () => a.doesNotThrow(() => thrower(Error), 'user message'),
   {
     type: a.AssertionError,
     code: 'ERR_ASSERTION',
@@ -131,7 +131,7 @@ common.expectsError(
 );
 
 common.expectsError(
-  () => assert.doesNotThrow(() => thrower(Error), 'user message'),
+  () => a.doesNotThrow(() => thrower(Error), 'user message'),
   {
     code: 'ERR_ASSERTION',
     message: /Got unwanted exception: user message\n\[object Object\]/
@@ -139,7 +139,7 @@ common.expectsError(
 );
 
 common.expectsError(
-  () => assert.doesNotThrow(() => thrower(Error)),
+  () => a.doesNotThrow(() => thrower(Error)),
   {
     code: 'ERR_ASSERTION',
     message: /Got unwanted exception\.\n\[object Object\]/
@@ -292,7 +292,7 @@ try {
 
   // Verify AssertionError is the result from doesNotThrow with custom Error.
   try {
-    assert.doesNotThrow(() => {
+    a.doesNotThrow(() => {
       throw new TypeError('wrong type');
     }, TypeError, rangeError);
   } catch (e) {
@@ -760,7 +760,6 @@ common.expectsError(
 
   errObj.code = '404';
   common.expectsError(
-  // eslint-disable-next-line no-restricted-syntax
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
@@ -772,7 +771,6 @@ common.expectsError(
   errObj.code = 404;
   errObj.foo = 'bar';
   common.expectsError(
-  // eslint-disable-next-line no-restricted-syntax
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
@@ -791,7 +789,7 @@ common.expectsError(
   );
 
   common.expectsError(
-    () => assert.doesNotThrow(() => { throw new Error(); }, { foo: 'bar' }),
+    () => a.doesNotThrow(() => { throw new Error(); }, { foo: 'bar' }),
     {
       type: TypeError,
       code: 'ERR_INVALID_ARG_TYPE',
@@ -822,7 +820,7 @@ common.expectsError(
   assert.throws(() => { throw undefined; }, /undefined/);
   common.expectsError(
     // eslint-disable-next-line no-throw-literal
-    () => assert.doesNotThrow(() => { throw undefined; }),
+    () => a.doesNotThrow(() => { throw undefined; }),
     {
       type: assert.AssertionError,
       code: 'ERR_ASSERTION',

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -62,7 +62,7 @@ assert.throws(() => b.write('test', 'utf8', 0),
               /is no longer supported/);
 
 
-// try to create 0-length buffers
+// Try to create 0-length buffers. Should not throw.
 Buffer.from('');
 Buffer.from('', 'ascii');
 Buffer.from('', 'latin1');
@@ -107,7 +107,7 @@ b.copy(Buffer.alloc(1), 0, 2048, 2048);
   assert.strictEqual(writeTest.toString(), 'nodejs');
 }
 
-// Offset points to the end of the buffer
+// Offset points to the end of the buffer and does not throw.
 // (see https://github.com/nodejs/node/issues/8127).
 Buffer.alloc(1).write('', 1, 0);
 
@@ -992,10 +992,10 @@ common.expectsError(() => {
   assert.strictEqual(ubuf.buffer.byteLength, 10);
 }
 
-// Regression test
+// Regression test to verify that an empty ArrayBuffer does not throw.
 Buffer.from(new ArrayBuffer());
 
-// Test that ArrayBuffer from a different context is detected correctly
+// Test that ArrayBuffer from a different context is detected correctly.
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 Buffer.from(arrayBuf);
 Buffer.from({ buffer: arrayBuf });

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -63,16 +63,16 @@ assert.throws(() => b.write('test', 'utf8', 0),
 
 
 // try to create 0-length buffers
-assert.doesNotThrow(() => Buffer.from(''));
-assert.doesNotThrow(() => Buffer.from('', 'ascii'));
-assert.doesNotThrow(() => Buffer.from('', 'latin1'));
-assert.doesNotThrow(() => Buffer.alloc(0));
-assert.doesNotThrow(() => Buffer.allocUnsafe(0));
-assert.doesNotThrow(() => new Buffer(''));
-assert.doesNotThrow(() => new Buffer('', 'ascii'));
-assert.doesNotThrow(() => new Buffer('', 'latin1'));
-assert.doesNotThrow(() => new Buffer('', 'binary'));
-assert.doesNotThrow(() => Buffer(0));
+Buffer.from('');
+Buffer.from('', 'ascii');
+Buffer.from('', 'latin1');
+Buffer.alloc(0);
+Buffer.allocUnsafe(0);
+new Buffer('');
+new Buffer('', 'ascii');
+new Buffer('', 'latin1');
+new Buffer('', 'binary');
+Buffer(0);
 
 // try to write a 0-length string beyond the end of b
 assert.throws(() => b.write('', 2048), RangeError);
@@ -109,7 +109,7 @@ b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
 // Offset points to the end of the buffer
 // (see https://github.com/nodejs/node/issues/8127).
-assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
+Buffer.alloc(1).write('', 1, 0);
 
 // ASCII slice test
 {
@@ -963,7 +963,7 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
                          Buffer.from(''));
 
   // Check pool offset after that by trying to write string into the pool.
-  assert.doesNotThrow(() => Buffer.from('abc'));
+  Buffer.from('abc');
 }
 
 
@@ -993,12 +993,12 @@ common.expectsError(() => {
 }
 
 // Regression test
-assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
+Buffer.from(new ArrayBuffer());
 
 // Test that ArrayBuffer from a different context is detected correctly
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
-assert.doesNotThrow(() => Buffer.from(arrayBuf));
-assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
+Buffer.from(arrayBuf);
+Buffer.from({ buffer: arrayBuf });
 
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);

--- a/test/parallel/test-buffer-bad-overload.js
+++ b/test/parallel/test-buffer-bad-overload.js
@@ -2,9 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-assert.doesNotThrow(function() {
-  Buffer.allocUnsafe(10);
-});
+Buffer.allocUnsafe(10);
 
 const err = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
@@ -16,6 +14,4 @@ assert.throws(function() {
   Buffer.from(10, 'hex');
 }, err);
 
-assert.doesNotThrow(function() {
-  Buffer.from('deadbeaf', 'hex');
-});
+Buffer.from('deadbeaf', 'hex');

--- a/test/parallel/test-buffer-bad-overload.js
+++ b/test/parallel/test-buffer-bad-overload.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-Buffer.allocUnsafe(10);
+Buffer.allocUnsafe(10); // Should not throw.
 
 const err = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
@@ -14,4 +14,4 @@ assert.throws(function() {
   Buffer.from(10, 'hex');
 }, err);
 
-Buffer.from('deadbeaf', 'hex');
+Buffer.from('deadbeaf', 'hex'); // Should not throw.

--- a/test/parallel/test-buffer-constants.js
+++ b/test/parallel/test-buffer-constants.js
@@ -11,7 +11,7 @@ assert(MAX_STRING_LENGTH <= MAX_LENGTH);
 assert.throws(() => ' '.repeat(MAX_STRING_LENGTH + 1),
               /^RangeError: Invalid string length$/);
 
-assert.doesNotThrow(() => ' '.repeat(MAX_STRING_LENGTH));
+' '.repeat(MAX_STRING_LENGTH);
 
 // Legacy values match:
 assert.strictEqual(kMaxLength, MAX_LENGTH);

--- a/test/parallel/test-buffer-constants.js
+++ b/test/parallel/test-buffer-constants.js
@@ -11,7 +11,7 @@ assert(MAX_STRING_LENGTH <= MAX_LENGTH);
 assert.throws(() => ' '.repeat(MAX_STRING_LENGTH + 1),
               /^RangeError: Invalid string length$/);
 
-' '.repeat(MAX_STRING_LENGTH);
+' '.repeat(MAX_STRING_LENGTH); // Should not throw.
 
 // Legacy values match:
 assert.strictEqual(kMaxLength, MAX_LENGTH);

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -93,7 +93,7 @@ bb.fill('hello crazy world');
 
 
 // try to copy from before the beginning of b
-assert.doesNotThrow(() => { b.copy(c, 0, 100, 10); });
+b.copy(c, 0, 100, 10);
 
 // copy throws at negative sourceStart
 assert.throws(function() {

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -92,7 +92,7 @@ const bb = Buffer.allocUnsafe(10);
 bb.fill('hello crazy world');
 
 
-// try to copy from before the beginning of b
+// Try to copy from before the beginning of b. Should not throw.
 b.copy(c, 0, 100, 10);
 
 // copy throws at negative sourceStart

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -51,10 +51,8 @@ assert.strictEqual(util.inspect(s), expected);
 
 buffer.INSPECT_MAX_BYTES = Infinity;
 
-assert.doesNotThrow(function() {
-  assert.strictEqual(util.inspect(b), expected);
-  assert.strictEqual(util.inspect(s), expected);
-});
+assert.strictEqual(util.inspect(b), expected);
+assert.strictEqual(util.inspect(s), expected);
 
 b.inspect = undefined;
 assert.strictEqual(util.inspect(b), expected);

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -15,11 +15,7 @@ function read(buff, funx, args, expected) {
     }
   );
 
-  assert.doesNotThrow(
-    () => assert.strictEqual(buff[funx](...args, true), expected),
-    'noAssert does not change return value for valid ranges'
-  );
-
+  assert.strictEqual(buff[funx](...args, true), expected);
 }
 
 // testing basic functionality of readDoubleBE() and readDoubleLE()

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -22,8 +22,7 @@ arr2[1] = 6000;
 
 assert.deepStrictEqual(arr_buf, ar_buf);
 
-// Checks for calling Buffer.byteLength on a SharedArrayBuffer
-
+// Checks for calling Buffer.byteLength on a SharedArrayBuffer.
 assert.strictEqual(Buffer.byteLength(sab), sab.byteLength);
 
-Buffer.from({ buffer: sab });
+Buffer.from({ buffer: sab }); // Should not throw.

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -26,4 +26,4 @@ assert.deepStrictEqual(arr_buf, ar_buf);
 
 assert.strictEqual(Buffer.byteLength(sab), sab.byteLength);
 
-assert.doesNotThrow(() => Buffer.from({ buffer: sab }));
+Buffer.from({ buffer: sab });

--- a/test/parallel/test-buffer-slice.js
+++ b/test/parallel/test-buffer-slice.js
@@ -77,9 +77,8 @@ expectedSameBufs.forEach(([buf1, buf2]) => {
 
 const utf16Buf = Buffer.from('0123456789', 'utf16le');
 assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
-// try to slice a zero length Buffer
-// see https://github.com/joyent/node/issues/5881
-Buffer.alloc(0).slice(0, 1);
+// Try to slice a zero length Buffer.
+// See https://github.com/joyent/node/issues/5881
 assert.strictEqual(Buffer.alloc(0).slice(0, 1).length, 0);
 
 {

--- a/test/parallel/test-buffer-slice.js
+++ b/test/parallel/test-buffer-slice.js
@@ -79,7 +79,7 @@ const utf16Buf = Buffer.from('0123456789', 'utf16le');
 assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
 // try to slice a zero length Buffer
 // see https://github.com/joyent/node/issues/5881
-assert.doesNotThrow(() => Buffer.alloc(0).slice(0, 1));
+Buffer.alloc(0).slice(0, 1);
 assert.strictEqual(Buffer.alloc(0).slice(0, 1).length, 0);
 
 {

--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -39,7 +39,5 @@ process.on('exit', function() {
   assert.throws(function() {
     process.kill(child.pid);
   }, /^Error: kill ESRCH$/);
-  assert.doesNotThrow(function() {
-    process.kill(persistentPid);
-  });
+  process.kill(persistentPid);
 });

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -41,21 +41,10 @@ assert.throws(function() {
 }, TypeError);
 
 // verify that valid argument combinations do not throw
-assert.doesNotThrow(function() {
-  spawn(cmd);
-});
-
-assert.doesNotThrow(function() {
-  spawn(cmd, []);
-});
-
-assert.doesNotThrow(function() {
-  spawn(cmd, {});
-});
-
-assert.doesNotThrow(function() {
-  spawn(cmd, [], {});
-});
+spawn(cmd);
+spawn(cmd, []);
+spawn(cmd, {});
+spawn(cmd, [], {});
 
 // verify that invalid argument combinations throw
 assert.throws(function() {
@@ -100,14 +89,14 @@ const n = null;
 //   (f, a)
 //   (f, a, o)
 //   (f, o)
-assert.doesNotThrow(function() { spawn(cmd); });
-assert.doesNotThrow(function() { spawn(cmd, a); });
-assert.doesNotThrow(function() { spawn(cmd, a, o); });
-assert.doesNotThrow(function() { spawn(cmd, o); });
+spawn(cmd);
+spawn(cmd, a);
+spawn(cmd, a, o);
+spawn(cmd, o);
 
 // Variants of undefined as explicit 'no argument' at a position
-assert.doesNotThrow(function() { spawn(cmd, u, o); });
-assert.doesNotThrow(function() { spawn(cmd, a, u); });
+spawn(cmd, u, o);
+spawn(cmd, a, u);
 
 assert.throws(function() { spawn(cmd, n, o); }, invalidArgTypeError);
 assert.throws(function() { spawn(cmd, a, n); }, invalidArgTypeError);
@@ -128,36 +117,36 @@ assert.throws(function() { spawn(cmd, a, s); }, invalidArgTypeError);
 //   (f, o)
 //   (f, o, c)
 //   (f, c)
-assert.doesNotThrow(function() { execFile(cmd); });
-assert.doesNotThrow(function() { execFile(cmd, a); });
-assert.doesNotThrow(function() { execFile(cmd, a, o); });
-assert.doesNotThrow(function() { execFile(cmd, a, o, c); });
-assert.doesNotThrow(function() { execFile(cmd, a, c); });
-assert.doesNotThrow(function() { execFile(cmd, o); });
-assert.doesNotThrow(function() { execFile(cmd, o, c); });
-assert.doesNotThrow(function() { execFile(cmd, c); });
+execFile(cmd);
+execFile(cmd, a);
+execFile(cmd, a, o);
+execFile(cmd, a, o, c);
+execFile(cmd, a, c);
+execFile(cmd, o);
+execFile(cmd, o, c);
+execFile(cmd, c);
 
 // Variants of undefined as explicit 'no argument' at a position
-assert.doesNotThrow(function() { execFile(cmd, u, o, c); });
-assert.doesNotThrow(function() { execFile(cmd, a, u, c); });
-assert.doesNotThrow(function() { execFile(cmd, a, o, u); });
-assert.doesNotThrow(function() { execFile(cmd, n, o, c); });
-assert.doesNotThrow(function() { execFile(cmd, a, n, c); });
-assert.doesNotThrow(function() { execFile(cmd, a, o, n); });
-assert.doesNotThrow(function() { execFile(cmd, u, u, u); });
-assert.doesNotThrow(function() { execFile(cmd, u, u, c); });
-assert.doesNotThrow(function() { execFile(cmd, u, o, u); });
-assert.doesNotThrow(function() { execFile(cmd, a, u, u); });
-assert.doesNotThrow(function() { execFile(cmd, n, n, n); });
-assert.doesNotThrow(function() { execFile(cmd, n, n, c); });
-assert.doesNotThrow(function() { execFile(cmd, n, o, n); });
-assert.doesNotThrow(function() { execFile(cmd, a, n, n); });
-assert.doesNotThrow(function() { execFile(cmd, a, u); });
-assert.doesNotThrow(function() { execFile(cmd, a, n); });
-assert.doesNotThrow(function() { execFile(cmd, o, u); });
-assert.doesNotThrow(function() { execFile(cmd, o, n); });
-assert.doesNotThrow(function() { execFile(cmd, c, u); });
-assert.doesNotThrow(function() { execFile(cmd, c, n); });
+execFile(cmd, u, o, c);
+execFile(cmd, a, u, c);
+execFile(cmd, a, o, u);
+execFile(cmd, n, o, c);
+execFile(cmd, a, n, c);
+execFile(cmd, a, o, n);
+execFile(cmd, u, u, u);
+execFile(cmd, u, u, c);
+execFile(cmd, u, o, u);
+execFile(cmd, a, u, u);
+execFile(cmd, n, n, n);
+execFile(cmd, n, n, c);
+execFile(cmd, n, o, n);
+execFile(cmd, a, n, n);
+execFile(cmd, a, u);
+execFile(cmd, a, n);
+execFile(cmd, o, u);
+execFile(cmd, o, n);
+execFile(cmd, c, u);
+execFile(cmd, c, n);
 
 // string is invalid in arg position (this may seem strange, but is
 // consistent across node API, cf. `net.createServer('not options', 'not
@@ -173,7 +162,7 @@ assert.throws(function() { execFile(cmd, a, u, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, a, n, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, u, o, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, n, o, s); }, invalidArgValueError);
-assert.doesNotThrow(function() { execFile(cmd, c, s); });
+execFile(cmd, c, s);
 
 
 // verify that fork has same argument parsing behavior as spawn
@@ -183,16 +172,16 @@ assert.doesNotThrow(function() { execFile(cmd, c, s); });
 //   (f, a)
 //   (f, a, o)
 //   (f, o)
-assert.doesNotThrow(function() { fork(empty); });
-assert.doesNotThrow(function() { fork(empty, a); });
-assert.doesNotThrow(function() { fork(empty, a, o); });
-assert.doesNotThrow(function() { fork(empty, o); });
-assert.doesNotThrow(function() { fork(empty, u, u); });
-assert.doesNotThrow(function() { fork(empty, u, o); });
-assert.doesNotThrow(function() { fork(empty, a, u); });
-assert.doesNotThrow(function() { fork(empty, n, n); });
-assert.doesNotThrow(function() { fork(empty, n, o); });
-assert.doesNotThrow(function() { fork(empty, a, n); });
+fork(empty);
+fork(empty, a);
+fork(empty, a, o);
+fork(empty, o);
+fork(empty, u, u);
+fork(empty, u, o);
+fork(empty, a, u);
+fork(empty, n, n);
+fork(empty, n, o);
+fork(empty, a, n);
 
 assert.throws(function() { fork(empty, s); }, invalidArgValueError);
 assert.throws(function() { fork(empty, a, s); }, invalidArgValueError);

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -40,13 +40,13 @@ assert.throws(function() {
   child.on('error', common.mustNotCall());
 }, TypeError);
 
-// verify that valid argument combinations do not throw
+// Verify that valid argument combinations do not throw.
 spawn(cmd);
 spawn(cmd, []);
 spawn(cmd, {});
 spawn(cmd, [], {});
 
-// verify that invalid argument combinations throw
+// Verify that invalid argument combinations throw.
 assert.throws(function() {
   spawn();
 }, invalidArgTypeError);
@@ -76,7 +76,7 @@ assert.throws(function() {
   spawn(cmd, [], 1);
 }, invalidArgTypeError);
 
-// Argument types for combinatorics
+// Argument types for combinatorics.
 const a = [];
 const o = {};
 function c() {}
@@ -94,7 +94,7 @@ spawn(cmd, a);
 spawn(cmd, a, o);
 spawn(cmd, o);
 
-// Variants of undefined as explicit 'no argument' at a position
+// Variants of undefined as explicit 'no argument' at a position.
 spawn(cmd, u, o);
 spawn(cmd, a, u);
 
@@ -105,7 +105,7 @@ assert.throws(function() { spawn(cmd, s); }, invalidArgTypeError);
 assert.throws(function() { spawn(cmd, a, s); }, invalidArgTypeError);
 
 
-// verify that execFile has same argument parsing behavior as spawn
+// Verify that execFile has same argument parsing behavior as spawn.
 //
 // function execFile(file=f [,args=a] [, options=o] [, callback=c]) has valid
 // combinations:
@@ -126,7 +126,7 @@ execFile(cmd, o);
 execFile(cmd, o, c);
 execFile(cmd, c);
 
-// Variants of undefined as explicit 'no argument' at a position
+// Variants of undefined as explicit 'no argument' at a position.
 execFile(cmd, u, o, c);
 execFile(cmd, a, u, c);
 execFile(cmd, a, o, u);
@@ -148,9 +148,9 @@ execFile(cmd, o, n);
 execFile(cmd, c, u);
 execFile(cmd, c, n);
 
-// string is invalid in arg position (this may seem strange, but is
+// String is invalid in arg position (this may seem strange, but is
 // consistent across node API, cf. `net.createServer('not options', 'not
-// callback')`
+// callback')`.
 assert.throws(function() { execFile(cmd, s, o, c); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, a, s, c); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, a, o, s); }, invalidArgValueError);
@@ -162,10 +162,10 @@ assert.throws(function() { execFile(cmd, a, u, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, a, n, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, u, o, s); }, invalidArgValueError);
 assert.throws(function() { execFile(cmd, n, o, s); }, invalidArgValueError);
-execFile(cmd, c, s);
 
+execFile(cmd, c, s); // Should not throw.
 
-// verify that fork has same argument parsing behavior as spawn
+// Verify that fork has same argument parsing behavior as spawn.
 //
 // function fork(file=f [,args=a] [, options=o]) has valid combinations:
 //   (f)

--- a/test/parallel/test-console-async-write-error.js
+++ b/test/parallel/test-console-async-write-error.js
@@ -11,6 +11,5 @@ for (const method of ['dir', 'log', 'warn']) {
   });
 
   const c = new Console(out, out, true);
-
-  c[method]('abc');
+  c[method]('abc'); // Should not throw.
 }

--- a/test/parallel/test-console-async-write-error.js
+++ b/test/parallel/test-console-async-write-error.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const { Console } = require('console');
 const { Writable } = require('stream');
-const assert = require('assert');
 
 for (const method of ['dir', 'log', 'warn']) {
   const out = new Writable({
@@ -13,7 +12,5 @@ for (const method of ['dir', 'log', 'warn']) {
 
   const c = new Console(out, out, true);
 
-  assert.doesNotThrow(() => {
-    c[method]('abc');
-  });
+  c[method]('abc');
 }

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -28,15 +28,15 @@ const Console = require('console').Console;
 const out = new Stream();
 const err = new Stream();
 
-// ensure the Console instance doesn't write to the
-// process' "stdout" or "stderr" streams
+// Ensure the Console instance doesn't write to the
+// process' "stdout" or "stderr" streams.
 process.stdout.write = process.stderr.write = common.mustNotCall();
 
-// make sure that the "Console" function exists
+// Make sure that the "Console" function exists.
 assert.strictEqual('function', typeof Console);
 
-// make sure that the Console constructor throws
-// when not given a writable stream instance
+// Make sure that the Console constructor throws
+// when not given a writable stream instance.
 common.expectsError(
   () => { new Console(); },
   {
@@ -46,7 +46,7 @@ common.expectsError(
   }
 );
 
-// Console constructor should throw if stderr exists but is not writable
+// Console constructor should throw if stderr exists but is not writable.
 common.expectsError(
   () => {
     out.write = () => {};
@@ -77,7 +77,7 @@ out.write = common.mustCall((d) => {
 
 c.dir({ foo: 1 });
 
-// ensure that the console functions are bound to the console instance
+// Ensure that the console functions are bound to the console instance.
 let called = 0;
 out.write = common.mustCall((d) => {
   called++;
@@ -86,7 +86,7 @@ out.write = common.mustCall((d) => {
 
 [1, 2, 3].forEach(c.log);
 
-// Console() detects if it is called without `new` keyword
+// Console() detects if it is called without `new` keyword.
 Console(out, err);
 
 // Instance that does not ignore the stream errors.

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -87,9 +87,7 @@ out.write = common.mustCall((d) => {
 [1, 2, 3].forEach(c.log);
 
 // Console() detects if it is called without `new` keyword
-assert.doesNotThrow(() => {
-  Console(out, err);
-});
+Console(out, err);
 
 // Instance that does not ignore the stream errors.
 const c2 = new Console(out, err, false);

--- a/test/parallel/test-console-is-a-namespace.js
+++ b/test/parallel/test-console-is-a-namespace.js
@@ -2,13 +2,10 @@
 
 require('../common');
 
-const assert = require('assert');
 const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
-assert.doesNotThrow(() => {
-  global.console = global.console;
-});
+global.console = global.console;
 
 const self = global;
 

--- a/test/parallel/test-console-is-a-namespace.js
+++ b/test/parallel/test-console-is-a-namespace.js
@@ -5,7 +5,7 @@ require('../common');
 const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
-global.console = global.console;
+global.console = global.console; // Should not throw.
 
 const self = global;
 

--- a/test/parallel/test-console-sync-write-error.js
+++ b/test/parallel/test-console-sync-write-error.js
@@ -12,8 +12,7 @@ for (const method of ['dir', 'log', 'warn']) {
     });
 
     const c = new Console(out, out, true);
-
-    c[method]('abc');
+    c[method]('abc'); // Should not throw.
   }
 
   {
@@ -24,8 +23,7 @@ for (const method of ['dir', 'log', 'warn']) {
     });
 
     const c = new Console(out, out, true);
-
-    c[method]('abc');
+    c[method]('abc'); // Should not throw.
   }
 
   {
@@ -36,7 +34,6 @@ for (const method of ['dir', 'log', 'warn']) {
     });
 
     const c = new Console(out, out, true);
-
-    c[method]('abc');
+    c[method]('abc'); // Should not throw.
   }
 }

--- a/test/parallel/test-console-sync-write-error.js
+++ b/test/parallel/test-console-sync-write-error.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const { Console } = require('console');
 const { Writable } = require('stream');
-const assert = require('assert');
 
 for (const method of ['dir', 'log', 'warn']) {
   {
@@ -14,9 +13,7 @@ for (const method of ['dir', 'log', 'warn']) {
 
     const c = new Console(out, out, true);
 
-    assert.doesNotThrow(() => {
-      c[method]('abc');
-    });
+    c[method]('abc');
   }
 
   {
@@ -28,9 +25,7 @@ for (const method of ['dir', 'log', 'warn']) {
 
     const c = new Console(out, out, true);
 
-    assert.doesNotThrow(() => {
-      c[method]('abc');
-    });
+    c[method]('abc');
   }
 
   {
@@ -42,8 +37,6 @@ for (const method of ['dir', 'log', 'warn']) {
 
     const c = new Console(out, out, true);
 
-    assert.doesNotThrow(() => {
-      c[method]('abc');
-    });
+    c[method]('abc');
   }
 }

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -29,18 +29,14 @@ assert.ok(process.stderr.writable);
 assert.strictEqual(typeof process.stdout.fd, 'number');
 assert.strictEqual(typeof process.stderr.fd, 'number');
 
-assert.doesNotThrow(function() {
-  process.once('warning', common.mustCall((warning) => {
-    assert(/no such label/.test(warning.message));
-  }));
+process.once('warning', common.mustCall((warning) => {
+  assert(/no such label/.test(warning.message));
+}));
 
-  console.timeEnd('no such label');
-});
+console.timeEnd('no such label');
 
-assert.doesNotThrow(function() {
-  console.time('label');
-  console.timeEnd('label');
-});
+console.time('label');
+console.timeEnd('label');
 
 // Check that the `Error` is a `TypeError` but do not check the message as it
 // will be different in different JavaScript engines.
@@ -140,15 +136,11 @@ console.timeEnd();
 console.time(NaN);
 console.timeEnd(NaN);
 
-assert.doesNotThrow(() => {
-  console.assert(false, '%s should', 'console.assert', 'not throw');
-  assert.strictEqual(errStrings[errStrings.length - 1],
-                     'Assertion failed: console.assert should not throw\n');
-});
+console.assert(false, '%s should', 'console.assert', 'not throw');
+assert.strictEqual(errStrings[errStrings.length - 1],
+                   'Assertion failed: console.assert should not throw\n');
 
-assert.doesNotThrow(() => {
-  console.assert(true, 'this should not throw');
-});
+console.assert(true, 'this should not throw');
 
 assert.strictEqual(strings.length, process.stdout.writeTimes);
 assert.strictEqual(errStrings.length, process.stderr.writeTimes);

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -46,9 +46,7 @@ const rsaPubPem = fixtures.readSync('test_rsa_pubkey.pem', 'ascii');
 const rsaKeyPem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
 
 // PFX tests
-assert.doesNotThrow(function() {
-  tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
-});
+tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
 
 assert.throws(function() {
   tls.createSecureContext({ pfx: certPfx });

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -201,18 +201,18 @@ testCipher2(Buffer.from('0123456789abcdef'));
   let decipher = crypto.createDecipher('aes192', key);
 
   let txt;
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs2'));
-  assert.doesNotThrow(() => txt += decipher.final('ucs2'));
+  txt = decipher.update(ciph, 'base64', 'ucs2');
+  txt += decipher.final('ucs2');
   assert.strictEqual(txt, plaintext);
 
   decipher = crypto.createDecipher('aes192', key);
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs-2'));
-  assert.doesNotThrow(() => txt += decipher.final('ucs-2'));
+  txt = decipher.update(ciph, 'base64', 'ucs-2');
+  txt += decipher.final('ucs-2');
   assert.strictEqual(txt, plaintext);
 
   decipher = crypto.createDecipher('aes192', key);
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'utf-16le'));
-  assert.doesNotThrow(() => txt += decipher.final('utf-16le'));
+  txt = decipher.update(ciph, 'base64', 'utf-16le');
+  txt += decipher.final('utf-16le');
   assert.strictEqual(txt, plaintext);
 }
 

--- a/test/parallel/test-crypto-dh-odd-key.js
+++ b/test/parallel/test-crypto-dh-odd-key.js
@@ -37,7 +37,7 @@ function test() {
 
 // FIPS requires a length of at least 1024
 if (!common.hasFipsCrypto) {
-  assert.doesNotThrow(function() { test(); });
+  test();
 } else {
   assert.throws(function() { test(); }, /key size too small/);
 }

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -371,9 +371,7 @@ if (availableCurves.has('prime256v1') && availableHashes.has('sha256')) {
     'AwEHoUQDQgAEurOxfSxmqIRYzJVagdZfMMSjRNNhB8i3mXyIMq704m2m52FdfKZ2\n' +
     'pQhByd5eyj3lgZ7m7jbchtdgyOF8Io/1ng==\n' +
     '-----END EC PRIVATE KEY-----';
-  assert.doesNotThrow(() => {
-    crypto.createSign('SHA256').sign(ecPrivateKey);
-  });
+  crypto.createSign('SHA256').sign(ecPrivateKey);
 }
 
 // invalid test: curve argument is undefined

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -29,11 +29,7 @@ const crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
-
-/*
- * Input data
- */
-
+// Input data.
 const ODD_LENGTH_PLAIN = 'Hello node world!';
 const EVEN_LENGTH_PLAIN = 'Hello node world!AbC09876dDeFgHi';
 
@@ -42,10 +38,7 @@ const IV_PLAIN = 'blahFizz2011Buzz';
 
 const CIPHER_NAME = 'aes-128-cbc';
 
-
-/*
- * Expected result data
- */
+// Expected result data.
 
 // echo -n 'Hello node world!' | \
 // openssl enc -aes-128-cbc -e -K 5333632e722e652e742e4b2e652e5921 \
@@ -67,10 +60,7 @@ const EVEN_LENGTH_ENCRYPTED_NOPAD =
     '7f57859550d4d2fdb9806da2a750461ab46e71b3d78ebe2d9684dfc87f7575b9';
 
 
-/*
- * Helper wrappers
- */
-
+// Helper wrappers.
 function enc(plain, pad) {
   const encrypt = crypto.createCipheriv(CIPHER_NAME, KEY_PLAIN, IV_PLAIN);
   encrypt.setAutoPadding(pad);
@@ -87,16 +77,12 @@ function dec(encd, pad) {
   return plain;
 }
 
-
-/*
- * Test encryption
- */
-
+// Test encryption
 assert.strictEqual(enc(ODD_LENGTH_PLAIN, true), ODD_LENGTH_ENCRYPTED);
 assert.strictEqual(enc(EVEN_LENGTH_PLAIN, true), EVEN_LENGTH_ENCRYPTED);
 
 assert.throws(function() {
-  // input must have block length %
+  // Input must have block length %.
   enc(ODD_LENGTH_PLAIN, false);
 }, /data not multiple of block length/);
 
@@ -104,24 +90,20 @@ assert.strictEqual(
   enc(EVEN_LENGTH_PLAIN, false), EVEN_LENGTH_ENCRYPTED_NOPAD
 );
 
-
-/*
- * Test decryption
- */
-
+// Test decryption.
 assert.strictEqual(dec(ODD_LENGTH_ENCRYPTED, true), ODD_LENGTH_PLAIN);
 assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, true), EVEN_LENGTH_PLAIN);
 
-// returns including original padding
+// Returns including original padding.
 assert.strictEqual(dec(ODD_LENGTH_ENCRYPTED, false).length, 32);
 assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, false).length, 48);
 
 assert.throws(function() {
-  // must have at least 1 byte of padding (PKCS):
+  // Must have at least 1 byte of padding (PKCS):
   assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED_NOPAD, true), EVEN_LENGTH_PLAIN);
 }, /bad decrypt/);
 
-// no-pad encrypted string should return the same:
+// No-pad encrypted string should return the same:
 assert.strictEqual(
   dec(EVEN_LENGTH_ENCRYPTED_NOPAD, false), EVEN_LENGTH_PLAIN
 );

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -100,11 +100,9 @@ assert.throws(function() {
   enc(ODD_LENGTH_PLAIN, false);
 }, /data not multiple of block length/);
 
-assert.doesNotThrow(function() {
-  assert.strictEqual(
-    enc(EVEN_LENGTH_PLAIN, false), EVEN_LENGTH_ENCRYPTED_NOPAD
-  );
-});
+assert.strictEqual(
+  enc(EVEN_LENGTH_PLAIN, false), EVEN_LENGTH_ENCRYPTED_NOPAD
+);
 
 
 /*
@@ -114,20 +112,16 @@ assert.doesNotThrow(function() {
 assert.strictEqual(dec(ODD_LENGTH_ENCRYPTED, true), ODD_LENGTH_PLAIN);
 assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, true), EVEN_LENGTH_PLAIN);
 
-assert.doesNotThrow(function() {
-  // returns including original padding
-  assert.strictEqual(dec(ODD_LENGTH_ENCRYPTED, false).length, 32);
-  assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, false).length, 48);
-});
+// returns including original padding
+assert.strictEqual(dec(ODD_LENGTH_ENCRYPTED, false).length, 32);
+assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, false).length, 48);
 
 assert.throws(function() {
   // must have at least 1 byte of padding (PKCS):
   assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED_NOPAD, true), EVEN_LENGTH_PLAIN);
 }, /bad decrypt/);
 
-assert.doesNotThrow(function() {
-  // no-pad encrypted string should return the same:
-  assert.strictEqual(
-    dec(EVEN_LENGTH_ENCRYPTED_NOPAD, false), EVEN_LENGTH_PLAIN
-  );
-});
+// no-pad encrypted string should return the same:
+assert.strictEqual(
+  dec(EVEN_LENGTH_ENCRYPTED_NOPAD, false), EVEN_LENGTH_PLAIN
+);

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -100,11 +100,9 @@ common.expectsError(
 
 // Should not get FATAL ERROR with empty password and salt
 // https://github.com/nodejs/node/issues/8571
-assert.doesNotThrow(() => {
-  crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall((e) => {
-    assert.ifError(e);
-  }));
-});
+crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall((e) => {
+  assert.ifError(e);
+}));
 
 common.expectsError(
   () => crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall()),

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -100,9 +100,7 @@ common.expectsError(
 
 // Should not get FATAL ERROR with empty password and salt
 // https://github.com/nodejs/node/issues/8571
-crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall((e) => {
-  assert.ifError(e);
-}));
+crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall(assert.ifError));
 
 common.expectsError(
   () => crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall()),

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -256,7 +256,6 @@ const input = 'I AM THE WALRUS';
   // against
   const sign = crypto.createSign('SHA1');
   sign.update(input);
-
   const signOptions = { key: dsaKeyPemEncrypted, passphrase: 'password' };
   const signature = sign.sign(signOptions, 'hex');
 

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -153,10 +153,8 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test RSA key signing/verification with encrypted key
 rsaSign = crypto.createSign('SHA1');
 rsaSign.update(rsaPubPem);
-assert.doesNotThrow(() => {
-  const signOptions = { key: rsaKeyPemEncrypted, passphrase: 'password' };
-  rsaSignature = rsaSign.sign(signOptions, 'hex');
-});
+const signOptions = { key: rsaKeyPemEncrypted, passphrase: 'password' };
+rsaSignature = rsaSign.sign(signOptions, 'hex');
 assert.strictEqual(rsaSignature, expectedSignature);
 
 rsaVerify = crypto.createVerify('SHA1');
@@ -259,11 +257,8 @@ const input = 'I AM THE WALRUS';
   const sign = crypto.createSign('SHA1');
   sign.update(input);
 
-  let signature;
-  assert.doesNotThrow(() => {
-    const signOptions = { key: dsaKeyPemEncrypted, passphrase: 'password' };
-    signature = sign.sign(signOptions, 'hex');
-  });
+  const signOptions = { key: dsaKeyPemEncrypted, passphrase: 'password' };
+  const signature = sign.sign(signOptions, 'hex');
 
   const verify = crypto.createVerify('SHA1');
   verify.update(input);

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -56,9 +56,7 @@ assert.throws(function() {
 });
 
 // PFX tests
-assert.doesNotThrow(function() {
-  tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
-});
+tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
 
 assert.throws(function() {
   tls.createSecureContext({ pfx: certPfx });

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -34,10 +34,8 @@ invalidTypes.forEach((invalidType) => {
 
 // Error must not be thrown with valid types
 validTypes.forEach((validType) => {
-  assert.doesNotThrow(() => {
-    const socket = dgram.createSocket(validType);
-    socket.close();
-  });
+  const socket = dgram.createSocket(validType);
+  socket.close();
 });
 
 // Ensure buffer sizes can be set

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -53,55 +53,47 @@ common.expectsError(() => {
   message: 'The value "20" is invalid for option "family"'
 });
 
-assert.doesNotThrow(() => {
-  dns.lookup(false, {
-    hints: 0,
-    family: 0,
-    all: true
-  }, common.mustCall((error, result, addressType) => {
-    assert.ifError(error);
-    assert.deepStrictEqual(result, []);
-    assert.strictEqual(addressType, undefined);
-  }));
-});
+dns.lookup(false, {
+  hints: 0,
+  family: 0,
+  all: true
+}, common.mustCall((error, result, addressType) => {
+  assert.ifError(error);
+  assert.deepStrictEqual(result, []);
+  assert.strictEqual(addressType, undefined);
+}));
 
-assert.doesNotThrow(() => {
-  dns.lookup('127.0.0.1', {
-    hints: 0,
-    family: 4,
-    all: true
-  }, common.mustCall((error, result, addressType) => {
-    assert.ifError(error);
-    assert.deepStrictEqual(result, [{
-      address: '127.0.0.1',
-      family: 4
-    }]);
-    assert.strictEqual(addressType, undefined);
-  }));
-});
+dns.lookup('127.0.0.1', {
+  hints: 0,
+  family: 4,
+  all: true
+}, common.mustCall((error, result, addressType) => {
+  assert.ifError(error);
+  assert.deepStrictEqual(result, [{
+    address: '127.0.0.1',
+    family: 4
+  }]);
+  assert.strictEqual(addressType, undefined);
+}));
 
-assert.doesNotThrow(() => {
-  dns.lookup('127.0.0.1', {
-    hints: 0,
-    family: 4,
-    all: false
-  }, common.mustCall((error, result, addressType) => {
-    assert.ifError(error);
-    assert.deepStrictEqual(result, '127.0.0.1');
-    assert.strictEqual(addressType, 4);
-  }));
-});
+dns.lookup('127.0.0.1', {
+  hints: 0,
+  family: 4,
+  all: false
+}, common.mustCall((error, result, addressType) => {
+  assert.ifError(error);
+  assert.deepStrictEqual(result, '127.0.0.1');
+  assert.strictEqual(addressType, 4);
+}));
 
-assert.doesNotThrow(() => {
-  let tickValue = 0;
+let tickValue = 0;
 
-  dns.lookup('example.com', common.mustCall((error, result, addressType) => {
-    assert(error);
-    assert.strictEqual(tickValue, 1);
-    assert.strictEqual(error.code, 'ENOENT');
-  }));
+dns.lookup('example.com', common.mustCall((error, result, addressType) => {
+  assert(error);
+  assert.strictEqual(tickValue, 1);
+  assert.strictEqual(error.code, 'ENOENT');
+}));
 
-  // Make sure that the error callback is called
-  // on next tick.
-  tickValue = 1;
-});
+// Make sure that the error callback is called
+// on next tick.
+tickValue = 1;

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -29,7 +29,7 @@ const existing = dns.getServers();
 assert(existing.length > 0);
 
 // Verify that setServers() handles arrays with holes and other oddities
-assert.doesNotThrow(() => {
+{
   const servers = [];
 
   servers[0] = '127.0.0.1';
@@ -37,9 +37,9 @@ assert.doesNotThrow(() => {
   dns.setServers(servers);
 
   assert.deepStrictEqual(dns.getServers(), ['127.0.0.1', '0.0.0.0']);
-});
+}
 
-assert.doesNotThrow(() => {
+{
   const servers = ['127.0.0.1', '192.168.1.1'];
 
   servers[3] = '127.1.0.1';
@@ -60,13 +60,13 @@ assert.doesNotThrow(() => {
     '192.168.1.1',
     '0.0.0.0'
   ]);
-});
+}
 
 const goog = [
   '8.8.8.8',
   '8.8.4.4',
 ];
-assert.doesNotThrow(() => dns.setServers(goog));
+dns.setServers(goog);
 assert.deepStrictEqual(dns.getServers(), goog);
 common.expectsError(() => dns.setServers(['foobar']), {
   code: 'ERR_INVALID_IP_ADDRESS',
@@ -84,7 +84,7 @@ const goog6 = [
   '2001:4860:4860::8888',
   '2001:4860:4860::8844',
 ];
-assert.doesNotThrow(() => dns.setServers(goog6));
+dns.setServers(goog6);
 assert.deepStrictEqual(dns.getServers(), goog6);
 
 goog6.push('4.4.4.4');
@@ -106,7 +106,7 @@ const portsExpected = [
 dns.setServers(ports);
 assert.deepStrictEqual(dns.getServers(), portsExpected);
 
-assert.doesNotThrow(() => dns.setServers([]));
+dns.setServers([]);
 assert.deepStrictEqual(dns.getServers(), []);
 
 common.expectsError(() => {
@@ -146,16 +146,11 @@ common.expectsError(() => {
     assert.strictEqual(family, 4);
   };
 
-  assert.doesNotThrow(() => dns.lookup('', common.mustCall(checkCallback)));
-
-  assert.doesNotThrow(() => dns.lookup(null, common.mustCall(checkCallback)));
-
-  assert.doesNotThrow(() => dns.lookup(undefined,
-                                       common.mustCall(checkCallback)));
-
-  assert.doesNotThrow(() => dns.lookup(0, common.mustCall(checkCallback)));
-
-  assert.doesNotThrow(() => dns.lookup(NaN, common.mustCall(checkCallback)));
+  dns.lookup('', common.mustCall(checkCallback));
+  dns.lookup(null, common.mustCall(checkCallback));
+  dns.lookup(undefined, common.mustCall(checkCallback));
+  dns.lookup(0, common.mustCall(checkCallback));
+  dns.lookup(NaN, common.mustCall(checkCallback));
 }
 
 /*
@@ -186,24 +181,18 @@ common.expectsError(() => dns.lookup('nodejs.org', 4), {
   type: TypeError
 });
 
-assert.doesNotThrow(() => dns.lookup('', { family: 4, hints: 0 },
-                                     common.mustCall()));
+dns.lookup('', { family: 4, hints: 0 }, common.mustCall());
 
-assert.doesNotThrow(() => {
-  dns.lookup('', {
-    family: 6,
-    hints: dns.ADDRCONFIG
-  }, common.mustCall());
-});
+dns.lookup('', {
+  family: 6,
+  hints: dns.ADDRCONFIG
+}, common.mustCall());
 
-assert.doesNotThrow(() => dns.lookup('', { hints: dns.V4MAPPED },
-                                     common.mustCall()));
+dns.lookup('', { hints: dns.V4MAPPED }, common.mustCall());
 
-assert.doesNotThrow(() => {
-  dns.lookup('', {
-    hints: dns.ADDRCONFIG | dns.V4MAPPED
-  }, common.mustCall());
-});
+dns.lookup('', {
+  hints: dns.ADDRCONFIG | dns.V4MAPPED
+}, common.mustCall());
 
 common.expectsError(() => dns.lookupService('0.0.0.0'), {
   code: 'ERR_MISSING_ARGS',

--- a/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
+++ b/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
@@ -13,5 +13,4 @@ common.expectsError(
 );
 
 process.setUncaughtExceptionCaptureCallback(null);
-
-require('domain');
+require('domain'); // Should not throw.

--- a/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
+++ b/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 process.setUncaughtExceptionCaptureCallback(common.mustNotCall());
 
@@ -15,4 +14,4 @@ common.expectsError(
 
 process.setUncaughtExceptionCaptureCallback(null);
 
-assert.doesNotThrow(() => require('domain'));
+require('domain');

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -81,7 +81,7 @@ function expect(expected) {
   // Check for regression where removeAllListeners() throws when
   // there exists a 'removeListener' listener, but there exists
   // no listeners for the provided event type.
-  assert.doesNotThrow(ee.removeAllListeners.bind(ee, 'foo'));
+  ee.removeAllListeners.bind(ee, 'foo');
 }
 
 {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -118,15 +118,10 @@ common.expectsError(
     type: TypeError
   });
 
-assert.doesNotThrow(() => {
-  fs.accessSync(__filename);
-});
+fs.accessSync(__filename);
 
-assert.doesNotThrow(() => {
-  const mode = fs.F_OK | fs.R_OK | fs.W_OK;
-
-  fs.accessSync(readWriteFile, mode);
-});
+const mode = fs.F_OK | fs.R_OK | fs.W_OK;
+fs.accessSync(readWriteFile, mode);
 
 assert.throws(
   () => { fs.accessSync(doesNotExist); },

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -118,8 +118,8 @@ common.expectsError(
     type: TypeError
   });
 
+// Regular access should not throw.
 fs.accessSync(__filename);
-
 const mode = fs.F_OK | fs.R_OK | fs.W_OK;
 fs.accessSync(readWriteFile, mode);
 

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -9,22 +9,18 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-assert.doesNotThrow(() => {
-  fs.access(Buffer.from(tmpdir.path), common.mustCall((err) => {
-    assert.ifError(err);
-  }));
-});
+fs.access(Buffer.from(tmpdir.path), common.mustCall((err) => {
+  assert.ifError(err);
+}));
 
-assert.doesNotThrow(() => {
-  const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
-  fs.open(buf, 'w+', common.mustCall((err, fd) => {
+const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
+fs.open(buf, 'w+', common.mustCall((err, fd) => {
+  assert.ifError(err);
+  assert(fd);
+  fs.close(fd, common.mustCall((err) => {
     assert.ifError(err);
-    assert(fd);
-    fs.close(fd, common.mustCall((err) => {
-      assert.ifError(err);
-    }));
   }));
-});
+}));
 
 common.expectsError(
   () => {

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -9,17 +9,13 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-fs.access(Buffer.from(tmpdir.path), common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.access(Buffer.from(tmpdir.path), common.mustCall(assert.ifError));
 
 const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
 fs.open(buf, 'w+', common.mustCall((err, fd) => {
   assert.ifError(err);
   assert(fd);
-  fs.close(fd, common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  fs.close(fd, common.mustCall(assert.ifError));
 }));
 
 common.expectsError(

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -27,9 +27,9 @@ const { URL } = require('url');
 const f = __filename;
 
 // Only warnings are emitted when the callback is invalid
-assert.doesNotThrow(() => fs.exists(f));
-assert.doesNotThrow(() => fs.exists());
-assert.doesNotThrow(() => fs.exists(f, {}));
+fs.exists(f);
+fs.exists();
+fs.exists(f, {});
 
 fs.exists(f, common.mustCall(function(y) {
   assert.strictEqual(y, true);

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
 const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
 
@@ -20,7 +19,7 @@ function testMakeCallback(cb) {
 common.expectWarning('DeprecationWarning', warn);
 
 // Passing undefined/nothing calls rethrow() internally, which emits a warning
-assert.doesNotThrow(testMakeCallback());
+testMakeCallback()();
 
 function invalidCallbackThrowsTests() {
   callbackThrowValues.forEach((value) => {

--- a/test/parallel/test-fs-makeStatsCallback.js
+++ b/test/parallel/test-fs-makeStatsCallback.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
 const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
 const warn = 'Calling an asynchronous function without callback is deprecated.';
@@ -15,10 +14,10 @@ function testMakeStatsCallback(cb) {
 common.expectWarning('DeprecationWarning', warn);
 
 // Verify the case where a callback function is provided
-assert.doesNotThrow(testMakeStatsCallback(common.mustCall()));
+testMakeStatsCallback(common.mustCall())();
 
 // Passing undefined/nothing calls rethrow() internally, which emits a warning
-assert.doesNotThrow(testMakeStatsCallback());
+testMakeStatsCallback()();
 
 function invalidCallbackThrowsTests() {
   callbackThrowValues.forEach((value) => {

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -32,5 +32,5 @@ fs.mkdtemp(path.join(tmpdir.path, 'bar.'), {}, common.mustCall(handler));
 
 // Making sure that not passing a callback doesn't crash, as a default function
 // is passed internally.
-assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-')));
-assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-'), {}));
+fs.mkdtemp(path.join(tmpdir.path, 'bar-'));
+fs.mkdtemp(path.join(tmpdir.path, 'bar-'), {});

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -17,19 +17,11 @@ const options = Object.freeze({});
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-{
-  assert.doesNotThrow(() =>
-    fs.readFile(__filename, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readFileSync(__filename, options));
-}
+fs.readFile(__filename, options, common.mustCall(errHandler));
+fs.readFileSync(__filename, options);
 
-{
-  assert.doesNotThrow(() =>
-    fs.readdir(__dirname, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readdirSync(__dirname, options));
-}
+fs.readdir(__dirname, options, common.mustCall(errHandler));
+fs.readdirSync(__dirname, options);
 
 if (common.canCreateSymLink()) {
   const sourceFile = path.resolve(tmpdir.path, 'test-readlink');
@@ -38,63 +30,46 @@ if (common.canCreateSymLink()) {
   fs.writeFileSync(sourceFile, '');
   fs.symlinkSync(sourceFile, linkFile);
 
-  assert.doesNotThrow(() =>
-    fs.readlink(linkFile, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readlinkSync(linkFile, options));
+  fs.readlink(linkFile, options, common.mustCall(errHandler));
+  fs.readlinkSync(linkFile, options);
 }
 
 {
   const fileName = path.resolve(tmpdir.path, 'writeFile');
-  assert.doesNotThrow(() => fs.writeFileSync(fileName, 'ABCD', options));
-  assert.doesNotThrow(() =>
-    fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler))
-  );
+  fs.writeFileSync(fileName, 'ABCD', options);
+  fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler));
 }
 
 {
   const fileName = path.resolve(tmpdir.path, 'appendFile');
-  assert.doesNotThrow(() => fs.appendFileSync(fileName, 'ABCD', options));
-  assert.doesNotThrow(() =>
-    fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler))
-  );
+  fs.appendFileSync(fileName, 'ABCD', options);
+  fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler));
 }
 
 {
-  let watch;
-  assert.doesNotThrow(() => {
-    watch = fs.watch(__filename, options, common.mustNotCall());
-  });
+  const watch = fs.watch(__filename, options, common.mustNotCall());
   watch.close();
 }
 
 {
-  assert.doesNotThrow(
-    () => fs.watchFile(__filename, options, common.mustNotCall())
-  );
+  fs.watchFile(__filename, options, common.mustNotCall());
   fs.unwatchFile(__filename);
 }
 
 {
-  assert.doesNotThrow(() => fs.realpathSync(__filename, options));
-  assert.doesNotThrow(() =>
-    fs.realpath(__filename, options, common.mustCall(errHandler))
-  );
+  fs.realpathSync(__filename, options);
+  fs.realpath(__filename, options, common.mustCall(errHandler));
 }
 
 {
   const tempFileName = path.resolve(tmpdir.path, 'mkdtemp-');
-  assert.doesNotThrow(() => fs.mkdtempSync(tempFileName, options));
-  assert.doesNotThrow(() =>
-    fs.mkdtemp(tempFileName, options, common.mustCall(errHandler))
-  );
+  fs.mkdtempSync(tempFileName, options);
+  fs.mkdtemp(tempFileName, options, common.mustCall(errHandler));
 }
 
 {
   const fileName = path.resolve(tmpdir.path, 'streams');
-  assert.doesNotThrow(() => {
-    fs.WriteStream(fileName, options).once('open', common.mustCall(() => {
-      assert.doesNotThrow(() => fs.ReadStream(fileName, options));
-    }));
-  });
+  fs.WriteStream(fileName, options).once('open', common.mustCall(() => {
+    fs.ReadStream(fileName, options);
+  }));
 }

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -4,7 +4,7 @@ const fixtures = require('../common/fixtures');
 const fs = require('fs');
 
 const example = fixtures.path('x.txt');
-
+// Should not throw.
 fs.createReadStream(example, undefined);
 fs.createReadStream(example, null);
 fs.createReadStream(example, 'utf8');

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,23 +1,14 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
-const assert = require('assert');
 const fs = require('fs');
 
 const example = fixtures.path('x.txt');
 
-assert.doesNotThrow(function() {
-  fs.createReadStream(example, undefined);
-});
-assert.doesNotThrow(function() {
-  fs.createReadStream(example, null);
-});
-assert.doesNotThrow(function() {
-  fs.createReadStream(example, 'utf8');
-});
-assert.doesNotThrow(function() {
-  fs.createReadStream(example, { encoding: 'utf8' });
-});
+fs.createReadStream(example, undefined);
+fs.createReadStream(example, null);
+fs.createReadStream(example, 'utf8');
+fs.createReadStream(example, { encoding: 'utf8' });
 
 const createReadStreamErr = (path, opt) => {
   common.expectsError(

--- a/test/parallel/test-fs-timestamp-parsing-error.js
+++ b/test/parallel/test-fs-timestamp-parsing-error.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const fs = require('fs');
-const assert = require('assert');
 
 [Infinity, -Infinity, NaN].forEach((input) => {
   common.expectsError(
@@ -25,5 +24,5 @@ common.expectsError(
 
 const okInputs = [1, -1, '1', '-1', Date.now()];
 okInputs.forEach((input) => {
-  assert.doesNotThrow(() => fs._toUnixTimestamp(input));
+  fs._toUnixTimestamp(input);
 });

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
@@ -10,21 +9,10 @@ const example = path.join(tmpdir.path, 'dummy');
 
 tmpdir.refresh();
 
-assert.doesNotThrow(() => {
-  fs.createWriteStream(example, undefined);
-});
-
-assert.doesNotThrow(() => {
-  fs.createWriteStream(example, null);
-});
-
-assert.doesNotThrow(() => {
-  fs.createWriteStream(example, 'utf8');
-});
-
-assert.doesNotThrow(() => {
-  fs.createWriteStream(example, { encoding: 'utf8' });
-});
+fs.createWriteStream(example, undefined);
+fs.createWriteStream(example, null);
+fs.createWriteStream(example, 'utf8');
+fs.createWriteStream(example, { encoding: 'utf8' });
 
 const createWriteStreamErr = (path, opt) => {
   common.expectsError(

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -8,7 +8,7 @@ const tmpdir = require('../common/tmpdir');
 const example = path.join(tmpdir.path, 'dummy');
 
 tmpdir.refresh();
-
+// Should not throw.
 fs.createWriteStream(example, undefined);
 fs.createWriteStream(example, null);
 fs.createWriteStream(example, 'utf8');

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -59,7 +59,7 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
   });
 
   acceptableAgentOptions.forEach((agent) => {
-    assert.doesNotThrow(() => createRequest(agent));
+    createRequest(agent);
   });
 }));
 

--- a/test/parallel/test-http-header-read.js
+++ b/test/parallel/test-http-header-read.js
@@ -37,11 +37,7 @@ const s = http.createServer(function(req, res) {
   res.end('hello world\n');
   // This checks that after the headers have been sent, getHeader works
   // and does not throw an exception (Issue 752)
-  assert.doesNotThrow(
-    function() {
-      assert.strictEqual(plain, res.getHeader(contentType));
-    }
-  );
+  assert.strictEqual(plain, res.getHeader(contentType));
 });
 
 s.listen(0, runTest);

--- a/test/parallel/test-http-hostname-typechecking.js
+++ b/test/parallel/test-http-hostname-typechecking.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 // All of these values should cause http.request() to throw synchronously
@@ -36,8 +35,6 @@ vals.forEach((v) => {
 // Only testing for 'hostname' validation so ignore connection errors.
 const dontCare = () => {};
 ['', undefined, null].forEach((v) => {
-  assert.doesNotThrow(() => {
-    http.request({ hostname: v }).on('error', dontCare).end();
-    http.request({ host: v }).on('error', dontCare).end();
-  });
+  http.request({ hostname: v }).on('error', dontCare).end();
+  http.request({ host: v }).on('error', dontCare).end();
 });

--- a/test/parallel/test-http-invalidheaderfield.js
+++ b/test/parallel/test-http-invalidheaderfield.js
@@ -35,6 +35,7 @@ server.listen(0, function() {
     }
   );
 
+  // Should not throw.
   const options = {
     port: server.address().port,
     headers: { 'testing_123': 123 }

--- a/test/parallel/test-http-invalidheaderfield.js
+++ b/test/parallel/test-http-invalidheaderfield.js
@@ -9,9 +9,7 @@ const ee = new EventEmitter();
 let count = 3;
 
 const server = http.createServer(function(req, res) {
-  assert.doesNotThrow(function() {
-    res.setHeader('testing_123', 123);
-  });
+  res.setHeader('testing_123', 123);
   assert.throws(function() {
     res.setHeader('testing 123', 123);
   }, TypeError);
@@ -37,17 +35,13 @@ server.listen(0, function() {
     }
   );
 
-  assert.doesNotThrow(
-    function() {
-      const options = {
-        port: server.address().port,
-        headers: { 'testing_123': 123 }
-      };
-      http.get(options, function() {
-        ee.emit('done');
-      });
-    }, TypeError
-  );
+  const options = {
+    port: server.address().port,
+    headers: { 'testing_123': 123 }
+  };
+  http.get(options, function() {
+    ee.emit('done');
+  });
 });
 
 ee.on('done', function() {

--- a/test/parallel/test-http-response-add-header-after-sent.js
+++ b/test/parallel/test-http-response-add-header-after-sent.js
@@ -1,12 +1,9 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer((req, res) => {
-  assert.doesNotThrow(() => {
-    res.setHeader('header1', 1);
-  });
+  res.setHeader('header1', 1);
   res.write('abc');
   common.expectsError(
     () => res.setHeader('header2', 2),

--- a/test/parallel/test-http-response-remove-header-after-sent.js
+++ b/test/parallel/test-http-response-remove-header-after-sent.js
@@ -1,12 +1,9 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer((req, res) => {
-  assert.doesNotThrow(() => {
-    res.removeHeader('header1', 1);
-  });
+  res.removeHeader('header1', 1);
   res.write('abc');
   common.expectsError(
     () => res.removeHeader('header2', 2),

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -5,7 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 
-assert.doesNotThrow(() => process.binding('http2'));
+process.binding('http2');
 
 const binding = process.binding('http2');
 const http2 = require('http2');

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -5,8 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 
-process.binding('http2');
-
 const binding = process.binding('http2');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -19,10 +19,10 @@ server.listen(0, common.mustCall(() => {
   req.close(1);
   assert.strictEqual(req.closed, true);
 
-  // make sure that destroy is called
+  // Make sure that destroy is called.
   req._destroy = common.mustCall(req._destroy.bind(req));
 
-  // second call doesn't do anything
+  // Second call doesn't do anything.
   req.close(8);
 
   req.on('close', common.mustCall((code) => {

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -23,7 +23,7 @@ server.listen(0, common.mustCall(() => {
   req._destroy = common.mustCall(req._destroy.bind(req));
 
   // second call doesn't do anything
-  assert.doesNotThrow(() => req.close(8));
+  req.close(8);
 
   req.on('close', common.mustCall((code) => {
     assert.strictEqual(req.destroyed, true);

--- a/test/parallel/test-http2-compat-serverrequest-pause.js
+++ b/test/parallel/test-http2-compat-serverrequest-pause.js
@@ -28,8 +28,8 @@ server.on('request', common.mustCall((req, res) => {
 
   // shouldn't throw if underlying Http2Stream no longer exists
   res.on('finish', common.mustCall(() => process.nextTick(() => {
-    assert.doesNotThrow(() => req.pause());
-    assert.doesNotThrow(() => req.resume());
+    req.pause();
+    req.resume();
   })));
 }));
 

--- a/test/parallel/test-http2-compat-serverrequest-settimeout.js
+++ b/test/parallel/test-http2-compat-serverrequest-settimeout.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const http2 = require('http2');
 
 const msecs = common.platformTimeout(1);
@@ -16,9 +15,7 @@ server.on('request', (req, res) => {
   res.on('finish', common.mustCall(() => {
     req.setTimeout(msecs, common.mustNotCall());
     process.nextTick(() => {
-      assert.doesNotThrow(
-        () => req.setTimeout(msecs, common.mustNotCall())
-      );
+      req.setTimeout(msecs, common.mustNotCall());
       server.close();
     });
   }));

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const http2 = require('http2');
 const Countdown = require('../common/countdown');
 
@@ -22,9 +21,9 @@ const server = http2.createServer(common.mustCall((req, res) => {
   res.on('error', common.mustNotCall());
 
   res.on('finish', common.mustCall(() => {
-    assert.doesNotThrow(() => res.destroy(nextError));
+    res.destroy(nextError);
     process.nextTick(() => {
-      assert.doesNotThrow(() => res.destroy(nextError));
+      res.destroy(nextError);
     });
   }));
 

--- a/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
@@ -15,12 +15,12 @@ server.listen(0, common.mustCall(function() {
   server.once('request', common.mustCall(function(request, response) {
     response.on('finish', common.mustCall(() => {
       assert.strictEqual(response.headersSent, false);
-      assert.doesNotThrow(() => response.setHeader('test', 'value'));
-      assert.doesNotThrow(() => response.removeHeader('test', 'value'));
+      response.setHeader('test', 'value');
+      response.removeHeader('test', 'value');
 
       process.nextTick(() => {
-        assert.doesNotThrow(() => response.setHeader('test', 'value'));
-        assert.doesNotThrow(() => response.removeHeader('test', 'value'));
+        response.setHeader('test', 'value');
+        response.removeHeader('test', 'value');
 
         server.close();
       });

--- a/test/parallel/test-http2-compat-serverresponse-settimeout.js
+++ b/test/parallel/test-http2-compat-serverresponse-settimeout.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const http2 = require('http2');
 
 const msecs = common.platformTimeout(1);
@@ -16,9 +15,7 @@ server.on('request', (req, res) => {
   res.on('finish', common.mustCall(() => {
     res.setTimeout(msecs, common.mustNotCall());
     process.nextTick(() => {
-      assert.doesNotThrow(
-        () => res.setTimeout(msecs, common.mustNotCall())
-      );
+      res.setTimeout(msecs, common.mustNotCall());
       server.close();
     });
   }));

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -27,12 +27,10 @@ server.listen(0, common.mustCall(function() {
 
     assert.strictEqual(response.statusCode, expectedDefaultStatusCode);
 
-    assert.doesNotThrow(function() {
-      response.statusCode = realStatusCodes.ok;
-      response.statusCode = realStatusCodes.multipleChoices;
-      response.statusCode = realStatusCodes.badRequest;
-      response.statusCode = realStatusCodes.internalServerError;
-    });
+    response.statusCode = realStatusCodes.ok;
+    response.statusCode = realStatusCodes.multipleChoices;
+    response.statusCode = realStatusCodes.badRequest;
+    response.statusCode = realStatusCodes.internalServerError;
 
     common.expectsError(function() {
       response.statusCode = realStatusCodes.continue;

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -27,6 +27,7 @@ server.listen(0, common.mustCall(function() {
 
     assert.strictEqual(response.statusCode, expectedDefaultStatusCode);
 
+    // Setting the response.statusCode should not throw.
     response.statusCode = realStatusCodes.ok;
     response.statusCode = realStatusCodes.multipleChoices;
     response.statusCode = realStatusCodes.badRequest;

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -49,7 +49,7 @@ server.on('request', common.mustCall(function(request, response) {
 
   request.on('end', common.mustCall(() => {
     assert.strictEqual(request.socket.readable, false);
-    assert.doesNotThrow(() => response.socket.destroy());
+    response.socket.destroy();
   }));
   response.on('finish', common.mustCall(() => {
     assert.ok(request.socket);

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -3,7 +3,6 @@
 const { mustCall, hasCrypto, skip, expectsError } = require('../common');
 if (!hasCrypto)
   skip('missing crypto');
-const { doesNotThrow, throws } = require('assert');
 const { createServer, connect } = require('http2');
 {
   const server = createServer();
@@ -13,10 +12,11 @@ const { createServer, connect } = require('http2');
     const listener = () => mustCall();
 
     const clients = new Set();
-    doesNotThrow(() => clients.add(connect(authority)));
-    doesNotThrow(() => clients.add(connect(authority, options)));
-    doesNotThrow(() => clients.add(connect(authority, options, listener())));
-    doesNotThrow(() => clients.add(connect(authority, listener())));
+    // Should not throw.
+    clients.add(connect(authority));
+    clients.add(connect(authority, options));
+    clients.add(connect(authority, options, listener()));
+    clients.add(connect(authority, listener()));
 
     for (const client of clients) {
       client.once('connect', mustCall((headers) => {
@@ -33,20 +33,18 @@ const { createServer, connect } = require('http2');
 // check for https as protocol
 {
   const authority = 'https://localhost';
-  doesNotThrow(() => {
-    // A socket error may or may not be reported, keep this as a non-op
-    // instead of a mustCall or mustNotCall
-    connect(authority).on('error', () => {});
-  });
+  // A socket error may or may not be reported, keep this as a non-op
+  // instead of a mustCall or mustNotCall
+  connect(authority).on('error', () => {});
 }
 
 // check for error for an invalid protocol (not http or https)
 {
   const authority = 'ssh://localhost';
-  throws(() => {
+  expectsError(() => {
     connect(authority);
-  }, expectsError({
+  }, {
     code: 'ERR_HTTP2_UNSUPPORTED_PROTOCOL',
     type: Error
-  }));
+  });
 }

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -26,11 +26,11 @@ assert.deepStrictEqual(val, check);
   ['maxHeaderListSize', 0],
   ['maxHeaderListSize', 2 ** 32 - 1]
 ].forEach((i) => {
-  assert.doesNotThrow(() => http2.getPackedSettings({ [i[0]]: i[1] }));
+  http2.getPackedSettings({ [i[0]]: i[1] });
 });
 
-assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: true }));
-assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
+http2.getPackedSettings({ enablePush: true });
+http2.getPackedSettings({ enablePush: false });
 
 [
   ['headerTableSize', -1],
@@ -151,9 +151,7 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
     0x00, 0x00, 0x00, 0x64, 0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
     0x00, 0x02, 0x00, 0x00, 0x00, 0x01]);
 
-  assert.doesNotThrow(() => {
-    http2.getUnpackedSettings(packed, { validate: true });
-  });
+  http2.getUnpackedSettings(packed, { validate: true });
 }
 
 // check for maxFrameSize failing the max number

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -26,6 +26,7 @@ assert.deepStrictEqual(val, check);
   ['maxHeaderListSize', 0],
   ['maxHeaderListSize', 2 ** 32 - 1]
 ].forEach((i) => {
+  // Valid options should not throw.
   http2.getPackedSettings({ [i[0]]: i[1] });
 });
 
@@ -85,7 +86,7 @@ http2.getPackedSettings({ enablePush: false });
   assert.deepStrictEqual(packed, check);
 }
 
-// check for not passing settings
+// Check for not passing settings.
 {
   const packed = http2.getPackedSettings();
   assert.strictEqual(packed.length, 0);
@@ -143,7 +144,7 @@ http2.getPackedSettings({ enablePush: false });
   assert.strictEqual(settings.enablePush, true);
 }
 
-//check for what happens if passing {validate: true} and no errors happen
+// Verify that passing {validate: true} does not throw.
 {
   const packed = Buffer.from([
     0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0x00, 0x03, 0x00, 0x00,
@@ -154,7 +155,7 @@ http2.getPackedSettings({ enablePush: false });
   http2.getUnpackedSettings(packed, { validate: true });
 }
 
-// check for maxFrameSize failing the max number
+// Check for maxFrameSize failing the max number.
 {
   const packed = Buffer.from([0x00, 0x05, 0x01, 0x00, 0x00, 0x00]);
 
@@ -167,7 +168,7 @@ http2.getPackedSettings({ enablePush: false });
   });
 }
 
-// check for maxConcurrentStreams failing the max number
+// Check for maxConcurrentStreams failing the max number.
 {
   const packed = Buffer.from([0x00, 0x03, 0xFF, 0xFF, 0xFF, 0xFF]);
 

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -19,20 +19,20 @@ const options = {
   cert: commonFixtures.readKey('agent2-cert.pem')
 };
 
-// There should not be any throws
+// There should not be any throws.
 const serverTLS = http2.createSecureServer(options, () => {});
 serverTLS.listen(0, common.mustCall(() => serverTLS.close()));
 
-// There should not be an error event reported either
+// There should not be an error event reported either.
 serverTLS.on('error', common.mustNotCall());
 
 const server = http2.createServer(options, common.mustNotCall());
 server.listen(0, common.mustCall(() => server.close()));
 
-// There should not be an error event reported either
+// There should not be an error event reported either.
 server.on('error', common.mustNotCall());
 
-// Test the plaintext server socket timeout
+// Test the plaintext server socket timeout.
 {
   let client;
   const server = http2.createServer();
@@ -48,7 +48,7 @@ server.on('error', common.mustNotCall());
   }));
 }
 
-// Test the secure server socket timeout
+// Test the secure server socket timeout.
 {
   let client;
   const server = http2.createSecureServer(options);

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -10,7 +10,6 @@ const commonFixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const http2 = require('http2');
 const tls = require('tls');
 const net = require('net');
@@ -21,25 +20,17 @@ const options = {
 };
 
 // There should not be any throws
-assert.doesNotThrow(() => {
+const serverTLS = http2.createSecureServer(options, () => {});
+serverTLS.listen(0, common.mustCall(() => serverTLS.close()));
 
-  const serverTLS = http2.createSecureServer(options, () => {});
+// There should not be an error event reported either
+serverTLS.on('error', common.mustNotCall());
 
-  serverTLS.listen(0, common.mustCall(() => serverTLS.close()));
+const server = http2.createServer(options, common.mustNotCall());
+server.listen(0, common.mustCall(() => server.close()));
 
-  // There should not be an error event reported either
-  serverTLS.on('error', common.mustNotCall());
-});
-
-// There should not be any throws
-assert.doesNotThrow(() => {
-  const server = http2.createServer(options, common.mustNotCall());
-
-  server.listen(0, common.mustCall(() => server.close()));
-
-  // There should not be an error event reported either
-  server.on('error', common.mustNotCall());
-});
+// There should not be an error event reported either
+server.on('error', common.mustNotCall());
 
 // Test the plaintext server socket timeout
 {

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -76,9 +76,7 @@ server.listen(
 
     // State will only be valid after connect event is emitted
     req.on('ready', common.mustCall(() => {
-      assert.doesNotThrow(() => {
-        client.settings({ maxHeaderListSize: 1 }, common.mustCall());
-      });
+      client.settings({ maxHeaderListSize: 1 }, common.mustCall());
 
       // Verify valid error ranges
       [

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -51,6 +51,7 @@ server.on('stream', common.mustCall(function(stream, headers) {
   common.expectsError(() => (socket.resume = undefined), errMsg);
   common.expectsError(() => (socket.write = undefined), errMsg);
 
+  // Resetting the socket listeners to their own value should not throw.
   socket.on = socket.on;
   socket.once = socket.once;
 

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -51,8 +51,8 @@ server.on('stream', common.mustCall(function(stream, headers) {
   common.expectsError(() => (socket.resume = undefined), errMsg);
   common.expectsError(() => (socket.write = undefined), errMsg);
 
-  assert.doesNotThrow(() => (socket.on = socket.on));
-  assert.doesNotThrow(() => (socket.once = socket.once));
+  socket.on = socket.on;
+  socket.once = socket.once;
 
   stream.respond();
 

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const {
   assertIsObject,
   assertWithinRange,
@@ -15,7 +14,7 @@ const {
   new Date(),
   new (class Foo {})()
 ].forEach((i) => {
-  assert.doesNotThrow(() => assertIsObject(i, 'foo', 'Object'));
+  assertIsObject(i, 'foo', 'Object');
 });
 
 [
@@ -34,7 +33,7 @@ const {
                       });
 });
 
-assert.doesNotThrow(() => assertWithinRange('foo', 1, 0, 2));
+assertWithinRange('foo', 1, 0, 2);
 
 common.expectsError(() => assertWithinRange('foo', 1, 2, 3),
                     {

--- a/test/parallel/test-http2-withflag.js
+++ b/test/parallel/test-http2-withflag.js
@@ -3,6 +3,5 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 
-assert.doesNotThrow(() => require('http2'));
+require('http2');

--- a/test/parallel/test-http2-withflag.js
+++ b/test/parallel/test-http2-withflag.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const common = require('../common');
-if (!common.hasCrypto)
-  common.skip('missing crypto');
-
-require('http2');

--- a/test/parallel/test-https-agent-constructor.js
+++ b/test/parallel/test-https-agent-constructor.js
@@ -6,5 +6,5 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const https = require('https');
 
-assert.doesNotThrow(() => { https.Agent(); });
+https.Agent();
 assert.ok(https.Agent() instanceof https.Agent);

--- a/test/parallel/test-https-agent-constructor.js
+++ b/test/parallel/test-https-agent-constructor.js
@@ -6,5 +6,4 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const https = require('https');
 
-https.Agent();
 assert.ok(https.Agent() instanceof https.Agent);

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -6,7 +6,6 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const https = require('https');
 
 function toArrayBuffer(buf) {
@@ -65,11 +64,9 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[{ pem: keyBuff }], false],
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
 ].forEach((params) => {
-  assert.doesNotThrow(() => {
-    https.createServer({
-      key: params[0],
-      cert: params[1]
-    });
+  https.createServer({
+    key: params[0],
+    cert: params[1]
   });
 });
 
@@ -124,12 +121,10 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
 ].forEach((params) => {
-  assert.doesNotThrow(() => {
-    https.createServer({
-      key: params[0],
-      cert: params[1],
-      ca: params[2]
-    });
+  https.createServer({
+    key: params[0],
+    cert: params[1],
+    ca: params[2]
   });
 });
 

--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -34,13 +34,12 @@ const wptToASCIITests = require('../fixtures/url-toascii.js');
     if (output === null) {
       assert.throws(() => icu.toASCII(input),
                     errMessage, `ToASCII ${caseComment}`);
-      assert.doesNotThrow(() => icu.toASCII(input, true),
-                          `ToASCII ${caseComment} in lenient mode`);
+      icu.toASCII(input, true);
     } else {
       assert.strictEqual(icu.toASCII(input), output, `ToASCII ${caseComment}`);
       assert.strictEqual(icu.toASCII(input, true), output,
                          `ToASCII ${caseComment} in lenient mode`);
     }
-    assert.doesNotThrow(() => icu.toUnicode(input), `ToUnicode ${caseComment}`);
+    icu.toUnicode(input);
   }
 }

--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -34,12 +34,12 @@ const wptToASCIITests = require('../fixtures/url-toascii.js');
     if (output === null) {
       assert.throws(() => icu.toASCII(input),
                     errMessage, `ToASCII ${caseComment}`);
-      icu.toASCII(input, true);
+      icu.toASCII(input, true); // Should not throw.
     } else {
       assert.strictEqual(icu.toASCII(input), output, `ToASCII ${caseComment}`);
       assert.strictEqual(icu.toASCII(input, true), output,
                          `ToASCII ${caseComment} in lenient mode`);
     }
-    icu.toUnicode(input);
+    icu.toUnicode(input); // Should not throw.
   }
 }

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -138,36 +138,24 @@ common.expectsError(
     message: invalidKey('true')
   });
 
-
 // Tests for common.expectsError
-assert.doesNotThrow(() => {
-  common.expectsError(() => {
-    throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, { code: 'TEST_ERROR_1' });
-});
-
-assert.doesNotThrow(() => {
-  common.expectsError(() => {
-    throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, { code: 'TEST_ERROR_1',
-       type: TypeError,
-       message: /^Error for testing/ });
-});
-
-assert.doesNotThrow(() => {
-  common.expectsError(() => {
-    throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, { code: 'TEST_ERROR_1', type: TypeError });
-});
-
-assert.doesNotThrow(() => {
-  common.expectsError(() => {
-    throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, {
-    code: 'TEST_ERROR_1',
-    type: TypeError,
-    message: 'Error for testing purposes: a'
-  });
+common.expectsError(() => {
+  throw new errors.TypeError('TEST_ERROR_1', 'a');
+}, { code: 'TEST_ERROR_1' });
+common.expectsError(() => {
+  throw new errors.TypeError('TEST_ERROR_1', 'a');
+}, { code: 'TEST_ERROR_1',
+     type: TypeError,
+     message: /^Error for testing/ });
+common.expectsError(() => {
+  throw new errors.TypeError('TEST_ERROR_1', 'a');
+}, { code: 'TEST_ERROR_1', type: TypeError });
+common.expectsError(() => {
+  throw new errors.TypeError('TEST_ERROR_1', 'a');
+}, {
+  code: 'TEST_ERROR_1',
+  type: TypeError,
+  message: 'Error for testing purposes: a'
 });
 
 common.expectsError(() => {

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -4,8 +4,10 @@
 const common = require('../common');
 const fs = require('internal/fs');
 
+// Valid encodings and no args should not throw.
 fs.assertEncoding();
 fs.assertEncoding('utf8');
+
 common.expectsError(
   () => fs.assertEncoding('foo'),
   { code: 'ERR_INVALID_OPT_VALUE_ENCODING', type: TypeError }

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -2,11 +2,10 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const fs = require('internal/fs');
 
-assert.doesNotThrow(() => fs.assertEncoding());
-assert.doesNotThrow(() => fs.assertEncoding('utf8'));
+fs.assertEncoding();
+fs.assertEncoding('utf8');
 common.expectsError(
   () => fs.assertEncoding('foo'),
   { code: 'ERR_INVALID_OPT_VALUE_ENCODING', type: TypeError }

--- a/test/parallel/test-internal-util-assertCrypto.js
+++ b/test/parallel/test-internal-util-assertCrypto.js
@@ -11,5 +11,5 @@ if (!process.versions.openssl) {
   });
   assert.throws(() => util.assertCrypto(), expectedError);
 } else {
-  assert.doesNotThrow(() => util.assertCrypto());
+  util.assertCrypto();
 }

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -12,12 +12,10 @@ const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 
 const decorateErrorStack = internalUtil.decorateErrorStack;
 
-assert.doesNotThrow(function() {
-  decorateErrorStack();
-  decorateErrorStack(null);
-  decorateErrorStack(1);
-  decorateErrorStack(true);
-});
+decorateErrorStack();
+decorateErrorStack(null);
+decorateErrorStack(1);
+decorateErrorStack(true);
 
 // Verify that a stack property is not added to non-Errors
 const obj = {};

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -12,12 +12,13 @@ const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 
 const decorateErrorStack = internalUtil.decorateErrorStack;
 
+// Verify that decorateErrorStack does not throw with non-objects.
 decorateErrorStack();
 decorateErrorStack(null);
 decorateErrorStack(1);
 decorateErrorStack(true);
 
-// Verify that a stack property is not added to non-Errors
+// Verify that a stack property is not added to non-Errors.
 const obj = {};
 decorateErrorStack(obj);
 assert.strictEqual(obj.stack, undefined);
@@ -46,12 +47,12 @@ try {
 assert(typeof err, 'object');
 checkStack(err.stack);
 
-// Verify that the stack is only decorated once
+// Verify that the stack is only decorated once.
 decorateErrorStack(err);
 decorateErrorStack(err);
 checkStack(err.stack);
 
-// Verify that the stack is only decorated once for uncaught exceptions
+// Verify that the stack is only decorated once for uncaught exceptions.
 const args = [
   '-e',
   `require('${badSyntaxPath}')`
@@ -59,14 +60,14 @@ const args = [
 const result = spawnSync(process.argv[0], args, { encoding: 'utf8' });
 checkStack(result.stderr);
 
-// Verify that the stack is unchanged when there is no arrow message
+// Verify that the stack is unchanged when there is no arrow message.
 err = new Error('foo');
 let originalStack = err.stack;
 decorateErrorStack(err);
 assert.strictEqual(originalStack, err.stack);
 
 // Verify that the arrow message is added to the start of the stack when it
-// exists
+// exists.
 const arrowMessage = 'arrow_message';
 err = new Error('foo');
 originalStack = err.stack;

--- a/test/parallel/test-module-symlinked-peer-modules.js
+++ b/test/parallel/test-module-symlinked-peer-modules.js
@@ -59,4 +59,4 @@ fs.writeFileSync(path.join(moduleB, 'package.json'),
 fs.writeFileSync(path.join(moduleB, 'index.js'),
                  'module.exports = 1;', 'utf8');
 
-require(path.join(app, 'index'));
+require(path.join(app, 'index')); // Should not throw.

--- a/test/parallel/test-module-symlinked-peer-modules.js
+++ b/test/parallel/test-module-symlinked-peer-modules.js
@@ -11,7 +11,6 @@
 const common = require('../common');
 const fs = require('fs');
 const path = require('path');
-const assert = require('assert');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
@@ -60,6 +59,4 @@ fs.writeFileSync(path.join(moduleB, 'package.json'),
 fs.writeFileSync(path.join(moduleB, 'index.js'),
                  'module.exports = 1;', 'utf8');
 
-assert.doesNotThrow(() => {
-  require(path.join(app, 'index'));
-});
+require(path.join(app, 'index'));

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -34,6 +34,8 @@ server.listen(0, common.mustCall(function() {
   c.on('close', common.mustCall(function() {
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
+    // Calling functions / accessing properties of a closed socket should not
+    // throw.
     c.setNoDelay();
     c.setKeepAlive();
     c.bufferSize;

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -34,16 +34,14 @@ server.listen(0, common.mustCall(function() {
   c.on('close', common.mustCall(function() {
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
-    assert.doesNotThrow(function() {
-      c.setNoDelay();
-      c.setKeepAlive();
-      c.bufferSize;
-      c.pause();
-      c.resume();
-      c.address();
-      c.remoteAddress;
-      c.remotePort;
-    });
+    c.setNoDelay();
+    c.setKeepAlive();
+    c.bufferSize;
+    c.pause();
+    c.resume();
+    c.address();
+    c.remoteAddress;
+    c.remotePort;
     server.close();
   }));
 }));

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -171,27 +171,26 @@ function canConnect(port) {
   // connect(port, cb) and connect(port)
   const portArgBlocks = doConnect([port], noop);
   for (const block of portArgBlocks) {
-    assert.doesNotThrow(block, `${block.name}(${port})`);
+    block();
   }
 
   // connect(port, host, cb) and connect(port, host)
   const portHostArgBlocks = doConnect([port, 'localhost'], noop);
   for (const block of portHostArgBlocks) {
-    assert.doesNotThrow(block, `${block.name}(${port})`);
+    block();
   }
 
   // connect({port}, cb) and connect({port})
   const portOptBlocks = doConnect([{ port }], noop);
   for (const block of portOptBlocks) {
-    assert.doesNotThrow(block, `${block.name}({port: ${port}})`);
+    block();
   }
 
   // connect({port, host}, cb) and connect({port, host})
   const portHostOptBlocks = doConnect([{ port: port, host: 'localhost' }],
                                       noop);
   for (const block of portHostOptBlocks) {
-    assert.doesNotThrow(block,
-                        `${block.name}({port: ${port}, host: 'localhost'})`);
+    block();
   }
 }
 
@@ -205,25 +204,19 @@ function asyncFailToConnect(port) {
   // connect(port, cb) and connect(port)
   const portArgBlocks = doConnect([port], dont);
   for (const block of portArgBlocks) {
-    assert.doesNotThrow(function() {
-      block().on('error', onError());
-    }, `${block.name}(${port})`);
+    block().on('error', onError());
   }
 
   // connect({port}, cb) and connect({port})
   const portOptBlocks = doConnect([{ port }], dont);
   for (const block of portOptBlocks) {
-    assert.doesNotThrow(function() {
-      block().on('error', onError());
-    }, `${block.name}({port: ${port}})`);
+    block().on('error', onError());
   }
 
   // connect({port, host}, cb) and connect({port, host})
   const portHostOptBlocks = doConnect([{ port: port, host: 'localhost' }],
                                       dont);
   for (const block of portHostOptBlocks) {
-    assert.doesNotThrow(function() {
-      block().on('error', onError());
-    }, `${block.name}({port: ${port}, host: 'localhost'})`);
+    block().on('error', onError());
   }
 }

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -21,7 +21,6 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const server = net.createServer(function(socket) {
@@ -33,11 +32,9 @@ server.listen(0, common.mustCall(function() {
   server.close();
   // server connection event has not yet fired
   // client is still attempting to connect
-  assert.doesNotThrow(function() {
-    client.remoteAddress;
-    client.remoteFamily;
-    client.remotePort;
-  });
+  client.remoteAddress;
+  client.remoteFamily;
+  client.remotePort;
   // exit now, do not wait for the client error event
   process.exit(0);
 }));

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -30,11 +30,11 @@ const server = net.createServer(function(socket) {
 server.listen(0, common.mustCall(function() {
   const client = net.createConnection(this.address().port);
   server.close();
-  // server connection event has not yet fired
-  // client is still attempting to connect
+  // Server connection event has not yet fired client is still attempting to
+  // connect. Accessing properties should not throw in this case.
   client.remoteAddress;
   client.remoteFamily;
   client.remotePort;
-  // exit now, do not wait for the client error event
+  // Exit now, do not wait for the client error event.
   process.exit(0);
 }));

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 ['foobar', 1, {}, []].forEach((input) => connectThrows(input));
@@ -30,7 +29,5 @@ function connectDoesNotThrow(input) {
     lookup: input
   };
 
-  assert.doesNotThrow(() => {
-    net.connect(opts);
-  });
+  net.connect(opts);
 }

--- a/test/parallel/test-net-server-call-listen-multiple-times.js
+++ b/test/parallel/test-net-server-call-listen-multiple-times.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 // First test. Check that after error event you can listen right away.
@@ -16,12 +15,10 @@ const net = require('net');
   }));
 
   server.on('error', common.mustCall((e) => {
-    assert.doesNotThrow(
-      () => server.listen(common.mustCall(() => {
-        dummyServer.close();
-        server.close();
-      }))
-    );
+    server.listen(common.mustCall(() => {
+      dummyServer.close();
+      server.close();
+    }));
   }));
 }
 
@@ -44,8 +41,6 @@ const net = require('net');
 
   server.listen(common.mustCall(() => {
     server.close();
-    assert.doesNotThrow(
-      () => server.listen(common.mustCall(() => server.close()))
-    );
+    server.listen(common.mustCall(() => server.close()));
   }));
 }

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -46,9 +46,7 @@ for (let i = 0; i < badRangeDelays.length; i++) {
 }
 
 for (let i = 0; i < validDelays.length; i++) {
-  assert.doesNotThrow(function() {
-    s.setTimeout(validDelays[i], () => {});
-  });
+  s.setTimeout(validDelays[i], () => {});
 }
 
 const server = net.Server();

--- a/test/parallel/test-performance.js
+++ b/test/parallel/test-performance.js
@@ -64,7 +64,7 @@ assert.strictEqual(typeof performance.timeOrigin, 'number');
 {
   performance.mark('A');
   [undefined, null, 'foo', 'initialize', 1].forEach((i) => {
-    performance.measure('test', i, 'A');
+    performance.measure('test', i, 'A'); // Should not throw.
   });
 
   [undefined, null, 'foo', 1].forEach((i) => {

--- a/test/parallel/test-performance.js
+++ b/test/parallel/test-performance.js
@@ -64,7 +64,7 @@ assert.strictEqual(typeof performance.timeOrigin, 'number');
 {
   performance.mark('A');
   [undefined, null, 'foo', 'initialize', 1].forEach((i) => {
-    assert.doesNotThrow(() => performance.measure('test', i, 'A'));
+    performance.measure('test', i, 'A');
   });
 
   [undefined, null, 'foo', 1].forEach((i) => {

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -77,7 +77,7 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
     countdown.dec();
   }
   assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_MARK], 1);
-  assert.doesNotThrow(() => observer.observe({ entryTypes: ['mark'] }));
+  observer.observe({ entryTypes: ['mark'] });
   assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_MARK], 2);
   performance.mark('test1');
   performance.mark('test2');
@@ -125,13 +125,9 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
     }
   }
 
-  assert.doesNotThrow(() => {
-    observer.observe({ entryTypes: ['mark', 'measure'], buffered: true });
-  });
+  observer.observe({ entryTypes: ['mark', 'measure'], buffered: true });
   // Do this twice to make sure it doesn't throw
-  assert.doesNotThrow(() => {
-    observer.observe({ entryTypes: ['mark', 'measure'], buffered: true });
-  });
+  observer.observe({ entryTypes: ['mark', 'measure'], buffered: true });
   // Even tho we called twice, count should be 1
   assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_MARK], 2);
   performance.mark('test1');

--- a/test/parallel/test-process-binding.js
+++ b/test/parallel/test-process-binding.js
@@ -9,10 +9,4 @@ assert.throws(
   /No such module: test/
 );
 
-assert.doesNotThrow(function() {
-  process.binding('buffer');
-}, function(err) {
-  if (err instanceof Error) {
-    return true;
-  }
-}, 'unexpected error');
+process.binding('buffer');

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -44,7 +44,7 @@ class CustomWarning extends Error {
   [testMsg, { type: testType, code: testCode, detail: null }],
   [testMsg, { type: testType, code: testCode, detail: 1 }]
 ].forEach((i) => {
-  assert.doesNotThrow(() => process.emitWarning.apply(null, i));
+  process.emitWarning.apply(null, i);
 });
 
 const warningNoToString = new CustomWarning();

--- a/test/parallel/test-process-env-symbols.js
+++ b/test/parallel/test-process-env-symbols.js
@@ -28,4 +28,4 @@ assert.strictEqual(symbol in process.env, false);
 assert.strictEqual(delete process.env[symbol], true);
 
 // Checks that well-known symbols like `Symbol.toStringTag` won’t throw.
-assert.doesNotThrow(() => Object.prototype.toString.call(process.env));
+Object.prototype.toString.call(process.env);

--- a/test/parallel/test-process-geteuid-getegid.js
+++ b/test/parallel/test-process-geteuid-getegid.js
@@ -21,6 +21,7 @@ assert.throws(() => {
 
 // If we're not running as super user...
 if (process.getuid() !== 0) {
+  // Should not throw.
   process.getegid();
   process.geteuid();
 

--- a/test/parallel/test-process-geteuid-getegid.js
+++ b/test/parallel/test-process-geteuid-getegid.js
@@ -21,10 +21,8 @@ assert.throws(() => {
 
 // If we're not running as super user...
 if (process.getuid() !== 0) {
-  assert.doesNotThrow(() => {
-    process.getegid();
-    process.geteuid();
-  });
+  process.getegid();
+  process.geteuid();
 
   assert.throws(() => {
     process.setegid('nobody');

--- a/test/parallel/test-process-setuid-setgid.js
+++ b/test/parallel/test-process-setuid-setgid.js
@@ -39,10 +39,8 @@ assert.throws(() => {
 
 // If we're not running as super user...
 if (process.getuid() !== 0) {
-  assert.doesNotThrow(() => {
-    process.getgid();
-    process.getuid();
-  });
+  process.getgid();
+  process.getuid();
 
   assert.throws(
     () => { process.setgid('nobody'); },

--- a/test/parallel/test-process-setuid-setgid.js
+++ b/test/parallel/test-process-setuid-setgid.js
@@ -39,6 +39,7 @@ assert.throws(() => {
 
 // If we're not running as super user...
 if (process.getuid() !== 0) {
+  // Should not throw.
   process.getgid();
   process.getuid();
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -300,7 +300,7 @@ assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
   assert.strictEqual(f, 'a=b&q=x%3Dy%26y%3Dz');
 }
 
-qs.parse(undefined);
+qs.parse(undefined); // Should not throw.
 
 // nested in colon
 {

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -300,9 +300,7 @@ assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
   assert.strictEqual(f, 'a=b&q=x%3Dy%26y%3Dz');
 }
 
-assert.doesNotThrow(() => {
-  qs.parse(undefined);
-});
+qs.parse(undefined);
 
 // nested in colon
 {

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -61,6 +61,7 @@ assert.deepStrictEqual(writable.data, CSI.kClearLine);
   assert.deepStrictEqual(writable.data, set[2]);
 });
 
+// Undefined or null as stream should not throw.
 readline.cursorTo(null);
 readline.cursorTo();
 

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -61,15 +61,15 @@ assert.deepStrictEqual(writable.data, CSI.kClearLine);
   assert.deepStrictEqual(writable.data, set[2]);
 });
 
-assert.doesNotThrow(() => readline.cursorTo(null));
-assert.doesNotThrow(() => readline.cursorTo());
+readline.cursorTo(null);
+readline.cursorTo();
 
 writable.data = '';
-assert.doesNotThrow(() => readline.cursorTo(writable, 'a'));
+readline.cursorTo(writable, 'a');
 assert.strictEqual(writable.data, '');
 
 writable.data = '';
-assert.doesNotThrow(() => readline.cursorTo(writable, 'a', 'b'));
+readline.cursorTo(writable, 'a', 'b');
 assert.strictEqual(writable.data, '');
 
 writable.data = '';
@@ -83,9 +83,9 @@ common.expectsError(
 assert.strictEqual(writable.data, '');
 
 writable.data = '';
-assert.doesNotThrow(() => readline.cursorTo(writable, 1, 'a'));
+readline.cursorTo(writable, 1, 'a');
 assert.strictEqual(writable.data, '\x1b[2G');
 
 writable.data = '';
-assert.doesNotThrow(() => readline.cursorTo(writable, 1, 2));
+readline.cursorTo(writable, 1, 2);
 assert.strictEqual(writable.data, '\x1b[3;2H');

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -823,23 +823,12 @@ function isWarned(emitter) {
     fi.emit('data', 'asdf\n');
     assert.ok(called);
 
-    assert.doesNotThrow(function() {
-      rli.setPrompt('ddd> ');
-    });
-
-    assert.doesNotThrow(function() {
-      rli.prompt();
-    });
-
-    assert.doesNotThrow(function() {
-      rli.write('really shouldnt be seeing this');
-    });
-
-    assert.doesNotThrow(function() {
-      rli.question('What do you think of node.js? ', function(answer) {
-        console.log('Thank you for your valuable feedback:', answer);
-        rli.close();
-      });
+    rli.setPrompt('ddd> ');
+    rli.prompt();
+    rli.write('really shouldnt be seeing this');
+    rli.question('What do you think of node.js? ', function(answer) {
+      console.log('Thank you for your valuable feedback:', answer);
+      rli.close();
     });
   }
 

--- a/test/parallel/test-regress-GH-6235.js
+++ b/test/parallel/test-regress-GH-6235.js
@@ -21,8 +21,5 @@
 
 'use strict';
 require('../common');
-const assert = require('assert');
 
-assert.doesNotThrow(function() {
-  require('vm').runInNewContext('"use strict"; var v = 1; v = 2');
-});
+require('vm').runInNewContext('"use strict"; var v = 1; v = 2');

--- a/test/parallel/test-repl-null.js
+++ b/test/parallel/test-repl-null.js
@@ -1,7 +1,6 @@
 'use strict';
 require('../common');
 const repl = require('repl');
-const assert = require('assert');
 
 const replserver = new repl.REPLServer();
 
@@ -10,8 +9,5 @@ replserver._inTemplateLiteral = true;
 // `null` gets treated like an empty string. (Should it? You have to do some
 // strange business to get it into the REPL. Maybe it should really throw?)
 
-assert.doesNotThrow(() => {
-  replserver.emit('line', null);
-});
-
+replserver.emit('line', null);
 replserver.emit('line', '.exit');

--- a/test/parallel/test-repl-throw-null-or-undefined.js
+++ b/test/parallel/test-repl-throw-null-or-undefined.js
@@ -3,16 +3,11 @@ require('../common');
 
 // This test ensures that the repl does not
 // crash or emit error when throwing `null|undefined`
-// ie `throw null` or `throw undefined`
+// ie `throw null` or `throw undefined`.
 
-const assert = require('assert');
-const repl = require('repl');
+const r = require('repl').start();
 
-const r = repl.start();
-
-assert.doesNotThrow(() => {
-  r.write('throw null\n');
-  r.write('throw undefined\n');
-}, TypeError, 'repl crashes/throw error on `throw null|undefined`');
-
+// Should not throw.
+r.write('throw null\n');
+r.write('throw undefined\n');
 r.write('.exit\n');

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -22,7 +22,7 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  [0, 1, 2].forEach((i) => assert.doesNotThrow(() => fs.fstatSync(i)));
+  [0, 1, 2].forEach((i) => fs.fstatSync(i));
   return;
 }
 

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -27,14 +27,14 @@ common.expectsError(
   }
 );
 
-assert.doesNotThrow(() => {
+{
   const m = new MyWritable({ objectMode: true }).on('error', (e) => {
     assert.ok(e);
   });
   m.write(null, (err) => {
     assert.ok(err);
   });
-});
+}
 
 common.expectsError(
   () => {
@@ -47,24 +47,25 @@ common.expectsError(
   }
 );
 
-assert.doesNotThrow(() => {
+{
   const m = new MyWritable().on('error', (e) => {
     assert.ok(e);
   });
   m.write(false, (err) => {
     assert.ok(err);
   });
-});
+}
 
-assert.doesNotThrow(() => {
+{
   const m = new MyWritable({ objectMode: true });
   m.write(false, (err) => assert.ifError(err));
-});
-assert.doesNotThrow(() => {
+}
+
+{
   const m = new MyWritable({ objectMode: true }).on('error', (e) => {
     assert.ifError(e || new Error('should not get here'));
   });
   m.write(false, (err) => {
     assert.ifError(err);
   });
-});
+}

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -27,13 +27,9 @@ common.expectsError(
   }
 );
 
-{
-  const m = new MyWritable({ objectMode: true }).on('error', (e) => {
-    assert.ok(e);
-  });
-  m.write(null, (err) => {
-    assert.ok(err);
-  });
+{ // Should not throw.
+  const m = new MyWritable({ objectMode: true }).on('error', assert);
+  m.write(null, assert);
 }
 
 common.expectsError(
@@ -47,25 +43,19 @@ common.expectsError(
   }
 );
 
-{
-  const m = new MyWritable().on('error', (e) => {
-    assert.ok(e);
-  });
-  m.write(false, (err) => {
-    assert.ok(err);
-  });
+{ // Should not throw.
+  const m = new MyWritable().on('error', assert);
+  m.write(false, assert);
 }
 
-{
+{ // Should not throw.
   const m = new MyWritable({ objectMode: true });
-  m.write(false, (err) => assert.ifError(err));
+  m.write(false, assert.ifError);
 }
 
-{
+{ // Should not throw.
   const m = new MyWritable({ objectMode: true }).on('error', (e) => {
     assert.ifError(e || new Error('should not get here'));
   });
-  m.write(false, (err) => {
-    assert.ifError(err);
-  });
+  m.write(false, assert.ifError);
 }

--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -1,18 +1,11 @@
 'use strict';
 require('../common');
-const assert = require('assert');
 
 // This test makes sure clearing timers with
 // 'null' or no input does not throw error
-
-assert.doesNotThrow(() => clearInterval(null));
-
-assert.doesNotThrow(() => clearInterval());
-
-assert.doesNotThrow(() => clearTimeout(null));
-
-assert.doesNotThrow(() => clearTimeout());
-
-assert.doesNotThrow(() => clearImmediate(null));
-
-assert.doesNotThrow(() => clearImmediate());
+clearInterval(null);
+clearInterval();
+clearTimeout(null);
+clearTimeout();
+clearImmediate(null);
+clearImmediate();

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 
 let unref_interval = false;
 let unref_timer = false;
@@ -31,13 +30,8 @@ let checks = 0;
 const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
-assert.doesNotThrow(() => {
-  setTimeout(() => {}, 10).unref().ref().unref();
-}, 'ref and unref are chainable');
-
-assert.doesNotThrow(() => {
-  setInterval(() => {}, 10).unref().ref().unref();
-}, 'ref and unref are chainable');
+setTimeout(() => {}, 10).unref().ref().unref();
+setInterval(() => {}, 10).unref().ref().unref();
 
 setInterval(common.mustNotCall('Interval should not fire'), LONG_TIME).unref();
 setTimeout(common.mustNotCall('Timer should not fire'), LONG_TIME).unref();

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -30,6 +30,7 @@ let checks = 0;
 const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
+// Should not throw.
 setTimeout(() => {}, 10).unref().ref().unref();
 setInterval(() => {}, 10).unref().ref().unref();
 

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -24,7 +24,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
@@ -32,8 +31,5 @@ const cert = fixtures.readSync('test_cert.pem');
 const key = fixtures.readSync('test_key.pem');
 
 const conn = tls.connect({ cert, key, port: 0 }, common.mustNotCall());
-conn.on('error', function() {
-});
-assert.doesNotThrow(function() {
-  conn.destroy();
-});
+conn.on('error', function() {});
+conn.destroy();

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -24,12 +24,9 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 
 const conn = tls.connect(0, common.mustNotCall());
 conn.on('error', common.mustCall(function() {
-  assert.doesNotThrow(function() {
-    conn.destroy();
-  });
+  conn.destroy();
 }));

--- a/test/parallel/test-tls-legacy-deprecated.js
+++ b/test/parallel/test-tls-legacy-deprecated.js
@@ -4,7 +4,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 
 common.expectWarning(
@@ -12,4 +11,4 @@ common.expectWarning(
   'tls.createSecurePair() is deprecated. Please use tls.TLSSocket instead.'
 );
 
-assert.doesNotThrow(() => tls.createSecurePair());
+tls.createSecurePair();

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -6,7 +6,6 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 
 function toArrayBuffer(buf) {
@@ -65,9 +64,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[{ pem: keyBuff }], false],
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
 ].forEach(([key, cert]) => {
-  assert.doesNotThrow(() => {
-    tls.createServer({ key, cert });
-  });
+  tls.createServer({ key, cert });
 });
 
 // Checks to ensure tls.createServer predictably throws an error
@@ -118,9 +115,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
 ].forEach(([key, cert, ca]) => {
-  assert.doesNotThrow(() => {
-    tls.createServer({ key, cert, ca });
-  });
+  tls.createServer({ key, cert, ca });
 });
 
 // Checks to ensure tls.createServer throws an error for CA assignment
@@ -168,7 +163,5 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   ['', '', ''],
   [0, 0, 0]
 ].forEach(([key, cert, ca]) => {
-  assert.doesNotThrow(() => {
-    tls.createSecureContext({ key, cert, ca });
-  });
+  tls.createSecureContext({ key, cert, ca });
 });

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -13,7 +13,7 @@ const handler = {
 const proxyObj = new Proxy(target, handler);
 
 // Inspecting the proxy should not actually walk it's properties
-assert.doesNotThrow(() => util.inspect(proxyObj, opts));
+util.inspect(proxyObj, opts);
 
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -146,7 +146,7 @@ for (const showHidden of [true, false]) {
                      '  y: 1337 }');
 }
 
-// Now do the same checks but from a different context
+// Now do the same checks but from a different context.
 for (const showHidden of [true, false]) {
   const ab = vm.runInNewContext('new ArrayBuffer(4)');
   const dv = vm.runInNewContext('new DataView(ab, 1, 2)', { ab });
@@ -211,7 +211,7 @@ for (const showHidden of [true, false]) {
   );
 });
 
-// Now check that declaring a TypedArray in a different context works the same
+// Now check that declaring a TypedArray in a different context works the same.
 [ Float32Array,
   Float64Array,
   Int16Array,
@@ -252,7 +252,7 @@ assert.strictEqual(
   }), { showHidden: true }),
   '{ visible: 1, [hidden]: 2 }'
 );
-// Objects without prototype
+// Objects without prototype.
 assert.strictEqual(
   util.inspect(Object.create(null, {
     name: { value: 'Tim', enumerable: true },
@@ -269,7 +269,7 @@ assert.strictEqual(
   '{ name: \'Tim\' }'
 );
 
-// Dynamic properties
+// Dynamic properties.
 {
   assert.strictEqual(
     util.inspect({ get readonly() {} }),
@@ -289,7 +289,7 @@ assert.strictEqual(
   assert.strictEqual(util.inspect(value), '{ a: [Circular] }');
 }
 
-// Array with dynamic properties
+// Array with dynamic properties.
 {
   const value = [1, 2, 3];
   Object.defineProperty(
@@ -312,7 +312,7 @@ assert.strictEqual(
                      '[ 1, 2, 3, growingLength: [Getter], \'-1\': -1 ]');
 }
 
-// Array with inherited number properties
+// Array with inherited number properties.
 {
   class CustomArray extends Array {}
   CustomArray.prototype[5] = 'foo';
@@ -320,7 +320,7 @@ assert.strictEqual(
   assert.strictEqual(util.inspect(arr), 'CustomArray [ <50 empty items> ]');
 }
 
-// Array with extra properties
+// Array with extra properties.
 {
   const arr = [1, 2, 3, , ];
   arr.foo = 'bar';
@@ -352,10 +352,10 @@ assert.strictEqual(
   assert.strictEqual(util.inspect(arr3), "[ '-1': -1 ]");
 }
 
-// Indices out of bounds
+// Indices out of bounds.
 {
   const arr = [];
-  arr[2 ** 32] = true; // not a valid array index
+  arr[2 ** 32] = true; // Not a valid array index.
   assert.strictEqual(util.inspect(arr), "[ '4294967296': true ]");
   arr[0] = true;
   arr[10] = true;
@@ -375,28 +375,28 @@ assert.strictEqual(
                      ].join('\n  '));
 }
 
-// Function with properties
+// Function with properties.
 {
   const value = () => {};
   value.aprop = 42;
   assert.strictEqual(util.inspect(value), '{ [Function: value] aprop: 42 }');
 }
 
-// Anonymous function with properties
+// Anonymous function with properties.
 {
   const value = (() => function() {})();
   value.aprop = 42;
   assert.strictEqual(util.inspect(value), '{ [Function] aprop: 42 }');
 }
 
-// Regular expressions with properties
+// Regular expressions with properties.
 {
   const value = /123/ig;
   value.aprop = 42;
   assert.strictEqual(util.inspect(value), '{ /123/gi aprop: 42 }');
 }
 
-// Dates with properties
+// Dates with properties.
 {
   const value = new Date('Sun, 14 Feb 2010 11:48:40 GMT');
   value.aprop = 42;
@@ -404,7 +404,7 @@ assert.strictEqual(
                      '{ 2010-02-14T11:48:40.000Z aprop: 42 }');
 }
 
-// test the internal isDate implementation
+// Test the internal isDate implementation.
 {
   const Date2 = vm.runInNewContext('Date');
   const d = new Date2();
@@ -414,13 +414,13 @@ assert.strictEqual(
   assert.strictEqual(orig, after);
 }
 
-// test positive/negative zero
+// Test positive/negative zero.
 assert.strictEqual(util.inspect(0), '0');
 assert.strictEqual(util.inspect(-0), '-0');
-// edge case from check
+// Edge case from check.
 assert.strictEqual(util.inspect(-5e-324), '-5e-324');
 
-// test for sparse array
+// Test for sparse array.
 {
   const a = ['foo', 'bar', 'baz'];
   assert.strictEqual(util.inspect(a), '[ \'foo\', \'bar\', \'baz\' ]');
@@ -444,7 +444,7 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   );
 }
 
-// test for Array constructor in different context
+// Test for Array constructor in different context.
 {
   const map = new Map();
   map.set(1, 2);
@@ -457,7 +457,7 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   assert.strictEqual(util.inspect(valsOutput), '[ [ 1, 2 ] ]');
 }
 
-// test for other constructors in different context
+// Test for other constructors in different context.
 {
   let obj = vm.runInNewContext('(function(){return {}})()', {});
   assert.strictEqual(util.inspect(obj), '{}');
@@ -469,7 +469,7 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   assert.strictEqual(util.inspect(obj), 'Promise { <pending> }');
 }
 
-// test for property descriptors
+// Test for property descriptors.
 {
   const getter = Object.create(null, {
     a: {
@@ -495,7 +495,7 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   );
 }
 
-// exceptions should print the error message, not '{}'
+// Exceptions should print the error message, not '{}'.
 {
   const errors = [];
   errors.push(new Error());
@@ -516,7 +516,7 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   assert(ex.includes('[message]'));
 }
 
-// Doesn't capture stack trace
+// Doesn't capture stack trace.
 {
   function BadCustomError(msg) {
     Error.call(this);
@@ -533,7 +533,6 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
 }
 
 // GH-1941
-// should not throw:
 assert.strictEqual(util.inspect(Object.create(Date.prototype)), 'Date {}');
 
 // GH-1944
@@ -543,20 +542,20 @@ assert.strictEqual(util.inspect(Object.create(Date.prototype)), 'Date {}');
   util.inspect(d);
 }
 
+// Should not throw.
 {
   const d = new Date();
   d.toISOString = null;
   util.inspect(d);
 }
 
+// Should not throw.
 const r = /regexp/;
 r.toString = null;
 util.inspect(r);
 
-// bug with user-supplied inspect function returns non-string
-util.inspect([{
-  inspect: () => 123
-}]);
+// Bug with user-supplied inspect function returns non-string.
+util.inspect([{ inspect: () => 123 }]);
 
 // GH-2225
 {
@@ -592,7 +591,7 @@ util.inspect([{
   );
 }
 
-// util.inspect.styles and util.inspect.colors
+// Test util.inspect.styles and util.inspect.colors.
 {
   function testColorStyle(style, input, implicit) {
     const colorName = util.inspect.styles[style];
@@ -619,12 +618,10 @@ util.inspect([{
   testColorStyle('regexp', /regexp/);
 }
 
-// an object with "hasOwnProperty" overwritten should not throw
-util.inspect({
-  hasOwnProperty: null
-});
+// An object with "hasOwnProperty" overwritten should not throw.
+util.inspect({ hasOwnProperty: null });
 
-// new API, accepts an "options" object
+// New API, accepts an "options" object.
 {
   const subject = { foo: 'bar', hello: 31, a: { b: { c: { d: 0 } } } };
   Object.defineProperty(subject, 'hidden', { enumerable: false, value: null });
@@ -664,7 +661,7 @@ util.inspect({
 }
 
 {
-  // "customInspect" option can enable/disable calling inspect() on objects
+  // "customInspect" option can enable/disable calling inspect() on objects.
   const subject = { inspect: () => 123 };
 
   assert.strictEqual(
@@ -684,7 +681,7 @@ util.inspect({
     true
   );
 
-  // custom inspect() functions should be able to return other Objects
+  // Custom inspect() functions should be able to return other Objects.
   subject.inspect = () => ({ foo: 'bar' });
 
   assert.strictEqual(util.inspect(subject), '{ foo: \'bar\' }');
@@ -697,7 +694,7 @@ util.inspect({
 }
 
 {
-  // "customInspect" option can enable/disable calling [util.inspect.custom]()
+  // "customInspect" option can enable/disable calling [util.inspect.custom]().
   const subject = { [util.inspect.custom]: () => 123 };
 
   assert.strictEqual(
@@ -709,7 +706,7 @@ util.inspect({
     false
   );
 
-  // a custom [util.inspect.custom]() should be able to return other Objects
+  // A custom [util.inspect.custom]() should be able to return other Objects.
   subject[util.inspect.custom] = () => ({ foo: 'bar' });
 
   assert.strictEqual(util.inspect(subject), '{ foo: \'bar\' }');
@@ -722,7 +719,7 @@ util.inspect({
 }
 
 {
-  // [util.inspect.custom] takes precedence over inspect
+  // [util.inspect.custom] takes precedence over inspect.
   const subject = {
     [util.inspect.custom]() { return 123; },
     inspect() { return 456; }
@@ -757,7 +754,7 @@ util.inspect({
                      `{ a: 123,\n  [Symbol(${UIC})]: [Function: [${UIC}]] }`);
 }
 
-// util.inspect with "colors" option should produce as many lines as without it
+// util.inspect with "colors" option should produce as many lines as without it.
 {
   function testLines(input) {
     const countLines = (str) => (str.match(/\n/g) || []).length;
@@ -781,7 +778,7 @@ util.inspect({
   });
 }
 
-// test boxed primitives output the correct values
+// Test boxed primitives output the correct values.
 assert.strictEqual(util.inspect(new String('test')), '[String: \'test\']');
 assert.strictEqual(
   util.inspect(Object(Symbol('test'))),
@@ -794,7 +791,7 @@ assert.strictEqual(util.inspect(new Number(-0)), '[Number: -0]');
 assert.strictEqual(util.inspect(new Number(-1.1)), '[Number: -1.1]');
 assert.strictEqual(util.inspect(new Number(13.37)), '[Number: 13.37]');
 
-// test boxed primitives with own properties
+// Test boxed primitives with own properties.
 {
   const str = new String('baz');
   str.foo = 'bar';
@@ -809,7 +806,7 @@ assert.strictEqual(util.inspect(new Number(13.37)), '[Number: 13.37]');
   assert.strictEqual(util.inspect(num), '{ [Number: 13.37] foo: \'bar\' }');
 }
 
-// test es6 Symbol
+// Test es6 Symbol.
 if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(Symbol()), 'Symbol()');
   assert.strictEqual(util.inspect(Symbol(123)), 'Symbol(123)');
@@ -845,7 +842,7 @@ if (typeof Symbol !== 'undefined') {
                      '[ 1, 2, 3, [Symbol(symbol)]: 42 ]');
 }
 
-// test Set
+// Test Set.
 {
   assert.strictEqual(util.inspect(new Set()), 'Set {}');
   assert.strictEqual(util.inspect(new Set([1, 2, 3])), 'Set { 1, 2, 3 }');
@@ -857,14 +854,14 @@ if (typeof Symbol !== 'undefined') {
   );
 }
 
-// Test circular Set
+// Test circular Set.
 {
   const set = new Set();
   set.add(set);
   assert.strictEqual(util.inspect(set), 'Set { [Circular] }');
 }
 
-// test Map
+// Test Map.
 {
   assert.strictEqual(util.inspect(new Map()), 'Map {}');
   assert.strictEqual(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])),
@@ -875,7 +872,7 @@ if (typeof Symbol !== 'undefined') {
                      'Map { \'foo\' => null, [size]: 1, bar: 42 }');
 }
 
-// Test circular Map
+// Test circular Map.
 {
   const map = new Map();
   map.set(map, 'map');
@@ -887,14 +884,14 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(map), "Map { 'map' => [Circular] }");
 }
 
-// test Promise
+// Test Promise.
 {
   const resolved = Promise.resolve(3);
   assert.strictEqual(util.inspect(resolved), 'Promise { 3 }');
 
   const rejected = Promise.reject(3);
   assert.strictEqual(util.inspect(rejected), 'Promise { <rejected> 3 }');
-  // squelch UnhandledPromiseRejection
+  // Squelch UnhandledPromiseRejection.
   rejected.catch(() => {});
 
   const pending = new Promise(() => {});
@@ -916,33 +913,33 @@ if (typeof Symbol !== 'undefined') {
   global.Promise = oldPromise;
 }
 
-// Test Map iterators
+// Test Map iterators.
 {
   const map = new Map([['foo', 'bar']]);
   assert.strictEqual(util.inspect(map.keys()), '[Map Iterator] { \'foo\' }');
   assert.strictEqual(util.inspect(map.values()), '[Map Iterator] { \'bar\' }');
   assert.strictEqual(util.inspect(map.entries()),
                      '[Map Iterator] { [ \'foo\', \'bar\' ] }');
-  // make sure the iterator doesn't get consumed
+  // Make sure the iterator doesn't get consumed.
   const keys = map.keys();
   assert.strictEqual(util.inspect(keys), '[Map Iterator] { \'foo\' }');
   assert.strictEqual(util.inspect(keys), '[Map Iterator] { \'foo\' }');
 }
 
-// Test Set iterators
+// Test Set iterators.
 {
   const aSet = new Set([1, 3]);
   assert.strictEqual(util.inspect(aSet.keys()), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(aSet.values()), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(aSet.entries()),
                      '[Set Iterator] { [ 1, 1 ], [ 3, 3 ] }');
-  // make sure the iterator doesn't get consumed
+  // Make sure the iterator doesn't get consumed.
   const keys = aSet.keys();
   assert.strictEqual(util.inspect(keys), '[Set Iterator] { 1, 3 }');
   assert.strictEqual(util.inspect(keys), '[Set Iterator] { 1, 3 }');
 }
 
-// Test alignment of items in container
+// Test alignment of items in container.
 // Assumes that the first numeric character is the start of an item.
 {
   function checkAlignment(container) {
@@ -977,7 +974,7 @@ if (typeof Symbol !== 'undefined') {
 }
 
 
-// Test display of constructors
+// Test display of constructors.
 {
   class ObjectSubclass {}
   class ArraySubclass extends Array {}
@@ -1003,7 +1000,7 @@ if (typeof Symbol !== 'undefined') {
   );
 }
 
-// Empty and circular before depth
+// Empty and circular before depth.
 {
   const arr = [[[[]]]];
   assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [] ] ] ]');
@@ -1099,14 +1096,14 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(twoLines, '{ foo: \'abc\',\n  bar: \'xyz\' }');
 }
 
-// util.inspect.defaultOptions tests
+// util.inspect.defaultOptions tests.
 {
   const arr = new Array(101).fill();
   const obj = { a: { a: { a: { a: 1 } } } };
 
   const oldOptions = Object.assign({}, util.inspect.defaultOptions);
 
-  // Set single option through property assignment
+  // Set single option through property assignment.
   util.inspect.defaultOptions.maxArrayLength = null;
   assert(!/1 more item/.test(util.inspect(arr)));
   util.inspect.defaultOptions.maxArrayLength = oldOptions.maxArrayLength;
@@ -1120,7 +1117,7 @@ if (typeof Symbol !== 'undefined') {
     JSON.stringify(oldOptions)
   );
 
-  // Set multiple options through object assignment
+  // Set multiple options through object assignment.
   util.inspect.defaultOptions = { maxArrayLength: null, depth: 2 };
   assert(!/1 more item/.test(util.inspect(arr)));
   assert(/Object/.test(util.inspect(obj)));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -537,30 +537,26 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
 assert.strictEqual(util.inspect(Object.create(Date.prototype)), 'Date {}');
 
 // GH-1944
-assert.doesNotThrow(() => {
+{
   const d = new Date();
   d.toUTCString = null;
   util.inspect(d);
-});
+}
 
-assert.doesNotThrow(() => {
+{
   const d = new Date();
   d.toISOString = null;
   util.inspect(d);
-});
+}
 
-assert.doesNotThrow(() => {
-  const r = /regexp/;
-  r.toString = null;
-  util.inspect(r);
-});
+const r = /regexp/;
+r.toString = null;
+util.inspect(r);
 
 // bug with user-supplied inspect function returns non-string
-assert.doesNotThrow(() => {
-  util.inspect([{
-    inspect: () => 123
-  }]);
-});
+util.inspect([{
+  inspect: () => 123
+}]);
 
 // GH-2225
 {
@@ -624,10 +620,8 @@ assert.doesNotThrow(() => {
 }
 
 // an object with "hasOwnProperty" overwritten should not throw
-assert.doesNotThrow(() => {
-  util.inspect({
-    hasOwnProperty: null
-  });
+util.inspect({
+  hasOwnProperty: null
 });
 
 // new API, accepts an "options" object
@@ -1157,7 +1151,7 @@ if (typeof Symbol !== 'undefined') {
   );
 }
 
-assert.doesNotThrow(() => util.inspect(process));
+util.inspect(process);
 
 // Setting custom inspect property to a non-function should do nothing.
 {

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -14,14 +14,12 @@ keys.forEach((key) => {
   if (!key.startsWith('UV_'))
     return;
 
-  assert.doesNotThrow(() => {
-    const err = _errnoException(uv[key], 'test');
-    const name = uv.errname(uv[key]);
-    assert.strictEqual(getSystemErrorName(uv[key]), name);
-    assert.strictEqual(err.code, name);
-    assert.strictEqual(err.code, err.errno);
-    assert.strictEqual(err.message, `test ${name}`);
-  });
+  const err = _errnoException(uv[key], 'test');
+  const name = uv.errname(uv[key]);
+  assert.strictEqual(getSystemErrorName(uv[key]), name);
+  assert.strictEqual(err.code, name);
+  assert.strictEqual(err.code, err.errno);
+  assert.strictEqual(err.message, `test ${name}`);
 });
 
 function runTest(fn) {

--- a/test/parallel/test-vm-access-process-env.js
+++ b/test/parallel/test-vm-access-process-env.js
@@ -28,8 +28,6 @@ require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-assert.doesNotThrow(function() {
-  const context = vm.createContext({ process });
-  const result = vm.runInContext('process.env["PATH"]', context);
-  assert.notStrictEqual(undefined, result);
-});
+const context = vm.createContext({ process });
+const result = vm.runInContext('process.env["PATH"]', context);
+assert.notStrictEqual(undefined, result);

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -28,6 +28,7 @@ assert.throws(function() {
   vm.createContext('string is not supported');
 }, /^TypeError: sandbox must be an object$/);
 
+// Should not throw.
 vm.createContext({ a: 1 });
 vm.createContext([0, 1, 2, 3]);
 

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -28,13 +28,9 @@ assert.throws(function() {
   vm.createContext('string is not supported');
 }, /^TypeError: sandbox must be an object$/);
 
-assert.doesNotThrow(function() {
-  vm.createContext({ a: 1 });
-  vm.createContext([0, 1, 2, 3]);
-});
+vm.createContext({ a: 1 });
+vm.createContext([0, 1, 2, 3]);
 
-assert.doesNotThrow(function() {
-  const sandbox = {};
-  vm.createContext(sandbox);
-  vm.createContext(sandbox);
-});
+const sandbox = {};
+vm.createContext(sandbox);
+vm.createContext(sandbox);

--- a/test/parallel/test-vm-cross-context.js
+++ b/test/parallel/test-vm-cross-context.js
@@ -25,4 +25,5 @@ require('../common');
 const vm = require('vm');
 const ctx = vm.createContext(global);
 
+// Should not throw.
 vm.runInContext('!function() { var x = console.log; }()', ctx);

--- a/test/parallel/test-vm-cross-context.js
+++ b/test/parallel/test-vm-cross-context.js
@@ -21,11 +21,8 @@
 
 'use strict';
 require('../common');
-const assert = require('assert');
 
 const vm = require('vm');
 const ctx = vm.createContext(global);
 
-assert.doesNotThrow(function() {
-  vm.runInContext('!function() { var x = console.log; }()', ctx);
-});
+vm.runInContext('!function() { var x = console.log; }()', ctx);

--- a/test/parallel/test-vm-proxy-failure-CP.js
+++ b/test/parallel/test-vm-proxy-failure-CP.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-const assert = require('assert');
 const vm = require('vm');
 
 // Check that we do not accidentally query attributes.
@@ -13,4 +12,4 @@ const handler = {
 const sandbox = new Proxy({ foo: 'bar' }, handler);
 const context = vm.createContext(sandbox);
 
-assert.doesNotThrow(() => vm.runInContext('', context));
+vm.runInContext('', context);

--- a/test/parallel/test-whatwg-encoding-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder.js
@@ -63,8 +63,8 @@ if (common.hasIntl) {
 
   ['unicode-1-1-utf-8', 'utf8', 'utf-8'].forEach((i) => {
     const dec = new TextDecoder(i, { fatal: true });
-    assert.doesNotThrow(() => dec.decode(buf.slice(0, 8), { stream: true }));
-    assert.doesNotThrow(() => dec.decode(buf.slice(8)));
+    dec.decode(buf.slice(0, 8), { stream: true });
+    dec.decode(buf.slice(8));
   });
 } else {
   common.expectsError(
@@ -107,11 +107,11 @@ if (common.hasIntl) {
     message: 'Value of "this" must be of type TextDecoder'
   };
 
-  assert.doesNotThrow(() => inspectFn.call(instance, Infinity, {}));
-  assert.doesNotThrow(() => decodeFn.call(instance));
-  assert.doesNotThrow(() => encodingGetter.call(instance));
-  assert.doesNotThrow(() => fatalGetter.call(instance));
-  assert.doesNotThrow(() => ignoreBOMGetter.call(instance));
+  inspectFn.call(instance, Infinity, {});
+  decodeFn.call(instance);
+  encodingGetter.call(instance);
+  fatalGetter.call(instance);
+  ignoreBOMGetter.call(instance);
 
   const invalidThisArgs = [{}, [], true, 1, '', new TextEncoder()];
   invalidThisArgs.forEach((i) => {

--- a/test/parallel/test-whatwg-encoding-textencoder.js
+++ b/test/parallel/test-whatwg-encoding-textencoder.js
@@ -48,9 +48,9 @@ assert(TextEncoder);
     message: 'Value of "this" must be of type TextEncoder'
   };
 
-  assert.doesNotThrow(() => inspectFn.call(instance, Infinity, {}));
-  assert.doesNotThrow(() => encodeFn.call(instance));
-  assert.doesNotThrow(() => encodingGetter.call(instance));
+  inspectFn.call(instance, Infinity, {});
+  encodeFn.call(instance);
+  encodingGetter.call(instance);
 
   const invalidThisArgs = [{}, [], true, 1, '', new TextDecoder()];
   invalidThisArgs.forEach((i) => {

--- a/test/parallel/test-zlib-close-after-error.js
+++ b/test/parallel/test-zlib-close-after-error.js
@@ -9,7 +9,7 @@ const decompress = zlib.createGunzip(15);
 
 decompress.on('error', common.mustCall((err) => {
   assert.strictEqual(decompress._closed, true);
-  assert.doesNotThrow(() => decompress.close());
+  decompress.close();
 }));
 
 assert.strictEqual(decompress._closed, false);

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -93,25 +93,11 @@ common.expectsError(
 );
 
 // Does not throw if opts.strategy is valid
-assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_FILTERED }); }
-);
-
-assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_HUFFMAN_ONLY }); }
-);
-
-assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_RLE }); }
-);
-
-assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_FIXED }); }
-);
-
-assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY }); }
-);
+new zlib.Deflate({ strategy: zlib.constants.Z_FILTERED });
+new zlib.Deflate({ strategy: zlib.constants.Z_HUFFMAN_ONLY });
+new zlib.Deflate({ strategy: zlib.constants.Z_RLE });
+new zlib.Deflate({ strategy: zlib.constants.Z_FIXED });
+new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY });
 
 // Throws if opt.strategy is the wrong type.
 common.expectsError(

--- a/test/parallel/test-zlib-flush-flags.js
+++ b/test/parallel/test-zlib-flush-flags.js
@@ -1,11 +1,8 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const zlib = require('zlib');
 
-assert.doesNotThrow(() => {
-  zlib.createGzip({ flush: zlib.constants.Z_SYNC_FLUSH });
-});
+zlib.createGzip({ flush: zlib.constants.Z_SYNC_FLUSH });
 
 common.expectsError(
   () => zlib.createGzip({ flush: 'foobar' }),
@@ -23,9 +20,7 @@ common.expectsError(
   }
 );
 
-assert.doesNotThrow(() => {
-  zlib.createGzip({ finishFlush: zlib.constants.Z_SYNC_FLUSH });
-});
+zlib.createGzip({ finishFlush: zlib.constants.Z_SYNC_FLUSH });
 
 common.expectsError(
   () => zlib.createGzip({ finishFlush: 'foobar' }),

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -43,11 +43,9 @@ const unzips = [
 
 nonStringInputs.forEach(common.mustCall((input) => {
   // zlib.gunzip should not throw an error when called with bad input.
-  assert.doesNotThrow(function() {
-    zlib.gunzip(input, function(err, buffer) {
-      // zlib.gunzip should pass the error to the callback.
-      assert.ok(err);
-    });
+  zlib.gunzip(input, function(err, buffer) {
+    // zlib.gunzip should pass the error to the callback.
+    assert.ok(err);
   });
 }, nonStringInputs.length));
 

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -29,10 +29,8 @@ const errMessage = /unexpected end of file/;
     const toUTF8 = (buffer) => buffer.toString('utf-8');
 
     // sync sanity
-    assert.doesNotThrow(function() {
-      const decompressed = zlib[methods.decompSync](compressed);
-      assert.strictEqual(toUTF8(decompressed), inputString);
-    });
+    const decompressed = zlib[methods.decompSync](compressed);
+    assert.strictEqual(toUTF8(decompressed), inputString);
 
     // async sanity
     zlib[methods.decomp](compressed, function(err, result) {
@@ -53,10 +51,8 @@ const errMessage = /unexpected end of file/;
     const syncFlushOpt = { finishFlush: zlib.constants.Z_SYNC_FLUSH };
 
     // sync truncated input test, finishFlush = Z_SYNC_FLUSH
-    assert.doesNotThrow(function() {
-      const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
-      assert.strictEqual(result, inputString.substr(0, result.length));
-    });
+    const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
+    assert.strictEqual(result, inputString.substr(0, result.length));
 
     // async truncated input test, finishFlush = Z_SYNC_FLUSH
     zlib[methods.decomp](truncated, syncFlushOpt, function(err, decompressed) {

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -152,9 +152,7 @@ class SlowStream extends stream.Stream {
 }
 
 // windowBits: 8 shouldn't throw
-assert.doesNotThrow(() => {
-  zlib.createDeflateRaw({ windowBits: 8 });
-}, 'windowsBits set to 8 should follow legacy zlib behavior');
+zlib.createDeflateRaw({ windowBits: 8 });
 
 {
   const node = fs.createReadStream(fixtures.path('person.jpg'));

--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -44,9 +44,7 @@ assert.strictEqual(readBuf.toString(), message);
 fs.readSync(fd, readBuf, 0, 1, 0);
 assert.strictEqual(readBuf[0], 0);
 
-assert.doesNotThrow(
-  () => { fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001); }
-);
+fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
 fs.close(fd);
 
 // Normally, we don't clean up tmp files at the end of a test, but we'll make an

--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -44,6 +44,7 @@ assert.strictEqual(readBuf.toString(), message);
 fs.readSync(fd, readBuf, 0, 1, 0);
 assert.strictEqual(readBuf[0], 0);
 
+// Verify that floating point positions do not throw.
 fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
 fs.close(fd);
 

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -68,6 +68,7 @@ assert.throws(
   }
 );
 
+// Does not throw.
 fs.watchFile(filepathOne, function() {
   fs.unwatchFile(filepathOne);
   ++watchSeenOne;
@@ -91,7 +92,7 @@ assert.throws(
   }
 );
 
-{
+{ // Does not throw.
   function a() {
     fs.unwatchFile(filepathTwo, a);
     ++watchSeenTwo;
@@ -108,7 +109,7 @@ setTimeout(function() {
   fs.writeFileSync(filepathTwoAbs, 'pardner');
 }, 1000);
 
-{
+{ // Does not throw.
   function b() {
     fs.unwatchFile(filenameThree, b);
     ++watchSeenThree;
@@ -130,7 +131,7 @@ setTimeout(function() {
   fs.writeFileSync(filenameFour, 'hey');
 }, 500);
 
-{
+{ // Does not throw.
   function a() {
     ++watchSeenFour;
     assert.strictEqual(1, watchSeenFour);

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -68,14 +68,10 @@ assert.throws(
   }
 );
 
-assert.doesNotThrow(
-  function() {
-    fs.watchFile(filepathOne, function() {
-      fs.unwatchFile(filepathOne);
-      ++watchSeenOne;
-    });
-  }
-);
+fs.watchFile(filepathOne, function() {
+  fs.unwatchFile(filepathOne);
+  ++watchSeenOne;
+});
 
 setTimeout(function() {
   fs.writeFileSync(filepathOne, 'world');
@@ -95,36 +91,32 @@ assert.throws(
   }
 );
 
-assert.doesNotThrow(
-  function() {
-    function a() {
-      fs.unwatchFile(filepathTwo, a);
-      ++watchSeenTwo;
-    }
-    function b() {
-      fs.unwatchFile(filepathTwo, b);
-      ++watchSeenTwo;
-    }
-    fs.watchFile(filepathTwo, a);
-    fs.watchFile(filepathTwo, b);
+{
+  function a() {
+    fs.unwatchFile(filepathTwo, a);
+    ++watchSeenTwo;
   }
-);
+  function b() {
+    fs.unwatchFile(filepathTwo, b);
+    ++watchSeenTwo;
+  }
+  fs.watchFile(filepathTwo, a);
+  fs.watchFile(filepathTwo, b);
+}
 
 setTimeout(function() {
   fs.writeFileSync(filepathTwoAbs, 'pardner');
 }, 1000);
 
-assert.doesNotThrow(
-  function() {
-    function b() {
-      fs.unwatchFile(filenameThree, b);
-      ++watchSeenThree;
-    }
-    fs.watchFile(filenameThree, common.mustNotCall());
-    fs.watchFile(filenameThree, b);
-    fs.unwatchFile(filenameThree, common.mustNotCall());
+{
+  function b() {
+    fs.unwatchFile(filenameThree, b);
+    ++watchSeenThree;
   }
-);
+  fs.watchFile(filenameThree, common.mustNotCall());
+  fs.watchFile(filenameThree, b);
+  fs.unwatchFile(filenameThree, common.mustNotCall());
+}
 
 setTimeout(function() {
   fs.writeFileSync(filenameThree, 'pardner');
@@ -138,13 +130,11 @@ setTimeout(function() {
   fs.writeFileSync(filenameFour, 'hey');
 }, 500);
 
-assert.doesNotThrow(
-  function() {
-    function a() {
-      ++watchSeenFour;
-      assert.strictEqual(1, watchSeenFour);
-      fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
-    }
-    fs.watchFile(filenameFour, a);
+{
+  function a() {
+    ++watchSeenFour;
+    assert.strictEqual(1, watchSeenFour);
+    fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
   }
-);
+  fs.watchFile(filenameFour, a);
+}

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -144,6 +144,4 @@ assert.strictEqual(ret, `${msg}\n`);
 }
 
 // Verify the shell option works properly
-assert.doesNotThrow(() => {
-  execFileSync(process.execPath, [], execOpts);
-});
+execFileSync(process.execPath, [], execOpts);

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -42,19 +42,15 @@ tmpdir.refresh();
 
   fs.writeFileSync(filepath, 'hello');
 
-  assert.doesNotThrow(
-    function() {
-      const watcher = fs.watch(filepath);
-      watcher.on('change', common.mustCall(function(event, filename) {
-        assert.strictEqual(event, 'change');
+  const watcher = fs.watch(filepath);
+  watcher.on('change', common.mustCall(function(event, filename) {
+    assert.strictEqual(event, 'change');
 
-        if (expectFilePath) {
-          assert.strictEqual(filename, 'watch.txt');
-        }
-        watcher.close();
-      }));
+    if (expectFilePath) {
+      assert.strictEqual(filename, 'watch.txt');
     }
-  );
+    watcher.close();
+  }));
 
   setImmediate(function() {
     fs.writeFileSync(filepath, 'world');
@@ -68,19 +64,15 @@ tmpdir.refresh();
 
   fs.writeFileSync(filepathAbs, 'howdy');
 
-  assert.doesNotThrow(
-    function() {
-      const watcher =
-        fs.watch('hasOwnProperty', common.mustCall(function(event, filename) {
-          assert.strictEqual(event, 'change');
+  const watcher =
+    fs.watch('hasOwnProperty', common.mustCall(function(event, filename) {
+      assert.strictEqual(event, 'change');
 
-          if (expectFilePath) {
-            assert.strictEqual(filename, 'hasOwnProperty');
-          }
-          watcher.close();
-        }));
-    }
-  );
+      if (expectFilePath) {
+        assert.strictEqual(filename, 'hasOwnProperty');
+      }
+      watcher.close();
+    }));
 
   setImmediate(function() {
     fs.writeFileSync(filepathAbs, 'pardner');
@@ -91,21 +83,17 @@ tmpdir.refresh();
   const testsubdir = fs.mkdtempSync(testDir + path.sep);
   const filepath = path.join(testsubdir, 'newfile.txt');
 
-  assert.doesNotThrow(
-    function() {
-      const watcher =
-        fs.watch(testsubdir, common.mustCall(function(event, filename) {
-          const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
-          assert.strictEqual(event, renameEv);
-          if (expectFilePath) {
-            assert.strictEqual(filename, 'newfile.txt');
-          } else {
-            assert.strictEqual(filename, null);
-          }
-          watcher.close();
-        }));
-    }
-  );
+  const watcher =
+    fs.watch(testsubdir, common.mustCall(function(event, filename) {
+      const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
+      assert.strictEqual(event, renameEv);
+      if (expectFilePath) {
+        assert.strictEqual(filename, 'newfile.txt');
+      } else {
+        assert.strictEqual(filename, null);
+      }
+      watcher.close();
+    }));
 
   setImmediate(function() {
     const fd = fs.openSync(filepath, 'w');

--- a/test/sequential/test-inspector-module.js
+++ b/test/sequential/test-inspector-module.js
@@ -4,7 +4,6 @@ const common = require('../common');
 
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { Session } = require('inspector');
 
 const session = new Session();
@@ -18,10 +17,8 @@ common.expectsError(
   }
 );
 
-assert.doesNotThrow(() => session.connect());
-
-assert.doesNotThrow(
-  () => session.post('Runtime.evaluate', { expression: '2 + 2' }));
+session.connect();
+session.post('Runtime.evaluate', { expression: '2 + 2' });
 
 [1, {}, [], true, Infinity, undefined].forEach((i) => {
   common.expectsError(
@@ -58,5 +55,5 @@ common.expectsError(
   }
 );
 
-assert.doesNotThrow(() => session.disconnect());
-assert.doesNotThrow(() => session.disconnect());
+session.disconnect();
+session.disconnect();

--- a/test/sequential/test-inspector-module.js
+++ b/test/sequential/test-inspector-module.js
@@ -56,4 +56,5 @@ common.expectsError(
 );
 
 session.disconnect();
+// Calling disconnect twice should not throw.
 session.disconnect();

--- a/test/sequential/test-tls-lookup.js
+++ b/test/sequential/test-tls-lookup.js
@@ -3,7 +3,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 
 ['foobar', 1, {}, []].forEach(function connectThrows(input) {
@@ -30,7 +29,5 @@ function connectDoesNotThrow(input) {
     lookup: input
   };
 
-  assert.doesNotThrow(function() {
-    tls.connect(opts);
-  });
+  tls.connect(opts);
 }


### PR DESCRIPTION
There is actually no reason to use `assert.doesNotThrow()` in the tests. If a test threw, just let the error bubble up right away instead of first catching it and then rethrowing it. That way we get the best stack trace and normally also the best possible error message.

Someone might argue that there are rare cases (I guess about 10) where it would actually make sense to keep the current behavior. The reason would be that a loop is used to execute something and a generated error message would be thrown that is individual per entry. Otherwise it might be hard to know what entry failed.

Nevertheless, I think a better way to deal with those would be to add a console.log. And we can add those as soon as something fails.

I can not think of any other reason to keep `assert.doesNotThrow()`. I personally feel we might want to deprecate that function actually.

I kept the calls in the assertion test file because I work on that right now in a different PR and those mainly test `assert.doesNotThrow()` on its own.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test