### PR TITLE
http2: fix endless loop when write an empty string

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1622,6 +1622,11 @@ class Http2Stream extends Duplex {
     if (!this.headersSent)
       this[kProceed]();
 
+    if (!data.length) {
+      cb();
+      return;
+    }
+
     const handle = this[kHandle];
     const req = new WriteWrap();
     req.stream = this[kID];
@@ -1658,6 +1663,11 @@ class Http2Stream extends Duplex {
 
     if (!this.headersSent)
       this[kProceed]();
+
+    if (!data.length) {
+      cb();
+      return;
+    }
 
     const handle = this[kHandle];
     const req = new WriteWrap();

--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+const http2 = require('http2');
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream, headers, flags) => {
+  stream.respond({ 'content-type': 'text/html' });
+
+  let data = '';
+  stream.on('data', common.mustNotCall((chunk) => {
+    data += chunk.toString();
+  }));
+  stream.on('end', common.mustCall(() => {
+    stream.end(`"${data}"`);
+  }));
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const req = client.request({
+    ':method': 'POST',
+    ':path': '/'
+  });
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+    assert.strictEqual(headers['content-type'], 'text/html');
+  }));
+
+  let data = '';
+  req.setEncoding('utf8');
+  req.on('data', common.mustCallAtLeast((d) => data += d));
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(data, '""');
+    server.close();
+    client.close();
+  }));
+
+  req.write('');
+  req.end();
+}));


### PR DESCRIPTION
If we do `req.write("")` (an empty string) on Http2Stream, the gather
logic will be messed up:

```cpp
while ((src_length = nghttp2_session_mem_send(session_, &src)) > 0) {
  DEBUG_HTTP2SESSION2(this, "nghttp2 has %d bytes to send", src_length);
  CopyDataIntoOutgoing(src, src_length);
}
```

The logic above is in function `Http2Session::SendPendingData` under
src/node_http2.cc. This `while` will be endless when an empty string is
inside because `src_length` will always be 9.

And then the main event loop thread will be blocked and the memory used
will be larger and larger.

This pull request is to ignore empty string or buffer in `_write()` and
`_writev()` of Http2Stream.

Fixes: https://github.com/nodejs/node/issues/18169
Refs: https://github.com/nodejs/node/blob/v9.5.0/src/node_http2.cc#L1481-L1484
Refs: https://github.com/nodejs/node/blob/v9.5.0/lib/_http_outgoing.js#L659-L661

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2