### PR TITLE
doc: fix arg definition in fs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3388,7 +3388,7 @@ added: REPLACEME
 Asynchronous fsync(2). The `Promise` is resolved with no arguments upon
 success.
 
-#### filehandle.truncate(len = 0)
+#### filehandle.truncate(len)
 <!-- YAML
 added: REPLACEME
 -->


### PR DESCRIPTION
Currently doc building doesn't support ES-style default params in
function definitions which causes a warning.

Here is the error:
```
Warning: invalid param "len "
 > {"textRaw":"`len` {integer} **Default:** `0` ","name":"len","type":"integer","desc":"**Default:** `0`"}
 > filehandle.truncate(len = 0)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc