### PR TITLE
test: fix flaky repl-timeout-throw

### DIFF
--- a/test/sequential/test-repl-timeout-throw.js
+++ b/test/sequential/test-repl-timeout-throw.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
@@ -13,6 +13,8 @@ child.stdout.setEncoding('utf8');
 child.stdout.on('data', function(c) {
   process.stdout.write(c);
   stdout += c;
+  if (stdout.includes('> THROW 2'))
+    child.stdin.end();
 });
 
 child.stdin.write = function(original) {
@@ -46,8 +48,6 @@ child.stdout.once('data', function() {
                       '    });\n' +
                       '  });\n' +
                       '});"";\n');
-
-    setTimeout(child.stdin.end.bind(child.stdin), common.platformTimeout(200));
   }
 });
 


### PR DESCRIPTION
Don't disconnect the child until all exceptions are thrown.

Fixes: https://github.com/nodejs/node/issues/18659

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
