### PR TITLE
cluster: fix inspector port assignment

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -14,6 +14,7 @@ const intercom = new EventEmitter();
 const SCHED_NONE = 1;
 const SCHED_RR = 2;
 const { isLegalPort } = require('internal/net');
+const [ minPort, maxPort ] = [ 1024, 65535 ];
 
 module.exports = cluster;
 
@@ -119,6 +120,8 @@ function createWorkerProcess(id, env) {
       }
     } else {
       inspectPort = process.debugPort + debugPortOffset;
+      if (inspectPort > maxPort)
+        inspectPort = inspectPort - maxPort + minPort - 1;
       debugPortOffset++;
     }
 

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -24,6 +24,16 @@ function testRunnerMain() {
     workers: [{ expectedPort: 9230 }]
   });
 
+  spawnMaster({
+    execArgv: ['--inspect=65534'],
+    workers: [
+      { expectedPort: 65535 },
+      { expectedPort: 1024 },
+      { expectedPort: 1025 },
+      { expectedPort: 1026 }
+    ]
+  });
+
   let port = debuggerPort + offset++ * 5;
 
   spawnMaster({

--- a/test/sequential/test-inspector-port-zero-cluster.js
+++ b/test/sequential/test-inspector-port-zero-cluster.js
@@ -30,16 +30,14 @@ function serialFork() {
 if (cluster.isMaster) {
   Promise.all([serialFork(), serialFork(), serialFork()])
     .then(common.mustCall((ports) => {
-      ports.push(process.debugPort);
-      ports.sort();
+      ports.splice(0, 0, process.debugPort);
       // 4 = [master, worker1, worker2, worker3].length()
       assert.strictEqual(ports.length, 4);
       assert(ports.every((port) => port > 0));
       assert(ports.every((port) => port < 65536));
-      // Ports should be consecutive.
-      assert.strictEqual(ports[0] + 1, ports[1]);
-      assert.strictEqual(ports[1] + 1, ports[2]);
-      assert.strictEqual(ports[2] + 1, ports[3]);
+      assert.strictEqual(ports[0] === 65535 ? 1024 : ports[0] + 1, ports[1]);
+      assert.strictEqual(ports[1] === 65535 ? 1024 : ports[1] + 1, ports[2]);
+      assert.strictEqual(ports[2] === 65535 ? 1024 : ports[2] + 1, ports[3]);
     }))
     .catch(
       (err) => {


### PR DESCRIPTION
Make sure that inspector ports in cluster are inside the valid range:
`[1024, 65535]`.
Fix flaky `test-inspector-port-zero-cluster`.

Fixes: https://github.com/nodejs/node/issues/18303

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
