### PR TITLE
doc: doc-only deprecate assert.doesNotThrow()

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -330,6 +330,11 @@ changes:
 Asserts that the function `block` does not throw an error. See
 [`assert.throws()`][] for more details.
 
+Please note: Using `assert.doesNotThrow()` is not recommended because there is
+no benefit by catching an error and then rethrowing it. Instead, consider adding
+a comment next to the specific code path that should not throw and keep all
+error messages in your code as expressive as possible.
+
 When `assert.doesNotThrow()` is called, it will immediately call the `block`
 function.
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -330,10 +330,10 @@ changes:
 Asserts that the function `block` does not throw an error. See
 [`assert.throws()`][] for more details.
 
-Please note: Using `assert.doesNotThrow()` is not recommended because there is
-no benefit by catching an error and then rethrowing it. Instead, consider adding
-a comment next to the specific code path that should not throw and keep all
-error messages in your code as expressive as possible.
+Please note: Using `assert.doesNotThrow()` is actually not useful because there
+is no benefit by catching an error and then rethrowing it. Instead, consider
+adding a comment next to the specific code path that should not throw and keep
+error messages as expressive as possible.
 
 When `assert.doesNotThrow()` is called, it will immediately call the `block`
 function.


### PR DESCRIPTION
Using `assert.doesNotThrow()` has no benefit over adding a comment
next to some code that should not throw. Therefore it is from now
on discouraged to use it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, assert