### PR TITLE
Simplify constructor URLSearchParams. Remove needless check null

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -98,8 +98,7 @@ class URLSearchParams {
   constructor(init = undefined) {
     if (init === null || init === undefined) {
       this[searchParams] = [];
-    } else if ((typeof init === 'object' && init !== null) ||
-               typeof init === 'function') {
+    } else if (typeof init === 'object' || typeof init === 'function') {
       const method = init[Symbol.iterator];
       if (method === this[Symbol.iterator]) {
         // While the spec does not have this branch, we can use it as a


### PR DESCRIPTION
Remove needless check `init !== null`. `init` can't be `null` because we check it in previous `if`
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
