### PR TITLE
child_process: fix stdio sockets creation

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -238,17 +238,7 @@ function flushStdio(subprocess) {
 
 
 function createSocket(pipe, readable) {
-  var s = new net.Socket({ handle: pipe });
-
-  if (readable) {
-    s.writable = false;
-    s.readable = true;
-  } else {
-    s.writable = true;
-    s.readable = false;
-  }
-
-  return s;
+  return net.Socket({ handle: pipe, readable, writable: !readable });
 }
 
 

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -78,7 +78,7 @@ function onexit() {
   // Usually it is just one event, but it can be more.
   assert.ok(ioEvents >= 3, `at least 3 stdout io events, got ${ioEvents}`);
 
-  checkInvocations(pipe1, { init: 1, before: 2, after: 2 },
+  checkInvocations(pipe1, { init: 1, before: 1, after: 1 },
                    'pipe wrap when sleep.spawn was called');
   checkInvocations(pipe2, { init: 1, before: ioEvents, after: ioEvents },
                    'pipe wrap when sleep.spawn was called');


### PR DESCRIPTION
`readable` and `writable` properties can be passed directly to the
`net.Socket` constructor. This change also avoids an unnecessary call
to `read(0)` on the `stdin` socket. This behavior was disclosed when
trying to merge `libuv@1.19.0` and specifically this commit:
https://github.com/libuv/libuv/commit/fd049399aa4ed8495928e375466970d98cb42e17.

Refs: https://github.com/libuv/libuv/pull/1655
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process
