### PR TITLE
timers: fix enroll deprecation wording

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -379,7 +379,7 @@ function enroll(item, msecs) {
 
 exports.enroll = util.deprecate(enroll,
                                 'timers.enroll() is deprecated. ' +
-                                'Please use clearTimeout instead.',
+                                'Please use setTimeout instead.',
                                 'DEP0095');
 
 


### PR DESCRIPTION
Fixes the suggested function to be `setTimeout` not `clearTimeout`, to match the docs. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers