### PR TITLE
net: simplify net.Socket#end()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -524,16 +524,8 @@ Socket.prototype._read = function(n) {
 
 Socket.prototype.end = function(data, encoding) {
   stream.Duplex.prototype.end.call(this, data, encoding);
-  this.writable = false;
   DTRACE_NET_STREAM_END(this);
   LTTNG_NET_STREAM_END(this);
-
-  // just in case we're waiting for an EOF.
-  if (this.readable && !this._readableState.endEmitted)
-    this.read(0);
-  else
-    maybeDestroy(this);
-
   return this;
 };
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -522,8 +522,8 @@ Socket.prototype._read = function(n) {
 };
 
 
-Socket.prototype.end = function(data, encoding) {
-  stream.Duplex.prototype.end.call(this, data, encoding);
+Socket.prototype.end = function(data, encoding, callback) {
+  stream.Duplex.prototype.end.call(this, data, encoding, callback);
   DTRACE_NET_STREAM_END(this);
   LTTNG_NET_STREAM_END(this);
   return this;


### PR DESCRIPTION
`writable` is already set by the streams side, and
there is a handler waiting for the writable side to finish
which already takes care of the other cleanup code that
was previously there; both of these things can therefore be removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

net