### PR TITLE
events: deprecate EventEmitter.defaultMaxListeners getter/setter

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -950,6 +950,13 @@ deprecated if the assigned value is not a string, boolean, or number. In the
 future, such assignment may result in a thrown error. Please convert the
 property to a string before assigning it to `process.env`.
 
+<a id="DEP00XX"></a>
+### DEP00XX: EventEmitter.defaultMaxListeners
+
+Type: Documentation-only (supports [`--pending-deprecation`][])
+
+The [`EventEmitter.defaultMaxListeners`][] property is deprecated.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
@@ -958,6 +965,7 @@ property to a string before assigning it to `process.env`.
 [`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout
+[`EventEmitter.defaultMaxListeners`]: events.html#events_eventemitter_defaultmaxlisteners
 [`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname
 [`Server.connections`]: net.html#net_server_connections
 [`Server.getConnections()`]: net.html#net_server_getconnections_callback

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -246,6 +246,7 @@ console.log(EventEmitter.listenerCount(myEmitter, 'event'));
 ### EventEmitter.defaultMaxListeners
 <!-- YAML
 added: v0.11.2
+deprecated: REPLACEME
 -->
 
 By default, a maximum of `10` listeners can be registered for any single
@@ -282,6 +283,25 @@ have the additional `emitter`, `type` and `count` properties, referring to
 the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+This property is deprecated. Please use `EventEmitter.getDefaultMaxListeners()`
+and `EventEmitter.setDefaultMaxListeners()` instead.
+
+### EventEmitter.getDefaultMaxListeners()
+<!-- YAML
+added: REPLACEME
+-->
+
+Returns the default max listener count.
+
+### EventEmitter.setDefaultMaxListeners(count)
+<!--YAML
+added: REPLACEME
+-->
+
+- `count` {number}
+
+Sets the default max listener count to `count`.
 
 ### emitter.addListener(eventName, listener)
 <!-- YAML

--- a/lib/events.js
+++ b/lib/events.js
@@ -21,6 +21,9 @@
 
 'use strict';
 
+const { deprecate } = require('internal/util');
+const { pendingDeprecation } = process.binding('config');
+
 var spliceOne;
 
 function EventEmitter() {
@@ -48,20 +51,33 @@ function lazyErrors() {
   return errors;
 }
 
+EventEmitter.getDefaultMaxListeners = function() {
+  return defaultMaxListeners;
+};
+
+EventEmitter.setDefaultMaxListeners = function(count) {
+  // check whether the input is a positive number (whose value is zero or
+  // greater and not a NaN).
+  if (typeof count !== 'number' || count < 0 || Number.isNaN(count)) {
+    const errors = lazyErrors();
+    throw new errors.ERR_OUT_OF_RANGE('count', 'a non-negative number', count);
+  }
+  defaultMaxListeners = count;
+};
+
+
 Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   enumerable: true,
-  get: function() {
-    return defaultMaxListeners;
-  },
-  set: function(arg) {
-    if (typeof arg !== 'number' || arg < 0 || Number.isNaN(arg)) {
-      const errors = lazyErrors();
-      throw new errors.ERR_OUT_OF_RANGE('defaultMaxListeners',
-                                        'a non-negative number',
-                                        arg);
-    }
-    defaultMaxListeners = arg;
-  }
+  get: pendingDeprecation ?
+    deprecate(EventEmitter.getDefaultMaxListeners,
+              'EventEmitter.defaultMaxListeners is deprecated.',
+              'DEP00XX') :
+    EventEmitter.getDefaultMaxListeners,
+  set: pendingDeprecation ?
+    deprecate(EventEmitter.setDefaultMaxListeners,
+              'EventEmitter.defaultMaxListeners is deprecated.',
+              'DEP00XX') :
+    EventEmitter.setDefaultMaxListeners,
 });
 
 EventEmitter.init = function() {
@@ -88,7 +104,7 @@ EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
 
 function $getMaxListeners(that) {
   if (that._maxListeners === undefined)
-    return EventEmitter.defaultMaxListeners;
+    return EventEmitter.getDefaultMaxListeners();
   return that._maxListeners;
 }
 

--- a/test/parallel/test-console-log-stdio-broken-dest.js
+++ b/test/parallel/test-console-log-stdio-broken-dest.js
@@ -18,7 +18,7 @@ const myConsole = new Console(stream, stream);
 process.on('warning', common.mustNotCall);
 
 stream.cork();
-for (let i = 0; i < EventEmitter.defaultMaxListeners + 1; i++) {
+for (let i = 0; i < EventEmitter.getDefaultMaxListeners() + 1; i++) {
   myConsole.log('a message');
 }
 stream.uncork();

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -70,7 +70,7 @@ const events = require('events');
 
 // process-wide
 {
-  events.EventEmitter.defaultMaxListeners = 42;
+  events.EventEmitter.setDefaultMaxListeners(42);
   const e = new events.EventEmitter();
 
   for (let i = 0; i < 42; ++i) {
@@ -81,7 +81,7 @@ const events = require('events');
   assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
   delete e._events.fortytwo.warned;
 
-  events.EventEmitter.defaultMaxListeners = 44;
+  events.EventEmitter.setDefaultMaxListeners(44);
   e.on('fortytwo', common.mustNotCall());
   assert.ok(!e._events.fortytwo.hasOwnProperty('warned'));
   e.on('fortytwo', common.mustNotCall());
@@ -90,7 +90,7 @@ const events = require('events');
 
 // but _maxListeners still has precedence over defaultMaxListeners
 {
-  events.EventEmitter.defaultMaxListeners = 42;
+  events.EventEmitter.setDefaultMaxListeners(42);
   const e = new events.EventEmitter();
   e.setMaxListeners(1);
   e.on('uno', common.mustNotCall());

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -5,7 +5,8 @@ const EventEmitter = require('events');
 
 const emitter = new EventEmitter();
 
-assert.strictEqual(emitter.getMaxListeners(), EventEmitter.defaultMaxListeners);
+assert.strictEqual(emitter.getMaxListeners(),
+                   EventEmitter.getDefaultMaxListeners());
 
 emitter.setMaxListeners(0);
 assert.strictEqual(emitter.getMaxListeners(), 0);

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -43,12 +43,10 @@ for (const obj of throwsObjs) {
   );
 
   common.expectsError(
-    () => events.defaultMaxListeners = obj,
+    () => events.setDefaultMaxListeners(obj),
     {
       code: 'ERR_OUT_OF_RANGE',
       type: RangeError,
-      message: 'The value of "defaultMaxListeners" is out of range. ' +
-               `It must be a non-negative number. Received ${obj}`
     }
   );
 }

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -18,7 +18,7 @@ process.on('warning', () => {
   // invoke the monkeypatched process.stderr.write
   // below.
   assert.strictEqual(writeTimes, 1);
-  EventEmitter.defaultMaxListeners = oldDefault;
+  EventEmitter.setDefaultMaxListeners(oldDefault);
   warningTimes++;
 });
 
@@ -35,8 +35,8 @@ process.stderr.write = (data) => {
   writeTimes++;
 };
 
-const oldDefault = EventEmitter.defaultMaxListeners;
-EventEmitter.defaultMaxListeners = 1;
+const oldDefault = EventEmitter.getDefaultMaxListeners();
+EventEmitter.setDefaultMaxListeners(1);
 
 const e = new EventEmitter();
 e.on('hello', () => {});


### PR DESCRIPTION
In preparation for upcoming ESM interop and to remain consistent with
other getters/setters being removed

Refs: #18131 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
events