### PR TITLE
doc: add process.debugPort to doc/api/process.md

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -639,7 +639,7 @@ added: v0.7.2
 The port used by Node.js's debugger when enabled.
 
 ```js
-  process.debugPort = 5858;
+process.debugPort = 5858;
 ```
 ## process.disconnect()
 <!-- YAML

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -636,7 +636,7 @@ added: v0.7.2
 -->
 * {number}
 
-The port used by Node's debugger when enabled.
+The port used by Node.js's debugger when enabled.
 
 ```js
   process.debugPort = 5858;

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -636,7 +636,7 @@ added: v0.7.2
 -->
 * {number}
 
-A port number for the debugger to listen to.
+The port used by Node's debugger when enabled.
 
 ```js
   process.debugPort = 5858;

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -630,7 +630,17 @@ process.
 ```js
 console.log(`Current directory: ${process.cwd()}`);
 ```
+## process.debugPort
+<!-- YAML
+added: v0.7.2
+-->
+* {number}
 
+A port number for the debugger to listen to.
+
+```js
+  process.debugPort = 5858;
+```
 ## process.disconnect()
 <!-- YAML
 added: v0.7.2


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/18639

Added `process.debugPort` to process api doc
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc