### PR TITLE
test: add multiline repl input regression test

### DIFF
--- a/test/parallel/test-repl-multiline.js
+++ b/test/parallel/test-repl-multiline.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const inputStream = new common.ArrayStream();
+const outputStream = new common.ArrayStream();
+const input = ['var foo = {', '};', 'foo;'];
+let output = '';
+
+outputStream.write = (data) => { output += data.replace('\r', ''); };
+
+const r = repl.start({
+  prompt: '',
+  input: inputStream,
+  output: outputStream,
+  terminal: true,
+  useColors: false
+});
+
+r.on('exit', common.mustCall(() => {
+  const actual = output.split('\n');
+
+  // Validate the output, which contains terminal escape codes.
+  assert.strictEqual(actual.length, 6);
+  assert.ok(actual[0].endsWith(input[0]));
+  assert.ok(actual[1].includes('... '));
+  assert.ok(actual[1].endsWith(input[1]));
+  assert.strictEqual(actual[2], 'undefined');
+  assert.ok(actual[3].endsWith(input[2]));
+  assert.strictEqual(actual[4], '{}');
+  // Ignore the last line, which is nothing but escape codes.
+}));
+
+inputStream.run(input);
+r.close();


### PR DESCRIPTION
This commit adds a regression test for de848ac1e0483327a2ce8716c3f8567eaeacb660, which broke multiline input in the REPL.

This will fail until de848ac1e0483327a2ce8716c3f8567eaeacb660 is reverted or fixed.

Refs: https://github.com/nodejs/node/pull/17828
Refs: https://github.com/nodejs/node/pull/18715

##### Checklist
- [] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test