### PR TITLE
test: remove unnecessary timer

### DIFF
--- a/test/addons-napi/test_callback_scope/test-resolve-async.js
+++ b/test/addons-napi/test_callback_scope/test-resolve-async.js
@@ -1,13 +1,6 @@
 'use strict';
 
 const common = require('../../common');
-const assert = require('assert');
 const { testResolveAsync } = require(`./build/${common.buildType}/binding`);
 
-let called = false;
-testResolveAsync().then(common.mustCall(() => {
-  called = true;
-}));
-
-setTimeout(common.mustCall(() => { assert(called); }),
-           common.platformTimeout(20));
+testResolveAsync().then(common.mustCall());


### PR DESCRIPTION
The timer in NAPI's `test_callback_scope/test-resolve-async.js` can be removed. If the test fails, it will timeout on its own. The extra timer increases the chances of the test being flaky.

Fixes: https://github.com/nodejs/node/issues/18702

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test