### PR TITLE
doc: enforce max-line-length lint rule

### DIFF
--- a/tools/remark-cli/package-lock.json
+++ b/tools/remark-cli/package-lock.json
@@ -2,7 +2,6 @@
   "name": "remark-cli",
   "version": "4.0.0",
   "lockfileVersion": 1,
-  "preserveSymlinks": "1",
   "requires": true,
   "dependencies": {
     "ansi-regex": {

--- a/tools/remark-preset-lint-node/index.js
+++ b/tools/remark-preset-lint-node/index.js
@@ -10,6 +10,7 @@ module.exports.plugins = [
   require('remark-lint-final-definition'),
   require('remark-lint-final-newline'),
   require('remark-lint-hard-break-spaces'),
+  require('remark-lint-maximum-line-length'),
   require('remark-lint-no-auto-link-without-protocol'),
   require('remark-lint-no-blockquote-without-caret'),
   require('remark-lint-no-duplicate-definitions'),

--- a/tools/remark-preset-lint-node/package-lock.json
+++ b/tools/remark-preset-lint-node/package-lock.json
@@ -185,6 +185,17 @@
         "unist-util-visit": "1.2.0"
       }
     },
+    "remark-lint-maximum-line-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.0.2.tgz",
+      "integrity": "sha512-M4UIXAAbtLgoQbTDVwdKOEFbTKtJSZ+pCW7ZqMFs+cbIN0Svm32LM9+xpVfVU0hLYt3Ypl++EAPfguBNe1PZEw==",
+      "requires": {
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.1",
+        "unist-util-position": "3.0.0",
+        "unist-util-visit": "1.2.0"
+      }
+    },
     "remark-lint-no-auto-link-without-protocol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-1.0.1.tgz",

--- a/tools/remark-preset-lint-node/package.json
+++ b/tools/remark-preset-lint-node/package.json
@@ -32,6 +32,7 @@
     "remark-lint-first-heading-level": "^1.0.0",
     "remark-lint-hard-break-spaces": "^1.0.1",
     "remark-lint-heading-style": "^1.0.0",
+    "remark-lint-maximum-line-length": "^1.0.2",
     "remark-lint-no-auto-link-without-protocol": "^1.0.0",
     "remark-lint-no-blockquote-without-caret": "^1.0.0",
     "remark-lint-no-duplicate-definitions": "^1.0.0",


### PR DESCRIPTION
Includes 80 character limit for docs linter.

I managed to add the linter rule for the docs, but I'm not sure of an elegant way to fix
existing lines than exceed 80 characters. 

Fixes: https://github.com/nodejs/node/issues/18703

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
