### PR TITLE
string_decoder: do not declare as a class

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -96,11 +96,19 @@ Object.defineProperties(StringDecoder.prototype, {
                                            kIncompleteCharactersEnd);
     }
   },
+  lastNeed: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this[kNativeDecoder][kMissingBytes];
+    }
+  },
   lastTotal: {
     configurable: true,
     enumerable: true,
     get() {
-      return this[kNativeDecoder][kBufferedBytes] + this.lastNeed;
+      return this[kNativeDecoder][kBufferedBytes] +
+             this[kNativeDecoder][kMissingBytes];
     }
   }
 });

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -56,47 +56,53 @@ for (var i = 0; i < encodings.length; ++i)
 // StringDecoder provides an interface for efficiently splitting a series of
 // buffers into a series of JS strings without breaking apart multi-byte
 // characters.
-class StringDecoder {
-  constructor(encoding) {
-    this.encoding = normalizeEncoding(encoding);
-    this[kNativeDecoder] = Buffer.alloc(kSize);
-    this[kNativeDecoder][kEncodingField] = encodingsMap[this.encoding];
-  }
-
-  write(buf) {
-    if (typeof buf === 'string')
-      return buf;
-    if (!ArrayBuffer.isView(buf))
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
-                                 ['Buffer', 'Uint8Array', 'ArrayBufferView']);
-    return decode(this[kNativeDecoder], buf);
-  }
-
-  end(buf) {
-    let ret = '';
-    if (buf !== undefined)
-      ret = this.write(buf);
-    if (this[kNativeDecoder][kBufferedBytes] > 0)
-      ret += flush(this[kNativeDecoder]);
-    return ret;
-  }
-
-  /* Everything below this line is undocumented legacy stuff. */
-
-  text(buf, offset) {
-    this[kNativeDecoder][kMissingBytes] = 0;
-    this[kNativeDecoder][kBufferedBytes] = 0;
-    return this.write(buf.slice(offset));
-  }
-
-  get lastTotal() {
-    return this[kNativeDecoder][kBufferedBytes] + this.lastNeed;
-  }
-
-  get lastChar() {
-    return this[kNativeDecoder].subarray(kIncompleteCharactersStart,
-                                         kIncompleteCharactersEnd);
-  }
+function StringDecoder(encoding) {
+  this.encoding = normalizeEncoding(encoding);
+  this[kNativeDecoder] = Buffer.alloc(kSize);
+  this[kNativeDecoder][kEncodingField] = encodingsMap[this.encoding];
 }
+
+StringDecoder.prototype.write = function write(buf) {
+  if (typeof buf === 'string')
+    return buf;
+  if (!ArrayBuffer.isView(buf))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
+                               ['Buffer', 'Uint8Array', 'ArrayBufferView']);
+  return decode(this[kNativeDecoder], buf);
+};
+
+StringDecoder.prototype.end = function end(buf) {
+  let ret = '';
+  if (buf !== undefined)
+    ret = this.write(buf);
+  if (this[kNativeDecoder][kBufferedBytes] > 0)
+    ret += flush(this[kNativeDecoder]);
+  return ret;
+};
+
+/* Everything below this line is undocumented legacy stuff. */
+StringDecoder.prototype.text = function text(buf, offset) {
+  this[kNativeDecoder][kMissingBytes] = 0;
+  this[kNativeDecoder][kBufferedBytes] = 0;
+  return this.write(buf.slice(offset));
+};
+
+Object.defineProperties(StringDecoder.prototype, {
+  lastChar: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this[kNativeDecoder].subarray(kIncompleteCharactersStart,
+                                           kIncompleteCharactersEnd);
+    }
+  },
+  lastTotal: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this[kNativeDecoder][kBufferedBytes] + this.lastNeed;
+    }
+  }
+});
 
 exports.StringDecoder = StringDecoder;

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -29,6 +29,11 @@ const StringDecoder = require('string_decoder').StringDecoder;
 let decoder = new StringDecoder();
 assert.strictEqual(decoder.encoding, 'utf8');
 
+// Should work without 'new' keyword
+const decoder2 = {};
+StringDecoder.call(decoder2);
+assert.strictEqual(decoder2.encoding, 'utf8');
+
 // UTF-8
 test('utf-8', Buffer.from('$', 'utf-8'), '$');
 test('utf-8', Buffer.from('¢', 'utf-8'), '¢');

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -89,6 +89,11 @@ test('utf16le', Buffer.from('3DD84DDC', 'hex'), '\ud83d\udc4d'); // thumbs up
 // Additional UTF-8 tests
 decoder = new StringDecoder('utf8');
 assert.strictEqual(decoder.write(Buffer.from('E1', 'hex')), '');
+
+// A quick test for lastNeed & lastTotal which are undocumented.
+assert.strictEqual(decoder.lastNeed, 2);
+assert.strictEqual(decoder.lastTotal, 3);
+
 assert.strictEqual(decoder.end(), '\ufffd');
 
 decoder = new StringDecoder('utf8');


### PR DESCRIPTION
There are libraries which invoke StringDecoder using .call and .inherits, which directly conflicts with making StringDecoder be a class which can only be invoked with the new keyword. Revert to declaring it as a function with prototype props.

This fixes the iconv-lite package: https://github.com/ashtuchkin/iconv-lite which is relied on by https://github.com/expressjs/body-parser and https://github.com/expressjs/express within CitGM

Refs: https://github.com/nodejs/node/pull/18537

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
string_decoder