### PR TITLE
test: add crypto check to test-benchmark-tls

### DIFF
--- a/test/sequential/test-benchmark-tls.js
+++ b/test/sequential/test-benchmark-tls.js
@@ -2,6 +2,9 @@
 
 const common = require('../common');
 
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
 if (!common.enoughTestMem)
   common.skip('Insufficient memory for TLS benchmark test');
 


### PR DESCRIPTION
Currently when building --without-ssl a 'ERR_NO_CRYPTO' error is
reported.

This is not currently being picked up by the crypto-check lint rule as
it does not actually require any crypto modules directly, but instead
this is done by common/benchmark.

I'll take a closer look at the check and see what can be done but I
don't have time straight away, so creating this commit to avoid breakage
in the short term.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test