### PR TITLE
esm: Add support for pjson cache and main without extensions

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -117,15 +117,18 @@ The resolve hook returns the resolved file URL and module format for a
 given module specifier and parent file URL:
 
 ```js
-import url from 'url';
+const baseURL = new URL('file://');
+baseURL.pathname = process.cwd() + '/';
 
 export async function resolve(specifier, parentModuleURL, defaultResolver) {
   return {
-    url: new URL(specifier, parentModuleURL).href,
+    url: new URL(specifier, parentModuleURL || baseURL).href,
     format: 'esm'
   };
 }
 ```
+
+The parentURL is provided as `undefined` when performing main NodeJS load itself.
 
 The default NodeJS ES module resolution function is provided as a third
 argument to the resolver for easy compatibility workflows.
@@ -155,7 +158,10 @@ import Module from 'module';
 const builtins = Module.builtinModules;
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
-export function resolve(specifier, parentModuleURL/*, defaultResolve */) {
+const baseURL = new URL('file://');
+baseURL.pathname = process.cwd() + '/';
+
+export function resolve(specifier, parentModuleURL = baseURL, defaultResolve) {
   if (builtins.includes(specifier)) {
     return {
       url: specifier,

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -120,17 +120,19 @@ given module specifier and parent file URL:
 const baseURL = new URL('file://');
 baseURL.pathname = process.cwd() + '/';
 
-export async function resolve(specifier, parentModuleURL, defaultResolver) {
+export async function resolve(specifier,
+                              parentModuleURL = baseURL,
+                              defaultResolver) {
   return {
-    url: new URL(specifier, parentModuleURL || baseURL).href,
+    url: new URL(specifier, parentModuleURL).href,
     format: 'esm'
   };
 }
 ```
 
-The parentURL is provided as `undefined` when performing main NodeJS load itself.
+The parentURL is provided as `undefined` when performing main Node.js load itself.
 
-The default NodeJS ES module resolution function is provided as a third
+The default Node.js ES module resolution function is provided as a third
 argument to the resolver for easy compatibility workflows.
 
 In addition to returning the resolved file URL value, the resolve hook also

--- a/lib/internal/loader/DefaultResolve.js
+++ b/lib/internal/loader/DefaultResolve.js
@@ -78,9 +78,13 @@ function resolve(specifier, parentURL) {
 
   const ext = extname(url.pathname);
 
-  const format = extensionFormatMap[ext] || parentURL === undefined && 'cjs';
-  if (!format)
-    throw new errors.Error('ERR_UNKNOWN_FILE_EXTENSION', url.pathname);
+  let format = extensionFormatMap[ext];
+  if (!format) {
+    if (parentURL === undefined)
+      format = 'cjs';
+    else
+      throw new errors.Error('ERR_UNKNOWN_FILE_EXTENSION', url.pathname);
+  }
 
   return { url: `${url}`, format };
 }

--- a/lib/internal/loader/DefaultResolve.js
+++ b/lib/internal/loader/DefaultResolve.js
@@ -80,7 +80,8 @@ function resolve(specifier, parentURL) {
 
   let format = extensionFormatMap[ext];
   if (!format) {
-    if (parentURL === undefined)
+    const isMain = parentURL === undefined;
+    if (isMain)
       format = 'cjs';
     else
       throw new errors.Error('ERR_UNKNOWN_FILE_EXTENSION', url.pathname);

--- a/lib/internal/loader/DefaultResolve.js
+++ b/lib/internal/loader/DefaultResolve.js
@@ -2,7 +2,6 @@
 
 const { URL } = require('url');
 const CJSmodule = require('module');
-const internalURLModule = require('internal/url');
 const internalFS = require('internal/fs');
 const NativeModule = require('native_module');
 const { extname } = require('path');
@@ -11,6 +10,7 @@ const preserveSymlinks = !!process.binding('config').preserveSymlinks;
 const errors = require('internal/errors');
 const { resolve: moduleWrapResolve } = internalBinding('module_wrap');
 const StringStartsWith = Function.call.bind(String.prototype.startsWith);
+const { getURLFromFilePath, getPathFromURL } = require('internal/url');
 
 const realpathCache = new Map();
 
@@ -57,7 +57,8 @@ function resolve(specifier, parentURL) {
 
   let url;
   try {
-    url = search(specifier, parentURL);
+    url = search(specifier,
+                 parentURL || getURLFromFilePath(`${process.cwd()}/`).href);
   } catch (e) {
     if (typeof e.message === 'string' &&
         StringStartsWith(e.message, 'Cannot find module'))
@@ -66,17 +67,22 @@ function resolve(specifier, parentURL) {
   }
 
   if (!preserveSymlinks) {
-    const real = realpathSync(internalURLModule.getPathFromURL(url), {
+    const real = realpathSync(getPathFromURL(url), {
       [internalFS.realpathCacheKey]: realpathCache
     });
     const old = url;
-    url = internalURLModule.getURLFromFilePath(real);
+    url = getURLFromFilePath(real);
     url.search = old.search;
     url.hash = old.hash;
   }
 
   const ext = extname(url.pathname);
-  return { url: `${url}`, format: extensionFormatMap[ext] || ext };
+
+  const format = extensionFormatMap[ext] || parentURL === undefined && 'cjs';
+  if (!format)
+    throw new errors.Error('ERR_UNKNOWN_FILE_EXTENSION', url.pathname);
+
+  return { url: `${url}`, format };
 }
 
 module.exports = resolve;

--- a/lib/internal/loader/Loader.js
+++ b/lib/internal/loader/Loader.js
@@ -42,7 +42,8 @@ class Loader {
   }
 
   async resolve(specifier, parentURL) {
-    if (parentURL !== undefined && typeof parentURL !== 'string')
+    const isMain = parentURL === undefined;
+    if (!isMain && typeof parentURL !== 'string')
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'parentURL', 'string');
 
     const { url, format } =

--- a/lib/internal/loader/Loader.js
+++ b/lib/internal/loader/Loader.js
@@ -1,51 +1,21 @@
 'use strict';
 
-const path = require('path');
-const { getURLFromFilePath, URL } = require('internal/url');
 const errors = require('internal/errors');
-
 const ModuleMap = require('internal/loader/ModuleMap');
 const ModuleJob = require('internal/loader/ModuleJob');
 const defaultResolve = require('internal/loader/DefaultResolve');
 const createDynamicModule = require('internal/loader/CreateDynamicModule');
 const translators = require('internal/loader/Translators');
-const { setImportModuleDynamicallyCallback } = internalBinding('module_wrap');
+
 const FunctionBind = Function.call.bind(Function.prototype.bind);
 
 const debug = require('util').debuglog('esm');
-
-// Returns a file URL for the current working directory.
-function getURLStringForCwd() {
-  try {
-    return getURLFromFilePath(`${process.cwd()}/`).href;
-  } catch (e) {
-    e.stack;
-    // If the current working directory no longer exists.
-    if (e.code === 'ENOENT') {
-      return undefined;
-    }
-    throw e;
-  }
-}
-
-function normalizeReferrerURL(referrer) {
-  if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
-    return getURLFromFilePath(referrer).href;
-  }
-  return new URL(referrer).href;
-}
 
 /* A Loader instance is used as the main entry point for loading ES modules.
  * Currently, this is a singleton -- there is only one used for loading
  * the main module and everything in its dependency graph. */
 class Loader {
-  constructor(base = getURLStringForCwd()) {
-    if (typeof base !== 'string')
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'base', 'string');
-
-    this.base = base;
-    this.isMain = true;
-
+  constructor() {
     // methods which translate input code or other information
     // into es modules
     this.translators = translators;
@@ -71,8 +41,8 @@ class Loader {
     this._dynamicInstantiate = undefined;
   }
 
-  async resolve(specifier, parentURL = this.base) {
-    if (typeof parentURL !== 'string')
+  async resolve(specifier, parentURL) {
+    if (parentURL !== undefined && typeof parentURL !== 'string')
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'parentURL', 'string');
 
     const { url, format } =
@@ -93,7 +63,7 @@ class Loader {
     return { url, format };
   }
 
-  async import(specifier, parent = this.base) {
+  async import(specifier, parent) {
     const job = await this.getModuleJob(specifier, parent);
     const module = await job.run();
     return module.namespace();
@@ -107,7 +77,7 @@ class Loader {
       this._dynamicInstantiate = FunctionBind(dynamicInstantiate, null);
   }
 
-  async getModuleJob(specifier, parentURL = this.base) {
+  async getModuleJob(specifier, parentURL) {
     const { url, format } = await this.resolve(specifier, parentURL);
     let job = this.moduleMap.get(url);
     if (job !== undefined)
@@ -134,24 +104,16 @@ class Loader {
     }
 
     let inspectBrk = false;
-    if (this.isMain) {
-      if (process._breakFirstLine) {
-        delete process._breakFirstLine;
-        inspectBrk = true;
-      }
-      this.isMain = false;
+    if (process._breakFirstLine) {
+      delete process._breakFirstLine;
+      inspectBrk = true;
     }
     job = new ModuleJob(this, url, loaderInstance, inspectBrk);
     this.moduleMap.set(url, job);
     return job;
   }
-
-  static registerImportDynamicallyCallback(loader) {
-    setImportModuleDynamicallyCallback(async (referrer, specifier) => {
-      return loader.import(specifier, normalizeReferrerURL(referrer));
-    });
-  }
 }
 
 Object.setPrototypeOf(Loader.prototype, null);
+
 module.exports = Loader;

--- a/lib/internal/loader/Translators.js
+++ b/lib/internal/loader/Translators.js
@@ -19,7 +19,7 @@ const JsonParse = JSON.parse;
 const translators = new SafeMap();
 module.exports = translators;
 
-// Stragety for loading a standard JavaScript module
+// Strategy for loading a standard JavaScript module
 translators.set('esm', async (url) => {
   const source = `${await readFileAsync(new URL(url))}`;
   debug(`Translating StandardModule ${url}`);
@@ -62,7 +62,7 @@ translators.set('builtin', async (url) => {
   });
 });
 
-// Stragety for loading a node native module
+// Strategy for loading a node native module
 translators.set('addon', async (url) => {
   debug(`Translating NativeModule ${url}`);
   return createDynamicModule(['default'], url, (reflect) => {
@@ -74,7 +74,7 @@ translators.set('addon', async (url) => {
   });
 });
 
-// Stragety for loading a JSON file
+// Strategy for loading a JSON file
 translators.set('json', async (url) => {
   debug(`Translating JSONModule ${url}`);
   return createDynamicModule(['default'], url, (reflect) => {

--- a/lib/internal/process/modules.js
+++ b/lib/internal/process/modules.js
@@ -1,8 +1,21 @@
 'use strict';
 
 const {
+  setImportModuleDynamicallyCallback,
   setInitializeImportMetaObjectCallback
 } = internalBinding('module_wrap');
+
+const { getURLFromFilePath } = require('internal/url');
+const Loader = require('internal/loader/Loader');
+const path = require('path');
+const { URL } = require('url');
+
+function normalizeReferrerURL(referrer) {
+  if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
+    return getURLFromFilePath(referrer).href;
+  }
+  return new URL(referrer).href;
+}
 
 function initializeImportMetaObject(wrap, meta) {
   meta.url = wrap.url;
@@ -10,8 +23,30 @@ function initializeImportMetaObject(wrap, meta) {
 
 function setupModules() {
   setInitializeImportMetaObjectCallback(initializeImportMetaObject);
+
+  let ESMLoader = new Loader();
+  const loaderPromise = (async () => {
+    const userLoader = process.binding('config').userLoader;
+    if (userLoader) {
+      const hooks = await ESMLoader.import(
+        userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
+      ESMLoader = new Loader();
+      ESMLoader.hook(hooks);
+      exports.ESMLoader = ESMLoader;
+    }
+    return ESMLoader;
+  })();
+  loaderPromise.catch(() => {});
+
+  setImportModuleDynamicallyCallback(async (referrer, specifier) => {
+    const loader = await loaderPromise;
+    return loader.import(specifier, normalizeReferrerURL(referrer));
+  });
+
+  exports.loaderPromise = loaderPromise;
+  exports.ESMLoader = ESMLoader;
 }
 
-module.exports = {
-  setup: setupModules
-};
+exports.setup = setupModules;
+exports.ESMLoader = undefined;
+exports.loaderPromise = undefined;

--- a/lib/internal/process/modules.js
+++ b/lib/internal/process/modules.js
@@ -21,10 +21,9 @@ function initializeImportMetaObject(wrap, meta) {
   meta.url = wrap.url;
 }
 
-let loaderResolve, loaderReject;
+let loaderResolve;
 exports.loaderPromise = new Promise((resolve, reject) => {
   loaderResolve = resolve;
-  loaderReject = reject;
 });
 
 exports.ESMLoader = undefined;
@@ -44,7 +43,7 @@ exports.setup = function() {
     }
     return ESMLoader;
   })();
-  loaderPromise.then(loaderResolve, loaderReject);
+  loaderResolve(loaderPromise);
 
   setImportModuleDynamicallyCallback(async (referrer, specifier) => {
     const loader = await loaderPromise;

--- a/lib/internal/process/modules.js
+++ b/lib/internal/process/modules.js
@@ -21,29 +21,35 @@ function initializeImportMetaObject(wrap, meta) {
   meta.url = wrap.url;
 }
 
+let loaderResolve, loaderReject;
 exports.loaderPromise = new Promise((resolve, reject) => {
-  exports.setup = function() {
-    setInitializeImportMetaObjectCallback(initializeImportMetaObject);
-
-    let ESMLoader = new Loader();
-    const loaderPromise = (async () => {
-      const userLoader = process.binding('config').userLoader;
-      if (userLoader) {
-        const hooks = await ESMLoader.import(
-          userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
-        ESMLoader = new Loader();
-        ESMLoader.hook(hooks);
-        exports.ESMLoader = ESMLoader;
-      }
-      return ESMLoader;
-    })();
-    loaderPromise.then(resolve, reject);
-
-    setImportModuleDynamicallyCallback(async (referrer, specifier) => {
-      const loader = await loaderPromise;
-      return loader.import(specifier, normalizeReferrerURL(referrer));
-    });
-
-    exports.ESMLoader = ESMLoader;
-  };
+  loaderResolve = resolve;
+  loaderReject = reject;
 });
+
+exports.ESMLoader = undefined;
+
+exports.setup = function() {
+  setInitializeImportMetaObjectCallback(initializeImportMetaObject);
+
+  let ESMLoader = new Loader();
+  const loaderPromise = (async () => {
+    const userLoader = process.binding('config').userLoader;
+    if (userLoader) {
+      const hooks = await ESMLoader.import(
+        userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
+      ESMLoader = new Loader();
+      ESMLoader.hook(hooks);
+      exports.ESMLoader = ESMLoader;
+    }
+    return ESMLoader;
+  })();
+  loaderPromise.then(loaderResolve, loaderReject);
+
+  setImportModuleDynamicallyCallback(async (referrer, specifier) => {
+    const loader = await loaderPromise;
+    return loader.import(specifier, normalizeReferrerURL(referrer));
+  });
+
+  exports.ESMLoader = ESMLoader;
+};

--- a/lib/internal/process/modules.js
+++ b/lib/internal/process/modules.js
@@ -21,32 +21,29 @@ function initializeImportMetaObject(wrap, meta) {
   meta.url = wrap.url;
 }
 
-function setupModules() {
-  setInitializeImportMetaObjectCallback(initializeImportMetaObject);
+exports.loaderPromise = new Promise((resolve, reject) => {
+  exports.setup = function() {
+    setInitializeImportMetaObjectCallback(initializeImportMetaObject);
 
-  let ESMLoader = new Loader();
-  const loaderPromise = (async () => {
-    const userLoader = process.binding('config').userLoader;
-    if (userLoader) {
-      const hooks = await ESMLoader.import(
-        userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
-      ESMLoader = new Loader();
-      ESMLoader.hook(hooks);
-      exports.ESMLoader = ESMLoader;
-    }
-    return ESMLoader;
-  })();
-  loaderPromise.catch(() => {});
+    let ESMLoader = new Loader();
+    const loaderPromise = (async () => {
+      const userLoader = process.binding('config').userLoader;
+      if (userLoader) {
+        const hooks = await ESMLoader.import(
+          userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
+        ESMLoader = new Loader();
+        ESMLoader.hook(hooks);
+        exports.ESMLoader = ESMLoader;
+      }
+      return ESMLoader;
+    })();
+    loaderPromise.then(resolve, reject);
 
-  setImportModuleDynamicallyCallback(async (referrer, specifier) => {
-    const loader = await loaderPromise;
-    return loader.import(specifier, normalizeReferrerURL(referrer));
-  });
+    setImportModuleDynamicallyCallback(async (referrer, specifier) => {
+      const loader = await loaderPromise;
+      return loader.import(specifier, normalizeReferrerURL(referrer));
+    });
 
-  exports.loaderPromise = loaderPromise;
-  exports.ESMLoader = ESMLoader;
-}
-
-exports.setup = setupModules;
-exports.ESMLoader = undefined;
-exports.loaderPromise = undefined;
+    exports.ESMLoader = ESMLoader;
+  };
+});

--- a/lib/module.js
+++ b/lib/module.js
@@ -24,7 +24,6 @@
 const NativeModule = require('native_module');
 const util = require('util');
 const { decorateErrorStack } = require('internal/util');
-const internalModule = require('internal/module');
 const { getURLFromFilePath } = require('internal/url');
 const vm = require('vm');
 const assert = require('assert').ok;
@@ -35,6 +34,7 @@ const {
   internalModuleReadJSON,
   internalModuleStat
 } = process.binding('fs');
+const internalModule = require('internal/module');
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
 const experimentalModules = !!process.binding('config').experimentalModules;
 
@@ -43,10 +43,9 @@ const errors = require('internal/errors');
 module.exports = Module;
 
 // these are below module.exports for the circular reference
-const Loader = require('internal/loader/Loader');
+const internalESModule = require('internal/process/modules');
 const ModuleJob = require('internal/loader/ModuleJob');
 const createDynamicModule = require('internal/loader/CreateDynamicModule');
-let ESMLoader;
 
 function stat(filename) {
   filename = path.toNamespacedPath(filename);
@@ -447,7 +446,6 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
   return (newReturn ? parentDir : [id, parentDir]);
 };
 
-
 // Check the cache for the requested file.
 // 1. If a module already exists in the cache: return its exports object.
 // 2. If the module is native: call `NativeModule.require()` with the
@@ -460,22 +458,10 @@ Module._load = function(request, parent, isMain) {
     debug('Module._load REQUEST %s parent: %s', request, parent.id);
   }
 
-  if (isMain && experimentalModules) {
-    (async () => {
-      // loader setup
-      if (!ESMLoader) {
-        ESMLoader = new Loader();
-        const userLoader = process.binding('config').userLoader;
-        if (userLoader) {
-          ESMLoader.isMain = false;
-          const hooks = await ESMLoader.import(userLoader);
-          ESMLoader = new Loader();
-          ESMLoader.hook(hooks);
-        }
-      }
-      Loader.registerImportDynamicallyCallback(ESMLoader);
-      await ESMLoader.import(getURLFromFilePath(request).pathname);
-    })()
+  if (experimentalModules && isMain) {
+    internalESModule.loaderPromise.then((loader) => {
+      return loader.import(getURLFromFilePath(request).pathname);
+    })
     .catch((e) => {
       decorateErrorStack(e);
       console.error(e);
@@ -578,7 +564,8 @@ Module.prototype.load = function(filename) {
   Module._extensions[extension](this, filename);
   this.loaded = true;
 
-  if (ESMLoader) {
+  if (experimentalModules) {
+    const ESMLoader = internalESModule.ESMLoader;
     const url = getURLFromFilePath(filename);
     const urlString = `${url}`;
     const exports = this.exports;

--- a/src/env.h
+++ b/src/env.h
@@ -55,10 +55,10 @@ class performance_state;
 namespace loader {
 class ModuleWrap;
 struct PackageConfig {
-  bool exists;
-  bool is_valid;
-  bool has_main;
-  std::string main;
+  const bool exists;
+  const bool is_valid;
+  const bool has_main;
+  const std::string main;
 };
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -610,6 +610,7 @@ class Environment {
 
   struct PackageConfig {
     bool exists;
+    bool is_valid;
     bool has_main;
     std::string main;
   };

--- a/src/env.h
+++ b/src/env.h
@@ -54,6 +54,12 @@ class performance_state;
 
 namespace loader {
 class ModuleWrap;
+struct PackageConfig {
+  bool exists;
+  bool is_valid;
+  bool has_main;
+  std::string main;
+};
 }
 
 // Pick an index that's hopefully out of the way when we're embedded inside
@@ -608,13 +614,7 @@ class Environment {
 
   std::unordered_multimap<int, loader::ModuleWrap*> module_map;
 
-  struct PackageConfig {
-    bool exists;
-    bool is_valid;
-    bool has_main;
-    std::string main;
-  };
-  std::unordered_map<std::string, PackageConfig> package_json_cache;
+  std::unordered_map<std::string, loader::PackageConfig> package_json_cache;
 
   inline double* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(double* pointer);

--- a/src/env.h
+++ b/src/env.h
@@ -54,13 +54,26 @@ class performance_state;
 
 namespace loader {
 class ModuleWrap;
+
+struct Exists {
+  enum Bool { Yes, No };
+};
+
+struct IsValid {
+  enum Bool { Yes, No };
+};
+
+struct HasMain {
+  enum Bool { Yes, No };
+};
+
 struct PackageConfig {
-  const bool exists;
-  const bool is_valid;
-  const bool has_main;
+  const Exists::Bool exists;
+  const IsValid::Bool is_valid;
+  const HasMain::Bool has_main;
   const std::string main;
 };
-}
+}  // namespace loader
 
 // Pick an index that's hopefully out of the way when we're embedded inside
 // another application. Performance-wise or memory-wise it doesn't matter:

--- a/src/env.h
+++ b/src/env.h
@@ -608,6 +608,13 @@ class Environment {
 
   std::unordered_multimap<int, loader::ModuleWrap*> module_map;
 
+  struct PackageConfig {
+    bool exists;
+    bool has_main;
+    std::string main;
+  };
+  std::unordered_map<std::string, PackageConfig> package_json_cache;
+
   inline double* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(double* pointer);
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -502,7 +502,7 @@ const PackageConfig& GetPackageConfig(Environment* env,
   Maybe<uv_file> check = CheckFile(path, LEAVE_OPEN_AFTER_CHECK);
   if (check.IsNothing()) {
     auto entry = env->package_json_cache.emplace(path,
-        PackageConfig{ false, true, false, "" });
+        PackageConfig { Exists::No, IsValid::Yes, HasMain::No, "" });
     return entry.first->second;
   }
 
@@ -520,7 +520,7 @@ const PackageConfig& GetPackageConfig(Environment* env,
                            v8::NewStringType::kNormal,
                            pkg_src.length()).ToLocal(&src)) {
     auto entry = env->package_json_cache.emplace(path,
-        PackageConfig{ false, true, false, "" });
+        PackageConfig { Exists::No, IsValid::Yes, HasMain::No, "" });
     return entry.first->second;
   }
 
@@ -530,21 +530,21 @@ const PackageConfig& GetPackageConfig(Environment* env,
   if (!JSON::Parse(env->context(), src).ToLocal(&pkg_json_v) ||
       !pkg_json_v->ToObject(env->context()).ToLocal(&pkg_json)) {
     auto entry = env->package_json_cache.emplace(path,
-        PackageConfig{ true, false, false, "" });
+        PackageConfig { Exists::Yes, IsValid::No, HasMain::No, "" });
     return entry.first->second;
   }
 
   Local<Value> pkg_main;
-  bool has_main = false;
+  HasMain::Bool has_main = HasMain::No;
   std::string main_std;
   if (pkg_json->Get(env->context(), env->main_string()).ToLocal(&pkg_main)) {
-    has_main = true;
+    has_main = HasMain::Yes;
     Utf8Value main_utf8(isolate, pkg_main);
     main_std.assign(std::string(*main_utf8, main_utf8.length()));
   }
 
   auto entry = env->package_json_cache.emplace(path,
-      PackageConfig{ true, true, has_main, main_std });
+      PackageConfig { Exists::Yes, IsValid::Yes, has_main, "" });
   return entry.first->second;
 }
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -528,9 +528,11 @@ const Environment::PackageConfig& GetPackageConfig(Environment* env,
   Local<Value> pkg_json_v;
   Local<Object> pkg_json;
 
+  // TODO: Invalid package.json MUST THROW the resolve
+  // currently this will just silently ignore
   if (!JSON::Parse(env->context(), src).ToLocal(&pkg_json_v) ||
       !pkg_json_v->ToObject(env->context()).ToLocal(&pkg_json))
-    return kEmptyPackage;  // Exception pending.
+    return kEmptyPackage;
 
   Local<Value> pkg_main;
   bool has_main = false;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -461,10 +461,9 @@ enum CheckFileOptions {
   CLOSE_AFTER_CHECK
 };
 
-Maybe<uv_file> CheckFile(const URL& search,
+Maybe<uv_file> CheckFile(const std::string& path,
                          CheckFileOptions opt = CLOSE_AFTER_CHECK) {
   uv_fs_t fs_req;
-  std::string path = search.ToFilePath();
   if (path.empty()) {
     return Nothing<uv_file>();
   }
@@ -494,40 +493,17 @@ Maybe<uv_file> CheckFile(const URL& search,
   return Just(fd);
 }
 
-enum ResolveExtensionsOptions {
-  TRY_EXACT_NAME,
-  ONLY_VIA_EXTENSIONS
-};
+PackageConfig emptyPackage = { false, false, "" };
+std::unordered_map<std::string, PackageConfig> pjson_cache_;
 
-template<ResolveExtensionsOptions options>
-Maybe<URL> ResolveExtensions(const URL& search) {
-  if (options == TRY_EXACT_NAME) {
-    Maybe<uv_file> check = CheckFile(search);
-    if (!check.IsNothing()) {
-      return Just(search);
-    }
+PackageConfig& GetPackageConfig(Environment* env, const std::string path) {
+  auto existing = pjson_cache_.find(path);
+  if (existing != pjson_cache_.end()) {
+    return existing->second;
   }
-
-  for (const char* extension : EXTENSIONS) {
-    URL guess(search.path() + extension, &search);
-    Maybe<uv_file> check = CheckFile(guess);
-    if (!check.IsNothing()) {
-      return Just(guess);
-    }
-  }
-
-  return Nothing<URL>();
-}
-
-inline Maybe<URL> ResolveIndex(const URL& search) {
-  return ResolveExtensions<ONLY_VIA_EXTENSIONS>(URL("index", search));
-}
-
-Maybe<URL> ResolveMain(Environment* env, const URL& search) {
-  URL pkg("package.json", &search);
-  Maybe<uv_file> check = CheckFile(pkg, LEAVE_OPEN_AFTER_CHECK);
+  Maybe<uv_file> check = CheckFile(path, LEAVE_OPEN_AFTER_CHECK);
   if (check.IsNothing()) {
-    return Nothing<URL>();
+    return pjson_cache_[path] = emptyPackage;
   }
 
   Isolate* isolate = env->isolate();
@@ -546,23 +522,67 @@ Maybe<URL> ResolveMain(Environment* env, const URL& search) {
                            pkg_src.c_str(),
                            v8::NewStringType::kNormal,
                            pkg_src.length()).ToLocal(&src)) {
-    return Nothing<URL>();
+    return pjson_cache_[path] = emptyPackage;
   }
 
   Local<Value> pkg_json;
   if (!JSON::Parse(context, src).ToLocal(&pkg_json) || !pkg_json->IsObject())
-    return Nothing<URL>();
+    return (pjson_cache_[path] = emptyPackage);
   Local<Value> pkg_main;
-  if (!pkg_json.As<Object>()->Get(context, env->main_string())
-                              .ToLocal(&pkg_main) || !pkg_main->IsString()) {
+  bool has_main = false;
+  std::string main_std;
+  if (pkg_json.As<Object>()->Get(context, env->main_string())
+                              .ToLocal(&pkg_main) && pkg_main->IsString()) {
+    has_main = true;
+    Utf8Value main_utf8(isolate, pkg_main.As<String>());
+    main_std = std::string(*main_utf8, main_utf8.length());
+  }
+
+  PackageConfig pjson = { true, has_main, main_std };
+  return pjson_cache_[path] = pjson;
+}
+
+enum ResolveExtensionsOptions {
+  TRY_EXACT_NAME,
+  ONLY_VIA_EXTENSIONS
+};
+
+template<ResolveExtensionsOptions options>
+Maybe<URL> ResolveExtensions(Environment* env, const URL& search) {
+  if (options == TRY_EXACT_NAME) {
+    std::string filePath = search.ToFilePath();
+    Maybe<uv_file> check = CheckFile(filePath);
+    if (!check.IsNothing()) {
+      return Just(search);
+    }
+  }
+
+  for (const char* extension : EXTENSIONS) {
+    URL guess(search.path() + extension, &search);
+    Maybe<uv_file> check = CheckFile(guess.ToFilePath());
+    if (!check.IsNothing()) {
+      return Just(guess);
+    }
+  }
+
+  return Nothing<URL>();
+}
+
+inline Maybe<URL> ResolveIndex(Environment* env, const URL& search) {
+  return ResolveExtensions<ONLY_VIA_EXTENSIONS>(env, URL("index", search));
+}
+
+Maybe<URL> ResolveMain(Environment* env, const URL& search) {
+  URL pkg("package.json", &search);
+
+  PackageConfig pjson = GetPackageConfig(env, pkg.ToFilePath());
+  if (!pjson.exists || !pjson.has_main) {
     return Nothing<URL>();
   }
-  Utf8Value main_utf8(isolate, pkg_main.As<String>());
-  std::string main_std(*main_utf8, main_utf8.length());
-  if (!ShouldBeTreatedAsRelativeOrAbsolutePath(main_std)) {
-    main_std.insert(0, "./");
+  if (!ShouldBeTreatedAsRelativeOrAbsolutePath(pjson.main)) {
+    return Resolve(env, "./" + pjson.main, search);
   }
-  return Resolve(env, main_std, search);
+  return Resolve(env, pjson.main, search);
 }
 
 Maybe<URL> ResolveModule(Environment* env,
@@ -594,26 +614,25 @@ Maybe<URL> ResolveModule(Environment* env,
 
 Maybe<URL> ResolveDirectory(Environment* env,
                             const URL& search,
-                            bool read_pkg_json) {
-  if (read_pkg_json) {
+                            bool check_pjson_main) {
+  if (check_pjson_main) {
     Maybe<URL> main = ResolveMain(env, search);
     if (!main.IsNothing())
       return main;
   }
-  return ResolveIndex(search);
+  return ResolveIndex(env, search);
 }
 
 }  // anonymous namespace
 
-
 Maybe<URL> Resolve(Environment* env,
                    const std::string& specifier,
                    const URL& base,
-                   bool read_pkg_json) {
+                   bool check_pjson_main) {
   URL pure_url(specifier);
   if (!(pure_url.flags() & URL_FLAGS_FAILED)) {
     // just check existence, without altering
-    Maybe<uv_file> check = CheckFile(pure_url);
+    Maybe<uv_file> check = CheckFile(pure_url.ToFilePath());
     if (check.IsNothing()) {
       return Nothing<URL>();
     }
@@ -624,13 +643,13 @@ Maybe<URL> Resolve(Environment* env,
   }
   if (ShouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     URL resolved(specifier, base);
-    Maybe<URL> file = ResolveExtensions<TRY_EXACT_NAME>(resolved);
+    Maybe<URL> file = ResolveExtensions<TRY_EXACT_NAME>(env, resolved);
     if (!file.IsNothing())
       return file;
     if (specifier.back() != '/') {
       resolved = URL(specifier + "/", base);
     }
-    return ResolveDirectory(env, resolved, read_pkg_json);
+    return ResolveDirectory(env, resolved, check_pjson_main);
   } else {
     return ResolveModule(env, specifier, base);
   }
@@ -667,7 +686,7 @@ void ModuleWrap::Resolve(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Maybe<URL> result = node::loader::Resolve(env, specifier_std, url, true);
+  Maybe<URL> result = node::loader::Resolve(env, specifier_std, url);
   if (result.IsNothing() || (result.FromJust().flags() & URL_FLAGS_FAILED)) {
     std::string msg = "Cannot find module " + specifier_std;
     env->ThrowError(msg.c_str());

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -503,7 +503,8 @@ PackageConfig& GetPackageConfig(Environment* env, const std::string path) {
   }
   Maybe<uv_file> check = CheckFile(path, LEAVE_OPEN_AFTER_CHECK);
   if (check.IsNothing()) {
-    return pjson_cache_[path] = emptyPackage;
+    return pjson_cache_[path] =
+           emptyPackage;
   }
 
   Isolate* isolate = env->isolate();
@@ -522,12 +523,14 @@ PackageConfig& GetPackageConfig(Environment* env, const std::string path) {
                            pkg_src.c_str(),
                            v8::NewStringType::kNormal,
                            pkg_src.length()).ToLocal(&src)) {
-    return pjson_cache_[path] = emptyPackage;
+    return pjson_cache_[path] =
+           emptyPackage;
   }
 
   Local<Value> pkg_json;
   if (!JSON::Parse(context, src).ToLocal(&pkg_json) || !pkg_json->IsObject())
-    return (pjson_cache_[path] = emptyPackage);
+    return pjson_cache_[path] =
+           emptyPackage;
   Local<Value> pkg_main;
   bool has_main = false;
   std::string main_std;
@@ -539,7 +542,8 @@ PackageConfig& GetPackageConfig(Environment* env, const std::string path) {
   }
 
   PackageConfig pjson = { true, has_main, main_std };
-  return pjson_cache_[path] = pjson;
+  return pjson_cache_[path] =
+         pjson;
 }
 
 enum ResolveExtensionsOptions {
@@ -548,7 +552,7 @@ enum ResolveExtensionsOptions {
 };
 
 template<ResolveExtensionsOptions options>
-Maybe<URL> ResolveExtensions(Environment* env, const URL& search) {
+Maybe<URL> ResolveExtensions(const URL& search) {
   if (options == TRY_EXACT_NAME) {
     std::string filePath = search.ToFilePath();
     Maybe<uv_file> check = CheckFile(filePath);
@@ -568,8 +572,8 @@ Maybe<URL> ResolveExtensions(Environment* env, const URL& search) {
   return Nothing<URL>();
 }
 
-inline Maybe<URL> ResolveIndex(Environment* env, const URL& search) {
-  return ResolveExtensions<ONLY_VIA_EXTENSIONS>(env, URL("index", search));
+inline Maybe<URL> ResolveIndex(const URL& search) {
+  return ResolveExtensions<ONLY_VIA_EXTENSIONS>(URL("index", search));
 }
 
 Maybe<URL> ResolveMain(Environment* env, const URL& search) {
@@ -620,7 +624,7 @@ Maybe<URL> ResolveDirectory(Environment* env,
     if (!main.IsNothing())
       return main;
   }
-  return ResolveIndex(env, search);
+  return ResolveIndex(search);
 }
 
 }  // anonymous namespace
@@ -643,7 +647,7 @@ Maybe<URL> Resolve(Environment* env,
   }
   if (ShouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     URL resolved(specifier, base);
-    Maybe<URL> file = ResolveExtensions<TRY_EXACT_NAME>(env, resolved);
+    Maybe<URL> file = ResolveExtensions<TRY_EXACT_NAME>(resolved);
     if (!file.IsNothing())
       return file;
     if (specifier.back() != '/') {

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -12,16 +12,15 @@
 namespace node {
 namespace loader {
 
-struct PackageConfig {
-  bool exists;
-  bool has_main;
-  std::string main;
+enum package_main_check : bool {
+    CheckMain = true,
+    IgnoreMain = false
 };
 
 v8::Maybe<url::URL> Resolve(Environment* env,
                             const std::string& specifier,
                             const url::URL& base,
-                            bool read_pkg_json = false);
+                            package_main_check read_pkg_json = CheckMain);
 
 class ModuleWrap : public BaseObject {
  public:

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -12,6 +12,12 @@
 namespace node {
 namespace loader {
 
+struct PackageConfig {
+  bool exists;
+  bool has_main;
+  std::string main;
+};
+
 v8::Maybe<url::URL> Resolve(Environment* env,
                             const std::string& specifier,
                             const url::URL& base,

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -12,7 +12,7 @@
 namespace node {
 namespace loader {
 
-enum package_main_check : bool {
+enum PackageMainCheck : bool {
     CheckMain = true,
     IgnoreMain = false
 };
@@ -20,7 +20,7 @@ enum package_main_check : bool {
 v8::Maybe<url::URL> Resolve(Environment* env,
                             const std::string& specifier,
                             const url::URL& base,
-                            package_main_check read_pkg_json = CheckMain);
+                            PackageMainCheck read_pkg_json = CheckMain);
 
 class ModuleWrap : public BaseObject {
  public:

--- a/test/fixtures/es-module-loaders/example-loader.mjs
+++ b/test/fixtures/es-module-loaders/example-loader.mjs
@@ -8,7 +8,10 @@ const builtins = new Set(
 );
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
-export function resolve(specifier, parentModuleURL/*, defaultResolve */) {
+const baseURL = new url.URL('file://');
+baseURL.pathname = process.cwd() + '/';
+
+export function resolve(specifier, parentModuleURL = baseURL /*, defaultResolve */) {
   if (builtins.has(specifier)) {
     return {
       url: specifier,

--- a/test/fixtures/es-module-loaders/js-loader.mjs
+++ b/test/fixtures/es-module-loaders/js-loader.mjs
@@ -3,7 +3,11 @@ const builtins = new Set(
   Object.keys(process.binding('natives')).filter(str =>
     /^(?!(?:internal|node|v8)\/)/.test(str))
 )
-export function resolve (specifier, base) {
+
+const baseURL = new _url.URL('file://');
+baseURL.pathname = process.cwd() + '/';
+
+export function resolve (specifier, base = baseURL) {
   if (builtins.has(specifier)) {
     return {
       url: specifier,

--- a/test/fixtures/es-modules/noext
+++ b/test/fixtures/es-modules/noext
@@ -1,0 +1,1 @@
+exports.cjs = true;

--- a/test/parallel/test-module-main-extension-lookup.js
+++ b/test/parallel/test-module-main-extension-lookup.js
@@ -5,3 +5,5 @@ const { execFileSync } = require('child_process');
 const node = process.argv[0];
 
 execFileSync(node, ['--experimental-modules', 'test/es-module/test-esm-ok']);
+execFileSync(node, ['--experimental-modules',
+                    'test/fixtures/es-modules/noext']);


### PR DESCRIPTION
I've pulled out the refactorings from #18392 that aren't directly related to the package.json flag, in particular two features:

1. Ensuring that `node --experimental-modules module-without-an-extension` works as a special case. This is necessary for ensuring backwards-compatibility with NodeJS bin workflows. But extensions are still not permitted in dependencies.
2. Adding a package.json cache to the C++ resolver code. As mentioned previously the goal here is to ultimately share the cache with the CommonJS resolver, but for now at least this is a first step and better than having no cache as we do currently.

Review much appreciated especially with the C++ code.

Hopefully this shouldn't be too controversial allowing these useful features to not be blocked by progress on #18392.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
esmodules