### PR TITLE
tools: fix eslint isRequired

### DIFF
--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -8,7 +8,7 @@
  * require calls.
  */
 module.exports.isRequired = function(node, modules) {
-  return node.callee.name === 'require' &&
+  return node.callee.name === 'require' && node.arguments.length !== 0 &&
     modules.includes(node.arguments[0].value);
 };
 


### PR DESCRIPTION
Currently the call can lead to a TypeError.

This fixes it by first checking that there are arguments to validate.

The error is triggered by writing: `require()`. Due to my auto completion in my editor the closing bracket is added as soon as I have a open one and this triggers the eslint rule for e.g. `crypto-check` or `inspector-check` and there are obviously no arguments yet in that case. 

```
[Error - 12:54:43 PM] ESLint stack trace:
[Error - 12:54:43 PM] TypeError: Cannot read property 'value' of undefined
    at Object.module.exports.isRequired (/home/ruben/repos/node/node/tools/eslint-rules/rules-utils.js:12:39)
    at checkAssertNode (/home/ruben/repos/node/node/tools/eslint-rules/prefer-assert-iferror.js:27:17)
    at CallExpression (/home/ruben/repos/node/node/tools/eslint-rules/prefer-assert-iferror.js:33:35)
    at listeners.(anonymous function).forEach.listener (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (native)
    at Object.emit (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at Traverser.enter [as _enter] (/home/ruben/repos/node/node/tools/node_modules/eslint/lib/linter.js:998:32)
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools