### PR TITLE
test: fix missing param in benchmark-timers

### DIFF
--- a/test/parallel/test-benchmark-timers.js
+++ b/test/parallel/test-benchmark-timers.js
@@ -7,6 +7,7 @@ const runBenchmark = require('../common/benchmark');
 runBenchmark('timers',
              [
                'type=depth',
+               'n=1',
                'millions=0.000001',
                'thousands=0.001'
              ],


### PR DESCRIPTION
When a new benchmark was added to `timers`, the test running these benchmarks was not updated to include the new `n` parameter.

Fixes: https://github.com/nodejs/node/issues/18730

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test