### PR TITLE
lib: switch to Number.isNaN

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -74,6 +74,7 @@ rules:
       message: __defineSetter__ is deprecated.
   no-return-await: error
   no-self-assign: error
+  no-self-compare: error
   no-throw-literal: error
   no-unused-labels: error
   no-useless-call: error

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -340,7 +340,7 @@ function howMuchToRead(n, state) {
     return 0;
   if (state.objectMode)
     return 1;
-  if (n !== n) {
+  if (Number.isNaN(n)) {
     // Only flow one buffer at a time
     if (state.flowing && state.length)
       return state.buffer.head.data.length;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -378,10 +378,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
   } else {
     // convert length to non-negative integer
     length = +length;
-    // Check for NaN
-    if (length !== length) {
-      length = 0;
-    } else if (length > 0) {
+    if (length > 0) {
       if (length > maxLength)
         throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'length');
     } else {
@@ -404,7 +401,7 @@ function fromObject(obj) {
   }
 
   if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
-    if (typeof obj.length !== 'number' || obj.length !== obj.length) {
+    if (typeof obj.length !== 'number') {
       return new FastBuffer();
     }
     return fromArrayLike(obj);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -363,8 +363,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
     byteOffset = 0;
   } else {
     byteOffset = +byteOffset;
-    // check for NaN
-    if (byteOffset !== byteOffset)
+    if (Number.isNaN(byteOffset))
       byteOffset = 0;
   }
 
@@ -376,7 +375,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
   if (length === undefined) {
     length = maxLength;
   } else {
-    // convert length to non-negative integer
+    // Convert length to non-negative integer.
     length = +length;
     if (length > 0) {
       if (length > maxLength)
@@ -760,8 +759,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   // Coerce to Number. Values like null and [] become 0.
   byteOffset = +byteOffset;
   // If the offset is undefined, "foo", {}, coerces to NaN, search whole buffer.
-  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
-  if (byteOffset !== byteOffset) {
+  if (Number.isNaN(byteOffset)) {
     byteOffset = dir ? 0 : buffer.length;
   }
   dir = !!dir;  // Cast to bool.
@@ -996,15 +994,17 @@ function adjustOffset(offset, length) {
   // Use Math.trunc() to convert offset to an integer value that can be larger
   // than an Int32. Hence, don't use offset | 0 or similar techniques.
   offset = Math.trunc(offset);
-  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
-  if (offset === 0 || offset !== offset) {
+  if (offset === 0) {
     return 0;
-  } else if (offset < 0) {
+  }
+  if (offset < 0) {
     offset += length;
     return offset > 0 ? offset : 0;
-  } else {
-    return offset < length ? offset : length;
   }
+  if (offset < length) {
+    return offset;
+  }
+  return Number.isNaN(offset) ? 0 : length;
 }
 
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -52,9 +52,7 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
     return defaultMaxListeners;
   },
   set: function(arg) {
-    // check whether the input is a positive number (whose value is zero or
-    // greater and not a NaN).
-    if (typeof arg !== 'number' || arg < 0 || arg !== arg) {
+    if (typeof arg !== 'number' || arg < 0 || Number.isNaN(arg)) {
       const errors = lazyErrors();
       throw new errors.RangeError('ERR_OUT_OF_RANGE',
                                   'defaultMaxListeners',
@@ -79,7 +77,7 @@ EventEmitter.init = function() {
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
-  if (typeof n !== 'number' || n < 0 || isNaN(n)) {
+  if (typeof n !== 'number' || n < 0 || Number.isNaN(n)) {
     const errors = lazyErrors();
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'n',
                                 'a non-negative number', n);

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -11,7 +11,7 @@ const { kMaxLength } = require('buffer');
 const kMaxUint32 = Math.pow(2, 32) - 1;
 
 function assertOffset(offset, length) {
-  if (typeof offset !== 'number' || offset !== offset) {
+  if (typeof offset !== 'number' || Number.isNaN(offset)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset', 'number');
   }
 
@@ -25,7 +25,7 @@ function assertOffset(offset, length) {
 }
 
 function assertSize(size, offset = 0, length = Infinity) {
-  if (typeof size !== 'number' || size !== size) {
+  if (typeof size !== 'number' || Number.isNaN(size)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number');
   }
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -51,7 +51,7 @@ function createRepl(env, opts, cb) {
   }
 
   const historySize = Number(env.NODE_REPL_HISTORY_SIZE);
-  if (!isNaN(historySize) && historySize > 0) {
+  if (!Number.isNaN(historySize) && historySize > 0) {
     opts.historySize = historySize;
   } else {
     // XXX(chrisdickinson): set here to avoid affecting existing applications

--- a/lib/net.js
+++ b/lib/net.js
@@ -1304,7 +1304,7 @@ function createServerHandle(address, port, addressType, fd) {
     handle = new Pipe(PipeConstants.SERVER);
     if (process.platform === 'win32') {
       var instances = parseInt(process.env.NODE_PENDING_PIPE_INSTANCES);
-      if (!isNaN(instances)) {
+      if (!Number.isNaN(instances)) {
         handle.setPendingInstances(instances);
       }
     }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -103,7 +103,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   if (typeof historySize !== 'number' ||
-      isNaN(historySize) ||
+      Number.isNaN(historySize) ||
       historySize < 0) {
     throw new errors.RangeError(
       'ERR_INVALID_OPT_VALUE',

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -575,7 +575,7 @@ function REPLServer(prompt,
     // display next prompt and return.
     if (trimmedCmd) {
       if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) !== '.' &&
-          isNaN(parseFloat(trimmedCmd))) {
+          Number.isNaN(parseFloat(trimmedCmd))) {
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -177,7 +177,7 @@ function Zlib(opts, mode) {
 
   if (opts) {
     chunkSize = opts.chunkSize;
-    if (chunkSize !== undefined && chunkSize === chunkSize) {
+    if (chunkSize !== undefined && !Number.isNaN(chunkSize)) {
       if (chunkSize < Z_MIN_CHUNK || !Number.isFinite(chunkSize))
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
                                     'chunkSize',
@@ -187,7 +187,7 @@ function Zlib(opts, mode) {
     }
 
     flush = opts.flush;
-    if (flush !== undefined && flush === flush) {
+    if (flush !== undefined && !Number.isNaN(flush)) {
       if (flush < Z_NO_FLUSH || flush > Z_BLOCK || !Number.isFinite(flush))
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE', 'flush', flush);
     } else {
@@ -195,7 +195,7 @@ function Zlib(opts, mode) {
     }
 
     finishFlush = opts.finishFlush;
-    if (finishFlush !== undefined && finishFlush === finishFlush) {
+    if (finishFlush !== undefined && !Number.isNaN(finishFlush)) {
       if (finishFlush < Z_NO_FLUSH || finishFlush > Z_BLOCK ||
           !Number.isFinite(finishFlush)) {
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
@@ -207,7 +207,7 @@ function Zlib(opts, mode) {
     }
 
     windowBits = opts.windowBits;
-    if (windowBits !== undefined && windowBits === windowBits) {
+    if (windowBits !== undefined && !Number.isNaN(windowBits)) {
       if (windowBits < Z_MIN_WINDOWBITS || windowBits > Z_MAX_WINDOWBITS ||
           !Number.isFinite(windowBits)) {
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
@@ -219,7 +219,7 @@ function Zlib(opts, mode) {
     }
 
     level = opts.level;
-    if (level !== undefined && level === level) {
+    if (level !== undefined && !Number.isNaN(level)) {
       if (level < Z_MIN_LEVEL || level > Z_MAX_LEVEL ||
           !Number.isFinite(level)) {
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
@@ -230,7 +230,7 @@ function Zlib(opts, mode) {
     }
 
     memLevel = opts.memLevel;
-    if (memLevel !== undefined && memLevel === memLevel) {
+    if (memLevel !== undefined && !Number.isNaN(memLevel)) {
       if (memLevel < Z_MIN_MEMLEVEL || memLevel > Z_MAX_MEMLEVEL ||
           !Number.isFinite(memLevel)) {
         throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
@@ -241,7 +241,7 @@ function Zlib(opts, mode) {
     }
 
     strategy = opts.strategy;
-    if (strategy !== undefined && strategy === strategy) {
+    if (strategy !== undefined && !Number.isNaN(strategy)) {
       if (strategy < Z_DEFAULT_STRATEGY || strategy > Z_FIXED ||
           !Number.isFinite(strategy)) {
         throw new errors.TypeError('ERR_INVALID_OPT_VALUE',

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -148,3 +148,6 @@ b.writeDoubleBE(11.11, 0, true);
     message: '"length" is outside of buffer bounds'
   });
 }
+
+// Test a array like entry with the length set to NaN.
+assert.deepStrictEqual(Buffer.from({ length: NaN }), Buffer.alloc(0));


### PR DESCRIPTION
This enables the eslint no-self-compare rule. 

The reason is to switch to the more natural `Number.isNaN()`check. I benchmarked both versions and they are on par so we do not have to use those old ones anymore.

I also removed a `NaN` check that was obsolete and added a test for that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib