### PR TITLE
tools: enable no-unsafe-finally

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -152,6 +152,7 @@ rules:
   }]
   no-tabs: error
   no-trailing-spaces: error
+  no-unsafe-finally: error
   object-curly-spacing: [error, always]
   one-var-declaration-per-line: error
   operator-linebreak: [error, after]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -504,17 +504,13 @@ exports.canCreateSymLink = function() {
     const whoamiPath = path.join(process.env['SystemRoot'],
                                  'System32', 'whoami.exe');
 
-    let err = false;
-    let output = '';
-
     try {
-      output = execSync(`${whoamiPath} /priv`, { timout: 1000 });
-    } catch (e) {
-      err = true;
-    } finally {
-      if (err || !output.includes('SeCreateSymbolicLinkPrivilege')) {
+      const output = execSync(`${whoamiPath} /priv`, { timout: 1000 });
+      if (!output.includes('SeCreateSymbolicLinkPrivilege')) {
         return false;
       }
+    } catch (e) {
+      return false;
     }
   }
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -506,15 +506,11 @@ exports.canCreateSymLink = function() {
 
     try {
       const output = execSync(`${whoamiPath} /priv`, { timout: 1000 });
-      if (!output.includes('SeCreateSymbolicLinkPrivilege')) {
-        return false;
-      }
+      return output.includes('SeCreateSymbolicLinkPrivilege');
     } catch (e) {
       return false;
     }
   }
-
-  return true;
 };
 
 exports.getCallSite = function getCallSite(top) {


### PR DESCRIPTION
This enables the `no-unsafe-finally` eslint rule to make sure we
have a proper control flow in try / catch.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools