### PR TITLE
doc: stricter `no-multiple-empty-lines` rule

### DIFF
--- a/doc/.eslintrc.yaml
+++ b/doc/.eslintrc.yaml
@@ -12,3 +12,6 @@ rules:
   no-var: error
   prefer-const: error
   prefer-rest-params: error
+
+  # Stylistic Issues
+  no-multiple-empty-lines: [error, {max: 1, maxEOF: 0, maxBOF: 0}]

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -93,7 +93,6 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
     s;
   `, { context: contextifiedSandbox });
 
-
   // Step 2
   //
   // "Link" the imported dependencies of this Module to it.
@@ -132,7 +131,6 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
   }
   await bar.link(linker);
 
-
   // Step 3
   //
   // Instantiate the top-level Module.
@@ -141,7 +139,6 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
   // dependencies will be recursively instantiated by instantiate().
 
   bar.instantiate();
-
 
   // Step 4
   //


### PR DESCRIPTION
This reduces the maximum line number in the `no-multiple-empty-lines` eslint rule to 1 for the docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc