### PR TITLE
lib: directly pass in the arguments

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -135,14 +135,14 @@ Agent.prototype.getName = function getName(options) {
   return name;
 };
 
-Agent.prototype.addRequest = function addRequest(req, options, port/*legacy*/,
-                                                 localAddress/*legacy*/) {
+Agent.prototype.addRequest = function addRequest(req, options, legacyPort,
+                                                 legacyLocalAddress) {
   // Legacy API: addRequest(req, host, port, localAddress)
   if (typeof options === 'string') {
     options = {
       host: options,
-      port,
-      localAddress
+      port: legacyPort,
+      localAddress: legacyLocalAddress
     };
   }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -121,29 +121,24 @@ exports._forkChild = function(fd) {
 };
 
 
-function normalizeExecArgs(command, options, callback) {
+function normalizeExecArgs(file, options, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = undefined;
+    options = {};
+  } else {
+    // Make a shallow copy so we don't clobber the user's options object.
+    options = util._extend({}, options);
   }
 
-  // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
   options.shell = typeof options.shell === 'string' ? options.shell : true;
 
-  return {
-    file: command,
-    options: options,
-    callback: callback
-  };
+  return { file, options, callback };
 }
 
 
-exports.exec = function(command /*, options, callback*/) {
-  var opts = normalizeExecArgs.apply(null, arguments);
-  return exports.execFile(opts.file,
-                          opts.options,
-                          opts.callback);
+exports.exec = function(command, opts, cb) {
+  const { file, options, callback } = normalizeExecArgs(command, opts, cb);
+  return exports.execFile(file, options, callback);
 };
 
 const customPromiseExecFunction = (orig) => {
@@ -396,84 +391,84 @@ function normalizeSpawnArguments(file, args, options) {
     args = [];
   }
 
-  if (options === undefined)
+  if (options === undefined) {
     options = {};
-  else if (options === null || typeof options !== 'object')
+  } else if (options === null || typeof options !== 'object') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'options',
                                'object',
                                options);
-
-  // Validate the cwd, if present.
-  if (options.cwd != null &&
+  } else {
+    // Validate the cwd, if present.
+    if (options.cwd != null &&
       typeof options.cwd !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.cwd',
-                               'string',
-                               options.cwd);
-  }
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.cwd',
+                                 'string',
+                                 options.cwd);
+    }
 
-  // Validate detached, if present.
-  if (options.detached != null &&
+    // Validate detached, if present.
+    if (options.detached != null &&
       typeof options.detached !== 'boolean') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.detached',
-                               'boolean',
-                               options.detached);
-  }
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.detached',
+                                 'boolean',
+                                 options.detached);
+    }
 
-  // Validate the uid, if present.
-  if (options.uid != null && !Number.isInteger(options.uid)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.uid',
-                               'integer',
-                               options.uid);
-  }
+    // Validate the uid, if present.
+    if (options.uid != null && !Number.isInteger(options.uid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.uid',
+                                 'integer',
+                                 options.uid);
+    }
 
-  // Validate the gid, if present.
-  if (options.gid != null && !Number.isInteger(options.gid)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.gid',
-                               'integer',
-                               options.gid);
-  }
+    // Validate the gid, if present.
+    if (options.gid != null && !Number.isInteger(options.gid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.gid',
+                                 'integer',
+                                 options.gid);
+    }
 
-  // Validate the shell, if present.
-  if (options.shell != null &&
+    // Validate the shell, if present.
+    if (options.shell != null &&
       typeof options.shell !== 'boolean' &&
       typeof options.shell !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.shell',
-                               ['boolean', 'string'],
-                               options.shell);
-  }
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.shell',
+                                 ['boolean', 'string'],
+                                 options.shell);
+    }
 
-  // Validate argv0, if present.
-  if (options.argv0 != null &&
+    // Validate argv0, if present.
+    if (options.argv0 != null &&
       typeof options.argv0 !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.argv0',
-                               'string',
-                               options.argv0);
-  }
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.argv0',
+                                 'string',
+                                 options.argv0);
+    }
 
-  // Validate windowsHide, if present.
-  if (options.windowsHide != null &&
+    // Validate windowsHide, if present.
+    if (options.windowsHide != null &&
       typeof options.windowsHide !== 'boolean') {
-    throw new TypeError('"windowsHide" must be a boolean');
-  }
+      throw new TypeError('"windowsHide" must be a boolean');
+    }
 
-  // Validate windowsVerbatimArguments, if present.
-  if (options.windowsVerbatimArguments != null &&
+    // Validate windowsVerbatimArguments, if present.
+    if (options.windowsVerbatimArguments != null &&
       typeof options.windowsVerbatimArguments !== 'boolean') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options.windowsVerbatimArguments',
-                               'boolean',
-                               options.windowsVerbatimArguments);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'options.windowsVerbatimArguments',
+                                 'boolean',
+                                 options.windowsVerbatimArguments);
+    }
+    // Make a shallow copy so we don't clobber the user's options object.
+    options = util._extend({}, options);
   }
-
-  // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');
@@ -502,11 +497,11 @@ function normalizeSpawnArguments(file, args, options) {
     args.unshift(file);
   }
 
-  var env = options.env || process.env;
-  var envPairs = [];
+  const env = options.env || process.env;
+  const envPairs = [];
 
   // Prototype values are intentionally included.
-  for (var key in env) {
+  for (const key in env) {
     const value = env[key];
     if (value !== undefined) {
       envPairs.push(`${key}=${value}`);
@@ -515,30 +510,25 @@ function normalizeSpawnArguments(file, args, options) {
 
   _convertCustomFds(options);
 
-  return {
-    file: file,
-    args: args,
-    options: options,
-    envPairs: envPairs
-  };
+  return { file, args, options, envPairs };
 }
 
 
-var spawn = exports.spawn = function(/*file, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
-  var options = opts.options;
-  var child = new ChildProcess();
+const spawn = exports.spawn = function(rawFile, rawArgs, opts) {
+  const { file, args, options, envPairs } =
+    normalizeSpawnArguments(rawFile, rawArgs, opts);
+  const child = new ChildProcess();
 
-  debug('spawn', opts.args, options);
+  debug('spawn', args, options);
 
   child.spawn({
-    file: opts.file,
-    args: opts.args,
+    file,
+    args,
     cwd: options.cwd,
     windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments,
     detached: !!options.detached,
-    envPairs: opts.envPairs,
+    envPairs,
     stdio: options.stdio,
     uid: options.uid,
     gid: options.gid
@@ -547,12 +537,11 @@ var spawn = exports.spawn = function(/*file, args, options*/) {
   return child;
 };
 
-function spawnSync(/*file, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
+function spawnSync(rawFile, rawArgs, rawOpts) {
+  const opts = normalizeSpawnArguments(rawFile, rawArgs, rawOpts);
+  const { args, file, envPairs, options } = opts;
 
-  var options = opts.options;
-
-  debug('spawnSync', opts.args, options);
+  debug('spawnSync', args, options);
 
   // Validate the timeout, if present.
   validateTimeout(options.timeout);
@@ -560,9 +549,9 @@ function spawnSync(/*file, args, options*/) {
   // Validate maxBuffer, if present.
   validateMaxBuffer(options.maxBuffer);
 
-  options.file = opts.file;
-  options.args = opts.args;
-  options.envPairs = opts.envPairs;
+  options.file = file;
+  options.args = args;
+  options.envPairs = envPairs;
 
   // Validate and translate the kill signal, if present.
   options.killSignal = sanitizeKillSignal(options.killSignal);
@@ -615,16 +604,17 @@ function checkExecSyncError(ret, args, cmd) {
 }
 
 
-function execFileSync(/*command, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
-  var inheritStderr = !opts.options.stdio;
+function execFileSync(rawFile, rawArgs, opts) {
+  const { file, args, options } =
+    normalizeSpawnArguments(rawFile, rawArgs, opts);
+  const inheritStderr = !options.stdio;
 
-  var ret = spawnSync(opts.file, opts.args.slice(1), opts.options);
+  const ret = spawnSync(file, args.slice(1), options);
 
   if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
-  var err = checkExecSyncError(ret, opts.args, undefined);
+  const err = checkExecSyncError(ret, args, undefined);
 
   if (err)
     throw err;
@@ -633,17 +623,16 @@ function execFileSync(/*command, args, options*/) {
 }
 exports.execFileSync = execFileSync;
 
+function execSync(command, rawArgs, rawOpts) {
+  const { file, args, options } = normalizeExecArgs(command, rawArgs, rawOpts);
+  const inheritStderr = !options.stdio;
 
-function execSync(command /*, options*/) {
-  var opts = normalizeExecArgs.apply(null, arguments);
-  var inheritStderr = !opts.options.stdio;
-
-  var ret = spawnSync(opts.file, opts.options);
+  const ret = spawnSync(file, options);
 
   if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
-  var err = checkExecSyncError(ret, opts.args, command);
+  const err = checkExecSyncError(ret, args, command);
 
   if (err)
     throw err;


### PR DESCRIPTION
This removes some `arguments` usage and instead passes in the arguments directly.

It also improves the performance by using `util._extends` instead of `Object.assign` and by adding fast paths.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process, http