### PR TITLE
test,benchmark,doc: enable dot-notation rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -47,6 +47,7 @@ rules:
   accessor-pairs: error
   array-callback-return: error
   dot-location: [error, property]
+  dot-notation: error
   eqeqeq: [error, smart]
   no-fallthrough: error
   no-global-assign: error

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable dot-notation */
+
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1220,7 +1220,7 @@ const server = http2.createServer();
 server.on('stream', (stream) => {
   stream.respond({ ':status': 200 }, {
     getTrailers(trailers) {
-      trailers['ABC'] = 'some value to send';
+      trailers.ABC = 'some value to send';
     }
   });
   stream.end('some data');
@@ -1303,7 +1303,7 @@ server.on('stream', (stream) => {
   };
   stream.respondWithFD(fd, headers, {
     getTrailers(trailers) {
-      trailers['ABC'] = 'some value to send';
+      trailers.ABC = 'some value to send';
     }
   });
 });
@@ -1410,7 +1410,7 @@ const http2 = require('http2');
 const server = http2.createServer();
 server.on('stream', (stream) => {
   function getTrailers(trailers) {
-    trailers['ABC'] = 'some value to send';
+    trailers.ABC = 'some value to send';
   }
   stream.respondWithFile('/some/file',
                          { 'content-type': 'text/plain' },

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,6 +1,4 @@
 rules:
-  dot-notation: error
-
   # Custom rules in tools/eslint-rules
   require-buffer: error
   buffer-constructor: error

--- a/test/addons-napi/test_symbol/test1.js
+++ b/test/addons-napi/test_symbol/test1.js
@@ -8,11 +8,10 @@ const test_symbol = require(`./build/${common.buildType}/test_symbol`);
 const sym = test_symbol.New('test');
 assert.strictEqual(sym.toString(), 'Symbol(test)');
 
-
 const myObj = {};
 const fooSym = test_symbol.New('foo');
 const otherSym = test_symbol.New('bar');
-myObj['foo'] = 'bar';
+myObj.foo = 'bar';
 myObj[fooSym] = 'baz';
 myObj[otherSym] = 'bing';
 assert.strictEqual(myObj.foo, 'bar');

--- a/test/addons-napi/test_symbol/test2.js
+++ b/test/addons-napi/test_symbol/test2.js
@@ -7,7 +7,7 @@ const test_symbol = require(`./build/${common.buildType}/test_symbol`);
 
 const fooSym = test_symbol.New('foo');
 const myObj = {};
-myObj['foo'] = 'bar';
+myObj.foo = 'bar';
 myObj[fooSym] = 'baz';
 Object.keys(myObj); // -> [ 'foo' ]
 Object.getOwnPropertyNames(myObj); // -> [ 'foo' ]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -501,7 +501,7 @@ exports.canCreateSymLink = function() {
     // whoami.exe needs to be the one from System32
     // If unix tools are in the path, they can shadow the one we want,
     // so use the full path while executing whoami
-    const whoamiPath = path.join(process.env['SystemRoot'],
+    const whoamiPath = path.join(process.env.SystemRoot,
                                  'System32', 'whoami.exe');
 
     let err = false;

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -31,8 +31,8 @@ const cluster = require('cluster');
 
 if (cluster.isWorker) {
   const result = cluster.worker.send({
-    prop: process.env['cluster_test_prop'],
-    overwrite: process.env['cluster_test_overwrite']
+    prop: process.env.cluster_test_prop,
+    overwrite: process.env.cluster_test_overwrite
   });
 
   assert.strictEqual(result, true);
@@ -45,7 +45,7 @@ if (cluster.isWorker) {
 
   // To check that the cluster extend on the process.env we will overwrite a
   // property
-  process.env['cluster_test_overwrite'] = 'old';
+  process.env.cluster_test_overwrite = 'old';
 
   // Fork worker
   const worker = cluster.fork({

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -87,13 +87,13 @@ const wikipedia = [
 ];
 
 for (let i = 0, l = wikipedia.length; i < l; i++) {
-  for (const hash in wikipedia[i]['hmac']) {
+  for (const hash in wikipedia[i].hmac) {
     // FIPS does not support MD5.
     if (common.hasFipsCrypto && hash === 'md5')
       continue;
-    const expected = wikipedia[i]['hmac'][hash];
-    const actual = crypto.createHmac(hash, wikipedia[i]['key'])
-                         .update(wikipedia[i]['data'])
+    const expected = wikipedia[i].hmac[hash];
+    const actual = crypto.createHmac(hash, wikipedia[i].key)
+                         .update(wikipedia[i].data)
                          .digest('hex');
     assert.strictEqual(
       actual,
@@ -252,18 +252,18 @@ const rfc4231 = [
 ];
 
 for (let i = 0, l = rfc4231.length; i < l; i++) {
-  for (const hash in rfc4231[i]['hmac']) {
+  for (const hash in rfc4231[i].hmac) {
     const str = crypto.createHmac(hash, rfc4231[i].key);
     str.end(rfc4231[i].data);
     let strRes = str.read().toString('hex');
-    let actual = crypto.createHmac(hash, rfc4231[i]['key'])
-                       .update(rfc4231[i]['data'])
+    let actual = crypto.createHmac(hash, rfc4231[i].key)
+                       .update(rfc4231[i].data)
                        .digest('hex');
-    if (rfc4231[i]['truncate']) {
+    if (rfc4231[i].truncate) {
       actual = actual.substr(0, 32); // first 128 bits == 32 hex chars
       strRes = strRes.substr(0, 32);
     }
-    const expected = rfc4231[i]['hmac'][hash];
+    const expected = rfc4231[i].hmac[hash];
     assert.strictEqual(
       actual,
       expected,
@@ -384,10 +384,10 @@ const rfc2202_sha1 = [
 
 if (!common.hasFipsCrypto) {
   for (let i = 0, l = rfc2202_md5.length; i < l; i++) {
-    const actual = crypto.createHmac('md5', rfc2202_md5[i]['key'])
-      .update(rfc2202_md5[i]['data'])
+    const actual = crypto.createHmac('md5', rfc2202_md5[i].key)
+      .update(rfc2202_md5[i].data)
       .digest('hex');
-    const expected = rfc2202_md5[i]['hmac'];
+    const expected = rfc2202_md5[i].hmac;
     assert.strictEqual(
       actual,
       expected,
@@ -396,10 +396,10 @@ if (!common.hasFipsCrypto) {
   }
 }
 for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
-  const actual = crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
-    .update(rfc2202_sha1[i]['data'])
+  const actual = crypto.createHmac('sha1', rfc2202_sha1[i].key)
+    .update(rfc2202_sha1[i].data)
     .digest('hex');
-  const expected = rfc2202_sha1[i]['hmac'];
+  const expected = rfc2202_sha1[i].hmac;
   assert.strictEqual(
     actual,
     expected,

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -32,9 +32,9 @@ const events = require('events');
   for (let i = 0; i < 10; i++) {
     e.on('default', common.mustNotCall());
   }
-  assert.ok(!e._events['default'].hasOwnProperty('warned'));
+  assert.ok(!e._events.default.hasOwnProperty('warned'));
   e.on('default', common.mustNotCall());
-  assert.ok(e._events['default'].warned);
+  assert.ok(e._events.default.warned);
 
   // symbol
   const symbol = Symbol('symbol');
@@ -49,9 +49,9 @@ const events = require('events');
   for (let i = 0; i < 5; i++) {
     e.on('specific', common.mustNotCall());
   }
-  assert.ok(!e._events['specific'].hasOwnProperty('warned'));
+  assert.ok(!e._events.specific.hasOwnProperty('warned'));
   e.on('specific', common.mustNotCall());
-  assert.ok(e._events['specific'].warned);
+  assert.ok(e._events.specific.warned);
 
   // only one
   e.setMaxListeners(1);
@@ -65,7 +65,7 @@ const events = require('events');
   for (let i = 0; i < 1000; i++) {
     e.on('unlimited', common.mustNotCall());
   }
-  assert.ok(!e._events['unlimited'].hasOwnProperty('warned'));
+  assert.ok(!e._events.unlimited.hasOwnProperty('warned'));
 }
 
 // process-wide
@@ -76,16 +76,16 @@ const events = require('events');
   for (let i = 0; i < 42; ++i) {
     e.on('fortytwo', common.mustNotCall());
   }
-  assert.ok(!e._events['fortytwo'].hasOwnProperty('warned'));
+  assert.ok(!e._events.fortytwo.hasOwnProperty('warned'));
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(e._events['fortytwo'].hasOwnProperty('warned'));
-  delete e._events['fortytwo'].warned;
+  assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
+  delete e._events.fortytwo.warned;
 
   events.EventEmitter.defaultMaxListeners = 44;
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(!e._events['fortytwo'].hasOwnProperty('warned'));
+  assert.ok(!e._events.fortytwo.hasOwnProperty('warned'));
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(e._events['fortytwo'].hasOwnProperty('warned'));
+  assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
 }
 
 // but _maxListeners still has precedence over defaultMaxListeners
@@ -94,9 +94,9 @@ const events = require('events');
   const e = new events.EventEmitter();
   e.setMaxListeners(1);
   e.on('uno', common.mustNotCall());
-  assert.ok(!e._events['uno'].hasOwnProperty('warned'));
+  assert.ok(!e._events.uno.hasOwnProperty('warned'));
   e.on('uno', common.mustNotCall());
-  assert.ok(e._events['uno'].hasOwnProperty('warned'));
+  assert.ok(e._events.uno.hasOwnProperty('warned'));
 
   // chainable
   assert.strictEqual(e, e.setMaxListeners(1));

--- a/test/parallel/test-http-automatic-headers.js
+++ b/test/parallel/test-http-automatic-headers.js
@@ -22,8 +22,8 @@ server.on('listening', common.mustCall(() => {
     assert.strictEqual(res.headers['x-date'], 'foo');
     assert.strictEqual(res.headers['x-connection'], 'bar');
     assert.strictEqual(res.headers['x-content-length'], 'baz');
-    assert(res.headers['date']);
-    assert.strictEqual(res.headers['connection'], 'keep-alive');
+    assert(res.headers.date);
+    assert.strictEqual(res.headers.connection, 'keep-alive');
     assert.strictEqual(res.headers['content-length'], '0');
     server.close();
     agent.destroy();

--- a/test/parallel/test-http-flush-headers.js
+++ b/test/parallel/test-http-flush-headers.js
@@ -5,7 +5,7 @@ const http = require('http');
 
 const server = http.createServer();
 server.on('request', function(req, res) {
-  assert.strictEqual(req.headers['foo'], 'bar');
+  assert.strictEqual(req.headers.foo, 'bar');
   res.end('ok');
   server.close();
 });

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -20,7 +20,7 @@ server.listen(0, common.localhostIPv4, function() {
   req.end();
 
   function onResponse(res) {
-    assert.strictEqual(res.headers['foo'], 'bar');
+    assert.strictEqual(res.headers.foo, 'bar');
     res.destroy();
     server.close();
   }

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -50,7 +50,7 @@ const proxy = http.createServer(function(req, res) {
 
     console.error(`proxy res headers: ${JSON.stringify(proxy_res.headers)}`);
 
-    assert.strictEqual('world', proxy_res.headers['hello']);
+    assert.strictEqual('world', proxy_res.headers.hello);
     assert.strictEqual('text/plain', proxy_res.headers['content-type']);
     assert.deepStrictEqual(cookies, proxy_res.headers['set-cookie']);
 
@@ -81,7 +81,7 @@ function startReq() {
     console.error('got res');
     assert.strictEqual(200, res.statusCode);
 
-    assert.strictEqual('world', res.headers['hello']);
+    assert.strictEqual('world', res.headers.hello);
     assert.strictEqual('text/plain', res.headers['content-type']);
     assert.deepStrictEqual(cookies, res.headers['set-cookie']);
 

--- a/test/parallel/test-http-server-multiheaders.js
+++ b/test/parallel/test-http-server-multiheaders.js
@@ -38,7 +38,7 @@ const srv = http.createServer(function(req, res) {
   assert.strictEqual(req.headers['sec-websocket-protocol'], 'chat, share');
   assert.strictEqual(req.headers['sec-websocket-extensions'],
                      'foo; 1, bar; 2, baz');
-  assert.strictEqual(req.headers['constructor'], 'foo, bar, baz');
+  assert.strictEqual(req.headers.constructor, 'foo, bar, baz');
 
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('EOF');

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -68,7 +68,7 @@ s.listen(0, common.mustCall(runTest));
 function runTest() {
   http.get({ port: this.address().port }, common.mustCall((response) => {
     response.on('end', common.mustCall(() => {
-      assert.strictEqual(response.headers['test'], '2');
+      assert.strictEqual(response.headers.test, '2');
       assert(response.rawHeaders.includes('Test'));
       s.close();
     }));

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -33,8 +33,8 @@ const server = http.Server(common.mustCall(function(req, res) {
   switch (req.url) {
     case '/hello':
       assert.strictEqual(req.method, 'GET');
-      assert.strictEqual(req.headers['accept'], '*/*');
-      assert.strictEqual(req.headers['foo'], 'bar');
+      assert.strictEqual(req.headers.accept, '*/*');
+      assert.strictEqual(req.headers.foo, 'bar');
       assert.strictEqual(req.headers.cookie, 'foo=bar; bar=baz; baz=quux');
       break;
     case '/there':

--- a/test/parallel/test-http2-compat-expect-handling.js
+++ b/test/parallel/test-http2-compat-expect-handling.js
@@ -11,7 +11,7 @@ const expectValue = 'meoww';
 const server = http2.createServer(common.mustNotCall());
 
 server.once('checkExpectation', common.mustCall((req, res) => {
-  assert.strictEqual(req.headers['expect'], expectValue);
+  assert.strictEqual(req.headers.expect, expectValue);
   res.statusCode = 417;
   res.end();
 }));

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -77,7 +77,7 @@ server.listen(0, common.mustCall(() => {
       let actual = '';
       pushStream.on('push', common.mustCall((headers) => {
         assert.strictEqual(headers[':status'], 200);
-        assert(headers['date']);
+        assert(headers.date);
       }));
       pushStream.setEncoding('utf8');
       pushStream.on('data', (chunk) => actual += chunk);
@@ -89,7 +89,7 @@ server.listen(0, common.mustCall(() => {
 
     req.on('response', common.mustCall((headers) => {
       assert.strictEqual(headers[':status'], 200);
-      assert(headers['date']);
+      assert(headers.date);
     }));
 
     let actual = '';

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -62,7 +62,7 @@ function verifySecureSession(key, cert, ca, opts) {
     req.on('response', common.mustCall((headers) => {
       assert.strictEqual(headers[':status'], 200);
       assert.strictEqual(headers['content-type'], 'application/json');
-      assert(headers['date']);
+      assert(headers.date);
     }));
 
     let data = '';

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -58,7 +58,7 @@ server.on('listening', common.mustCall(() => {
       assert.strictEqual(headers[':status'], 200, 'status code is set');
       assert.strictEqual(headers['content-type'], 'text/html',
                          'content type is set');
-      assert(headers['date'], 'there is a date');
+      assert(headers.date);
     }));
 
     let data = '';

--- a/test/parallel/test-http2-multiheaders-raw.js
+++ b/test/parallel/test-http2-multiheaders-raw.js
@@ -12,7 +12,7 @@ const src = Object.create(null);
 src['www-authenticate'] = 'foo';
 src['WWW-Authenticate'] = 'bar';
 src['WWW-AUTHENTICATE'] = 'baz';
-src['test'] = 'foo, bar, baz';
+src.test = 'foo, bar, baz';
 
 server.on('stream', common.mustCall((stream, headers, flags, rawHeaders) => {
   const expected = [

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -24,21 +24,21 @@ src.constructor = 'foo';
 src.Constructor = 'bar';
 src.CONSTRUCTOR = 'baz';
 // eslint-disable-next-line no-proto
-src['__proto__'] = 'foo';
-src['__PROTO__'] = 'bar';
-src['__Proto__'] = 'baz';
+src.__proto__ = 'foo';
+src.__PROTO__ = 'bar';
+src.__Proto__ = 'baz';
 
 function checkHeaders(headers) {
-  assert.deepStrictEqual(headers['accept'],
+  assert.deepStrictEqual(headers.accept,
                          'abc, def, ghijklmnop');
   assert.deepStrictEqual(headers['www-authenticate'],
                          'foo, bar, baz');
   assert.deepStrictEqual(headers['proxy-authenticate'],
                          'foo, bar, baz');
   assert.deepStrictEqual(headers['x-foo'], 'foo, bar, baz');
-  assert.deepStrictEqual(headers['constructor'], 'foo, bar, baz');
+  assert.deepStrictEqual(headers.constructor, 'foo, bar, baz');
   // eslint-disable-next-line no-proto
-  assert.deepStrictEqual(headers['__proto__'], 'foo, bar, baz');
+  assert.deepStrictEqual(headers.__proto__, 'foo, bar, baz');
 }
 
 server.on('stream', common.mustCall((stream, headers) => {

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -26,7 +26,7 @@ const tests = [
 
 const server = http2.createServer();
 server.on('stream', (stream, headers) => {
-  stream.close(headers['rstcode'] | 0);
+  stream.close(headers.rstcode | 0);
 });
 
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -20,7 +20,7 @@ server.listen(0, common.mustCall(() => {
   const req = client.request(headers);
   req.setEncoding('utf8');
   req.on('response', common.mustCall(function(headers) {
-    assert.strictEqual(headers['foobar'], 'baz');
+    assert.strictEqual(headers.foobar, 'baz');
     assert.strictEqual(headers['x-powered-by'], 'node-test');
   }));
 

--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -112,11 +112,11 @@ const server = https.createServer(options, function(req, res) {
 
 process.on('exit', function() {
   assert.strictEqual(serverRequests, 6);
-  assert.strictEqual(clientSessions['first'].toString('hex'),
+  assert.strictEqual(clientSessions.first.toString('hex'),
                      clientSessions['first-reuse'].toString('hex'));
-  assert.notStrictEqual(clientSessions['first'].toString('hex'),
+  assert.notStrictEqual(clientSessions.first.toString('hex'),
                         clientSessions['cipher-change'].toString('hex'));
-  assert.notStrictEqual(clientSessions['first'].toString('hex'),
+  assert.notStrictEqual(clientSessions.first.toString('hex'),
                         clientSessions['before-drop'].toString('hex'));
   assert.notStrictEqual(clientSessions['cipher-change'].toString('hex'),
                         clientSessions['before-drop'].toString('hex'));

--- a/test/parallel/test-inspector-esm.js
+++ b/test/parallel/test-inspector-esm.js
@@ -17,9 +17,9 @@ function assertNoUrlsWhileConnected(response) {
 function assertScopeValues({ result }, expected) {
   const unmatched = new Set(Object.keys(expected));
   for (const actual of result) {
-    const value = expected[actual['name']];
-    assert.strictEqual(actual['value']['value'], value);
-    unmatched.delete(actual['name']);
+    const value = expected[actual.name];
+    assert.strictEqual(actual.value.value, value);
+    unmatched.delete(actual.name);
   }
   assert.deepStrictEqual(Array.from(unmatched.values()), []);
 }
@@ -93,14 +93,14 @@ async function testBreakpoint(session) {
     }
   });
 
-  assert.strictEqual(result['value'], 1002);
+  assert.strictEqual(result.value, 1002);
 
   result = (await session.send({
     'method': 'Runtime.evaluate', 'params': {
       'expression': '5 * 5'
     }
   })).result;
-  assert.strictEqual(result['value'], 25);
+  assert.strictEqual(result.value, 25);
 }
 
 async function runTest() {

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -7,8 +7,8 @@ const internalUtil = require('internal/util');
 const binding = process.binding('util');
 const spawnSync = require('child_process').spawnSync;
 
-const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
-const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
+const kArrowMessagePrivateSymbolIndex = binding.arrow_message_private_symbol;
+const kDecoratedPrivateSymbolIndex = binding.decorated_private_symbol;
 
 const decorateErrorStack = internalUtil.decorateErrorStack;
 

--- a/test/parallel/test-memory-usage-emfile.js
+++ b/test/parallel/test-memory-usage-emfile.js
@@ -10,4 +10,4 @@ while (files.length < 256)
   files.push(fs.openSync(__filename, 'r'));
 
 const r = process.memoryUsage();
-assert.strictEqual(true, r['rss'] > 0);
+assert.strictEqual(true, r.rss > 0);

--- a/test/parallel/test-module-globalpaths-nodepath.js
+++ b/test/parallel/test-module-globalpaths-nodepath.js
@@ -30,11 +30,11 @@ const partC = '';
 if (common.isWindows) {
   partA = 'C:\\Users\\Rocko Artischocko\\AppData\\Roaming\\npm';
   partB = 'C:\\Program Files (x86)\\nodejs\\';
-  process.env['NODE_PATH'] = `${partA};${partB};${partC}`;
+  process.env.NODE_PATH = `${partA};${partB};${partC}`;
 } else {
   partA = '/usr/test/lib/node_modules';
   partB = '/usr/test/lib/node';
-  process.env['NODE_PATH'] = `${partA}:${partB}:${partC}`;
+  process.env.NODE_PATH = `${partA}:${partB}:${partC}`;
 }
 
 mod._initPaths();

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -39,14 +39,14 @@ if (process.argv[2] === 'child') {
 
   const env = Object.assign({}, process.env);
   // Turn on module debug to aid diagnosing failures.
-  env['NODE_DEBUG'] = 'module';
+  env.NODE_DEBUG = 'module';
   // Unset NODE_PATH.
-  delete env['NODE_PATH'];
+  delete env.NODE_PATH;
 
   // Test empty global path.
   const noPkgHomeDir = path.join(tmpdir.path, 'home-no-pkg');
   fs.mkdirSync(noPkgHomeDir);
-  env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
+  env.HOME = env.USERPROFILE = noPkgHomeDir;
   assert.throws(
     () => {
       child_process.execFileSync(testExecPath, [ __filename, 'child' ],
@@ -56,17 +56,17 @@ if (process.argv[2] === 'child') {
 
   // Test module in $HOME/.node_modules.
   const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');
-  env['HOME'] = env['USERPROFILE'] = modHomeDir;
+  env.HOME = env.USERPROFILE = modHomeDir;
   runTest('$HOME/.node_modules', env);
 
   // Test module in $HOME/.node_libraries.
   const libHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_libraries');
-  env['HOME'] = env['USERPROFILE'] = libHomeDir;
+  env.HOME = env.USERPROFILE = libHomeDir;
   runTest('$HOME/.node_libraries', env);
 
   // Test module both $HOME/.node_modules and $HOME/.node_libraries.
   const bothHomeDir = path.join(testFixturesDir, 'home-pkg-in-both');
-  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  env.HOME = env.USERPROFILE = bothHomeDir;
   runTest('$HOME/.node_modules', env);
 
   // Test module in $PREFIX/lib/node.
@@ -79,22 +79,22 @@ if (process.argv[2] === 'child') {
   const pkgPath = path.join(prefixLibNodePath, `${pkgName}.js`);
   fs.writeFileSync(pkgPath, `exports.string = '${expectedString}';`);
 
-  env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
+  env.HOME = env.USERPROFILE = noPkgHomeDir;
   runTest(expectedString, env);
 
   // Test module in all global folders.
-  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  env.HOME = env.USERPROFILE = bothHomeDir;
   runTest('$HOME/.node_modules', env);
 
   // Test module in NODE_PATH is loaded ahead of global folders.
-  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
-  env['NODE_PATH'] = path.join(testFixturesDir, 'node_path');
+  env.HOME = env.USERPROFILE = bothHomeDir;
+  env.NODE_PATH = path.join(testFixturesDir, 'node_path');
   runTest('$NODE_PATH', env);
 
   // Test module in local folder is loaded ahead of global folders.
   const localDir = path.join(testFixturesDir, 'local-pkg');
-  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
-  env['NODE_PATH'] = path.join(testFixturesDir, 'node_path');
+  env.HOME = env.USERPROFILE = bothHomeDir;
+  env.NODE_PATH = path.join(testFixturesDir, 'node_path');
   const child = child_process.execFileSync(testExecPath,
                                            [ path.join(localDir, 'test.js') ],
                                            { encoding: 'utf8', env: env });

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -24,7 +24,7 @@ const cipherlist = {
 };
 
 function test(size, type, name, next) {
-  const cipher = type ? cipherlist[type] : cipherlist['NOT_PFS'];
+  const cipher = type ? cipherlist[type] : cipherlist.NOT_PFS;
 
   if (name) tls.DEFAULT_ECDH_CURVE = name;
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -285,7 +285,7 @@ assert.strictEqual(
     '{ writeonly: [Setter] }');
 
   const value = {};
-  value['a'] = value;
+  value.a = value;
   assert.strictEqual(util.inspect(value), '{ a: [Circular] }');
 }
 

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const child = require('child_process');
 const fixtures = require('../common/fixtures');
 
-if (process.env['TEST_INIT']) {
+if (process.env.TEST_INIT) {
   return process.stdout.write('Loaded successfully!');
 }
 

--- a/test/sequential/test-inspector-bindings.js
+++ b/test/sequential/test-inspector-bindings.js
@@ -27,9 +27,9 @@ function checkScope(session, scopeId) {
 }
 
 function debuggerPausedCallback(session, notification) {
-  const params = notification['params'];
-  const callFrame = params['callFrames'][0];
-  const scopeId = callFrame['scopeChain'][0]['object']['objectId'];
+  const params = notification.params;
+  const callFrame = params.callFrames[0];
+  const scopeId = callFrame.scopeChain[0].object.objectId;
   checkScope(session, scopeId);
 }
 
@@ -65,11 +65,11 @@ function testSampleDebugSession() {
   scopeCallback = function(error, result) {
     const i = cur++;
     let v, actual, expected;
-    for (v of result['result']) {
-      actual = v['value']['value'];
-      expected = expects[v['name']][i];
+    for (v of result.result) {
+      actual = v.value.value;
+      expected = expects[v.name][i];
       if (actual !== expected) {
-        failures.push(`Iteration ${i} variable: ${v['name']} ` +
+        failures.push(`Iteration ${i} variable: ${v.name} ` +
           `expected: ${expected} actual: ${actual}`);
       }
     }

--- a/test/sequential/test-inspector-ip-detection.js
+++ b/test/sequential/test-inspector-ip-detection.js
@@ -15,12 +15,12 @@ if (!ip)
 
 function checkIpAddress(ip, response) {
   const res = response[0];
-  const wsUrl = res['webSocketDebuggerUrl'];
+  const wsUrl = res.webSocketDebuggerUrl;
   assert.ok(wsUrl);
   const match = wsUrl.match(/^ws:\/\/(.*):\d+\/(.*)/);
   assert.strictEqual(ip, match[1]);
-  assert.strictEqual(res['id'], match[2]);
-  assert.strictEqual(ip, res['devtoolsFrontendUrl'].match(/.*ws=(.*):\d+/)[1]);
+  assert.strictEqual(res.id, match[2]);
+  assert.strictEqual(ip, res.devtoolsFrontendUrl.match(/.*ws=(.*):\d+/)[1]);
 }
 
 function pickIPv4Address() {

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -9,10 +9,10 @@ const { NodeInstance } = require('../common/inspector-helper.js');
 
 function checkListResponse(response) {
   assert.strictEqual(1, response.length);
-  assert.ok(response[0]['devtoolsFrontendUrl']);
+  assert.ok(response[0].devtoolsFrontendUrl);
   assert.ok(
     /ws:\/\/127\.0\.0\.1:\d+\/[0-9A-Fa-f]{8}-/
-      .test(response[0]['webSocketDebuggerUrl']));
+      .test(response[0].webSocketDebuggerUrl));
 }
 
 function checkVersion(response) {
@@ -32,7 +32,7 @@ function checkBadPath(err) {
 }
 
 function checkException(message) {
-  assert.strictEqual(message['exceptionDetails'], undefined,
+  assert.strictEqual(message.exceptionDetails, undefined,
                      'An exception occurred during execution');
 }
 
@@ -45,10 +45,10 @@ function assertNoUrlsWhileConnected(response) {
 function assertScopeValues({ result }, expected) {
   const unmatched = new Set(Object.keys(expected));
   for (const actual of result) {
-    const value = expected[actual['name']];
+    const value = expected[actual.name];
     if (value) {
-      assert.strictEqual(value, actual['value']['value']);
-      unmatched.delete(actual['name']);
+      assert.strictEqual(value, actual.value.value);
+      unmatched.delete(actual.name);
     }
   }
   if (unmatched.size)
@@ -124,14 +124,14 @@ async function testBreakpoint(session) {
     }
   });
 
-  assert.strictEqual(1002, result['value']);
+  assert.strictEqual(1002, result.value);
 
   result = (await session.send({
     'method': 'Runtime.evaluate', 'params': {
       'expression': '5 * 5'
     }
   })).result;
-  assert.strictEqual(25, result['value']);
+  assert.strictEqual(25, result.value);
 }
 
 async function testI18NCharacters(session) {
@@ -168,7 +168,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.strictEqual(result['result']['value'], true);
+  assert.strictEqual(result.result.value, true);
 
   // the global require has the same properties as a normal `require`
   result = await session.send(
@@ -183,7 +183,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.strictEqual(result['result']['value'], true);
+  assert.strictEqual(result.result.value, true);
   // `require` twice returns the same value
   result = await session.send(
     {
@@ -199,7 +199,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.strictEqual(result['result']['value'], true);
+  assert.strictEqual(result.result.value, true);
   // after require the module appears in require.cache
   result = await session.send(
     {
@@ -211,7 +211,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.deepStrictEqual(JSON.parse(result['result']['value']),
+  assert.deepStrictEqual(JSON.parse(result.result.value),
                          { old: 'yes' });
   // remove module from require.cache
   result = await session.send(
@@ -222,7 +222,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.strictEqual(result['result']['value'], true);
+  assert.strictEqual(result.result.value, true);
   // require again, should get fresh (empty) exports
   result = await session.send(
     {
@@ -232,7 +232,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.deepStrictEqual(JSON.parse(result['result']['value']), {});
+  assert.deepStrictEqual(JSON.parse(result.result.value), {});
   // require 2nd module, exports an empty object
   result = await session.send(
     {
@@ -242,7 +242,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.deepStrictEqual(JSON.parse(result['result']['value']), {});
+  assert.deepStrictEqual(JSON.parse(result.result.value), {});
   // both modules end up with the same module.parent
   result = await session.send(
     {
@@ -257,7 +257,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.deepStrictEqual(JSON.parse(result['result']['value']), {
+  assert.deepStrictEqual(JSON.parse(result.result.value), {
     parentsEqual: true,
     parentId: '<inspector console>'
   });
@@ -274,7 +274,7 @@ async function testCommandLineAPI(session) {
       }
     });
   checkException(result);
-  assert.notStrictEqual(result['result']['value'],
+  assert.notStrictEqual(result.result.value,
                         '<inspector console>');
 }
 


### PR DESCRIPTION
This enables the eslint dot-notation rule for all code instead of
only in /lib.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test,doc,benchmark