### PR TITLE
lib,doc: enable no-prototype-builtins

### DIFF
--- a/doc/.eslintrc.yaml
+++ b/doc/.eslintrc.yaml
@@ -12,3 +12,7 @@ rules:
   no-var: error
   prefer-const: error
   prefer-rest-params: error
+
+  # Possible Errors
+  # http://eslint.org/docs/rules/#possible-errors
+  no-prototype-builtins: error

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -65,7 +65,7 @@ is wrapped in an `Error` with the original value stored in a field named
   callbackFunction((err, ret) => {
     // When the Promise was rejected with `null` it is wrapped with an Error and
     // the original value is stored in `reason`.
-    err && err.hasOwnProperty('reason') && err.reason === null;  // true
+    err && Object.prototype.call(err, 'reason') && err.reason === null;  // true
   });
   ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -65,8 +65,7 @@ is wrapped in an `Error` with the original value stored in a field named
   callbackFunction((err, ret) => {
     // When the Promise was rejected with `null` it is wrapped with an Error and
     // the original value is stored in `reason`.
-    console.log(err && Object.prototype.hasOwnProperty.call(err, 'reason') &&
-      err.reason === null);
+    console.log(err && err.reason === null);
     // Prints: true
   });
   ```

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -65,7 +65,9 @@ is wrapped in an `Error` with the original value stored in a field named
   callbackFunction((err, ret) => {
     // When the Promise was rejected with `null` it is wrapped with an Error and
     // the original value is stored in `reason`.
-    err && Object.prototype.call(err, 'reason') && err.reason === null;  // true
+   console.log(err && Object.prototype.hasOwnProperty.call(err, 'reason') &&
+      err.reason === null);
+    // Prints: true
   });
   ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -65,7 +65,7 @@ is wrapped in an `Error` with the original value stored in a field named
   callbackFunction((err, ret) => {
     // When the Promise was rejected with `null` it is wrapped with an Error and
     // the original value is stored in `reason`.
-   console.log(err && Object.prototype.hasOwnProperty.call(err, 'reason') &&
+    console.log(err && Object.prototype.hasOwnProperty.call(err, 'reason') &&
       err.reason === null);
     // Prints: true
   });

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -7,3 +7,7 @@ rules:
   no-let-in-for-declaration: error
   lowercase-name-for-primitive: error
   non-ascii-character: error
+
+  # Possible Errors
+  # http://eslint.org/docs/rules/#possible-errors
+  no-prototype-builtins: error

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -31,6 +31,7 @@ const { parseExpressionAt } = require('internal/deps/acorn/dist/acorn');
 const { inspect } = require('util');
 const { EOL } = require('os');
 const nativeModule = require('native_module');
+const { isPrototypeOf } = Object.prototype;
 
 // Escape control characters but not \n and \t to keep the line breaks and
 // indentation intact.
@@ -400,7 +401,7 @@ function expectedException(actual, expected, msg) {
   if (expected.prototype !== undefined && actual instanceof expected) {
     return true;
   }
-  if (Error.isPrototypeOf(expected)) {
+  if (isPrototypeOf.call(Error, expected)) {
     return false;
   }
   return expected.call({}, actual) === true;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -82,6 +82,8 @@ const emitDestroyNative = emitHookFactory(destroy_symbol, 'emitDestroyNative');
 const emitPromiseResolveNative =
     emitHookFactory(promise_resolve_symbol, 'emitPromiseResolveNative');
 
+const { hasOwnProperty } = Object.prototype;
+
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
 // are setup immediately to prevent async_wrap.setupHooks() from being hijacked
@@ -250,7 +252,7 @@ function newUid() {
 }
 
 function getOrSetAsyncId(object) {
-  if (object.hasOwnProperty(async_id_symbol)) {
+  if (hasOwnProperty.call(object, async_id_symbol)) {
     return object[async_id_symbol];
   }
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -5,6 +5,8 @@
 // to the performance of the startup process, many dependencies are invoked
 // lazily.
 
+/* eslint-disable no-prototype-builtins */
+
 'use strict';
 
 (function(process) {

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -16,6 +16,7 @@ const {
 const { isArrayBufferView } = require('internal/util/types');
 const { Writable } = require('stream');
 const { inherits } = require('util');
+const { hasOwnProperty } = Object.prototype;
 
 function Sign(algorithm, options) {
   if (!(this instanceof Sign))
@@ -55,7 +56,7 @@ Sign.prototype.sign = function sign(options, encoding) {
 
   // Options specific to RSA
   var rsaPadding = RSA_PKCS1_PADDING;
-  if (options.hasOwnProperty('padding')) {
+  if (hasOwnProperty.call(options, 'padding')) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
@@ -66,7 +67,7 @@ Sign.prototype.sign = function sign(options, encoding) {
   }
 
   var pssSaltLength = RSA_PSS_SALTLEN_AUTO;
-  if (options.hasOwnProperty('saltLength')) {
+  if (hasOwnProperty.call(options, 'saltLength')) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
@@ -114,7 +115,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   // Options specific to RSA
   var rsaPadding = RSA_PKCS1_PADDING;
-  if (options.hasOwnProperty('padding')) {
+  if (hasOwnProperty.call(options, 'padding')) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
@@ -125,7 +126,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   }
 
   var pssSaltLength = RSA_PSS_SALTLEN_AUTO;
-  if (options.hasOwnProperty('saltLength')) {
+  if (hasOwnProperty.call(options, 'saltLength')) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {


### PR DESCRIPTION
This enables the `no-prototype-builtins` eslint rule for /lib and
for /doc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib,doc