### PR TITLE
src: changing node_file's usage of v8::Resolver

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -283,7 +283,8 @@ void FSReqWrap::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
 void FSReqPromise::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
   Local<Context> context = env()->context();
   args.GetReturnValue().Set(
-    object()->Get(context, env()->promise_string()).ToLocalChecked());
+    object()->Get(context, env()->promise_string()).ToLocalChecked()
+      .As<Promise::Resolver>()->GetPromise());
 }
 
 void NewFSReqWrap(const FunctionCallbackInfo<Value>& args) {
@@ -300,7 +301,7 @@ FSReqPromise::FSReqPromise(Environment* env)
       stats_field_array_(env->isolate(), 14) {
   auto resolver = Promise::Resolver::New(env->context()).ToLocalChecked();
   object()->Set(env->context(), env->promise_string(),
-                resolver.As<Promise>()).FromJust();
+                resolver).FromJust();
 }
 
 FSReqPromise::~FSReqPromise() {
@@ -315,9 +316,7 @@ void FSReqPromise::Reject(Local<Value> reject) {
   Local<Value> value =
       object()->Get(env()->context(),
                     env()->promise_string()).ToLocalChecked();
-  CHECK(value->IsPromise());
-  Local<Promise> promise = value.As<Promise>();
-  Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
+  Local<Promise::Resolver> resolver = value.As<Promise::Resolver>();
   resolver->Reject(env()->context(), reject).FromJust();
 }
 
@@ -336,7 +335,6 @@ void FSReqPromise::Resolve(Local<Value> value) {
   Local<Value> val =
       object()->Get(env()->context(),
                     env()->promise_string()).ToLocalChecked();
-  CHECK(val->IsPromise());
   Local<Promise::Resolver> resolver = val.As<Promise::Resolver>();
   resolver->Resolve(env()->context(), value).FromJust();
 }


### PR DESCRIPTION
node_file was casting back and forth between `v8::Promise::Resolver` and `v8::Promise`
This is unnecessary; most of the time it just wants the `v8::Promise::Resolver`,
converting to the `v8::Promise` only as a return value.

This was causing issues for node-chakracore, since the v8 shim that we use there did not have `v8::Promise` as pointer-convertible with `v8::Promise::Resolver`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src