### PR TITLE
http2: use `util._extend` instead of `Object.assign`

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -675,7 +675,7 @@ function pingCallback(cb) {
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
 function validateSettings(settings) {
-  settings = Object.assign({}, settings);
+  settings = util._extend({}, settings);
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
                     0, kMaxInt);
@@ -1305,8 +1305,8 @@ class ClientHttp2Session extends Http2Session {
     assertIsObject(headers, 'headers');
     assertIsObject(options, 'options');
 
-    headers = Object.assign(Object.create(null), headers);
-    options = Object.assign({}, options);
+    headers = util._extend(Object.create(null), headers);
+    options = util._extend({}, options);
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
@@ -1706,7 +1706,7 @@ class Http2Stream extends Duplex {
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = util._extend({}, options);
     validatePriorityOptions(options);
 
     const priorityFn = submitPriority.bind(this, options);
@@ -1854,7 +1854,7 @@ class Http2Stream extends Duplex {
 
 function processHeaders(headers) {
   assertIsObject(headers, 'headers');
-  headers = Object.assign(Object.create(null), headers);
+  headers = util._extend(Object.create(null), headers);
   if (headers[HTTP2_HEADER_STATUS] == null)
     headers[HTTP2_HEADER_STATUS] = HTTP_STATUS_OK;
   headers[HTTP2_HEADER_DATE] = utcDate();
@@ -2064,11 +2064,11 @@ class ServerHttp2Stream extends Http2Stream {
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = util._extend({}, options);
     options.endStream = !!options.endStream;
 
     assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
+    headers = util._extend(Object.create(null), headers);
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
@@ -2131,7 +2131,7 @@ class ServerHttp2Stream extends Http2Stream {
     const state = this[kState];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = util._extend({}, options);
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
@@ -2198,7 +2198,7 @@ class ServerHttp2Stream extends Http2Stream {
     const session = this[kSession];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = util._extend({}, options);
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
@@ -2272,7 +2272,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = util._extend({}, options);
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
@@ -2335,7 +2335,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
 
     assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
+    headers = util._extend(Object.create(null), headers);
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
@@ -2498,10 +2498,10 @@ function connectionListener(socket) {
 
 function initializeOptions(options) {
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = util._extend({}, options);
   options.allowHalfOpen = true;
   assertIsObject(options.settings, 'options.settings');
-  options.settings = Object.assign({}, options.settings);
+  options.settings = util._extend({}, options.settings);
 
   // Used only with allowHTTP1
   options.Http1IncomingMessage = options.Http1IncomingMessage ||
@@ -2607,7 +2607,7 @@ function connect(authority, options, listener) {
   }
 
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = util._extend({}, options);
 
   if (typeof authority === 'string')
     authority = new URL(authority);

--- a/test/parallel/test-http2-multiheaders-raw.js
+++ b/test/parallel/test-http2-multiheaders-raw.js
@@ -24,14 +24,14 @@ server.on('stream', common.mustCall((stream, headers, flags, rawHeaders) => {
     `localhost:${server.address().port}`,
     ':method',
     'GET',
+    'test',
+    'foo, bar, baz',
     'www-authenticate',
-    'foo',
+    'baz',
     'www-authenticate',
     'bar',
     'www-authenticate',
-    'baz',
-    'test',
-    'foo, bar, baz'
+    'foo'
   ];
 
   assert.deepStrictEqual(expected, rawHeaders);

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -30,15 +30,15 @@ src['__Proto__'] = 'baz';
 
 function checkHeaders(headers) {
   assert.deepStrictEqual(headers['accept'],
-                         'abc, def, ghijklmnop');
+                         'ghijklmnop, abc, def');
   assert.deepStrictEqual(headers['www-authenticate'],
-                         'foo, bar, baz');
+                         'baz, bar, foo');
   assert.deepStrictEqual(headers['proxy-authenticate'],
-                         'foo, bar, baz');
-  assert.deepStrictEqual(headers['x-foo'], 'foo, bar, baz');
-  assert.deepStrictEqual(headers['constructor'], 'foo, bar, baz');
+                         'baz, bar, foo');
+  assert.deepStrictEqual(headers['x-foo'], 'baz, bar, foo');
+  assert.deepStrictEqual(headers['constructor'], 'baz, bar, foo');
   // eslint-disable-next-line no-proto
-  assert.deepStrictEqual(headers['__proto__'], 'foo, bar, baz');
+  assert.deepStrictEqual(headers['__proto__'], 'baz, bar, foo');
 }
 
 server.on('stream', common.mustCall((stream, headers) => {


### PR DESCRIPTION
Since `util._extend()` still wins currently over `Object.assign`
it is better to use it in terms of performance here in http2

Benchmark before
![image](https://user-images.githubusercontent.com/1050904/36171403-93190e98-10d0-11e8-98c9-6470839e8fef.png)

Benchmark after
![image](https://user-images.githubusercontent.com/1050904/36171419-a31f3d58-10d0-11e8-8925-deb5bf6b9dd8.png)

```
 http2/headers.js benchmarker='h2load' nheaders=0 n=1000                    0.13 %       ±1.81% ±2.39% ±3.07%
 http2/headers.js benchmarker='h2load' nheaders=1000 n=1000        ***      9.42 %       ±1.88% ±2.48% ±3.19%
 http2/headers.js benchmarker='h2load' nheaders=100 n=1000         ***      5.91 %       ±1.31% ±1.73% ±2.22%
 http2/headers.js benchmarker='h2load' nheaders=10 n=1000            *      1.55 %       ±1.23% ±1.62% ±2.08%

Be aware that when doing many comparisions the risk of a false-positive
result increases. In this case there are 4 comparisions, you can thus
expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
Notifying upstream projects of job completion
Finished: SUCCESS
```

Refs: https://github.com/nodejs/node/issues/18707
Refs: https://github.com/nodejs/node/pull/18442

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2, test