### PR TITLE
stream, http, http2: make all stream.end() call return this

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -513,11 +513,16 @@ See [`request.socket`][]
 ### request.end([data[, encoding]][, callback])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18780
+    description: This method now returns a reference to `ClientRequest`.
 -->
 
 * `data` {string|Buffer}
 * `encoding` {string}
 * `callback` {Function}
+* Returns: {this}
 
 Finishes sending the request. If any parts of the body are
 unsent, it will flush them to the stream. If the request is
@@ -1010,11 +1015,16 @@ See [`response.socket`][].
 ### response.end([data][, encoding][, callback])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18780
+    description: This method now returns a reference to `ServerResponse`.
 -->
 
 * `data` {string|Buffer}
 * `encoding` {string}
 * `callback` {Function}
+* Returns: {this}
 
 This method signals to the server that all of the response headers and body
 have been sent; that server should consider this message complete.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2617,11 +2617,16 @@ See [`response.socket`][].
 #### response.end([data][, encoding][, callback])
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18780
+    description: This method now returns a reference to `ServerResponse`.
 -->
 
 * `data` {string|Buffer}
 * `encoding` {string}
 * `callback` {Function}
+* Returns: {this}
 
 This method signals to the server that all of the response headers and body
 have been sent; that server should consider this message complete.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -355,6 +355,9 @@ See also: [`writable.uncork()`][].
 <!-- YAML
 added: v0.9.4
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/18780
+    description: This method now returns a reference to `writable`.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11608
     description: The `chunk` argument can now be a `Uint8Array` instance.
@@ -366,6 +369,7 @@ changes:
   other than `null`.
 * `encoding` {string} The encoding, if `chunk` is a string
 * `callback` {Function} Optional callback for when the stream is finished
+* Returns: {this}
 
 Calling the `writable.end()` method signals that no more data will be written
 to the [Writable][]. The optional `chunk` and `encoding` arguments allow one

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -736,7 +736,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   }
 
   if (this.finished) {
-    return false;
+    return this;
   }
 
   var uncork;
@@ -766,12 +766,11 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
 
   var finish = onFinish.bind(undefined, this);
 
-  var ret;
   if (this._hasBody && this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
+    this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
   } else {
     // Force a flush, HACK.
-    ret = this._send('', 'latin1', finish);
+    this._send('', 'latin1', finish);
   }
 
   if (uncork)
@@ -788,7 +787,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this._finish();
   }
 
-  return ret;
+  return this;
 };
 
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -570,6 +570,8 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   // ignore unnecessary end() calls.
   if (!state.ending)
     endWritable(this, state, cb);
+
+  return this;
 };
 
 Object.defineProperty(Writable.prototype, 'writableLength', {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -596,6 +596,8 @@ class Http2ServerResponse extends Stream {
       this[kFinish]();
     else
       stream.end();
+
+    return this;
   }
 
   destroy(err) {

--- a/test/parallel/test-http-request-end-twice.js
+++ b/test/parallel/test-http-request-end-twice.js
@@ -31,7 +31,7 @@ const server = http.Server(function(req, res) {
 server.listen(0, function() {
   const req = http.get({ port: this.address().port }, function(res) {
     res.on('end', function() {
-      assert.ok(!req.end());
+      assert.strictEqual(req.end(), req);
       server.close();
     });
     res.resume();

--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -44,7 +44,7 @@ const server = http.Server(function(req, res) {
 });
 
 server.listen(0, function() {
-  http.request({
+  const req = http.request({
     port: this.address().port,
     path: '/',
     method: 'POST'
@@ -54,5 +54,9 @@ server.listen(0, function() {
   }).on('error', function(e) {
     console.log(e.message);
     process.exit(1);
-  }).end(expected);
+  });
+
+  const result = req.end(expected);
+
+  assert.strictEqual(req, result);
 });

--- a/test/parallel/test-http2-compat-serverrequest-end.js
+++ b/test/parallel/test-http2-compat-serverrequest-end.js
@@ -26,7 +26,7 @@ server.listen(0, common.mustCall(function() {
 
         server.close();
       }));
-      response.end();
+      assert.strictEqual(response.end(), response);
     }));
   }));
 

--- a/test/parallel/test-stream-writableState-ending.js
+++ b/test/parallel/test-stream-writableState-ending.js
@@ -24,10 +24,13 @@ writable.on('finish', () => {
   testStates(true, true, true);
 });
 
-writable.end('testing function end()', () => {
+const result = writable.end('testing function end()', () => {
   // ending, finished, ended = true.
   testStates(true, true, true);
 });
+
+// end returns the writable instance
+assert.strictEqual(result, writable);
 
 // ending, ended = true.
 // finished = false.


### PR DESCRIPTION
This PR make all the instances of `stream.end()` return this. This includes both http and http2 pseudo-writables.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

stream, http, http2