### PR TITLE
Fix typos of func call in promises.lchmod & lchown

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2896,7 +2896,7 @@ const promises = {
     if (constants.O_SYMLINK !== undefined) {
       const fd = await promises.open(path,
                                      constants.O_WRONLY | constants.O_SYMLINK);
-      return promises.fschmod(fd, mode).finally(fd.close.bind(fd));
+      return promises.fchmod(fd, mode).finally(fd.close.bind(fd));
     }
     throw new errors.Error('ERR_METHOD_NOT_IMPLEMENTED');
   },
@@ -2905,7 +2905,7 @@ const promises = {
     if (constants.O_SYMLINK !== undefined) {
       const fd = await promises.open(path,
                                      constants.O_WRONLY | constants.O_SYMLINK);
-      return promises.fschmod(fd, uid, gid).finally(fd.close.bind(fd));
+      return promises.fchown(fd, uid, gid).finally(fd.close.bind(fd));
     }
     throw new errors.Error('ERR_METHOD_NOT_IMPLEMENTED');
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Overview
I fixed 2 typos of function call in `fs.promises`.
- in `lchmod`: `fschmod` to `fchmod`
- in `lchown`: `fschmod` to `fchown`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs