### PR TITLE
perf_hooks: emit user timing marks, measures and timerify to trace events

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -268,8 +268,8 @@ added: v8.5.0
 
 * {string}
 
-The type of the performance entry. Current it may be one of: `'node'`, `'mark'`,
-`'measure'`, `'gc'`, or `'function'`.
+The type of the performance entry. Currently it may be one of: `'node'`,
+`'mark'`, `'measure'`, `'gc'`, or `'function'`.
 
 ### performanceEntry.kind
 <!-- YAML

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -10,8 +10,20 @@ starting a Node.js application.
 
 The set of categories for which traces are recorded can be specified using the
 `--trace-event-categories` flag followed by a list of comma separated category
-names. By default the `node`, `node.async_hooks`, and `v8` categories are
-enabled.
+names.
+
+The available categories are:
+
+* `node`
+* `node.async_hooks` - Enables capture of detailed async_hooks trace data.
+* `node.perf` - Enables capture of [Performance API] measurements.
+  * `node.perf.usertiming` - Enables capture of only Performance API User Timing
+    measures and marks.
+  * `node.perf.timerify` - Enables capture of only Performance API timerify
+    measurements.
+* `v8`
+
+By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
 ```txt
 node --trace-events-enabled --trace-event-categories v8,node,node.async_hooks server.js
@@ -24,3 +36,5 @@ tab of Chrome.
 Starting with Node 10.0.0, the tracing system uses the same time source as the
 one used by `process.hrtime()` however the trace-event timestamps are expressed
 in microseconds, unlike `process.hrtime()` which returns nanoseconds.
+
+[Performance API]: perf_hooks.html

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -36,6 +36,7 @@ const {
   NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END
 } = constants;
 
+const { AsyncResource } = require('async_hooks');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 const { inherits } = require('util');
@@ -317,12 +318,13 @@ class PerformanceObserverEntryList {
   }
 }
 
-class PerformanceObserver {
+class PerformanceObserver extends AsyncResource {
   constructor(callback) {
     if (typeof callback !== 'function') {
       const errors = lazyErrors();
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
     }
+    super('PerformanceObserver');
     Object.defineProperties(this, {
       [kTypes]: {
         enumerable: false,
@@ -568,7 +570,7 @@ function getObserversList(type) {
 
 function doNotify() {
   this[kQueued] = false;
-  this[kCallback](this[kBuffer], this);
+  this.runInAsyncScope(this[kCallback], this, this[kBuffer], this);
   this[kBuffer][kEntries] = [];
   L.init(this[kBuffer][kEntries]);
 }

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -89,7 +89,7 @@ void PerformanceEntry::Notify(Environment* env,
   if (type != NODE_PERFORMANCE_ENTRY_TYPE_INVALID &&
       observers[type]) {
     node::MakeCallback(env->isolate(),
-                       env->process_object(),
+                       object.As<Object>(),
                        env->performance_entry_callback(),
                        1, &object,
                        node::async_context{0, 0}).ToLocalChecked();

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
+#include "node_internals.h"
 #include "node_perf_common.h"
 #include "env.h"
 #include "base_object-inl.h"

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -244,9 +244,20 @@ enum CategoryGroupEnabledFlags {
 
 // Adds a trace event with a given id, thread_id, and timestamp. Not
 // Implemented.
-#define INTERNAL_TRACE_EVENT_ADD_WITH_ID_TID_AND_TIMESTAMP(            \
-    phase, category_group, name, id, thread_id, timestamp, flags, ...) \
-  UNIMPLEMENTED()
+#define INTERNAL_TRACE_EVENT_ADD_WITH_ID_TID_AND_TIMESTAMP(                  \
+    phase, category_group, name, id, thread_id, timestamp, flags, ...)       \
+  do {                                                                       \
+    INTERNAL_TRACE_EVENT_GET_CATEGORY_INFO(category_group);                  \
+    if (INTERNAL_TRACE_EVENT_CATEGORY_GROUP_ENABLED_FOR_RECORDING_MODE()) {  \
+      unsigned int trace_event_flags = flags | TRACE_EVENT_FLAG_HAS_ID;      \
+      node::tracing::TraceID trace_event_trace_id(id,                        \
+                                                  &trace_event_flags);       \
+      node::tracing::AddTraceEventWithTimestamp(                             \
+          phase, INTERNAL_TRACE_EVENT_UID(category_group_enabled), name,     \
+          trace_event_trace_id.scope(), trace_event_trace_id.raw_id(),       \
+          node::tracing::kNoId, trace_event_flags, timestamp, ##__VA_ARGS__);\
+    }                                                                        \
+  } while (0)
 
 // Enter and leave a context based on the current scope.
 #define INTERNAL_TRACE_EVENT_SCOPED_CONTEXT(category_group, name, context) \

--- a/test/parallel/test-trace-events-perf.js
+++ b/test/parallel/test-trace-events-perf.js
@@ -1,0 +1,82 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+if (process.argv[2] === 'child') {
+  const { performance } = require('perf_hooks');
+
+  // Will emit mark and measure trace events
+  performance.mark('A');
+  setTimeout(() => {
+    performance.mark('B');
+    performance.measure('A to B', 'A', 'B');
+  }, 1);
+
+  // Intentional non-op, part of the test
+  function f() {}
+  const ff = performance.timerify(f);
+  ff();  // Will emit a timerify trace event
+} else {
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
+
+  const expectedMarks = ['A', 'B'];
+  const expectedBegins = [
+    { cat: 'node.perf,node.perf.timerify', name: 'f' },
+    { cat: 'node.perf,node.perf.usertiming', name: 'A to B' }
+  ];
+  const expectedEnds = [
+    { cat: 'node.perf,node.perf.timerify', name: 'f' },
+    { cat: 'node.perf,node.perf.usertiming', name: 'A to B' }
+  ];
+
+  const proc = cp.fork(__filename,
+                       [
+                         'child'
+                       ], {
+                         execArgv: [
+                           '--trace-events-enabled',
+                           '--trace-event-categories',
+                           'node.perf'
+                         ]
+                       });
+
+  proc.once('exit', common.mustCall(() => {
+    const file = path.join(tmpdir.path, 'node_trace.1.log');
+
+    assert(common.fileExists(file));
+    fs.readFile(file, common.mustCall((err, data) => {
+      const traces = JSON.parse(data.toString()).traceEvents;
+      assert.strictEqual(traces.length,
+                         expectedMarks.length +
+                         expectedBegins.length +
+                         expectedEnds.length);
+
+      traces.forEach((trace) => {
+        assert.strictEqual(trace.pid, proc.pid);
+        switch (trace.ph) {
+          case 'R':
+            assert.strictEqual(trace.cat, 'node.perf,node.perf.usertiming');
+            assert.strictEqual(trace.name, expectedMarks.shift());
+            break;
+          case 'b':
+            const expectedBegin = expectedBegins.shift();
+            assert.strictEqual(trace.cat, expectedBegin.cat);
+            assert.strictEqual(trace.name, expectedBegin.name);
+            break;
+          case 'e':
+            const expectedEnd = expectedEnds.shift();
+            assert.strictEqual(trace.cat, expectedEnd.cat);
+            assert.strictEqual(trace.name, expectedEnd.name);
+            break;
+          default:
+            assert.fail('Unexpected trace event phase');
+        }
+      });
+    }));
+  }));
+}


### PR DESCRIPTION
Emit user timing marks/measures and performance.timerify() measures to trace events.

![image](https://user-images.githubusercontent.com/439929/36232973-b90d6888-1198-11e8-9141-3cd356efa5ff.png)

/cc @nodejs/diagnostics @mcollina 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
perf_hooks, trace_events