### PR TITLE
test: make tls test more rigorous

### DIFF
--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-
 const assert = require('assert');
 
 const cert = fixtures.readSync('test_cert.pem');
@@ -15,10 +14,10 @@ const key = fixtures.readSync('test_key.pem');
 // https://github.com/nodejs/node/issues/1489
 // tls.connect(options) with no options.host should accept a cert with
 //   CN:'localhost'
-tls.createServer({
+const server = tls.createServer({
   key,
   cert
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   const socket = tls.connect({
     port: this.address().port,
     ca: cert,
@@ -26,8 +25,9 @@ tls.createServer({
     // but tls.checkServerIdentity() breaks before the fix with:
     // Error: Hostname/IP doesn't match certificate's altnames:
     //   "Host: undefined. is not cert's CN: localhost"
-  }, function() {
+  }, common.mustCall(function() {
     assert(socket.authorized);
-    process.exit();
-  });
-});
+    socket.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
* exit naturally, don't use process.exit()
* ensure callbacks are actually called