### PR TITLE
doc: add fs declarations to stream doc js examples

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -378,6 +378,7 @@ Calling the [`stream.write()`][stream-write] method after calling
 
 ```js
 // write 'hello, ' and then end with 'world!'
+const fs = require('fs');
 const file = fs.createWriteStream('example.txt');
 file.write('hello, ');
 file.end('world!');
@@ -861,6 +862,7 @@ The following example pipes all of the data from the `readable` into a file
 named `file.txt`:
 
 ```js
+const fs = require('fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt'
@@ -872,6 +874,7 @@ The `readable.pipe()` method returns a reference to the *destination* stream
 making it possible to set up chains of piped streams:
 
 ```js
+const fs = require('fs');
 const r = fs.createReadStream('file.txt');
 const z = zlib.createGzip();
 const w = fs.createWriteStream('file.txt.gz');
@@ -1036,6 +1039,7 @@ If the `destination` is specified, but no pipe is set up for it, then
 the method does nothing.
 
 ```js
+const fs = require('fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
@@ -1173,6 +1177,8 @@ added: REPLACEME
 Returns an [AsyncIterator][async-iterator] to fully consume the stream.
 
 ```js
+const fs = require('fs');
+
 async function print(readable) {
   readable.setEncoding('utf8');
   let data = '';


### PR DESCRIPTION
Noticed that `const fs = require('fs');` declaration is missing in some stream doc examples. So if you copy-paste code you get:
```
ReferenceError: fs is not defined
```

[Here is a code example](https://nodejs.org/download/nightly/v10.0.0-nightly20180205d4b605b990/docs/api/stream.html#stream_readable_asynciterator)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

- **Version:** master
- **Platform:** all
- **Subsystem:** doc
