### PR TITLE
test: check symbols in shared lib

### DIFF
--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -1,5 +1,5 @@
-/* eslint-disable node-core/required-modules */
 'use strict';
+const common = require('../common');
 const path = require('path');
 
 // If node executable is linked to shared lib, need to take care about the
@@ -26,4 +26,18 @@ exports.addLibraryPath = function(env) {
   env.PATH =
     (env.PATH ? env.PATH + path.delimiter : '') +
     path.dirname(process.execPath);
+};
+
+// Get the full path of shared lib
+exports.getSharedLibPath = function() {
+  if (common.isWindows) {
+    return path.join(path.dirname(process.execPath), 'node.dll');
+  } else if (common.isOSX) {
+    return path.join(path.dirname(process.execPath),
+                     `libnode.${process.config.variables.shlib_suffix}`);
+  } else {
+    return path.join(path.dirname(process.execPath),
+                     'lib.target',
+                     `libnode.${process.config.variables.shlib_suffix}`);
+  }
 };

--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -7,7 +7,13 @@
 const common = require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
-const args = [process.execPath];
+const { getSharedLibPath } = require('../common/shared-lib-util.js');
+
+// For shared lib case, check shared lib instead
+const args = [
+  process.config.variables.node_shared ?
+    getSharedLibPath() : process.execPath
+];
 
 if (common.isAIX)
   args.unshift('-Xany', '-B');


### PR DESCRIPTION
When building the node with `--shared` option, we need
to verify the symbols in shared lib instead of executable.

Refs: https://github.com/nodejs/node/issues/18535

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test