### PR TITLE
test: add common.hasEslint

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -353,6 +353,11 @@ Path to the 'root' directory. either `/` or `c:\\` (windows)
 
 Logs '1..0 # Skipped: ' + `msg` and exits with exit code `0`.
 
+### skipIfEslintMissing()
+
+Skip the rest of the tests in the current file when `ESLint` is not available
+at `tools/node_modules/eslint`
+
 ### skipIfInspectorDisabled()
 
 Skip the rest of the tests in the current file when the Inspector

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -493,6 +493,14 @@ exports.fileExists = function(pathname) {
   }
 };
 
+exports.skipIfEslintMissing = function() {
+  if (!exports.fileExists(
+    path.join('..', '..', 'tools', 'node_modules', 'eslint')
+  )) {
+    exports.skip('missing ESLint');
+  }
+};
+
 exports.canCreateSymLink = function() {
   // On Windows, creating symlinks requires admin privileges.
   // We'll only try to run symlink test if we have enough privileges.

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/crypto-check');

--- a/test/parallel/test-eslint-lowercase-name-for-primitive.js
+++ b/test/parallel/test-eslint-lowercase-name-for-primitive.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/lowercase-name-for-primitive');

--- a/test/parallel/test-eslint-no-let-in-for-declaration.js
+++ b/test/parallel/test-eslint-no-let-in-for-declaration.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/no-let-in-for-declaration');

--- a/test/parallel/test-eslint-no-unescaped-regexp-dot.js
+++ b/test/parallel/test-eslint-no-unescaped-regexp-dot.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/no-unescaped-regexp-dot');

--- a/test/parallel/test-eslint-number-isnan.js
+++ b/test/parallel/test-eslint-number-isnan.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/number-isnan');

--- a/test/parallel/test-eslint-prefer-assert-iferror.js
+++ b/test/parallel/test-eslint-prefer-assert-iferror.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/prefer-assert-iferror');

--- a/test/parallel/test-eslint-prefer-assert-methods.js
+++ b/test/parallel/test-eslint-prefer-assert-methods.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/prefer-assert-methods');

--- a/test/parallel/test-eslint-prefer-common-expectserror.js
+++ b/test/parallel/test-eslint-prefer-common-expectserror.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/prefer-common-expectserror');

--- a/test/parallel/test-eslint-prefer-common-mustnotcall.js
+++ b/test/parallel/test-eslint-prefer-common-mustnotcall.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/prefer-common-mustnotcall');

--- a/test/parallel/test-eslint-prefer-util-format-errors.js
+++ b/test/parallel/test-eslint-prefer-util-format-errors.js
@@ -2,7 +2,9 @@
 
 /* eslint-disable no-template-curly-in-string */
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/prefer-util-format-errors');

--- a/test/parallel/test-eslint-require-buffer.js
+++ b/test/parallel/test-eslint-require-buffer.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/require-buffer');

--- a/test/parallel/test-eslint-required-modules.js
+++ b/test/parallel/test-eslint-required-modules.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/required-modules');


### PR DESCRIPTION
We've added a number of tests that hook into ESLint which can error
when running the test suite with the distributed tarball. This PR
adds a new test helper `common.hasEslint` and will skip ESLint related
tests when `ESLint` is not available at `tools/node_modules/eslint`