### PR TITLE
http2: trace events for http2

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -14,6 +14,8 @@
 namespace node {
 namespace http2 {
 
+#define NODE_HTTP2_TRACING "node.http2,node.net"
+
 using v8::Array;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -755,6 +757,7 @@ class Http2Stream : public AsyncWrap,
   int64_t fd_length_ = -1;
 
   Http2StreamListener stream_listener_;
+  bool eos_ = false;
 
   friend class Http2Session;
 };
@@ -924,10 +927,16 @@ class Http2Session : public AsyncWrap, public StreamListener {
 
   void IncrementCurrentSessionMemory(uint64_t amount) {
     current_session_memory_ += amount;
+    TRACE_COUNTER_ID1(NODE_HTTP2_TRACING, "Session Memory",
+                      static_cast<uint64_t>(get_async_id()),
+                      current_session_memory_);
   }
 
   void DecrementCurrentSessionMemory(uint64_t amount) {
     current_session_memory_ -= amount;
+    TRACE_COUNTER_ID1(NODE_HTTP2_TRACING, "Session Memory",
+                      static_cast<uint64_t>(get_async_id()),
+                      current_session_memory_);
   }
 
   // Returns the current session memory including the current size of both
@@ -980,6 +989,10 @@ class Http2Session : public AsyncWrap, public StreamListener {
   inline void HandleAltSvcFrame(const nghttp2_frame* frame);
 
   // nghttp2 callbacks
+  static inline int OnBeforeFrameSend(
+      nghttp2_session* session,
+      const nghttp2_frame* frame,
+      void* user_data);
   static inline int OnBeginHeadersCallback(
       nghttp2_session* session,
       const nghttp2_frame* frame,


### PR DESCRIPTION
This is a work in progress .

Adds a new `node.http2` trace events category intended to provide detailed tracing of http2 flow. This is a work in progress and I'm no where near done with this but want to start getting some detailed feedback before going further down this path.

![image](https://user-images.githubusercontent.com/439929/36289203-a604ebcc-1273-11e8-8bda-8dc547bf6a9d.png)

<details>
<summary>Trace example</summary>

```
{
  "traceEvents": [
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986046589,
      "tts": 199214,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xe",
      "args": {
        "type": "server",
        "session id": 14
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986048755,
      "tts": 201381,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x13",
      "args": {
        "type": "client",
        "session id": 19
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986051078,
      "tts": 203703,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "id": 1,
        "session": 19
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986053385,
      "tts": 205997,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "id": 1,
        "session": 14
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986053394,
      "tts": 206008,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986064558,
      "tts": 217146,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986065045,
      "tts": 217635,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986066160,
      "tts": 218749,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986066328,
      "tts": 218919,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986066339,
      "tts": 218931,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986067113,
      "tts": 219703,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986067341,
      "tts": 219931,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068344,
      "tts": 220919,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068433,
      "tts": 221009,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068674,
      "tts": 221250,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068718,
      "tts": 221294,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068905,
      "tts": 221482,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068950,
      "tts": 221526,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986068956,
      "tts": 221533,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986070035,
      "tts": 222610,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986073231,
      "tts": 225804,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986073655,
      "tts": 226228,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x17",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986075190,
      "tts": 227761,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x13",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986083272,
      "tts": 235375,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xe",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986083851,
      "tts": 235955,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x3f",
      "args": {
        "type": "server",
        "session id": 63
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986084411,
      "tts": 236499,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x43",
      "args": {
        "type": "client",
        "session id": 67
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986084764,
      "tts": 236851,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "id": 1,
        "session": 67
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986085375,
      "tts": 237463,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "id": 1,
        "session": 63
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986085381,
      "tts": 237469,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986085783,
      "tts": 237869,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986085859,
      "tts": 237946,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986085870,
      "tts": 237958,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086050,
      "tts": 238138,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086129,
      "tts": 238217,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086137,
      "tts": 238225,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086202,
      "tts": 238290,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086210,
      "tts": 238299,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086217,
      "tts": 238305,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086390,
      "tts": 238478,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086398,
      "tts": 238486,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086404,
      "tts": 238492,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086529,
      "tts": 238617,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086536,
      "tts": 238625,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086542,
      "tts": 238631,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086692,
      "tts": 238780,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086699,
      "tts": 238788,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086704,
      "tts": 238793,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986086799,
      "tts": 238887,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x4d",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986087150,
      "tts": 239237,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986087181,
      "tts": 239269,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x47",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986087252,
      "tts": 239340,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x43",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986088933,
      "tts": 241020,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x3f",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986089362,
      "tts": 241450,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x6d",
      "args": {
        "type": "server",
        "session id": 109
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986089552,
      "tts": 241640,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x71",
      "args": {
        "type": "client",
        "session id": 113
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986089758,
      "tts": 241846,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "id": 1,
        "session": 113
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090194,
      "tts": 242282,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "id": 1,
        "session": 109
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090202,
      "tts": 242291,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090419,
      "tts": 242507,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090453,
      "tts": 242542,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090461,
      "tts": 242549,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090594,
      "tts": 242682,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090638,
      "tts": 242726,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090644,
      "tts": 242732,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090687,
      "tts": 242775,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090712,
      "tts": 242799,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090718,
      "tts": 242807,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090854,
      "tts": 242942,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090861,
      "tts": 242949,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090867,
      "tts": 242955,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986090992,
      "tts": 243079,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091030,
      "tts": 243118,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091037,
      "tts": 243126,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091191,
      "tts": 243279,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091198,
      "tts": 243287,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091203,
      "tts": 243292,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091242,
      "tts": 243331,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x7b",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091448,
      "tts": 243536,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091478,
      "tts": 243566,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x75",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986091522,
      "tts": 243610,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x71",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986092559,
      "tts": 244647,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x6d",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986093083,
      "tts": 244980,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x9b",
      "args": {
        "type": "server",
        "session id": 155
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986093285,
      "tts": 245181,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x9f",
      "args": {
        "type": "client",
        "session id": 159
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986093448,
      "tts": 245344,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "id": 1,
        "session": 159
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986093870,
      "tts": 245767,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "id": 1,
        "session": 155
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986093875,
      "tts": 245773,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094062,
      "tts": 245958,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094088,
      "tts": 245985,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094094,
      "tts": 245992,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094277,
      "tts": 246174,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094320,
      "tts": 246217,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094326,
      "tts": 246223,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094379,
      "tts": 246276,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094387,
      "tts": 246284,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094393,
      "tts": 246290,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094546,
      "tts": 246443,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094553,
      "tts": 246451,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094559,
      "tts": 246457,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094729,
      "tts": 246626,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094739,
      "tts": 246636,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094745,
      "tts": 246642,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094897,
      "tts": 246794,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094904,
      "tts": 246802,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094909,
      "tts": 246807,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986094937,
      "tts": 246835,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xa9",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986095095,
      "tts": 246992,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986095129,
      "tts": 247026,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xa3",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986095205,
      "tts": 247102,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x9f",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986096229,
      "tts": 248126,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x9b",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986096550,
      "tts": 248447,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xc9",
      "args": {
        "type": "server",
        "session id": 201
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986096712,
      "tts": 248609,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xcd",
      "args": {
        "type": "client",
        "session id": 205
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986096914,
      "tts": 248811,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "id": 1,
        "session": 205
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097325,
      "tts": 249222,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "id": 1,
        "session": 201
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097331,
      "tts": 249229,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097625,
      "tts": 249521,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097698,
      "tts": 249595,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097707,
      "tts": 249604,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986097916,
      "tts": 249813,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098003,
      "tts": 249900,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098011,
      "tts": 249908,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098086,
      "tts": 249983,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098096,
      "tts": 249993,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098104,
      "tts": 250002,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098629,
      "tts": 250523,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098670,
      "tts": 250567,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986098814,
      "tts": 250709,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099307,
      "tts": 251203,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099320,
      "tts": 251217,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099329,
      "tts": 251226,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099621,
      "tts": 251518,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099630,
      "tts": 251527,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099635,
      "tts": 251532,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099697,
      "tts": 251594,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xd7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099953,
      "tts": 251823,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986099990,
      "tts": 251887,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xd1",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986100130,
      "tts": 252026,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xcd",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986101383,
      "tts": 253279,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xc9",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986101693,
      "tts": 253590,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xf7",
      "args": {
        "type": "server",
        "session id": 247
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986101888,
      "tts": 253785,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xfb",
      "args": {
        "type": "client",
        "session id": 251
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102079,
      "tts": 253976,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "id": 1,
        "session": 251
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102467,
      "tts": 254364,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "id": 1,
        "session": 247
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102474,
      "tts": 254371,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102669,
      "tts": 254566,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102701,
      "tts": 254598,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102860,
      "tts": 254756,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102901,
      "tts": 254798,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102907,
      "tts": 254805,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986102952,
      "tts": 254849,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103013,
      "tts": 254910,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103115,
      "tts": 255011,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103158,
      "tts": 255055,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103218,
      "tts": 255115,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103251,
      "tts": 255149,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103315,
      "tts": 255212,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103349,
      "tts": 255247,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103408,
      "tts": 255305,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103443,
      "tts": 255341,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103504,
      "tts": 255402,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103536,
      "tts": 255434,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103593,
      "tts": 255491,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103627,
      "tts": 255524,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103681,
      "tts": 255578,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103754,
      "tts": 255651,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103838,
      "tts": 255735,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103874,
      "tts": 255770,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103942,
      "tts": 255839,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986103983,
      "tts": 255880,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104134,
      "tts": 256030,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104195,
      "tts": 256092,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104271,
      "tts": 256167,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104308,
      "tts": 256205,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104371,
      "tts": 256268,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104405,
      "tts": 256302,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104465,
      "tts": 256362,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104501,
      "tts": 256398,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104560,
      "tts": 256457,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104593,
      "tts": 256490,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986104599,
      "tts": 256496,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105323,
      "tts": 257216,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105511,
      "tts": 257407,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105581,
      "tts": 257478,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105657,
      "tts": 257553,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105890,
      "tts": 257786,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986105939,
      "tts": 257835,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106014,
      "tts": 257911,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106049,
      "tts": 257946,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106119,
      "tts": 258015,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106156,
      "tts": 258053,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106229,
      "tts": 258125,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106262,
      "tts": 258159,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106322,
      "tts": 258218,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106355,
      "tts": 258252,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106411,
      "tts": 258308,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106462,
      "tts": 258359,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106518,
      "tts": 258415,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106554,
      "tts": 258451,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106610,
      "tts": 258507,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106646,
      "tts": 258543,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106746,
      "tts": 258643,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106792,
      "tts": 258689,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106855,
      "tts": 258752,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106893,
      "tts": 258790,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106950,
      "tts": 258847,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986106986,
      "tts": 258883,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107048,
      "tts": 258945,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107081,
      "tts": 258978,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107147,
      "tts": 259044,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107183,
      "tts": 259080,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107238,
      "tts": 259135,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107271,
      "tts": 259168,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107328,
      "tts": 259225,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107361,
      "tts": 259258,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107418,
      "tts": 259315,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107453,
      "tts": 259351,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107526,
      "tts": 259423,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107558,
      "tts": 259455,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107615,
      "tts": 259512,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107647,
      "tts": 259544,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107742,
      "tts": 259639,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107791,
      "tts": 259688,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107856,
      "tts": 259753,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107889,
      "tts": 259787,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107954,
      "tts": 259851,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986107987,
      "tts": 259885,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108165,
      "tts": 260047,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108211,
      "tts": 260093,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108274,
      "tts": 260156,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108311,
      "tts": 260193,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108374,
      "tts": 260256,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108410,
      "tts": 260292,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108474,
      "tts": 260357,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108507,
      "tts": 260389,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108563,
      "tts": 260445,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108599,
      "tts": 260481,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108657,
      "tts": 260540,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108725,
      "tts": 260606,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108847,
      "tts": 260728,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108885,
      "tts": 260768,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108952,
      "tts": 260834,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986108988,
      "tts": 260871,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109055,
      "tts": 260937,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109091,
      "tts": 260973,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109151,
      "tts": 261033,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109184,
      "tts": 261067,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109240,
      "tts": 261123,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109276,
      "tts": 261159,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109339,
      "tts": 261221,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109371,
      "tts": 261254,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109430,
      "tts": 261312,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109463,
      "tts": 261346,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109518,
      "tts": 261400,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109554,
      "tts": 261436,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109608,
      "tts": 261491,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109641,
      "tts": 261523,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109749,
      "tts": 261631,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109794,
      "tts": 261677,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109888,
      "tts": 261770,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986109945,
      "tts": 261827,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110011,
      "tts": 261893,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110047,
      "tts": 261930,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110105,
      "tts": 261987,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110138,
      "tts": 262020,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110201,
      "tts": 262084,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110234,
      "tts": 262116,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110292,
      "tts": 262174,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110328,
      "tts": 262210,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110389,
      "tts": 262271,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110421,
      "tts": 262303,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110481,
      "tts": 262363,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110514,
      "tts": 262396,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110567,
      "tts": 262449,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110605,
      "tts": 262487,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110664,
      "tts": 262546,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110730,
      "tts": 262612,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110813,
      "tts": 262695,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110848,
      "tts": 262730,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986110854,
      "tts": 262736,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111181,
      "tts": 263063,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111187,
      "tts": 263070,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111222,
      "tts": 263104,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x105",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111352,
      "tts": 263233,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111558,
      "tts": 263440,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111584,
      "tts": 263466,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0xff",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986111676,
      "tts": 263558,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xfb",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986112874,
      "tts": 264755,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0xf7",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986113206,
      "tts": 265088,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x160",
      "args": {
        "type": "server",
        "session id": 352
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986113348,
      "tts": 265230,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x164",
      "args": {
        "type": "client",
        "session id": 356
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986113509,
      "tts": 265391,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "id": 1,
        "session": 356
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986113926,
      "tts": 265808,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "id": 1,
        "session": 352
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986113932,
      "tts": 265815,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114183,
      "tts": 266064,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114218,
      "tts": 266100,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114362,
      "tts": 266242,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114408,
      "tts": 266291,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114414,
      "tts": 266297,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114458,
      "tts": 266340,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114524,
      "tts": 266407,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114680,
      "tts": 266561,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114733,
      "tts": 266615,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114850,
      "tts": 266732,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986114893,
      "tts": 266776,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115063,
      "tts": 266945,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115142,
      "tts": 267024,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115148,
      "tts": 267030,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115183,
      "tts": 267065,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x16e",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115387,
      "tts": 267269,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115417,
      "tts": 267299,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x168",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986115464,
      "tts": 267346,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x164",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986117061,
      "tts": 268930,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x160",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986117456,
      "tts": 269326,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x18e",
      "args": {
        "type": "server",
        "session id": 398
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986117639,
      "tts": 269508,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x192",
      "args": {
        "type": "client",
        "session id": 402
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986117821,
      "tts": 269692,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "id": 1,
        "session": 402
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118275,
      "tts": 270146,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "id": 1,
        "session": 398
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118281,
      "tts": 270152,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118473,
      "tts": 270343,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118510,
      "tts": 270380,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118516,
      "tts": 270387,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118683,
      "tts": 270553,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118732,
      "tts": 270602,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118739,
      "tts": 270610,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118789,
      "tts": 270660,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118830,
      "tts": 270701,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118919,
      "tts": 270790,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118941,
      "tts": 270812,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986118947,
      "tts": 270818,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119012,
      "tts": 270882,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119212,
      "tts": 271080,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119554,
      "tts": 271422,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119688,
      "tts": 271558,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119697,
      "tts": 271568,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119827,
      "tts": 271697,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986119992,
      "tts": 271862,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120259,
      "tts": 272128,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120336,
      "tts": 272207,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120344,
      "tts": 272215,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120472,
      "tts": 272342,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120479,
      "tts": 272350,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120527,
      "tts": 272398,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x19c",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120760,
      "tts": 272630,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986120987,
      "tts": 272857,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986121031,
      "tts": 272901,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x196",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986121164,
      "tts": 273034,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x192",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986122760,
      "tts": 274629,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x18e",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986123217,
      "tts": 275087,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1bf",
      "args": {
        "type": "server",
        "session id": 447
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986123442,
      "tts": 275312,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c3",
      "args": {
        "type": "client",
        "session id": 451
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986123770,
      "tts": 275640,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "id": 1,
        "session": 451
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986124552,
      "tts": 276399,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "id": 1,
        "session": 447
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986124559,
      "tts": 276410,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125010,
      "tts": 276859,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125052,
      "tts": 276902,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125060,
      "tts": 276911,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125420,
      "tts": 277269,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125510,
      "tts": 277360,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125519,
      "tts": 277369,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125603,
      "tts": 277453,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125647,
      "tts": 277465,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125658,
      "tts": 277508,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125907,
      "tts": 277757,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125919,
      "tts": 277769,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986125928,
      "tts": 277778,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126142,
      "tts": 277991,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126152,
      "tts": 278002,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126161,
      "tts": 278011,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126380,
      "tts": 278229,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126391,
      "tts": 278241,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126397,
      "tts": 278248,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126446,
      "tts": 278296,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1cd",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126791,
      "tts": 278641,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126835,
      "tts": 278685,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c7",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986126903,
      "tts": 278753,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1c3",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986128403,
      "tts": 280224,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1bf",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986128855,
      "tts": 280677,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1ed",
      "args": {
        "type": "server",
        "session id": 493
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986129063,
      "tts": 280885,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f1",
      "args": {
        "type": "client",
        "session id": 497
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986129635,
      "tts": 281456,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "id": 1,
        "session": 497
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986130602,
      "tts": 282422,
      "ph": "b",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "id": 1,
        "session": 493
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986130610,
      "tts": 282432,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136437,
      "tts": 288256,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136498,
      "tts": 288320,
      "ph": "b",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "provider": "stream"
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136504,
      "tts": 288327,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136717,
      "tts": 288539,
      "ph": "b",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136823,
      "tts": 288644,
      "ph": "e",
      "cat": "node.http2",
      "name": "Headers",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136833,
      "tts": 288655,
      "ph": "b",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136985,
      "tts": 288806,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986136995,
      "tts": 288817,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137001,
      "tts": 288824,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137463,
      "tts": 289284,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137475,
      "tts": 289298,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137487,
      "tts": 289309,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137914,
      "tts": 289735,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137924,
      "tts": 289746,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986137930,
      "tts": 289753,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138086,
      "tts": 289908,
      "ph": "n",
      "cat": "node.http2",
      "name": "Receive DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138093,
      "tts": 289916,
      "ph": "n",
      "cat": "node.http2",
      "name": "Send DATA Frame",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {
        "stream id": 1
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138098,
      "tts": 289921,
      "ph": "e",
      "cat": "node.http2",
      "name": "Send Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138135,
      "tts": 289957,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1fb",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138389,
      "tts": 290210,
      "ph": "e",
      "cat": "node.http2",
      "name": "Receive Data",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138488,
      "tts": 290309,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Stream",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f5",
      "args": {}
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986138552,
      "tts": 290374,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1f1",
      "args": {
        "code": 0
      }
    },
    {
      "pid": 134326,
      "tid": 134326,
      "ts": 77986139018,
      "tts": 290840,
      "ph": "e",
      "cat": "node.http2",
      "name": "Http2Session",
      "dur": 0,
      "tdur": 0,
      "id": "0x1ed",
      "args": {
        "code": 0
      }
    }
  ]
}
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
