### PR TITLE
test: fix warnings in addon tests

### DIFF
--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -15,6 +15,7 @@ struct async_req {
   int output;
   v8::Isolate* isolate;
   v8::Persistent<v8::Function> callback;
+  node::async_context context;
 };
 
 void DoAsync(uv_work_t* r) {
@@ -47,7 +48,8 @@ void AfterAsync(uv_work_t* r) {
 
   if (use_makecallback) {
     v8::Local<v8::Value> ret =
-        node::MakeCallback(isolate, global, callback, 2, argv);
+        node::MakeCallback(isolate, global, callback, 2, argv, req->context)
+            .ToLocalChecked();
     // This should be changed to an empty handle.
     assert(!ret.IsEmpty());
   } else {
@@ -55,6 +57,7 @@ void AfterAsync(uv_work_t* r) {
   }
 
   // cleanup
+  node::EmitAsyncDestroy(isolate, req->context);
   req->callback.Reset();
   delete req;
 
@@ -73,6 +76,7 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   req->input = args[0]->IntegerValue();
   req->output = 0;
   req->isolate = isolate;
+  req->context = node::EmitAsyncInit(isolate, v8::Object::New(isolate), "test");
 
   v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[1]);
   req->callback.Reset(isolate, callback);

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -36,7 +36,8 @@ static v8::Persistent<v8::Promise::Resolver> persistent;
 static void Callback(uv_work_t* req, int ignored) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope scope(isolate);
-  node::CallbackScope callback_scope(isolate, v8::Object::New(isolate), {0, 0});
+  node::CallbackScope callback_scope(isolate, v8::Object::New(isolate),
+                                     node::async_context{0, 0});
 
   v8::Local<v8::Promise::Resolver> local =
       v8::Local<v8::Promise::Resolver>::New(isolate, persistent);

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -19,7 +19,8 @@ void MakeCallback(const FunctionCallbackInfo<Value>& args) {
   Local<Object> recv = args[0].As<Object>();
   Local<Function> method = args[1].As<Function>();
 
-  node::MakeCallback(isolate, recv, method, 0, nullptr);
+  node::MakeCallback(isolate, recv, method, 0, nullptr,
+                     node::async_context{0, 0});
 }
 
 void Initialize(Local<Object> exports) {

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -19,11 +19,13 @@ void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   if (args[1]->IsFunction()) {
     auto method = args[1].As<v8::Function>();
     result =
-        node::MakeCallback(isolate, recv, method, argv.size(), argv.data());
+        node::MakeCallback(isolate, recv, method, argv.size(), argv.data(),
+                           node::async_context{0, 0}).ToLocalChecked();
   } else if (args[1]->IsString()) {
     auto method = args[1].As<v8::String>();
     result =
-        node::MakeCallback(isolate, recv, method, argv.size(), argv.data());
+        node::MakeCallback(isolate, recv, method, argv.size(), argv.data(),
+                           node::async_context{0, 0}).ToLocalChecked();
   } else {
     assert(0 && "unreachable");
   }

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -36,11 +36,10 @@ void Method(const FunctionCallbackInfo<Value>& args) {
     Boolean::New(isolate, true),
     Boolean::New(isolate, false)
   };
-  Local<Value> ret = node::MakeCallback(isolate,
-                                        isolate->GetCurrentContext()->Global(),
-                                        args[0].As<Function>(),
-                                        2,
-                                        params);
+  Local<Value> ret =
+      node::MakeCallback(isolate, isolate->GetCurrentContext()->Global(),
+                         args[0].As<Function>(), 2, params,
+                         node::async_context{0, 0}).ToLocalChecked();
   assert(ret->IsTrue());
 }
 


### PR DESCRIPTION
The legacy MakeCallback deprecation was resulting in compile time
warnings in adddon tests. Fix them.

Ref: https://github.com/nodejs/node/pull/18632

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

CI: https://ci.nodejs.org/job/node-test-pull-request/13190/