### PR TITLE
src: replace var for (let|const) in utilities module

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -47,7 +47,7 @@ function deprecate(fn, msg, code) {
   if (code !== undefined && typeof code !== 'string')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'string');
 
-  var warned = false;
+  let warned = false;
   function deprecated(...args) {
     if (!warned) {
       warned = true;
@@ -103,7 +103,7 @@ function assertCrypto() {
 // Return undefined if there is no match.
 function normalizeEncoding(enc) {
   if (!enc) return 'utf8';
-  var retried;
+  let retried;
   while (true) {
     switch (enc) {
       case 'utf8':
@@ -152,7 +152,7 @@ function filterDuplicateStrings(items, low) {
 }
 
 function cachedResult(fn) {
-  var result;
+  let result;
   return () => {
     if (result === undefined)
       result = fn();
@@ -207,7 +207,7 @@ function convertToValidSignal(signal) {
 
 function getConstructorOf(obj) {
   while (obj) {
-    var descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
+    const descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
         typeof descriptor.value === 'function' &&
         descriptor.value.name !== '') {
@@ -323,7 +323,7 @@ promisify.custom = kCustomPromisifiedSymbol;
 
 // The build-in Array#join is slower in v8 6.0
 function join(output, separator) {
-  var str = '';
+  let str = '';
   if (output.length !== 0) {
     for (var i = 0; i < output.length - 1; i++) {
       // It is faster not to use a template string here

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,7 +79,7 @@ const regExpToString = RegExp.prototype.toString;
 const dateToISOString = Date.prototype.toISOString;
 const errorToString = Error.prototype.toString;
 
-var CIRCULAR_ERROR_MESSAGE;
+let CIRCULAR_ERROR_MESSAGE;
 
 /* eslint-disable */
 const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c]/;
@@ -119,8 +119,8 @@ function strEscape(str) {
     return `'${str}'`;
   if (str.length > 100)
     return `'${str.replace(strEscapeSequencesReplacer, escapeFn)}'`;
-  var result = '';
-  var last = 0;
+  let result = '';
+  let last = 0;
   for (var i = 0; i < str.length; i++) {
     const point = str.charCodeAt(i);
     if (point === 39 || point === 92 || point < 32) {
@@ -159,10 +159,10 @@ function tryStringify(arg) {
 }
 
 function format(f) {
-  var i, tempStr;
+  let i, tempStr;
   if (typeof f !== 'string') {
     if (arguments.length === 0) return '';
-    var res = '';
+    let res = '';
     for (i = 0; i < arguments.length - 1; i++) {
       res += inspect(arguments[i]);
       res += ' ';
@@ -173,9 +173,9 @@ function format(f) {
 
   if (arguments.length === 1) return f;
 
-  var str = '';
-  var a = 1;
-  var lastPos = 0;
+  let str = '';
+  let a = 1;
+  let lastPos = 0;
   for (i = 0; i < f.length - 1; i++) {
     if (f.charCodeAt(i) === 37) { // '%'
       const nextChar = f.charCodeAt(++i);
@@ -250,9 +250,9 @@ function debuglog(set) {
   set = set.toUpperCase();
   if (!debugs[set]) {
     if (debugEnvRegex.test(set)) {
-      var pid = process.pid;
+      const pid = process.pid;
       debugs[set] = function() {
-        var msg = exports.format.apply(exports, arguments);
+        const msg = exports.format.apply(exports, arguments);
         console.error('%s %d: %s', set, pid, msg);
       };
     } else {
@@ -426,8 +426,8 @@ function formatValue(ctx, value, recurseTimes, ln) {
     }
   }
 
-  var keys;
-  var symbols = Object.getOwnPropertySymbols(value);
+  let keys;
+  let symbols = Object.getOwnPropertySymbols(value);
 
   // Look up the keys of the object.
   if (ctx.showHidden) {
@@ -441,7 +441,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
   const keyLength = keys.length + symbols.length;
 
   const { constructor, tag } = getIdentificationOf(value);
-  var prefix = '';
+  let prefix = '';
   if (constructor && tag && constructor !== tag)
     prefix = `${constructor} [${tag}] `;
   else if (constructor)
@@ -449,11 +449,11 @@ function formatValue(ctx, value, recurseTimes, ln) {
   else if (tag)
     prefix = `[${tag}] `;
 
-  var base = '';
-  var formatter = formatObject;
-  var braces;
-  var noIterator = true;
-  var raw;
+  let base = '';
+  let formatter = formatObject;
+  let braces;
+  let noIterator = true;
+  let raw;
 
   // Iterators and the rest are split to reduce checks
   if (value[Symbol.iterator]) {
@@ -623,7 +623,7 @@ function formatPrimitive(fn, value, ctx) {
       // eslint-disable-next-line max-len
       const averageLineLength = Math.ceil(value.length / Math.ceil(value.length / minLineLength));
       const divisor = Math.max(averageLineLength, MIN_LINE_LENGTH);
-      var res = '';
+      let res = '';
       if (readableRegExps[divisor] === undefined) {
         // Build a new RegExp that naturally breaks text into multiple lines.
         //
@@ -678,8 +678,8 @@ function formatObject(ctx, value, recurseTimes, keys) {
 function formatSpecialArray(ctx, value, recurseTimes, keys, maxLength, valLen) {
   const output = [];
   const keyLen = keys.length;
-  var visibleLength = 0;
-  var i = 0;
+  let visibleLength = 0;
+  let i = 0;
   if (keyLen !== 0 && numberRegExp.test(keys[0])) {
     for (const key of keys) {
       if (visibleLength === maxLength)
@@ -728,7 +728,7 @@ function formatSpecialArray(ctx, value, recurseTimes, keys, maxLength, valLen) {
   } else if (keys[keyLen - 1] !== `${valLen - 1}`) {
     const extra = [];
     // Only handle special keys
-    var key;
+    let key;
     for (i = keys.length - 1; i >= 0; i--) {
       key = keys[i];
       if (numberRegExp.test(key) && +key < 2 ** 32 - 1)
@@ -792,7 +792,7 @@ function formatTypedArray(ctx, value, recurseTimes, keys) {
 
 function formatSet(ctx, value, recurseTimes, keys) {
   const output = new Array(value.size + keys.length + (ctx.showHidden ? 1 : 0));
-  var i = 0;
+  let i = 0;
   for (const v of value)
     output[i++] = formatValue(ctx, v, recurseTimes);
   // With `showHidden`, `length` will display as a hidden property for
@@ -808,7 +808,7 @@ function formatSet(ctx, value, recurseTimes, keys) {
 
 function formatMap(ctx, value, recurseTimes, keys) {
   const output = new Array(value.size + keys.length + (ctx.showHidden ? 1 : 0));
-  var i = 0;
+  let i = 0;
   for (const [k, v] of value)
     output[i++] = `${formatValue(ctx, k, recurseTimes)} => ` +
       formatValue(ctx, v, recurseTimes);
@@ -823,9 +823,9 @@ function formatMap(ctx, value, recurseTimes, keys) {
 
 function formatCollectionIterator(preview, ctx, value, recurseTimes,
                                   visibleKeys, keys) {
-  var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
-  var vals = preview(value, 100);
-  var output = [];
+  const nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+  const vals = preview(value, 100);
+  const output = [];
   for (const o of vals) {
     output.push(formatValue(ctx, o, nextRecurseTimes));
   }
@@ -843,7 +843,7 @@ function formatSetIterator(ctx, value, recurseTimes, visibleKeys, keys) {
 }
 
 function formatPromise(ctx, value, recurseTimes, keys) {
-  var output;
+  let output;
   const [state, result] = getPromiseDetails(value);
   if (state === kPending) {
     output = ['<pending>'];
@@ -858,7 +858,7 @@ function formatPromise(ctx, value, recurseTimes, keys) {
 }
 
 function formatProperty(ctx, value, recurseTimes, key, array) {
-  var name, str;
+  let name, str;
   const desc = Object.getOwnPropertyDescriptor(value, key) ||
     { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
@@ -895,10 +895,10 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
 
 function reduceToSingleString(ctx, output, base, braces, addLn) {
   const breakLength = ctx.breakLength;
-  var i = 0;
+  let i = 0;
   if (ctx.compact === false) {
     const indentation = ' '.repeat(ctx.indentationLvl);
-    var res = `${base ? `${base} ` : ''}${braces[0]}\n${indentation}  `;
+    let res = `${base ? `${base} ` : ''}${braces[0]}\n${indentation}  `;
     for (; i < output.length - 1; i++) {
       res += `${output[i]},\n${indentation}  `;
     }
@@ -906,7 +906,7 @@ function reduceToSingleString(ctx, output, base, braces, addLn) {
     return res;
   }
   if (output.length * 2 <= breakLength) {
-    var length = 0;
+    let length = 0;
     for (; i < output.length && length <= breakLength; i++) {
       if (ctx.colors) {
         length += removeColors(output[i]).length + 1;
@@ -979,10 +979,10 @@ const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
 
 // 26 Feb 16:19:34
 function timestamp() {
-  var d = new Date();
-  var time = [pad(d.getHours()),
-              pad(d.getMinutes()),
-              pad(d.getSeconds())].join(':');
+  const d = new Date();
+  const time = [pad(d.getHours()),
+                pad(d.getMinutes()),
+                pad(d.getSeconds())].join(':');
   return [d.getDate(), months[d.getMonth()], time].join(' ');
 }
 
@@ -1026,8 +1026,8 @@ function _extend(target, source) {
   // Don't do anything if source isn't an object
   if (source === null || typeof source !== 'object') return target;
 
-  var keys = Object.keys(source);
-  var i = keys.length;
+  const keys = Object.keys(source);
+  let i = keys.length;
   while (i--) {
     target[keys[i]] = source[keys[i]];
   }


### PR DESCRIPTION
Update Utilities module to replace var for let or const depending on the case.



##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
utils
