### PR TITLE
src: add nullptr check for session in DEBUG macro

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -39,16 +39,20 @@ void inline debug_vfprintf(const char* format, ...) {
 #define DEBUG_HTTP2(...) debug_vfprintf(__VA_ARGS__);
 #define DEBUG_HTTP2SESSION(session, message)                                  \
   do {                                                                        \
-    DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                      \
-                   session->TypeName(),                                       \
-                   session->get_async_id());                                  \
+    if (session != nullptr) {                                                 \
+      DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                    \
+                  session->TypeName(),                                        \
+                  session->get_async_id());                                   \
+     }                                                                        \
   } while (0)
 #define DEBUG_HTTP2SESSION2(session, message, ...)                            \
   do {                                                                        \
-    DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                      \
-                   session->TypeName(),                                       \
-                   session->get_async_id(),                                   \
+    if (session != nullptr) {                                                 \
+      DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                    \
+                  session->TypeName(),                                        \
+                  session->get_async_id(),                                    \
                   __VA_ARGS__);                                               \
+    }                                                                         \
   } while (0)
 #define DEBUG_HTTP2STREAM(stream, message)                                    \
   do {                                                                        \


### PR DESCRIPTION
Currenlty when configuring `--debug-http2`
`test/parallel/test-http2-getpackedsettings.js` will segment fault:
```console
$ out/Debug/node test/parallel/test-http2-getpackedsettings.js
Segmentation fault: 11
```
This is happening because the settings is created with the Environment in
`PackSettings`:
```c++
Http2Session::Http2Settings settings(env);
```
This will cause the session to be set to nullptr. When the init
function is later called the expanded `DEBUG_HTTP2SESSION` macro will
cause the segment fault when the session is dereferenced.

I'm not sure about what the proper solution is here as I'm not very
familiar with the http2 code yet. Creating this so that others can
provide some feedback.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, http2