### PR TITLE
test: refactor stream-*-constructor-set-methods

### DIFF
--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,19 +1,19 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
-const Transform = require('stream').Transform;
+const { strictEqual } = require('assert');
+const { Transform } = require('stream');
 
-const _transform = common.mustCall(function _transform(d, e, n) {
-  n();
+const _transform = common.mustCall((chunk, _, next) => {
+  next();
 });
 
-const _final = common.mustCall(function _final(n) {
-  n();
+const _final = common.mustCall((next) => {
+  next();
 });
 
-const _flush = common.mustCall(function _flush(n) {
-  n();
+const _flush = common.mustCall((next) => {
+  next();
 });
 
 const t = new Transform({
@@ -22,10 +22,14 @@ const t = new Transform({
   final: _final
 });
 
-const t2 = new Transform({});
+strictEqual(t._transform, _transform);
+strictEqual(t._flush, _flush);
+strictEqual(t._final, _final);
 
 t.end(Buffer.from('blerg'));
 t.resume();
+
+const t2 = new Transform({});
 
 common.expectsError(() => {
   t2.end(Buffer.from('blerg'));
@@ -33,10 +37,4 @@ common.expectsError(() => {
   type: Error,
   code: 'ERR_METHOD_NOT_IMPLEMENTED',
   message: 'The _transform method is not implemented'
-});
-
-process.on('exit', () => {
-  assert.strictEqual(t._transform, _transform);
-  assert.strictEqual(t._flush, _flush);
-  assert.strictEqual(t._final, _final);
 });

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,30 +1,30 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
-const Writable = require('stream').Writable;
+const { strictEqual } = require('assert');
+const { Writable } = require('stream');
 
-let _writeCalled = false;
-function _write(d, e, n) {
-  _writeCalled = true;
-}
+const _write = common.mustCall((chunk, _, next) => {
+  next();
+});
 
-const w = new Writable({ write: _write });
-w.end(Buffer.from('blerg'));
+const _writev = common.mustCall((chunks, next) => {
+  strictEqual(chunks.length, 2);
+  next();
+});
 
-let _writevCalled = false;
-let dLength = 0;
-function _writev(d, n) {
-  dLength = d.length;
-  _writevCalled = true;
-}
+const w = new Writable({ write: _write, writev: _writev });
 
-const w2 = new Writable({ writev: _writev });
-w2.cork();
+strictEqual(w._write, _write);
+strictEqual(w._writev, _writev);
 
-w2.write(Buffer.from('blerg'));
-w2.write(Buffer.from('blerg'));
-w2.end();
+w.write(Buffer.from('blerg'));
+
+w.cork();
+w.write(Buffer.from('blerg'));
+w.write(Buffer.from('blerg'));
+
+w.end();
 
 const w3 = new Writable();
 
@@ -35,11 +35,3 @@ w3.on('error', common.expectsError({
 }));
 
 w3.end(Buffer.from('blerg'));
-
-process.on('exit', function() {
-  assert.strictEqual(w._write, _write);
-  assert(_writeCalled);
-  assert.strictEqual(w2._writev, _writev);
-  assert.strictEqual(dLength, 2);
-  assert(_writevCalled);
-});

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -26,12 +26,12 @@ w.write(Buffer.from('blerg'));
 
 w.end();
 
-const w3 = new Writable();
+const w2 = new Writable();
 
-w3.on('error', common.expectsError({
+w2.on('error', common.expectsError({
   type: Error,
   code: 'ERR_METHOD_NOT_IMPLEMENTED',
   message: 'The _write method is not implemented'
 }));
 
-w3.end(Buffer.from('blerg'));
+w2.end(Buffer.from('blerg'));


### PR DESCRIPTION
- Use `common.mustCall()` to ensure that callbacks are called.
- Remove no longer needed variables.
- Remove unnecessary `process.on('exit')` usage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test