### PR TITLE
timers: add helper fn for async init

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -24,6 +24,7 @@ module.exports = {
   async_id_symbol,
   trigger_async_id_symbol,
   Timeout,
+  initAsyncResource,
   refreshFnSymbol,
   setUnrefTimeout,
   validateTimerDuration
@@ -35,6 +36,14 @@ function getTimers() {
     timers = require('timers');
   }
   return timers;
+}
+
+function initAsyncResource(resource, type = 'Timeout') {
+  const asyncId = resource[async_id_symbol] = newAsyncId();
+  const triggerAsyncId =
+    resource[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
+  if (initHooksExist())
+    emitInit(asyncId, type, triggerAsyncId, resource);
 }
 
 // Timer constructor function.
@@ -66,14 +75,7 @@ function Timeout(callback, after, args, isRepeat, isUnrefed) {
 
   this[unrefedSymbol] = isUnrefed;
 
-  this[async_id_symbol] = newAsyncId();
-  this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
-  if (initHooksExist()) {
-    emitInit(this[async_id_symbol],
-             'Timeout',
-             this[trigger_async_id_symbol],
-             this);
-  }
+  initAsyncResource(this);
 }
 
 Timeout.prototype[refreshFnSymbol] = function refresh() {

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -38,7 +38,7 @@ function getTimers() {
   return timers;
 }
 
-function initAsyncResource(resource, type = 'Timeout') {
+function initAsyncResource(resource, type) {
   const asyncId = resource[async_id_symbol] = newAsyncId();
   const triggerAsyncId =
     resource[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
@@ -75,7 +75,7 @@ function Timeout(callback, after, args, isRepeat, isUnrefed) {
 
   this[unrefedSymbol] = isUnrefed;
 
-  initAsyncResource(this);
+  initAsyncResource(this, 'Timeout');
 }
 
 Timeout.prototype[refreshFnSymbol] = function refresh() {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -30,6 +30,7 @@ const {
   async_id_symbol,
   trigger_async_id_symbol,
   Timeout,
+  initAsyncResource,
   validateTimerDuration
 } = require('internal/timers');
 const internalUtil = require('internal/util');
@@ -39,12 +40,8 @@ const util = require('util');
 const errors = require('internal/errors');
 const debug = util.debuglog('timer');
 const {
-  getDefaultTriggerAsyncId,
-  newAsyncId,
-  initHooksExist,
   destroyHooksExist,
   // The needed emit*() functions.
-  emitInit,
   emitBefore,
   emitAfter,
   emitDestroy
@@ -188,14 +185,7 @@ function insert(item, unrefed, start) {
 
   if (!item[async_id_symbol] || item._destroyed) {
     item._destroyed = false;
-    item[async_id_symbol] = newAsyncId();
-    item[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
-    if (initHooksExist()) {
-      emitInit(item[async_id_symbol],
-               'Timeout',
-               item[trigger_async_id_symbol],
-               item);
-    }
+    initAsyncResource(item);
   }
 
   L.append(list, item);
@@ -720,14 +710,7 @@ const Immediate = class Immediate {
     this._destroyed = false;
     this[kRefed] = false;
 
-    this[async_id_symbol] = newAsyncId();
-    this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
-    if (initHooksExist()) {
-      emitInit(this[async_id_symbol],
-               'Immediate',
-               this[trigger_async_id_symbol],
-               this);
-    }
+    initAsyncResource(this, 'Immediate');
 
     this.ref();
     immediateInfo[kCount]++;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -185,7 +185,7 @@ function insert(item, unrefed, start) {
 
   if (!item[async_id_symbol] || item._destroyed) {
     item._destroyed = false;
-    initAsyncResource(item);
+    initAsyncResource(item, 'Timeout');
   }
 
   L.append(list, item);


### PR DESCRIPTION
There are currently 3 places in Timers where this exact same code appears. Instead create a helper function that does the same job.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers