### PR TITLE
[WIP] process: add process.[start|stop]TracingAgent()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -194,6 +194,7 @@ static node_module* modlist_builtin;
 static node_module* modlist_internal;
 static node_module* modlist_linked;
 static node_module* modlist_addon;
+static bool trace_forced = false;
 static bool trace_enabled = false;
 static std::string trace_enabled_categories;  // NOLINT(runtime/string)
 static bool abort_on_uncaught_exception = false;
@@ -331,6 +332,16 @@ static struct {
     tracing_agent_->Stop();
   }
 
+  void SetTracingAgent(tracing::Agent* agent) {
+    if (agent) {
+      tracing_agent_.reset(agent);
+      platform_->SetTracingController(agent->GetTracingController());
+    } else {
+      tracing_agent_.reset(nullptr);
+      platform_->SetTracingController(nullptr);
+    }
+  }
+
   NodePlatform* Platform() {
     return platform_;
   }
@@ -353,6 +364,7 @@ static struct {
                     "so event tracing is not available.\n");
   }
   void StopTracingAgent() {}
+  void SetTracingAgent(tracing::Agent* agent) {}
 
   NodePlatform* Platform() {
     return nullptr;
@@ -1996,6 +2008,35 @@ static void Exit(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+static void StartTracingAgent(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  if (!trace_enabled) {
+    if (args[0]->IsString()) {
+      Utf8Value categories(env->isolate(), args[0]);
+      trace_enabled_categories = *categories;
+    }
+    trace_enabled = true;
+    tracing::Agent* agent = new tracing::Agent();
+    v8_platform.SetTracingAgent(agent);
+    tracing::TraceEventHelper::SetTracingController(
+      agent->GetTracingController());
+    v8_platform.StartTracingAgent();
+    return args.GetReturnValue().Set(true);
+  }
+  args.GetReturnValue().Set(false);
+}
+
+static void StopTracingAgent(const FunctionCallbackInfo<Value>& args) {
+  if (trace_enabled && !trace_forced) {
+    v8_platform.StopTracingAgent();
+    v8_platform.SetTracingAgent(nullptr);
+    tracing::TraceEventHelper::SetTracingController(nullptr);
+    trace_enabled = false;
+    return args.GetReturnValue().Set(true);
+  }
+  args.GetReturnValue().Set(false);
+}
+
 static void Uptime(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   double uptime;
@@ -3234,6 +3275,9 @@ void SetupProcessObject(Environment* env,
   env->SetMethod(process, "uptime", Uptime);
   env->SetMethod(process, "memoryUsage", MemoryUsage);
 
+  env->SetMethod(process, "startTracingAgent", StartTracingAgent);
+  env->SetMethod(process, "stopTracingAgent", StopTracingAgent);
+
   env->SetMethod(process, "binding", Binding);
   env->SetMethod(process, "_linkedBinding", LinkedBinding);
   env->SetMethod(process, "_internalBinding", InternalBinding);
@@ -3667,6 +3711,7 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--no-force-async-hooks-checks") == 0) {
       no_force_async_hooks_checks = true;
     } else if (strcmp(arg, "--trace-events-enabled") == 0) {
+      trace_forced = true;
       trace_enabled = true;
     } else if (strcmp(arg, "--trace-event-categories") == 0) {
       const char* categories = argv[index + 1];

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -114,12 +114,7 @@ int PerIsolatePlatformData::unref() {
 
 NodePlatform::NodePlatform(int thread_pool_size,
                            TracingController* tracing_controller) {
-  if (tracing_controller) {
-    tracing_controller_.reset(tracing_controller);
-  } else {
-    TracingController* controller = new TracingController();
-    tracing_controller_.reset(controller);
-  }
+  SetTracingController(tracing_controller);
   background_task_runner_ =
       std::make_shared<BackgroundTaskRunner>(thread_pool_size);
 }
@@ -285,6 +280,14 @@ double NodePlatform::CurrentClockTimeMillis() {
 
 TracingController* NodePlatform::GetTracingController() {
   return tracing_controller_.get();
+}
+
+void NodePlatform::SetTracingController(v8::TracingController* controller) {
+  if (controller) {
+    tracing_controller_.reset(controller);
+  } else {
+    tracing_controller_.reset(new TracingController());
+  }
 }
 
 template <class T>

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -129,6 +129,7 @@ class NodePlatform : public MultiIsolatePlatform {
   double MonotonicallyIncreasingTime() override;
   double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
+  void SetTracingController(v8::TracingController* controller);
 
   void FlushForegroundTasks(v8::Isolate* isolate);
 


### PR DESCRIPTION
**Work in progress. Do not land. Not ready for CI**

Ping @nodejs/diagnostics ...

One of the identified limitations of the v8 trace event support is that it is not currently possible to enable it at runtime. This PR is an attempt to start working towards enabling that capability. 

So far it's pretty simple:

```js
process.startTracingAgent('list,of,categories'); // returns true if agent was started as a result of this call, false otherwise

process.stopTracingAgent(); // returns true if agent was stopped, false otherwise
```

If the `--trace-events--enabled` command-line flag is used, then both of these are non-ops that will return `false`. 

There are several key questions:

1. Is it *safe* to allow starting and stopping of the tracing agent dynamically like this? Note that starting will cause the existing `node_trace.1.log` to be overwritten each time, just like starting a new trace. We should be able to allow better handling of that once https://github.com/nodejs/node/pull/18480 lands.

2. Is this the way that we *should* allow the tracing to be enabled/disabled dynamically at runtime? Is there an alternative that would work better?

3. There's currently no indication at the JS layer that tracing is enabled or disabled. Does there need to be and what form should that take (simple `process.traceEnabled` flag, perhaps?)

4. Is this barking up the wrong tree entirely? If so, what alternate route should we take?

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
process, trace_events