### PR TITLE
process: make getActive{Handles,Requests} official

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1041,6 +1041,33 @@ a code.
 Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
 previous setting of `process.exitCode`.
 
+## process.getActiveHandles()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array}
+
+Returns an array containing all handles that are preventing the Node.js process
+from exiting.
+
+```js
+console.log(`Active handles: ${util.inspect(process.getActiveHandles())}`);
+```
+
+## process.getActiveRequests()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array}
+
+Returns an array containing all requests that are preventing the Node.js process
+from exiting.
+
+```js
+console.log(`Active requests: ${util.inspect(process.getActiveRequests())}`);
+```
 
 ## process.getegid()
 <!-- YAML

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -298,6 +298,8 @@
 
   function setupProcessObject() {
     process._setupProcessObject(pushValueToArray);
+    process._getActiveHandles = process.getActiveHandles;
+    process._getActiveRequests = process.getActiveRequests;
 
     function pushValueToArray() {
       for (var i = 0; i < arguments.length; i++)

--- a/src/node.cc
+++ b/src/node.cc
@@ -3195,8 +3195,8 @@ void SetupProcessObject(Environment* env,
   env->SetMethod(process,
                  "_stopProfilerIdleNotifier",
                  StopProfilerIdleNotifier);
-  env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
-  env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
+  env->SetMethod(process, "getActiveRequests", GetActiveRequests);
+  env->SetMethod(process, "getActiveHandles", GetActiveHandles);
   env->SetMethod(process, "reallyExit", Exit);
   env->SetMethod(process, "abort", Abort);
   env->SetMethod(process, "chdir", Chdir);

--- a/test/parallel/test-process-getactivehandles.js
+++ b/test/parallel/test-process-getactivehandles.js
@@ -30,7 +30,7 @@ function clientConnected(client) {
 
 
 function checkAll() {
-  const handles = process._getActiveHandles();
+  const handles = process.getActiveHandles();
 
   clients.forEach(function(item) {
     assert.ok(handles.includes(item));

--- a/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
+++ b/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
@@ -65,6 +65,6 @@ const handle1 = setTimeout(common.mustCall(function() {
 }), TIMEOUT);
 
 function getActiveTimers() {
-  const activeHandles = process._getActiveHandles();
+  const activeHandles = process.getActiveHandles();
   return activeHandles.filter((handle) => handle instanceof Timer);
 }

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -12,7 +12,7 @@ handle.readStart();
 handle.onread = () => {};
 
 function isHandleActive(handle) {
-  return process._getActiveHandles().some((active) => active === handle);
+  return process.getActiveHandles().some((active) => active === handle);
 }
 
 strictEqual(isHandleActive(handle), true, 'TTY handle not initially active');

--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -51,8 +51,8 @@ function pummel() {
 
 function check() {
   setTimeout(function() {
-    assert.strictEqual(process._getActiveRequests().length, 0);
-    assert.strictEqual(process._getActiveHandles().length, 1); // the timer
+    assert.strictEqual(process.getActiveRequests().length, 0);
+    assert.strictEqual(process.getActiveHandles().length, 1); // the timer
     check_called = true;
   }, 0);
 }


### PR DESCRIPTION
`process._getActiveHandles()` and `process._getActiveRequests()` have been around for a long time, and are utilized to a large enough degree that it makes sense to make them official
APIs.

If this PR is accepted, I'll submit a follow up that deprecates the underscore prefixed versions.

Fixes: https://github.com/nodejs/node/issues/1128

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
process