### PR TITLE
test: http2 client operations after destroy

### DIFF
--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -59,7 +59,6 @@ const Countdown = require('../common/countdown');
       assert(socket.destroyed);
     }));
 
-
     const req = client.request();
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_CANCEL',
@@ -77,15 +76,21 @@ const Countdown = require('../common/countdown');
       message: 'The session has been destroyed'
     };
 
-    common.expectsError(() => client.request(), sessionError);
+    common.expectsError(() => client.setNextStreamID(), sessionError);
+    common.expectsError(() => client.ping(), sessionError);
     common.expectsError(() => client.settings({}), sessionError);
+    common.expectsError(() => client.goaway(), sessionError);
+    common.expectsError(() => client.request(), sessionError);
     client.close();  // should be a non-op at this point
 
     // Wait for setImmediate call from destroy() to complete
     // so that state.destroyed is set to true
     setImmediate(() => {
-      common.expectsError(() => client.request(), sessionError);
+      common.expectsError(() => client.setNextStreamID(), sessionError);
+      common.expectsError(() => client.ping(), sessionError);
       common.expectsError(() => client.settings({}), sessionError);
+      common.expectsError(() => client.goaway(), sessionError);
+      common.expectsError(() => client.request(), sessionError);
       client.close();  // should be a non-op at this point
     });
 


### PR DESCRIPTION
This code change tests client operations `setNextStreamID`, `ping`, `goaway` after `client.destroy()`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2