### PR TITLE
test: http2 client settings invalid callback

### DIFF
--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -35,13 +35,26 @@ server.listen(0, common.mustCall(() => {
     ['enablePush', 0, TypeError],
     ['enablePush', null, TypeError],
     ['enablePush', {}, TypeError]
-  ].forEach((i) => {
+  ].forEach(([name, value, errorType]) =>
     common.expectsError(
-      () => client.settings({ [i[0]]: i[1] }),
+      () => client.settings({ [name]: value }),
       {
         code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-        type: i[2] });
-  });
+        type: errorType
+      }
+    )
+  );
+
+  [1, true, {}, []].forEach((invalidCallback) =>
+    common.expectsError(
+      () => client.settings({}, invalidCallback),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_CALLBACK',
+        message: 'Callback must be a function'
+      }
+    )
+  );
 
   client.settings({ maxFrameSize: 1234567 });
 


### PR DESCRIPTION
This code change adds test for the following line: https://github.com/nodejs/node/blob/472cde603ef60aafcff00a4d09743758dfd0d928/lib/internal/http2/core.js#L1045

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
