### PR TITLE
tools: fix custom eslint rule errors

### DIFF
--- a/tools/eslint-rules/alphabetize-errors.js
+++ b/tools/eslint-rules/alphabetize-errors.js
@@ -1,17 +1,12 @@
 'use strict';
 
+const { isDefiningError } = require('./rules-utils.js');
+
 const prefix = 'Out of ASCIIbetical order - ';
 const opStr = ' >= ';
 
 function errorForNode(node) {
   return node.expression.arguments[0].value;
-}
-
-function isDefiningError(node) {
-  return node.expression &&
-         node.expression.type === 'CallExpression' &&
-         node.expression.callee &&
-         node.expression.callee.name === 'E';
 }
 
 module.exports = {

--- a/tools/eslint-rules/documented-errors.js
+++ b/tools/eslint-rules/documented-errors.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { isDefiningError } = require('./rules-utils.js');
 
 const doc = fs.readFileSync(path.resolve(__dirname, '../../doc/api/errors.md'),
                             'utf8');
@@ -18,18 +19,11 @@ function errorForNode(node) {
   return node.expression.arguments[0].value;
 }
 
-function isDefiningError(node) {
-  return node.expression &&
-         node.expression.type === 'CallExpression' &&
-         node.expression.callee &&
-         node.expression.callee.name === 'E';
-}
-
 module.exports = {
   create: function(context) {
     return {
       ExpressionStatement: function(node) {
-        if (!isDefiningError(node)) return;
+        if (!isDefiningError(node) || !errorForNode(node)) return;
         const code = errorForNode(node);
         if (!isInDoc(code)) {
           const message = `"${code}" is not documented in doc/api/errors.md`;

--- a/tools/eslint-rules/prefer-util-format-errors.js
+++ b/tools/eslint-rules/prefer-util-format-errors.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isDefiningError } = require('./rules-utils.js');
+
 const errMsg = 'Please use a printf-like formatted string that util.format' +
                ' can consume.';
 
@@ -8,18 +10,11 @@ function isArrowFunctionWithTemplateLiteral(node) {
          node.body.type === 'TemplateLiteral';
 }
 
-function isDefiningError(node) {
-  return node.expression &&
-         node.expression.type === 'CallExpression' &&
-         node.expression.callee &&
-         node.expression.callee.name === 'E';
-}
-
 module.exports = {
   create: function(context) {
     return {
       ExpressionStatement: function(node) {
-        if (!isDefiningError(node))
+        if (!isDefiningError(node) || node.expression.arguments.length < 2)
           return;
 
         const msg = node.expression.arguments[1];

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -3,6 +3,14 @@
  */
 'use strict';
 
+module.exports.isDefiningError = function(node) {
+  return node.expression &&
+         node.expression.type === 'CallExpression' &&
+         node.expression.callee &&
+         node.expression.callee.name === 'E' &&
+         node.expression.arguments.length !== 0;
+};
+
 /**
  * Returns true if any of the passed in modules are used in
  * require calls.


### PR DESCRIPTION
This fixes a few rules by making sure the input is actually ready
to be checked. Otherwise those can throw TypeErrors or result in
faulty error messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools