### PR TITLE
test: http2 errors on req.close()

### DIFF
--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -16,18 +16,30 @@ server.on('stream', (stream) => {
 server.listen(0, common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
-  req.close(1);
+  const closeCode = 1;
+
+  common.expectsError(
+    () => req.close(2 ** 32),
+    {
+      type: RangeError,
+      code: 'ERR_OUT_OF_RANGE',
+      message: 'The value of "code" is out of range.'
+    }
+  );
+  assert.strictEqual(req.closed, false);
+
+  req.close(closeCode, common.mustCall());
   assert.strictEqual(req.closed, true);
 
   // Make sure that destroy is called.
   req._destroy = common.mustCall(req._destroy.bind(req));
 
   // Second call doesn't do anything.
-  req.close(8);
+  req.close(closeCode + 1);
 
   req.on('close', common.mustCall((code) => {
     assert.strictEqual(req.destroyed, true);
-    assert.strictEqual(code, 1);
+    assert.strictEqual(code, closeCode);
     server.close();
     client.close();
   }));
@@ -35,7 +47,7 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     type: Error,
-    message: 'Stream closed with error code 1'
+    message: `Stream closed with error code ${closeCode}`
   }));
 
   req.on('response', common.mustCall());


### PR DESCRIPTION
This code adds test for the following code:
https://github.com/nodejs/node/blob/472cde603ef60aafcff00a4d09743758dfd0d928/lib/internal/http2/core.js#L1743

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
