### PR TITLE
lib: new error implementation

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -793,12 +793,6 @@ An invalid symlink type was passed to the [`fs.symlink()`][] or
 
 An attempt was made to add more headers after the headers had already been sent.
 
-<a id="ERR_HTTP_INVALID_CHAR"></a>
-### ERR_HTTP_INVALID_CHAR
-
-An invalid character was found in an HTTP response status message (reason
-phrase).
-
 <a id="ERR_HTTP_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP_INVALID_HEADER_VALUE
 
@@ -814,11 +808,6 @@ Status code was outside the regular status code range (100-999).
 
 The `Trailer` header was set even though the transfer encoding does not support
 that.
-
-<a id="ERR_HTTP2_ALREADY_SHUTDOWN"></a>
-### ERR_HTTP2_ALREADY_SHUTDOWN
-
-Occurs with multiple attempts to shutdown an HTTP/2 session.
 
 <a id="ERR_HTTP2_ALTSVC_INVALID_ORIGIN"></a>
 ### ERR_HTTP2_ALTSVC_INVALID_ORIGIN
@@ -848,21 +837,11 @@ forbidden.
 For HTTP/2 requests using the `CONNECT` method, the `:scheme` pseudo-header is
 forbidden.
 
-<a id="ERR_HTTP2_FRAME_ERROR"></a>
-### ERR_HTTP2_FRAME_ERROR
-
-A failure occurred sending an individual frame on the HTTP/2 session.
-
 <a id="ERR_HTTP2_GOAWAY_SESSION"></a>
 ### ERR_HTTP2_GOAWAY_SESSION
 
 New HTTP/2 Streams may not be opened after the `Http2Session` has received a
 `GOAWAY` frame from the connected peer.
-
-<a id="ERR_HTTP2_HEADER_REQUIRED"></a>
-### ERR_HTTP2_HEADER_REQUIRED
-
-A required header was missing in an HTTP/2 message.
 
 <a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
 ### ERR_HTTP2_HEADER_SINGLE_VALUE
@@ -875,21 +854,10 @@ have only a single value.
 
 An additional headers was specified after an HTTP/2 response was initiated.
 
-<a id="ERR_HTTP2_HEADERS_OBJECT"></a>
-### ERR_HTTP2_HEADERS_OBJECT
-
-An HTTP/2 Headers Object was expected.
-
 <a id="ERR_HTTP2_HEADERS_SENT"></a>
 ### ERR_HTTP2_HEADERS_SENT
 
 An attempt was made to send multiple response headers.
-
-<a id="ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND"></a>
-### ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND
-
-HTTP/2 Informational headers must only be sent *prior* to calling the
-`Http2Stream.prototype.respond()` method.
 
 <a id="ERR_HTTP2_INFO_STATUS_NOT_ALLOWED"></a>
 ### ERR_HTTP2_INFO_STATUS_NOT_ALLOWED
@@ -1280,14 +1248,6 @@ strict compliance with the API specification (which in some cases may accept
 `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
 
-<a id="ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK"></a>
-### ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK
-
-> Stability: 1 - Experimental
-
-An [ES6 module][] loader hook specified `format: 'dynamic` but did not provide a
-`dynamicInstantiate` hook.
-
 <a id="ERR_MISSING_MODULE"></a>
 ### ERR_MISSING_MODULE
 
@@ -1315,11 +1275,6 @@ would be possible by calling a callback more than once.
 ### ERR_NAPI_CONS_FUNCTION
 
 While using `N-API`, a constructor passed was not a function.
-
-<a id="ERR_NAPI_CONS_PROTOTYPE_OBJECT"></a>
-### ERR_NAPI_CONS_PROTOTYPE_OBJECT
-
-While using `N-API`, `Constructor.prototype` was not an object.
 
 <a id="ERR_NAPI_INVALID_DATAVIEW_ARGS"></a>
 ### ERR_NAPI_INVALID_DATAVIEW_ARGS
@@ -1362,11 +1317,6 @@ For example: `Buffer.write(string, encoding, offset[, length])`
 ### ERR_OUT_OF_RANGE
 
 A given value is out of the accepted range.
-
-<a id="ERR_PARSE_HISTORY_DATA"></a>
-### ERR_PARSE_HISTORY_DATA
-
-The `REPL` module was unable parse data from the REPL history file.
 
 <a id="ERR_REQUIRE_ESM"></a>
 ### ERR_REQUIRE_ESM
@@ -1523,11 +1473,6 @@ recommended to use 2048 bits or larger for stronger security.
 
 A TLS/SSL handshake timed out. In this case, the server must also abort the
 connection.
-
-<a id="ERR_TLS_RENEGOTIATION_FAILED"></a>
-### ERR_TLS_RENEGOTIATION_FAILED
-
-A TLS renegotiation request has failed in a non-specific way.
 
 <a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
 ### ERR_TLS_REQUIRED_SERVER_NAME

--- a/lib/console.js
+++ b/lib/console.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const errors = require('internal/errors');
+const { ERR_CONSOLE_WRITABLE_STREAM } = require('internal/errors').codes;
 const util = require('util');
 const kCounts = Symbol('counts');
 
@@ -35,12 +35,12 @@ function Console(stdout, stderr, ignoreErrors = true) {
     return new Console(stdout, stderr, ignoreErrors);
   }
   if (!stdout || typeof stdout.write !== 'function') {
-    throw new errors.TypeError('ERR_CONSOLE_WRITABLE_STREAM', 'stdout');
+    throw new ERR_CONSOLE_WRITABLE_STREAM('stdout');
   }
   if (!stderr) {
     stderr = stdout;
   } else if (typeof stderr.write !== 'function') {
-    throw new errors.TypeError('ERR_CONSOLE_WRITABLE_STREAM', 'stderr');
+    throw new ERR_CONSOLE_WRITABLE_STREAM('stderr');
   }
 
   var prop = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,7 @@
 const kCode = Symbol('code');
 const kInfo = Symbol('info');
 const messages = new Map();
+const codes = {};
 
 var green = '';
 var red = '';
@@ -84,6 +85,54 @@ function makeNodeError(Base) {
       });
     }
   };
+}
+
+function makeNodeError2(Base, key) {
+  return class NodeError extends Base {
+    constructor(...args) {
+      super(message(key, args));
+    }
+
+    get name() {
+      return `${super.name} [${key}]`;
+    }
+
+    set name(value) {
+      defineProperty(this, 'name', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+
+    get code() {
+      return key;
+    }
+
+    set code(value) {
+      defineProperty(this, 'code', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+  };
+}
+
+// Utility function for registering the error codes. Only used here. Exported
+// *only* to allow for testing.
+function E(sym, val, def, otherClasses) {
+  messages.set(sym, val);
+  if (def === undefined) return;
+  def = makeNodeError2(def, sym);
+  if (otherClasses) {
+    otherClasses.forEach((clazz) => {
+      def[clazz.name] = makeNodeError2(clazz, sym);
+    });
+  }
+  codes[sym] = def;
 }
 
 function lazyBuffer() {
@@ -367,12 +416,6 @@ function message(key, args) {
   return String(fmt.apply(null, args));
 }
 
-// Utility function for registering the error codes. Only used here. Exported
-// *only* to allow for testing.
-function E(sym, val) {
-  messages.set(sym, typeof val === 'function' ? val : String(val));
-}
-
 /**
  * This creates an error compatible with errors produced in the C++
  * function UVException using a context object with data assembled in C++.
@@ -523,6 +566,7 @@ module.exports = exports = {
   URIError: makeNodeError(URIError),
   AssertionError,
   SystemError,
+  codes,
   E, // This is exported only to facilitate testing.
   errorCache: new Map() // This is in here only to facilitate testing.
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -842,7 +842,7 @@ E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
   'stream.unshift() after end event', Error);
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
 E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
-E('ERR_SYSTEM_ERROR', sysError('A system error occurred'));
+E('ERR_SYSTEM_ERROR', sysError);
 E('ERR_TLS_CERT_ALTNAME_INVALID',
   'Hostname/IP does not match certificate\'s altnames: %s', Error);
 E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);
@@ -903,26 +903,21 @@ E('ERR_VM_MODULE_STATUS', 'Module status %s', Error);
 E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed', Error);
 E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed', Error);
 
-function sysError(defaultMessage) {
-  return function(code,
-                  syscall,
-                  path,
-                  dest,
-                  message = defaultMessage) {
-    if (code !== undefined)
-      message += `: ${code}`;
-    if (syscall !== undefined) {
-      if (code === undefined)
-        message += ':';
-      message += ` [${syscall}]`;
-    }
-    if (path !== undefined) {
-      message += `: ${path}`;
-      if (dest !== undefined)
-        message += ` => ${dest}`;
-    }
-    return message;
-  };
+function sysError(code, syscall, path, dest,
+                  message = 'A system error occurred') {
+  if (code !== undefined)
+    message += `: ${code}`;
+  if (syscall !== undefined) {
+    if (code === undefined)
+      message += ':';
+    message += ` [${syscall}]`;
+  }
+  if (path !== undefined) {
+    message += `: ${path}`;
+    if (dest !== undefined)
+      message += ` => ${dest}`;
+  }
+  return message;
 }
 
 function invalidArgType(name, expected, actual) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -123,11 +123,11 @@ function makeNodeError2(Base, key) {
 
 // Utility function for registering the error codes. Only used here. Exported
 // *only* to allow for testing.
-function E(sym, val, def, otherClasses) {
+function E(sym, val, def, ...otherClasses) {
   messages.set(sym, val);
   if (def === undefined) return;
   def = makeNodeError2(def, sym);
-  if (otherClasses) {
+  if (otherClasses.length !== 0) {
     otherClasses.forEach((clazz) => {
       def[clazz.name] = makeNodeError2(clazz, sym);
     });
@@ -683,7 +683,7 @@ E('ERR_HTTP2_INVALID_PSEUDOHEADER',
   '"%s" is an invalid pseudoheader or is used incorrectly', Error);
 E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed', Error);
 E('ERR_HTTP2_INVALID_SETTING_VALUE',
-  'Invalid value for setting "%s": %s', TypeError, [RangeError]);
+  'Invalid value for setting "%s": %s', TypeError, RangeError);
 E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed', Error);
 E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
   'Maximum number of pending settings acknowledgements (%s)', Error);
@@ -735,7 +735,7 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
     inspected = inspected.slice(0, 128) + '...';
   }
   return `The argument '${name}' ${reason}. Received ${inspected}`;
-}, TypeError, [RangeError]); // Some are currently falsy implemented as "Error"
+}, TypeError, RangeError); // Some are currently falsy implemented as "Error"
 E('ERR_INVALID_ARRAY_LENGTH',
   (name, len, actual) => {
     internalAssert(typeof actual === 'number', 'actual must be a number');
@@ -763,11 +763,11 @@ E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
 
 // The `Error` should probably be a `TypeError`.
-E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError, [Error]);
+E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError, Error);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
   TypeError,
-  [RangeError]);
+  RangeError);
 E('ERR_INVALID_OPT_VALUE_ENCODING',
   'The value "%s" is invalid for option "encoding"', TypeError);
 E('ERR_INVALID_PERFORMANCE_MARK',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -587,134 +587,137 @@ module.exports = exports = {
 //
 // Note: Node.js specific errors must begin with the prefix ERR_
 
-E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
-E('ERR_ASSERTION', '%s');
-E('ERR_ASYNC_CALLBACK', '%s must be a function');
-E('ERR_ASYNC_TYPE', 'Invalid name for async "type": %s');
-E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
+E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
+E('ERR_ASSERTION', '%s', AssertionError);
+E('ERR_ASYNC_CALLBACK', '%s must be a function', TypeError);
+E('ERR_ASYNC_TYPE', 'Invalid name for async "type": %s', TypeError);
+E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds, RangeError);
 E('ERR_BUFFER_TOO_LARGE',
-  `Cannot create a Buffer larger than 0x${kMaxLength.toString(16)} bytes`);
-E('ERR_CANNOT_WATCH_SIGINT', 'Cannot watch for SIGINT signals');
-E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
+  `Cannot create a Buffer larger than 0x${kMaxLength.toString(16)} bytes`,
+  RangeError);
+E('ERR_CANNOT_WATCH_SIGINT', 'Cannot watch for SIGINT signals', Error);
+E('ERR_CHILD_CLOSED_BEFORE_REPLY',
+  'Child closed before reply received', Error);
 E('ERR_CHILD_PROCESS_IPC_REQUIRED',
-  "Forked processes must have an IPC channel, missing value 'ipc' in %s");
-E('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', '%s maxBuffer length exceeded');
+  "Forked processes must have an IPC channel, missing value 'ipc' in %s",
+  Error);
+E('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', '%s maxBuffer length exceeded',
+  RangeError);
 E('ERR_CONSOLE_WRITABLE_STREAM',
-  'Console expects a writable stream instance for %s');
-E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+  'Console expects a writable stream instance for %s', TypeError);
+E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s', Error);
 E('ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
-  'Custom engines not supported by this OpenSSL');
-E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s');
+  'Custom engines not supported by this OpenSSL', Error);
+E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s', TypeError);
 E('ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY',
-  'Public key is not valid for specified curve');
-E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found');
+  'Public key is not valid for specified curve', TypeError);
+E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found', Error);
 E('ERR_CRYPTO_FIPS_FORCED',
-  'Cannot set FIPS mode, it was forced with --force-fips at startup.');
-E('ERR_CRYPTO_FIPS_UNAVAILABLE', 'Cannot set FIPS mode in a non-FIPS build.');
-E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16');
-E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called');
-E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed');
-E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s');
-E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s');
-E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign');
+  'Cannot set FIPS mode, it was forced with --force-fips at startup.', Error);
+E('ERR_CRYPTO_FIPS_UNAVAILABLE', 'Cannot set FIPS mode in a non-FIPS build.',
+  Error);
+E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16',
+  Error);
+E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called', Error);
+E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed', Error);
+E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s', TypeError);
+E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s', Error);
+E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  'Input buffers must have the same length');
-E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]');
+  'Input buffers must have the same length', RangeError);
+E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]',
+  Error);
 E('ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',
   'A callback was registered through ' +
-  'process.setUncaughtExceptionCaptureCallback(), which is mutually ' +
-  'exclusive with using the `domain` module');
+     'process.setUncaughtExceptionCaptureCallback(), which is mutually ' +
+     'exclusive with using the `domain` module',
+  Error);
 E('ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE',
   'The `domain` module is in use, which is mutually exclusive with calling ' +
-  'process.setUncaughtExceptionCaptureCallback()');
+     'process.setUncaughtExceptionCaptureCallback()',
+  Error);
 E('ERR_ENCODING_INVALID_ENCODED_DATA',
-  'The encoded data was not valid for encoding %s');
-E('ERR_ENCODING_NOT_SUPPORTED', 'The "%s" encoding is not supported');
-E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
+  'The encoded data was not valid for encoding %s', TypeError);
+E('ERR_ENCODING_NOT_SUPPORTED', 'The "%s" encoding is not supported',
+  RangeError); // One entry is currently falsy implemented as "Error"
+E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value', Error);
 E('ERR_FS_INVALID_SYMLINK_TYPE',
-  'Symlink type must be one of "dir", "file", or "junction". Received "%s"');
-E('ERR_HTTP2_ALREADY_SHUTDOWN',
-  'Http2Session is already shutdown or destroyed');
+  'Symlink type must be one of "dir", "file", or "junction". Received "%s"',
+  Error);
 E('ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
-  'HTTP/2 ALTSVC frames require a valid origin');
+  'HTTP/2 ALTSVC frames require a valid origin', TypeError);
 E('ERR_HTTP2_ALTSVC_LENGTH',
-  'HTTP/2 ALTSVC frames are limited to 16382 bytes');
+  'HTTP/2 ALTSVC frames are limited to 16382 bytes', TypeError);
 E('ERR_HTTP2_CONNECT_AUTHORITY',
-  ':authority header is required for CONNECT requests');
+  ':authority header is required for CONNECT requests', Error);
 E('ERR_HTTP2_CONNECT_PATH',
-  'The :path header is forbidden for CONNECT requests');
+  'The :path header is forbidden for CONNECT requests', Error);
 E('ERR_HTTP2_CONNECT_SCHEME',
-  'The :scheme header is forbidden for CONNECT requests');
-E('ERR_HTTP2_FRAME_ERROR',
-  (type, code, id) => {
-    let msg = `Error sending frame type ${type}`;
-    if (id !== undefined)
-      msg += ` for stream ${id}`;
-    msg += ` with code ${code}`;
-    return msg;
-  });
+  'The :scheme header is forbidden for CONNECT requests', Error);
 E('ERR_HTTP2_GOAWAY_SESSION',
-  'New streams cannot be created after receiving a GOAWAY');
+  'New streams cannot be created after receiving a GOAWAY', Error);
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
-  'Cannot specify additional headers after response initiated');
-E('ERR_HTTP2_HEADERS_OBJECT', 'Headers must be an object');
-E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
-E('ERR_HTTP2_HEADER_REQUIRED', 'The %s header is required');
+  'Cannot specify additional headers after response initiated', Error);
+E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.', Error);
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
-  'Header field "%s" must have only a single value');
-E('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND',
-  'Cannot send informational headers after the HTTP message has been sent');
+  'Header field "%s" must have only a single value', Error);
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
-  'Informational status codes cannot be used');
+  'Informational status codes cannot be used', RangeError);
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-  'HTTP/1 Connection specific headers are forbidden: "%s"');
-E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Invalid value "%s" for header "%s"');
+  'HTTP/1 Connection specific headers are forbidden: "%s"', Error);
+E('ERR_HTTP2_INVALID_HEADER_VALUE',
+  'Invalid value "%s" for header "%s"', TypeError);
 E('ERR_HTTP2_INVALID_INFO_STATUS',
-  'Invalid informational status code: %s');
+  'Invalid informational status code: %s', RangeError);
 E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
-  'Packed settings length must be a multiple of six');
+  'Packed settings length must be a multiple of six', RangeError);
 E('ERR_HTTP2_INVALID_PSEUDOHEADER',
-  '"%s" is an invalid pseudoheader or is used incorrectly');
-E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed');
+  '"%s" is an invalid pseudoheader or is used incorrectly', Error);
+E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed', Error);
 E('ERR_HTTP2_INVALID_SETTING_VALUE',
-  'Invalid value for setting "%s": %s');
-E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed');
+  'Invalid value for setting "%s": %s', TypeError, [RangeError]);
+E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed', Error);
 E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
-  'Maximum number of pending settings acknowledgements (%s)');
+  'Maximum number of pending settings acknowledgements (%s)', Error);
 E('ERR_HTTP2_NO_SOCKET_MANIPULATION',
-  'HTTP/2 sockets should not be directly manipulated (e.g. read and written)');
+  'HTTP/2 sockets should not be directly manipulated (e.g. read and written)',
+  Error);
 E('ERR_HTTP2_OUT_OF_STREAMS',
-  'No stream ID is available because maximum stream ID has been reached');
+  'No stream ID is available because maximum stream ID has been reached',
+  Error);
 E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
-  'Responses with %s status must not have a payload');
-E('ERR_HTTP2_PING_CANCEL', 'HTTP2 ping cancelled');
-E('ERR_HTTP2_PING_LENGTH', 'HTTP2 ping payload must be 8 bytes');
-E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
-E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
-E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');
-E('ERR_HTTP2_SESSION_ERROR', 'Session closed with error code %s');
+  'Responses with %s status must not have a payload', Error);
+E('ERR_HTTP2_PING_CANCEL', 'HTTP2 ping cancelled', Error);
+E('ERR_HTTP2_PING_LENGTH', 'HTTP2 ping payload must be 8 bytes', RangeError);
+E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
+  'Cannot set HTTP/2 pseudo-headers', Error);
+E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams', Error);
+E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent', Error);
+E('ERR_HTTP2_SESSION_ERROR', 'Session closed with error code %s', Error);
 E('ERR_HTTP2_SOCKET_BOUND',
-  'The socket is already bound to an Http2Session');
+  'The socket is already bound to an Http2Session', Error);
 E('ERR_HTTP2_STATUS_101',
-  'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2');
-E('ERR_HTTP2_STATUS_INVALID', 'Invalid status code: %s');
-E('ERR_HTTP2_STREAM_CANCEL', 'The pending stream has been canceled');
-E('ERR_HTTP2_STREAM_ERROR', 'Stream closed with error code %s');
-E('ERR_HTTP2_STREAM_SELF_DEPENDENCY', 'A stream cannot depend on itself');
-E('ERR_HTTP2_UNSUPPORTED_PROTOCOL', 'protocol "%s" is unsupported.');
+  'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2', Error);
+E('ERR_HTTP2_STATUS_INVALID', 'Invalid status code: %s', RangeError);
+E('ERR_HTTP2_STREAM_CANCEL', 'The pending stream has been canceled', Error);
+E('ERR_HTTP2_STREAM_ERROR', 'Stream closed with error code %s', Error);
+E('ERR_HTTP2_STREAM_SELF_DEPENDENCY',
+  'A stream cannot depend on itself', Error);
+E('ERR_HTTP2_UNSUPPORTED_PROTOCOL', 'protocol "%s" is unsupported.', Error);
 E('ERR_HTTP_HEADERS_SENT',
-  'Cannot %s headers after they are sent to the client');
-E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
-E('ERR_HTTP_INVALID_HEADER_VALUE', 'Invalid value "%s" for header "%s"');
-E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s');
+  'Cannot %s headers after they are sent to the client', Error);
+E('ERR_HTTP_INVALID_HEADER_VALUE',
+  'Invalid value "%s" for header "%s"', TypeError);
+E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP_TRAILER_INVALID',
-  'Trailers are invalid with this transfer encoding');
-E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
-E('ERR_INSPECTOR_ALREADY_CONNECTED', 'The inspector is already connected');
-E('ERR_INSPECTOR_CLOSED', 'Session was closed');
-E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
-E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');
-E('ERR_INVALID_ARG_TYPE', invalidArgType);
+  'Trailers are invalid with this transfer encoding', Error);
+E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range', RangeError);
+E('ERR_INSPECTOR_ALREADY_CONNECTED',
+  'The inspector is already connected', Error);
+E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);
+E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available', Error);
+E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected', Error);
+E('ERR_INVALID_ARG_TYPE', invalidArgType, TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
   const util = lazyUtil();
   let inspected = util.inspect(value);
@@ -722,141 +725,153 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
     inspected = inspected.slice(0, 128) + '...';
   }
   return `The argument '${name}' ${reason}. Received ${inspected}`;
-}),
+}, TypeError, [RangeError]); // Some are currently falsy implemented as "Error"
 E('ERR_INVALID_ARRAY_LENGTH',
   (name, len, actual) => {
     internalAssert(typeof actual === 'number', 'actual must be a number');
     return `The array "${name}" (length ${actual}) must be of length ${len}.`;
-  });
-E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s');
-E('ERR_INVALID_BUFFER_SIZE', 'Buffer size must be a multiple of %s');
-E('ERR_INVALID_CALLBACK', 'Callback must be a function');
-E('ERR_INVALID_CHAR', invalidChar);
+  }, TypeError);
+E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s', RangeError);
+E('ERR_INVALID_BUFFER_SIZE',
+  'Buffer size must be a multiple of %s', RangeError);
+E('ERR_INVALID_CALLBACK', 'Callback must be a function', TypeError);
+E('ERR_INVALID_CHAR', invalidChar, TypeError); //Check falsy "Error" entries.
 E('ERR_INVALID_CURSOR_POS',
-  'Cannot set cursor row without setting its column');
-E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name');
-E('ERR_INVALID_FD', '"fd" must be a positive integer: %s');
-E('ERR_INVALID_FD_TYPE', 'Unsupported fd type: %s');
+  'Cannot set cursor row without setting its column', Error);
+E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name', Error);
+E('ERR_INVALID_FD',
+  '"fd" must be a positive integer: %s', RangeError);
+E('ERR_INVALID_FD_TYPE', 'Unsupported fd type: %s', TypeError);
 E('ERR_INVALID_FILE_URL_HOST',
-  'File URL host must be "localhost" or empty on %s');
-E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
-E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
-E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]');
-E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s');
+  'File URL host must be "localhost" or empty on %s', TypeError);
+E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
+E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
+E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
+E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError, [Error]);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
-  `The value "${String(value)}" is invalid for option "${name}"`);
+  `The value "${String(value)}" is invalid for option "${name}"`,
+  TypeError,
+  [RangeError]);
 E('ERR_INVALID_OPT_VALUE_ENCODING',
-  'The value "%s" is invalid for option "encoding"');
-E('ERR_INVALID_PERFORMANCE_MARK', 'The "%s" performance mark has not been set');
-E('ERR_INVALID_PROTOCOL', 'Protocol "%s" not supported. Expected "%s"');
+  'The value "%s" is invalid for option "encoding"', TypeError);
+E('ERR_INVALID_PERFORMANCE_MARK',
+  'The "%s" performance mark has not been set', Error);
+E('ERR_INVALID_PROTOCOL', 'Protocol "%s" not supported. Expected "%s"', Error);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
-  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
+  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', Error);
 E('ERR_INVALID_SYNC_FORK_INPUT',
-  'Asynchronous forks do not support Buffer, Uint8Array or string input: %s');
-E('ERR_INVALID_THIS', 'Value of "this" must be of type %s');
-E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple');
-E('ERR_INVALID_URI', 'URI malformed');
-E('ERR_INVALID_URL', 'Invalid URL: %s');
+  'Asynchronous forks do not support Buffer, Uint8Array or string input: %s',
+  TypeError);
+E('ERR_INVALID_THIS', 'Value of "this" must be of type %s', TypeError);
+E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple', TypeError);
+E('ERR_INVALID_URI', 'URI malformed', URIError);
+E('ERR_INVALID_URL', 'Invalid URL: %s', TypeError);
 E('ERR_INVALID_URL_SCHEME',
-  (expected) => `The URL must be ${oneOf(expected, 'scheme')}`);
-E('ERR_IPC_CHANNEL_CLOSED', 'Channel closed');
-E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected');
-E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe');
-E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
-E('ERR_METHOD_NOT_IMPLEMENTED', 'The %s method is not implemented');
-E('ERR_MISSING_ARGS', missingArgs);
-E('ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK',
-  'The ES Module loader may not return a format of \'dynamic\' when no ' +
-  'dynamicInstantiate function was provided');
-E('ERR_MISSING_MODULE', 'Cannot find module %s');
-E('ERR_MODULE_RESOLUTION_LEGACY', '%s not found by import in %s.' +
-  ' Legacy behavior in require() would have found it at %s');
-E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times');
-E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function');
-E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
+  (expected) => `The URL must be ${oneOf(expected, 'scheme')}`, TypeError);
+E('ERR_IPC_CHANNEL_CLOSED', 'Channel closed', Error);
+E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected', Error);
+E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe', Error);
+E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks', Error);
+E('ERR_METHOD_NOT_IMPLEMENTED', 'The %s method is not implemented', Error);
+E('ERR_MISSING_ARGS', missingArgs, TypeError);
+E('ERR_MISSING_MODULE', 'Cannot find module %s', Error);
+E('ERR_MODULE_RESOLUTION_LEGACY',
+  '%s not found by import in %s.' +
+    ' Legacy behavior in require() would have found it at %s',
+  Error);
+E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times', Error);
+E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function', TypeError);
 E('ERR_NAPI_INVALID_DATAVIEW_ARGS',
   'byte_offset + byte_length should be less than or eqaul to the size in ' +
-  'bytes of the array passed in');
-E('ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT', 'start offset of %s should be a ' +
-  'multiple of %s');
-E('ERR_NAPI_INVALID_TYPEDARRAY_LENGTH', 'Invalid typed array length');
-E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
-E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
-E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
-E('ERR_OUT_OF_RANGE', outOfRange);
-E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
-E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
+    'bytes of the array passed in',
+  RangeError);
+E('ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT',
+  'start offset of %s should be a multiple of %s', RangeError);
+E('ERR_NAPI_INVALID_TYPEDARRAY_LENGTH',
+  'Invalid typed array length', RangeError);
+E('ERR_NO_CRYPTO',
+  'Node.js is not compiled with OpenSSL crypto support', Error);
+E('ERR_NO_ICU',
+  '%s is not supported on Node.js compiled without ICU', TypeError);
+E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported', Error);
+E('ERR_OUT_OF_RANGE', outOfRange, RangeError);
+E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s', Error);
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',
-  'Script execution was interrupted by `SIGINT`.');
+  'Script execution was interrupted by `SIGINT`.', Error);
 E('ERR_SERVER_ALREADY_LISTEN',
-  'Listen method has been called more than once without closing.');
-E('ERR_SERVER_NOT_RUNNING', 'Server is not running.');
-E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
-E('ERR_SOCKET_BAD_BUFFER_SIZE', 'Buffer size must be a positive integer');
-E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536. Received %s.');
+  'Listen method has been called more than once without closing.', Error);
+E('ERR_SERVER_NOT_RUNNING', 'Server is not running.', Error);
+E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound', Error);
+E('ERR_SOCKET_BAD_BUFFER_SIZE',
+  'Buffer size must be a positive integer', TypeError);
+E('ERR_SOCKET_BAD_PORT',
+  'Port should be > 0 and < 65536. Received %s.', RangeError);
 E('ERR_SOCKET_BAD_TYPE',
-  'Bad socket type specified. Valid types are: udp4, udp6');
-E('ERR_SOCKET_BUFFER_SIZE', 'Could not get or set buffer size: %s');
-E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
-E('ERR_SOCKET_CLOSED', 'Socket is closed');
-E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
-E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
-E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
-E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable');
-E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream');
-E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF');
-E('ERR_STREAM_READ_NOT_IMPLEMENTED', '_read() is not implemented');
-E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT', 'stream.unshift() after end event');
-E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');
-E('ERR_STREAM_WRITE_AFTER_END', 'write after end');
+  'Bad socket type specified. Valid types are: udp4, udp6', TypeError);
+E('ERR_SOCKET_BUFFER_SIZE', 'Could not get or set buffer size: %s', Error);
+E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data', Error);
+E('ERR_SOCKET_CLOSED', 'Socket is closed', Error);
+E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running', Error);
+E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed', Error);
+E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed', Error);
+E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable', Error);
+E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);
+E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF', Error);
+E('ERR_STREAM_READ_NOT_IMPLEMENTED', '_read() is not implemented', Error);
+E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
+  'stream.unshift() after end event', Error);
+E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
+E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
 E('ERR_SYSTEM_ERROR', sysError('A system error occurred'));
 E('ERR_TLS_CERT_ALTNAME_INVALID',
-  'Hostname/IP does not match certificate\'s altnames: %s');
-E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048');
-E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout');
+  'Hostname/IP does not match certificate\'s altnames: %s', Error);
+E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);
+E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout', Error);
 E('ERR_TLS_RENEGOTIATION_DISABLED',
-  'TLS session renegotiation disabled for this socket');
-E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
+  'TLS session renegotiation disabled for this socket', Error);
 E('ERR_TLS_REQUIRED_SERVER_NAME',
-  '"servername" is required parameter for Server.addContext');
-E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected');
+  '"servername" is required parameter for Server.addContext', Error);
+E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected', Error);
 E('ERR_TLS_SNI_FROM_SERVER',
-  'Cannot issue SNI from a TLS server-side socket');
+  'Cannot issue SNI from a TLS server-side socket', Error);
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
-  'Calling transform done when still transforming');
+  'Calling transform done when still transforming', Error);
 E('ERR_TRANSFORM_WITH_LENGTH_0',
-  'Calling transform done when writableState.length != 0');
+  'Calling transform done when writableState.length != 0', Error);
 E('ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
   '`process.setupUncaughtExceptionCapture()` was called while a capture ' +
-  'callback was already active');
-E('ERR_UNESCAPED_CHARACTERS', '%s contains unescaped characters');
+    'callback was already active',
+  Error);
+E('ERR_UNESCAPED_CHARACTERS', '%s contains unescaped characters', TypeError);
 E('ERR_UNHANDLED_ERROR',
   (err) => {
     const msg = 'Unhandled error.';
     if (err === undefined) return msg;
     return `${msg} (${err})`;
-  });
-E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s');
-E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s');
-E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s');
-E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s');
-E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
-E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
-E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
-  'See https://github.com/nodejs/node/wiki/Intl');
+  }, Error);
+E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
+E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s', Error);
+E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
+E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
+E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type', Error);
+E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type', Error);
+E('ERR_V8BREAKITERATOR',
+  'Full ICU data not installed. See https://github.com/nodejs/node/wiki/Intl',
+  Error);
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
-  'At least one valid performance entry type is required');
-E('ERR_VM_MODULE_ALREADY_LINKED', 'Module has already been linked');
+  'At least one valid performance entry type is required', Error);
+E('ERR_VM_MODULE_ALREADY_LINKED', 'Module has already been linked', Error);
 E('ERR_VM_MODULE_DIFFERENT_CONTEXT',
-  'Linked modules must use the same context');
+  'Linked modules must use the same context', Error);
 E('ERR_VM_MODULE_LINKING_ERRORED',
-  'Linking has already failed for the provided module');
+  'Linking has already failed for the provided module', Error);
 E('ERR_VM_MODULE_NOT_LINKED',
-  'Module must be linked before it can be instantiated');
-E('ERR_VM_MODULE_NOT_MODULE', 'Provided module is not an instance of Module');
-E('ERR_VM_MODULE_STATUS', 'Module status %s');
-E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
-E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed');
+  'Module must be linked before it can be instantiated', Error);
+E('ERR_VM_MODULE_NOT_MODULE',
+  'Provided module is not an instance of Module', Error);
+E('ERR_VM_MODULE_STATUS', 'Module status %s', Error);
+E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed', Error);
+E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed', Error);
 
 function sysError(defaultMessage) {
   return function(code,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -87,7 +87,7 @@ function makeNodeError(Base) {
   };
 }
 
-function makeNodeError2(Base, key) {
+function makeNodeErrorWithCode(Base, key) {
   return class NodeError extends Base {
     constructor(...args) {
       super(message(key, args));
@@ -126,10 +126,10 @@ function makeNodeError2(Base, key) {
 function E(sym, val, def, ...otherClasses) {
   messages.set(sym, val);
   if (def === undefined) return;
-  def = makeNodeError2(def, sym);
+  def = makeNodeErrorWithCode(def, sym);
   if (otherClasses.length !== 0) {
     otherClasses.forEach((clazz) => {
-      def[clazz.name] = makeNodeError2(clazz, sym);
+      def[clazz.name] = makeNodeErrorWithCode(clazz, sym);
     });
   }
   codes[sym] = def;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -622,6 +622,8 @@ E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called', Error);
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed', Error);
 E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s', TypeError);
 E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s', Error);
+
+// Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
   'Input buffers must have the same length', RangeError);
@@ -643,7 +645,7 @@ E('ERR_ENCODING_NOT_SUPPORTED', 'The "%s" encoding is not supported',
 E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value', Error);
 E('ERR_FS_INVALID_SYMLINK_TYPE',
   'Symlink type must be one of "dir", "file", or "junction". Received "%s"',
-  Error);
+  Error); // Switch to TypeError. The current implementation does not seem right
 E('ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
   'HTTP/2 ALTSVC frames require a valid origin', TypeError);
 E('ERR_HTTP2_ALTSVC_LENGTH',
@@ -659,10 +661,14 @@ E('ERR_HTTP2_GOAWAY_SESSION',
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
   'Cannot specify additional headers after response initiated', Error);
 E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
   'Header field "%s" must have only a single value', Error);
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
   'Informational status codes cannot be used', RangeError);
+
+// This should probably be a `TypeError`.
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
   'HTTP/1 Connection specific headers are forbidden: "%s"', Error);
 E('ERR_HTTP2_INVALID_HEADER_VALUE',
@@ -671,6 +677,8 @@ E('ERR_HTTP2_INVALID_INFO_STATUS',
   'Invalid informational status code: %s', RangeError);
 E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
   'Packed settings length must be a multiple of six', RangeError);
+
+// This should probably be a `TypeError`.
 E('ERR_HTTP2_INVALID_PSEUDOHEADER',
   '"%s" is an invalid pseudoheader or is used incorrectly', Error);
 E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed', Error);
@@ -689,6 +697,8 @@ E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
   'Responses with %s status must not have a payload', Error);
 E('ERR_HTTP2_PING_CANCEL', 'HTTP2 ping cancelled', Error);
 E('ERR_HTTP2_PING_LENGTH', 'HTTP2 ping payload must be 8 bytes', RangeError);
+
+// This should probably be a `TypeError`.
 E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
   'Cannot set HTTP/2 pseudo-headers', Error);
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams', Error);
@@ -736,8 +746,12 @@ E('ERR_INVALID_BUFFER_SIZE',
   'Buffer size must be a multiple of %s', RangeError);
 E('ERR_INVALID_CALLBACK', 'Callback must be a function', TypeError);
 E('ERR_INVALID_CHAR', invalidChar, TypeError); //Check falsy "Error" entries.
+
+// This should probably be a `TypeError`.
 E('ERR_INVALID_CURSOR_POS',
   'Cannot set cursor row without setting its column', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name', Error);
 E('ERR_INVALID_FD',
   '"fd" must be a positive integer: %s', RangeError);
@@ -747,6 +761,8 @@ E('ERR_INVALID_FILE_URL_HOST',
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
+
+// The `Error` should probably be a `TypeError`.
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError, [Error]);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
@@ -756,7 +772,11 @@ E('ERR_INVALID_OPT_VALUE_ENCODING',
   'The value "%s" is invalid for option "encoding"', TypeError);
 E('ERR_INVALID_PERFORMANCE_MARK',
   'The "%s" performance mark has not been set', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_INVALID_PROTOCOL', 'Protocol "%s" not supported. Expected "%s"', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', Error);
 E('ERR_INVALID_SYNC_FORK_INPUT',
@@ -829,6 +849,8 @@ E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);
 E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout', Error);
 E('ERR_TLS_RENEGOTIATION_DISABLED',
   'TLS session renegotiation disabled for this socket', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_TLS_REQUIRED_SERVER_NAME',
   '"servername" is required parameter for Server.addContext', Error);
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected', Error);
@@ -836,6 +858,8 @@ E('ERR_TLS_SNI_FROM_SERVER',
   'Cannot issue SNI from a TLS server-side socket', Error);
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming', Error);
+
+// This should probably be a `RangeError`.
 E('ERR_TRANSFORM_WITH_LENGTH_0',
   'Calling transform done when writableState.length != 0', Error);
 E('ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
@@ -850,14 +874,20 @@ E('ERR_UNHANDLED_ERROR',
     return `${msg} (${err})`;
   }, Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
+
+// This should probably be a `TypeError`.
 E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s', Error);
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type', Error);
+
+// This should probably be a `TypeError`.
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type', Error);
 E('ERR_V8BREAKITERATOR',
   'Full ICU data not installed. See https://github.com/nodejs/node/wiki/Intl',
   Error);
+
+// This should probably be a `TypeError`.
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required', Error);
 E('ERR_VM_MODULE_ALREADY_LINKED', 'Module has already been linked', Error);

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -305,19 +305,6 @@ assert.strictEqual(
   errors.message('ERR_ENCODING_NOT_SUPPORTED', ['enc']),
   'The "enc" encoding is not supported');
 
-// Test ERR_HTTP2_HEADER_REQUIRED
-assert.strictEqual(
-  errors.message('ERR_HTTP2_HEADER_REQUIRED', ['test']),
-  'The test header is required');
-
-// Test ERR_HTTP2_FRAME_ERROR
-assert.strictEqual(
-  errors.message('ERR_HTTP2_FRAME_ERROR', ['foo', 'bar', 'baz']),
-  'Error sending frame type foo for stream baz with code bar');
-assert.strictEqual(
-  errors.message('ERR_HTTP2_FRAME_ERROR', ['foo', 'bar']),
-  'Error sending frame type foo with code bar');
-
 // Test error messages for async_hooks
 assert.strictEqual(
   errors.message('ERR_ASYNC_CALLBACK', ['init']),


### PR DESCRIPTION
This implements a function based error system. Instead of passing in the
error code as first argument, the error code itself is a error class.
It already contains the correct error type, so while adding a new
error no one has to think about the error type anymore. In case a
single error code has more than one error type, the error class has
properties for the non default error types. Those can be used as
fallback.

This prevents typos, makes the implementation easier and it is less
verbose when writing the code for a new error.

The implementation itself does not interfere with the old
implementation. So the old and the new system can co-exist and it is
possible to slowly migrate the old ones to the new system.

By doing this I also realized that there are multiple error codes that
are currently not used at all. I also found other mistakes where a
wrong error type was in place.

So far this is only WIP and I wanted to get some feedback.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib