### PR TITLE
tls: use after free in tls_wrap

### DIFF
--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -152,6 +152,7 @@ class TLSWrap : public AsyncWrap,
   std::vector<uv_buf_t> pending_cleartext_input_;
   size_t write_size_;
   WriteWrap* current_write_ = nullptr;
+  WriteWrap* current_empty_write_ = nullptr;
   bool write_callback_scheduled_ = false;
   bool started_;
   bool established_;


### PR DESCRIPTION
The root cause is that `req_wrap` is created in `StreamBase::Write`
and passed to `TLSWrap::DoWrite`. In the TLS case the object gets
disposed and replaced with a new instance, but the caller's pointer is
never updated. When the `StreamBase::Write` method returns, it returns
a pointer to the freed object to the caller. In some cases when the
object memory has already been reused an assert is hit in
`WriteWrap::SetAllocatedStorage` because the pointer is non-null.

Refs: #18676

This was introduced in @addaleax recent PR (#18676) and hasn't propagated to any release branches yet, so I'm going ahead and opening a PR here.

In node-chakracore this was causing a pretty consistent crash only on macOS.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls