### PR TITLE
tests: introduce runWithInvalidFD to trigger EBADF reliably

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -139,6 +139,14 @@ consisting of all `ArrayBufferView` and an `ArrayBuffer`.
 
 Returns the file name and line number for the provided Function.
 
+### runWithInvalidFD(func)
+* `func` [&lt;Function>]
+
+Runs `func` with an invalid file descriptor that is an unsigned integer and
+can be used to trigger `EBADF` as the first argument. If no such file
+descriptor could be generated, a skip message will be printed and the `func`
+will not be run.
+
 ### globalCheck
 * [&lt;Boolean>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -799,6 +799,19 @@ function restoreWritable(name) {
   delete process[name].writeTimes;
 }
 
+exports.runWithInvalidFD = function(func) {
+  let fd = 1 << 30;
+  // Get first known bad file descriptor. 1 << 30 is usually unlikely to
+  // be an valid one.
+  try {
+    while (fs.fstatSync(fd--) && fd > 0);
+  } catch (e) {
+    return func(fd);
+  }
+
+  exports.printSkipMessage('Could not generate an invalid fd');
+};
+
 exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
 exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -4,9 +4,7 @@
 // include the desired properties
 
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
-const uv = process.binding('uv');
 
 ['', false, null, undefined, {}, []].forEach((i) => {
   common.expectsError(
@@ -26,41 +24,3 @@ const uv = process.binding('uv');
     }
   );
 });
-
-{
-  assert.throws(
-    () => {
-      const fd = fs.openSync(__filename, 'r');
-      fs.closeSync(fd);
-      fs.closeSync(fd);
-    },
-    (err) => {
-      assert.strictEqual(err.code, 'EBADF');
-      assert.strictEqual(
-        err.message,
-        'EBADF: bad file descriptor, close'
-      );
-      assert.strictEqual(err.constructor, Error);
-      assert.strictEqual(err.syscall, 'close');
-      assert.strictEqual(err.errno, uv.UV_EBADF);
-      return true;
-    }
-  );
-}
-
-{
-  const fd = fs.openSync(__filename, 'r');
-  fs.close(fd, common.mustCall((err) => {
-    assert.ifError(err);
-    fs.close(fd, common.mustCall((err) => {
-      assert.strictEqual(err.code, 'EBADF');
-      assert.strictEqual(
-        err.message,
-        'EBADF: bad file descriptor, close'
-      );
-      assert.strictEqual(err.constructor, Error);
-      assert.strictEqual(err.syscall, 'close');
-      assert.strictEqual(err.errno, uv.UV_EBADF);
-    }));
-  }));
-}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -94,15 +94,14 @@ function re(literals, ...values) {
     return true;
   };
 
-  const fd = fs.openSync(existingFile, 'r');
-  fs.closeSync(fd);
+  common.runWithInvalidFD((fd) => {
+    fs.fstat(fd, common.mustCall(validateError));
 
-  fs.fstat(fd, common.mustCall(validateError));
-
-  assert.throws(
-    () => fs.fstatSync(fd),
-    validateError
-  );
+    assert.throws(
+      () => fs.fstatSync(fd),
+      validateError
+    );
+  });
 }
 
 // realpath
@@ -414,6 +413,27 @@ function re(literals, ...values) {
   );
 }
 
+
+// close
+{
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, close');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'close');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    fs.close(fd, common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.closeSync(fd),
+      validateError
+    );
+  });
+}
+
 // readFile
 {
   const validateError = (err) => {
@@ -472,15 +492,14 @@ function re(literals, ...values) {
     return true;
   };
 
-  const fd = fs.openSync(existingFile, 'r');
-  fs.closeSync(fd);
+  common.runWithInvalidFD((fd) => {
+    fs.ftruncate(fd, 4, common.mustCall(validateError));
 
-  fs.ftruncate(fd, 4, common.mustCall(validateError));
-
-  assert.throws(
-    () => fs.ftruncateSync(fd, 4),
-    validateError
-  );
+    assert.throws(
+      () => fs.ftruncateSync(fd, 4),
+      validateError
+    );
+  });
 }
 
 // fdatasync
@@ -493,15 +512,14 @@ function re(literals, ...values) {
     return true;
   };
 
-  const fd = fs.openSync(existingFile, 'r');
-  fs.closeSync(fd);
+  common.runWithInvalidFD((fd) => {
+    fs.fdatasync(fd, common.mustCall(validateError));
 
-  fs.fdatasync(fd, common.mustCall(validateError));
-
-  assert.throws(
-    () => fs.fdatasyncSync(fd),
-    validateError
-  );
+    assert.throws(
+      () => fs.fdatasyncSync(fd),
+      validateError
+    );
+  });
 }
 
 // fsync
@@ -514,13 +532,12 @@ function re(literals, ...values) {
     return true;
   };
 
-  const fd = fs.openSync(existingFile, 'r');
-  fs.closeSync(fd);
+  common.runWithInvalidFD((fd) => {
+    fs.fsync(fd, common.mustCall(validateError));
 
-  fs.fsync(fd, common.mustCall(validateError));
-
-  assert.throws(
-    () => fs.fsyncSync(fd),
-    validateError
-  );
+    assert.throws(
+      () => fs.fsyncSync(fd),
+      validateError
+    );
+  });
 }

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -2,7 +2,6 @@
 // Flags: --expose-internals
 
 const common = require('../common');
-const fs = require('fs');
 const tty = require('tty');
 const { SystemError } = require('internal/errors');
 
@@ -22,12 +21,9 @@ common.expectsError(
 
   common.expectsError(
     () => {
-      let fd = 2;
-      // Get first known bad file descriptor.
-      try {
-        while (fs.fstatSync(++fd));
-      } catch (e) { }
-      new tty.WriteStream(fd);
+      common.runWithInvalidFD((fd) => {
+        new tty.WriteStream(fd);
+      });
     }, {
       code: 'ERR_SYSTEM_ERROR',
       type: SystemError,
@@ -37,12 +33,9 @@ common.expectsError(
 
   common.expectsError(
     () => {
-      let fd = 2;
-      // Get first known bad file descriptor.
-      try {
-        while (fs.fstatSync(++fd));
-      } catch (e) { }
-      new tty.ReadStream(fd);
+      common.runWithInvalidFD((fd) => {
+        new tty.ReadStream(fd);
+      });
     }, {
       code: 'ERR_SYSTEM_ERROR',
       type: SystemError,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/18820

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test