### PR TITLE
http: allow _httpMessage to be GC'ed

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -277,6 +277,7 @@ function installListeners(agent, s, options) {
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
     s.removeListener('agentRemove', onRemove);
+    s._httpMessage = null;
   }
   s.on('agentRemove', onRemove);
 }

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -49,6 +49,10 @@ server.listen(0, common.mustCall(() => {
     path: 'google.com:443'
   }, common.mustNotCall());
 
+  req.on('socket', common.mustCall((socket) => {
+    assert.strictEqual(socket._httpMessage, req);
+  }));
+
   req.on('close', common.mustCall());
 
   req.on('connect', common.mustCall((res, socket, firstBodyChunk) => {
@@ -60,6 +64,7 @@ server.listen(0, common.mustCall(() => {
     // Make sure this socket has detached.
     assert(!socket.ondata);
     assert(!socket.onend);
+    assert.strictEqual(socket._httpMessage, null);
     assert.strictEqual(socket.listeners('connect').length, 0);
     assert.strictEqual(socket.listeners('data').length, 0);
 


### PR DESCRIPTION
Set `socket._httpMessage` to `null` before emitting the `'connect'` or `'upgrade'` event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http