### PR TITLE
http: remove default 'drain' listener on upgrade

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -37,7 +37,7 @@ const { OutgoingMessage } = require('_http_outgoing');
 const Agent = require('_http_agent');
 const { Buffer } = require('buffer');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
-const { outHeadersKey } = require('internal/http');
+const { outHeadersKey, ondrain } = require('internal/http');
 const { nextTick } = require('internal/process/next_tick');
 const errors = require('internal/errors');
 
@@ -424,6 +424,7 @@ function socketOnData(d) {
 
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
+    socket.removeListener('drain', ondrain);
     parser.finish();
     freeParser(parser, req, socket);
 

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -62,6 +62,7 @@ server.listen(0, common.mustCall(() => {
     assert(!socket.onend);
     assert.strictEqual(socket.listeners('connect').length, 0);
     assert.strictEqual(socket.listeners('data').length, 0);
+    assert.strictEqual(socket.listeners('drain').length, 0);
 
     // the stream.Duplex onend listener
     // allow 0 here, so that i can run the same test on streams1 impl


### PR DESCRIPTION
Ensure that the default `'drain'` listener is removed before the `'connect'` or `'upgrade'` event is emitted.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http