### PR TITLE
doc: improve nodejs/help adoption/awareness

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,14 @@
 <!--
 Thank you for reporting an issue.
 
-This issue tracker is for bugs and issues found within Node.js core.
-If you require more general support please file an issue on our help
-repo. https://github.com/nodejs/help
+This issue tracker is exclusively for bugs and issues found within
+Node.js core: either a confirmed bug that manifests as a difference
+in documented behavior, or an unexpected program state such as
+a crash or a hang.
 
+If that is not the case or if you are unable to make judgement,
+please file an issue on our help repo instead:
+https://github.com/nodejs/help . This repo is actively tracked.
 
 Please fill in as much of the template below as you're able.
 


### PR DESCRIPTION
More than one-third of the issues raised by first time reporters
were inadvertantly targeted nodejs/issues and needed to be closed
and re-posted in nodejs/help.

While the issue template contain accurate guidelines on what should
go where, people continue to raise content in the wrong repo. Major
reasons seems to be: (i) custom interpretation of bugs and issues
(ii) apprehension on the lack of attention to the nodejs/help repo.

/cc @bnoordhuis (who might have spent a considerable time redirecting people)
/cc @Trott (who may be able to make this message more eloquent.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
