### PR TITLE
http: remove default 'error' listener on upgrade

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -521,6 +521,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     socket.removeListener('close', state.onClose);
     socket.removeListener('drain', state.onDrain);
     socket.removeListener('drain', ondrain);
+    socket.removeListener('error', socketOnError);
     unconsume(parser, socket);
     parser.finish();
     freeParser(parser, req, null);

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -30,6 +30,13 @@ server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
   assert.strictEqual(req.method, 'CONNECT');
   assert.strictEqual(req.url, 'google.com:443');
 
+  // Make sure this socket has detached.
+  assert.strictEqual(socket.listeners('close').length, 0);
+  assert.strictEqual(socket.listeners('drain').length, 0);
+  assert.strictEqual(socket.listeners('data').length, 0);
+  assert.strictEqual(socket.listeners('end').length, 1);
+  assert.strictEqual(socket.listeners('error').length, 0);
+
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
 
   let data = firstBodyChunk.toString();


### PR DESCRIPTION
Remove the default `'error'` listener when the socket is freed. This is consistent with the client and prevents spurious `'clientError'` events from being emitted on the server.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http