### PR TITLE
doc: fix nits in tools/doc/README.md

### DIFF
--- a/tools/doc/README.md
+++ b/tools/doc/README.md
@@ -1,56 +1,55 @@
 Here's how the node docs work.
 
-1:1 relationship from `lib/<module>.js` to `doc/api/<module>.md`
+1:1 relationship from `lib/<module>.js` to `doc/api/<module>.md`.
 
 Each type of heading has a description block.
 
 ```md
-## module
+# module
+
+<!--introduced_in=v0.10.0-->
+
+> Stability: 2 - Stable
+
+A description and examples.
+
+## module.property
 <!-- YAML
 added: v0.10.0
 -->
 
-> Stability: 3 - Stable
+* {type}
 
-description and examples.
+A description of the property.
 
-### module.property
+## module.someFunction(x, y, [z=100])
 <!-- YAML
 added: v0.10.0
 -->
 
-* Type
-
-description of the property.
-
-### module.someFunction(x, y, [z=100])
-<!-- YAML
-added: v0.10.0
--->
-
-* `x` {String} the description of the string
-* `y` {Boolean} Should I stay or should I go?
-* `z` {Number} How many zebras to bring.
+* `x` {string} The description of the string.
+* `y` {boolean} Should I stay or should I go?
+* `z` {number} How many zebras to bring.
 
 A description of the function.
 
-### module.someNewFunction(x)
+## module.someNewFunction(x)
 <!-- YAML
 added: REPLACEME
 -->
 
-* `x` {String} the description of the string
+* `x` {string} The description of the string.
 
 This feature is not in a release yet.
 
-### Event: 'blerg'
+## Event: 'blerg'
 <!-- YAML
 added: v0.10.0
 -->
 
-* Argument: SomeClass object.
+* `anArg` {type} A description of the listener argument.
 
-Modules don't usually raise events on themselves.  `cluster` is the
+Modules don't usually raise events on themselves. `cluster` is the
 only exception.
 
 ## Class: SomeClass
@@ -58,50 +57,50 @@ only exception.
 added: v0.10.0
 -->
 
-description of the class.
+A description of the class.
 
-### Class Method: SomeClass.classMethod(anArg)
+### SomeClass.classMethod(anArg)
 <!-- YAML
 added: v0.10.0
 -->
 
-* `anArg` {Object}  Just an argument
-  * `field` {String} anArg can have this field.
-  * `field2` {Boolean}  Another field.  Default: `false`.
-* Return: {Boolean} `true` if it worked.
+* `anArg` {Object} Just an argument.
+  * `field` {string} `anArg` can have this field.
+  * `field2` {boolean} Another field. Default: `false`.
+* Returns: {boolean} `true` if it worked.
 
-Description of the method for humans.
+A description of the method for humans.
 
-### someClass.nextSibling()
+### SomeClass.nextSibling()
 <!-- YAML
 added: v0.10.0
 -->
 
-* Return: {SomeClass object | null}  The next someClass in line.
+* Returns: {SomeClass | null} The next `SomeClass` in line.
 
-### someClass.someProperty
+### SomeClass.someProperty
 <!-- YAML
 added: v0.10.0
 -->
 
-* String
+* {string}
 
-The indication of what someProperty is.
+The indication of what `someProperty` is.
 
 ### Event: 'grelb'
 <!-- YAML
 added: v0.10.0
 -->
 
-* `isBlerg` {Boolean}
+* `isBlerg` {boolean}
 
-This event is emitted on instances of SomeClass, not on the module itself.
+This event is emitted on instances of `SomeClass`, not on the module itself.
 ```
 
 
-* Classes have (description, Properties, Methods, Events)
-* Events have (list of arguments, description)
-* Functions have (list of arguments, description)
-* Methods have (list of arguments, description)
-* Modules have (description, Properties, Functions, Classes, Examples)
-* Properties have (type, description)
+* Classes have (description, Properties, Methods, Events).
+* Events have (list of arguments, description).
+* Functions have (list of arguments, description).
+* Methods have (list of arguments, description).
+* Modules have (description, Properties, Functions, Classes, Examples).
+* Properties have (type, description).


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, tools

* Sync format schemes with the current doc state.
* Lowercase primitive types.
* Fix typos and unify the style.
* Remove tautological info.
