### PR TITLE
src: fix deprecation warning in node_perf.cc

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -91,7 +91,8 @@ void PerformanceEntry::Notify(Environment* env,
     node::MakeCallback(env->isolate(),
                        env->process_object(),
                        env->performance_entry_callback(),
-                       1, &object);
+                       1, &object,
+                       node::async_context{0, 0}).ToLocalChecked();
   }
 }
 

--- a/test/addons/make-callback-domain-warning/binding.cc
+++ b/test/addons/make-callback-domain-warning/binding.cc
@@ -19,7 +19,8 @@ void MakeCallback(const FunctionCallbackInfo<Value>& args) {
   Local<Object> recv = args[0].As<Object>();
   Local<Function> method = args[1].As<Function>();
 
-  node::MakeCallback(isolate, recv, method, 0, nullptr);
+  node::MakeCallback(isolate, recv, method, 0, nullptr,
+                     node::async_context{0, 0});
 }
 
 void Initialize(Local<Object> exports) {


### PR DESCRIPTION
Currently the following deprecation warning is produced when compiling
node_perf.cc:
```console
./src/node_perf.cc:91:11: warning: 'MakeCallback' is deprecated: Use MakeCallback(...,
      async_context) [-Wdeprecated-declarations]
    node::MakeCallback(env->isolate(),
          ^
../src/node.h:172:50: note: 'MakeCallback' has been explicitly marked deprecated here
                NODE_EXTERN v8::Local<v8::Value> MakeCallback(
                                                 ^
1 warning generated.
```
This commit adds an async_context to the call and checks the maybe
result.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src