### PR TITLE
Fixed broken link in onboarding.md. Removed Members team link.

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -14,9 +14,8 @@ onboarding session.
 
 ## Fifteen minutes before the onboarding session
 
-* Prior to the onboarding session, add the new Collaborator to
-  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators),
-  and to [the Members team](https://github.com/orgs/nodejs/teams/members) if
+* Prior to the onboarding session, add the new Collaborator to the
+  [the Collaborators team](https://github.com/nodejs/node#collaborators), if
   they are not already part of it. Note that this is the step that gives the
   account elevated privileges, so do not perform this step (or any subsequent
   steps) unless two-factor authentication is enabled on the new Collaborator's

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -15,7 +15,7 @@ onboarding session.
 ## Fifteen minutes before the onboarding session
 
 * Prior to the onboarding session, add the new Collaborator to
-  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators), if
+  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators) if
   they are not already part of it. Note that this is the step that gives the
   account elevated privileges, so do not perform this step (or any subsequent
   steps) unless two-factor authentication is enabled on the new Collaborator's

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -15,11 +15,10 @@ onboarding session.
 ## Fifteen minutes before the onboarding session
 
 * Prior to the onboarding session, add the new Collaborator to
-  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators) if
-  they are not already part of it. Note that this is the step that gives the
-  account elevated privileges, so do not perform this step (or any subsequent
-  steps) unless two-factor authentication is enabled on the new Collaborator's
-  GitHub account.
+  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators).
+  Note that this is the step that gives the account elevated privileges, so do
+  not perform this step (or any subsequent steps) unless two-factor
+  authentication is enabled on the new Collaborator's GitHub account.
 
 ## Onboarding session
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -15,7 +15,7 @@ onboarding session.
 ## Fifteen minutes before the onboarding session
 
 * Prior to the onboarding session, add the new Collaborator to the
-  [the Collaborators team](https://github.com/nodejs/node#collaborators), if
+  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators), if
   they are not already part of it. Note that this is the step that gives the
   account elevated privileges, so do not perform this step (or any subsequent
   steps) unless two-factor authentication is enabled on the new Collaborator's

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -14,7 +14,7 @@ onboarding session.
 
 ## Fifteen minutes before the onboarding session
 
-* Prior to the onboarding session, add the new Collaborator to the
+* Prior to the onboarding session, add the new Collaborator to
   [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators), if
   they are not already part of it. Note that this is the step that gives the
   account elevated privileges, so do not perform this step (or any subsequent


### PR DESCRIPTION
These two links are broken: 

https://github.com/orgs/nodejs/teams/collaborators
https://github.com/orgs/nodejs/teams/members

I've relinked the collaborators to the main README.md's collaborator section, but could not find a member's section to link to, so I removed it. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
