### PR TITLE
repl: fix tab-complete warning

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -753,7 +753,7 @@ REPLServer.prototype.createContext = function() {
   } else {
     sendInspectorCommand((session) => {
       session.post('Runtime.enable');
-      session.on('Runtime.executionContextCreated', ({ params }) => {
+      session.once('Runtime.executionContextCreated', ({ params }) => {
         this[kContextId] = params.context.id;
       });
       context = vm.createContext();
@@ -937,7 +937,6 @@ function complete(line, callback) {
     var flat = new ArrayStream();         // make a new "input" stream
     var magic = new REPLServer('', flat); // make a nested REPL
     replMap.set(magic, replMap.get(this));
-    magic.resetContext();
     flat.run(tmp);                        // eval the flattened code
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand

--- a/test/parallel/test-repl-tab-complete-no-warn.js
+++ b/test/parallel/test-repl-tab-complete-no-warn.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const repl = require('repl');
+const DEFAULT_MAX_LISTENERS = require('events').defaultMaxListeners;
+
+common.ArrayStream.prototype.write = () => {
+};
+
+const putIn = new common.ArrayStream();
+const testMe = repl.start('', putIn);
+
+// https://github.com/nodejs/node/issues/18284
+// Tab-completion should not repeatedly add the
+// `Runtime.executionContextCreated` listener
+process.on('warning', common.mustNotCall());
+
+putIn.run(['.clear']);
+putIn.run(['async function test() {']);
+for (let i = 0; i < DEFAULT_MAX_LISTENERS; i++) {
+  testMe.complete('await Promise.resolve()', () => {});
+}


### PR DESCRIPTION
When create a nest repl, will register `Runtime.executionContextCreated`
listener to the inspector session.This patch will fix listener 
repeatedly register.

Fixes: https://github.com/nodejs/node/issues/18284

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl