### PR TITLE
[v6.x backport] test: preserve env in test cases

### DIFF
--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -6,7 +6,8 @@ const cp = require('child_process');
 if (process.argv[2] === 'child') {
   process.emitWarning('foo');
 } else {
-  function test(env) {
+  function test(newEnv) {
+    const env = Object.assign({}, process.env, newEnv);
     const cmd = `"${process.execPath}" "${__filename}" child`;
 
     cp.exec(cmd, { env }, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-tls-env-bad-extra-ca.js
+++ b/test/parallel/test-tls-env-bad-extra-ca.js
@@ -16,10 +16,10 @@ if (process.env.CHILD) {
   return tls.createServer({});
 }
 
-const env = {
+const env = Object.assign({}, process.env, {
   CHILD: 'yes',
-  NODE_EXTRA_CA_CERTS: `${fixtures.fixturesDir}/no-such-file-exists`
-};
+  NODE_EXTRA_CA_CERTS: `${fixtures.fixturesDir}/no-such-file-exists`,
+});
 
 const opts = {
   env: env,

--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -32,11 +32,11 @@ const server = tls.createServer(options, common.mustCall(function(s) {
   s.end('bye');
   server.close();
 })).listen(0, common.mustCall(function() {
-  const env = {
+  const env = Object.assign({}, process.env, {
     CHILD: 'yes',
     PORT: this.address().port,
     NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca1-cert.pem')
-  };
+  });
 
   fork(__filename, {env: env}).on('exit', common.mustCall(function(status) {
     assert.strictEqual(status, 0, 'client did not succeed in connecting');


### PR DESCRIPTION
Allows env vars to be passed through to child processes. This is needed for
things like NODE_TEST_DIR or LD_LIBRARY_PATH if testing the shared library.

Refs: https://github.com/nodejs/node/pull/13390

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

Original PR: https://github.com/nodejs/node/pull/14822