### PR TITLE
doc: update description of 'clientError' event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -784,10 +784,11 @@ changes:
 
 If a client connection emits an `'error'` event, it will be forwarded here.
 Listener of this event is responsible for closing/destroying the underlying
-socket. For example, one may wish to more gracefully close the socket with an
-HTTP '400 Bad Request' response instead of abruptly severing the connection.
+socket. For example, one may wish to more gracefully close the socket with a
+custom HTTP response instead of abruptly severing the connection.
 
-Default behavior is to destroy the socket immediately on malformed request.
+Default behavior is to close the socket with an HTTP '400 Bad Request' response
+if possible, otherwise the socket is immediately destroyed.
 
 `socket` is the [`net.Socket`][] object that the error originated from.
 


### PR DESCRIPTION
Default behavior is to send a '400 Bad Request' response if the socket is writable.

Refs: https://github.com/nodejs/node/pull/15324

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc