### PR TITLE
test: actually test the ttywrap portion of getasyncid

### DIFF
--- a/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
+++ b/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// see also test/sequential/test-async-wrap-getasyncid.js
+
+const common = require('../common');
+const assert = require('assert');
+const tty_wrap = process.binding('tty_wrap');
+const { TTYWRAP } = process.binding('async_wrap').Providers;
+const providers = { TTYWRAP };
+
+// Make sure that the TTYWRAP Provider is tested.
+{
+  const hooks = require('async_hooks').createHook({
+    init(id, type) {
+      if (type === 'NONE')
+        throw new Error('received a provider type of NONE');
+      delete providers[type];
+    },
+  }).enable();
+  process.on('beforeExit', common.mustCall(() => {
+    process.removeAllListeners('uncaughtException');
+    hooks.disable();
+
+    const objKeys = Object.keys(providers);
+    if (objKeys.length > 0)
+      process._rawDebug(objKeys);
+    assert.strictEqual(objKeys.length, 0);
+  }));
+}
+
+function testInitialized(req, ctor_name) {
+  assert.strictEqual(typeof req.getAsyncId, 'function');
+  assert(Number.isSafeInteger(req.getAsyncId()));
+  assert(req.getAsyncId() > 0);
+  assert.strictEqual(req.constructor.name, ctor_name);
+}
+
+{
+  const ttyFd = common.getTTYfd();
+
+  const handle = new tty_wrap.TTY(ttyFd, false);
+  testInitialized(handle, 'TTY');
+}


### PR DESCRIPTION
Follow-up from https://github.com/nodejs/node/pull/18800

Code that tries to exercise tty fds must be placed in `/pseudo-tty/`.

CI: https://ci.nodejs.org/job/node-test-pull-request/13290/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, tty
