### PR TITLE
doc: add URL.format() example

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -948,6 +948,24 @@ changes:
 The `url.format()` method returns a formatted URL string derived from
 `urlObject`.
 
+Example:
+
+```js
+const URL = require('url');
+
+URL.format({
+  protocol: 'https',
+  hostname: `example.com`,
+  pathname: '/some/path',
+  query: {
+    page: 1,
+    format: 'json'
+  }
+});
+
+// => 'https://example.com/some/path?page=1&format=json'
+```
+
 If `urlObject` is not an object or a string, `url.format()` will throw a
 [`TypeError`][].
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -951,7 +951,7 @@ The `url.format()` method returns a formatted URL string derived from
 ```js
 url.format({
   protocol: 'https',
-  hostname: `example.com`,
+  hostname: 'example.com',
   pathname: '/some/path',
   query: {
     page: 1,

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -948,8 +948,6 @@ changes:
 The `url.format()` method returns a formatted URL string derived from
 `urlObject`.
 
-Example:
-
 ```js
 url.format({
   protocol: 'https',

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -951,9 +951,7 @@ The `url.format()` method returns a formatted URL string derived from
 Example:
 
 ```js
-const URL = require('url');
-
-URL.format({
+url.format({
   protocol: 'https',
   hostname: `example.com`,
   pathname: '/some/path',


### PR DESCRIPTION
This PR adds an example use of the `URL.format()` method.

Resolves https://github.com/nodejs/node/issues/18887

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- [x] doc
- [x] url