### PR TITLE
[9.x] Backport 18513, 18694

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -545,10 +545,6 @@ own resources.
 
 The `init` hook will trigger when an `AsyncResource` is instantiated.
 
-*Note*: `before` and `after` calls must be unwound in the same order that they
-are called. Otherwise, an unrecoverable exception will occur and the process
-will abort.
-
 The following is an overview of the `AsyncResource` API.
 
 ```js
@@ -561,11 +557,13 @@ const asyncResource = new AsyncResource(
   type, { triggerAsyncId: executionAsyncId(), requireManualDestroy: false }
 );
 
-// Call AsyncHooks before callbacks.
-asyncResource.emitBefore();
-
-// Call AsyncHooks after callbacks.
-asyncResource.emitAfter();
+// Run a function in the execution context of the resource. This will
+// * establish the context of the resource
+// * trigger the AsyncHooks before callbacks
+// * call the provided function `fn` with the supplied arguments
+// * trigger the AsyncHooks after callbacks
+// * restore the original execution context
+asyncResource.runInAsyncScope(fn, thisArg, ...args);
 
 // Call AsyncHooks destroy callbacks.
 asyncResource.emitDestroy();
@@ -575,6 +573,14 @@ asyncResource.asyncId();
 
 // Return the trigger ID for the AsyncResource instance.
 asyncResource.triggerAsyncId();
+
+// Call AsyncHooks before callbacks.
+// Deprecated: Use asyncResource.runInAsyncScope instead.
+asyncResource.emitBefore();
+
+// Call AsyncHooks after callbacks.
+// Deprecated: Use asyncResource.runInAsyncScope instead.
+asyncResource.emitAfter();
 ```
 
 #### `AsyncResource(type[, options])`
@@ -600,9 +606,7 @@ class DBQuery extends AsyncResource {
 
   getInfo(query, callback) {
     this.db.get(query, (err, data) => {
-      this.emitBefore();
-      callback(err, data);
-      this.emitAfter();
+      this.runInAsyncScope(callback, null, err, data);
     });
   }
 
@@ -613,7 +617,26 @@ class DBQuery extends AsyncResource {
 }
 ```
 
+#### `asyncResource.runInAsyncScope(fn[, thisArg, ...args])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function} The function to call in the execution context of this async
+  resource.
+* `thisArg` {any} The receiver to be used for the function call.
+* `...args` {any} Optional arguments to pass to the function.
+
+Call the provided function with the provided arguments in the execution context
+of the async resource. This will establish the context, trigger the AsyncHooks
+before callbacks, call the function, trigger the AsyncHooks after callbacks, and
+then restore the original execution context.
+
 #### `asyncResource.emitBefore()`
+<!-- YAML
+deprecated: REPLACEME
+-->
+> Stability: 0 - Deprecated: Use [`asyncResource.runInAsyncScope()`][] instead.
 
 * Returns: {undefined}
 
@@ -621,7 +644,17 @@ Call all `before` callbacks to notify that a new asynchronous execution context
 is being entered. If nested calls to `emitBefore()` are made, the stack of
 `asyncId`s will be tracked and properly unwound.
 
+`before` and `after` calls must be unwound in the same order that they
+are called. Otherwise, an unrecoverable exception will occur and the process
+will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
+considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
+alternative.
+
 #### `asyncResource.emitAfter()`
+<!-- YAML
+deprecated: REPLACEME
+-->
+> Stability: 0 - Deprecated: Use [`asyncResource.runInAsyncScope()`][] instead.
 
 * Returns: {undefined}
 
@@ -631,6 +664,12 @@ make sure the stack is unwound properly. Otherwise an error will be thrown.
 If the user's callback throws an exception, `emitAfter()` will automatically be
 called for all `asyncId`s on the stack if the error is handled by a domain or
 `'uncaughtException'` handler.
+
+`before` and `after` calls must be unwound in the same order that they
+are called. Otherwise, an unrecoverable exception will occur and the process
+will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
+considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
+alternative.
 
 #### `asyncResource.emitDestroy()`
 
@@ -651,6 +690,7 @@ never be called.
 constructor.
 
 [`after` callback]: #async_hooks_after_asyncid
+[`asyncResource.runInAsyncScope()`]: #async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`before` callback]: #async_hooks_before_asyncid
 [`destroy` callback]: #async_hooks_destroy_asyncid
 [`init` callback]: #async_hooks_init_asyncid_type_triggerasyncid_resource

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -768,6 +768,18 @@ Type: Runtime
 cause a lot of issues. See https://github.com/nodejs/node/issues/14328 for more
 details.
 
+<a id="DEP0098"></a>
+### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs
+
+Type: Runtime
+
+The embedded API provided by AsyncHooks exposes emit{Before,After} methods
+which are very easy to use incorrectly which can lead to unrecoverable errors.
+
+Use [`asyncResource.runInAsyncScope()`][] API instead which provides a much
+safer, and more convenient, alternative. See
+https://github.com/nodejs/node/pull/18513 for more details.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
@@ -777,6 +789,7 @@ details.
 [`Server.getConnections()`]: net.html#net_server_getconnections_callback
 [`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`asyncResource.runInAsyncScope()`]: async_hooks.html#async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`child_process`]: child_process.html
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -143,6 +143,17 @@ function triggerAsyncId() {
 
 const destroyedSymbol = Symbol('destroyed');
 
+let emitBeforeAfterWarning = true;
+function showEmitBeforeAfterWarning() {
+  if (emitBeforeAfterWarning) {
+    process.emitWarning(
+      'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
+      'asyncResource.runInAsyncScope instead',
+      'DeprecationWarning', 'DEP00XX');
+    emitBeforeAfterWarning = false;
+  }
+}
+
 class AsyncResource {
   constructor(type, opts = {}) {
     if (typeof type !== 'string')
@@ -178,13 +189,26 @@ class AsyncResource {
   }
 
   emitBefore() {
+    showEmitBeforeAfterWarning();
     emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
     return this;
   }
 
   emitAfter() {
+    showEmitBeforeAfterWarning();
     emitAfter(this[async_id_symbol]);
     return this;
+  }
+
+  runInAsyncScope(fn, thisArg, ...args) {
+    emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
+    let ret;
+    try {
+      ret = Reflect.apply(fn, thisArg, args);
+    } finally {
+      emitAfter(this[async_id_symbol]);
+    }
+    return ret;
   }
 
   emitDestroy() {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -149,7 +149,7 @@ function showEmitBeforeAfterWarning() {
     process.emitWarning(
       'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
       'asyncResource.runInAsyncScope instead',
-      'DeprecationWarning', 'DEP00XX');
+      'DeprecationWarning', 'DEP0098');
     emitBeforeAfterWarning = false;
   }
 }

--- a/test/async-hooks/test-embedder.api.async-resource.runInAsyncScope.js
+++ b/test/async-hooks/test-embedder.api.async-resource.runInAsyncScope.js
@@ -1,0 +1,11 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// Ensure that asyncResource.makeCallback returns the callback return value.
+const a = new async_hooks.AsyncResource('foobar');
+const ret = a.runInAsyncScope(() => {
+  return 1729;
+});
+assert.strictEqual(ret, 1729);

--- a/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
+++ b/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// This test verifies that the async ID stack can grow indefinitely.
+
+function recurse(n) {
+  const a = new async_hooks.AsyncResource('foobar');
+  a.runInAsyncScope(() => {
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+    if (n >= 0)
+      recurse(n - 1);
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  });
+}
+
+recurse(1000);

--- a/test/parallel/test-emit-after-uncaught-exception-runInAsyncScope.js
+++ b/test/parallel/test-emit-after-uncaught-exception-runInAsyncScope.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+const id_obj = {};
+let collect = true;
+
+const hook = async_hooks.createHook({
+  before(id) { if (collect) id_obj[id] = true; },
+  after(id) { delete id_obj[id]; },
+}).enable();
+
+process.once('uncaughtException', common.mustCall((er) => {
+  assert.strictEqual(er.message, 'bye');
+  collect = false;
+}));
+
+setImmediate(common.mustCall(() => {
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(Object.keys(id_obj).length, 0);
+    hook.disable();
+  }));
+
+  // Create a stack of async ids that will need to be emitted in the case of
+  // an uncaught exception.
+  const ar1 = new async_hooks.AsyncResource('Mine');
+  ar1.runInAsyncScope(() => {
+    const ar2 = new async_hooks.AsyncResource('Mine');
+    ar2.runInAsyncScope(() => {
+      throw new Error('bye');
+    });
+  });
+
+  // TODO(trevnorris): This test shows that the after() hooks are always called
+  // correctly, but it doesn't solve where the emitDestroy() is missed because
+  // of the uncaught exception. Simple solution is to always call emitDestroy()
+  // before the emitAfter(), but how to codify this?
+}));


### PR DESCRIPTION
9.x backport of #18513, #18694.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_hooks

CI: https://ci.nodejs.org/job/node-test-pull-request/13298/