### PR TITLE
src: fix abort when taking a heap snapshot

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -127,7 +127,7 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
   CHECK_GT(object->InternalFieldCount(), 0);
 
   AsyncWrap* wrap = Unwrap<AsyncWrap>(object);
-  CHECK_NE(nullptr, wrap);
+  if (wrap == nullptr) return nullptr;  // ClearWrap() already called.
 
   return new RetainedAsyncInfo(class_id, wrap);
 }


### PR DESCRIPTION
Remove an erroneous CHECK that asserted the persistent object's internal
field pointer still pointed to a valid object.  If ClearWrap() has been
called, the field pointer equals nullptr and that is expected behavior.

Fixes: https://github.com/nodejs/node/issues/18256