### PR TITLE
http: emit timeout duration overflow warning sync

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -40,6 +40,7 @@ const { urlToOptions, searchParamsSymbol } = require('internal/url');
 const { outHeadersKey, ondrain } = require('internal/http');
 const { nextTick } = require('internal/process/next_tick');
 const errors = require('internal/errors');
+const { validateTimerDuration } = require('internal/timers');
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 
@@ -678,6 +679,7 @@ function _deferToConnect(method, arguments_, cb) {
 }
 
 ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
+  msecs = validateTimerDuration(msecs);
   if (callback) this.once('timeout', callback);
 
   const emitTimeout = () => this.emit('timeout');

--- a/test/parallel/test-http-timeout-client-warning.js
+++ b/test/parallel/test-http-timeout-client-warning.js
@@ -14,7 +14,8 @@ const server = http.createServer((req, resp) => resp.end());
 server.listen(common.mustCall(() => {
   http.request(`http://localhost:${server.address().port}`)
     .setTimeout(2 ** 40)
-    .end(() => {
+    .on('response', common.mustCall(() => {
       server.close();
-    });
+    }))
+    .end();
 }));

--- a/test/parallel/test-http-timeout-client-warning.js
+++ b/test/parallel/test-http-timeout-client-warning.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+// Checks that the setTimeout duration overflow warning is emitted
+// synchronously and therefore contains a meaningful stacktrace.
+
+process.on('warning', common.mustCall((warning) => {
+  assert(warning.stack.includes(__filename));
+}));
+
+const server = http.createServer((req, resp) => resp.end());
+server.listen(common.mustCall(() => {
+  http.request(`http://localhost:${server.address().port}`)
+    .setTimeout(2 ** 40)
+    .end(() => {
+      server.close();
+    });
+}));


### PR DESCRIPTION
Emit the `TimeoutOverflowWarning` synchronously, even when
still connecting, to get a better stack trace.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

http