### PR TITLE
[v9.x] stream: always reset awaitDrain when emitting data 

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -266,6 +266,7 @@ function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
 
 function addChunk(stream, state, chunk, addToFront) {
   if (state.flowing && state.length === 0 && !state.sync) {
+    state.awaitDrain = 0;
     stream.emit('data', chunk);
     stream.read(0);
   } else {
@@ -465,6 +466,7 @@ Readable.prototype.read = function(n) {
     n = 0;
   } else {
     state.length -= n;
+    state.awaitDrain = 0;
   }
 
   if (state.length === 0) {
@@ -634,17 +636,12 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
       ondrain();
   }
 
-  // If the user pushes more data while we're writing to dest then we'll end up
-  // in ondata again. However, we only want to increase awaitDrain once because
-  // dest will only emit one 'drain' event for the multiple writes.
-  // => Introduce a guard on increasing awaitDrain.
-  var increasedAwaitDrain = false;
   src.on('data', ondata);
   function ondata(chunk) {
     debug('ondata');
-    increasedAwaitDrain = false;
     var ret = dest.write(chunk);
-    if (false === ret && !increasedAwaitDrain) {
+    debug('dest.write', ret);
+    if (ret === false) {
       // If the user unpiped during `dest.write()`, it is possible
       // to get stuck in a permanently paused state if that write
       // also returned false.
@@ -654,7 +651,6 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
           !cleanedUp) {
         debug('false write response, pause', state.awaitDrain);
         state.awaitDrain++;
-        increasedAwaitDrain = true;
       }
       src.pause();
     }
@@ -830,7 +826,6 @@ function resume_(stream, state) {
   }
 
   state.resumeScheduled = false;
-  state.awaitDrain = 0;
   stream.emit('resume');
   flow(stream);
   if (state.flowing && !state.reading)

--- a/test/parallel/test-stream-pipe-manual-resume.js
+++ b/test/parallel/test-stream-pipe-manual-resume.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const stream = require('stream');
+
+function test(throwCodeInbetween) {
+  // Check that a pipe does not stall if .read() is called unexpectedly
+  // (i.e. the stream is not resumed by the pipe).
+
+  const n = 1000;
+  let counter = n;
+  const rs = stream.Readable({
+    objectMode: true,
+    read: common.mustCallAtLeast(() => {
+      if (--counter >= 0)
+        rs.push({ counter });
+      else
+        rs.push(null);
+    }, n)
+  });
+
+  const ws = stream.Writable({
+    objectMode: true,
+    write: common.mustCall((data, enc, cb) => {
+      setImmediate(cb);
+    }, n)
+  });
+
+  setImmediate(() => throwCodeInbetween(rs, ws));
+
+  rs.pipe(ws);
+}
+
+test((rs) => rs.read());
+test((rs) => rs.resume());
+test(() => 0);


### PR DESCRIPTION
Backport of #18516, only conflict being the added `debug()` line that is being borrowed from 1e0f3315c7703