### PR TITLE
[v9.x] backport 17338, 18186, 18358, 18546

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -228,6 +228,25 @@ without any formatting.
 util.format('%% %s'); // '%% %s'
 ```
 
+## util.getSystemErrorName(err)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `err` {number}
+* Returns: {string}
+
+Returns the string name for a numeric error code that comes from a Node.js API.
+The mapping between error codes and error names is platform-dependent.
+See [Common System Errors][] for the names of common errors.
+
+```js
+fs.access('file/that/does/not/exist', (err) => {
+  const name = util.getSystemErrorName(err.errno);
+  console.error(name);  // ENOENT
+});
+```
+
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
@@ -1228,5 +1247,6 @@ Deprecated predecessor of `console.log`.
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [Internationalization]: intl.html
 [WHATWG Encoding Standard]: https://encoding.spec.whatwg.org/
-[constructor]: https://developer.mozilla.org/en-US/JavaScript/Reference/Global_Objects/Object/constructor
+[Common System Errors]: errors.html#errors_common_system_errors
+[constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,14 +22,15 @@
 'use strict';
 
 const util = require('util');
-const { deprecate, convertToValidSignal } = require('internal/util');
+const {
+  deprecate, convertToValidSignal, getSystemErrorName
+} = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const { createPromise,
         promiseResolve, promiseReject } = process.binding('util');
 const debug = util.debuglog('child_process');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
-const { errname } = process.binding('uv');
 const child_process = require('internal/child_process');
 const {
   _validateStdio,
@@ -271,7 +272,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (!ex) {
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
       ex.killed = child.killed || killed;
-      ex.code = code < 0 ? errname(code) : code;
+      ex.code = code < 0 ? getSystemErrorName(code) : code;
       ex.signal = signal;
     }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -45,8 +45,8 @@ const SEND_BUFFER = false;
 // Lazily loaded
 var cluster = null;
 
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = errors.errnoException;
+const exceptionWithHostPort = errors.exceptionWithHostPort;
 
 
 function lookup4(lookup, address, callback) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -21,17 +21,10 @@
 
 'use strict';
 
-const util = require('util');
-
 const cares = process.binding('cares_wrap');
 const { isLegalPort } = require('internal/net');
 const { customPromisifyArgs } = require('internal/util');
 const errors = require('internal/errors');
-const {
-  UV_EAI_MEMORY,
-  UV_EAI_NODATA,
-  UV_EAI_NONAME
-} = process.binding('uv');
 
 const {
   GetAddrInfoReqWrap,
@@ -40,30 +33,6 @@ const {
   ChannelWrap,
   isIP
 } = cares;
-
-function errnoException(err, syscall, hostname) {
-  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
-  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-  if (err === UV_EAI_MEMORY ||
-      err === UV_EAI_NODATA ||
-      err === UV_EAI_NONAME) {
-    err = 'ENOTFOUND';
-  }
-  var ex = null;
-  if (typeof err === 'string') {  // c-ares error code.
-    const errHost = hostname ? ` ${hostname}` : '';
-    ex = new Error(`${syscall} ${err}${errHost}`);
-    ex.code = err;
-    ex.errno = err;
-    ex.syscall = syscall;
-  } else {
-    ex = util._errnoException(err, syscall);
-  }
-  if (hostname) {
-    ex.hostname = hostname;
-  }
-  return ex;
-}
 
 const IANA_DNS_PORT = 53;
 const digits = [
@@ -91,10 +60,11 @@ function isIPv4(str) {
   return (str.length > 3 && str.charCodeAt(3) === 46/*'.'*/);
 }
 
+const dnsException = errors.dnsException;
 
 function onlookup(err, addresses) {
   if (err) {
-    return this.callback(errnoException(err, 'getaddrinfo', this.hostname));
+    return this.callback(dnsException(err, 'getaddrinfo', this.hostname));
   }
   if (this.family) {
     this.callback(null, addresses[0], this.family);
@@ -106,7 +76,7 @@ function onlookup(err, addresses) {
 
 function onlookupall(err, addresses) {
   if (err) {
-    return this.callback(errnoException(err, 'getaddrinfo', this.hostname));
+    return this.callback(dnsException(err, 'getaddrinfo', this.hostname));
   }
 
   var family = this.family;
@@ -186,7 +156,7 @@ function lookup(hostname, options, callback) {
 
   var err = cares.getaddrinfo(req, hostname, family, hints, verbatim);
   if (err) {
-    process.nextTick(callback, errnoException(err, 'getaddrinfo', hostname));
+    process.nextTick(callback, dnsException(err, 'getaddrinfo', hostname));
     return {};
   }
   return req;
@@ -198,7 +168,7 @@ Object.defineProperty(lookup, customPromisifyArgs,
 
 function onlookupservice(err, host, service) {
   if (err)
-    return this.callback(errnoException(err, 'getnameinfo', this.host));
+    return this.callback(dnsException(err, 'getnameinfo', this.host));
 
   this.callback(null, host, service);
 }
@@ -227,7 +197,7 @@ function lookupService(host, port, callback) {
   req.oncomplete = onlookupservice;
 
   var err = cares.getnameinfo(req, host, port);
-  if (err) throw errnoException(err, 'getnameinfo', host);
+  if (err) throw dnsException(err, 'getnameinfo', host);
   return req;
 }
 
@@ -240,7 +210,7 @@ function onresolve(err, result, ttls) {
     result = result.map((address, index) => ({ address, ttl: ttls[index] }));
 
   if (err)
-    this.callback(errnoException(err, this.bindingName, this.hostname));
+    this.callback(dnsException(err, this.bindingName, this.hostname));
   else
     this.callback(null, result);
 }
@@ -278,7 +248,7 @@ function resolver(bindingName) {
     req.oncomplete = onresolve;
     req.ttl = !!(options && options.ttl);
     var err = this._handle[bindingName](req, name);
-    if (err) throw errnoException(err, bindingName);
+    if (err) throw dnsException(err, bindingName);
     return req;
   }
   Object.defineProperty(query, 'name', { value: bindingName });

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -63,7 +63,7 @@ const { kMaxLength } = require('buffer');
 const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
-const errnoException = util._errnoException;
+const errnoException = errors.errnoException;
 
 let truncateWarn = true;
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -29,7 +29,7 @@ const {
   UV_ESRCH
 } = process.binding('uv');
 
-const errnoException = util._errnoException;
+const errnoException = errors.errnoException;
 const { SocketListSend, SocketListReceive } = SocketList;
 
 const MAX_HANDLE_RETRANSMISSIONS = 3;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,11 @@
 const kCode = Symbol('code');
 const messages = new Map();
 
+const {
+  UV_EAI_MEMORY,
+  UV_EAI_NODATA,
+  UV_EAI_NONAME
+} = process.binding('uv');
 const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
 
@@ -23,6 +28,14 @@ function lazyUtil() {
     util_ = require('util');
   }
   return util_;
+}
+
+var internalUtil = null;
+function lazyInternalUtil() {
+  if (!internalUtil) {
+    internalUtil = require('internal/util');
+  }
+  return internalUtil;
 }
 
 function makeNodeError(Base) {
@@ -128,7 +141,110 @@ function E(sym, val) {
   messages.set(sym, typeof val === 'function' ? val : String(val));
 }
 
+/**
+ * This used to be util._errnoException().
+ *
+ * @param {number} err - A libuv error number
+ * @param {string} syscall
+ * @param {string} [original]
+ * @returns {Error}
+ */
+function errnoException(err, syscall, original) {
+  // TODO(joyeecheung): We have to use the type-checked
+  // getSystemErrorName(err) to guard against invalid arguments from users.
+  // This can be replaced with [ code ] = errmap.get(err) when this method
+  // is no longer exposed to user land.
+  const code = lazyUtil().getSystemErrorName(err);
+  const message = original ?
+    `${syscall} ${code} ${original}` : `${syscall} ${code}`;
+
+  const ex = new Error(message);
+  // TODO(joyeecheung): errno is supposed to err, like in uvException
+  ex.code = ex.errno = code;
+  ex.syscall = syscall;
+
+  Error.captureStackTrace(ex, errnoException);
+  return ex;
+}
+
+/**
+ * This used to be util._exceptionWithHostPort().
+ *
+ * @param {number} err - A libuv error number
+ * @param {string} syscall
+ * @param {string} address
+ * @param {number} [port]
+ * @param {string} [additional]
+ * @returns {Error}
+ */
+function exceptionWithHostPort(err, syscall, address, port, additional) {
+  // TODO(joyeecheung): We have to use the type-checked
+  // getSystemErrorName(err) to guard against invalid arguments from users.
+  // This can be replaced with [ code ] = errmap.get(err) when this method
+  // is no longer exposed to user land.
+  const code = lazyUtil().getSystemErrorName(err);
+  let details = '';
+  if (port && port > 0) {
+    details = ` ${address}:${port}`;
+  } else if (address) {
+    details = ` ${address}`;
+  }
+  if (additional) {
+    details += ` - Local (${additional})`;
+  }
+
+  const ex = new Error(`${syscall} ${code}${details}`);
+  // TODO(joyeecheung): errno is supposed to err, like in uvException
+  ex.code = ex.errno = code;
+  ex.syscall = syscall;
+  ex.address = address;
+  if (port) {
+    ex.port = port;
+  }
+
+  Error.captureStackTrace(ex, exceptionWithHostPort);
+  return ex;
+}
+
+/**
+ * @param {number|string} err - A libuv error number or a c-ares error code
+ * @param {string} syscall
+ * @param {string} [hostname]
+ * @returns {Error}
+ */
+function dnsException(err, syscall, hostname) {
+  const ex = new Error();
+  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
+  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
+  if (err === UV_EAI_MEMORY ||
+      err === UV_EAI_NODATA ||
+      err === UV_EAI_NONAME) {
+    err = 'ENOTFOUND';  // Fabricated error name.
+  }
+  if (typeof err === 'string') {  // c-ares error code.
+    const errHost = hostname ? ` ${hostname}` : '';
+    ex.message = `${syscall} ${err}${errHost}`;
+    // TODO(joyeecheung): errno is supposed to be a number, like in uvException
+    ex.code = ex.errno = err;
+    ex.syscall = syscall;
+  } else {  // libuv error number
+    const code = lazyInternalUtil().getSystemErrorName(err);
+    ex.message = `${syscall} ${code}`;
+    // TODO(joyeecheung): errno is supposed to be err, like in uvException
+    ex.code = ex.errno = code;
+    ex.syscall = syscall;
+  }
+  if (hostname) {
+    ex.hostname = hostname;
+  }
+  Error.captureStackTrace(ex, dnsException);
+  return ex;
+}
+
 module.exports = exports = {
+  dnsException,
+  errnoException,
+  exceptionWithHostPort,
   message,
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -17,7 +17,13 @@ const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
 
 // Lazily loaded
-var util = null;
+var util_ = null;
+function lazyUtil() {
+  if (!util_) {
+    util_ = require('util');
+  }
+  return util_;
+}
 
 function makeNodeError(Base) {
   return class NodeError extends Base {
@@ -68,11 +74,11 @@ class AssertionError extends Error {
     if (message) {
       super(message);
     } else {
+      const util = lazyUtil();
       if (actual && actual.stack && actual instanceof Error)
         actual = `${actual.name}: ${actual.message}`;
       if (expected && expected.stack && expected instanceof Error)
         expected = `${expected.name}: ${expected.message}`;
-      if (util === null) util = require('util');
       super(`${util.inspect(actual).slice(0, 128)} ` +
         `${operator} ${util.inspect(expected).slice(0, 128)}`);
     }
@@ -107,7 +113,7 @@ function message(key, args) {
   if (typeof msg === 'function') {
     fmt = msg;
   } else {
-    if (util === null) util = require('util');
+    const util = lazyUtil();
     fmt = util.format;
     if (args === undefined || args.length === 0)
       return msg;
@@ -263,8 +269,14 @@ E('ERR_INSPECTOR_CLOSED', 'Session was closed');
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
-E('ERR_INVALID_ARG_VALUE', (name, value) =>
-  `The value "${String(value)}" is invalid for argument "${name}"`);
+E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
+  const util = lazyUtil();
+  let inspected = util.inspect(value);
+  if (inspected.length > 128) {
+    inspected = inspected.slice(0, 128) + '...';
+  }
+  return `The argument '${name}' ${reason}. Received ${inspected}`;
+}),
 E('ERR_INVALID_ARRAY_LENGTH',
   (name, len, actual) => {
     internalAssert(typeof actual === 'number', 'actual must be a number');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1619,7 +1619,7 @@ class Http2Stream extends Duplex {
     req.async = false;
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
-      throw util._errnoException(err, 'write', req.error);
+      throw errors.errnoException(err, 'write', req.error);
     trackWriteState(this, req.bytes);
   }
 
@@ -1662,7 +1662,7 @@ class Http2Stream extends Duplex {
     }
     const err = handle.writev(req, chunks);
     if (err)
-      throw util._errnoException(err, 'write', req.error);
+      throw errors.errnoException(err, 'write', req.error);
     trackWriteState(this, req.bytes);
   }
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -170,7 +170,7 @@ function setupKillAndExit() {
     }
 
     if (err)
-      throw util._errnoException(err, 'kill');
+      throw errors.errnoException(err, 'kill');
 
     return true;
   };
@@ -200,7 +200,7 @@ function setupSignalHandlers() {
       const err = wrap.start(signum);
       if (err) {
         wrap.close();
-        throw util._errnoException(err, 'uv_signal_start');
+        throw errors.errnoException(err, 'uv_signal_start');
       }
 
       signalWraps[type] = wrap;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -3,8 +3,8 @@
 const errors = require('internal/errors');
 const binding = process.binding('util');
 const { signals } = process.binding('constants').os;
-
 const { createPromise, promiseResolve, promiseReject } = binding;
+const { errmap } = process.binding('uv');
 
 const kArrowMessagePrivateSymbolIndex = binding.arrow_message_private_symbol;
 const kDecoratedPrivateSymbolIndex = binding.decorated_private_symbol;
@@ -207,6 +207,16 @@ function getConstructorOf(obj) {
   return null;
 }
 
+function getSystemErrorName(err) {
+  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
+                               'negative number');
+  }
+
+  const entry = errmap.get(err);
+  return entry ? entry[0] : `Unknown system error ${err}`;
+}
+
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
@@ -297,6 +307,7 @@ module.exports = {
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,
+  getSystemErrorName,
   isError,
   join,
   normalizeEncoding,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -208,11 +208,6 @@ function getConstructorOf(obj) {
 }
 
 function getSystemErrorName(err) {
-  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
-                               'negative number');
-  }
-
   const entry = errmap.get(err);
   return entry ? entry[0] : `Unknown system error ${err}`;
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -54,8 +54,8 @@ const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 // reasons it's lazy loaded.
 var cluster = null;
 
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = errors.errnoException;
+const exceptionWithHostPort = errors.exceptionWithHostPort;
 
 function noop() {}
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -21,11 +21,9 @@
 
 'use strict';
 
-const util = require('util');
+const { inherits, _extend } = require('util');
 const net = require('net');
 const { TTY, isTTY } = process.binding('tty_wrap');
-const { inherits } = util;
-const errnoException = util._errnoException;
 const errors = require('internal/errors');
 const readline = require('readline');
 
@@ -40,7 +38,7 @@ function ReadStream(fd, options) {
   if (fd >> 0 !== fd || fd < 0)
     throw new errors.RangeError('ERR_INVALID_FD', fd);
 
-  options = util._extend({
+  options = _extend({
     highWaterMark: 0,
     readable: true,
     writable: false,
@@ -99,7 +97,7 @@ WriteStream.prototype._refreshSize = function() {
   var winSize = new Array(2);
   var err = this._handle.getWindowSize(winSize);
   if (err) {
-    this.emit('error', errnoException(err, 'getWindowSize'));
+    this.emit('error', errors.errnoException(err, 'getWindowSize'));
     return;
   }
   var newCols = winSize[0];

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,8 +25,6 @@ const errors = require('internal/errors');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 
-const { errname } = process.binding('uv');
-
 const {
   getPromiseDetails,
   getProxyDetails,
@@ -56,6 +54,7 @@ const {
   customInspectSymbol,
   deprecate,
   getConstructorOf,
+  getSystemErrorName,
   isError,
   promisify,
   join,
@@ -992,11 +991,7 @@ function error(...args) {
 }
 
 function _errnoException(err, syscall, original) {
-  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
-                               'negative number');
-  }
-  const name = errname(err);
+  const name = getSystemErrorName(err);
   var message = `${syscall} ${name}`;
   if (original)
     message += ` ${original}`;
@@ -1085,6 +1080,7 @@ module.exports = exports = {
   debuglog,
   deprecate,
   format,
+  getSystemErrorName,
   inherits,
   inspect,
   isArray: Array.isArray,

--- a/lib/util.js
+++ b/lib/util.js
@@ -990,40 +990,6 @@ function error(...args) {
   }
 }
 
-function _errnoException(err, syscall, original) {
-  const name = getSystemErrorName(err);
-  var message = `${syscall} ${name}`;
-  if (original)
-    message += ` ${original}`;
-  const e = new Error(message);
-  e.code = e.errno = name;
-  e.syscall = syscall;
-  return e;
-}
-
-function _exceptionWithHostPort(err,
-                                syscall,
-                                address,
-                                port,
-                                additional) {
-  var details;
-  if (port && port > 0) {
-    details = `${address}:${port}`;
-  } else {
-    details = address;
-  }
-
-  if (additional) {
-    details += ` - Local (${additional})`;
-  }
-  var ex = exports._errnoException(err, syscall, details);
-  ex.address = address;
-  if (port) {
-    ex.port = port;
-  }
-  return ex;
-}
-
 function callbackifyOnRejected(reason, cb) {
   // `!reason` guard inspired by bluebird (Ref: https://goo.gl/t5IS6M).
   // Because `null` is a special error value in callbacks which means "no error
@@ -1081,8 +1047,8 @@ function getSystemErrorName(err) {
 
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
-  _errnoException,
-  _exceptionWithHostPort,
+  _errnoException: errors.errnoException,
+  _exceptionWithHostPort: errors.exceptionWithHostPort,
   _extend,
   callbackify,
   debuglog,

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,7 @@ const {
   customInspectSymbol,
   deprecate,
   getConstructorOf,
-  getSystemErrorName,
+  getSystemErrorName: internalErrorName,
   isError,
   promisify,
   join,
@@ -1069,6 +1069,14 @@ function callbackify(original) {
   Object.defineProperties(callbackified,
                           Object.getOwnPropertyDescriptors(original));
   return callbackified;
+}
+
+function getSystemErrorName(err) {
+  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
+                               'negative number');
+  }
+  return internalErrorName(err);
 }
 
 // Keep the `exports =` so that various functions can still be monkeypatched

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -39,6 +39,8 @@ using v8::String;
 using v8::Value;
 
 
+// TODO(joyeecheung): deprecate this function in favor of
+// lib/util.getSystemErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int err = args[0]->Int32Value();

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -1,8 +1,9 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const uv = process.binding('uv');
+const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
@@ -27,7 +28,7 @@ const execOpts = { encoding: 'utf8', shell: true };
   const code = -1;
   const callback = common.mustCall((err, stdout, stderr) => {
     assert.strictEqual(err.toString().trim(), errorString);
-    assert.strictEqual(err.code, uv.errname(code));
+    assert.strictEqual(err.code, getSystemErrorName(code));
     assert.strictEqual(err.killed, true);
     assert.strictEqual(err.signal, null);
     assert.strictEqual(err.cmd, process.execPath);

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -334,10 +334,20 @@ assert.strictEqual(
 }
 
 {
-  const error = new errors.Error('ERR_INVALID_ARG_VALUE', 'foo', 'bar');
+  const error = new errors.Error('ERR_INVALID_ARG_VALUE', 'foo', '\u0000bar');
   assert.strictEqual(
     error.message,
-    'The value "bar" is invalid for argument "foo"'
+    'The argument \'foo\' is invalid. Received \'\\u0000bar\''
+  );
+}
+
+{
+  const error = new errors.Error(
+    'ERR_INVALID_ARG_VALUE',
+    'foo', { a: 1 }, 'must have property \'b\'');
+  assert.strictEqual(
+    error.message,
+    'The argument \'foo\' must have property \'b\'. Received { a: 1 }'
   );
 }
 

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const fs = require('fs');
-const uv = process.binding('uv');
+const { getSystemErrorName } = require('util');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
@@ -47,9 +47,10 @@ function randomHandle(type) {
     handleName = `pipe ${path}`;
   }
 
-  if (errno < 0) {  // uv.errname requires err < 0
-    assert(errno >= 0, `unable to bind ${handleName}: ${uv.errname(errno)}`);
+  if (errno < 0) {
+    assert.fail(`unable to bind ${handleName}: ${getSystemErrorName(errno)}`);
   }
+
   if (!common.isWindows) {  // fd doesn't work on windows
     // err >= 0 but fd = -1, should not happen
     assert.notStrictEqual(handle.fd, -1,

--- a/test/parallel/test-uv-binding-constant.js
+++ b/test/parallel/test-uv-binding-constant.js
@@ -9,10 +9,10 @@ const uv = process.binding('uv');
 
 const keys = Object.keys(uv);
 keys.forEach((key) => {
-  if (key === 'errname')
-    return; // skip this
-  const val = uv[key];
-  assert.throws(() => uv[key] = 1,
-                /^TypeError: Cannot assign to read only property/);
-  assert.strictEqual(uv[key], val);
+  if (key.startsWith('UV_')) {
+    const val = uv[key];
+    assert.throws(() => uv[key] = 1,
+                  /^TypeError: Cannot assign to read only property/);
+    assert.strictEqual(uv[key], val);
+  }
 });

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -2,9 +2,12 @@
 
 const common = require('../common');
 const assert = require('assert');
-const util = require('util');
-const uv = process.binding('uv');
+const {
+  getSystemErrorName,
+  _errnoException
+} = require('util');
 
+const uv = process.binding('uv');
 const keys = Object.keys(uv);
 
 keys.forEach((key) => {
@@ -12,17 +15,18 @@ keys.forEach((key) => {
     return;
 
   assert.doesNotThrow(() => {
-    const err = util._errnoException(uv[key], 'test');
+    const err = _errnoException(uv[key], 'test');
     const name = uv.errname(uv[key]);
-    assert.strictEqual(err.code, err.errno);
+    assert.strictEqual(getSystemErrorName(uv[key]), name);
     assert.strictEqual(err.code, name);
+    assert.strictEqual(err.code, err.errno);
     assert.strictEqual(err.message, `test ${name}`);
   });
 });
 
 [0, 1, 'test', {}, [], Infinity, -Infinity, NaN].forEach((key) => {
   common.expectsError(
-    () => util._errnoException(key),
+    () => _errnoException(key),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -8,7 +8,7 @@ const uv = process.binding('uv');
 const keys = Object.keys(uv);
 
 keys.forEach((key) => {
-  if (key === 'errname')
+  if (!key.startsWith('UV_'))
     return;
 
   assert.doesNotThrow(() => {

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -7,6 +7,7 @@ const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
+const { getSystemErrorName } = require('util');
 
 // Make sure that all Providers are tested.
 {
@@ -214,7 +215,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
       // Use a long string to make sure the write happens asynchronously.
       const err = handle.writeLatin1String(wreq, 'hi'.repeat(100000));
       if (err)
-        throw new Error(`write failed: ${process.binding('uv').errname(err)}`);
+        throw new Error(`write failed: ${getSystemErrorName(err)}`);
       testInitialized(wreq, 'WriteWrap');
     });
     req.address = common.localhostIPv4;


### PR DESCRIPTION
Only two commits from https://github.com/nodejs/node/pull/18546 are backported. The remaining one is related to the fs error migration and should be backported differently, if worth backporting at all.

src: expose uv.errmap to binding
Refs: https://github.com/nodejs/node/pull/17338

util: implement util.getSystemErrorName()
Refs: https://github.com/nodejs/node/pull/18186

errors: improve the description of ERR_INVALID_ARG_VALUE
Refs: https://github.com/nodejs/node/pull/18358

util: skip type checks in internal getSystemErrorName
errors: move error creation helpers to errors.js
Refs: https://github.com/nodejs/node/pull/18546

