### PR TITLE
http2: fix endless loop when writing empty string

### DIFF
--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+const http2 = require('http2');
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream, headers, flags) => {
+  stream.respond({ 'content-type': 'text/html' });
+
+  let data = '';
+  stream.on('data', common.mustNotCall((chunk) => {
+    data += chunk.toString();
+  }));
+  stream.on('end', common.mustCall(() => {
+    stream.end(`"${data}"`);
+  }));
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const req = client.request({
+    ':method': 'POST',
+    ':path': '/'
+  });
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+    assert.strictEqual(headers['content-type'], 'text/html');
+  }));
+
+  let data = '';
+  req.setEncoding('utf8');
+  req.on('data', common.mustCallAtLeast((d) => data += d));
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(data, '""');
+    server.close();
+    client.close();
+  }));
+
+  req.write('');
+  req.end();
+}));

--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -7,42 +7,48 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const server = http2.createServer();
-server.on('stream', common.mustCall((stream, headers, flags) => {
-  stream.respond({ 'content-type': 'text/html' });
+for (const chunkSequence of [
+  [ '' ],
+  [ '', '' ]
+]) {
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, headers, flags) => {
+    stream.respond({ 'content-type': 'text/html' });
 
-  let data = '';
-  stream.on('data', common.mustNotCall((chunk) => {
-    data += chunk.toString();
-  }));
-  stream.on('end', common.mustCall(() => {
-    stream.end(`"${data}"`);
-  }));
-}));
-
-server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
-  const client = http2.connect(`http://localhost:${port}`);
-
-  const req = client.request({
-    ':method': 'POST',
-    ':path': '/'
-  });
-
-  req.on('response', common.mustCall((headers) => {
-    assert.strictEqual(headers[':status'], 200);
-    assert.strictEqual(headers['content-type'], 'text/html');
+    let data = '';
+    stream.on('data', common.mustNotCall((chunk) => {
+      data += chunk.toString();
+    }));
+    stream.on('end', common.mustCall(() => {
+      stream.end(`"${data}"`);
+    }));
   }));
 
-  let data = '';
-  req.setEncoding('utf8');
-  req.on('data', common.mustCallAtLeast((d) => data += d));
-  req.on('end', common.mustCall(() => {
-    assert.strictEqual(data, '""');
-    server.close();
-    client.close();
-  }));
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
 
-  req.write('');
-  req.end();
-}));
+    const req = client.request({
+      ':method': 'POST',
+      ':path': '/'
+    });
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+      assert.strictEqual(headers['content-type'], 'text/html');
+    }));
+
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', common.mustCallAtLeast((d) => data += d));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(data, '""');
+      server.close();
+      client.close();
+    }));
+
+    for (const chunk of chunkSequence)
+      req.write(chunk);
+    req.end();
+  }));
+}


### PR DESCRIPTION
Alternative to #18673 that addresses the problem on the HTTP/2 level rather than the streams level itself. The test is taken from @XadillaX, whom I’d be very thankful if he could take a look at this :)

Refs: #18673
Fixes: #18169
Refs: https://github.com/nodejs/node/blob/v9.5.0/src/node_http2.cc#L1481-L1484
Refs: https://github.com/nodejs/node/blob/v9.5.0/lib/_http_outgoing.js#L659-L661

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2