### PR TITLE
util: use blue on non-windows systems for number/bigint

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -339,10 +339,11 @@ inspect.colors = Object.assign(Object.create(null), {
 });
 
 // Don't use 'blue' not visible on cmd.exe
+const windows = process.platform === 'win32';
 inspect.styles = Object.assign(Object.create(null), {
   'special': 'cyan',
-  'number': 'yellow',
-  'bigint': 'yellow',
+  'number': windows ? 'yellow' : 'blue',
+  'bigint': windows ? 'yellow' : 'blue',
   'boolean': 'yellow',
   'undefined': 'grey',
   'null': 'bold',

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -34,7 +34,8 @@ assert.deepStrictEqual(list, new BufferList());
 
 const tmp = util.inspect.defaultOptions.colors;
 util.inspect.defaultOptions = { colors: true };
+const color = util.inspect.colors[util.inspect.styles.number];
 assert.strictEqual(
   util.inspect(list),
-  'BufferList { length: \u001b[33m0\u001b[39m }');
+  `BufferList { length: \u001b[${color[0]}m0\u001b[${color[1]}m }`);
 util.inspect.defaultOptions = { colors: tmp };


### PR DESCRIPTION
the only reason these stopped being blue is windows, and honestly util.inspect output looks so much more balanced with blue.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
util