### PR TITLE
tools: add falsely removed eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
     'accessor-pairs': 'error',
     'array-callback-return': 'error',
     'dot-location': ['error', 'property'],
+    'dot-notation': 'error',
     eqeqeq: ['error', 'smart'],
     'no-fallthrough': 'error',
     'no-global-assign': 'error',
@@ -111,6 +112,7 @@ module.exports = {
     ],
     'no-return-await': 'error',
     'no-self-assign': 'error',
+    'no-self-compare': 'error',
     'no-throw-literal': 'error',
     'no-unused-labels': 'error',
     'no-useless-call': 'error',
@@ -181,6 +183,10 @@ module.exports = {
     'no-restricted-syntax': [
       'error',
       {
+        selector: "CallExpression[callee.object.name='assert'][callee.property.name='doesNotThrow']",
+        message: "Please replace `assert.doesNotThrow()` and add a comment next to the code instead."
+      },
+      {
         selector: `CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.1.type='Literal']:not([arguments.1.regex])`,
         message: 'use a regular expression for second argument of assert.throws()',
       },
@@ -204,6 +210,7 @@ module.exports = {
     /* eslint-enable max-len, quotes */
     'no-tabs': 'error',
     'no-trailing-spaces': 'error',
+    'no-unsafe-finally': 'error',
     'object-curly-spacing': ['error', 'always'],
     'one-var-declaration-per-line': 'error',
     'operator-linebreak': ['error', 'after'],


### PR DESCRIPTION
This adds the eslint rules back in that were falsely removed while
landing https://github.com/nodejs/node/pull/18566.

Refs: https://github.com/nodejs/node/pull/18566

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools