### PR TITLE
src: make process.dlopen() load well-known symbol

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2158,6 +2158,7 @@ struct DLib {
 
   inline bool Open();
   inline void Close();
+  inline void* GetSymbolAddress(const char* name);
 
   const std::string filename_;
   const int flags_;
@@ -2185,6 +2186,10 @@ void DLib::Close() {
   dlclose(handle_);
   handle_ = nullptr;
 }
+
+void* DLib::GetSymbolAddress(const char* name) {
+  return dlsym(handle_, name);
+}
 #else  // !__POSIX__
 bool DLib::Open() {
   int ret = uv_dlopen(filename_.c_str(), &lib_);
@@ -2202,7 +2207,22 @@ void DLib::Close() {
   uv_dlclose(&lib_);
   handle_ = nullptr;
 }
+
+void* DLib::GetSymbolAddress(const char* name) {
+  void* address;
+  if (0 == uv_dlsym(&lib_, name, &address)) return address;
+  return nullptr;
+}
 #endif  // !__POSIX__
+
+using InitializerCallback = void (*)(Local<Object> exports,
+                                     Local<Value> module,
+                                     Local<Context> context);
+
+inline InitializerCallback GetInitializerCallback(DLib* dlib) {
+  const char* name = "node_register_module_v" STRINGIFY(NODE_MODULE_VERSION);
+  return reinterpret_cast<InitializerCallback>(dlib->GetSymbolAddress(name));
+}
 
 // DLOpen is process.dlopen(module, filename, flags).
 // Used to load 'module.node' dynamically shared objects.
@@ -2258,10 +2278,15 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (mp == nullptr) {
-    dlib.Close();
-    env->ThrowError("Module did not self-register.");
+    if (auto callback = GetInitializerCallback(&dlib)) {
+      callback(exports, module, context);
+    } else {
+      dlib.Close();
+      env->ThrowError("Module did not self-register.");
+    }
     return;
   }
+
   if (mp->nm_version == -1) {
     if (env->EmitNapiWarning()) {
       if (ProcessEmitWarning(env, "N-API is an experimental feature and could "

--- a/src/node.cc
+++ b/src/node.cc
@@ -2147,46 +2147,62 @@ node_module* get_linked_module(const char* name) {
 }
 
 struct DLib {
-  std::string filename_;
-  std::string errmsg_;
-  void* handle_;
-  int flags_;
-
 #ifdef __POSIX__
   static const int kDefaultFlags = RTLD_LAZY;
-
-  bool Open() {
-    handle_ = dlopen(filename_.c_str(), flags_);
-    if (handle_ != nullptr)
-      return true;
-    errmsg_ = dlerror();
-    return false;
-  }
-
-  void Close() {
-    if (handle_ != nullptr)
-      dlclose(handle_);
-  }
-#else  // !__POSIX__
+#else
   static const int kDefaultFlags = 0;
+#endif
+
+  inline DLib(const char* filename, int flags)
+      : filename_(filename), flags_(flags), handle_(nullptr) {}
+
+  inline bool Open();
+  inline void Close();
+
+  const std::string filename_;
+  const int flags_;
+  std::string errmsg_;
+  void* handle_;
+#ifndef __POSIX__
   uv_lib_t lib_;
+#endif
 
-  bool Open() {
-    int ret = uv_dlopen(filename_.c_str(), &lib_);
-    if (ret == 0) {
-      handle_ = static_cast<void*>(lib_.handle);
-      return true;
-    }
-    errmsg_ = uv_dlerror(&lib_);
-    uv_dlclose(&lib_);
-    return false;
-  }
-
-  void Close() {
-    uv_dlclose(&lib_);
-  }
-#endif  // !__POSIX__
+  DISALLOW_COPY_AND_ASSIGN(DLib);
 };
+
+
+#ifdef __POSIX__
+bool DLib::Open() {
+  handle_ = dlopen(filename_.c_str(), flags_);
+  if (handle_ != nullptr)
+    return true;
+  errmsg_ = dlerror();
+  return false;
+}
+
+void DLib::Close() {
+  if (handle_ == nullptr) return;
+  dlclose(handle_);
+  handle_ = nullptr;
+}
+#else  // !__POSIX__
+bool DLib::Open() {
+  int ret = uv_dlopen(filename_.c_str(), &lib_);
+  if (ret == 0) {
+    handle_ = static_cast<void*>(lib_.handle);
+    return true;
+  }
+  errmsg_ = uv_dlerror(&lib_);
+  uv_dlclose(&lib_);
+  return false;
+}
+
+void DLib::Close() {
+  if (handle_ == nullptr) return;
+  uv_dlclose(&lib_);
+  handle_ = nullptr;
+}
+#endif  // !__POSIX__
 
 // DLOpen is process.dlopen(module, filename, flags).
 // Used to load 'module.node' dynamically shared objects.
@@ -2196,6 +2212,7 @@ struct DLib {
 // cache that's a plain C list or hash table that's shared across contexts?
 static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  auto context = env->context();
 
   CHECK_EQ(modpending, nullptr);
 
@@ -2205,16 +2222,21 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   }
 
   int32_t flags = DLib::kDefaultFlags;
-  if (args.Length() > 2 && !args[2]->Int32Value(env->context()).To(&flags)) {
+  if (args.Length() > 2 && !args[2]->Int32Value(context).To(&flags)) {
     return env->ThrowTypeError("flag argument must be an integer.");
   }
 
-  Local<Object> module =
-      args[0]->ToObject(env->context()).ToLocalChecked();  // Cast
+  Local<Object> module;
+  Local<Object> exports;
+  Local<Value> exports_v;
+  if (!args[0]->ToObject(context).ToLocal(&module) ||
+      !module->Get(context, env->exports_string()).ToLocal(&exports_v) ||
+      !exports_v->ToObject(context).ToLocal(&exports)) {
+    return;  // Exception pending.
+  }
+
   node::Utf8Value filename(env->isolate(), args[1]);  // Cast
-  DLib dlib;
-  dlib.filename_ = *filename;
-  dlib.flags_ = flags;
+  DLib dlib(*filename, flags);
   bool is_opened = dlib.Open();
 
   // Objects containing v14 or later modules will have registered themselves
@@ -2229,7 +2251,7 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
 #ifdef _WIN32
     // Windows needs to add the filename into the error message
     errmsg = String::Concat(errmsg,
-                            args[1]->ToString(env->context()).ToLocalChecked());
+                            args[1]->ToString(context).ToLocalChecked());
 #endif  // _WIN32
     env->isolate()->ThrowException(Exception::Error(errmsg));
     return;
@@ -2276,22 +2298,8 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   mp->nm_link = modlist_addon;
   modlist_addon = mp;
 
-  Local<String> exports_string = env->exports_string();
-  MaybeLocal<Value> maybe_exports =
-      module->Get(env->context(), exports_string);
-
-  if (maybe_exports.IsEmpty() ||
-      maybe_exports.ToLocalChecked()->ToObject(env->context()).IsEmpty()) {
-    dlib.Close();
-    return;
-  }
-
-  Local<Object> exports =
-      maybe_exports.ToLocalChecked()->ToObject(env->context())
-          .FromMaybe(Local<Object>());
-
   if (mp->nm_context_register_func != nullptr) {
-    mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);
+    mp->nm_context_register_func(exports, module, context, mp->nm_priv);
   } else if (mp->nm_register_func != nullptr) {
     mp->nm_register_func(exports, module, mp->nm_priv);
   } else {

--- a/src/node.h
+++ b/src/node.h
@@ -535,6 +535,9 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
     }                                                                 \
   }
 
+// Usage: `NODE_MODULE(NODE_GYP_MODULE_NAME, InitializerFunction)`
+// If no NODE_MODULE is declared, Node.js looks for the well-known
+// symbol `node_register_module_v${NODE_MODULE_VERSION}`.
 #define NODE_MODULE(modname, regfunc)                                 \
   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
 

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -6,8 +6,12 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(v8::Local<v8::Object> exports) {
+#define CONCAT(a, b) CONCAT_HELPER(a, b)
+#define CONCAT_HELPER(a, b) a##b
+#define INITIALIZER CONCAT(node_register_module_v, NODE_MODULE_VERSION)
+
+extern "C" NODE_MODULE_EXPORT void INITIALIZER(v8::Local<v8::Object> exports,
+                                               v8::Local<v8::Value> module,
+                                               v8::Local<v8::Context> context) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
-
-NODE_MODULE(NODE_GYP_MODULE_NAME, init)


### PR DESCRIPTION
Look for symbol `node_register_module_v${NODE_MODULE_VERSION}` if the
add-on didn't self-register.  This can be used to create add-ons that
support multiple Node.js versions from a single shared object.

An experiment to make add-on loading more flexible.  Can be extended to n-api, cc @nodejs/n-api.

Longer term, I'd like to get rid of the `__attribute__((constructor))` approach.  It's convoluted and complicated for no good reason.