### PR TITLE
path: refactor some methods to reduce duplicated codes

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -120,6 +120,71 @@ function _normalizeString(path, allowAboveRoot, win32) {
   return res;
 }
 
+function _extname(path, win32) {
+  assertPath(path);
+  var start = 0;
+  var startDot = -1;
+  var startPart = 0;
+  var end = -1;
+  var matchedSlash = true;
+  // Track the state of characters (if any) we see before our first dot and
+  // after any path separator we find
+  var preDotState = 0;
+
+  // Check for a drive letter prefix so as not to mistake the following
+  // path separator as an extra separator at the end of the path that can be
+  // disregarded
+
+  if (win32 &&
+      path.length >= 2 &&
+      path.charCodeAt(1) === CHAR_COLON &&
+      isWindowsDeviceRoot(path.charCodeAt(0))) {
+    start = startPart = 2;
+  }
+
+  for (var i = path.length - 1; i >= start; --i) {
+    const code = path.charCodeAt(i);
+    if (isPathSeparator(code, !win32)) {
+      // If we reached a path separator that was not part of a set of path
+      // separators at the end of the string, stop now
+      if (!matchedSlash) {
+        startPart = i + 1;
+        break;
+      }
+      continue;
+    }
+    if (end === -1) {
+      // We saw the first non-path separator, mark this as the end of our
+      // extension
+      matchedSlash = false;
+      end = i + 1;
+    }
+    if (code === CHAR_DOT) {
+      // If this is our first dot, mark it as the start of our extension
+      if (startDot === -1)
+        startDot = i;
+      else if (preDotState !== 1)
+        preDotState = 1;
+    } else if (startDot !== -1) {
+      // We saw a non-dot and non-path separator before our dot, so we should
+      // have a good chance at having a non-empty extension
+      preDotState = -1;
+    }
+  }
+
+  if (startDot === -1 ||
+      end === -1 ||
+      // We saw a non-dot character immediately before the dot
+      preDotState === 0 ||
+      // The (right-most) trimmed path component is exactly '..'
+      (preDotState === 1 &&
+       startDot === end - 1 &&
+       startDot === startPart + 1)) {
+    return '';
+  }
+  return path.slice(startDot, end);
+}
+
 function _format(sep, pathObject) {
   const dir = pathObject.dir || pathObject.root;
   const base = pathObject.base ||
@@ -829,67 +894,7 @@ const win32 = {
 
 
   extname: function extname(path) {
-    assertPath(path);
-    var start = 0;
-    var startDot = -1;
-    var startPart = 0;
-    var end = -1;
-    var matchedSlash = true;
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-    var preDotState = 0;
-
-    // Check for a drive letter prefix so as not to mistake the following
-    // path separator as an extra separator at the end of the path that can be
-    // disregarded
-
-    if (path.length >= 2 &&
-        path.charCodeAt(1) === CHAR_COLON &&
-        isWindowsDeviceRoot(path.charCodeAt(0))) {
-      start = startPart = 2;
-    }
-
-    for (var i = path.length - 1; i >= start; --i) {
-      const code = path.charCodeAt(i);
-      if (isPathSeparator(code)) {
-        // If we reached a path separator that was not part of a set of path
-        // separators at the end of the string, stop now
-        if (!matchedSlash) {
-          startPart = i + 1;
-          break;
-        }
-        continue;
-      }
-      if (end === -1) {
-        // We saw the first non-path separator, mark this as the end of our
-        // extension
-        matchedSlash = false;
-        end = i + 1;
-      }
-      if (code === CHAR_DOT) {
-        // If this is our first dot, mark it as the start of our extension
-        if (startDot === -1)
-          startDot = i;
-        else if (preDotState !== 1)
-          preDotState = 1;
-      } else if (startDot !== -1) {
-        // We saw a non-dot and non-path separator before our dot, so we should
-        // have a good chance at having a non-empty extension
-        preDotState = -1;
-      }
-    }
-
-    if (startDot === -1 ||
-        end === -1 ||
-        // We saw a non-dot character immediately before the dot
-        preDotState === 0 ||
-        // The (right-most) trimmed path component is exactly '..'
-        (preDotState === 1 &&
-         startDot === end - 1 &&
-         startDot === startPart + 1)) {
-      return '';
-    }
-    return path.slice(startDot, end);
+    return _extname(path, true);
   },
 
 
@@ -1367,55 +1372,7 @@ const posix = {
 
 
   extname: function extname(path) {
-    assertPath(path);
-    var startDot = -1;
-    var startPart = 0;
-    var end = -1;
-    var matchedSlash = true;
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-    var preDotState = 0;
-    for (var i = path.length - 1; i >= 0; --i) {
-      const code = path.charCodeAt(i);
-      if (code === CHAR_FORWARD_SLASH) {
-        // If we reached a path separator that was not part of a set of path
-        // separators at the end of the string, stop now
-        if (!matchedSlash) {
-          startPart = i + 1;
-          break;
-        }
-        continue;
-      }
-      if (end === -1) {
-        // We saw the first non-path separator, mark this as the end of our
-        // extension
-        matchedSlash = false;
-        end = i + 1;
-      }
-      if (code === CHAR_DOT) {
-        // If this is our first dot, mark it as the start of our extension
-        if (startDot === -1)
-          startDot = i;
-        else if (preDotState !== 1)
-          preDotState = 1;
-      } else if (startDot !== -1) {
-        // We saw a non-dot and non-path separator before our dot, so we should
-        // have a good chance at having a non-empty extension
-        preDotState = -1;
-      }
-    }
-
-    if (startDot === -1 ||
-        end === -1 ||
-        // We saw a non-dot character immediately before the dot
-        preDotState === 0 ||
-        // The (right-most) trimmed path component is exactly '..'
-        (preDotState === 1 &&
-         startDot === end - 1 &&
-         startDot === startPart + 1)) {
-      return '';
-    }
-    return path.slice(startDot, end);
+    return _extname(path);
   },
 
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -185,6 +185,93 @@ function _extname(path, win32) {
   return path.slice(startDot, end);
 }
 
+function _basename(path, ext, win32) {
+  if (ext !== undefined && typeof ext !== 'string')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
+  assertPath(path);
+  var start = 0;
+  var end = -1;
+  var matchedSlash = true;
+  var i;
+
+  // Check for a drive letter prefix so as not to mistake the following
+  // path separator as an extra separator at the end of the path that can be
+  // disregarded
+  if (win32 && path.length >= 2) {
+    const drive = path.charCodeAt(0);
+    if (isWindowsDeviceRoot(drive)) {
+      if (path.charCodeAt(1) === CHAR_COLON)
+        start = 2;
+    }
+  }
+
+  if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+    if (ext.length === path.length && ext === path)
+      return '';
+    var extIdx = ext.length - 1;
+    var firstNonSlashEnd = -1;
+    for (i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (isPathSeparator(code, !win32)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else {
+        if (firstNonSlashEnd === -1) {
+          // We saw the first non-path separator, remember this index in case
+          // we need it if the extension ends up not matching
+          matchedSlash = false;
+          firstNonSlashEnd = i + 1;
+        }
+        if (extIdx >= 0) {
+          // Try to match the explicit extension
+          if (code === ext.charCodeAt(extIdx)) {
+            if (--extIdx === -1) {
+              // We matched the extension, so mark this as the end of our path
+              // component
+              end = i;
+            }
+          } else {
+            // Extension does not match, so our result is the entire path
+            // component
+            extIdx = -1;
+            end = firstNonSlashEnd;
+          }
+        }
+      }
+    }
+
+    if (start === end)
+      end = firstNonSlashEnd;
+    else if (end === -1)
+      end = path.length;
+    return path.slice(start, end);
+  } else {
+    for (i = path.length - 1; i >= start; --i) {
+      if (isPathSeparator(path.charCodeAt(i), !win32)) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1)
+      return '';
+    return path.slice(start, end);
+  }
+}
+
 function _format(sep, pathObject) {
   const dir = pathObject.dir || pathObject.root;
   const base = pathObject.base ||
@@ -806,90 +893,7 @@ const win32 = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
-    assertPath(path);
-    var start = 0;
-    var end = -1;
-    var matchedSlash = true;
-    var i;
-
-    // Check for a drive letter prefix so as not to mistake the following
-    // path separator as an extra separator at the end of the path that can be
-    // disregarded
-    if (path.length >= 2) {
-      const drive = path.charCodeAt(0);
-      if (isWindowsDeviceRoot(drive)) {
-        if (path.charCodeAt(1) === CHAR_COLON)
-          start = 2;
-      }
-    }
-
-    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
-      if (ext.length === path.length && ext === path)
-        return '';
-      var extIdx = ext.length - 1;
-      var firstNonSlashEnd = -1;
-      for (i = path.length - 1; i >= start; --i) {
-        const code = path.charCodeAt(i);
-        if (isPathSeparator(code)) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else {
-          if (firstNonSlashEnd === -1) {
-            // We saw the first non-path separator, remember this index in case
-            // we need it if the extension ends up not matching
-            matchedSlash = false;
-            firstNonSlashEnd = i + 1;
-          }
-          if (extIdx >= 0) {
-            // Try to match the explicit extension
-            if (code === ext.charCodeAt(extIdx)) {
-              if (--extIdx === -1) {
-                // We matched the extension, so mark this as the end of our path
-                // component
-                end = i;
-              }
-            } else {
-              // Extension does not match, so our result is the entire path
-              // component
-              extIdx = -1;
-              end = firstNonSlashEnd;
-            }
-          }
-        }
-      }
-
-      if (start === end)
-        end = firstNonSlashEnd;
-      else if (end === -1)
-        end = path.length;
-      return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= start; --i) {
-        if (isPathSeparator(path.charCodeAt(i))) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
-    }
+    return _basename(path, ext, true);
   },
 
 
@@ -1294,80 +1298,7 @@ const posix = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
-    assertPath(path);
-
-    var start = 0;
-    var end = -1;
-    var matchedSlash = true;
-    var i;
-
-    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
-      if (ext.length === path.length && ext === path)
-        return '';
-      var extIdx = ext.length - 1;
-      var firstNonSlashEnd = -1;
-      for (i = path.length - 1; i >= 0; --i) {
-        const code = path.charCodeAt(i);
-        if (code === CHAR_FORWARD_SLASH) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else {
-          if (firstNonSlashEnd === -1) {
-            // We saw the first non-path separator, remember this index in case
-            // we need it if the extension ends up not matching
-            matchedSlash = false;
-            firstNonSlashEnd = i + 1;
-          }
-          if (extIdx >= 0) {
-            // Try to match the explicit extension
-            if (code === ext.charCodeAt(extIdx)) {
-              if (--extIdx === -1) {
-                // We matched the extension, so mark this as the end of our path
-                // component
-                end = i;
-              }
-            } else {
-              // Extension does not match, so our result is the entire path
-              // component
-              extIdx = -1;
-              end = firstNonSlashEnd;
-            }
-          }
-        }
-      }
-
-      if (start === end)
-        end = firstNonSlashEnd;
-      else if (end === -1)
-        end = path.length;
-      return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= 0; --i) {
-        if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
-    }
+    return _basename(path, ext);
   },
 
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -40,8 +40,9 @@ function assertPath(path) {
   }
 }
 
-function isPathSeparator(code) {
-  return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+function isPathSeparator(code, posixOnly) {
+  return code === CHAR_FORWARD_SLASH ||
+         (!posixOnly && code === CHAR_BACKWARD_SLASH);
 }
 
 function isWindowsDeviceRoot(code) {
@@ -50,21 +51,22 @@ function isWindowsDeviceRoot(code) {
 }
 
 // Resolves . and .. elements in a path with directory names
-function normalizeStringWin32(path, allowAboveRoot) {
+function _normalizeString(path, allowAboveRoot, win32) {
   var res = '';
   var lastSegmentLength = 0;
   var lastSlash = -1;
   var dots = 0;
   var code;
+  var slash = win32 ? '\\' : '/';
   for (var i = 0; i <= path.length; ++i) {
     if (i < path.length)
       code = path.charCodeAt(i);
-    else if (isPathSeparator(code))
+    else if (isPathSeparator(code, !win32))
       break;
     else
       code = CHAR_FORWARD_SLASH;
 
-    if (isPathSeparator(code)) {
+    if (isPathSeparator(code, !win32)) {
       if (lastSlash === i - 1 || dots === 1) {
         // NOOP
       } else if (lastSlash !== i - 1 && dots === 2) {
@@ -72,14 +74,14 @@ function normalizeStringWin32(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== CHAR_DOT ||
             res.charCodeAt(res.length - 2) !== CHAR_DOT) {
           if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('\\');
+            const lastSlashIndex = res.lastIndexOf(slash);
             if (lastSlashIndex !== res.length - 1) {
               if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
                 res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('\\');
+                lastSegmentLength = res.length - 1 - res.lastIndexOf(slash);
               }
               lastSlash = i;
               dots = 0;
@@ -95,82 +97,14 @@ function normalizeStringWin32(path, allowAboveRoot) {
         }
         if (allowAboveRoot) {
           if (res.length > 0)
-            res += '\\..';
+            res += slash + '..';
           else
             res = '..';
           lastSegmentLength = 2;
         }
       } else {
         if (res.length > 0)
-          res += '\\' + path.slice(lastSlash + 1, i);
-        else
-          res = path.slice(lastSlash + 1, i);
-        lastSegmentLength = i - lastSlash - 1;
-      }
-      lastSlash = i;
-      dots = 0;
-    } else if (code === CHAR_DOT && dots !== -1) {
-      ++dots;
-    } else {
-      dots = -1;
-    }
-  }
-  return res;
-}
-
-// Resolves . and .. elements in a path with directory names
-function normalizeStringPosix(path, allowAboveRoot) {
-  var res = '';
-  var lastSegmentLength = 0;
-  var lastSlash = -1;
-  var dots = 0;
-  var code;
-  for (var i = 0; i <= path.length; ++i) {
-    if (i < path.length)
-      code = path.charCodeAt(i);
-    else if (code === CHAR_FORWARD_SLASH)
-      break;
-    else
-      code = CHAR_FORWARD_SLASH;
-    if (code === CHAR_FORWARD_SLASH) {
-      if (lastSlash === i - 1 || dots === 1) {
-        // NOOP
-      } else if (lastSlash !== i - 1 && dots === 2) {
-        if (res.length < 2 || lastSegmentLength !== 2 ||
-            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
-            res.charCodeAt(res.length - 2) !== CHAR_DOT) {
-          if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('/');
-            if (lastSlashIndex !== res.length - 1) {
-              if (lastSlashIndex === -1) {
-                res = '';
-                lastSegmentLength = 0;
-              } else {
-                res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('/');
-              }
-              lastSlash = i;
-              dots = 0;
-              continue;
-            }
-          } else if (res.length === 2 || res.length === 1) {
-            res = '';
-            lastSegmentLength = 0;
-            lastSlash = i;
-            dots = 0;
-            continue;
-          }
-        }
-        if (allowAboveRoot) {
-          if (res.length > 0)
-            res += '/..';
-          else
-            res = '..';
-          lastSegmentLength = 2;
-        }
-      } else {
-        if (res.length > 0)
-          res += '/' + path.slice(lastSlash + 1, i);
+          res += slash + path.slice(lastSlash + 1, i);
         else
           res = path.slice(lastSlash + 1, i);
         lastSegmentLength = i - lastSlash - 1;
@@ -340,7 +274,7 @@ const win32 = {
     // fails)
 
     // Normalize the tail path
-    resolvedTail = normalizeStringWin32(resolvedTail, !resolvedAbsolute);
+    resolvedTail = _normalizeString(resolvedTail, !resolvedAbsolute, true);
 
     return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
            '.';
@@ -432,7 +366,7 @@ const win32 = {
 
     var tail;
     if (rootEnd < len)
-      tail = normalizeStringWin32(path.slice(rootEnd), !isAbsolute);
+      tail = _normalizeString(path.slice(rootEnd), !isAbsolute, true);
     else
       tail = '';
     if (tail.length === 0 && !isAbsolute)
@@ -1164,7 +1098,7 @@ const posix = {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeStringPosix(resolvedPath, !resolvedAbsolute);
+    resolvedPath = _normalizeString(resolvedPath, !resolvedAbsolute);
 
     if (resolvedAbsolute) {
       if (resolvedPath.length > 0)
@@ -1190,7 +1124,7 @@ const posix = {
       path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
 
     // Normalize the path
-    path = normalizeStringPosix(path, !isAbsolute);
+    path = _normalizeString(path, !isAbsolute);
 
     if (path.length === 0 && !isAbsolute)
       path = '.';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
The codes in `normalizeString`, `extname` and `basename` are almost the same. This change is to reduce these duplicated codes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
path