### PR TITLE
 repl: no RegExp side effects for static properties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -164,11 +164,11 @@ function REPLServer(prompt,
   // Just for backwards compat, see github.com/joyent/node/pull/7127
   self.rli = this;
 
-  const savedRegExMatches = ['', '', '', '', '', '', '', '', '', ''];
-  const sep = '\u0000\u0000\u0000';
-  const regExMatcher = new RegExp(`^${sep}(.*)${sep}(.*)${sep}(.*)${sep}(.*)` +
-                                  `${sep}(.*)${sep}(.*)${sep}(.*)${sep}(.*)` +
-                                  `${sep}(.*)$`);
+  const savedRegExMatches = ['', '', '', '', '', '', '', '', ''];
+  const savedRegEx = {
+    input: '', // '$_'
+    lastMatch: '', //'$&'
+  };
 
   eval_ = eval_ || defaultEval;
 
@@ -262,7 +262,10 @@ function REPLServer(prompt,
 
     // This will set the values from `savedRegExMatches` to corresponding
     // predefined RegExp properties `RegExp.$1`, `RegExp.$2` ... `RegExp.$9`
-    regExMatcher.test(savedRegExMatches.join(sep));
+    const matcher = savedRegExMatches[0].length ?
+      regexBuildGroup(savedRegExMatches, savedRegEx.lastMatch) :
+      new RegExp(regexpEscape(savedRegEx.lastMatch));
+    matcher.test(savedRegEx.input);
 
     let finished = false;
     function finishExecution(err, result) {
@@ -271,9 +274,11 @@ function REPLServer(prompt,
 
       // After executing the current expression, store the values of RegExp
       // predefined properties back in `savedRegExMatches`
-      for (var idx = 1; idx < savedRegExMatches.length; idx += 1) {
-        savedRegExMatches[idx] = RegExp[`$${idx}`];
+      for (var idx = 0; idx < savedRegExMatches.length; idx += 1) {
+        savedRegExMatches[idx] = RegExp[`$${idx + 1}`];
       }
+      savedRegEx.input = '' + RegExp.input;
+      savedRegEx.lastMatch = '' + RegExp.lastMatch;
 
       cb(err, result);
     }
@@ -1447,6 +1452,35 @@ function defineDefaultCommands(repl) {
 
 function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+function regexBuildGroup(matches, input) {
+  const groups = [];
+  const lowercase = input.toLocaleLowerCase();
+  let offset = 0;
+  let ignoreCase = false;
+  for (const m of matches) {
+    if (!m.length) {
+      if (input.length - offset > 0) {
+        groups.push(regexpEscape(input.substring(offset, input.length)));
+      }
+      break;
+    }
+
+    let idx = input.indexOf(m, offset);
+    if (idx === -1) {
+      ignoreCase = true;
+      idx = lowercase.indexOf(m.toLocaleLowerCase(), offset);
+    }
+
+    if (idx - offset > 0) {
+      groups.push(regexpEscape(input.substring(offset, idx)));
+    }
+
+    groups.push('(.{' + m.length + '})');
+    offset = idx + m.length;
+  }
+  return new RegExp(groups.join(''), ignoreCase ? 'i' : '');
 }
 
 // If the error is that we've unexpectedly ended the input,

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -440,7 +440,7 @@ const errorTests = [
   },
   // Regression test for https://github.com/nodejs/node/issues/597
   {
-    send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
+    send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789abc\')\n',
     expect: 'true'
   },
   // the following test's result depends on the RegExp's match from the above
@@ -449,6 +449,66 @@ const errorTests = [
           'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
     expect: ['\'1\'', '\'2\'', '\'3\'', '\'4\'', '\'5\'', '\'6\'',
              '\'7\'', '\'8\'', '\'9\'']
+  },
+  // input against which a regular expression is matched
+  {
+    send: 'RegExp.$_',
+    expect: '\'123456789abc\''
+  },
+  // substring of input against which a regular expression is matched
+  {
+    send: 'RegExp.lastMatch',
+    expect: '\'123456789\''
+  },
+  {
+    send: 'RegExp.lastParen',
+    expect: '\'9\''
+  },
+  {
+    send: 'RegExp.leftContext',
+    expect: '\'\''
+  },
+  {
+    send: 'RegExp.rightContext',
+    expect: '\'abc\''
+  },
+  {
+    send: 'new RegExp(\'XXX(.*)x(Jkl.*)XxX\', \'i\')' +
+      '.test(\'ABCDXXXEFGHIXJKLMNXXXOPQ\')\n',
+    expect: 'true'
+  },
+  // the following test's result depends on the RegExp's match from the above
+  {
+    send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
+          'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
+    expect: ['\'EFGHI\'', '\'JKLMN\'', '\'\'', '\'\'', '\'\'', '\'\'',
+             '\'\'', '\'\'', '\'\'']
+  },
+  // input against which a regular expression is matched
+  {
+    send: 'RegExp.$_',
+    expect: '\'ABCDXXXEFGHIXJKLMNXXXOPQ\''
+  },
+  // substring of input against which a regular expression is matched
+  {
+    send: 'RegExp.lastMatch',
+    expect: '\'XXXEFGHIXJKLMNXXX\''
+  },
+  {
+    send: 'RegExp.lastParen',
+    expect: '\'JKLMN\''
+  },
+  {
+    send: 'RegExp.leftContext',
+    expect: '\'ABCD\''
+  },
+  {
+    send: 'RegExp.rightContext',
+    expect: '\'OPQ\''
+  },
+  {
+    send: '/XXX(.*)X(.*)XXX/.test(\'ABCDXXXEFGHIXJKLMNXXXOPQ\')\n',
+    expect: 'true'
   },
   // regression tests for https://github.com/nodejs/node/issues/2749
   {


### PR DESCRIPTION
Preserve all RegExp static properties
  - RegExp.$1 to RegExp.9
  - input, lastMatch, lastParen
  - leftContext and rightContext

Fixes: https://github.com/nodejs/node/issues/18931

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

cc: @bnoordhuis 