### PR TITLE
http: do not replace .read() in IncomingMessage

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -38,13 +38,6 @@ function readStop(socket) {
 function IncomingMessage(socket) {
   Stream.Readable.call(this);
 
-  // Set this to `true` so that stream.Readable won't attempt to read more
-  // data on `IncomingMessage#push` (see `maybeReadMore` in
-  // `_stream_readable.js`). This is important for proper tracking of
-  // `IncomingMessage#_consuming` which is used to dump requests that users
-  // haven't attempted to read.
-  this._readableState.readingMore = true;
-
   this.socket = socket;
   this.connection = socket;
 
@@ -70,9 +63,6 @@ function IncomingMessage(socket) {
   this.statusMessage = null;
   this.client = socket;
 
-  // flag for backwards compatibility grossness.
-  this._consuming = false;
-
   // flag for when we decide that this message cannot possibly be
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
@@ -85,15 +75,6 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
     this.on('timeout', callback);
   this.socket.setTimeout(msecs);
   return this;
-};
-
-
-IncomingMessage.prototype.read = function read(n) {
-  if (!this._consuming)
-    this._readableState.readingMore = false;
-  this._consuming = true;
-  this.read = Stream.Readable.prototype.read;
-  return this.read(n);
 };
 
 

--- a/test/parallel/test-http-dump-req-when-res-ends.js
+++ b/test/parallel/test-http-dump-req-when-res-ends.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const common = require('../common');
+const http = require('http');
+const fs = require('fs');
+
+const server = http.createServer(function(req, res) {
+  // this checks if the request gets dumped
+  req.on('resume', common.mustCall(function() {
+    console.log('resume called');
+
+    req.on('data', common.mustCallAtLeast(function(d) {
+      console.log('data', d)
+    }, 1));
+  }));
+
+  // end is not called as we are just exhausting
+  // the in-memory buffer
+  req.on('end', common.mustNotCall);
+
+  // this 'data' handler will be removed when dumped
+  req.on('data', common.mustNotCall);
+
+  // start sending the response
+  res.flushHeaders();
+
+  setTimeout(function () {
+    res.end('hello world');
+  }, common.platformTimeout(100));
+});
+
+server.listen(0, function() {
+  const req = http.request({
+    method: 'POST',
+    port: server.address().port
+  })
+
+  // Send the http request without waiting
+  // for the body
+  req.flushHeaders();
+
+  req.on('response', common.mustCall(function (res) {
+    // pipe the body as soon as we get the headers of the
+    // response back
+    fs.createReadStream(__filename).pipe(req);
+
+    res.setEncoding('utf8');
+
+    let data = ''
+
+    res.on('data', function(d) {
+      data += d;
+    });
+
+    // wait for the response
+    res.on('end', function() {
+      server.close();
+    });
+  }));
+});


### PR DESCRIPTION
This removes some monkeypatching in `IncomingMessage.prototype.read()` that I did not understand. Surprisingly, __none of our tests fails__ if I remove them.

I'm opening this PR mainly to gather understanding of what these lines of code do, and if we really need those.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

http