### PR TITLE
events: preset `usingDomains` to false

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -31,6 +31,8 @@ module.exports = EventEmitter;
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 
+EventEmitter.usingDomains = false;
+
 EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._eventsCount = 0;
 EventEmitter.prototype._maxListeners = undefined;

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -36,6 +36,7 @@ function MyEE(cb) {
 
 const myee = new MyEE(common.mustCall());
 
+myee.hasOwnProperty('usingDomains');
 
 util.inherits(ErrorEE, EventEmitter);
 function ErrorEE() {


### PR DESCRIPTION
The line setting this was removed in a previous commit. This
potentially breaks code in the wild using this property.

Refs: https://github.com/nodejs/node/pull/17403#issuecomment-367814130

Alternative to https://github.com/nodejs/node/pull/18942