### PR TITLE
src: fix build with --with-lttng

### DIFF
--- a/src/node_lttng.cc
+++ b/src/node_lttng.cc
@@ -1,4 +1,4 @@
-#include "util.h"
+#include "node_internals.h"
 
 #ifdef HAVE_LTTNG
 #include "node_lttng.h"
@@ -247,7 +247,7 @@ void InitLTTNG(Environment* env, Local<Object> target) {
 #undef NODE_PROBE
   };
 
-  for (size_t i = 0; i < arraysize(tab); i++) {
+  for (size_t i = 0; i < node::arraysize(tab); i++) {
     Local<String> key = OneByteString(env->isolate(), tab[i].name);
     Local<Value> val = env->NewFunctionTemplate(tab[i].func)->GetFunction();
     target->Set(key, val);

--- a/src/node_lttng_tp.h
+++ b/src/node_lttng_tp.h
@@ -25,6 +25,7 @@ TRACEPOINT_EVENT(
     ctf_string(url, url)
     ctf_string(method, method)
     ctf_string(forwardedFor, forwardedFor))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -37,6 +38,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_string(remote, remote)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -47,6 +49,7 @@ TRACEPOINT_EVENT(
   TP_FIELDS(
     ctf_string(url, url)
     ctf_string(method, method))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -59,6 +62,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_string(remote, remote)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -73,6 +77,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_integer(int, fd, fd)
     ctf_integer(int, buffered, buffered))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -85,6 +90,7 @@ TRACEPOINT_EVENT(
     ctf_string(remote, remote)
     ctf_integer(int, port, port)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -106,6 +112,7 @@ TRACEPOINT_EVENT(
   TP_FIELDS(
     ctf_string(gctype, gctype)
     ctf_string(gcflags, gcflags))
+)
 
 #endif /* __NODE_LTTNG_TP_H */
 


### PR DESCRIPTION
Building with --with-lttng hits a few issues.

- There are missing parentheses in node_lttng_tp.h since

  src: lint node_lttng_tp.h
  f1d2792c1c7ec0473832a9b0b2025be64953820b

  This patch adds them.

- The arraysize function in node_lttng.cc is not found.  I included
  node_internals.h and added the node namespace (node::arraysize).

- The -llttng-ust flag is passed when building the static library libnode.a,
  but it's actually when linking a final executable that it's required.
  I see that node can be built as a shared library as well, so maybe the
  flag is relevant in that case.  But in the case where the intermediate
  library is a static one, it doesn't work.  I am not familiar with
  node's build system, so I did not fix this one, I am fine with
  changing the generated Makefile by hand for now.  But if somebody
  wants to take a look, it's of course very appreciated :).