### PR TITLE
src: move http2 module to openssl builtin modules

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -82,7 +82,7 @@ struct sockaddr;
 
 
 #if HAVE_OPENSSL
-#define NODE_BUILTIN_OPENSSL_MODULES(V) V(crypto) V(tls_wrap)
+#define NODE_BUILTIN_OPENSSL_MODULES(V) V(crypto) V(tls_wrap) V(http2)
 #else
 #define NODE_BUILTIN_OPENSSL_MODULES(V)
 #endif
@@ -108,7 +108,6 @@ struct sockaddr;
     V(domain)                                                                 \
     V(fs)                                                                     \
     V(fs_event_wrap)                                                          \
-    V(http2)                                                                  \
     V(http_parser)                                                            \
     V(inspector)                                                              \
     V(js_stream)                                                              \

--- a/test/parallel/test-http2-util-assert-valid-pseudoheader.js
+++ b/test/parallel/test-http2-util-assert-valid-pseudoheader.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 // Tests the assertValidPseudoHeader function that is used within the
 // mapToHeaders function. The assert function is not exported so we

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const {
   assertIsObject,
   assertWithinRange,

--- a/test/parallel/test-http2-util-nghttp2error.js
+++ b/test/parallel/test-http2-util-nghttp2error.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const { strictEqual } = require('assert');
 const { NghttpError } = require('internal/http2/util');
 


### PR DESCRIPTION
Currently, the http2 module is listed in the standard modules list.
This means that if configured --without-ssl it is still possible to use
the module with process.binding('http2') without an error.

This commit moves http2 into the openssl list so that it is not loaded
unless crypto support is available. Using it will result in "No
such module: http2" error instead.

I realise that [crypto is not required for http2](https://http2.github.io/faq/#does-http2-require-encryption), but I was under the impression that it is for node.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, http2