### PR TITLE
stream: add no-half-open enforcer only if needed

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -58,10 +58,10 @@ function Duplex(options) {
     this.writable = false;
 
   this.allowHalfOpen = true;
-  if (options && options.allowHalfOpen === false)
+  if (options && options.allowHalfOpen === false) {
     this.allowHalfOpen = false;
-
-  this.once('end', onend);
+    this.once('end', onend);
+  }
 }
 
 Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
@@ -96,9 +96,8 @@ Object.defineProperty(Duplex.prototype, 'writableLength', {
 
 // the no-half-open enforcer
 function onend() {
-  // if we allow half-open state, or if the writable side ended,
-  // then we're ok.
-  if (this.allowHalfOpen || this._writableState.ended)
+  // If the writable side ended, then we're ok.
+  if (this._writableState.ended)
     return;
 
   // no more data can be written.

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -34,7 +34,7 @@ server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
   assert.strictEqual(socket.listeners('close').length, 0);
   assert.strictEqual(socket.listeners('drain').length, 0);
   assert.strictEqual(socket.listeners('data').length, 0);
-  assert.strictEqual(socket.listeners('end').length, 2);
+  assert.strictEqual(socket.listeners('end').length, 1);
   assert.strictEqual(socket.listeners('error').length, 0);
 
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');

--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -29,6 +29,8 @@ const stream = new Duplex({ objectMode: true });
 assert(Duplex() instanceof Duplex);
 assert(stream._readableState.objectMode);
 assert(stream._writableState.objectMode);
+assert(stream.allowHalfOpen);
+assert.strictEqual(stream.listenerCount('end'), 0);
 
 let written;
 let read;


### PR DESCRIPTION
The listener does not do anything if `allowHalfOpen` is enabled. Add it only when `allowHalfOpen` is disabled.

If `allowHalfOpen` can be changed on the fly this PR doesn't make sense and should be closed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream