### PR TITLE
[v9.x backport] test: introduce SetUpTestCase/TearDownTestCase

### DIFF
--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -1,3 +1,6 @@
 #include "node_test_fixture.h"
 
-uv_loop_t current_loop;
+uv_loop_t NodeTestFixture::current_loop;
+std::unique_ptr<node::NodePlatform> NodeTestFixture::platform;
+std::unique_ptr<v8::ArrayBuffer::Allocator> NodeTestFixture::allocator;
+v8::Isolate::CreateParams NodeTestFixture::params;


### PR DESCRIPTION
This commit add SetUpTestCase and TearDownTestCase functions that will
be called once per test case. Currently we only have SetUp/TearDown
which are called for each test.

This commit moves the initialization and configuration of Node and V8 to
be done on a per test case basis, but gives each test a new Isolate.

PR-URL: https://github.com/nodejs/node/pull/18558
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test