### PR TITLE
build: fix coverage after gcovr update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,8 @@ coverage-build: all
 		--single-branch git://github.com/gcovr/gcovr.git; fi
 	if [ ! -d build ]; then git clone --depth=1 \
 		--single-branch https://github.com/nodejs/build.git; fi
-	if [ ! -f gcovr/scripts/gcovr.orig ]; then \
-		(cd gcovr && patch -N -p1 < \
+	if [ ! -f gcovr/gcovr/gcov.py.orig ]; then \
+		(cd gcovr && patch -b -N -p1 < \
 		"$(CURDIR)/build/jenkins/scripts/coverage/gcovr-patches.diff"); fi
 	if [ -d lib_ ]; then $(RM) -r lib; mv lib_ lib; fi
 	mv lib lib_
@@ -203,7 +203,7 @@ coverage-test: coverage-build
 	(cd lib && .$(NODE) ../node_modules/.bin/nyc report \
 		--temp-directory "$(CURDIR)/.cov_tmp" \
 		--report-dir "../coverage")
-	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \
+	-(cd out && PYTHONPATH=$(CURDIR)/gcovr $(PYTHON) -m gcovr --gcov-exclude='.*deps' \
 		--gcov-exclude='.*usr' -v -r Release/obj.target \
 		--html --html-detail -o ../coverage/cxxcoverage.html \
 		--gcov-executable="$(GCOV)")


### PR DESCRIPTION
The patch will fix the broken coverage report.
It can be merged after https://github.com/nodejs/build/pull/1145 accept

Fixes: https://github.com/nodejs/node/issues/18938
Refs: https://github.com/nodejs/build/pull/1145

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
