### PR TITLE
[v9.x backport] src: fix GetCpuProfiler() deprecation warning

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1,6 +1,5 @@
 #include "node_internals.h"
 #include "async_wrap.h"
-#include "v8-profiler.h"
 
 #include <stdio.h>
 #include <algorithm>
@@ -65,6 +64,15 @@ IsolateData::IsolateData(Isolate* isolate,
 IsolateData::~IsolateData() {
   if (platform_ != nullptr)
     platform_->UnregisterIsolate(this);
+  if (cpu_profiler_ != nullptr)
+    cpu_profiler_->Dispose();
+}
+
+v8::CpuProfiler* IsolateData::GetCpuProfiler() {
+  if (cpu_profiler_ != nullptr) return cpu_profiler_;
+  cpu_profiler_ = v8::CpuProfiler::New(isolate());
+  CHECK_NE(cpu_profiler_, nullptr);
+  return cpu_profiler_;
 }
 
 void Environment::Start(int argc,
@@ -148,12 +156,12 @@ void Environment::CleanupHandles() {
 void Environment::StartProfilerIdleNotifier() {
   uv_prepare_start(&idle_prepare_handle_, [](uv_prepare_t* handle) {
     Environment* env = ContainerOf(&Environment::idle_prepare_handle_, handle);
-    env->isolate()->GetCpuProfiler()->SetIdle(true);
+    env->isolate_data()->GetCpuProfiler()->SetIdle(true);
   });
 
   uv_check_start(&idle_check_handle_, [](uv_check_t* handle) {
     Environment* env = ContainerOf(&Environment::idle_check_handle_, handle);
-    env->isolate()->GetCpuProfiler()->SetIdle(false);
+    env->isolate_data()->GetCpuProfiler()->SetIdle(false);
   });
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -33,6 +33,7 @@
 #include "req_wrap.h"
 #include "util.h"
 #include "uv.h"
+#include "v8-profiler.h"
 #include "v8.h"
 #include "node.h"
 #include "node_http2_state.h"
@@ -335,6 +336,8 @@ class IsolateData {
   std::unordered_map<nghttp2_rcbuf*, v8::Eternal<v8::String>> http2_static_strs;
   inline v8::Isolate* isolate() const;
 
+  v8::CpuProfiler* GetCpuProfiler();
+
  private:
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VS(PropertyName, StringValue) V(v8::String, PropertyName)
@@ -350,6 +353,7 @@ class IsolateData {
   uv_loop_t* const event_loop_;
   uint32_t* const zero_fill_field_;
   MultiIsolatePlatform* platform_;
+  v8::CpuProfiler* cpu_profiler_ = nullptr;
 
   DISALLOW_COPY_AND_ASSIGN(IsolateData);
 };


### PR DESCRIPTION
Replace `v8::Isolate::GetCpuProfiler()` with `v8::CpuProfiler::New()`
and cache the instance; creating and disposing an instance every loop
tick is too expensive.

PR-URL: https://github.com/nodejs/node/pull/18534
Fixes: https://github.com/nodejs/node/issues/18039
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src