### PR TITLE
src: refactor setting JS properties on WriteWrap

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -220,8 +220,6 @@ inline StreamWriteResult StreamBase::Write(
     ClearError();
   }
 
-  req_wrap_obj->Set(env->async(), v8::Boolean::New(env->isolate(), async));
-
   return StreamWriteResult { async, err, req_wrap };
 }
 


### PR DESCRIPTION
Splitting out from #18936:

`async` and `bytes` are only interesting when the write
is coming from JS, and unnecessary otherwise.

Also, make all of the stream `Write*()` bindings use the same
code for setting these, and upgrade to the non-deprecated versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

src