### PR TITLE
module: fix cyclical dynamic import

### DIFF
--- a/lib/internal/loader/ModuleJob.js
+++ b/lib/internal/loader/ModuleJob.js
@@ -53,10 +53,11 @@ class ModuleJob {
   }
 
   async instantiate() {
-    if (this.instantiated) {
-      return this.instantiated;
+    if (!this.instantiated) {
+      return this.instantiated = this._instantiate();
     }
-    return this.instantiated = this._instantiate();
+    await this.instantiated;
+    return this.module;
   }
 
   // This method instantiates the module associated with this job and its

--- a/test/es-module/test-esm-cyclic-dynamic-import.mjs
+++ b/test/es-module/test-esm-cyclic-dynamic-import.mjs
@@ -1,0 +1,3 @@
+// Flags: --experimental-modules
+import '../common';
+import('./test-esm-cyclic-dynamic-import');


### PR DESCRIPTION
ensures that instantiation result is only used during initial loading. current loading mechanism would use the empty promise sentinel if the `import()` fired in a cyclic manner.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module