### PR TITLE
doc: deprecate lttng

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -914,6 +914,13 @@ Type: Runtime
 
 This was never a documented feature.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: with-lttng
+
+Type: Documentation-only
+
+`with-lttng` compile time option is deprecated.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array


### PR DESCRIPTION
Building with-lttng has been broken for 2 years. We should
deprecate and remove this dead code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
