### PR TITLE
doc: update REPLACEME tag to correct version

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -17,7 +17,7 @@ For more information about the used equality comparisons see
 <!-- YAML
 added: REPLACEME
 changes:
-  - version: REPLACEME
+  - version: 9.5.0
     pr-url: https://github.com/nodejs/node/pull/17615
     description: Added error diffs to the strict mode
   - version: REPLACEME


### PR DESCRIPTION
Looks like @evanlucas forgot to update one REPLACEME tag in assert.md doc on 9.5.0 release
[Here is a change in 9.5.0 change logs](https://github.com/nodejs/node/blame/master/doc/changelogs/CHANGELOG_V9.md#L417)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
