### PR TITLE
test, bechmark: use new Buffer API where appropriate

### DIFF
--- a/benchmark/streams/pipe.js
+++ b/benchmark/streams/pipe.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const b = new Buffer(1024);
+  const b = Buffer.alloc(1024);
   const r = new Readable();
   const w = new Writable();
 

--- a/benchmark/streams/readable-bigread.js
+++ b/benchmark/streams/readable-bigread.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const b = new Buffer(32);
+  const b = Buffer.alloc(32);
   const s = new Readable();
   function noop() {}
   s._read = noop;

--- a/benchmark/streams/readable-bigunevenread.js
+++ b/benchmark/streams/readable-bigunevenread.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const b = new Buffer(32);
+  const b = Buffer.alloc(32);
   const s = new Readable();
   function noop() {}
   s._read = noop;

--- a/benchmark/streams/readable-readall.js
+++ b/benchmark/streams/readable-readall.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const b = new Buffer(32);
+  const b = Buffer.alloc(32);
   const s = new Readable();
   function noop() {}
   s._read = noop;

--- a/benchmark/streams/readable-unevenread.js
+++ b/benchmark/streams/readable-unevenread.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-  const b = new Buffer(32);
+  const b = Buffer.alloc(32);
   const s = new Readable();
   function noop() {}
   s._read = noop;

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -18,7 +18,7 @@ const sock = dgram
 
 function onlistening() {
   sock.send(
-    new Buffer(2), 0, 2, sock.address().port,
+    Buffer.alloc(2), 0, 2, sock.address().port,
     undefined, common.mustCall(onsent));
 
   // init not called synchronously because dns lookup always wraps

--- a/test/parallel/test-buffer-badhex.js
+++ b/test/parallel/test-buffer-badhex.js
@@ -6,12 +6,12 @@ const assert = require('assert');
 {
   const buf = Buffer.alloc(4);
   assert.strictEqual(buf.length, 4);
-  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
   assert.strictEqual(buf.write('abcdxx', 0, 'hex'), 2);
-  assert.deepStrictEqual(buf, new Buffer([0xab, 0xcd, 0x00, 0x00]));
+  assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0x00, 0x00]));
   assert.strictEqual(buf.toString('hex'), 'abcd0000');
   assert.strictEqual(buf.write('abcdef01', 0, 'hex'), 4);
-  assert.deepStrictEqual(buf, new Buffer([0xab, 0xcd, 0xef, 0x01]));
+  assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0xef, 0x01]));
   assert.strictEqual(buf.toString('hex'), 'abcdef01');
 
   const copy = Buffer.from(buf.toString('hex'), 'hex');
@@ -26,13 +26,13 @@ const assert = require('assert');
 
 {
   const buf = Buffer.alloc(4);
-  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
   assert.strictEqual(buf.write('xxabcd', 0, 'hex'), 0);
-  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
   assert.strictEqual(buf.write('xxab', 1, 'hex'), 0);
-  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
   assert.strictEqual(buf.write('cdxxab', 0, 'hex'), 1);
-  assert.deepStrictEqual(buf, new Buffer([0xcd, 0, 0, 0]));
+  assert.deepStrictEqual(buf, Buffer.from([0xcd, 0, 0, 0]));
 }
 
 {

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -430,7 +430,7 @@ common.expectsError(() => {
 
 // Test that bypassing 'length' won't cause an abort.
 common.expectsError(() => {
-  const buf = new Buffer('w00t');
+  const buf = Buffer.from('w00t');
   Object.defineProperty(buf, 'length', {
     value: 1337,
     enumerable: true

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -504,7 +504,7 @@ assert.strictEqual(buf_bc.lastIndexOf('你好', 5, 'binary'), -1);
 assert.strictEqual(buf_bc.lastIndexOf(Buffer.from('你好'), 7), -1);
 
 // Test lastIndexOf on a longer buffer:
-const bufferString = new Buffer('a man a plan a canal panama');
+const bufferString = Buffer.from('a man a plan a canal panama');
 assert.strictEqual(15, bufferString.lastIndexOf('canal'));
 assert.strictEqual(21, bufferString.lastIndexOf('panama'));
 assert.strictEqual(0, bufferString.lastIndexOf('a man a plan a canal panama'));
@@ -566,7 +566,7 @@ const parts = [];
 for (let i = 0; i < 1000000; i++) {
   parts.push((countBits(i) % 2 === 0) ? 'yolo' : 'swag');
 }
-const reallyLong = new Buffer(parts.join(' '));
+const reallyLong = Buffer.from(parts.join(' '));
 assert.strictEqual('yolo swag swag yolo', reallyLong.slice(0, 19).toString());
 
 // Expensive reverse searches. Stress test lastIndexOf:

--- a/test/parallel/test-buffer-zero-fill.js
+++ b/test/parallel/test-buffer-zero-fill.js
@@ -3,6 +3,7 @@
 require('../common');
 const assert = require('assert');
 
+// Tests deprecated Buffer API on purpose
 const buf1 = Buffer(100);
 const buf2 = new Buffer(100);
 

--- a/test/parallel/test-net-socket-byteswritten.js
+++ b/test/parallel/test-net-socket-byteswritten.js
@@ -16,7 +16,7 @@ server.listen(0, common.mustCall(function() {
   socket.cork();
 
   socket.write('one');
-  socket.write(new Buffer('twø', 'utf8'));
+  socket.write(Buffer.from('twø', 'utf8'));
 
   socket.uncork();
 

--- a/test/parallel/test-zlib-empty-buffer.js
+++ b/test/parallel/test-zlib-empty-buffer.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const zlib = require('zlib');
 const { inspect, promisify } = require('util');
 const assert = require('assert');
-const emptyBuffer = new Buffer(0);
+const emptyBuffer = Buffer.alloc(0);
 
 common.crashOnUnhandledRejection();
 


### PR DESCRIPTION
For tests / benchmarks that are creating Buffer instances for any reason other than to test Buffer constructor, use the new `Buffer.alloc`/`Buffer.from` API instead of the deprecated API.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, benchmark
