### PR TITLE
test: Remove unnecessary asserion messages in test-crypto-hash.js

### DIFF
--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -82,15 +82,15 @@ assert.deepStrictEqual(
 );
 
 // stream interface should produce the same result.
-assert.deepStrictEqual(a5, a3, 'stream interface is consistent');
-assert.deepStrictEqual(a6, a3, 'stream interface is consistent');
-assert.notStrictEqual(a7, undefined, 'no data should return data');
-assert.notStrictEqual(a8, undefined, 'empty string should generate data');
+assert.deepStrictEqual(a5, a3);
+assert.deepStrictEqual(a6, a3);
+assert.notStrictEqual(a7, undefined);
+assert.notStrictEqual(a8, undefined);
 
 // Test multiple updates to same hash
 const h1 = crypto.createHash('sha1').update('Test123').digest('hex');
 const h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
-assert.strictEqual(h1, h2, 'multipled updates');
+assert.strictEqual(h1, h2);
 
 // Test hashing for binary files
 const fn = fixtures.path('sample.png');


### PR DESCRIPTION
This commit improves asserion messages in parallel/test-crypto-hash.js.
Instead of just simple string literal, messages are changed to also
include values used in assertion, which should improve debugging
in case of errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
None