### PR TITLE
http2: send error text in case of ALPN mismatch

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2472,8 +2472,17 @@ function connectionListener(socket) {
       return httpConnectionListener.call(this, socket);
     }
     // Let event handler deal with the socket
-    if (!this.emit('unknownProtocol', socket))
-      socket.destroy();
+    debug(`Unknown protocol from ${socket.remoteAddress}:${socket.remotePort}`);
+    if (!this.emit('unknownProtocol', socket)) {
+      // We don't know what to do, so let's just tell the other side what's
+      // going on in a format that they *might* understand.
+      socket.end('HTTP/1.0 403 Forbidden\r\n' +
+                 'Content-Type: text/plain\r\n\r\n' +
+                 'Unknown ALPN Protocol, expected `h2` to be available.\n' +
+                 'If this is a HTTP request: The server was not ' +
+                 'configured with the `allowHTTP1` option or a ' +
+                 'listener for the `unknownProtocol` event.\n');
+    }
     return;
   }
 


### PR DESCRIPTION
Send a human-readable HTTP/1 response in case of an unexpected
ALPN protocol. This helps with debugging this condition,
since previously the only result of it would be a closed socket.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/http2