### PR TITLE
http2: use original error for cancelling pending streams

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1109,6 +1109,11 @@ class Http2Session extends EventEmitter {
 
     // Destroy any pending and open streams
     const cancel = new errors.Error('ERR_HTTP2_STREAM_CANCEL');
+    if (error) {
+      cancel.cause = error;
+      if (typeof error.message === 'string')
+        cancel.message += ` (caused by: ${error.message})`;
+    }
     state.pendingStreams.forEach((stream) => stream.destroy(cancel));
     state.streams.forEach((stream) => stream.destroy(error));
 

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -91,9 +91,14 @@ function runTest(test) {
     req.on('error', errorMustCall);
   } else {
     client.on('error', errorMustCall);
-    req.on('error', common.expectsError({
-      code: 'ERR_HTTP2_STREAM_CANCEL'
-    }));
+    req.on('error', (err) => {
+      common.expectsError({
+        code: 'ERR_HTTP2_STREAM_CANCEL'
+      })(err);
+      common.expectsError({
+        code: 'ERR_HTTP2_ERROR'
+      })(err.cause);
+    });
   }
 
   req.on('end', common.mustCall());


### PR DESCRIPTION
Previously, if `session.destroy()` was called with an error object,
the information contained in it would be discarded and a generic
`ERR_HTTP2_STREAM_CANCEL` would be used for all pending streams.

Instead, make the information from the original error object
available.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/http2