### PR TITLE
tls: better error message for socket disconnect

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1074,7 +1074,6 @@ function onConnectSecure() {
     this.emit('secureConnect');
   }
 
-  // Uncork incoming data
   this.removeListener('end', onConnectEnd);
 }
 
@@ -1083,7 +1082,8 @@ function onConnectEnd() {
   if (!this._hadError) {
     const options = this[kConnectOptions];
     this._hadError = true;
-    const error = new Error('socket hang up');
+    const error = new Error('Client network socket disconnected before ' +
+                            'secure TLS connection was established');
     error.code = 'ECONNRESET';
     error.path = options.path;
     error.host = options.host;

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -29,6 +29,6 @@ const server = tls.createServer(options, (c) => {
   }, common.mustNotCall());
 
   c.on('error', common.mustCall((err) => {
-    assert(/socket hang up/.test(err.message));
+    assert(/Client network socket disconnected/.test(err.message));
   }));
 }));

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -175,7 +175,9 @@ process.on('exit', function() {
   ]);
   assert.deepStrictEqual(clientResults, [true, true, true, false, false]);
   assert.deepStrictEqual(clientErrors, [
-    null, null, null, null, 'socket hang up'
+    null, null, null, null,
+    'Client network socket disconnected before secure TLS ' +
+    'connection was established'
   ]);
   assert.deepStrictEqual(serverErrors, [
     null, null, null, null, 'Invalid SNI context'


### PR DESCRIPTION
The error emitted when a connection is closed before the
TLS handshake completes seemed rather unspefic by just saying
`socket hang up`.

Use a more verbose message, that also indicates that this is
a purely client-side error, and remove a misleading comment.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

tls