### PR TITLE
test: allow running with `NODE_PENDING_DEPRECATION`

### DIFF
--- a/test/parallel/test-pending-deprecation.js
+++ b/test/parallel/test-pending-deprecation.js
@@ -25,7 +25,8 @@ switch (process.argv[2]) {
     break;
   default:
     // Verify that the flag is off by default.
-    assert.strictEqual(config.pendingDeprecation, undefined);
+    const envvar = process.env.NODE_PENDING_DEPRECATION;
+    assert.strictEqual(config.pendingDeprecation, envvar && envvar[0] === '1');
 
     // Test the --pending-deprecation command line switch.
     fork(__filename, ['switch'], {


### PR DESCRIPTION
Make the test for pending deprecations work when the env var
is set during the whole test suite run.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

test