### PR TITLE
http: prevent aborted event when request is complete

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -321,7 +321,7 @@ function socketCloseListener() {
   var parser = socket.parser;
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.
-    req.res.emit('aborted');
+    if (!req.res.complete) req.res.emit('aborted');
     var res = req.res;
     res.on('end', function() {
       res.emit('close');

--- a/test/parallel/test-http-client-spurious-aborted.js
+++ b/test/parallel/test-http-client-spurious-aborted.js
@@ -5,7 +5,6 @@ const http = require('http');
 const assert = require('assert');
 const fs = require('fs');
 const Countdown = require('../common/countdown');
-const { URL } = require('url');
 
 function cleanup(fname) {
   try {
@@ -13,35 +12,57 @@ function cleanup(fname) {
   } catch (err) {}
 }
 
-const N = 1;
+const N = 2;
 const fname = '/dev/null';
-const keepAlive = false;
-const useRemote = process.env.SPURIOUS_ABORTED_REMOTE === 'on';
-let url = new URL('http://www.pdf995.com/samples/pdf.pdf');
-let server;
+let abortRequest = true;
 
-const keepAliveAgent = new http.Agent({ keepAlive: true });
+const server = http.Server(common.mustCall((req, res) => {
+  const headers = { 'Content-Type': 'text/plain' };
+  headers['Content-Length'] = 50;
+  const socket = res.socket;
+  res.writeHead(200, headers);
+  setTimeout(() => res.write('aaaaaaaaaa'), 100);
+  setTimeout(() => res.write('bbbbbbbbbb'), 200);
+  setTimeout(() => res.write('cccccccccc'), 300);
+  setTimeout(() => res.write('dddddddddd'), 400);
+  if (abortRequest) {
+    setTimeout(() => socket.destroy(), 600);
+  } else {
+    setTimeout(() => res.end('eeeeeeeeee'), 1000);
+  }
+}, N));
+
+server.listen(0, common.mustCall(() => {
+  cleanup(fname);
+  download();
+}));
+
+const finishCountdown = new Countdown(N, common.mustCall(() => {
+  server.close();
+}));
 const reqCountdown = new Countdown(N, common.mustCall());
 
 function download() {
   const opts = {
-    host: url.hostname,
-    path: url.pathname,
-    port: url.port
+    port: server.address().port,
+    path: '/',
   };
-  if (keepAlive) opts.agent = keepAliveAgent;
   const req = http.get(opts);
   req.on('error', common.mustNotCall());
   req.on('response', (res) => {
     assert.strictEqual(res.statusCode, 200);
-    if (keepAlive) {
-      assert.strictEqual(res.headers.connection, 'keep-alive');
-    } else {
-      assert.strictEqual(res.headers.connection, 'close');
-    }
+    assert.strictEqual(res.headers.connection, 'close');
     let aborted = false;
     const fstream = fs.createWriteStream(fname);
     res.pipe(fstream);
+    const _handle = res.socket._handle;
+    _handle._close = res.socket._handle.close;
+    _handle.close = function(callback) {
+      _handle._close();
+      // set readable to true event though request is complete
+      if (res.complete) res.readable = true;
+      callback();
+    };
     res.on('end', common.mustCall(() => {
       reqCountdown.dec();
     }));
@@ -50,44 +71,13 @@ function download() {
     });
     res.on('error', common.mustNotCall());
     fstream.on('finish', () => {
-      assert.strictEqual(aborted, false);
+      assert.strictEqual(aborted, abortRequest);
       cleanup(fname);
       finishCountdown.dec();
       if (finishCountdown.remaining === 0) return;
+      abortRequest = false; // next one should be a good response
       download();
     });
   });
   req.end();
-}
-
-const finishCountdown = new Countdown(N, common.mustCall(() => {
-  if (!useRemote) server.close();
-}));
-
-if (useRemote) {
-  cleanup(fname);
-  download();
-} else {
-  server = http.Server(common.mustCall((req, res) => {
-    const headers = { 'Content-Type': 'text/plain' };
-    if (req.url === '/content-length') {
-      headers['Content-Length'] = 50;
-    }
-    const socket = res.socket;
-    res.writeHead(200, headers);
-    setTimeout(() => res.write('aaaaaaaaaa'), 100);
-    setTimeout(() => res.write('bbbbbbbbbb'), 200);
-    setTimeout(() => res.write('cccccccccc'), 300);
-    setTimeout(() => res.write('dddddddddd'), 400);
-    setTimeout(() => {
-      res.end('eeeeeeeeee');
-      const endAfter = Math.floor(Math.random() * 400);
-      setTimeout(() => socket.destroy(), endAfter);
-    }, 600);
-  }, N));
-  server.listen(0, common.mustCall(() => {
-    url = new URL(`http://127.0.0.1:${server.address().port}/content-length`);
-    cleanup(fname);
-    download();
-  }));
 }

--- a/test/parallel/test-http-client-spurious-aborted.js
+++ b/test/parallel/test-http-client-spurious-aborted.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+const fs = require('fs');
+const Countdown = require('../common/countdown');
+const { URL } = require('url');
+
+function cleanup(fname) {
+  try {
+    if (fs.statSync(fname)) fs.unlinkSync(fname);
+  } catch (err) {}
+}
+
+const N = 1;
+const fname = '/dev/null';
+const keepAlive = false;
+const useRemote = process.env.SPURIOUS_ABORTED_REMOTE === 'on';
+let url = new URL('http://www.pdf995.com/samples/pdf.pdf');
+let server;
+
+const keepAliveAgent = new http.Agent({ keepAlive: true });
+const reqCountdown = new Countdown(N, common.mustCall());
+
+function download() {
+  const opts = {
+    host: url.hostname,
+    path: url.pathname,
+    port: url.port
+  };
+  if (keepAlive) opts.agent = keepAliveAgent;
+  const req = http.get(opts);
+  req.on('error', common.mustNotCall());
+  req.on('response', (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    if (keepAlive) {
+      assert.strictEqual(res.headers.connection, 'keep-alive');
+    } else {
+      assert.strictEqual(res.headers.connection, 'close');
+    }
+    let aborted = false;
+    const fstream = fs.createWriteStream(fname);
+    res.pipe(fstream);
+    res.on('end', common.mustCall(() => {
+      reqCountdown.dec();
+    }));
+    res.on('aborted', () => {
+      aborted = true;
+    });
+    res.on('error', common.mustNotCall());
+    fstream.on('finish', () => {
+      assert.strictEqual(aborted, false);
+      cleanup(fname);
+      finishCountdown.dec();
+      if (finishCountdown.remaining === 0) return;
+      download();
+    });
+  });
+  req.end();
+}
+
+const finishCountdown = new Countdown(N, common.mustCall(() => {
+  if (!useRemote) server.close();
+}));
+
+if (useRemote) {
+  cleanup(fname);
+  download();
+} else {
+  server = http.Server(common.mustCall((req, res) => {
+    const headers = { 'Content-Type': 'text/plain' };
+    if (req.url === '/content-length') {
+      headers['Content-Length'] = 50;
+    }
+    const socket = res.socket;
+    res.writeHead(200, headers);
+    setTimeout(() => res.write('aaaaaaaaaa'), 100);
+    setTimeout(() => res.write('bbbbbbbbbb'), 200);
+    setTimeout(() => res.write('cccccccccc'), 300);
+    setTimeout(() => res.write('dddddddddd'), 400);
+    setTimeout(() => {
+      res.end('eeeeeeeeee');
+      const endAfter = Math.floor(Math.random() * 400);
+      setTimeout(() => socket.destroy(), endAfter);
+    }, 600);
+  }, N));
+  server.listen(0, common.mustCall(() => {
+    url = new URL(`http://127.0.0.1:${server.address().port}/content-length`);
+    cleanup(fname);
+    download();
+  }));
+}


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http

When socket is closed on a response for a request that is being piped to a stream
there is a condition where aborted event will be fired to http client when socket is
closing and the incomingMessage stream is still set to readable.

We need a check for request being complete and to only raise the 'aborted' event
on the http client if we have not yet completed reading the response from the server.