### PR TITLE
src: fix error message in async_hooks constructor

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -41,15 +41,15 @@ const {
 class AsyncHook {
   constructor({ init, before, after, destroy, promiseResolve }) {
     if (init !== undefined && typeof init !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'init');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'hook.init');
     if (before !== undefined && typeof before !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'before');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'hook.before');
     if (after !== undefined && typeof after !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'after');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'hook.after');
     if (destroy !== undefined && typeof destroy !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'destroy');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'hook.destroy');
     if (promiseResolve !== undefined && typeof promiseResolve !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'promiseResolve');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'hook.promiseResolve');
 
     this[init_symbol] = init;
     this[before_symbol] = before;

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -45,9 +45,9 @@ class AsyncHook {
     if (before !== undefined && typeof before !== 'function')
       throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'before');
     if (after !== undefined && typeof after !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'before');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'after');
     if (destroy !== undefined && typeof destroy !== 'function')
-      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'before');
+      throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'destroy');
     if (promiseResolve !== undefined && typeof promiseResolve !== 'function')
       throw new errors.TypeError('ERR_ASYNC_CALLBACK', 'promiseResolve');
 

--- a/test/parallel/test-async-hooks-constructor.js
+++ b/test/parallel/test-async-hooks-constructor.js
@@ -6,30 +6,18 @@ const common = require('../common');
 const async_hooks = require('async_hooks');
 const non_function = 10;
 
-common.expectsError(() => {
-  async_hooks.createHook({ init: non_function });
-}, typeErrorForFunction('init'));
-
-common.expectsError(() => {
-  async_hooks.createHook({ before: non_function });
-}, typeErrorForFunction('before'));
-
-common.expectsError(() => {
-  async_hooks.createHook({ after: non_function });
-}, typeErrorForFunction('after'));
-
-common.expectsError(() => {
-  async_hooks.createHook({ destroy: non_function });
-}, typeErrorForFunction('destroy'));
-
-common.expectsError(() => {
-  async_hooks.createHook({ promiseResolve: non_function });
-}, typeErrorForFunction('promiseResolve'));
+typeErrorForFunction('init');
+typeErrorForFunction('before');
+typeErrorForFunction('after');
+typeErrorForFunction('destroy');
+typeErrorForFunction('promiseResolve');
 
 function typeErrorForFunction(functionName) {
-  return {
+  common.expectsError(() => {
+    async_hooks.createHook({ [functionName]: non_function });
+  }, {
     code: 'ERR_ASYNC_CALLBACK',
     type: TypeError,
-    message: `${functionName} must be a function`,
-  };
+    message: `hook.${functionName} must be a function`
+  });
 }

--- a/test/parallel/test-async-hooks-constructor.js
+++ b/test/parallel/test-async-hooks-constructor.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// This tests that AsyncHooks throws an error if bad parameters are passed.
+
+const common = require('../common');
+const async_hooks = require('async_hooks');
+const non_function = 10;
+
+common.expectsError(() => {
+  async_hooks.createHook({ init: non_function });
+}, typeErrorForFunction('init'));
+
+common.expectsError(() => {
+  async_hooks.createHook({ before: non_function });
+}, typeErrorForFunction('before'));
+
+common.expectsError(() => {
+  async_hooks.createHook({ after: non_function });
+}, typeErrorForFunction('after'));
+
+common.expectsError(() => {
+  async_hooks.createHook({ destroy: non_function });
+}, typeErrorForFunction('destroy'));
+
+common.expectsError(() => {
+  async_hooks.createHook({ promiseResolve: non_function });
+}, typeErrorForFunction('promiseResolve'));
+
+function typeErrorForFunction(functionName) {
+  return {
+    code: 'ERR_ASYNC_CALLBACK',
+    type: TypeError,
+    message: `${functionName} must be a function`,
+  };
+}


### PR DESCRIPTION
There are two minor issues in the AsyncHook constructor, if the object
passed in has an after and/or destroy property that are not functions
the errors thrown will still be:
```console
TypeError [ERR_ASYNC_CALLBACK]: before must be a function
```
This commit updates the code and adds a unit test.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src