### PR TITLE
doc: fix/add link to Android info

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -322,7 +322,7 @@ Equivalent to [`process.platform`][].
 
 The value `'android'` may also be returned if the Node.js is built on the
 Android operating system. However, Android support in Node.js is considered
-to be experimental at this time.
+[to be experimental][Android building] at this time.
 
 ## os.release()
 <!-- YAML
@@ -1220,4 +1220,5 @@ information.
 
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
+[Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [uname(3)]: https://linux.die.net/man/3/uname

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1450,7 +1450,7 @@ console.log(`This platform is ${process.platform}`);
 
 The value `'android'` may also be returned if the Node.js is built on the
 Android operating system. However, Android support in Node.js
-[is experimental][Supported platforms].
+[is experimental][Android building].
 
 ## process.ppid
 <!-- YAML
@@ -2007,6 +2007,7 @@ cases:
 [`require.resolve()`]: modules.html#modules_require_resolve_request_options
 [`setTimeout(fn, 0)`]: timers.html#timers_settimeout_callback_delay_args
 [`v8.setFlagsFromString()`]: v8.html#v8_v8_setflagsfromstring_flags
+[Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [Child Process]: child_process.html
 [Cluster]: cluster.html
 [debugger]: debugger.html
@@ -2018,6 +2019,5 @@ cases:
 [Readable]: stream.html#stream_readable_streams
 [Signal Events]: #process_signal_events
 [Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
-[Supported platforms]: https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1
 [TTY]: tty.html#tty_tty
 [Writable]: stream.html#stream_writable_streams


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, build

We have two notes in API docs about Android support: the first has no links, the second links to the table of supported OSs where Android is not mentioned which may be confusing.

This PR makes both notes link to dedicated Android part of BUILDING.md.
