### PR TITLE
Remove redundant `the`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -882,7 +882,7 @@ Type: Runtime
 
 Users of `MakeCallback` that add the `domain` property to carry context,
 should start using the `async_context` variant of `MakeCallback` or
-`CallbackScope`, or the the high-level `AsyncResource` class.
+`CallbackScope`, or the high-level `AsyncResource` class.
 
 <a id="DEP0098"></a>
 ### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs


### PR DESCRIPTION
Fix `the the` → `the`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc