### PR TITLE
fs: check for symlink support in fs-promises test

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -116,21 +116,24 @@ function verifyStatObject(stat) {
     stats = await stat(newPath);
     verifyStatObject(stats);
 
-    const newLink = path.resolve(tmpDir, 'baz3.js');
-    await symlink(newPath, newLink);
+    if (common.canCreateSymLink()) {
+      const newLink = path.resolve(tmpDir, 'baz3.js');
+      await symlink(newPath, newLink);
+
+      stats = await lstat(newLink);
+      verifyStatObject(stats);
+
+      assert.strictEqual(newPath.toLowerCase(),
+                         (await realpath(newLink)).toLowerCase());
+      assert.strictEqual(newPath.toLowerCase(),
+                         (await readlink(newLink)).toLowerCase());
+
+      await unlink(newLink);
+    }
 
     const newLink2 = path.resolve(tmpDir, 'baz4.js');
     await link(newPath, newLink2);
 
-    stats = await lstat(newLink);
-    verifyStatObject(stats);
-
-    assert.strictEqual(newPath.toLowerCase(),
-                       (await realpath(newLink)).toLowerCase());
-    assert.strictEqual(newPath.toLowerCase(),
-                       (await readlink(newLink)).toLowerCase());
-
-    await unlink(newLink);
     await unlink(newLink2);
 
     const newdir = path.resolve(tmpDir, 'dir');


### PR DESCRIPTION
Attempting to make symlinks as a non-administrator user in Windows
causes a permission error. We need to update test-fs-promises to expect
this error case, as is already done in various other tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- fs