### PR TITLE
fs: throw more synchronous errors in JS land

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1004,7 +1004,9 @@ fs.fchmodSync = function(fd, mode) {
   validateUint32(mode, 'mode');
   if (mode < 0 || mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
-  return binding.fchmod(fd, mode);
+  const ctx = {};
+  binding.fchmod(fd, mode, undefined, ctx);
+  handleErrorFromBinding(ctx);
 };
 
 if (constants.O_SYMLINK !== undefined) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -577,7 +577,11 @@ fs.readSync = function(fd, buffer, offset, length, position) {
   if (!isUint32(position))
     position = -1;
 
-  return binding.read(fd, buffer, offset, length, position);
+  const ctx = {};
+  const result = binding.read(fd, buffer, offset, length, position,
+                              undefined, ctx);
+  handleErrorFromBinding(ctx);
+  return result;
 };
 
 // usage:

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1183,7 +1183,9 @@ fs.futimesSync = function(fd, atime, mtime) {
   validateUint32(fd, 'fd');
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  binding.futimes(fd, atime, mtime);
+  const ctx = {};
+  binding.futimes(fd, atime, mtime, undefined, ctx);
+  handleErrorFromBinding(ctx);
 };
 
 function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1110,7 +1110,9 @@ fs.fchownSync = function(fd, uid, gid) {
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
 
-  return binding.fchown(fd, uid, gid);
+  const ctx = {};
+  binding.fchown(fd, uid, gid, undefined, ctx);
+  handleErrorFromBinding(ctx);
 };
 
 fs.chown = function(path, uid, gid, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -635,6 +635,8 @@ Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
   validateUint32(fd, 'fd');
+  const ctx = {};
+  let result;
   if (isUint8Array(buffer)) {
     if (position === undefined)
       position = null;
@@ -643,13 +645,18 @@ fs.writeSync = function(fd, buffer, offset, length, position) {
     if (typeof length !== 'number')
       length = buffer.length - offset;
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
-    return binding.writeBuffer(fd, buffer, offset, length, position);
+    result = binding.writeBuffer(fd, buffer, offset, length, position,
+                                 undefined, ctx);
+  } else {
+    if (typeof buffer !== 'string')
+      buffer += '';
+    if (offset === undefined)
+      offset = null;
+    result = binding.writeString(fd, buffer, offset, length,
+                                 undefined, ctx);
   }
-  if (typeof buffer !== 'string')
-    buffer += '';
-  if (offset === undefined)
-    offset = null;
-  return binding.writeString(fd, buffer, offset, length, position);
+  handleErrorFromBinding(ctx);
+  return result;
 };
 
 fs.rename = function(oldPath, newPath, callback) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -575,24 +575,6 @@ inline int SyncCall(Environment* env, Local<Value> ctx, fs_req_wrap* req_wrap,
   return err;
 }
 
-#define SYNC_DEST_CALL(func, path, dest, ...)                                 \
-  fs_req_wrap sync_wrap;                                                      \
-  env->PrintSyncTrace();                                                      \
-  int err = uv_fs_ ## func(env->event_loop(),                                 \
-                         &sync_wrap.req,                                      \
-                         __VA_ARGS__,                                         \
-                         nullptr);                                            \
-  if (err < 0) {                                                              \
-    return env->ThrowUVException(err, #func, nullptr, path, dest);            \
-  }                                                                           \
-
-#define SYNC_CALL(func, path, ...)                                            \
-  SYNC_DEST_CALL(func, path, nullptr, __VA_ARGS__)                            \
-
-#define SYNC_REQ sync_wrap.req
-
-#define SYNC_RESULT err
-
 inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value) {
   if (value->IsObject()) {
     return Unwrap<FSReqBase>(value.As<Object>());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -110,7 +110,7 @@ using v8::Value;
 # define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
-#define GET_OFFSET(a) ((a)->IsNumber() ? (a)->IntegerValue() : -1)
+#define GET_OFFSET(a) ((a)->IsNumber() ? (a).As<Integer>()->Value() : -1)
 
 // The FileHandle object wraps a file descriptor and will close it on garbage
 // collection if necessary. If that happens, a process warning will be
@@ -1411,51 +1411,50 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
  *
  * bytesRead = fs.read(fd, buffer, offset, length, position)
  *
- * 0 fd        integer. file descriptor
+ * 0 fd        int32. file descriptor
  * 1 buffer    instance of Buffer
- * 2 offset    integer. offset to start reading into inside buffer
- * 3 length    integer. length to read
- * 4 position  file position - null for current position
- *
+ * 2 offset    int32. offset to start reading into inside buffer
+ * 3 length    int32. length to read
+ * 4 position  int64. file position - -1 for current position
  */
 static void Read(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  const int argc = args.Length();
+  CHECK_GE(argc, 4);
+
   CHECK(args[0]->IsInt32());
+  const int fd = args[0].As<Int32>()->Value();
+
   CHECK(Buffer::HasInstance(args[1]));
-
-  int fd = args[0]->Int32Value();
-
-  Local<Value> req;
-
-  size_t len;
-  int64_t pos;
-
-  char * buf = nullptr;
-
   Local<Object> buffer_obj = args[1].As<Object>();
-  char *buffer_data = Buffer::Data(buffer_obj);
+  char* buffer_data = Buffer::Data(buffer_obj);
   size_t buffer_length = Buffer::Length(buffer_obj);
 
-  size_t off = args[2]->Int32Value();
+  CHECK(args[2]->IsInt32());
+  const size_t off = static_cast<size_t>(args[2].As<Int32>()->Value());
   CHECK_LT(off, buffer_length);
 
-  len = args[3]->Int32Value();
+  CHECK(args[3]->IsInt32());
+  const size_t len = static_cast<size_t>(args[3].As<Int32>()->Value());
   CHECK(Buffer::IsWithinBounds(off, len, buffer_length));
 
-  pos = GET_OFFSET(args[4]);
+  CHECK(args[4]->IsNumber());
+  const int64_t pos = args[4].As<Integer>()->Value();
 
-  buf = buffer_data + off;
-
+  char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
   FSReqBase* req_wrap = GetReqWrap(env, args[5]);
-  if (req_wrap != nullptr) {
+  if (req_wrap != nullptr) {  // read(fd, buffer, offset, len, pos, req)
     AsyncCall(env, req_wrap, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, &uvbuf, 1, pos);
-  } else {
-    SYNC_CALL(read, 0, fd, &uvbuf, 1, pos)
-    args.GetReturnValue().Set(SYNC_RESULT);
+  } else {  // read(fd, buffer, offset, len, pos, undefined, ctx)
+    CHECK_EQ(argc, 7);
+    fs_req_wrap req_wrap;
+    const int bytesRead = SyncCall(env, args[6], &req_wrap, "read",
+                                   uv_fs_read, fd, &uvbuf, 1, pos);
+    args.GetReturnValue().Set(bytesRead);
   }
 }
 

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -749,3 +749,24 @@ if (!common.isAIX) {
     );
   });
 }
+
+// fchown
+if (!common.isWindows) {
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fchown');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'fchown');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    fs.fchown(fd, process.getuid(), process.getgid(),
+              common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.fchownSync(fd, process.getuid(), process.getgid()),
+      validateError
+    );
+  });
+}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -708,3 +708,24 @@ if (!common.isAIX) {
     validateError
   );
 }
+
+// read
+{
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, read');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'read');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    const buf = Buffer.alloc(5);
+    fs.read(fd, buf, 0, 1, 1, common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.readSync(fd, buf, 0, 1, 1),
+      validateError
+    );
+  });
+}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -770,3 +770,44 @@ if (!common.isWindows) {
     );
   });
 }
+
+// write buffer
+{
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, write');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'write');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    const buf = Buffer.alloc(5);
+    fs.write(fd, buf, 0, 1, 1, common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.writeSync(fd, buf, 0, 1, 1),
+      validateError
+    );
+  });
+}
+
+// write string
+{
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, write');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'write');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    fs.write(fd, 'test', 1, common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.writeSync(fd, 'test', 1),
+      validateError
+    );
+  });
+}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -811,3 +811,24 @@ if (!common.isWindows) {
     );
   });
 }
+
+
+// futimes
+if (!common.isAIX) {
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, futime');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'futime');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    fs.futimes(fd, new Date(), new Date(), common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.futimesSync(fd, new Date(), new Date()),
+      validateError
+    );
+  });
+}

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -729,3 +729,23 @@ if (!common.isAIX) {
     );
   });
 }
+
+// fchmod
+{
+  const validateError = (err) => {
+    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fchmod');
+    assert.strictEqual(err.errno, uv.UV_EBADF);
+    assert.strictEqual(err.code, 'EBADF');
+    assert.strictEqual(err.syscall, 'fchmod');
+    return true;
+  };
+
+  common.runWithInvalidFD((fd) => {
+    fs.fchmod(fd, 0o666, common.mustCall(validateError));
+
+    assert.throws(
+      () => fs.fchmodSync(fd, 0o666),
+      validateError
+    );
+  });
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

After this PR, all synchronous errors in node_file.cc are migrated into JS land, and they all have error tests in `test-fs-error-messages.js` (the asynchronous errors are tested as well).

The only synchronous errors left in `fs` is being fixed in https://github.com/nodejs/node/pull/17851
