### PR TITLE
build: disable openssl build warnings on macos

### DIFF
--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -157,6 +157,9 @@
       }, {
         'defines': ['<@(openssl_default_defines_not_win)'],
         'cflags': ['-Wno-missing-field-initializers'],
+        'xcode_settings': {
+          'WARNING_CFLAGS': ['-Wno-missing-field-initializers'],
+        },
         'conditions': [
           ['OS=="mac"', {
             'defines': ['<@(openssl_default_defines_mac)'],


### PR DESCRIPTION
We already disable `-Wmissing-field-initializers` on other Unices but
not on MacOS.

Fixes: #18983 (partially)