### PR TITLE
[v8.x backport] build: refine static and shared lib build

### DIFF
--- a/configure
+++ b/configure
@@ -878,7 +878,6 @@ def configure_node(o):
     configure_mips(o)
 
   if flavor == 'aix':
-    o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
@@ -987,6 +986,13 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  if options.shared:
+    o['variables']['node_target_type'] = 'shared_library'
+  elif options.enable_static:
+    o['variables']['node_target_type'] = 'static_library'
+  else:
+    o['variables']['node_target_type'] = 'executable'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
@@ -1484,8 +1490,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
-  'NODE_TARGET_TYPE': variables['node_target_type'] if options.enable_static \
-      else '',
+  'NODE_TARGET_TYPE': variables['node_target_type'],
 }
 
 if options.prefix:

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -1,8 +1,4 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
@@ -10,13 +6,6 @@
         ['node_use_openssl=="true"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
-          'conditions': [
-            ['OS=="win" and node_target_type=="static_library"', {
-	      'libraries': [
-                '../../../../$(Configuration)/lib/<(OPENSSL_PRODUCT)'
-              ],
-            }],
-          ],
         }]
       ]
     },

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -1,22 +1,9 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
-      'conditions': [
-        ['node_target_type=="static_library"', {
-          'conditions': [
-            ['OS=="win"', {
-	      'libraries': ['../../../../$(Configuration)/lib/zlib.lib'],
-            }],
-          ],
-        }],
-      ],
     },
   ]
 }


### PR DESCRIPTION
Refine the static and shared lib build process in order
to integrate static and shared lib verfication into CI.
When building both static and shared lib, we still build
node executable now and it uses the shared and static lib.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

Refs: https://github.com/nodejs/node/issues/14158
PR-URL: https://github.com/nodejs/node/pull/17604
Reviewed-By: Bartosz Sosnowski <bartosz@janeasystems.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
