### PR TITLE
test: specify 'dir' for directory symlinks

### DIFF
--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -19,7 +19,7 @@ const addonPath = path.join(__dirname, 'build', common.buildType);
 const addonLink = path.join(tmpdir.path, 'addon');
 
 try {
-  fs.symlinkSync(addonPath, addonLink);
+  fs.symlinkSync(addonPath, addonLink, 'dir');
 } catch (err) {
   if (err.code !== 'EPERM') throw err;
   common.skip('module identity test (no privs for symlinks)');

--- a/test/es-module/test-esm-symlink.js
+++ b/test/es-module/test-esm-symlink.js
@@ -37,7 +37,7 @@ try {
   fs.symlinkSync(real, link_absolute_path);
   fs.symlinkSync(path.basename(real), link_relative_path);
   fs.symlinkSync(real, link_ignore_extension);
-  fs.symlinkSync(path.dirname(real), link_directory);
+  fs.symlinkSync(path.dirname(real), link_directory, 'dir');
 } catch (err) {
   if (err.code !== 'EPERM') throw err;
   common.skip('insufficient privileges for symlinks');

--- a/test/parallel/test-module-symlinked-peer-modules.js
+++ b/test/parallel/test-module-symlinked-peer-modules.js
@@ -42,7 +42,7 @@ fs.mkdirSync(moduleB);
 // Attempt to make the symlink. If this fails due to lack of sufficient
 // permissions, the test will bail out and be skipped.
 try {
-  fs.symlinkSync(moduleA, moduleA_link);
+  fs.symlinkSync(moduleA, moduleA_link, 'dir');
 } catch (err) {
   if (err.code !== 'EPERM') throw err;
   common.skip('insufficient privileges for symlinks');


### PR DESCRIPTION
Directory symlinks in Windows require the 'dir' flag to be passed to
create the symlink correctly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test