### PR TITLE
[v6.x backport] build: refine static and shared lib build

### DIFF
--- a/configure
+++ b/configure
@@ -842,7 +842,6 @@ def configure_node(o):
     configure_mips(o)
 
   if flavor == 'aix':
-    o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
@@ -941,6 +940,13 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  if options.shared:
+    o['variables']['node_target_type'] = 'shared_library'
+  elif options.enable_static:
+    o['variables']['node_target_type'] = 'static_library'
+  else:
+    o['variables']['node_target_type'] = 'executable'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
@@ -1437,6 +1443,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
+  'NODE_TARGET_TYPE': variables['node_target_type'],
 }
 
 if options.prefix:

--- a/node.gypi
+++ b/node.gypi
@@ -1,4 +1,29 @@
 {
+  # 'force_load' means to include the static libs into the shared lib or
+  # executable. Therefore, it is enabled when building:
+  # 1. The executable and it uses static lib (cctest and node)
+  # 2. The shared lib
+  # Linker optimizes out functions that are not used. When force_load=true,
+  # --whole-archive,force_load and /WHOLEARCHIVE are used to include
+  # all obj files in static libs into the executable or shared lib.
+  'variables': {
+    'variables': {
+      'variables': {
+        'force_load%': 'true',
+        'current_type%': '<(_type)',
+      },
+      'force_load%': '<(force_load)',
+      'conditions': [
+        ['current_type=="static_library"', {
+          'force_load': 'false',
+        }],
+        [ 'current_type=="executable" and node_target_type=="shared_library"', {
+          'force_load': 'false',
+        }]
+      ],
+    },
+    'force_load%': '<(force_load)',
+  },
   'conditions': [
     [ 'node_shared=="false"', {
       'msvs_settings': {
@@ -36,12 +61,6 @@
     [ 'node_v8_options!=""', {
       'defines': [ 'NODE_V8_OPTIONS="<(node_v8_options)"'],
     }],
-    # No node_main.cc for anything except executable
-    [ 'node_target_type!="executable"', {
-      'sources!': [
-        'src/node_main.cc',
-      ],
-    }],
     [ 'node_release_urlbase!=""', {
       'defines': [
         'NODE_RELEASE_URLBASE="<(node_release_urlbase)"',
@@ -66,40 +85,121 @@
         'deps/v8/src/third_party/vtune/v8vtune.gyp:v8_vtune'
       ],
     }],
-    ['v8_inspector=="true"', {
-      'defines': [
-        'HAVE_INSPECTOR=1',
+    [ 'node_no_browser_globals=="true"', {
+      'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
+    } ],
+    [ 'node_use_bundled_v8=="true" and v8_postmortem_support=="true"', {
+      'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
+      'conditions': [
+        # -force_load is not applicable for the static library
+        [ 'force_load=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(V8_BASE)',
+            ],
+          },
+        }],
       ],
-      'sources': [
-        'src/inspector_agent.cc',
-        'src/inspector_socket.cc',
-        'src/inspector_agent.h',
-        'src/inspector_socket.h',
-      ],
-      'dependencies': [
-        'deps/v8_inspector/third_party/v8_inspector/platform/'
-                'v8_inspector/v8_inspector.gyp:v8_inspector_stl',
-        'v8_inspector_compress_protocol_json#host',
-      ],
-      'include_dirs': [
-        'deps/v8_inspector/third_party/v8_inspector',
-        '<(SHARED_INTERMEDIATE_DIR)/blink', # for inspector
-      ],
-    }, {
-      'defines': [ 'HAVE_INSPECTOR=0' ]
     }],
+    [ 'node_shared_zlib=="false"', {
+      'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+    }],
+
+    [ 'node_shared_http_parser=="false"', {
+      'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+    }],
+
+    [ 'node_shared_cares=="false"', {
+      'dependencies': [ 'deps/cares/cares.gyp:cares' ],
+    }],
+
+    [ 'node_shared_libuv=="false"', {
+      'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
+    }],
+
+    [ 'OS=="mac"', {
+      # linking Corefoundation is needed since certain OSX debugging tools
+      # like Instruments require it for some features
+      'libraries': [ '-framework CoreFoundation' ],
+      'defines!': [
+        'NODE_PLATFORM="mac"',
+      ],
+      'defines': [
+        # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
+        'NODE_PLATFORM="darwin"',
+      ],
+    }],
+    [ 'OS=="freebsd"', {
+      'libraries': [
+        '-lutil',
+        '-lkvm',
+      ],
+    }],
+    [ 'OS=="aix"', {
+      'defines': [
+        '_LINUX_SOURCE_COMPAT',
+      ],
+      'conditions': [
+        [ 'force_load=="true"', {
+
+          'actions': [
+            {
+              'action_name': 'expfile',
+              'inputs': [
+                '<(OBJ_DIR)'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/node.exp'
+              ],
+              'action': [
+                'sh', 'tools/create_expfile.sh',
+                      '<@(_inputs)', '<@(_outputs)'
+              ],
+            }
+          ],
+          'ldflags': ['-Wl,-bE:<(PRODUCT_DIR)/node.exp', '-Wl,-brtl'],
+        }],
+      ],
+    }],
+    [ 'OS=="solaris"', {
+      'libraries': [
+        '-lkstat',
+        '-lumem',
+      ],
+      'defines!': [
+        'NODE_PLATFORM="solaris"',
+      ],
+      'defines': [
+        # we need to use node's preferred "sunos"
+        # rather than gyp's preferred "solaris"
+        'NODE_PLATFORM="sunos"',
+      ],
+    }],
+    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
+        ' and coverage=="false" and force_load=="true"', {
+      'ldflags': [ '-Wl,-z,noexecstack',
+                   '-Wl,--whole-archive <(V8_BASE)',
+                   '-Wl,--no-whole-archive' ]
+    }],
+    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
+        ' and coverage=="true" and force_load=="true"', {
+      'ldflags': [ '-Wl,-z,noexecstack',
+                   '-Wl,--whole-archive <(V8_BASE)',
+                   '-Wl,--no-whole-archive',
+                   '--coverage',
+                   '-g',
+                   '-O0' ],
+       'cflags': [ '--coverage',
+                   '-g',
+                   '-O0' ],
+       'cflags!': [ '-O3' ]
+    }],
+    [ 'OS=="sunos"', {
+      'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
+    }],
+
     [ 'node_use_openssl=="true"', {
       'defines': [ 'HAVE_OPENSSL=1' ],
-      'sources': [
-        'src/node_crypto.cc',
-        'src/node_crypto_bio.cc',
-        'src/node_crypto_clienthello.cc',
-        'src/node_crypto.h',
-        'src/node_crypto_bio.h',
-        'src/node_crypto_clienthello.h',
-        'src/tls_wrap.cc',
-        'src/tls_wrap.h'
-      ],
       'conditions': [
         ['openssl_fips != ""', {
           'defines': [ 'NODE_FIPS_MODE' ],
@@ -111,11 +211,10 @@
             # For tests
             './deps/openssl/openssl.gyp:openssl-cli',
           ],
-          # Do not let unused OpenSSL symbols to slip away
           'conditions': [
             # -force_load or --whole-archive are not applicable for
             # the static library
-            [ 'node_target_type!="static_library"', {
+            [ 'force_load=="true"', {
               'xcode_settings': {
                 'OTHER_LDFLAGS': [
                   '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
@@ -142,187 +241,10 @@
             }],
           ],
         }]]
+
     }, {
       'defines': [ 'HAVE_OPENSSL=0' ]
     }],
-    [ 'node_use_dtrace=="true"', {
-      'defines': [ 'HAVE_DTRACE=1' ],
-      'dependencies': [
-        'node_dtrace_header',
-        'specialize_node_d',
-      ],
-      'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
 
-      #
-      # DTrace is supported on linux, solaris, mac, and bsd.  There are
-      # three object files associated with DTrace support, but they're
-      # not all used all the time:
-      #
-      #   node_dtrace.o           all configurations
-      #   node_dtrace_ustack.o    not supported on mac and linux
-      #   node_dtrace_provider.o  All except OS X.  "dtrace -G" is not
-      #                           used on OS X.
-      #
-      # Note that node_dtrace_provider.cc and node_dtrace_ustack.cc do not
-      # actually exist.  They're listed here to trick GYP into linking the
-      # corresponding object files into the final "node" executable.  These
-      # object files are generated by "dtrace -G" using custom actions
-      # below, and the GYP-generated Makefiles will properly build them when
-      # needed.
-      #
-      'sources': [ 'src/node_dtrace.cc' ],
-      'conditions': [
-        [ 'OS=="linux"', {
-          'sources': [
-            '<(SHARED_INTERMEDIATE_DIR)/node_dtrace_provider.o'
-          ],
-        }],
-        [ 'OS!="mac" and OS!="linux"', {
-          'sources': [
-            'src/node_dtrace_ustack.cc',
-            'src/node_dtrace_provider.cc',
-          ]
-        }
-      ] ]
-    } ],
-    [ 'node_use_lttng=="true"', {
-      'defines': [ 'HAVE_LTTNG=1' ],
-      'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
-      'libraries': [ '-llttng-ust' ],
-      'sources': [
-        'src/node_lttng.cc'
-      ],
-    } ],
-    [ 'node_use_etw=="true"', {
-      'defines': [ 'HAVE_ETW=1' ],
-      'dependencies': [ 'node_etw' ],
-      'sources': [
-        'src/node_win32_etw_provider.h',
-        'src/node_win32_etw_provider-inl.h',
-        'src/node_win32_etw_provider.cc',
-        'src/node_dtrace.cc',
-        'tools/msvs/genfiles/node_etw_provider.h',
-        'tools/msvs/genfiles/node_etw_provider.rc',
-      ]
-    } ],
-    [ 'node_use_perfctr=="true"', {
-      'defines': [ 'HAVE_PERFCTR=1' ],
-      'dependencies': [ 'node_perfctr' ],
-      'sources': [
-        'src/node_win32_perfctr_provider.h',
-        'src/node_win32_perfctr_provider.cc',
-        'src/node_counters.cc',
-        'src/node_counters.h',
-        'tools/msvs/genfiles/node_perfctr_provider.rc',
-      ]
-    } ],
-    [ 'node_no_browser_globals=="true"', {
-      'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
-    } ],
-    [ 'node_use_bundled_v8=="true" and v8_postmortem_support=="true"', {
-      'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
-      'conditions': [
-        # -force_load is not applicable for the static library
-        [ 'node_target_type!="static_library"', {
-          'xcode_settings': {
-            'OTHER_LDFLAGS': [
-              '-Wl,-force_load,<(V8_BASE)',
-            ],
-          },
-        }],
-      ],
-    }],
-    [ 'node_shared_zlib=="false"', {
-      'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
-    }],
-
-    [ 'node_shared_http_parser=="false"', {
-      'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
-    }],
-
-    [ 'node_shared_cares=="false"', {
-      'dependencies': [ 'deps/cares/cares.gyp:cares' ],
-    }],
-
-    [ 'node_shared_libuv=="false"', {
-      'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
-    }],
-
-    [ 'OS=="win"', {
-      'sources': [
-        'src/backtrace_win32.cc',
-        'src/res/node.rc',
-      ],
-      'defines!': [
-        'NODE_PLATFORM="win"',
-      ],
-      'defines': [
-        'FD_SETSIZE=1024',
-        # we need to use node's preferred "win32" rather than gyp's preferred "win"
-        'NODE_PLATFORM="win32"',
-        '_UNICODE=1',
-      ],
-      'libraries': [ '-lpsapi.lib' ]
-    }, { # POSIX
-      'defines': [ '__POSIX__' ],
-      'sources': [ 'src/backtrace_posix.cc' ],
-    }],
-    [ 'OS=="mac"', {
-      # linking Corefoundation is needed since certain OSX debugging tools
-      # like Instruments require it for some features
-      'libraries': [ '-framework CoreFoundation' ],
-      'defines!': [
-        'NODE_PLATFORM="mac"',
-      ],
-      'defines': [
-        # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
-        'NODE_PLATFORM="darwin"',
-      ],
-    }],
-    [ 'OS=="freebsd"', {
-      'libraries': [
-        '-lutil',
-        '-lkvm',
-      ],
-    }],
-    [ 'OS=="aix"', {
-      'defines': [
-        '_LINUX_SOURCE_COMPAT',
-      ],
-    }],
-    [ 'OS=="solaris"', {
-      'libraries': [
-        '-lkstat',
-        '-lumem',
-      ],
-      'defines!': [
-        'NODE_PLATFORM="solaris"',
-      ],
-      'defines': [
-        # we need to use node's preferred "sunos"
-        # rather than gyp's preferred "solaris"
-        'NODE_PLATFORM="sunos"',
-      ],
-    }],
-    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="false"', {
-      'ldflags': [ '-Wl,-z,noexecstack',
-                   '-Wl,--whole-archive <(V8_BASE)',
-                   '-Wl,--no-whole-archive' ]
-    }],
-    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="true"', {
-      'ldflags': [ '-Wl,-z,noexecstack',
-                   '-Wl,--whole-archive <(V8_BASE)',
-                   '-Wl,--no-whole-archive',
-                   '--coverage',
-                   '-g',
-                   '-O0' ],
-       'cflags': [ '--coverage',
-                   '-g',
-                   '-O0' ],
-       'cflags!': [ '-O3' ]
-    }],
-    [ 'OS=="sunos"', {
-      'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
-    }],
   ],
 }

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -1,6 +1,7 @@
 #include "node.h"
 
 #ifdef _WIN32
+#include <windows.h>
 #include <VersionHelpers.h>
 
 int wmain(int argc, wchar_t *wargv[]) {


### PR DESCRIPTION
Refine the static and shared lib build process in order
to integrate static and shared lib verfication into CI.
When building both static and shared lib, we still build
node executable now and it uses the shared and static lib.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

Refs: https://github.com/nodejs/node/issues/14158
PR-URL: https://github.com/nodejs/node/pull/17604
Reviewed-By: Bartosz Sosnowski <bartosz@janeasystems.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
