### PR TITLE
doc: add RegExp Unicode Property Escapes to intl

### DIFF
--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -19,6 +19,7 @@ programs. Some of them are:
 - [`require('buffer').transcode()`][]
 - More accurate [REPL][] line editing
 - [`require('util').TextDecoder`][]
+- [RegExp Unicode Property Escapes][]
 
 Node.js (and its underlying V8 engine) uses [ICU][] to implement these features
 in native C/C++ code. However, some of them require a very large ICU data file
@@ -55,6 +56,7 @@ option:
 | [`require('buffer').transcode()`][]     | none (function does not exist)    | full                         | full                   | full       |
 | [REPL][]                                | partial (inaccurate line editing) | full                         | full                   | full       |
 | [`require('util').TextDecoder`][]       | partial (basic encodings support) | partial/full (depends on OS) | partial (Unicode-only) | full       |
+| [RegExp Unicode Property Escapes][]     | none (invalid RegExp error)       | full                         | full                   | full       |
 
 The "(not locale-aware)" designation denotes that the function carries out its
 operation just like the non-`Locale` version of the function, if one
@@ -207,6 +209,7 @@ to be helpful:
 [ECMA-402]: https://tc39.github.io/ecma402/
 [ICU]: http://icu-project.org/
 [REPL]: repl.html#repl_repl
+[RegExp Unicode Property Escapes]: https://github.com/tc39/proposal-regexp-unicode-property-escapes
 [Test262]: https://github.com/tc39/test262/tree/master/test/intl402
 [WHATWG URL parser]: url.html#url_the_whatwg_url_api
 [btest402]: https://github.com/srl295/btest402


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, intl

[RegExp Unicode Property Escapes](https://github.com/tc39/proposal-regexp-unicode-property-escapes) are at stage 4 and [will be included in ES2018](https://github.com/tc39/proposals/blob/master/finished-proposals.md). They are available [since V8 6.4 without a flag](https://bugs.chromium.org/p/v8/issues/detail?id=4743&desc=2) so they will be unflagged in Node.js v10. They are also available under the `--harmony_regexp_property` flag in Node.js v6-v9 and under the `--harmony` flag in Node.js v8-v9.

So it seems we should already warn about this and maybe backport these notes till v6 LTS.

Simple test:
```console
> node.10.0.0.v8-6.4.20180227.nightly.exe

> process.versions

{ http_parser: '2.7.0',
  node: '10.0.0-nightly20180227a27e6d7321',
  v8: '6.4.388.46-node.4',
  uv: '1.19.2',
  zlib: '1.2.11',
  ares: '1.13.0',
  modules: '61',
  nghttp2: '1.29.0',
  napi: '2',
  openssl: '1.0.2n',
  icu: '60.2',
  unicode: '10.0',
  cldr: '32.0.1',
  tz: '2017c' }

> 'abc абв'.match(/\p{Letter}+/gu);

[ 'abc', 'абв' ]

'abc абв'.match(/\p{Script=Cyrillic}+/gu);

[ 'абв' ]
```
```console
> .\vcbuild without-intl test

...

> node.10.0.0-pre.v8-6.4.20180228.without-intl.exe

> process.versions

{ http_parser: '2.7.0',
  node: '10.0.0-pre',
  v8: '6.4.388.46-node.4',
  uv: '1.19.2',
  zlib: '1.2.11',
  ares: '1.13.0',
  modules: '61',
  nghttp2: '1.29.0',
  napi: '2',
  openssl: '1.0.2n' }

> 'abc абв'.match(/\p{Letter}+/gu);

SyntaxError: Invalid regular expression: /\p{Letter}+/: Invalid property name

> 'abc абв'.match(/\p{Script=Cyrillic}+/gu);

SyntaxError: Invalid regular expression: /\p{Script=Cyrillic}+/: Invalid property name
```
I am not sure if this suffices to state full support also for `system-icu`, please check and correct me if this is needed.

Additional refs:

https://mathiasbynens.be/notes/es-unicode-property-escapes
https://mathiasbynens.be/notes/es-regexp-proposals#unicode-property-escapes

http://2ality.com/2017/07/regexp-unicode-property-escapes.html

https://ponyfoo.com/articles/regular-expressions-post-es6#unicode-property-escapes

Unfortunately, still no info in [MDN RegExp page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) to link to.