### PR TITLE
lib: re-fix v8_prof_processor

### DIFF
--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -34,9 +34,9 @@ if (process.platform === 'darwin') {
   tickArguments.push('--windows');
 }
 tickArguments.push.apply(tickArguments, process.argv.slice(1));
-script = `(function(require) {
+script = `(function(module, require) {
   arguments = ${JSON.stringify(tickArguments)};
   function write (s) { process.stdout.write(s) }
   ${script}
 })`;
-vm.runInThisContext(script)(require);
+vm.runInThisContext(script)(module, require);


### PR DESCRIPTION
Make the script not error out immediately because of a missing
pseudo-global.
(Note that it seems like tests are still broken on `master`.)

Fixes: https://github.com/nodejs/node/issues/19044
Refs: https://github.com/nodejs/node/pull/18623

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

lib