### PR TITLE
http2: callback valid check before closing request

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1764,6 +1764,8 @@ class Http2Stream extends Duplex {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'number');
     if (code < 0 || code > kMaxInt)
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'code');
+    if (callback !== undefined && typeof callback !== 'function')
+      throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
     // Clear timeout and remove timeout listeners
     this.setTimeout(0);
@@ -1781,8 +1783,6 @@ class Http2Stream extends Duplex {
     state.rstCode = code;
 
     if (callback !== undefined) {
-      if (typeof callback !== 'function')
-        throw new errors.TypeError('ERR_INVALID_CALLBACK');
       this.once('close', callback);
     }
 

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -28,6 +28,18 @@ server.listen(0, common.mustCall(() => {
   );
   assert.strictEqual(req.closed, false);
 
+  [true, 1, {}, [], null, 'test'].forEach((notFunction) => {
+    common.expectsError(
+      () => req.close(closeCode, notFunction),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_CALLBACK',
+        message: 'Callback must be a function'
+      }
+    );
+    assert.strictEqual(req.closed, false);
+  });
+
   req.close(closeCode, common.mustCall());
   assert.strictEqual(req.closed, true);
 


### PR DESCRIPTION
Do not close the request if callback is not a function, and throw ERR_INVALID_CALLBACK TypeError

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
