### PR TITLE
test: add test cases for fsPromises

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -9,8 +9,10 @@ const fsPromises = require('fs/promises');
 const {
   access,
   chmod,
+  chown,
   copyFile,
   fchmod,
+  fchown,
   fdatasync,
   fstat,
   fsync,
@@ -27,6 +29,8 @@ const {
   realpath,
   rename,
   rmdir,
+  lchmod,
+  lchown,
   stat,
   symlink,
   write,
@@ -95,6 +99,21 @@ function verifyStatObject(stat) {
 
     await chmod(dest, 0o666);
     await fchmod(handle, 0o666);
+    // lchmod is only available on OSX
+    if (common.isOSX) {
+      await lchmod(dest, 0o666);
+    }
+
+    if (!common.isWindows) {
+      const gid = process.getgid();
+      const uid = process.getuid();
+      await chown(dest, uid, gid);
+      await fchown(handle, uid, gid);
+      // lchown is only available on OSX
+      if (common.isOSX) {
+        await lchown(dest, uid, gid);
+      }
+    }
 
     await utimes(dest, new Date(), new Date());
 


### PR DESCRIPTION
Add tests of lchmod, chown, fchown and lchown. These tests will increase the coverage of `fs/promises`: https://coverage.nodejs.org/coverage-3f78d3fcf8029a0a/root/fs/promises.js.html.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test