### PR TITLE
http2: fix respondWithFile and respondWithFD headers_sent.

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1901,8 +1901,6 @@ function processHeaders(headers) {
 
 function processRespondWithFD(self, fd, headers, offset = 0, length = -1,
                               streamOptions = 0) {
-  const state = self[kState];
-  state.flags |= STREAM_FLAGS_HEADERS_SENT;
 
   const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
   self[kSentHeaders] = headers;
@@ -2003,9 +2001,8 @@ function doSendFileFD(session, options, fd, headers, streamOptions, err, stat) {
   // response operation. If statCheck explicitly returns false, the
   // response is canceled. The user code may also send a separate type
   // of response so check again for the HEADERS_SENT flag
-  if ((typeof options.statCheck === 'function' &&
-       options.statCheck.call(this, stat, headers) === false) ||
-       (this[kState].flags & STREAM_FLAGS_HEADERS_SENT)) {
+  if (typeof options.statCheck === 'function' &&
+       options.statCheck.call(this, stat, headers) === false) {
     return;
   }
 
@@ -2222,6 +2219,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
 
     const session = this[kSession];
+    const state = this[kState];
 
     assertIsObject(options, 'options');
     options = Object.assign({}, options);
@@ -2270,6 +2268,8 @@ class ServerHttp2Stream extends Http2Stream {
         statusCode === HTTP_STATUS_NOT_MODIFIED) {
       throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
     }
+
+    state.flags |= STREAM_FLAGS_HEADERS_SENT;
 
     if (options.statCheck !== undefined) {
       fs.fstat(fd,
@@ -2329,6 +2329,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     const session = this[kSession];
+    const state = this[kState];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
           `${sessionName(session[kType])}]: initiating response`);
     this[kUpdateTimer]();
@@ -2342,6 +2343,8 @@ class ServerHttp2Stream extends Http2Stream {
         statusCode === HTTP_STATUS_NOT_MODIFIED) {
       throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
     }
+
+    state.flags = STREAM_FLAGS_HEADERS_SENT;
 
     fs.open(path, 'r',
             afterOpen.bind(this, session, options, headers, streamOptions));

--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -48,5 +48,6 @@ server.listen(0, () => {
     client.close();
     server.close();
   }));
+  assert.strictEqual(req.headersSent, true);
   req.end();
 });


### PR DESCRIPTION
When using respondWithFile or respondWithFD the headersSent flags was
never set to true. Fix it to set state.flags to
STREAM_FLAGS_HEADERS_SENT after processing headers into these methods.

Fixes: https://github.com/nodejs/node/issues/18862

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
