### PR TITLE
doc: fix n-api asynchronous threading documentation

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3272,7 +3272,7 @@ being provided for diagnostic information exposed by the `async_hooks` API.
 the logic asynchronously. The given function is called from a worker pool
 thread and executes in parallel with the main event loop thread.
 - `[in] complete`: The native function which will be called when the
-asynchronous logic is comple or is cancelled. The given function is called
+asynchronous logic is completed or is cancelled. The given function is called
 from the main event loop thread.
 - `[in] data`: User-provided data context. This will be passed back into the
 execute and complete functions.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3270,7 +3270,7 @@ napi_status napi_create_async_work(napi_env env,
 being provided for diagnostic information exposed by the `async_hooks` API.
 - `[in] execute`: The native function which should be called to excute
 the logic asynchronously. The given function is called from a worker pool
-thread and executes in parallel with the main event loop thread.
+thread and can execute in parallel with the main event loop thread.
 - `[in] complete`: The native function which will be called when the
 asynchronous logic is completed or is cancelled. The given function is called
 from the main event loop thread.
@@ -3348,8 +3348,9 @@ callback invocation, even if it has been successfully cancelled.
 
 ## Custom Asynchronous Operations
 The simple asynchronous work APIs above may not be appropriate for every
-scenario. When using any other async mechanism, the following APIs are
-necessary to ensure an async operation is properly tracked by the runtime.
+scenario. When using any other asynchronous mechanism, the following APIs 
+are necessary to ensure an asynchronous operation is properly tracked by 
+the runtime.
 
 ### napi_async_init
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3269,9 +3269,11 @@ napi_status napi_create_async_work(napi_env env,
 - `[in] async_resource_name`: Identifier for the kind of resource that is
 being provided for diagnostic information exposed by the `async_hooks` API.
 - `[in] execute`: The native function which should be called to excute
-the logic asynchronously.
+the logic asynchronously. The given function is called from a worker pool
+thread and executes in parallel with the main event loop thread.
 - `[in] complete`: The native function which will be called when the
-asynchronous logic is comple or is cancelled.
+asynchronous logic is comple or is cancelled. The given function is called
+from the main event loop thread.
 - `[in] data`: User-provided data context. This will be passed back into the
 execute and complete functions.
 - `[out] result`: `napi_async_work*` which is the handle to the newly created
@@ -3346,8 +3348,7 @@ callback invocation, even if it has been successfully cancelled.
 
 ## Custom Asynchronous Operations
 The simple asynchronous work APIs above may not be appropriate for every
-scenario, because with those the async execution still happens on the main
-event loop. When using any other async mechanism, the following APIs are
+scenario. When using any other async mechanism, the following APIs are
 necessary to ensure an async operation is properly tracked by the runtime.
 
 ### napi_async_init


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Documentation for N-API Custom Asynchronous Operations incorrectly stated that async execution happens on the main event loop. Added details to napi_create_async_work about which threads are used to invoke the execute and complete callbacks.

Fixes: #19071

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc