### PR TITLE
crypto: ECDH convertKey to convert public keys between different formats

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -656,9 +656,9 @@ assert.strictEqual(aliceSecret.toString('hex'), bobSecret.toString('hex'));
 // OK
 ```
 
-### ECDH.convertKey(key, curve[, inputEncoding][, outputEncoding][, format])
+### ECDH.convertKey(key, curve[, inputEncoding[, outputEncoding[, format]]])
 <!-- YAML
-added: v10.0.0
+added: REPLACEME
 -->
 
 - `key` {string | Buffer | TypedArray | DataView}
@@ -687,7 +687,7 @@ If the `inputEncoding` is not provided, `key` is expected to be a [`Buffer`][],
 Example (uncompressing a key):
 
 ```js
-const ECDH = require('crypto').ECDH;
+const { ECDH } = require('crypto');
 
 const ecdh = ECDH('secp256k1');
 ecdh.generateKeys();

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -656,6 +656,54 @@ assert.strictEqual(aliceSecret.toString('hex'), bobSecret.toString('hex'));
 // OK
 ```
 
+### ECDH.convertKey(key, curve[, inputEncoding][, outputEncoding][, format])
+<!-- YAML
+added: v10.0.0
+-->
+
+- `key` {string | Buffer | TypedArray | DataView}
+- `curve` {string}
+- `inputEncoding` {string}
+- `outputEncoding` {string}
+- `format` {string} Defaults to `uncompressed`.
+
+Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the
+format specified by `format`. The `format` argument specifies point encoding
+and can be `'compressed'`, `'uncompressed'` or `'hybrid'`. The supplied key is
+interpreted using the specified `inputEncoding`, and the returned key is encoded
+using the specified `outputEncoding`. Encodings can be `'latin1'`, `'hex'`,
+or `'base64'`.
+
+Use [`crypto.getCurves()`][] to obtain a list of available curve names.
+On recent OpenSSL releases, `openssl ecparam -list_curves` will also display
+the name and description of each available elliptic curve.
+
+If `format` is not specified the point will be returned in `'uncompressed'`
+format.
+
+If the `inputEncoding` is not provided, `key` is expected to be a [`Buffer`][],
+`TypedArray`, or `DataView`.
+
+Example (uncompressing a key):
+
+```js
+const ECDH = require('crypto').ECDH;
+
+const ecdh = ECDH('secp256k1');
+ecdh.generateKeys();
+
+const compressedKey = ecdh.getPublicKey('hex', 'compressed');
+
+const uncompressedKey = ECDH.convertKey(compressedKey,
+                                        'secp256k1',
+                                        'hex',
+                                        'hex',
+                                        'uncompressed');
+
+// the converted key and the uncompressed public key should be the same
+console.log(uncompressedKey === ecdh.getPublicKey('hex'));
+```
+
 ### ecdh.computeSecret(otherPublicKey[, inputEncoding][, outputEncoding])
 <!-- YAML
 added: v0.11.14

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -198,31 +198,28 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 };
 
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
-  var f;
-  if (format) {
-    if (format === 'compressed')
-      f = POINT_CONVERSION_COMPRESSED;
-    else if (format === 'hybrid')
-      f = POINT_CONVERSION_HYBRID;
-    // Default
-    else if (format === 'uncompressed')
-      f = POINT_CONVERSION_UNCOMPRESSED;
-    else
-      throw new ERR_CRYPTO_ECDH_INVALID_FORMAT(format);
-  } else {
-    f = POINT_CONVERSION_UNCOMPRESSED;
-  }
+  var f = getFormat(format);
   var key = this._handle.getPublicKey(f);
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
+  return encode(key, encoding);
 };
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;
+  var f = getFormat(format);
+  var convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
+  return encode(convertedKey, outEnc);
+};
+
+function encode(buffer, encoding) {
+  if (encoding && encoding !== 'buffer')
+    buffer = buffer.toString(encoding);
+  return buffer;
+}
+
+function getFormat(format) {
   var f;
   if (format) {
     if (format === 'compressed')
@@ -237,11 +234,8 @@ ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   } else {
     f = POINT_CONVERSION_UNCOMPRESSED;
   }
-  var convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
-  if (outEnc && outEnc !== 'buffer')
-    convertedKey = convertedKey.toString(outEnc);
-  return convertedKey;
-};
+  return f;
+}
 
 module.exports = {
   DiffieHellman,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -85,7 +85,7 @@ DiffieHellmanGroup.prototype.generateKeys =
     dhGenerateKeys;
 
 function dhGenerateKeys(encoding) {
-  var keys = this._handle.generateKeys();
+  const keys = this._handle.generateKeys();
   encoding = encoding || getDefaultEncoding();
   return encode(keys, encoding);
 }
@@ -99,7 +99,7 @@ function dhComputeSecret(key, inEnc, outEnc) {
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;
-  var ret = this._handle.computeSecret(toBuf(key, inEnc));
+  const ret = this._handle.computeSecret(toBuf(key, inEnc));
   if (typeof ret === 'string')
     throw new ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY();
   return encode(ret, outEnc);
@@ -111,7 +111,7 @@ DiffieHellmanGroup.prototype.getPrime =
     dhGetPrime;
 
 function dhGetPrime(encoding) {
-  var prime = this._handle.getPrime();
+  const prime = this._handle.getPrime();
   encoding = encoding || getDefaultEncoding();
   return encode(prime, encoding);
 }
@@ -122,7 +122,7 @@ DiffieHellmanGroup.prototype.getGenerator =
     dhGetGenerator;
 
 function dhGetGenerator(encoding) {
-  var generator = this._handle.getGenerator();
+  const generator = this._handle.getGenerator();
   encoding = encoding || getDefaultEncoding();
   return encode(generator, encoding);
 }
@@ -133,7 +133,7 @@ DiffieHellmanGroup.prototype.getPublicKey =
     dhGetPublicKey;
 
 function dhGetPublicKey(encoding) {
-  var key = this._handle.getPublicKey();
+  const key = this._handle.getPublicKey();
   encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 }
@@ -144,7 +144,7 @@ DiffieHellmanGroup.prototype.getPrivateKey =
     dhGetPrivateKey;
 
 function dhGetPrivateKey(encoding) {
-  var key = this._handle.getPrivateKey();
+  const key = this._handle.getPrivateKey();
   encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 }
@@ -186,8 +186,8 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 };
 
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
-  var f = getFormat(format);
-  var key = this._handle.getPublicKey(f);
+  const f = getFormat(format);
+  const key = this._handle.getPublicKey(f);
   encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 };
@@ -196,8 +196,8 @@ ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;
-  var f = getFormat(format);
-  var convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
+  const f = getFormat(format);
+  const convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
   return encode(convertedKey, outEnc);
 };
 
@@ -208,7 +208,7 @@ function encode(buffer, encoding) {
 }
 
 function getFormat(format) {
-  var f;
+  let f;
   if (format) {
     if (format === 'compressed')
       f = POINT_CONVERSION_COMPRESSED;

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -194,12 +194,14 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   if (typeof key !== 'string' && !isArrayBufferView(key)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'key',
-                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+    throw new ERR_INVALID_ARG_TYPE(
+      'key',
+      ['string', 'Buffer', 'TypedArray', 'DataView']
+    );
   }
 
   if (typeof curve !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
+    throw new ERR_INVALID_ARG_TYPE('curve', 'string');
   }
 
   const encoding = getDefaultEncoding();
@@ -227,7 +229,7 @@ function getFormat(format) {
     else if (format === 'uncompressed')
       f = POINT_CONVERSION_UNCOMPRESSED;
     else
-      throw new errors.TypeError('ERR_CRYPTO_ECDH_INVALID_FORMAT', format);
+      throw new ERR_CRYPTO_ECDH_INVALID_FORMAT(format);
   } else {
     f = POINT_CONVERSION_UNCOMPRESSED;
   }

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -193,6 +193,15 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
 };
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
+  if (typeof key !== 'string' && !isArrayBufferView(key)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'key',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+
+  if (typeof curve !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
+  }
+
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -87,9 +87,7 @@ DiffieHellmanGroup.prototype.generateKeys =
 function dhGenerateKeys(encoding) {
   var keys = this._handle.generateKeys();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    keys = keys.toString(encoding);
-  return keys;
+  return encode(keys, encoding);
 }
 
 
@@ -104,9 +102,7 @@ function dhComputeSecret(key, inEnc, outEnc) {
   var ret = this._handle.computeSecret(toBuf(key, inEnc));
   if (typeof ret === 'string')
     throw new ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY();
-  if (outEnc && outEnc !== 'buffer')
-    ret = ret.toString(outEnc);
-  return ret;
+  return encode(ret, outEnc);
 }
 
 
@@ -117,9 +113,7 @@ DiffieHellmanGroup.prototype.getPrime =
 function dhGetPrime(encoding) {
   var prime = this._handle.getPrime();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    prime = prime.toString(encoding);
-  return prime;
+  return encode(prime, encoding);
 }
 
 
@@ -130,9 +124,7 @@ DiffieHellmanGroup.prototype.getGenerator =
 function dhGetGenerator(encoding) {
   var generator = this._handle.getGenerator();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    generator = generator.toString(encoding);
-  return generator;
+  return encode(generator, encoding);
 }
 
 
@@ -143,9 +135,7 @@ DiffieHellmanGroup.prototype.getPublicKey =
 function dhGetPublicKey(encoding) {
   var key = this._handle.getPublicKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
+  return encode(key, encoding);
 }
 
 
@@ -156,9 +146,7 @@ DiffieHellmanGroup.prototype.getPrivateKey =
 function dhGetPrivateKey(encoding) {
   var key = this._handle.getPrivateKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
+  return encode(key, encoding);
 }
 
 

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -14,7 +14,8 @@ const {
 const {
   DiffieHellman: _DiffieHellman,
   DiffieHellmanGroup: _DiffieHellmanGroup,
-  ECDH: _ECDH
+  ECDH: _ECDH,
+  ECDHConvertKey: _ECDHConvertKey
 } = process.binding('crypto');
 const {
   POINT_CONVERSION_COMPRESSED,
@@ -216,6 +217,30 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   if (encoding && encoding !== 'buffer')
     key = key.toString(encoding);
   return key;
+};
+
+ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
+  const encoding = getDefaultEncoding();
+  inEnc = inEnc || encoding;
+  outEnc = outEnc || encoding;
+  var f;
+  if (format) {
+    if (format === 'compressed')
+      f = POINT_CONVERSION_COMPRESSED;
+    else if (format === 'hybrid')
+      f = POINT_CONVERSION_HYBRID;
+    // Default
+    else if (format === 'uncompressed')
+      f = POINT_CONVERSION_UNCOMPRESSED;
+    else
+      throw new errors.TypeError('ERR_CRYPTO_ECDH_INVALID_FORMAT', format);
+  } else {
+    f = POINT_CONVERSION_UNCOMPRESSED;
+  }
+  var convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
+  if (outEnc && outEnc !== 'buffer')
+    convertedKey = convertedKey.toString(outEnc);
+  return convertedKey;
 };
 
 module.exports = {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5575,7 +5575,7 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
 
   int nid = OBJ_sn2nid(*curve);
   if (nid == NID_undef)
-    return env->ThrowTypeError("Second argument should be a valid curve name");
+    return env->ThrowTypeError("Invalid ECDH curve name");
 
   EC_GROUP* group = EC_GROUP_new_by_curve_name(nid);
   if (group == nullptr)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5561,13 +5561,10 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 3);
 
-  THROW_AND_RETURN_IF_NOT_BUFFER(args[0], "Public key");
-
   size_t len = Buffer::Length(args[0]);
   if (len == 0)
     return args.GetReturnValue().SetEmptyString();
 
-  THROW_AND_RETURN_IF_NOT_STRING(args[1], "ECDH curve name");
   node::Utf8Value curve(env->isolate(), args[1]);
 
   int nid = OBJ_sn2nid(*curve);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -625,6 +625,10 @@ class ECDH : public BaseObject {
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
+  static EC_POINT* BufferToPoint(Environment* env,
+                                 const EC_GROUP* group,
+                                 char* data,
+                                 size_t len);
 
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, EC_KEY* key)
@@ -642,8 +646,6 @@ class ECDH : public BaseObject {
   static void SetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  EC_POINT* BufferToPoint(char* data, size_t len);
 
   bool IsKeyPairValid();
   bool IsKeyValidForCurve(const BIGNUM* private_key);

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -1,0 +1,104 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const ECDH = crypto.ECDH;
+
+// A valid private key for the secp256k1 curve.
+const cafebabeKey = 'cafebabe'.repeat(8);
+// Associated compressed and uncompressed public keys (points).
+const cafebabePubPtComp =
+'03672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3';
+const cafebabePubPtUnComp =
+'04672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3' +
+'2e02c7f93d13dc2732b760ca377a5897b9dd41a1c1b29dc0442fdce6d0a04d1d';
+
+// invalid test: key argument is undefined
+common.expectsError(
+  () => ECDH.convertKey(),
+  {
+    type: TypeError,
+    message: 'Public key must be a buffer'
+  });
+
+// invalid test: curve argument is undefined
+common.expectsError(
+  () => ECDH.convertKey(cafebabePubPtComp),
+  {
+    type: TypeError,
+    message: 'ECDH curve name must be a string'
+  });
+
+// invalid test: curve argument is invalid
+common.expectsError(
+  () => ECDH.convertKey(cafebabePubPtComp, 'badcurve'),
+  {
+    type: TypeError,
+    message: 'Invalid ECDH curve name'
+  });
+
+const availableCurves = new Set(crypto.getCurves());
+
+if (availableCurves.has('secp256k1')) {
+  // invalid test: format argument is undefined
+  common.expectsError(
+    () => ECDH.convertKey(cafebabePubPtComp, 'secp256k1', 'hex', 'hex', 10),
+    {
+      code: 'ERR_CRYPTO_ECDH_INVALID_FORMAT',
+      type: TypeError,
+      message: 'Invalid ECDH format: 10'
+    });
+
+  // Point formats
+  let uncompressed = ECDH.convertKey(cafebabePubPtComp,
+                                     'secp256k1',
+                                     'hex',
+                                     'buffer',
+                                     'uncompressed');
+  let compressed = ECDH.convertKey(cafebabePubPtComp,
+                                   'secp256k1',
+                                   'hex',
+                                   'buffer',
+                                   'compressed');
+  let hybrid = ECDH.convertKey(cafebabePubPtComp,
+                               'secp256k1',
+                               'hex',
+                               'buffer',
+                               'hybrid');
+  assert.strictEqual(uncompressed[0], 4);
+  let firstByte = compressed[0];
+  assert(firstByte === 2 || firstByte === 3);
+  firstByte = hybrid[0];
+  assert(firstByte === 6 || firstByte === 7);
+
+  // format conversion
+  uncompressed = ECDH.convertKey(cafebabePubPtComp,
+                                 'secp256k1',
+                                 'hex',
+                                 'hex',
+                                 'uncompressed');
+  compressed = ECDH.convertKey(cafebabePubPtComp,
+                               'secp256k1',
+                               'hex',
+                               'hex',
+                               'compressed');
+  hybrid = ECDH.convertKey(cafebabePubPtComp,
+                           'secp256k1',
+                           'hex',
+                           'hex',
+                           'hybrid');
+  assert.strictEqual(uncompressed, cafebabePubPtUnComp);
+  assert.strictEqual(compressed, cafebabePubPtComp);
+
+  // compare to getPublicKey
+  const ecdh1 = ECDH('secp256k1');
+  ecdh1.generateKeys();
+  ecdh1.setPrivateKey(cafebabeKey, 'hex');
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'uncompressed'), uncompressed);
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'compressed'), compressed);
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'hybrid'), hybrid);
+}

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -12,12 +12,12 @@ const ECDH = crypto.ECDH;
 const cafebabeKey = 'cafebabe'.repeat(8);
 // Associated compressed and uncompressed public keys (points).
 const cafebabePubPtComp =
-'03672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3';
+    '03672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3';
 const cafebabePubPtUnComp =
-'04672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3' +
-'2e02c7f93d13dc2732b760ca377a5897b9dd41a1c1b29dc0442fdce6d0a04d1d';
+    '04672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3' +
+    '2e02c7f93d13dc2732b760ca377a5897b9dd41a1c1b29dc0442fdce6d0a04d1d';
 
-// invalid test: key argument is undefined
+// Invalid test: key argument is undefined.
 common.expectsError(
   () => ECDH.convertKey(),
   {
@@ -25,7 +25,7 @@ common.expectsError(
     message: 'Public key must be a buffer'
   });
 
-// invalid test: curve argument is undefined
+// Invalid test: curve argument is undefined.
 common.expectsError(
   () => ECDH.convertKey(cafebabePubPtComp),
   {
@@ -33,7 +33,7 @@ common.expectsError(
     message: 'ECDH curve name must be a string'
   });
 
-// invalid test: curve argument is invalid
+// Invalid test: curve argument is invalid.
 common.expectsError(
   () => ECDH.convertKey(cafebabePubPtComp, 'badcurve'),
   {
@@ -44,7 +44,7 @@ common.expectsError(
 const availableCurves = new Set(crypto.getCurves());
 
 if (availableCurves.has('secp256k1')) {
-  // invalid test: format argument is undefined
+  // Invalid test: format argument is undefined.
   common.expectsError(
     () => ECDH.convertKey(cafebabePubPtComp, 'secp256k1', 'hex', 'hex', 10),
     {
@@ -53,7 +53,7 @@ if (availableCurves.has('secp256k1')) {
       message: 'Invalid ECDH format: 10'
     });
 
-  // Point formats
+  // Point formats.
   let uncompressed = ECDH.convertKey(cafebabePubPtComp,
                                      'secp256k1',
                                      'hex',
@@ -75,7 +75,7 @@ if (availableCurves.has('secp256k1')) {
   firstByte = hybrid[0];
   assert(firstByte === 6 || firstByte === 7);
 
-  // format conversion
+  // Format conversion from hex to hex
   uncompressed = ECDH.convertKey(cafebabePubPtComp,
                                  'secp256k1',
                                  'hex',
@@ -94,7 +94,7 @@ if (availableCurves.has('secp256k1')) {
   assert.strictEqual(uncompressed, cafebabePubPtUnComp);
   assert.strictEqual(compressed, cafebabePubPtComp);
 
-  // compare to getPublicKey
+  // Compare to getPublicKey.
   const ecdh1 = ECDH('secp256k1');
   ecdh1.generateKeys();
   ecdh1.setPrivateKey(cafebabeKey, 'hex');

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-const ECDH = crypto.ECDH;
+const { ECDH, getCurves } = crypto;
 
 // A valid private key for the secp256k1 curve.
 const cafebabeKey = 'cafebabe'.repeat(8);
@@ -41,7 +41,7 @@ common.expectsError(
     message: 'Invalid ECDH curve name'
   });
 
-const availableCurves = new Set(crypto.getCurves());
+const availableCurves = new Set(getCurves());
 
 if (availableCurves.has('secp256k1')) {
   // Invalid test: format argument is undefined.

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -4,9 +4,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const crypto = require('crypto');
 
-const { ECDH, getCurves } = crypto;
+const { ECDH, getCurves } = require('crypto');
 
 // A valid private key for the secp256k1 curve.
 const cafebabeKey = 'cafebabe'.repeat(8);
@@ -21,16 +20,16 @@ const cafebabePubPtUnComp =
 common.expectsError(
   () => ECDH.convertKey(),
   {
+    code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'Public key must be a buffer'
   });
 
 // Invalid test: curve argument is undefined.
 common.expectsError(
   () => ECDH.convertKey(cafebabePubPtComp),
   {
+    code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'ECDH curve name must be a string'
   });
 
 // Invalid test: curve argument is invalid.
@@ -41,9 +40,7 @@ common.expectsError(
     message: 'Invalid ECDH curve name'
   });
 
-const availableCurves = new Set(getCurves());
-
-if (availableCurves.has('secp256k1')) {
+if (getCurves().includes('secp256k1')) {
   // Invalid test: format argument is undefined.
   common.expectsError(
     () => ECDH.convertKey(cafebabePubPtComp, 'secp256k1', 'hex', 'hex', 10),


### PR DESCRIPTION
ECDH#convertKey is used to convert public keys between different formats, as per #18977 

`ECDH#convertKey(key, curve[, inputEncoding[, outputEncoding[, format]]])`

- **`key`** `<string>` | `<Buffer>` | `<TypedArray>` | `<DataView>`
- **`curve`** `<string>`
- **`inputEncoding`** `<string>`
- **`outputEncoding`** `<string>`
- **`format`** `<string>` can be `'uncompressed'`, `'compressed'`, `'hybrid'`

Returns the input key converted to the specified encoding and format.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto, doc, test