### PR TITLE
src: add incr/decr operators for Reference

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -154,13 +154,7 @@ class AliasedBuffer {
 
     template <typename T>
     inline Reference& operator-=(const T& val) {
-      const T current = aliased_buffer_->GetValue(index_);
-      aliased_buffer_->SetValue(index_, current - val);
-      return *this;
-    }
-
-    inline Reference& operator-=(const Reference& val) {
-      return *this->operator-=(static_cast<NativeT>(val));
+      return this->operator+=(-val);
     }
 
    private:

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -149,7 +149,7 @@ class AliasedBuffer {
     }
 
     inline Reference& operator+=(const Reference& val) {
-      return *this->operator+=(static_cast<NativeT>(val));
+      return this->operator+=(static_cast<NativeT>(val));
     }
 
     template <typename T>

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -141,6 +141,30 @@ class AliasedBuffer {
       return aliased_buffer_->GetValue(index_);
     }
 
+    template <typename T>
+    inline Reference& operator+=(const T& val) {
+      const T current = aliased_buffer_->GetValue(index_);
+      aliased_buffer_->SetValue(index_, current + val);
+      return *this;
+    }
+
+    inline Reference& operator+=(const Reference& val) {
+      this->operator+=(static_cast<NativeT>(val));
+      return *this;
+    }
+
+    template <typename T>
+    inline Reference& operator-=(const T& val) {
+      const T current = aliased_buffer_->GetValue(index_);
+      aliased_buffer_->SetValue(index_, current - val);
+      return *this;
+    }
+
+    inline Reference& operator-=(const Reference& val) {
+      this->operator-=(static_cast<NativeT>(val));
+      return *this;
+    }
+
    private:
     AliasedBuffer<NativeT, V8T>* aliased_buffer_;
     size_t index_;

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -149,8 +149,7 @@ class AliasedBuffer {
     }
 
     inline Reference& operator+=(const Reference& val) {
-      this->operator+=(static_cast<NativeT>(val));
-      return *this;
+      return *this->operator+=(static_cast<NativeT>(val));
     }
 
     template <typename T>
@@ -161,8 +160,7 @@ class AliasedBuffer {
     }
 
     inline Reference& operator-=(const Reference& val) {
-      this->operator-=(static_cast<NativeT>(val));
-      return *this;
+      return *this->operator-=(static_cast<NativeT>(val));
     }
 
    private:

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -112,8 +112,7 @@ inline v8::Local<v8::String> Environment::AsyncHooks::provider_string(int idx) {
 }
 
 inline void Environment::AsyncHooks::no_force_checks() {
-  // fields_ does not have the -= operator defined
-  fields_[kCheck] = fields_[kCheck] - 1;
+  fields_[kCheck] -= 1;
 }
 
 inline Environment* Environment::AsyncHooks::env() {
@@ -135,7 +134,7 @@ inline void Environment::AsyncHooks::push_async_ids(double async_id,
     grow_async_ids_stack();
   async_ids_stack_[2 * offset] = async_id_fields_[kExecutionAsyncId];
   async_ids_stack_[2 * offset + 1] = async_id_fields_[kTriggerAsyncId];
-  fields_[kStackLength] = fields_[kStackLength] + 1;
+  fields_[kStackLength] += 1;
   async_id_fields_[kExecutionAsyncId] = async_id;
   async_id_fields_[kTriggerAsyncId] = trigger_async_id;
 }
@@ -240,19 +239,19 @@ inline bool Environment::ImmediateInfo::has_outstanding() const {
 }
 
 inline void Environment::ImmediateInfo::count_inc(uint32_t increment) {
-  fields_[kCount] = fields_[kCount] + increment;
+  fields_[kCount] += increment;
 }
 
 inline void Environment::ImmediateInfo::count_dec(uint32_t decrement) {
-  fields_[kCount] = fields_[kCount] - decrement;
+  fields_[kCount] -= decrement;
 }
 
 inline void Environment::ImmediateInfo::ref_count_inc(uint32_t increment) {
-  fields_[kRefCount] = fields_[kRefCount] + increment;
+  fields_[kRefCount] += increment;
 }
 
 inline void Environment::ImmediateInfo::ref_count_dec(uint32_t decrement) {
-  fields_[kRefCount] = fields_[kRefCount] - decrement;
+  fields_[kRefCount] -= decrement;
 }
 
 inline Environment::TickInfo::TickInfo(v8::Isolate* isolate)
@@ -478,8 +477,7 @@ inline std::vector<double>* Environment::destroy_async_id_list() {
 }
 
 inline double Environment::new_async_id() {
-  async_hooks()->async_id_fields()[AsyncHooks::kAsyncIdCounter] =
-    async_hooks()->async_id_fields()[AsyncHooks::kAsyncIdCounter] + 1;
+  async_hooks()->async_id_fields()[AsyncHooks::kAsyncIdCounter] += 1;
   return async_hooks()->async_id_fields()[AsyncHooks::kAsyncIdCounter];
 }
 

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -221,3 +221,19 @@ TEST_F(AliasBufferTest, OperatorOverloads) {
   EXPECT_EQ(static_cast<uint32_t>(2), ab[0] -= 2);
   EXPECT_EQ(static_cast<uint32_t>(-2), -ab[0]);
 }
+
+TEST_F(AliasBufferTest, OperatorOverloadsRefs) {
+  v8::Isolate::Scope isolate_scope(isolate_);
+  v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+  AliasedBuffer<uint32_t, v8::Uint32Array> ab{isolate_, 2};
+  using Reference = AliasedBuffer<uint32_t, v8::Uint32Array>::Reference;
+  Reference ref = ab[0];
+  Reference ref_value = ab[1] = 2;
+
+  EXPECT_EQ(static_cast<uint32_t>(2), ref = ref_value);
+  EXPECT_EQ(static_cast<uint32_t>(4), ref += ref_value);
+  EXPECT_EQ(static_cast<uint32_t>(2), ref -= ref_value);
+  EXPECT_EQ(static_cast<uint32_t>(-2), -ref);
+}

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -207,3 +207,17 @@ TEST_F(AliasBufferTest, SharedArrayBuffer4) {
       int8_t, v8::Int8Array,
       int32_t, v8::Int32Array>(isolate_, 1, 3, 1);
 }
+
+TEST_F(AliasBufferTest, OperatorOverloads) {
+  v8::Isolate::Scope isolate_scope(isolate_);
+  v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+  const size_t size = 10;
+  AliasedBuffer<uint32_t, v8::Uint32Array> ab{isolate_, size};
+
+  EXPECT_EQ(static_cast<uint32_t>(1), ab[0] = 1);
+  EXPECT_EQ(static_cast<uint32_t>(4), ab[0] += 3);
+  EXPECT_EQ(static_cast<uint32_t>(2), ab[0] -= 2);
+  EXPECT_EQ(static_cast<uint32_t>(-2), -ab[0]);
+}


### PR DESCRIPTION
This commit adds operator overloads for increment/decrement to
AliasedBuffer::Reference.
The motivation for doing this is to hopefully make code that needs
to increment/decrement a little simpler.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src