### PR TITLE
benchmarks: fix benchmark for url

### DIFF
--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
@@ -2,10 +2,10 @@
 const common = require('../common.js');
 const { URLSearchParams } = require('url');
 const querystring = require('querystring');
-const inputs = require('../fixtures/url-inputs.js').searchParams;
+const searchParams = require('../fixtures/url-inputs.js').searchParams;
 
 const bench = common.createBenchmark(main, {
-  type: Object.keys(inputs),
+  searchParam: Object.keys(searchParams),
   method: ['legacy', 'whatwg'],
   n: [1e6]
 });
@@ -19,27 +19,27 @@ function useLegacy(n, input) {
   bench.end(n);
 }
 
-function useWHATWG(n, input) {
-  new URLSearchParams(input);
+function useWHATWG(n, param) {
+  new URLSearchParams(param);
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    new URLSearchParams(input);
+    new URLSearchParams(param);
   }
   bench.end(n);
 }
 
-function main({ type, n, method }) {
-  const input = inputs[type];
-  if (!input) {
-    throw new Error(`Unknown input type "${type}"`);
+function main({ searchParam, n, method }) {
+  const param = searchParams[searchParam];
+  if (!param) {
+    throw new Error(`Unknown search parameter type "${searchParam}"`);
   }
 
   switch (method) {
     case 'legacy':
-      useLegacy(n, input);
+      useLegacy(n, param);
       break;
     case 'whatwg':
-      useWHATWG(n, input);
+      useWHATWG(n, param);
       break;
     default:
       throw new Error(`Unknown method ${method}`);

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -2,10 +2,10 @@
 const common = require('../common.js');
 const { URLSearchParams } = require('url');
 const querystring = require('querystring');
-const inputs = require('../fixtures/url-inputs.js').searchParams;
+const searchParams = require('../fixtures/url-inputs.js').searchParams;
 
 const bench = common.createBenchmark(main, {
-  type: Object.keys(inputs),
+  searchParam: Object.keys(searchParams),
   method: ['legacy', 'whatwg'],
   n: [1e6]
 });
@@ -20,8 +20,8 @@ function useLegacy(n, input, prop) {
   bench.end(n);
 }
 
-function useWHATWG(n, input, prop) {
-  const obj = new URLSearchParams(input);
+function useWHATWG(n, param, prop) {
+  const obj = new URLSearchParams(param);
   obj.toString();
   bench.start();
   for (var i = 0; i < n; i += 1) {
@@ -30,18 +30,18 @@ function useWHATWG(n, input, prop) {
   bench.end(n);
 }
 
-function main({ type, n, method }) {
-  const input = inputs[type];
-  if (!input) {
-    throw new Error(`Unknown input type "${type}"`);
+function main({ searchParam, n, method }) {
+  const param = searchParams[searchParam];
+  if (!param) {
+    throw new Error(`Unknown search parameter type "${searchParam}"`);
   }
 
   switch (method) {
     case 'legacy':
-      useLegacy(n, input);
+      useLegacy(n, param);
       break;
     case 'whatwg':
-      useWHATWG(n, input);
+      useWHATWG(n, param);
       break;
     default:
       throw new Error(`Unknown method ${method}`);

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const { URLSearchParams } = require('url');
 
 const bench = common.createBenchmark(main, {
-  method: ['forEach', 'iterator'],
+  loopMethod: ['forEach', 'iterator'],
   n: [1e6]
 });
 
@@ -44,8 +44,8 @@ function iterator(n) {
   assert.strictEqual(noDead[1], '3rd');
 }
 
-function main({ method, n }) {
-  switch (method) {
+function main({ loopMethod, n }) {
+  switch (loopMethod) {
     case 'forEach':
       forEach(n);
       break;
@@ -53,6 +53,6 @@ function main({ method, n }) {
       iterator(n);
       break;
     default:
-      throw new Error(`Unknown method ${method}`);
+      throw new Error(`Unknown method ${loopMethod}`);
   }
 }

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -12,12 +12,11 @@ const str = 'one=single&two=first&three=first&two=2nd&three=2nd&three=3rd';
 
 function main({ method, param, n }) {
   const params = new URLSearchParams(str);
-  const fn = params[method];
-  if (!fn)
+  if (!params[method])
     throw new Error(`Unknown method ${method}`);
 
   bench.start();
   for (var i = 0; i < n; i += 1)
-    fn(param);
+    params[method](param);
   bench.end(n);
 }

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -3,20 +3,20 @@ const common = require('../common.js');
 const { URLSearchParams } = require('url');
 
 const bench = common.createBenchmark(main, {
-  method: ['get', 'getAll', 'has'],
+  accessMethod: ['get', 'getAll', 'has'],
   param: ['one', 'two', 'three', 'nonexistent'],
   n: [2e7]
 });
 
 const str = 'one=single&two=first&three=first&two=2nd&three=2nd&three=3rd';
 
-function main({ method, param, n }) {
+function main({ accessMethod, param, n }) {
   const params = new URLSearchParams(str);
-  if (!params[method])
-    throw new Error(`Unknown method ${method}`);
+  if (!params[accessMethod])
+    throw new Error(`Unknown method ${accessMethod}`);
 
   bench.start();
   for (var i = 0; i < n; i += 1)
-    params[method](param);
+    params[accessMethod](param);
   bench.end(n);
 }

--- a/benchmark/url/whatwg-url-idna.js
+++ b/benchmark/url/whatwg-url-idna.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 const { domainToASCII, domainToUnicode } = require('url');
 
-const inputs = {
+const domains = {
   empty: {
     ascii: '',
     unicode: ''
@@ -26,13 +26,13 @@ const inputs = {
 };
 
 const bench = common.createBenchmark(main, {
-  input: Object.keys(inputs),
+  domain: Object.keys(domains),
   to: ['ascii', 'unicode'],
   n: [5e6]
 });
 
-function main({ n, to, input }) {
-  const value = inputs[input][to];
+function main({ n, to, domain }) {
+  const value = domains[domain][to];
   const method = to === 'ascii' ? domainToASCII : domainToUnicode;
 
   bench.start();

--- a/test/parallel/test-benchmark-url.js
+++ b/test/parallel/test-benchmark-url.js
@@ -4,4 +4,19 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('url', ['n=1'], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+runBenchmark('url',
+             [
+               'method=legacy',
+               'loopMethod=forEach',
+               'accessMethod=get',
+               'type=short',
+               'searchParam=noencode',
+               'href=short',
+               'input=short',
+               'domain=empty',
+               'path=up',
+               'to=ascii',
+               'prop=href',
+               'n=1',
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/parallel/test-benchmark-url.js
+++ b/test/parallel/test-benchmark-url.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('url', ['n=1'], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
It fixes an error which occurs after running this test:

```bash
node benchmark/url/url-searchparams-read.js
```

Error:
```                                
internal/url.js:983
      throw new errors.TypeError('ERR_INVALID_THIS', 'URLSearchParams');
      ^

TypeError [ERR_INVALID_THIS]: Value of "this" must be of type URLSearchParams
    at get (internal/url.js:983:13)
    at main (/Users/daynin/Documents/projects/node/benchmark/url/url-searchparams-read.js:21:5)
    at Benchmark.process.nextTick (/Users/daynin/Documents/projects/node/benchmark/common.js:34:28)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:678:11)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark