### PR TITLE
http2: fix flaky test-http2-https-fallback

### DIFF
--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -31,7 +31,7 @@ function onRequest(request, response) {
   }));
 }
 
-function onSession(session) {
+function onSession(session, next) {
   const headers = {
     ':path': '/',
     ':method': 'GET',
@@ -54,6 +54,10 @@ function onSession(session) {
 
     session.close();
     this.cleanup();
+
+    if (typeof next === 'function') {
+      next();
+    }
   }));
   request.end();
 }
@@ -126,22 +130,29 @@ function onSession(session) {
     connect(
       origin,
       clientOptions,
-      common.mustCall(onSession.bind({ cleanup, server }))
+      common.mustCall(function (session) {
+        onSession.call({ cleanup, server }, session, testNoTls);
+      })
     );
 
-    // HTTP/1.1 client
-    get(Object.assign(parse(origin), clientOptions), common.mustNotCall())
-      .on('error', common.mustCall(cleanup))
-      .end();
+    function testNoTls () {
+      // HTTP/1.1 client
+      get(Object.assign(parse(origin), clientOptions), common.mustNotCall)
+        .on('error', common.mustCall(cleanup))
+        .on('error', common.mustCall(testWrongALPN))
+        .end();
+    }
 
-    // Incompatible ALPN TLS client
-    let text = '';
-    tls(Object.assign({ port, ALPNProtocols: ['fake'] }, clientOptions))
-      .setEncoding('utf8')
-      .on('data', (chunk) => text += chunk)
-      .on('end', common.mustCall(() => {
-        ok(/Unknown ALPN Protocol, expected `h2` to be available/.test(text));
-        cleanup();
-      }));
+    function testWrongALPN() {
+      // Incompatible ALPN TLS client
+      let text = '';
+      tls(Object.assign({ port, ALPNProtocols: ['fake'] }, clientOptions))
+        .setEncoding('utf8')
+        .on('data', (chunk) => text += chunk)
+        .on('end', common.mustCall(() => {
+          ok(/Unknown ALPN Protocol, expected `h2` to be available/.test(text));
+          cleanup();
+        }));
+    }
   }));
 }

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -130,12 +130,14 @@ function onSession(session, next) {
     connect(
       origin,
       clientOptions,
-      common.mustCall(function (session) {
-        onSession.call({ cleanup, server }, session, testNoTls);
+      common.mustCall(function(session) {
+        onSession.call({ cleanup, server },
+                       session,
+                       common.mustCall(testNoTls));
       })
     );
 
-    function testNoTls () {
+    function testNoTls() {
       // HTTP/1.1 client
       get(Object.assign(parse(origin), clientOptions), common.mustNotCall)
         .on('error', common.mustCall(cleanup))


### PR DESCRIPTION
The test was flaky because it relied on a specific order of
asynchronous operation that were fired paralellely. This was true
on most platform and conditions, but not all the time.

This test was introduced in https://github.com/nodejs/node/pull/18986.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2, test