### PR TITLE
test : refactor parallel/test-tls-cert-chains-concat

### DIFF
--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 
 // Check cert chain is received by client, and is completed with the ca cert
@@ -19,7 +19,7 @@ connect({
     cert: keys.agent6.cert,
     key: keys.agent6.key,
   },
-}, function(err, pair, cleanup) {
+}, common.mustCall((err, pair, cleanup) => {
   assert.ifError(err);
 
   const peer = pair.client.conn.getPeerCertificate();
@@ -47,4 +47,4 @@ connect({
   assert.deepStrictEqual(pair.server.conn.getPeerCertificate(true), {});
 
   return cleanup();
-});
+}));


### PR DESCRIPTION
added common.mustCall and replaced the function with arrow function

Fixes : https://github.com/nodejs/node/issues/14544

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test