### PR TITLE
doc: new team for bundlers or delivery of Node.js

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -41,7 +41,7 @@
 | upgrading libuv                          | @saghul                                                               |
 | upgrading npm                            | @fishrock123, @MylesBorins                                            |
 | upgrading V8                             | @nodejs/v8, @nodejs/post-mortem                                       |
-| Embedded use or delivery of Node.js      | @nodejs/delivery_channels                                             |
+| Embedded use or delivery of Node.js      | @nodejs/delivery-channels                                             |
 
 When things need extra attention, are controversial, or `semver-major`:
 @nodejs/tsc

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -41,6 +41,7 @@
 | upgrading libuv                          | @saghul                                                               |
 | upgrading npm                            | @fishrock123, @MylesBorins                                            |
 | upgrading V8                             | @nodejs/v8, @nodejs/post-mortem                                       |
+| Embedded use or delivery of Node.js      | @nodejs/delivery_channels                                             |
 
 When things need extra attention, are controversial, or `semver-major`:
 @nodejs/tsc


### PR DESCRIPTION
Add team that we can use to cc organizations or people
who do one of the following:

* bundle node into their product
* bundle node into their distributions
* provide an installer
* provide a version manager

This would  be the description I would add when creating the team itself:

This team is used to be able to communicate with organizations or people who do 
one of the following:

* bundle node into their product
* bundle node into their distributions
* provide an installer
* provide a version manager

If you are making a change to node core or elsewhere that might affect these parties
please include an @nodejs/delivery-channels in the issue.


##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc