### PR TITLE
Revert "test: add test cases for fsPromises"

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -9,10 +9,8 @@ const fsPromises = require('fs/promises');
 const {
   access,
   chmod,
-  chown,
   copyFile,
   fchmod,
-  fchown,
   fdatasync,
   fstat,
   fsync,
@@ -29,8 +27,6 @@ const {
   realpath,
   rename,
   rmdir,
-  lchmod,
-  lchown,
   stat,
   symlink,
   write,
@@ -99,21 +95,6 @@ function verifyStatObject(stat) {
 
     await chmod(dest, 0o666);
     await fchmod(handle, 0o666);
-    // lchmod is only available on OSX
-    if (common.isOSX) {
-      await lchmod(dest, 0o666);
-    }
-
-    if (!common.isWindows) {
-      const gid = process.getgid();
-      const uid = process.getuid();
-      await chown(dest, uid, gid);
-      await fchown(handle, uid, gid);
-      // lchown is only available on OSX
-      if (common.isOSX) {
-        await lchown(dest, uid, gid);
-      }
-    }
 
     await utimes(dest, new Date(), new Date());
 


### PR DESCRIPTION
This reverts commit c05c73a634e3a88372e32e500f462851add7ea66.

The commit breaks Raspberry Pi CI.

Refs: https://github.com/nodejs/node/pull/19064#issuecomment-370092633

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test