### PR TITLE
net: fix usage of writeBuffer in makeSyncWrite

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -426,7 +426,23 @@ function message(key, args) {
  * @returns {Error}
  */
 function uvException(ctx) {
-  const err = new Error();
+  const [ code, uvmsg ] = errmap.get(ctx.errno);
+  let message = `${code}: ${uvmsg}, ${ctx.syscall}`;
+
+  let path;
+  let dest;
+  if (ctx.path) {
+    path = ctx.path.toString();
+    message += ` '${path}'`;
+  }
+  if (ctx.dest) {
+    dest = ctx.dest.toString();
+    message += ` -> '${dest}'`;
+  }
+
+  // Pass the message to the constructor instead of setting it on the object
+  // to make sure it is the same as the one created in C++
+  const err = new Error(message);
 
   for (const prop of Object.keys(ctx)) {
     if (prop === 'message' || prop === 'path' || prop === 'dest') {
@@ -435,20 +451,13 @@ function uvException(ctx) {
     err[prop] = ctx[prop];
   }
 
-  const [ code, uvmsg ] = errmap.get(ctx.errno);
   err.code = code;
-  let message = `${code}: ${uvmsg}, ${ctx.syscall}`;
-  if (ctx.path) {
-    const path = ctx.path.toString();
-    message += ` '${path}'`;
+  if (path) {
     err.path = path;
   }
-  if (ctx.dest) {
-    const dest = ctx.dest.toString();
-    message += ` -> '${dest}'`;
+  if (dest) {
     err.dest = dest;
   }
-  err.message = message;
 
   Error.captureStackTrace(err, uvException);
   return err;

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -3,6 +3,7 @@
 const Buffer = require('buffer').Buffer;
 const { isIPv6 } = process.binding('cares_wrap');
 const { writeBuffer } = process.binding('fs');
+const errors = require('internal/errors');
 
 const octet = '(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
 const re = new RegExp(`^${octet}[.]${octet}[.]${octet}[.]${octet}$`);
@@ -33,13 +34,13 @@ function makeSyncWrite(fd) {
 
     this._bytesDispatched += chunk.length;
 
-    try {
-      writeBuffer(fd, chunk, 0, chunk.length, null);
-    } catch (ex) {
+    const ctx = {};
+    writeBuffer(fd, chunk, 0, chunk.length, null, undefined, ctx);
+    if (ctx.errno !== undefined) {
+      const ex = errors.uvException(ctx);
       // Legacy: net writes have .code === .errno, whereas writeBuffer gives the
       // raw errno number in .errno.
-      if (typeof ex.code === 'string')
-        ex.errno = ex.code;
+      ex.errno = ex.code;
       return cb(ex);
     }
     cb();


### PR DESCRIPTION
The binding writeBuffer has been changed in
https://github.com/nodejs/node/pull/19041 and it now requires
the last argument to be a context object. makeSyncWrite
was not updated accordingly, resulting assertions on Windows.
This patch fixes the usage of writeBuffer there.

Refs: https://github.com/nodejs/node/pull/19041 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net