### PR TITLE
test: skip postmortem metadata test when nm fails

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -26,6 +26,11 @@ const nm = spawnSync('nm', args);
 if (nm.error && nm.error.errno === 'ENOENT')
   common.skip('nm not found on system');
 
+const stderr = nm.stderr.toString();
+if (stderr.length > 0) {
+  common.skip(`Failed to execute nm: ${stderr}`);
+}
+
 const symbolRe = /\s_?(v8dbg_.+)$/;
 const symbols = nm.stdout.toString().split('\n').reduce((filtered, line) => {
   const match = line.match(symbolRe);


### PR DESCRIPTION
On Windows with msys installation, `nm` is available but
it is not able to grab symbols from the Windows build.
Skipping the test if nm outputs anything to stderr fixes that.

cc @cjihrig 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test