### PR TITLE
test: move require http2 to after crypto check

### DIFF
--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const assert = require('assert');
-const http2 = require('http2');
 
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+
+const http2 = require('http2');
 
 for (const chunkSequence of [
   [ '' ],


### PR DESCRIPTION
Currently test-http2-client-write-empty-string.js will throw "Error
[ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto support"
when configured --without-ssl.

This commit moves the require of http2 to after the crypto check to
avoid this error.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test