### PR TITLE
doc: add introduced_in metadata to _toc.md

### DIFF
--- a/doc/api/_toc.md
+++ b/doc/api/_toc.md
@@ -1,5 +1,8 @@
 @// NB(chrisdickinson): if you move this file, be sure to update
 @// tools/doc/html.js to point at the new location.
+
+<!--introduced_in=v0.10.0-->
+
 * [About these Docs](documentation.html)
 * [Usage & Example](synopsis.html)
 


### PR DESCRIPTION
Allow users to switch to the table of contents for older versions of
Node.js. This gets rid of the "Failed to add alternative version link"
warnings when building docs.

@nodejs/documentation @nodejs/website 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc