### PR TITLE
(v8.x backport) crypto: reuse variable instead of reevaluation

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3565,7 +3565,7 @@ void CipherBase::Init(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<unsigned char*>(key),
                     reinterpret_cast<unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
 }
 
 
@@ -3634,7 +3634,7 @@ void CipherBase::InitIv(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<const unsigned char*>(key),
                     reinterpret_cast<const unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
 }
 
 


### PR DESCRIPTION
Backport of #17735 to v8.x.