### PR TITLE
(v6.x backport) crypto: reuse variable instead of reevaluation

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3372,7 +3372,7 @@ void CipherBase::Init(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<unsigned char*>(key),
                     reinterpret_cast<unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
   initialised_ = true;
 }
 
@@ -3440,7 +3440,7 @@ void CipherBase::InitIv(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<const unsigned char*>(key),
                     reinterpret_cast<const unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
   initialised_ = true;
 }
 


### PR DESCRIPTION
Backport of #17735 to v6.x.