### PR TITLE
(v6.x backport) lib,test: fix spelling in comments

### DIFF
--- a/test/abort/test-http-parser-consume.js
+++ b/test/abort/test-http-parser-consume.js
@@ -11,12 +11,12 @@ if (process.argv[2] === 'child') {
     const rr = get({ port: server.address().port }, common.mustCall(() => {
       // This bad input (0) should abort the parser and the process
       rr.parser.consume(0);
-      // This line should be unreachanble.
+      // This line should be unreachable.
       assert.fail('this should be unreachable');
     }));
   }));
 } else {
-  // super-proces
+  // super-process
   const child = spawn(process.execPath, [__filename, 'child']);
   child.stdout.on('data', common.mustNotCall());
 

--- a/test/fixtures/net-fd-passing-receiver.js
+++ b/test/fixtures/net-fd-passing-receiver.js
@@ -24,7 +24,7 @@ receiver = net.createServer(function(socket) {
   });
 });
 
-/* To signal the test runne we're up and listening */
+/* To signal the test runner we're up and listening */
 receiver.on('listening', function() {
   console.log('ready');
 });

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -334,7 +334,7 @@ Buffer.alloc(8, '');
           return 0;
         } else {
           elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
+          // Once buffer.js calls the C++ implementation of fill, return -1
           return -1;
         }
       }
@@ -367,7 +367,7 @@ assert.throws(() => {
           return 1;
         } else {
           elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
+          // Once buffer.js calls the C++ implementation of fill, return -1
           return -1;
         }
       }

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -137,7 +137,7 @@ assert.strictEqual(
 );
 
 
-// test usc2 encoding
+// test ucs2 encoding
 let twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 
 assert(twoByteString.includes('\u0395', 4, 'ucs2'));

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -553,7 +553,7 @@ assert.strictEqual(511, longBufferString.lastIndexOf(pattern, 1534));
 // "yolo swag swag yolo swag yolo yolo swag" ..., goes on for about 5MB.
 // This is hard to search because it all looks similar, but never repeats.
 
-// countBits returns the number of bits in the binary reprsentation of n.
+// countBits returns the number of bits in the binary representation of n.
 function countBits(n) {
   let count;
   for (count = 0; n > 0; count++) {

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -20,11 +20,11 @@ function read(buff, funx, args, expected) {
 
 }
 
-// testing basic functionality of readDoubleBE() and readDOubleLE()
+// testing basic functionality of readDoubleBE() and readDoubleLE()
 read(buf, 'readDoubleBE', [1], -3.1827727774563287e+295);
 read(buf, 'readDoubleLE', [1], -6.966010051009108e+144);
 
-// testing basic functionality of readFLoatBE() and readFloatLE()
+// testing basic functionality of readFloatBE() and readFloatLE()
 read(buf, 'readFloatBE', [1], -1.6691549692541768e+37);
 read(buf, 'readFloatLE', [1], -7861303808);
 

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -11,7 +11,7 @@ if (process.argv[2] === 'child') {
   //send non-internal message containing PREFIX at a non prefix position
   process.send(normal);
 
-  //send inernal message
+  //send internal message
   process.send(internal);
 
   process.exit(0);

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -14,7 +14,7 @@ common.expectWarning('DeprecationWarning', [
 
 // Accessing the deprecated function is enough to trigger the warning event.
 // It does not need to be called. So the assert serves the purpose of both
-// triggering the warning event and confirming that the deprected function is
+// triggering the warning event and confirming that the deprecated function is
 // mapped to the correct non-deprecated function.
 assert.strictEqual(crypto.Credentials, tls.SecureContext);
 assert.strictEqual(crypto.createCredentials, tls.createSecureContext);

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -91,7 +91,7 @@ testHelper(
 // to try to call the fips setter, to try to detect this situation, as
 // that would throw an error:
 // ("Error: Cannot set FIPS mode in a non-FIPS build.").
-// Due to this uncertanty the following tests are skipped when configured
+// Due to this uncertainty the following tests are skipped when configured
 // with --shared-openssl.
 if (!sharedOpenSSL()) {
   // OpenSSL config file should be able to turn on FIPS mode

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'child') {
       // is not properly flushed in V8's Isolate::Throw right before the
       // process aborts due to an uncaught exception, and thus the error
       // message representing the error that was thrown cannot be read by the
-      // parent process. So instead of parsing the child process' stdandard
+      // parent process. So instead of parsing the child process' standard
       // error, the parent process will check that in the case
       // --abort-on-uncaught-exception was passed, the process did not exit
       // with exit code RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -98,10 +98,10 @@ function listener2() {}
 
   // listener4 will still be called although it is removed by listener 3.
   ee.emit('hello');
-  // This is so because the interal listener array at time of emit
+  // This is so because the internal listener array at time of emit
   // was [listener3,listener4]
 
-  // Interal listener array [listener3]
+  // Internal listener array [listener3]
   ee.emit('hello');
 }
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -37,7 +37,7 @@ createFileWithPerms(readWriteFile, 0o666);
  * The change of user id is done after creating the fixtures files for the same
  * reason: the test may be run as the superuser within a directory in which
  * only the superuser can create files, and thus it may need superuser
- * priviledges to create them.
+ * privileges to create them.
  *
  * There's not really any point in resetting the process' user id to 0 after
  * changing it to 'nobody', since in the case that the test runs without

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -68,7 +68,7 @@ function remoteClose() {
       process.nextTick(common.mustCall(() => {
         assert.strictEqual(agent.sockets[name], undefined);
         assert.strictEqual(agent.freeSockets[name].length, 1);
-        // waitting remote server close the socket
+        // waiting remote server close the socket
         setTimeout(common.mustCall(() => {
           assert.strictEqual(agent.sockets[name], undefined);
           assert.strictEqual(agent.freeSockets[name], undefined,
@@ -81,7 +81,7 @@ function remoteClose() {
 }
 
 function remoteError() {
-  // remove server will destroy ths socket
+  // remote server will destroy the socket
   const req = get('/error', common.mustNotCall());
   req.on('error', common.mustCall((err) => {
     assert(err);

--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -30,7 +30,6 @@ const server = net.createServer(function(socket) {
 
     if (postBody.includes('\r\n')) {
       socket.write(fullResponse);
-      // omg, I wrote the response twice, what a terrible HTTP server I am.
       socket.end(fullResponse);
     }
   });

--- a/test/parallel/test-https-agent-secure-protocol.js
+++ b/test/parallel/test-https-agent-secure-protocol.js
@@ -45,7 +45,7 @@ server.listen(0, common.mustCall(function() {
       }, common.mustCall(function(res) {
         res.resume();
         globalAgent.once('free', common.mustCall(function() {
-          // Verify that two keep-alived connections are created
+          // Verify that two keep-alive connections are created
           // due to the different secureProtocol settings:
           const keys = Object.keys(globalAgent.freeSockets);
           assert.strictEqual(keys.length, 2);

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -40,7 +40,7 @@ server_http.listen(0, function() {
 });
 
 // Then try https server (requires functions to be
-// mirroed in tls.js's CryptoStream)
+// mirrored in tls.js's CryptoStream)
 
 const server_https = https.createServer(options, function(req, res) {
   console.log('got HTTPS request');

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -4,5 +4,5 @@ const net = require('net');
 
 const server = net.createServer(function(socket) {
 });
-server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCESS or EADDRNOTAVAIL
+server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCES or EADDRNOTAVAIL
 server.on('error', common.mustCall(function(error) {}));

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -16,7 +16,7 @@ if (common.isWindows) {
   emptyTxt = fixtures.path('empty.txt');
 } else {
   common.refreshTmpDir();
-  // Keep the file name very short so tht we don't exceed the 108 char limit
+  // Keep the file name very short so that we don't exceed the 108 char limit
   // on CI for a POSIX socket. Even though this isn't actually a socket file,
   // the error will be different from the one we are expecting if we exceed the
   // limit.

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -92,7 +92,7 @@ is.string(arch);
 assert.ok(arch.length > 0);
 
 if (!common.isSunOS) {
-  // not implemeneted yet
+  // not implemented yet
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);
   assert.ok(os.totalmem() > 0);

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -293,7 +293,7 @@ asyncTest('While inside setImmediate, catching a rejected promise derived ' +
   });
 });
 
-// State adapation tests
+// State adaptation tests
 asyncTest('catching a promise which is asynchronously rejected (via ' +
           'resolution to an asynchronously-rejected promise) prevents' +
           ' unhandledRejection', function(done) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -765,7 +765,7 @@ function isWarned(emitter) {
     assert.strictEqual(isWarned(process.stdout._events), false);
   }
 
-  // can create a new readline Interface with a null output arugument
+  // can create a new readline Interface with a null output argument
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -281,7 +281,7 @@ function error_test() {
     { client: client_unix,
       send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
       expect: `true\n${prompt_unix}` },
-    // the following test's result depends on the RegEx's match from the above
+    // the following test's result depends on the RegExp's match from the above
     { client: client_unix,
       send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
             'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -154,7 +154,7 @@ const Transform = require('_stream_transform');
 }
 
 {
-  // Verify assymetric transform (expand)
+  // Verify asymmetric transform (expand)
   const pt = new Transform();
 
   // emit each chunk 2 times.
@@ -186,7 +186,7 @@ const Transform = require('_stream_transform');
 }
 
 {
-  // Verify assymetric trasform (compress)
+  // Verify asymmetric transform (compress)
   const pt = new Transform();
 
   // each output is the first char of 3 consecutive chunks,
@@ -241,7 +241,7 @@ const Transform = require('_stream_transform');
 // this tests for a stall when data is written to a full stream
 // that has empty transforms.
 {
-  // Verify compex transform behavior
+  // Verify complex transform behavior
   let count = 0;
   let saved = null;
   const pt = new Transform({highWaterMark: 3});

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -65,7 +65,7 @@ writeChunks(inputChunks, () => {
   // trigger writing out the buffer
   w.uncork();
 
-  // buffered bytes shoud be seen in current tick
+  // buffered bytes should be seen in current tick
   assert.strictEqual(seenChunks.length, 4);
 
   // did the chunks match

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -61,7 +61,7 @@ assert.strictEqual(c_bin.toString('latin1'), ucs2_control);
 assert.strictEqual(c_ucs.toString('latin1'), ucs2_control);
 
 
-// now let's test BASE64 and HEX ecoding/decoding
+// now let's test BASE64 and HEX encoding/decoding
 const RADIOS = 2;
 const PRE_HALF_APEX = Math.ceil(EXTERN_APEX / 2) - RADIOS;
 const PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -31,7 +31,7 @@ const testCases = [
     errorCode: 'CERT_REVOKED'
   },
   // Test 1: for the fix of node#2061
-  // agent6-cert.pem is signed by intermidate cert of ca3.
+  // agent6-cert.pem is signed by intermediate cert of ca3.
   // The server has a cert chain of agent6->ca3->ca1(root) but
   // tls.connect should be failed with an error of
   // UNABLE_TO_GET_ISSUER_CERT_LOCALLY since the root CA of ca1 is not

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -265,8 +265,8 @@ function runTest(port, testIndex) {
   let renegotiated = false;
   const server = tls.Server(serverOptions, function handleConnection(c) {
     c.on('error', function(e) {
-      // child.kill() leads ECONNRESET errro in the TLS connection of
-      // openssl s_client via spawn(). A Test result is already
+      // child.kill() leads ECONNRESET error in the TLS connection of
+      // openssl s_client via spawn(). A test result is already
       // checked by the data of client.stdout before child.kill() so
       // these tls errors can be ignored.
     });


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/18018 to v6.x.