### PR TITLE
doc: remove subsystem from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,3 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 - [ ] tests and/or benchmarks are included
 - [ ] documentation is changed or added
 - [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
-
-##### Affected core subsystem(s)
-<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


### PR DESCRIPTION
Remove request that user provide a list of subsystems in the pull
request template.

* We already ask them to put the subsystems in the first line of the
  commit message.
* The subsystem is usually easy to determine.
* We have a bot that applies subsystem labels on new PRs and it seems to
  do a rather good job. Tools over rules. Let the bot do it.
* The fewer unnecessary things we ask for in the template, the lower the
  barrier to entry.
* Anecdotal, but I have never found it useful to have the person
  submitting the PR list out subsystems in the pull request post.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc