### PR TITLE
tools/bootstrap_node: preprocess gypi files to json

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -122,15 +122,8 @@ function setupMemoryUsage() {
 function setupConfig(_source) {
   // NativeModule._source
   // used for `process.config`, but not a real module
-  var config = _source.config;
+  const config = _source.config;
   delete _source.config;
-
-  // strip the gyp comment line at the beginning
-  config = config.split('\n')
-      .slice(1)
-      .join('\n')
-      .replace(/"/g, '\\"')
-      .replace(/'/g, '"');
 
   process.config = JSON.parse(config, function(key, value) {
     if (value === 'true') return true;

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -288,6 +288,11 @@ def JS2C(source, target):
         split = split[1:]
       name = '/'.join(split)
 
+    # if its a gypi file we're going to want it as json
+    # later on anyway, so get it out of the way now
+    if name.endswith(".gypi"):
+      lines = re.sub(r'#.*?\n', '', lines)
+      lines = re.sub(r'\'', '"', lines)
     name = name.split('.', 1)[0]
     var = name.replace('-', '_').replace('/', '_')
     key = '%s_key' % var


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
bootstrap, tools