### PR TITLE
[v8.x backport] trace_events: add file pattern cli option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -238,6 +238,14 @@ added: v7.7.0
 A comma separated list of categories that should be traced when trace event
 tracing is enabled using `--trace-events-enabled`.
 
+### `--trace-event-file-pattern`
+<!-- YAML
+added: REPLACEME
+-->
+
+Template string specifying the filepath for the trace event data, it
+supports `${rotation}` and `${pid}`.
+
 ### `--zero-fill-buffers`
 <!-- YAML
 added: v6.0.0
@@ -474,6 +482,7 @@ Node options that are allowed are:
 - `--trace-deprecation`
 - `--trace-events-categories`
 - `--trace-events-enabled`
+- `--trace-event-file-pattern`
 - `--trace-sync-io`
 - `--trace-warnings`
 - `--track-heap-objects`

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -19,3 +19,16 @@ node --trace-events-enabled --trace-event-categories v8,node,node.async_hooks se
 Running Node.js with tracing enabled will produce log files that can be opened
 in the [`chrome://tracing`](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
 tab of Chrome.
+
+The logging file is by default called `node_trace.${rotation}.log`, where
+`${rotation}` is an incrementing log-rotation id. The filepath pattern can
+be specified with `--trace-event-file-pattern` that accepts a template
+string that supports `${rotation}` and `${pid}`. For example:
+
+```txt
+node --trace-events-enabled --trace-event-file-pattern '${pid}-${rotation}.log' server.js
+```
+
+Starting with Node 10.0.0, the tracing system uses the same time source as the
+one used by `process.hrtime()` however the trace-event timestamps are expressed
+in microseconds, unlike `process.hrtime()` which returns nanoseconds.

--- a/doc/node.1
+++ b/doc/node.1
@@ -167,6 +167,11 @@ A comma separated list of categories that should be traced when trace event
 tracing is enabled using \fB--trace-events-enabled\fR.
 
 .TP
+.BR \-\-trace-event\-file\-pattern " " \fIpattern\fR
+Template string specifying the filepath for the trace event data, it
+supports \fB${rotation}\fR and \fB${pid}\fR.
+
+.TP
 .BR \-\-zero\-fill\-buffers
 Automatically zero-fills all newly allocated Buffer and SlowBuffer instances.
 

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -13,11 +13,12 @@ namespace tracing {
 using v8::platform::tracing::TraceConfig;
 using std::string;
 
-Agent::Agent() {
+Agent::Agent(const std::string& log_file_pattern) {
   int err = uv_loop_init(&tracing_loop_);
   CHECK_EQ(err, 0);
 
-  NodeTraceWriter* trace_writer = new NodeTraceWriter(&tracing_loop_);
+  NodeTraceWriter* trace_writer = new NodeTraceWriter(
+      log_file_pattern, &tracing_loop_);
   TraceBuffer* trace_buffer = new NodeTraceBuffer(
       NodeTraceBuffer::kBufferChunks, trace_writer, &tracing_loop_);
   tracing_controller_ = new TracingController();

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -12,7 +12,7 @@ using v8::platform::tracing::TracingController;
 
 class Agent {
  public:
-  Agent();
+  explicit Agent(const std::string& log_file_pattern);
   void Start(const std::string& enabled_categories);
   void Stop();
 

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -16,7 +16,8 @@ using v8::platform::tracing::TraceWriter;
 
 class NodeTraceWriter : public TraceWriter {
  public:
-  explicit NodeTraceWriter(uv_loop_t* tracing_loop);
+  explicit NodeTraceWriter(const std::string& log_file_pattern,
+                           uv_loop_t* tracing_loop);
   ~NodeTraceWriter();
 
   void AppendTraceEvent(TraceObject* trace_event) override;
@@ -62,6 +63,7 @@ class NodeTraceWriter : public TraceWriter {
   int highest_request_id_completed_ = 0;
   int total_traces_ = 0;
   int file_num_ = 0;
+  const std::string& log_file_pattern_;
   std::ostringstream stream_;
   TraceWriter* json_trace_writer_ = nullptr;
   bool exited_ = false;

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -24,6 +24,8 @@ expect('--throw-deprecation', 'B\n');
 expect('--zero-fill-buffers', 'B\n');
 expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
+// eslint-disable-next-line no-template-curly-in-string
+expect('--trace-event-file-pattern {pid}-${rotation}.trace_events', 'B\n');
 
 if (common.hasCrypto) {
   expect('--use-openssl-ca', 'B\n');

--- a/test/parallel/test-trace-events-file-pattern.js
+++ b/test/parallel/test-trace-events-file-pattern.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+
+common.refreshTmpDir();
+process.chdir(common.tmpDir);
+
+const CODE =
+  'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
+
+const proc = cp.spawn(process.execPath, [
+  '--trace-events-enabled',
+  '--trace-event-file-pattern',
+  // eslint-disable-next-line no-template-curly-in-string
+  '${pid}-${rotation}-${pid}-${rotation}.tracing.log',
+  '-e', CODE
+]);
+
+proc.once('exit', common.mustCall(() => {
+  const expectedFilename = `${proc.pid}-1-${proc.pid}-1.tracing.log`;
+
+  assert(common.fileExists(expectedFilename));
+  fs.readFile(expectedFilename, common.mustCall((err, data) => {
+    const traces = JSON.parse(data.toString()).traceEvents;
+    assert(traces.length > 0);
+  }));
+}));


### PR DESCRIPTION
Allow the user to specify the filepath for the trace_events log file
using a template string.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
trace-events