### PR TITLE
src: add #include <stdio.h> to iculslocs

### DIFF
--- a/tools/icu/iculslocs.cc
+++ b/tools/icu/iculslocs.cc
@@ -55,6 +55,7 @@ Japanese, it doesn't *claim* to have Japanese.
 #include <unicode/ures.h>
 #include <unicode/udata.h>
 #include <unicode/putil.h>
+#include <stdio.h>
 
 const char* PROG = "iculslocs";
 const char* NAME = U_ICUDATA_NAME;  // assume ICU data


### PR DESCRIPTION
iculslocs uses `printf()` and friends, but didn't include the header.
 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
src