### PR TITLE
process: small nextTick cleanup, including removing manual args copying

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -127,7 +127,7 @@ function setupNextTick() {
       // on the hidden class, revisit in V8 versions after 6.2
       this.callback = null;
       this.callback = callback;
-      this.args = args;
+      this.args = args.length > 0 ? args : undefined;
 
       const asyncId = newAsyncId();
       this[async_id_symbol] = asyncId;
@@ -144,24 +144,12 @@ function setupNextTick() {
 
   // `nextTick()` will not enqueue any callback when the process is about to
   // exit since the callback would not have a chance to be executed.
-  function nextTick(callback) {
+  function nextTick(callback, ...args) {
     if (typeof callback !== 'function')
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
     if (process._exiting)
       return;
-
-    var args;
-    switch (arguments.length) {
-      case 1: break;
-      case 2: args = [arguments[1]]; break;
-      case 3: args = [arguments[1], arguments[2]]; break;
-      case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
-      default:
-        args = new Array(arguments.length - 1);
-        for (var i = 1; i < arguments.length; i++)
-          args[i - 1] = arguments[i];
-    }
 
     push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
   }

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -123,9 +123,6 @@ function setupNextTick() {
 
   class TickObject {
     constructor(callback, args, triggerAsyncId) {
-      // this must be set to null first to avoid function tracking
-      // on the hidden class, revisit in V8 versions after 6.2
-      this.callback = null;
       this.callback = callback;
       this.args = args.length > 0 ? args : undefined;
 

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -153,7 +153,7 @@ function setupNextTick() {
 
   // `internalNextTick()` will not enqueue any callback when the process is
   // about to exit since the callback would not have a chance to be executed.
-  function internalNextTick(triggerAsyncId, callback) {
+  function internalNextTick(triggerAsyncId, callback, ...args) {
     if (typeof callback !== 'function')
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
     // CHECK(Number.isSafeInteger(triggerAsyncId) || triggerAsyncId === null)
@@ -161,18 +161,6 @@ function setupNextTick() {
 
     if (process._exiting)
       return;
-
-    var args;
-    switch (arguments.length) {
-      case 2: break;
-      case 3: args = [arguments[2]]; break;
-      case 4: args = [arguments[2], arguments[3]]; break;
-      case 5: args = [arguments[2], arguments[3], arguments[4]]; break;
-      default:
-        args = new Array(arguments.length - 2);
-        for (var i = 2; i < arguments.length; i++)
-          args[i - 2] = arguments[i];
-    }
 
     if (triggerAsyncId === null)
       triggerAsyncId = getDefaultTriggerAsyncId();


### PR DESCRIPTION
A couple of small changes to nextTick, mostly dependant on V8 6.4+ so we shouldn't back-port these.

1. Instead of manually copying the arguments into a new Array, use rest syntax to gather up the arguments as it's actually more performant starting with V8 6.4.

2. As of V8 6.4 it appears to no longer be necessary to preset the callback on TickObject to null to avoid hidden class function tracking. The benchmark perf is now equivalent regardless. (Edit: this doesn't seem to apply universally so it's possible the reasoning here is different. In Timers, I'm still unable to get rid of similar code without tanking the performance 3x. Strangely we have a similar benchmark for both timers & nextTick but clearly something else is going on...)

3. This is a temporary commit that introduces the 1st change to internalNextTick but will be made redundant once #19147 lands.

~~There's a performance benefit to this change on most of our nextTick benchmarks except for two but the regression there is smaller than the overall gains. It also slightly improves some of the streams benchmarks which should be more representative of real usage.~~ Edit: see below for more info.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
