### PR TITLE
test: replace third argument in assert.strictEqual

### DIFF
--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -272,7 +272,8 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
     assert.strictEqual(
       actual,
       strRes,
-      `Should get same result from stream: ${actual} must be ${strRes}`
+      `Should get same result from stream (hash: ${hash} and case: ${i + 1})` +
+      ` => ${actual} must be ${strRes}`
     );
   }
 }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -269,7 +269,11 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
       expected,
       `Test HMAC-${hash} rfc 4231 case ${i + 1}: ${actual} must be ${expected}`
     );
-    assert.strictEqual(actual, strRes, 'Should get same result from stream');
+    assert.strictEqual(
+      actual,
+      strRes,
+      `Should get same result from stream: ${actual} must be ${strRes}`
+    );
   }
 }
 


### PR DESCRIPTION
Replace the third argument in assert.strictEqual with something much
more informative so that it display relevant information when the
test fails

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test