### PR TITLE
build: update arm minimum supported platform

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -39,7 +39,8 @@ platforms in production.
 
 |  System      | Support type | Version                          | Architectures        | Notes            |
 |--------------|--------------|----------------------------------|----------------------|------------------|
-| GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm, arm64      |                  |
+| GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
+| GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
 | macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7/2008 R2             | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |


### PR DESCRIPTION
This is already true in practice.

Fixes: https://github.com/nodejs/build/issues/1164

cc/ @nodejs/build @rvagg @gdams 

@rvagg I'm not sure if this applies to `arm` (not `arm64`) as well.