### PR TITLE
cluster: Add support to cluster to work with `NODE_OPTIONS="--inspect"

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -102,11 +102,14 @@ function createWorkerProcess(id, env) {
   const workerEnv = util._extend({}, process.env);
   const execArgv = cluster.settings.execArgv.slice();
   const debugArgRegex = /--inspect(?:-brk|-port)?|--debug-port/;
+  const nodeOptions = process.env.NODE_OPTIONS ?
+    process.env.NODE_OPTIONS.split(' ') : [];
 
   util._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
-  if (execArgv.some((arg) => arg.match(debugArgRegex))) {
+  if (execArgv.some((arg) => arg.match(debugArgRegex)) ||
+      nodeOptions.some((arg) => arg.match(debugArgRegex))) {
     let inspectPort;
     if ('inspectPort' in cluster.settings) {
       if (typeof cluster.settings.inspectPort === 'function')

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -103,13 +103,13 @@ function createWorkerProcess(id, env) {
   const execArgv = cluster.settings.execArgv.slice();
   const debugArgRegex = /--inspect(?:-brk|-port)?|--debug-port/;
   const nodeOptions = process.env.NODE_OPTIONS ?
-    process.env.NODE_OPTIONS.split(' ') : [];
+    process.env.NODE_OPTIONS : '';
 
   util._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
   if (execArgv.some((arg) => arg.match(debugArgRegex)) ||
-      nodeOptions.some((arg) => arg.match(debugArgRegex))) {
+      nodeOptions.match(debugArgRegex)) {
     let inspectPort;
     if ('inspectPort' in cluster.settings) {
       if (typeof cluster.settings.inspectPort === 'function')

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -21,10 +21,9 @@ function checkForInspectSupport(flag) {
       worker.disconnect();
     });
 
-    cluster.on('exit', (worker, code, signal) => {
-      if (worker.exitedAfterDisconnect === false) {
-        assert.fail(`For NODE_OPTIONS ${nodeOptions}, failed to start cluster`);
-      }
-    });
+    cluster.on('exit', common.mustCall((worker, code, signal) => {
+      const errMsg = `For NODE_OPTIONS ${nodeOptions}, failed to start cluster`;
+      assert.strictEqual(worker.exitedAfterDisconnect, true, errMsg);
+    }, 2));
   }
 }

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const cluster = require('cluster');
+const assert = require('assert');
+
+if (process.config.variables.node_without_node_options)
+  common.skip('missing NODE_OPTIONS support');
+
+
+checkForInspectSupport('--inspect');
+
+function checkForInspectSupport(flag) {
+  const env = Object.assign({}, process.env, { NODE_OPTIONS: flag });
+  const o = JSON.stringify(flag);
+
+  if (cluster.isMaster) {
+    cluster.fork(env);
+
+    cluster.on('online', (worker) => {
+      process.exit(0);
+    });
+
+    cluster.on('exit', (worker, code, signal) => {
+      assert.fail(`For ${o}, failed to start a cluster with inspect option`);
+    });
+  }
+}

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
-const numCPUs = require('os').cpus().length;
 
 common.skipIfInspectorDisabled();
 
@@ -14,7 +13,7 @@ function checkForInspectSupport(flag) {
   process.env.NODE_OPTIONS = flag;
 
   if (cluster.isMaster) {
-    for (let i = 0; i < numCPUs; i++) {
+    for (let i = 0; i < 2; i++) {
       cluster.fork();
     }
 

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -10,10 +10,11 @@ checkForInspectSupport('--inspect');
 function checkForInspectSupport(flag) {
 
   const nodeOptions = JSON.stringify(flag);
+  const numWorkers = 2;
   process.env.NODE_OPTIONS = flag;
 
   if (cluster.isMaster) {
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < numWorkers; i++) {
       cluster.fork();
     }
 
@@ -24,6 +25,6 @@ function checkForInspectSupport(flag) {
     cluster.on('exit', common.mustCall((worker, code, signal) => {
       const errMsg = `For NODE_OPTIONS ${nodeOptions}, failed to start cluster`;
       assert.strictEqual(worker.exitedAfterDisconnect, true, errMsg);
-    }, 2));
+    }, numWorkers));
   }
 }

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -24,8 +24,7 @@ function checkForInspectSupport(flag) {
 
     cluster.on('exit', (worker, code, signal) => {
       if (worker.exitedAfterDisconnect === false) {
-        assert.fail(`For ${nodeOptions}, failed to start cluster\
- with inspect option`);
+        assert.fail(`For NODE_OPTIONS ${nodeOptions}, failed to start cluster`);
       }
     });
   }


### PR DESCRIPTION
When using cluster and --inspect as cli argument it is correctly
handled and each worker will use a different port, this was
fixed by #13619. But when env var NODE_OPTIONS="--inspect"
is set this logic doesn't apply and the workers will fail as they
try to attach to the same port.

Fixes: https://github.com/nodejs/node/issues/19026

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] tests and/or benchmarks are included
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Affected core subsystem(s)
- cluster
