### PR TITLE
src: use smart pointer in AsyncWrap::WeakCallback

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -415,14 +415,13 @@ void AsyncWrap::WeakCallback(const v8::WeakCallbackInfo<DestroyParam>& info) {
   HandleScope scope(info.GetIsolate());
 
   Environment* env = Environment::GetCurrent(info.GetIsolate());
-  DestroyParam* p = info.GetParameter();
+  std::unique_ptr<DestroyParam> p{info.GetParameter()};
   Local<Object> prop_bag = PersistentToLocal(info.GetIsolate(), p->propBag);
 
   Local<Value> val = prop_bag->Get(env->destroyed_string());
   if (val->IsFalse()) {
     AsyncWrap::EmitDestroy(env, p->asyncId);
   }
-  delete p;
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -422,6 +422,7 @@ void AsyncWrap::WeakCallback(const v8::WeakCallbackInfo<DestroyParam>& info) {
   if (val->IsFalse()) {
     AsyncWrap::EmitDestroy(env, p->asyncId);
   }
+  // unique_ptr goes out of scope here and pointer is deleted.
 }
 
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
