### PR TITLE
doc: remove personal pronoun guidance from style guide

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -13,13 +13,9 @@
 * American English spelling is preferred. "Capitalize" vs. "Capitalise",
   "color" vs. "colour", etc.
 * Use [serial commas][].
-* Generally avoid personal pronouns in reference documentation ("I", "you",
-  "we").
-  * Pronouns are acceptable in more colloquial documentation, like guides.
-  * Use gender-neutral pronouns and mass nouns. Non-comprehensive
-    examples:
-    * OK: "they", "their", "them", "folks", "people", "developers", "cats"
-    * NOT OK: "his", "hers", "him", "her", "guys", "dudes"
+* Use gender-neutral pronouns and mass nouns. Non-comprehensive examples:
+  * OK: "they", "their", "them", "folks", "people", "developers", "cats"
+  * NOT OK: "his", "hers", "him", "her", "guys", "dudes"
 * When combining wrapping elements (parentheses and quotes), terminal
   punctuation should be placed:
   * Inside the wrapping element if the wrapping element contains a complete


### PR DESCRIPTION
In order to facilitate a more formal voice, the style guide recommends
avoiding personal pronouns. In practice, this results in lots of nits
for our docs without actually improving them. There are lots of ways our
docs can be improved. Making them more formal seems low value,
especially for all the PR comments this guidance generates.

So, remove that guidance from the style guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
