### PR TITLE
repl: remove magic mode

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -560,16 +560,16 @@ The `tls.createSecurePair()` API was deprecated in documentation in Node.js
 <a id="DEP0065"></a>
 ### DEP0065: repl.REPL_MODE_MAGIC and NODE_REPL_MODE=magic
 
-Type: Documentation-only
+Type: End-of-Life
 
 The `repl` module's `REPL_MODE_MAGIC` constant, used for `replMode` option, has
-been deprecated. Its behavior has been functionally identical to that of
+been removed. Its behavior has been functionally identical to that of
 `REPL_MODE_SLOPPY` since Node.js v6.0.0, when V8 5.0 was imported. Please use
 `REPL_MODE_SLOPPY` instead.
 
 The `NODE_REPL_MODE` environment variable is used to set the underlying
-`replMode` of an interactive `node` session. Its default value, `magic`, is
-similarly deprecated in favor of `sloppy`.
+`replMode` of an interactive `node` session. Its value, `magic`, is also
+removed. Please use `sloppy` instead.
 
 <a id="DEP0066"></a>
 ### DEP0066: outgoingMessage.\_headers, outgoingMessage.\_headerNames

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -421,6 +421,9 @@ Returns `true` if `keyword` is a valid keyword, otherwise `false`.
 <!-- YAML
 added: v0.1.91
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `REPL_MAGIC_MODE` replMode was removed.
   - version: v5.8.0
     pr-url: https://github.com/nodejs/node/pull/5388
     description: The `options` parameter is optional now.
@@ -462,9 +465,6 @@ changes:
     * `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
     * `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is
       equivalent to prefacing every repl statement with `'use strict'`.
-    * `repl.REPL_MODE_MAGIC` - This value is **deprecated**, since enhanced
-      spec compliance in V8 has rendered magic mode unnecessary. It is now
-      equivalent to `repl.REPL_MODE_SLOPPY` (documented above).
   * `breakEvalOnSigint` - Stop evaluating the current piece of code when
     `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
     with a custom `eval` function. Defaults to `false`.
@@ -512,9 +512,8 @@ environment variables:
    REPL history. Whitespace will be trimmed from the value.
  - `NODE_REPL_HISTORY_SIZE` - Defaults to `1000`. Controls how many lines of
    history will be persisted if history is available. Must be a positive number.
- - `NODE_REPL_MODE` - May be any of `sloppy`, `strict`, or `magic`. Defaults
-   to `sloppy`, which will allow non-strict mode code to be run. `magic` is
-   **deprecated** and treated as an alias of `sloppy`.
+ - `NODE_REPL_MODE` - May be either `sloppy` or `strict`. Defaults
+   to `sloppy`, which will allow non-strict mode code to be run.
 
 ### Persistent History
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -716,7 +716,6 @@ exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
 exports.REPL_MODE_STRICT = Symbol('repl-strict');
-exports.REPL_MODE_MAGIC = exports.REPL_MODE_SLOPPY;
 
 // prompt is a string to print on each line for the prompt,
 // source is a stream to use for I/O, defaulting to stdin/stdout.

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -67,7 +67,8 @@ const r2 = repl.start({
   ignoreUndefined: true,
   eval: evaler,
   writer: writer,
-  replMode: repl.REPL_MODE_STRICT
+  replMode: repl.REPL_MODE_STRICT,
+  historySize: 50
 });
 assert.strictEqual(r2.input, stream);
 assert.strictEqual(r2.output, stream);
@@ -79,6 +80,7 @@ assert.strictEqual(r2.useGlobal, true);
 assert.strictEqual(r2.ignoreUndefined, true);
 assert.strictEqual(r2.writer, writer);
 assert.strictEqual(r2.replMode, repl.REPL_MODE_STRICT);
+assert.strictEqual(r2.historySize, 50);
 
 // test r2 for backwards compact
 assert.strictEqual(r2.rli.input, stream);
@@ -86,18 +88,6 @@ assert.strictEqual(r2.rli.output, stream);
 assert.strictEqual(r2.rli.input, r2.inputStream);
 assert.strictEqual(r2.rli.output, r2.outputStream);
 assert.strictEqual(r2.rli.terminal, false);
-
-// testing out "magic" replMode
-const r3 = repl.start({
-  input: stream,
-  output: stream,
-  writer: writer,
-  replMode: repl.REPL_MODE_MAGIC,
-  historySize: 50
-});
-
-assert.strictEqual(r3.replMode, repl.REPL_MODE_MAGIC);
-assert.strictEqual(r3.historySize, 50);
 
 // Verify that defaults are used when no arguments are provided
 const r4 = repl.start();


### PR DESCRIPTION
The magic mode is long deprecated and works the same as the sloppy
mode. Since the sloppy mode is the default, removing the magic mode
should be safe (passing in `undefined` or a unknown value will just use
the sloppy mode as before).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
