### PR TITLE
util: add regression test

### DIFF
--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -42,7 +42,7 @@ assert.strictEqual(false, util.isArray(Object.create(Array.prototype)));
 
 // isRegExp
 assert.strictEqual(true, util.isRegExp(/regexp/));
-assert.strictEqual(true, util.isRegExp(RegExp()));
+assert.strictEqual(true, util.isRegExp(RegExp(), 'foo'));
 assert.strictEqual(true, util.isRegExp(new RegExp()));
 assert.strictEqual(true, util.isRegExp(context('RegExp')()));
 assert.strictEqual(false, util.isRegExp({}));
@@ -52,7 +52,7 @@ assert.strictEqual(false, util.isRegExp(Object.create(RegExp.prototype)));
 
 // isDate
 assert.strictEqual(true, util.isDate(new Date()));
-assert.strictEqual(true, util.isDate(new Date(0)));
+assert.strictEqual(true, util.isDate(new Date(0), 'foo'));
 assert.strictEqual(true, util.isDate(new (context('Date'))()));
 assert.strictEqual(false, util.isDate(Date()));
 assert.strictEqual(false, util.isDate({}));


### PR DESCRIPTION
<s>This fixes util.isDate and util.isRegExp to abort in case more than
one argument is passed to the utility function.</s>

This adds regression tests to make sure passing multiple args to these functions does not abort.

This got fixed in https://github.com/nodejs/node/pull/18415.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
