### PR TITLE
[v8.x backport] backport 17338, 18186, 18358, 18546

### DIFF
--- a/deps/nghttp2/lib/includes/config.h
+++ b/deps/nghttp2/lib/includes/config.h
@@ -1,8 +1,18 @@
 /* Hint to the compiler that a function never returns */
 #define NGHTTP2_NORETURN
 
-/* Define to `int' if <sys/types.h> does not define. */
-#define ssize_t int
+/* Edited to match src/node.h. */
+#include <stdint.h>
+
+#ifdef _WIN32
+#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+typedef intptr_t ssize_t;
+# define _SSIZE_T_
+# define _SSIZE_T_DEFINED
+#endif
+#else  // !_WIN32
+# include <sys/types.h>  // size_t, ssize_t
+#endif  // _WIN32
 
 /* Define to 1 if you have the `std::map::emplace`. */
 #define HAVE_STD_MAP_EMPLACE 1

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1663,10 +1663,21 @@ A collection of all the standard HTTP response status codes, and the
 short description of each. For example, `http.STATUS_CODES[404] === 'Not
 Found'`.
 
-## http.createServer([requestListener])
+## http.createServer([options][, requestListener])
 <!-- YAML
 added: v0.1.13
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15752
+    description: The `options` argument is supported now.
 -->
+- `options` {Object}
+  * `IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage class
+    to be used. Useful for extending the original `IncomingMessage`. Defaults
+    to: `IncomingMessage`
+  * `ServerResponse` {http.ServerResponse} Specifies the ServerResponse class to
+    be used. Useful for extending the original `ServerResponse`. Defaults to:
+    `ServerResponse`
 - `requestListener` {Function}
 
 * Returns: {http.Server}

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1714,6 +1714,14 @@ changes:
   * `Http1ServerResponse` {http.ServerResponse} Specifies the ServerResponse
     class to used for HTTP/1 fallback. Useful for extending the original
     `http.ServerResponse`. **Default:** `http.ServerResponse`
+  * `Http2ServerRequest` {http2.Http2ServerRequest} Specifies the
+    Http2ServerRequest class to use.
+    Useful for extending the original `Http2ServerRequest`.
+    **Default:** `Http2ServerRequest`
+  * `Http2ServerResponse` {htt2.Http2ServerResponse} Specifies the
+    Http2ServerResponse class to use.
+    Useful for extending the original `Http2ServerResponse`.
+    **Default:** `Http2ServerResponse`
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1725,7 +1725,7 @@ changes:
     Http2ServerRequest class to use.
     Useful for extending the original `Http2ServerRequest`.
     **Default:** `Http2ServerRequest`
-  * `Http2ServerResponse` {htt2.Http2ServerResponse} Specifies the
+  * `Http2ServerResponse` {http2.Http2ServerResponse} Specifies the
     Http2ServerResponse class to use.
     Useful for extending the original `Http2ServerResponse`.
     **Default:** `Http2ServerResponse`

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -24,8 +24,11 @@ be emitted either by client-side code or server-side code.
 
 ### Server-side example
 
-The following illustrates a simple, plain-text HTTP/2 server using the
-Core API:
+The following illustrates a simple HTTP/2 server using the Core API.
+Since there are no browsers known that support
+[unencrypted HTTP/2][HTTP/2 Unencrypted], the use of
+[`http2.createSecureServer()`][] is necessary when communicating
+with browser clients.
 
 ```js
 const http2 = require('http2');
@@ -253,7 +256,7 @@ and would instead register a handler for the `'stream'` event emitted by the
 ```js
 const http2 = require('http2');
 
-// Create a plain-text HTTP/2 server
+// Create an unencrypted HTTP/2 server
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {
@@ -1735,10 +1738,18 @@ changes:
 Returns a `net.Server` instance that creates and manages `Http2Session`
 instances.
 
+Since there are no browsers known that support
+[unencrypted HTTP/2][HTTP/2 Unencrypted], the use of
+[`http2.createSecureServer()`][] is necessary when communicating
+with browser clients.
+
 ```js
 const http2 = require('http2');
 
-// Create a plain-text HTTP/2 server
+// Create an unencrypted HTTP/2 server.
+// Since there are no browsers known that support
+// unencrypted HTTP/2, the use of `http2.createSecureServer()`
+// is necessary when communicating with browser clients.
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {
@@ -3093,6 +3104,7 @@ following additional properties:
 [Compatibility API]: #http2_compatibility_api
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
+[HTTP/2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
 [HTTP2 Headers Object]: #http2_headers_object
 [HTTP2 Settings Object]: #http2_settings_object
 [HTTPS]: https.html

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1262,10 +1262,10 @@ automatically.
 const http2 = require('http2');
 const fs = require('fs');
 
-const fd = fs.openSync('/some/file', 'r');
-
 const server = http2.createServer();
 server.on('stream', (stream) => {
+  const fd = fs.openSync('/some/file', 'r');
+
   const stat = fs.fstatSync(fd);
   const headers = {
     'content-length': stat.size,
@@ -1273,8 +1273,8 @@ server.on('stream', (stream) => {
     'content-type': 'text/plain'
   };
   stream.respondWithFD(fd, headers);
+  stream.on('close', () => fs.closeSync(fd));
 });
-server.on('close', () => fs.closeSync(fd));
 ```
 
 The optional `options.statCheck` function may be specified to give user code
@@ -1287,6 +1287,12 @@ The `offset` and `length` options may be used to limit the response to a
 specific range subset. This can be used, for instance, to support HTTP Range
 requests.
 
+The file descriptor is not closed when the stream is closed, so it will need
+to be closed manually once it is no longer needed.
+Note that using the same file descriptor concurrently for multiple streams
+is not supported and may result in data loss. Re-using a file descriptor
+after a stream has finished is supported.
+
 When set, the `options.getTrailers()` function is called immediately after
 queuing the last chunk of payload data to be sent. The callback is passed a
 single object (with a `null` prototype) that the listener may use to specify
@@ -1296,10 +1302,10 @@ the trailing header fields to send to the peer.
 const http2 = require('http2');
 const fs = require('fs');
 
-const fd = fs.openSync('/some/file', 'r');
-
 const server = http2.createServer();
 server.on('stream', (stream) => {
+  const fd = fs.openSync('/some/file', 'r');
+
   const stat = fs.fstatSync(fd);
   const headers = {
     'content-length': stat.size,
@@ -1311,8 +1317,9 @@ server.on('stream', (stream) => {
       trailers['ABC'] = 'some value to send';
     }
   });
+
+  stream.on('close', () => fs.closeSync(fd));
 });
-server.on('close', () => fs.closeSync(fd));
 ```
 
 *Note*: The HTTP/1 specification forbids trailers from containing HTTP/2

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2073,8 +2073,8 @@ properties.
 * `maxConcurrentStreams` {number} Specifies the maximum number of concurrent
   streams permitted on an `Http2Session`. There is no default value which
   implies, at least theoretically, 2<sup>31</sup>-1 streams may be open
-  concurrently at any given time in an `Http2Session`. The minimum value is
-  0. The maximum allowed value is 2<sup>31</sup>-1.
+  concurrently at any given time in an `Http2Session`. The minimum value
+  is 0. The maximum allowed value is 2<sup>31</sup>-1.
 * `maxHeaderListSize` {number} Specifies the maximum size (uncompressed octets)
   of header list that will be accepted. The minimum allowed value is 0. The
   maximum allowed value is 2<sup>32</sup>-1. **Default:** 65535.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1544,6 +1544,18 @@ added: v8.4.0
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 
+#### server.close([callback])
+<!-- YAML
+added: v8.4.0
+-->
+- `callback` {Function}
+
+Stops the server from accepting new connections.  See [`net.Server.close()`][].
+
+Note that this is not analogous to restricting new requests since HTTP/2
+connections are persistent. To achieve a similar graceful shutdown behavior,
+consider also using [`http2session.close()`] on active sessions.
+
 ### Class: Http2SecureServer
 <!-- YAML
 added: v8.4.0
@@ -1650,6 +1662,18 @@ The `'unknownProtocol'` event is emitted when a connecting client fails to
 negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
 receives the socket for handling. If no listener is registered for this event,
 the connection is terminated. See the [Compatibility API][].
+
+#### server.close([callback])
+<!-- YAML
+added: v8.4.0
+-->
+- `callback` {Function}
+
+Stops the server from accepting new connections.  See [`tls.Server.close()`][].
+
+Note that this is not analogous to restricting new requests since HTTP/2
+connections are persistent. To achieve a similar graceful shutdown behavior,
+consider also using [`http2session.close()`] on active sessions.
 
 ### http2.createServer(options[, onRequestHandler])
 <!-- YAML
@@ -3126,7 +3150,9 @@ following additional properties:
 [`http2.createSecureServer()`]: #http2_http2_createsecureserver_options_onrequesthandler
 [`http2.Server`]: #http2_class_http2server
 [`http2.createServer()`]: #http2_http2_createserver_options_onrequesthandler
+[`http2session.close()`]: #http2_http2session_close_callback
 [`http2stream.pushStream()`]: #http2_http2stream_pushstream_headers_options_callback
+[`net.Server.close()`]: net.html#net_server_close_callback
 [`net.Socket`]: net.html#net_class_net_socket
 [`net.Socket.prototype.ref`]: net.html#net_socket_ref
 [`net.Socket.prototype.unref`]: net.html#net_socket_unref
@@ -3139,6 +3165,7 @@ following additional properties:
 [`response.write(data, encoding)`]: http.html#http_response_write_chunk_encoding_callback
 [`response.writeContinue()`]: #http2_response_writecontinue
 [`response.writeHead()`]: #http2_response_writehead_statuscode_statusmessage_headers
+[`tls.Server.close()`]: tls.html#tls_server_close_callback
 [`tls.TLSSocket`]: tls.html#tls_class_tls_tlssocket
 [`tls.connect()`]: tls.html#tls_tls_connect_options_callback
 [`tls.createServer()`]: tls.html#tls_tls_createserver_options_secureconnectionlistener

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1655,6 +1655,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/16676
     description: Added the `maxHeaderListPairs` option with a default limit of
                  128 header pairs.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15752
+    description: Added the `Http1IncomingMessage` and `Http1ServerResponse`
+                 option.
 -->
 
 * `options` {Object}
@@ -1704,6 +1708,12 @@ changes:
     used to determine the padding. See [Using options.selectPadding][].
   * `settings` {HTTP2 Settings Object} The initial settings to send to the
     remote peer upon connection.
+  * `Http1IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage
+    class to used for HTTP/1 fallback. Useful for extending the original
+    `http.IncomingMessage`. **Default:** `http.IncomingMessage`
+  * `Http1ServerResponse` {http.ServerResponse} Specifies the ServerResponse
+    class to used for HTTP/1 fallback. Useful for extending the original
+    `http.ServerResponse`. **Default:** `http.ServerResponse`
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -321,6 +321,17 @@ added: REPLACEME
 Will be `true` if this `Http2Session` instance has been closed, otherwise
 `false`.
 
+#### http2session.connecting
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Will be `true` if this `Http2Session` instance is still connecting, will be set
+to `false` before emitting `connect` event and/or calling the `http2.connect`
+callback.
+
 #### http2session.destroy([error,][code])
 <!-- YAML
 added: v8.4.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1,4 +1,4 @@
-# HTTP2
+# HTTP/2
 
 <!--introduced_in=v8.4.0-->
 
@@ -230,7 +230,7 @@ added: v8.4.0
 
 The `'stream'` event is emitted when a new `Http2Stream` is created. When
 invoked, the handler function will receive a reference to the `Http2Stream`
-object, a [HTTP2 Headers Object][], and numeric flags associated with the
+object, a [HTTP/2 Headers Object][], and numeric flags associated with the
 creation of the stream.
 
 ```js
@@ -383,7 +383,7 @@ Transmits a `GOAWAY` frame to the connected peer *without* shutting down the
 added: v8.4.0
 -->
 
-* Value: {HTTP2 Settings Object}
+* Value: {HTTP/2 Settings Object}
 
 A prototype-less object describing the current local settings of this
 `Http2Session`. The local settings are local to *this* `Http2Session` instance.
@@ -462,7 +462,7 @@ instance's underlying [`net.Socket`].
 added: v8.4.0
 -->
 
-* Value: {HTTP2 Settings Object}
+* Value: {HTTP/2 Settings Object}
 
 A prototype-less object describing the current remote settings of this
 `Http2Session`. The remote settings are set by the *connected* HTTP/2 peer.
@@ -533,8 +533,7 @@ An object describing the current status of this `Http2Session`.
 added: v8.4.0
 -->
 
-* `settings` {HTTP2 Settings Object}
-* Returns {undefined}
+* `settings` {HTTP/2 Settings Object}
 
 Updates the current local settings for this `Http2Session` and sends a new
 `SETTINGS` frame to the connected HTTP/2 peer.
@@ -674,7 +673,7 @@ client.on('altsvc', (alt, origin, streamId) => {
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `endStream` {boolean} `true` if the `Http2Stream` *writable* side should
     be closed initially, such as when sending a `GET` request that should not
@@ -862,7 +861,7 @@ added: v8.4.0
 
 The `'trailers'` event is emitted when a block of headers associated with
 trailing header fields is received. The listener callback is passed the
-[HTTP2 Headers Object][] and flags associated with the headers.
+[HTTP/2 Headers Object][] and flags associated with the headers.
 
 ```js
 stream.on('trailers', (headers, flags) => {
@@ -961,7 +960,7 @@ calling `http2stream.close()`, or `http2stream.destroy()`. Will be
 added: REPLACEME
 -->
 
-* Value: {HTTP2 Headers Object}
+* Value: {HTTP/2 Headers Object}
 
 An object containing the outbound headers sent for this `Http2Stream`.
 
@@ -970,7 +969,7 @@ An object containing the outbound headers sent for this `Http2Stream`.
 added: REPLACEME
 -->
 
-* Value: {HTTP2 Headers Object[]}
+* Value: {HTTP/2 Headers Object[]}
 
 An array of objects containing the outbound informational (additional) headers
 sent for this `Http2Stream`.
@@ -980,7 +979,7 @@ sent for this `Http2Stream`.
 added: REPLACEME
 -->
 
-* Value: {HTTP2 Headers Object}
+* Value: {HTTP/2 Headers Object}
 
 An object containing the outbound trailers sent for this this `HttpStream`.
 
@@ -1063,7 +1062,7 @@ added: v8.4.0
 
 The `'headers'` event is emitted when an additional block of headers is received
 for a stream, such as when a block of `1xx` informational headers is received.
-The listener callback is passed the [HTTP2 Headers Object][] and flags
+The listener callback is passed the [HTTP/2 Headers Object][] and flags
 associated with the headers.
 
 ```js
@@ -1078,7 +1077,7 @@ added: v8.4.0
 -->
 
 The `'push'` event is emitted when response headers for a Server Push stream
-are received. The listener callback is passed the [HTTP2 Headers Object][] and
+are received. The listener callback is passed the [HTTP/2 Headers Object][] and
 flags associated with the headers.
 
 ```js
@@ -1095,7 +1094,7 @@ added: v8.4.0
 The `'response'` event is emitted when a response `HEADERS` frame has been
 received for this stream from the connected HTTP/2 server. The listener is
 invoked with two arguments: an Object containing the received
-[HTTP2 Headers Object][], and flags associated with the headers.
+[HTTP/2 Headers Object][], and flags associated with the headers.
 
 For example:
 
@@ -1125,8 +1124,7 @@ provide additional methods such as `http2stream.pushStream()` and
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
-* Returns: {undefined}
+* `headers` {HTTP/2 Headers Object}
 
 Sends an additional informational `HEADERS` frame to the connected HTTP/2 peer.
 
@@ -1156,7 +1154,7 @@ accepts push streams, `false` otherwise. Settings are the same for every
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     the created stream is made the sole direct dependency of the parent, with
@@ -1168,7 +1166,7 @@ added: v8.4.0
   initiated.
   * `err` {Error}
   * `pushStream` {ServerHttp2Stream} The returned pushStream object.
-  * `headers` {HTTP2 Headers Object} Headers object the pushStream was
+  * `headers` {HTTP/2 Headers Object} Headers object the pushStream was
   initiated with.
 * Returns: {undefined}
 
@@ -1199,7 +1197,7 @@ a `weight` value to `http2stream.priority` with the `silent` option set to
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `endStream` {boolean} Set to `true` to indicate that the response will not
     include payload data.
@@ -1245,7 +1243,7 @@ added: v8.4.0
 -->
 
 * `fd` {number} A readable file descriptor.
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}
   * `getTrailers` {Function} Callback function invoked to collect trailer
@@ -1336,7 +1334,7 @@ added: v8.4.0
 -->
 
 * `path` {string|Buffer|URL}
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}
   * `onError` {Function} Callback function invoked in the case of an
@@ -1716,7 +1714,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `Http1IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage
     class to used for HTTP/1 fallback. Useful for extending the original
@@ -1825,7 +1823,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For
     servers, the identity options (`pfx` or `key`/`cert`) are usually required.
@@ -1921,7 +1919,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `createConnection` {Function} An optional callback that receives the `URL`
     instance passed to `connect` and the `options` object, and returns any
@@ -1974,7 +1972,7 @@ a given number of milliseconds set using `http2server.setTimeout()`.
 added: v8.4.0
 -->
 
-* Returns: {HTTP2 Settings Object}
+* Returns: {HTTP/2 Settings Object}
 
 Returns an object containing the default settings for an `Http2Session`
 instance. This method returns a new object instance every time it is called
@@ -1985,7 +1983,7 @@ so instances returned may be safely modified for use.
 added: v8.4.0
 -->
 
-* `settings` {HTTP2 Settings Object}
+* `settings` {HTTP/2 Settings Object}
 * Returns: {Buffer}
 
 Returns a `Buffer` instance containing serialized representation of the given
@@ -2007,9 +2005,9 @@ added: v8.4.0
 -->
 
 * `buf` {Buffer|Uint8Array} The packed settings.
-* Returns: {HTTP2 Settings Object}
+* Returns: {HTTP/2 Settings Object}
 
-Returns a [HTTP2 Settings Object][] containing the deserialized settings from
+Returns a [HTTP/2 Settings Object][] containing the deserialized settings from
 the given `Buffer` as generated by `http2.getPackedSettings()`.
 
 ### Headers Object
@@ -2274,7 +2272,7 @@ In order to create a mixed [HTTPS][] and HTTP/2 server, refer to the
 [ALPN negotiation][] section.
 Upgrading from non-tls HTTP/1 servers is not supported.
 
-The HTTP2 compatibility API is composed of [`Http2ServerRequest`]() and
+The HTTP/2 compatibility API is composed of [`Http2ServerRequest`]() and
 [`Http2ServerResponse`](). They aim at API compatibility with HTTP/1, but
 they do not hide the differences between the protocols. As an example,
 the status message for HTTP codes is ignored.
@@ -2382,7 +2380,7 @@ Example:
 console.log(request.headers);
 ```
 
-See [HTTP2 Headers Object][].
+See [HTTP/2 Headers Object][].
 
 *Note*: In HTTP/2, the request path, hostname, protocol, and method are
 represented as special headers prefixed with the `:` character (e.g. `':path'`).
@@ -3105,8 +3103,8 @@ following additional properties:
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
 [HTTP/2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
-[HTTP2 Headers Object]: #http2_headers_object
-[HTTP2 Settings Object]: #http2_settings_object
+[HTTP/2 Headers Object]: #http2_headers_object
+[HTTP/2 Settings Object]: #http2_settings_object
 [HTTPS]: https.html
 [Http2Session and Sockets]: #http2_http2session_and_sockets
 [Performance Observer]: perf_hooks.html

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -65,7 +65,8 @@ See [`http.Server#keepAliveTimeout`][].
 <!-- YAML
 added: v0.3.4
 -->
-- `options` {Object} Accepts `options` from [`tls.createServer()`][] and [`tls.createSecureContext()`][].
+- `options` {Object} Accepts `options` from [`tls.createServer()`][],
+ [`tls.createSecureContext()`][] and [`http.createServer()`][].
 - `requestListener` {Function} A listener to be added to the `request` event.
 
 Example:
@@ -255,6 +256,7 @@ const req = https.request(options, (res) => {
 [`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback
 [`http.Server#timeout`]: http.html#http_server_timeout
 [`http.Server`]: http.html#http_class_http_server
+[`http.createServer()`]: http.html#httpcreateserveroptions-requestlistener
 [`http.close()`]: http.html#http_server_close_callback
 [`http.get()`]: http.html#http_http_get_options_callback
 [`http.request()`]: http.html#http_http_request_options_callback

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -217,6 +217,25 @@ without any formatting.
 util.format('%% %s'); // '%% %s'
 ```
 
+## util.getSystemErrorName(err)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `err` {number}
+* Returns: {string}
+
+Returns the string name for a numeric error code that comes from a Node.js API.
+The mapping between error codes and error names is platform-dependent.
+See [Common System Errors][] for the names of common errors.
+
+```js
+fs.access('file/that/does/not/exist', (err) => {
+  const name = util.getSystemErrorName(err.errno);
+  console.error(name);  // ENOENT
+});
+```
+
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
@@ -1196,6 +1215,7 @@ Deprecated predecessor of `console.log`.
 [`console.log()`]: console.html#console_console_log_data_args
 [`util.inspect()`]: #util_util_inspect_object_options
 [`util.promisify()`]: #util_util_promisify_original
+[Common System Errors]: errors.html#errors_common_system_errors
 [Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
 [Custom promisified functions]: #util_custom_promisified_functions
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -34,6 +34,7 @@ const {
 
 const debug = require('util').debuglog('http');
 
+const kIncomingMessage = Symbol('IncomingMessage');
 const kOnHeaders = HTTPParser.kOnHeaders | 0;
 const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
 const kOnBody = HTTPParser.kOnBody | 0;
@@ -73,7 +74,11 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
     parser._url = '';
   }
 
-  parser.incoming = new IncomingMessage(parser.socket);
+  // Parser is also used by http client
+  var ParserIncomingMessage = parser.socket && parser.socket.server ?
+    parser.socket.server[kIncomingMessage] : IncomingMessage;
+
+  parser.incoming = new ParserIncomingMessage(parser.socket);
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
   parser.incoming.httpVersion = `${versionMajor}.${versionMinor}`;
@@ -353,5 +358,6 @@ module.exports = {
   freeParser,
   httpSocketSetup,
   methods,
-  parsers
+  parsers,
+  kIncomingMessage
 };

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -33,6 +33,7 @@ const {
   continueExpression,
   chunkExpression,
   httpSocketSetup,
+  kIncomingMessage,
   _checkInvalidHeaderChar: checkInvalidHeaderChar
 } = require('_http_common');
 const { OutgoingMessage } = require('_http_outgoing');
@@ -41,6 +42,9 @@ const {
   defaultTriggerAsyncIdScope,
   getOrSetAsyncId
 } = require('internal/async_hooks');
+const { IncomingMessage } = require('_http_incoming');
+
+const kServerResponse = Symbol('ServerResponse');
 
 const STATUS_CODES = {
   100: 'Continue',
@@ -260,9 +264,19 @@ function writeHead(statusCode, reason, obj) {
 // Docs-only deprecated: DEP0063
 ServerResponse.prototype.writeHeader = ServerResponse.prototype.writeHead;
 
+function Server(options, requestListener) {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
 
-function Server(requestListener) {
-  if (!(this instanceof Server)) return new Server(requestListener);
+  if (typeof options === 'function') {
+    requestListener = options;
+    options = {};
+  } else if (options == null || typeof options === 'object') {
+    options = util._extend({}, options);
+  }
+
+  this[kIncomingMessage] = options.IncomingMessage || IncomingMessage;
+  this[kServerResponse] = options.ServerResponse || ServerResponse;
+
   net.Server.call(this, { allowHalfOpen: true });
 
   if (requestListener) {
@@ -578,7 +592,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     }
   }
 
-  var res = new ServerResponse(req);
+  var res = new server[kServerResponse](req);
   res._onPendingData = updateOutgoingData.bind(undefined, socket, state);
 
   res.shouldKeepAlive = keepAlive;
@@ -681,5 +695,6 @@ module.exports = {
   STATUS_CODES,
   Server,
   ServerResponse,
-  _connectionListener: connectionListener
+  _connectionListener: connectionListener,
+  kServerResponse
 };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,13 +22,14 @@
 'use strict';
 
 const util = require('util');
-const { deprecate, convertToValidSignal } = require('internal/util');
+const {
+  deprecate, convertToValidSignal, getSystemErrorName
+} = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const { createPromise,
         promiseResolve, promiseReject } = process.binding('util');
 const debug = util.debuglog('child_process');
 
-const uv = process.binding('uv');
 const spawn_sync = process.binding('spawn_sync');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
@@ -274,7 +275,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (!ex) {
       ex = new Error('Command failed: ' + cmd + '\n' + stderr);
       ex.killed = child.killed || killed;
-      ex.code = code < 0 ? uv.errname(code) : code;
+      ex.code = code < 0 ? getSystemErrorName(code) : code;
       ex.signal = signal;
     }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -45,8 +45,8 @@ const SEND_BUFFER = false;
 // Lazily loaded
 var cluster = null;
 
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = errors.errnoException;
+const exceptionWithHostPort = errors.exceptionWithHostPort;
 
 
 function lookup4(lookup, address, callback) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -21,12 +21,10 @@
 
 'use strict';
 
-const util = require('util');
-
 const cares = process.binding('cares_wrap');
-const uv = process.binding('uv');
 const { isLegalPort } = require('internal/net');
 const { customPromisifyArgs } = require('internal/util');
+const errors = require('internal/errors');
 
 const {
   GetAddrInfoReqWrap,
@@ -35,30 +33,6 @@ const {
   ChannelWrap,
   isIP
 } = cares;
-
-function errnoException(err, syscall, hostname) {
-  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
-  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-  if (err === uv.UV_EAI_MEMORY ||
-      err === uv.UV_EAI_NODATA ||
-      err === uv.UV_EAI_NONAME) {
-    err = 'ENOTFOUND';
-  }
-  var ex = null;
-  if (typeof err === 'string') {  // c-ares error code.
-    const errHost = hostname ? ` ${hostname}` : '';
-    ex = new Error(`${syscall} ${err}${errHost}`);
-    ex.code = err;
-    ex.errno = err;
-    ex.syscall = syscall;
-  } else {
-    ex = util._errnoException(err, syscall);
-  }
-  if (hostname) {
-    ex.hostname = hostname;
-  }
-  return ex;
-}
 
 const IANA_DNS_PORT = 53;
 const digits = [
@@ -86,10 +60,11 @@ function isIPv4(str) {
   return (str.length > 3 && str.charCodeAt(3) === 46/*'.'*/);
 }
 
+const dnsException = errors.dnsException;
 
 function onlookup(err, addresses) {
   if (err) {
-    return this.callback(errnoException(err, 'getaddrinfo', this.hostname));
+    return this.callback(dnsException(err, 'getaddrinfo', this.hostname));
   }
   if (this.family) {
     this.callback(null, addresses[0], this.family);
@@ -101,7 +76,7 @@ function onlookup(err, addresses) {
 
 function onlookupall(err, addresses) {
   if (err) {
-    return this.callback(errnoException(err, 'getaddrinfo', this.hostname));
+    return this.callback(dnsException(err, 'getaddrinfo', this.hostname));
   }
 
   var family = this.family;
@@ -181,7 +156,7 @@ function lookup(hostname, options, callback) {
 
   var err = cares.getaddrinfo(req, hostname, family, hints, verbatim);
   if (err) {
-    process.nextTick(callback, errnoException(err, 'getaddrinfo', hostname));
+    process.nextTick(callback, dnsException(err, 'getaddrinfo', hostname));
     return {};
   }
   return req;
@@ -193,7 +168,7 @@ Object.defineProperty(lookup, customPromisifyArgs,
 
 function onlookupservice(err, host, service) {
   if (err)
-    return this.callback(errnoException(err, 'getnameinfo', this.host));
+    return this.callback(dnsException(err, 'getnameinfo', this.host));
 
   this.callback(null, host, service);
 }
@@ -222,7 +197,7 @@ function lookupService(host, port, callback) {
   req.oncomplete = onlookupservice;
 
   var err = cares.getnameinfo(req, host, port);
-  if (err) throw errnoException(err, 'getnameinfo', host);
+  if (err) throw dnsException(err, 'getnameinfo', host);
   return req;
 }
 
@@ -235,7 +210,7 @@ function onresolve(err, result, ttls) {
     result = result.map((address, index) => ({ address, ttl: ttls[index] }));
 
   if (err)
-    this.callback(errnoException(err, this.bindingName, this.hostname));
+    this.callback(dnsException(err, this.bindingName, this.hostname));
   else
     this.callback(null, result);
 }
@@ -272,7 +247,7 @@ function resolver(bindingName) {
     req.oncomplete = onresolve;
     req.ttl = !!(options && options.ttl);
     var err = this._handle[bindingName](req, name);
-    if (err) throw errnoException(err, bindingName);
+    if (err) throw dnsException(err, bindingName);
     return req;
   }
   Object.defineProperty(query, 'name', { value: bindingName });

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -59,7 +59,7 @@ const { kMaxLength } = require('buffer');
 const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
-const errnoException = util._errnoException;
+const errnoException = errors.errnoException;
 
 function getOptions(options, defaultOptions) {
   if (options === null || options === undefined ||

--- a/lib/https.js
+++ b/lib/https.js
@@ -30,6 +30,9 @@ const util = require('util');
 const { inherits } = util;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
+const { IncomingMessage, ServerResponse } = require('http');
+const { kIncomingMessage } = require('_http_common');
+const { kServerResponse } = require('_http_server');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -51,9 +54,10 @@ function Server(opts, requestListener) {
     opts.ALPNProtocols = ['http/1.1'];
   }
 
-  tls.Server.call(this, opts, http._connectionListener);
+  this[kIncomingMessage] = opts.IncomingMessage || IncomingMessage;
+  this[kServerResponse] = opts.ServerResponse || ServerResponse;
 
-  this.httpAllowHalfOpen = false;
+  tls.Server.call(this, opts, http._connectionListener);
 
   if (requestListener) {
     this.addListener('request', requestListener);

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -18,7 +18,7 @@ const SocketList = require('internal/socket_list');
 const { convertToValidSignal } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 
-const errnoException = util._errnoException;
+const errnoException = errors.errnoException;
 const { SocketListSend, SocketListReceive } = SocketList;
 
 const MAX_HANDLE_RETRANSMISSIONS = 3;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -11,6 +11,11 @@
 const kCode = Symbol('code');
 const messages = new Map();
 
+const {
+  UV_EAI_MEMORY,
+  UV_EAI_NODATA,
+  UV_EAI_NONAME
+} = process.binding('uv');
 const { defineProperty } = Object;
 
 // Lazily loaded
@@ -20,6 +25,14 @@ function lazyUtil() {
     util_ = require('util');
   }
   return util_;
+}
+
+var internalUtil = null;
+function lazyInternalUtil() {
+  if (!internalUtil) {
+    internalUtil = require('internal/util');
+  }
+  return internalUtil;
 }
 
 function makeNodeError(Base) {
@@ -125,7 +138,110 @@ function E(sym, val) {
   messages.set(sym, typeof val === 'function' ? val : String(val));
 }
 
+/**
+ * This used to be util._errnoException().
+ *
+ * @param {number} err - A libuv error number
+ * @param {string} syscall
+ * @param {string} [original]
+ * @returns {Error}
+ */
+function errnoException(err, syscall, original) {
+  // TODO(joyeecheung): We have to use the type-checked
+  // getSystemErrorName(err) to guard against invalid arguments from users.
+  // This can be replaced with [ code ] = errmap.get(err) when this method
+  // is no longer exposed to user land.
+  const code = lazyUtil().getSystemErrorName(err);
+  const message = original ?
+    `${syscall} ${code} ${original}` : `${syscall} ${code}`;
+
+  const ex = new Error(message);
+  // TODO(joyeecheung): errno is supposed to err, like in uvException
+  ex.code = ex.errno = code;
+  ex.syscall = syscall;
+
+  Error.captureStackTrace(ex, errnoException);
+  return ex;
+}
+
+/**
+ * This used to be util._exceptionWithHostPort().
+ *
+ * @param {number} err - A libuv error number
+ * @param {string} syscall
+ * @param {string} address
+ * @param {number} [port]
+ * @param {string} [additional]
+ * @returns {Error}
+ */
+function exceptionWithHostPort(err, syscall, address, port, additional) {
+  // TODO(joyeecheung): We have to use the type-checked
+  // getSystemErrorName(err) to guard against invalid arguments from users.
+  // This can be replaced with [ code ] = errmap.get(err) when this method
+  // is no longer exposed to user land.
+  const code = lazyUtil().getSystemErrorName(err);
+  let details = '';
+  if (port && port > 0) {
+    details = ` ${address}:${port}`;
+  } else if (address) {
+    details = ` ${address}`;
+  }
+  if (additional) {
+    details += ` - Local (${additional})`;
+  }
+
+  const ex = new Error(`${syscall} ${code}${details}`);
+  // TODO(joyeecheung): errno is supposed to err, like in uvException
+  ex.code = ex.errno = code;
+  ex.syscall = syscall;
+  ex.address = address;
+  if (port) {
+    ex.port = port;
+  }
+
+  Error.captureStackTrace(ex, exceptionWithHostPort);
+  return ex;
+}
+
+/**
+ * @param {number|string} err - A libuv error number or a c-ares error code
+ * @param {string} syscall
+ * @param {string} [hostname]
+ * @returns {Error}
+ */
+function dnsException(err, syscall, hostname) {
+  const ex = new Error();
+  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
+  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
+  if (err === UV_EAI_MEMORY ||
+      err === UV_EAI_NODATA ||
+      err === UV_EAI_NONAME) {
+    err = 'ENOTFOUND';  // Fabricated error name.
+  }
+  if (typeof err === 'string') {  // c-ares error code.
+    const errHost = hostname ? ` ${hostname}` : '';
+    ex.message = `${syscall} ${err}${errHost}`;
+    // TODO(joyeecheung): errno is supposed to be a number, like in uvException
+    ex.code = ex.errno = err;
+    ex.syscall = syscall;
+  } else {  // libuv error number
+    const code = lazyInternalUtil().getSystemErrorName(err);
+    ex.message = `${syscall} ${code}`;
+    // TODO(joyeecheung): errno is supposed to be err, like in uvException
+    ex.code = ex.errno = code;
+    ex.syscall = syscall;
+  }
+  if (hostname) {
+    ex.hostname = hostname;
+  }
+  Error.captureStackTrace(ex, dnsException);
+  return ex;
+}
+
 module.exports = exports = {
+  dnsException,
+  errnoException,
+  exceptionWithHostPort,
   message,
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -204,33 +204,33 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
 }
 
 /**
- * @param {number|string} err - A libuv error number or a c-ares error code
+ * @param {number|string} code - A libuv error number or a c-ares error code
  * @param {string} syscall
  * @param {string} [hostname]
  * @returns {Error}
  */
-function dnsException(err, syscall, hostname) {
-  const ex = new Error();
+function dnsException(code, syscall, hostname) {
+  let message;
   // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
   // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-  if (err === UV_EAI_MEMORY ||
-      err === UV_EAI_NODATA ||
-      err === UV_EAI_NONAME) {
-    err = 'ENOTFOUND';  // Fabricated error name.
+  if (code === UV_EAI_MEMORY ||
+      code === UV_EAI_NODATA ||
+      code === UV_EAI_NONAME) {
+    code = 'ENOTFOUND'; // Fabricated error name.
   }
-  if (typeof err === 'string') {  // c-ares error code.
-    const errHost = hostname ? ` ${hostname}` : '';
-    ex.message = `${syscall} ${err}${errHost}`;
-    // TODO(joyeecheung): errno is supposed to be a number, like in uvException
-    ex.code = ex.errno = err;
-    ex.syscall = syscall;
+  if (typeof code === 'string') { // c-ares error code.
+    message = `${syscall} ${code}${hostname ? ` ${hostname}` : ''}`;
   } else {  // libuv error number
-    const code = lazyInternalUtil().getSystemErrorName(err);
-    ex.message = `${syscall} ${code}`;
-    // TODO(joyeecheung): errno is supposed to be err, like in uvException
-    ex.code = ex.errno = code;
-    ex.syscall = syscall;
+    code = lazyInternalUtil().getSystemErrorName(code);
+    message = `${syscall} ${code}`;
   }
+  // eslint-disable-next-line no-restricted-syntax
+  const ex = new Error(message);
+  // TODO(joyeecheung): errno is supposed to be a number / err, like in
+  // uvException.
+  ex.errno = code;
+  ex.code = code;
+  ex.syscall = syscall;
   if (hostname) {
     ex.hostname = hostname;
   }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,7 +14,13 @@ const messages = new Map();
 const { defineProperty } = Object;
 
 // Lazily loaded
-var util = null;
+var util_ = null;
+function lazyUtil() {
+  if (!util_) {
+    util_ = require('util');
+  }
+  return util_;
+}
 
 function makeNodeError(Base) {
   return class NodeError extends Base {
@@ -65,11 +71,11 @@ class AssertionError extends Error {
     if (message) {
       super(message);
     } else {
+      const util = lazyUtil();
       if (actual && actual.stack && actual instanceof Error)
         actual = `${actual.name}: ${actual.message}`;
       if (expected && expected.stack && expected instanceof Error)
         expected = `${expected.name}: ${expected.message}`;
-      if (util === null) util = require('util');
       super(`${util.inspect(actual).slice(0, 128)} ` +
         `${operator} ${util.inspect(expected).slice(0, 128)}`);
     }
@@ -104,7 +110,7 @@ function message(key, args) {
   if (typeof msg === 'function') {
     fmt = msg;
   } else {
-    if (util === null) util = require('util');
+    const util = lazyUtil();
     fmt = util.format;
     if (args === undefined || args.length === 0)
       return msg;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -661,11 +661,11 @@ class Http2ServerResponse extends Stream {
   }
 }
 
-function onServerStream(stream, headers, flags, rawHeaders) {
+function onServerStream(ServerRequest, ServerResponse,
+                        stream, headers, flags, rawHeaders) {
   const server = this;
-  const request = new Http2ServerRequest(stream, headers, undefined,
-                                         rawHeaders);
-  const response = new Http2ServerResponse(stream);
+  const request = new ServerRequest(stream, headers, undefined, rawHeaders);
+  const response = new ServerResponse(stream);
 
   // Check for the CONNECT method
   const method = headers[HTTP2_HEADER_METHOD];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -734,7 +734,7 @@ function setupHandle(socket, type, options) {
   // core will check for session.destroyed before progressing, this
   // ensures that those at l`east get cleared out.
   if (this.destroyed) {
-    this.emit('connect', this, socket);
+    process.nextTick(emit, this, 'connect', this, socket);
     return;
   }
   debug(`Http2Session ${sessionName(type)}: setting up session handle`);
@@ -776,7 +776,7 @@ function setupHandle(socket, type, options) {
     options.settings : {};
 
   this.settings(settings);
-  this.emit('connect', this, socket);
+  process.nextTick(emit, this, 'connect', this, socket);
 }
 
 // Emits a close event followed by an error event if err is truthy. Used

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1129,6 +1129,11 @@ class Http2Session extends EventEmitter {
 
     // Destroy any pending and open streams
     const cancel = new errors.Error('ERR_HTTP2_STREAM_CANCEL');
+    if (error) {
+      cancel.cause = error;
+      if (typeof error.message === 'string')
+        cancel.message += ` (caused by: ${error.message})`;
+    }
     state.pendingStreams.forEach((stream) => stream.destroy(cancel));
     state.streams.forEach((stream) => stream.destroy(error));
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -5,6 +5,7 @@
 require('internal/util').assertCrypto();
 
 const { async_id_symbol } = process.binding('async_wrap');
+const http = require('http');
 const binding = process.binding('http2');
 const assert = require('assert');
 const { Buffer } = require('buffer');
@@ -67,6 +68,8 @@ const NETServer = net.Server;
 const TLSServer = tls.Server;
 
 const kInspect = require('internal/util').customInspectSymbol;
+const { kIncomingMessage } = require('_http_common');
+const { kServerResponse } = require('_http_server');
 
 const kAlpnProtocol = Symbol('alpnProtocol');
 const kAuthority = Symbol('authority');
@@ -2442,8 +2445,11 @@ function connectionListener(socket) {
 
   if (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1') {
     // Fallback to HTTP/1.1
-    if (options.allowHTTP1 === true)
+    if (options.allowHTTP1 === true) {
+      socket.server[kIncomingMessage] = options.Http1IncomingMessage;
+      socket.server[kServerResponse] = options.Http1ServerResponse;
       return httpConnectionListener.call(this, socket);
+    }
     // Let event handler deal with the socket
     if (!this.emit('unknownProtocol', socket))
       socket.destroy();
@@ -2474,6 +2480,13 @@ function initializeOptions(options) {
   options.allowHalfOpen = true;
   assertIsObject(options.settings, 'options.settings');
   options.settings = Object.assign({}, options.settings);
+
+  // Used only with allowHTTP1
+  options.Http1IncomingMessage = options.Http1IncomingMessage ||
+    http.IncomingMessage;
+  options.Http1ServerResponse = options.Http1ServerResponse ||
+    http.ServerResponse;
+
   return options;
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2487,6 +2487,10 @@ function initializeOptions(options) {
   options.Http1ServerResponse = options.Http1ServerResponse ||
     http.ServerResponse;
 
+  options.Http2ServerRequest = options.Http2ServerRequest ||
+                                       Http2ServerRequest;
+  options.Http2ServerResponse = options.Http2ServerResponse ||
+                                        Http2ServerResponse;
   return options;
 }
 
@@ -2552,7 +2556,11 @@ class Http2Server extends NETServer {
 function setupCompat(ev) {
   if (ev === 'request') {
     this.removeListener('newListener', setupCompat);
-    this.on('stream', onServerStream);
+    this.on('stream', onServerStream.bind(
+      this,
+      this[kOptions].Http2ServerRequest,
+      this[kOptions].Http2ServerResponse)
+    );
   }
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1412,18 +1412,6 @@ function afterDoStreamWrite(status, handle, req) {
   req.handle = undefined;
 }
 
-function onHandleFinish() {
-  const handle = this[kHandle];
-  if (this[kID] === undefined) {
-    this.once('ready', onHandleFinish);
-  } else if (handle !== undefined) {
-    const req = new ShutdownWrap();
-    req.oncomplete = () => {};
-    req.handle = handle;
-    handle.shutdown(req);
-  }
-}
-
 function streamOnResume() {
   if (!this.destroyed && !this.pending)
     this[kHandle].readStart();
@@ -1442,6 +1430,13 @@ function abort(stream) {
     process.nextTick(emit, stream, 'aborted');
     stream[kState].flags |= STREAM_FLAGS_ABORTED;
   }
+}
+
+function afterShutdown() {
+  this.callback();
+  const stream = this.handle[kOwner];
+  if (stream)
+    stream[kMaybeDestroy]();
 }
 
 // An Http2Stream is a Duplex stream that is backed by a
@@ -1466,7 +1461,6 @@ class Http2Stream extends Duplex {
       writeQueueSize: 0
     };
 
-    this.once('finish', onHandleFinish);
     this.on('resume', streamOnResume);
     this.on('pause', streamOnPause);
   }
@@ -1670,6 +1664,23 @@ class Http2Stream extends Duplex {
     if (err)
       throw util._errnoException(err, 'write', req.error);
     trackWriteState(this, req.bytes);
+  }
+
+  _final(cb) {
+    const handle = this[kHandle];
+    if (this[kID] === undefined) {
+      this.once('ready', () => this._final(cb));
+    } else if (handle !== undefined) {
+      debug(`Http2Stream ${this[kID]} [Http2Session ` +
+            `${sessionName(this[kSession][kType])}]: _final shutting down`);
+      const req = new ShutdownWrap();
+      req.oncomplete = afterShutdown;
+      req.callback = cb;
+      req.handle = handle;
+      handle.shutdown(req);
+    } else {
+      cb();
+    }
   }
 
   _read(nread) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1764,6 +1764,8 @@ class Http2Stream extends Duplex {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'number');
     if (code < 0 || code > kMaxInt)
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'code');
+    if (callback !== undefined && typeof callback !== 'function')
+      throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
     // Unenroll the timeout.
     unenroll(this);
@@ -1781,8 +1783,6 @@ class Http2Stream extends Duplex {
     state.rstCode = code;
 
     if (callback !== undefined) {
-      if (typeof callback !== 'function')
-        throw new errors.TypeError('ERR_INVALID_CALLBACK');
       this.once('close', callback);
     }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2489,8 +2489,17 @@ function connectionListener(socket) {
       return httpConnectionListener.call(this, socket);
     }
     // Let event handler deal with the socket
-    if (!this.emit('unknownProtocol', socket))
-      socket.destroy();
+    debug(`Unknown protocol from ${socket.remoteAddress}:${socket.remotePort}`);
+    if (!this.emit('unknownProtocol', socket)) {
+      // We don't know what to do, so let's just tell the other side what's
+      // going on in a format that they *might* understand.
+      socket.end('HTTP/1.0 403 Forbidden\r\n' +
+                 'Content-Type: text/plain\r\n\r\n' +
+                 'Unknown ALPN Protocol, expected `h2` to be available.\n' +
+                 'If this is a HTTP request: The server was not ' +
+                 'configured with the `allowHTTP1` option or a ' +
+                 'listener for the `unknownProtocol` event.\n');
+    }
     return;
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1647,7 +1647,7 @@ class Http2Stream extends Duplex {
     req.async = false;
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
-      throw util._errnoException(err, 'write', req.error);
+      return this.destroy(util._errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 
@@ -1690,7 +1690,7 @@ class Http2Stream extends Duplex {
     }
     const err = handle.writev(req, chunks);
     if (err)
-      throw util._errnoException(err, 'write', req.error);
+      return this.destroy(util._errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -306,8 +306,23 @@ function onStreamClose(code) {
 
   if (state.fd !== undefined)
     tryClose(state.fd);
-  stream.push(null);
-  stream[kMaybeDestroy](null, code);
+
+  // Defer destroy we actually emit end.
+  if (stream._readableState.endEmitted || code !== NGHTTP2_NO_ERROR) {
+    // If errored or ended, we can destroy immediately.
+    stream[kMaybeDestroy](null, code);
+  } else {
+    // Wait for end to destroy.
+    stream.on('end', stream[kMaybeDestroy]);
+    // Push a null so the stream can end whenever the client consumes
+    // it completely.
+    stream.push(null);
+
+    // Same as net.
+    if (stream._readableState.length === 0) {
+      stream.read(0);
+    }
+  }
 }
 
 // Receives a chunk of data for a given stream and forwards it on
@@ -325,11 +340,19 @@ function onStreamRead(nread, buf) {
     }
     return;
   }
+
   // Last chunk was received. End the readable side.
   debug(`Http2Stream ${stream[kID]} [Http2Session ` +
         `${sessionName(stream[kSession][kType])}]: ending readable.`);
-  stream.push(null);
-  stream[kMaybeDestroy]();
+
+  // defer this until we actually emit end
+  if (stream._readableState.endEmitted) {
+    stream[kMaybeDestroy]();
+  } else {
+    stream.on('end', stream[kMaybeDestroy]);
+    stream.push(null);
+    stream.read(0);
+  }
 }
 
 // Called when the remote peer settings have been updated.
@@ -1826,21 +1849,25 @@ class Http2Stream extends Duplex {
     session[kMaybeDestroy]();
     process.nextTick(emit, this, 'close', code);
     callback(err);
-  }
 
+  }
   // The Http2Stream can be destroyed if it has closed and if the readable
   // side has received the final chunk.
   [kMaybeDestroy](error, code = NGHTTP2_NO_ERROR) {
-    if (error == null) {
-      if (code === NGHTTP2_NO_ERROR &&
-          (!this._readableState.ended ||
-          !this._writableState.ended ||
-          this._writableState.pendingcb > 0 ||
-          !this.closed)) {
-        return;
-      }
+    if (error || code !== NGHTTP2_NO_ERROR) {
+      this.destroy(error);
+      return;
     }
-    this.destroy(error);
+
+    // TODO(mcollina): remove usage of _*State properties
+    if (this._readableState.ended &&
+        this._writableState.ended &&
+        this._writableState.pendingcb === 0 &&
+        this.closed) {
+      this.destroy();
+      // This should return, but eslint complains.
+      // return
+    }
   }
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -364,7 +364,7 @@ function onSettings() {
   session[kUpdateTimer]();
   debug(`Http2Session ${sessionName(session[kType])}: new settings received`);
   session[kRemoteSettings] = undefined;
-  process.nextTick(emit, session, 'remoteSettings', session.remoteSettings);
+  session.emit('remoteSettings', session.remoteSettings);
 }
 
 // If the stream exists, an attempt will be made to emit an event
@@ -380,7 +380,7 @@ function onPriority(id, parent, weight, exclusive) {
   const emitter = session[kState].streams.get(id) || session;
   if (!emitter.destroyed) {
     emitter[kUpdateTimer]();
-    process.nextTick(emit, emitter, 'priority', id, parent, weight, exclusive);
+    emitter.emit('priority', id, parent, weight, exclusive);
   }
 }
 
@@ -394,7 +394,7 @@ function onFrameError(id, type, code) {
         `type ${type} on stream ${id}, code: ${code}`);
   const emitter = session[kState].streams.get(id) || session;
   emitter[kUpdateTimer]();
-  process.nextTick(emit, emitter, 'frameError', type, code, id);
+  emitter.emit('frameError', type, code, id);
 }
 
 function onAltSvc(stream, origin, alt) {
@@ -404,7 +404,7 @@ function onAltSvc(stream, origin, alt) {
   debug(`Http2Session ${sessionName(session[kType])}: altsvc received: ` +
         `stream: ${stream}, origin: ${origin}, alt: ${alt}`);
   session[kUpdateTimer]();
-  process.nextTick(emit, session, 'altsvc', alt, origin, stream);
+  session.emit('altsvc', alt, origin, stream);
 }
 
 // Receiving a GOAWAY frame from the connected peer is a signal that no
@@ -734,7 +734,7 @@ function setupHandle(socket, type, options) {
   // core will check for session.destroyed before progressing, this
   // ensures that those at l`east get cleared out.
   if (this.destroyed) {
-    process.nextTick(emit, this, 'connect', this, socket);
+    this.emit('connect', this, socket);
     return;
   }
   debug(`Http2Session ${sessionName(type)}: setting up session handle`);
@@ -776,7 +776,7 @@ function setupHandle(socket, type, options) {
     options.settings : {};
 
   this.settings(settings);
-  process.nextTick(emit, this, 'connect', this, socket);
+  this.emit('connect', this, socket);
 }
 
 // Emits a close event followed by an error event if err is truthy. Used
@@ -1227,7 +1227,7 @@ class Http2Session extends EventEmitter {
       }
     }
 
-    process.nextTick(emit, this, 'timeout');
+    this.emit('timeout');
   }
 
   ref() {
@@ -1455,8 +1455,8 @@ function streamOnPause() {
 function abort(stream) {
   if (!stream.aborted &&
       !(stream._writableState.ended || stream._writableState.ending)) {
-    process.nextTick(emit, stream, 'aborted');
     stream[kState].flags |= STREAM_FLAGS_ABORTED;
+    stream.emit('aborted');
   }
 }
 
@@ -1578,7 +1578,7 @@ class Http2Stream extends Duplex {
       }
     }
 
-    process.nextTick(emit, this, 'timeout');
+    this.emit('timeout');
   }
 
   // true if the HEADERS frame has been sent

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1647,7 +1647,7 @@ class Http2Stream extends Duplex {
     req.async = false;
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
-      return this.destroy(util._errnoException(err, 'write', req.error), cb);
+      return this.destroy(errors.errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 
@@ -1690,7 +1690,7 @@ class Http2Stream extends Duplex {
     }
     const err = handle.writev(req, chunks);
     if (err)
-      return this.destroy(util._errnoException(err, 'write', req.error), cb);
+      return this.destroy(errors.errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const errors = require('internal/errors');
 const util = require('util');
 const constants = process.binding('constants').os.signals;
 
@@ -180,7 +181,7 @@ function setupKillAndExit() {
     }
 
     if (err)
-      throw util._errnoException(err, 'kill');
+      throw errors.errnoException(err, 'kill');
 
     return true;
   };
@@ -211,7 +212,7 @@ function setupSignalHandlers() {
       const err = wrap.start(signum);
       if (err) {
         wrap.close();
-        throw util._errnoException(err, 'uv_signal_start');
+        throw errors.errnoException(err, 'uv_signal_start');
       }
 
       signalWraps[type] = wrap;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -3,8 +3,8 @@
 const errors = require('internal/errors');
 const binding = process.binding('util');
 const { signals } = process.binding('constants').os;
-
 const { createPromise, promiseResolve, promiseReject } = binding;
+const { errmap } = process.binding('uv');
 
 const kArrowMessagePrivateSymbolIndex = binding.arrow_message_private_symbol;
 const kDecoratedPrivateSymbolIndex = binding.decorated_private_symbol;
@@ -201,6 +201,16 @@ function getConstructorOf(obj) {
   return null;
 }
 
+function getSystemErrorName(err) {
+  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
+                               'negative number');
+  }
+
+  const entry = errmap.get(err);
+  return entry ? entry[0] : `Unknown system error ${err}`;
+}
+
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
@@ -286,6 +296,7 @@ module.exports = {
   emitExperimentalWarning,
   filterDuplicateStrings,
   getConstructorOf,
+  getSystemErrorName,
   isError,
   join,
   normalizeEncoding,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -202,11 +202,6 @@ function getConstructorOf(obj) {
 }
 
 function getSystemErrorName(err) {
-  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
-                               'negative number');
-  }
-
   const entry = errmap.get(err);
   return entry ? entry[0] : `Unknown system error ${err}`;
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -48,8 +48,8 @@ const dns = require('dns');
 // reasons it's lazy loaded.
 var cluster = null;
 
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = errors.errnoException;
+const exceptionWithHostPort = errors.exceptionWithHostPort;
 
 function noop() {}
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -21,11 +21,9 @@
 
 'use strict';
 
-const util = require('util');
+const { inherits, _extend } = require('util');
 const net = require('net');
 const { TTY, isTTY } = process.binding('tty_wrap');
-const { inherits } = util;
-const errnoException = util._errnoException;
 const errors = require('internal/errors');
 const readline = require('readline');
 
@@ -40,7 +38,7 @@ function ReadStream(fd, options) {
   if (fd >> 0 !== fd || fd < 0)
     throw new errors.RangeError('ERR_INVALID_FD', fd);
 
-  options = util._extend({
+  options = _extend({
     highWaterMark: 0,
     readable: true,
     writable: false,
@@ -99,7 +97,7 @@ WriteStream.prototype._refreshSize = function() {
   var winSize = new Array(2);
   var err = this._handle.getWindowSize(winSize);
   if (err) {
-    this.emit('error', errnoException(err, 'getWindowSize'));
+    this.emit('error', errors.errnoException(err, 'getWindowSize'));
     return;
   }
   var newCols = winSize[0];

--- a/lib/util.js
+++ b/lib/util.js
@@ -983,41 +983,6 @@ function error(...args) {
   }
 }
 
-function _errnoException(err, syscall, original) {
-  const name = getSystemErrorName(err);
-  var message = `${syscall} ${name}`;
-  if (original)
-    message += ` ${original}`;
-  var e = new Error(message);
-  e.code = name;
-  e.errno = name;
-  e.syscall = syscall;
-  return e;
-}
-
-function _exceptionWithHostPort(err,
-                                syscall,
-                                address,
-                                port,
-                                additional) {
-  var details;
-  if (port && port > 0) {
-    details = `${address}:${port}`;
-  } else {
-    details = address;
-  }
-
-  if (additional) {
-    details += ` - Local (${additional})`;
-  }
-  var ex = exports._errnoException(err, syscall, details);
-  ex.address = address;
-  if (port) {
-    ex.port = port;
-  }
-  return ex;
-}
-
 function callbackifyOnRejected(reason, cb) {
   // `!reason` guard inspired by bluebird (Ref: https://goo.gl/t5IS6M).
   // Because `null` is a special error value in callbacks which means "no error
@@ -1075,8 +1040,8 @@ function getSystemErrorName(err) {
 
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
-  _errnoException,
-  _exceptionWithHostPort,
+  _errnoException: errors.errnoException,
+  _exceptionWithHostPort: errors.exceptionWithHostPort,
   _extend,
   callbackify,
   debuglog,

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,8 +25,6 @@ const errors = require('internal/errors');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 
-const { errname } = process.binding('uv');
-
 const {
   getPromiseDetails,
   getProxyDetails,
@@ -52,6 +50,7 @@ const {
   customInspectSymbol,
   deprecate,
   getConstructorOf,
+  getSystemErrorName,
   isError,
   promisify,
   join
@@ -985,7 +984,7 @@ function error(...args) {
 }
 
 function _errnoException(err, syscall, original) {
-  var name = errname(err);
+  const name = getSystemErrorName(err);
   var message = `${syscall} ${name}`;
   if (original)
     message += ` ${original}`;
@@ -1075,6 +1074,7 @@ module.exports = exports = {
   debuglog,
   deprecate,
   format,
+  getSystemErrorName,
   inherits,
   inspect,
   isArray: Array.isArray,

--- a/lib/util.js
+++ b/lib/util.js
@@ -50,7 +50,7 @@ const {
   customInspectSymbol,
   deprecate,
   getConstructorOf,
-  getSystemErrorName,
+  getSystemErrorName: internalErrorName,
   isError,
   promisify,
   join
@@ -1063,6 +1063,14 @@ function callbackify(original) {
   Object.defineProperties(callbackified,
                           Object.getOwnPropertyDescriptors(original));
   return callbackified;
+}
+
+function getSystemErrorName(err) {
+  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
+                               'negative number');
+  }
+  return internalErrorName(err);
 }
 
 // Keep the `exports =` so that various functions can still be monkeypatched

--- a/src/node.h
+++ b/src/node.h
@@ -178,7 +178,6 @@ NODE_EXTERN v8::Local<v8::Value> MakeCallback(
 #endif
 
 #ifdef _WIN32
-// TODO(tjfontaine) consider changing the usage of ssize_t to ptrdiff_t
 #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
 typedef intptr_t ssize_t;
 # define _SSIZE_T_

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2209,6 +2209,17 @@ ssize_t Http2Stream::Provider::Stream::OnRead(nghttp2_session* handle,
 
   size_t amount = 0;          // amount of data being sent in this data frame.
 
+  // Remove all empty chunks from the head of the queue.
+  // This is done here so that .write('', cb) is still a meaningful way to
+  // find out when the HTTP2 stream wants to consume data, and because the
+  // StreamBase API allows empty input chunks.
+  while (!stream->queue_.empty() && stream->queue_.front().buf.len == 0) {
+    WriteWrap* finished = stream->queue_.front().req_wrap;
+    stream->queue_.pop();
+    if (finished != nullptr)
+      finished->Done(0);
+  }
+
   if (!stream->queue_.empty()) {
     DEBUG_HTTP2SESSION2(session, "stream %d has pending outbound data", id);
     amount = std::min(stream->available_outbound_length_, length);
@@ -2222,7 +2233,8 @@ ssize_t Http2Stream::Provider::Stream::OnRead(nghttp2_session* handle,
     }
   }
 
-  if (amount == 0 && stream->IsWritable() && stream->queue_.empty()) {
+  if (amount == 0 && stream->IsWritable()) {
+    CHECK(stream->queue_.empty());
     DEBUG_HTTP2SESSION2(session, "deferring stream %d", id);
     return NGHTTP2_ERR_DEFERRED;
   }

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1712,6 +1712,14 @@ void Http2Session::OnStreamDestructImpl(void* ctx) {
   session->stream_ = nullptr;
 }
 
+bool Http2Session::HasWritesOnSocketForStream(Http2Stream* stream) {
+  for (const nghttp2_stream_write& wr : outgoing_buffers_) {
+    if (wr.req_wrap != nullptr && wr.req_wrap->stream() == stream)
+      return true;
+  }
+  return false;
+}
+
 // Every Http2Session session is tightly bound to a single i/o StreamBase
 // (typically a net.Socket or tls.TLSSocket). The lifecycle of the two is
 // tightly coupled with all data transfer between the two happening at the
@@ -1770,13 +1778,12 @@ Http2Stream::Http2Stream(
 
 
 Http2Stream::~Http2Stream() {
+  DEBUG_HTTP2STREAM(this, "tearing down stream");
   if (session_ != nullptr) {
     session_->RemoveStream(this);
     session_ = nullptr;
   }
 
-  if (!object().IsEmpty())
-    ClearWrap(object());
   persistent().Reset();
   CHECK(persistent().IsEmpty());
 }
@@ -1861,7 +1868,7 @@ inline void Http2Stream::Destroy() {
     Http2Stream* stream = static_cast<Http2Stream*>(data);
     // Free any remaining outgoing data chunks here. This should be done
     // here because it's possible for destroy to have been called while
-    // we still have qeueued outbound writes.
+    // we still have queued outbound writes.
     while (!stream->queue_.empty()) {
       nghttp2_stream_write& head = stream->queue_.front();
       if (head.req_wrap != nullptr)
@@ -1869,7 +1876,11 @@ inline void Http2Stream::Destroy() {
       stream->queue_.pop();
     }
 
-    delete stream;
+    // We can destroy the stream now if there are no writes for it
+    // already on the socket. Otherwise, we'll wait for the garbage collector
+    // to take care of cleaning up.
+    if (!stream->session()->HasWritesOnSocketForStream(stream))
+      delete stream;
   }, this, this->object());
 
   statistics_.end_time = uv_hrtime();

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -775,13 +775,7 @@ inline ssize_t Http2Session::Write(const uv_buf_t* bufs, size_t nbufs) {
                                bufs[n].len);
     CHECK_NE(ret, NGHTTP2_ERR_NOMEM);
 
-    // If there is an error calling any of the callbacks, ret will be a
-    // negative number identifying the error code. This can happen, for
-    // instance, if the session is destroyed during any of the JS callbacks
-    // Note: if ssize_t is not defined (e.g. on Win32), nghttp2 will typedef
-    // ssize_t to int. Cast here so that the < 0 check actually works on
-    // Windows.
-    if (static_cast<int>(ret) < 0)
+    if (ret < 0)
       return ret;
 
     total += ret;
@@ -1693,7 +1687,7 @@ void Http2Session::OnStreamReadImpl(ssize_t nread,
     // ssize_t to int. Cast here so that the < 0 check actually works on
     // Windows.
     if (static_cast<int>(ret) < 0) {
-      DEBUG_HTTP2SESSION2(session, "fatal error receiving data: %d", ret);
+      DEBUG_HTTP2SESSION2(this, "fatal error receiving data: %d", ret);
 
       Local<Value> argv[1] = {
         Integer::New(isolate, ret),

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -39,16 +39,20 @@ void inline debug_vfprintf(const char* format, ...) {
 #define DEBUG_HTTP2(...) debug_vfprintf(__VA_ARGS__);
 #define DEBUG_HTTP2SESSION(session, message)                                  \
   do {                                                                        \
-    DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                      \
-                   session->TypeName(),                                       \
-                   session->get_async_id());                                  \
+    if (session != nullptr) {                                                 \
+      DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                    \
+                  session->TypeName(),                                        \
+                  session->get_async_id());                                   \
+     }                                                                        \
   } while (0)
 #define DEBUG_HTTP2SESSION2(session, message, ...)                            \
   do {                                                                        \
-    DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                      \
-                   session->TypeName(),                                       \
-                   session->get_async_id(),                                   \
+    if (session != nullptr) {                                                 \
+      DEBUG_HTTP2("Http2Session %s (%.0lf) " message "\n",                    \
+                  session->TypeName(),                                        \
+                  session->get_async_id(),                                    \
                   __VA_ARGS__);                                               \
+    }                                                                         \
   } while (0)
 #define DEBUG_HTTP2STREAM(stream, message)                                    \
   do {                                                                        \

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -869,6 +869,9 @@ class Http2Session : public AsyncWrap {
   // Removes a stream instance from this session
   inline void RemoveStream(Http2Stream* stream);
 
+  // Indicates whether there currently exist outgoing buffers for this stream.
+  bool HasWritesOnSocketForStream(Http2Stream* stream);
+
   // Write data to the session
   inline ssize_t Write(const uv_buf_t* bufs, size_t nbufs);
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -39,6 +39,8 @@ using v8::String;
 using v8::Value;
 
 
+// TODO(joyeecheung): deprecate this function in favor of
+// lib/util.getSystemErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int err = args[0]->Int32Value();

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -27,11 +27,15 @@
 namespace node {
 namespace {
 
+using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Integer;
+using v8::Isolate;
 using v8::Local;
+using v8::Map;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 
@@ -49,15 +53,31 @@ void InitializeUV(Local<Object> target,
                   Local<Value> unused,
                   Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "errname"),
+  Isolate* isolate = env->isolate();
+  target->Set(FIXED_ONE_BYTE_STRING(isolate, "errname"),
               env->NewFunctionTemplate(ErrName)->GetFunction());
 #define V(name, _)                                                            \
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "UV_" # name),            \
               Integer::New(env->isolate(), UV_ ## name));
   UV_ERRNO_MAP(V)
 #undef V
-}
 
+  Local<Map> err_map = Map::New(isolate);
+
+#define V(name, msg) do {                                                     \
+  Local<Array> arr = Array::New(isolate, 2);                                  \
+  arr->Set(0, OneByteString(isolate, #name));                                 \
+  arr->Set(1, OneByteString(isolate, msg));                                   \
+  err_map->Set(context,                                                       \
+               Integer::New(isolate, UV_##name),                              \
+               arr).ToLocalChecked();                                         \
+} while (0);
+  UV_ERRNO_MAP(V)
+#undef V
+
+  target->Set(context, FIXED_ONE_BYTE_STRING(isolate, "errmap"),
+              err_map).FromJust();
+}
 
 }  // anonymous namespace
 }  // namespace node

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -692,6 +692,9 @@ exports.expectsError = function expectsError(fn, settings, exact) {
   }
   function innerFn(error) {
     assert.strictEqual(error.code, settings.code);
+    const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
+    assert.strictEqual(descriptor.enumerable,
+                       false, 'The error message should be non-enumerable');
     if ('type' in settings) {
       const type = settings.type;
       if (type !== Error && !Error.isPrototypeOf(type)) {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -1,8 +1,9 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const uv = process.binding('uv');
+const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
@@ -27,7 +28,7 @@ const execOpts = { encoding: 'utf8', shell: true };
   const code = -1;
   const callback = common.mustCall((err, stdout, stderr) => {
     assert.strictEqual(err.toString().trim(), errorString);
-    assert.strictEqual(err.code, uv.errname(code));
+    assert.strictEqual(err.code, getSystemErrorName(code));
     assert.strictEqual(err.killed, true);
     assert.strictEqual(err.signal, null);
     assert.strictEqual(err.cmd, process.execPath);

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -81,6 +81,9 @@ assert.doesNotThrow(() => {
     assert(error);
     assert.strictEqual(tickValue, 1);
     assert.strictEqual(error.code, 'ENOENT');
+    const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
+    assert.strictEqual(descriptor.enumerable,
+                       false, 'The error message should be non-enumerable');
   }));
 
   // Make sure that the error callback is called

--- a/test/parallel/test-dns-resolveany-bad-ancount.js
+++ b/test/parallel/test-dns-resolveany-bad-ancount.js
@@ -30,6 +30,9 @@ server.bind(0, common.mustCall(() => {
     assert.strictEqual(err.code, 'EBADRESP');
     assert.strictEqual(err.syscall, 'queryAny');
     assert.strictEqual(err.hostname, 'example.org');
+    const descriptor = Object.getOwnPropertyDescriptor(err, 'message');
+    assert.strictEqual(descriptor.enumerable,
+                       false, 'The error message should be non-enumerable');
     server.close();
   }));
 }));

--- a/test/parallel/test-http-server-options-incoming-message.js
+++ b/test/parallel/test-http-server-options-incoming-message.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * This test covers http.Server({ IncomingMessage }) option:
+ * With IncomingMessage option the server should use
+ * the new class for creating req Object instead of the default
+ * http.IncomingMessage.
+ */
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+class MyIncomingMessage extends http.IncomingMessage {
+  getUserAgent() {
+    return this.headers['user-agent'] || 'unknown';
+  }
+}
+
+const server = http.Server({
+  IncomingMessage: MyIncomingMessage
+}, common.mustCall(function(req, res) {
+  assert.strictEqual(req.getUserAgent(), 'node-test');
+  res.statusCode = 200;
+  res.end();
+}));
+server.listen();
+
+server.on('listening', function makeRequest() {
+  http.get({
+    port: this.address().port,
+    headers: {
+      'User-Agent': 'node-test'
+    }
+  }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.on('end', () => {
+      server.close();
+    });
+    res.resume();
+  });
+});

--- a/test/parallel/test-http-server-options-server-response.js
+++ b/test/parallel/test-http-server-options-server-response.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * This test covers http.Server({ ServerResponse }) option:
+ * With ServerResponse option the server should use
+ * the new class for creating res Object instead of the default
+ * http.ServerResponse.
+ */
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+class MyServerResponse extends http.ServerResponse {
+  status(code) {
+    return this.writeHead(code, { 'Content-Type': 'text/plain' });
+  }
+}
+
+const server = http.Server({
+  ServerResponse: MyServerResponse
+}, common.mustCall(function(req, res) {
+  res.status(200);
+  res.end();
+}));
+server.listen();
+
+server.on('listening', function makeRequest() {
+  http.get({ port: this.address().port }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.on('end', () => {
+      server.close();
+    });
+    res.resume();
+  });
+});

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -88,9 +88,14 @@ function runTest(test) {
     req.on('error', errorMustCall);
   } else {
     client.on('error', errorMustCall);
-    req.on('error', common.expectsError({
-      code: 'ERR_HTTP2_STREAM_CANCEL'
-    }));
+    req.on('error', (err) => {
+      common.expectsError({
+        code: 'ERR_HTTP2_STREAM_CANCEL'
+      })(err);
+      common.expectsError({
+        code: 'ERR_HTTP2_ERROR'
+      })(err.cause);
+    });
   }
 
   req.on('end', common.mustCall());

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -16,18 +16,30 @@ server.on('stream', (stream) => {
 server.listen(0, common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
-  req.close(1);
+  const closeCode = 1;
+
+  common.expectsError(
+    () => req.close(2 ** 32),
+    {
+      type: RangeError,
+      code: 'ERR_OUT_OF_RANGE',
+      message: 'The "code" argument is out of range'
+    }
+  );
+  assert.strictEqual(req.closed, false);
+
+  req.close(closeCode, common.mustCall());
   assert.strictEqual(req.closed, true);
 
   // make sure that destroy is called
   req._destroy = common.mustCall(req._destroy.bind(req));
 
-  // second call doesn't do anything
-  assert.doesNotThrow(() => req.close(8));
+  // Second call doesn't do anything.
+  req.close(closeCode + 1);
 
   req.on('close', common.mustCall((code) => {
     assert.strictEqual(req.destroyed, true);
-    assert.strictEqual(code, 1);
+    assert.strictEqual(code, closeCode);
     server.close();
     client.close();
   }));
@@ -35,7 +47,7 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     type: Error,
-    message: 'Stream closed with error code 1'
+    message: `Stream closed with error code ${closeCode}`
   }));
 
   req.on('response', common.mustCall());

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -28,6 +28,18 @@ server.listen(0, common.mustCall(() => {
   );
   assert.strictEqual(req.closed, false);
 
+  [true, 1, {}, [], null, 'test'].forEach((notFunction) => {
+    common.expectsError(
+      () => req.close(closeCode, notFunction),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_CALLBACK',
+        message: 'callback must be a function'
+      }
+    );
+    assert.strictEqual(req.closed, false);
+  });
+
   req.close(closeCode, common.mustCall());
   assert.strictEqual(req.closed, true);
 

--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('assert');
+const http2 = require('http2');
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+for (const chunkSequence of [
+  [ '' ],
+  [ '', '' ]
+]) {
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, headers, flags) => {
+    stream.respond({ 'content-type': 'text/html' });
+
+    let data = '';
+    stream.on('data', common.mustNotCall((chunk) => {
+      data += chunk.toString();
+    }));
+    stream.on('end', common.mustCall(() => {
+      stream.end(`"${data}"`);
+    }));
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
+
+    const req = client.request({
+      ':method': 'POST',
+      ':path': '/'
+    });
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+      assert.strictEqual(headers['content-type'], 'text/html');
+    }));
+
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', common.mustCallAtLeast((d) => data += d));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(data, '""');
+      server.close();
+      client.close();
+    }));
+
+    for (const chunk of chunkSequence)
+      req.write(chunk);
+    req.end();
+  }));
+}

--- a/test/parallel/test-http2-compat-short-stream-client-server.js
+++ b/test/parallel/test-http2-compat-short-stream-client-server.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const { Readable } = require('stream');
+
+const server = http2.createServer(common.mustCall((req, res) => {
+  res.setHeader('content-type', 'text/html');
+  const input = new Readable({
+    read() {
+      this.push('test');
+      this.push(null);
+    }
+  });
+  input.pipe(res);
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+    assert.strictEqual(headers['content-type'], 'text/html');
+  }));
+
+  let data = '';
+
+  const notCallClose = common.mustNotCall();
+
+  setTimeout(() => {
+    req.setEncoding('utf8');
+    req.removeListener('close', notCallClose);
+    req.on('close', common.mustCall(() => {
+      server.close();
+      client.close();
+    }));
+    req.on('data', common.mustCallAtLeast((d) => data += d));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(data, 'test');
+    }));
+  }, common.platformTimeout(100));
+
+  req.on('close', notCallClose);
+}));

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -5,6 +5,9 @@ if (!hasCrypto)
   skip('missing crypto');
 const { doesNotThrow, throws } = require('assert');
 const { createServer, connect } = require('http2');
+const { connect: netConnect } = require('net');
+
+// check for session connect callback and event
 {
   const server = createServer();
   server.listen(0, mustCall(() => {
@@ -27,6 +30,28 @@ const { createServer, connect } = require('http2');
         }
       }));
     }
+  }));
+}
+
+// check for session connect callback on already connected socket
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const { port } = server.address();
+
+    const onSocketConnect = () => {
+      const authority = `http://localhost:${port}`;
+      const createConnection = mustCall(() => socket);
+      const options = { createConnection };
+      connect(authority, options, mustCall(onSessionConnect));
+    };
+
+    const onSessionConnect = (session) => {
+      session.close();
+      server.close();
+    };
+
+    const socket = netConnect(port, mustCall(onSocketConnect));
   }));
 }
 

--- a/test/parallel/test-http2-https-fallback-http-server-options.js
+++ b/test/parallel/test-http2-https-fallback-http-server-options.js
@@ -1,0 +1,90 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const url = require('url');
+const tls = require('tls');
+const http2 = require('http2');
+const https = require('https');
+const http = require('http');
+
+const key = fixtures.readKey('agent8-key.pem');
+const cert = fixtures.readKey('agent8-cert.pem');
+const ca = fixtures.readKey('fake-startcom-root-cert.pem');
+
+function onRequest(request, response) {
+  const { socket: { alpnProtocol } } = request.httpVersion === '2.0' ?
+    request.stream.session : request;
+  response.status(200);
+  response.end(JSON.stringify({
+    alpnProtocol,
+    httpVersion: request.httpVersion,
+    userAgent: request.getUserAgent()
+  }));
+}
+
+class MyIncomingMessage extends http.IncomingMessage {
+  getUserAgent() {
+    return this.headers['user-agent'] || 'unknown';
+  }
+}
+
+class MyServerResponse extends http.ServerResponse {
+  status(code) {
+    return this.writeHead(code, { 'Content-Type': 'application/json' });
+  }
+}
+
+// HTTP/2 & HTTP/1.1 server
+{
+  const server = http2.createSecureServer(
+    {
+      cert,
+      key, allowHTTP1: true,
+      Http1IncomingMessage: MyIncomingMessage,
+      Http1ServerResponse: MyServerResponse
+    },
+    common.mustCall(onRequest, 1)
+  );
+
+  server.listen(0);
+
+  server.on('listening', common.mustCall(() => {
+    const { port } = server.address();
+    const origin = `https://localhost:${port}`;
+
+    // HTTP/1.1 client
+    https.get(
+      Object.assign(url.parse(origin), {
+        secureContext: tls.createSecureContext({ ca }),
+        headers: { 'User-Agent': 'node-test' }
+      }),
+      common.mustCall((response) => {
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.statusMessage, 'OK');
+        assert.strictEqual(
+          response.headers['content-type'],
+          'application/json'
+        );
+
+        response.setEncoding('utf8');
+        let raw = '';
+        response.on('data', (chunk) => { raw += chunk; });
+        response.on('end', common.mustCall(() => {
+          const { alpnProtocol, httpVersion, userAgent } = JSON.parse(raw);
+          assert.strictEqual(alpnProtocol, false);
+          assert.strictEqual(httpVersion, '1.1');
+          assert.strictEqual(userAgent, 'node-test');
+
+          server.close();
+        }));
+      })
+    );
+  }));
+}

--- a/test/parallel/test-http2-options-server-request.js
+++ b/test/parallel/test-http2-options-server-request.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+class MyServerRequest extends h2.Http2ServerRequest {
+  getUserAgent() {
+    return this.headers['user-agent'] || 'unknown';
+  }
+}
+
+const server = h2.createServer({
+  Http2ServerRequest: MyServerRequest
+}, (req, res) => {
+  assert.strictEqual(req.getUserAgent(), 'node-test');
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end();
+});
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({
+    ':path': '/',
+    'User-Agent': 'node-test'
+  });
+
+  req.on('response', common.mustCall());
+
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+}));

--- a/test/parallel/test-http2-options-server-response.js
+++ b/test/parallel/test-http2-options-server-response.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+class MyServerResponse extends h2.Http2ServerResponse {
+  status(code) {
+    return this.writeHead(code, { 'Content-Type': 'text/plain' });
+  }
+}
+
+const server = h2.createServer({
+  Http2ServerResponse: MyServerResponse
+}, (req, res) => {
+  res.status(200);
+  res.end();
+});
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustCall());
+
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+}));

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -5,93 +5,81 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
-const {
-  constants,
-  Http2Stream,
-  nghttp2ErrorString
-} = process.binding('http2');
+const { Http2Stream } = process.binding('http2');
 
-// tests error handling within respond
-// - every other NGHTTP2 error from binding (should emit stream error)
-
-const specificTestKeys = [];
-
-const specificTests = [];
-
-const genericTests = Object.getOwnPropertyNames(constants)
-  .filter((key) => (
-    key.indexOf('NGHTTP2_ERR') === 0 && specificTestKeys.indexOf(key) < 0
-  ))
-  .map((key) => ({
-    ngError: constants[key],
-    error: {
-      code: 'ERR_HTTP2_ERROR',
-      type: Error,
-      message: nghttp2ErrorString(constants[key])
-    },
-    type: 'stream'
-  }));
-
-
-const tests = specificTests.concat(genericTests);
-
-let currentError;
-
-// mock submitResponse because we only care about testing error handling
-Http2Stream.prototype.respond = () => currentError.ngError;
+const types = {
+  boolean: true,
+  function: () => {},
+  number: 1,
+  object: {},
+  array: [],
+  null: null,
+  symbol: Symbol('test')
+};
 
 const server = http2.createServer();
-server.on('stream', common.mustCall((stream, headers) => {
-  const errorMustCall = common.expectsError(currentError.error);
-  const errorMustNotCall = common.mustNotCall(
-    `${currentError.error.code} should emit on ${currentError.type}`
+
+Http2Stream.prototype.respond = () => 1;
+server.on('stream', common.mustCall((stream) => {
+
+  // Check for all possible TypeError triggers on options.getTrailers
+  Object.entries(types).forEach(([type, value]) => {
+    if (type === 'function') {
+      return;
+    }
+
+    common.expectsError(
+      () => stream.respond({
+        'content-type': 'text/plain'
+      }, {
+        ['getTrailers']: value
+      }),
+      {
+        type: TypeError,
+        code: 'ERR_INVALID_OPT_VALUE',
+        message: `The value "${String(value)}" is invalid ` +
+                  'for option "getTrailers"'
+      }
+    );
+  });
+
+  // Send headers
+  stream.respond({
+    'content-type': 'text/plain'
+  }, {
+    ['getTrailers']: () => common.mustCall()
+  });
+
+  // Should throw if headers already sent
+  common.expectsError(
+    () => stream.respond(),
+    {
+      type: Error,
+      code: 'ERR_HTTP2_HEADERS_SENT',
+      message: 'Response has already been initiated.'
+    }
   );
 
-  if (currentError.type === 'stream') {
-    stream.session.on('error', errorMustNotCall);
-    stream.on('error', errorMustCall);
-    stream.on('error', common.mustCall(() => {
-      stream.destroy();
-    }));
-  } else {
-    stream.session.once('error', errorMustCall);
-    stream.on('error', errorMustNotCall);
-  }
+  // Should throw if stream already destroyed
+  stream.destroy();
+  common.expectsError(
+    () => stream.respond(),
+    {
+      type: Error,
+      code: 'ERR_HTTP2_INVALID_STREAM',
+      message: 'The stream has been destroyed'
+    }
+  );
+}));
 
-  stream.respond();
-}, tests.length));
-
-server.listen(0, common.mustCall(() => runTest(tests.shift())));
-
-function runTest(test) {
-  const port = server.address().port;
-  const url = `http://localhost:${port}`;
-  const headers = {
-    ':path': '/',
-    ':method': 'POST',
-    ':scheme': 'http',
-    ':authority': `localhost:${port}`
-  };
-
-  const client = http2.connect(url);
-  const req = client.request(headers);
-  req.on('error', common.expectsError({
-    code: 'ERR_HTTP2_STREAM_ERROR',
-    type: Error,
-    message: 'Stream closed with error code 2'
-  }));
-
-  currentError = test;
-  req.resume();
-  req.end();
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
 
   req.on('end', common.mustCall(() => {
     client.close();
-
-    if (!tests.length) {
-      server.close();
-    } else {
-      runTest(tests.shift());
-    }
+    server.close();
   }));
-}
+  req.resume();
+  req.end();
+}));

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -1,0 +1,99 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const {
+  constants,
+  Http2Stream,
+  nghttp2ErrorString
+} = process.binding('http2');
+const { NghttpError } = require('internal/http2/util');
+
+// tests error handling within respond
+// - every other NGHTTP2 error from binding (should emit stream error)
+
+const specificTestKeys = [];
+
+const specificTests = [];
+
+const genericTests = Object.getOwnPropertyNames(constants)
+  .filter((key) => (
+    key.indexOf('NGHTTP2_ERR') === 0 && specificTestKeys.indexOf(key) < 0
+  ))
+  .map((key) => ({
+    ngError: constants[key],
+    error: {
+      code: 'ERR_HTTP2_ERROR',
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
+      message: nghttp2ErrorString(constants[key])
+    },
+    type: 'stream'
+  }));
+
+
+const tests = specificTests.concat(genericTests);
+
+let currentError;
+
+// mock submitResponse because we only care about testing error handling
+Http2Stream.prototype.respond = () => currentError.ngError;
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream, headers) => {
+  const errorMustCall = common.expectsError(currentError.error);
+  const errorMustNotCall = common.mustNotCall(
+    `${currentError.error.code} should emit on ${currentError.type}`
+  );
+
+  if (currentError.type === 'stream') {
+    stream.session.on('error', errorMustNotCall);
+    stream.on('error', errorMustCall);
+    stream.on('error', common.mustCall(() => {
+      stream.destroy();
+    }));
+  } else {
+    stream.session.once('error', errorMustCall);
+    stream.on('error', errorMustNotCall);
+  }
+
+  stream.respond();
+}, tests.length));
+
+server.listen(0, common.mustCall(() => runTest(tests.shift())));
+
+function runTest(test) {
+  const port = server.address().port;
+  const url = `http://localhost:${port}`;
+  const headers = {
+    ':path': '/',
+    ':method': 'POST',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  };
+
+  const client = http2.connect(url);
+  const req = client.request(headers);
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    type: Error,
+    message: 'Stream closed with error code 2'
+  }));
+
+  currentError = test;
+  req.resume();
+  req.end();
+
+  req.on('end', common.mustCall(() => {
+    client.close();
+
+    if (!tests.length) {
+      server.close();
+    } else {
+      runTest(tests.shift());
+    }
+  }));
+}

--- a/test/parallel/test-http2-short-stream-client-server.js
+++ b/test/parallel/test-http2-short-stream-client-server.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const { Readable } = require('stream');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({
+    ':status': 200,
+    'content-type': 'text/html'
+  });
+  const input = new Readable({
+    read() {
+      this.push('test');
+      this.push(null);
+    }
+  });
+  input.pipe(stream);
+}));
+
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+    assert.strictEqual(headers['content-type'], 'text/html');
+  }));
+
+  let data = '';
+
+  const notCallClose = common.mustNotCall();
+
+  setTimeout(() => {
+    req.setEncoding('utf8');
+    req.removeListener('close', notCallClose);
+    req.on('close', common.mustCall(() => {
+      server.close();
+      client.close();
+    }));
+    req.on('data', common.mustCallAtLeast((d) => data += d));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(data, 'test');
+    }));
+  }, common.platformTimeout(100));
+
+  req.on('close', notCallClose);
+}));

--- a/test/parallel/test-http2-write-finishes-after-stream-destroy.js
+++ b/test/parallel/test-http2-write-finishes-after-stream-destroy.js
@@ -1,0 +1,62 @@
+// Flags: --expose-gc
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const makeDuplexPair = require('../common/duplexpair');
+
+// Make sure the Http2Stream destructor works, since we don't clean the
+// stream up like we would otherwise do.
+process.on('exit', global.gc);
+
+{
+  const { clientSide, serverSide } = makeDuplexPair();
+
+  let serverSideHttp2Stream;
+  let serverSideHttp2StreamDestroyed = false;
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, headers) => {
+    serverSideHttp2Stream = stream;
+    stream.respond({
+      'content-type': 'text/html',
+      ':status': 200
+    });
+
+    const originalWrite = serverSide._write;
+    serverSide._write = (buf, enc, cb) => {
+      if (serverSideHttp2StreamDestroyed) {
+        serverSide.destroy();
+        serverSide.write = () => {};
+      } else {
+        setImmediate(() => {
+          originalWrite.call(serverSide, buf, enc, () => setImmediate(cb));
+        });
+      }
+    };
+
+    // Enough data to fit into a single *session* window,
+    // not enough data to fit into a single *stream* window.
+    stream.write(Buffer.alloc(40000));
+  }));
+
+  server.emit('connection', serverSide);
+
+  const client = http2.connect('http://localhost:80', {
+    createConnection: common.mustCall(() => clientSide)
+  });
+
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+  }));
+
+  req.on('data', common.mustCallAtLeast(() => {
+    if (!serverSideHttp2StreamDestroyed) {
+      serverSideHttp2Stream.destroy();
+      serverSideHttp2StreamDestroyed = true;
+    }
+  }));
+}

--- a/test/parallel/test-https-server-options-incoming-message.js
+++ b/test/parallel/test-https-server-options-incoming-message.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * This test covers http.Server({ IncomingMessage }) option:
+ * With IncomingMessage option the server should use
+ * the new class for creating req Object instead of the default
+ * http.IncomingMessage.
+ */
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http = require('http');
+const https = require('https');
+
+class MyIncomingMessage extends http.IncomingMessage {
+  getUserAgent() {
+    return this.headers['user-agent'] || 'unknown';
+  }
+}
+
+const server = https.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca: fixtures.readKey('ca1-cert.pem'),
+  IncomingMessage: MyIncomingMessage
+}, common.mustCall(function(req, res) {
+  assert.strictEqual(req.getUserAgent(), 'node-test');
+  res.statusCode = 200;
+  res.end();
+}));
+server.listen();
+
+server.on('listening', function makeRequest() {
+  https.get({
+    port: this.address().port,
+    rejectUnauthorized: false,
+    headers: {
+      'User-Agent': 'node-test'
+    }
+  }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.on('end', () => {
+      server.close();
+    });
+    res.resume();
+  });
+});

--- a/test/parallel/test-https-server-options-server-response.js
+++ b/test/parallel/test-https-server-options-server-response.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * This test covers http.Server({ ServerResponse }) option:
+ * With ServerResponse option the server should use
+ * the new class for creating res Object instead of the default
+ * http.ServerResponse.
+ */
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http = require('http');
+const https = require('https');
+
+class MyServerResponse extends http.ServerResponse {
+  status(code) {
+    return this.writeHead(code, { 'Content-Type': 'text/plain' });
+  }
+}
+
+const server = https.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca: fixtures.readKey('ca1-cert.pem'),
+  ServerResponse: MyServerResponse
+}, common.mustCall(function(req, res) {
+  res.status(200);
+  res.end();
+}));
+server.listen();
+
+server.on('listening', function makeRequest() {
+  https.get({
+    port: this.address().port,
+    rejectUnauthorized: false
+  }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.on('end', () => {
+      server.close();
+    });
+    res.resume();
+  });
+});

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const fs = require('fs');
-const uv = process.binding('uv');
+const { getSystemErrorName } = require('util');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
@@ -47,9 +47,10 @@ function randomHandle(type) {
     handleName = `pipe ${path}`;
   }
 
-  if (errno < 0) {  // uv.errname requires err < 0
-    assert(errno >= 0, `unable to bind ${handleName}: ${uv.errname(errno)}`);
+  if (errno < 0) {
+    assert.fail(`unable to bind ${handleName}: ${getSystemErrorName(errno)}`);
   }
+
   if (!common.isWindows) {  // fd doesn't work on windows
     // err >= 0 but fd = -1, should not happen
     assert.notStrictEqual(handle.fd, -1,

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  getSystemErrorName,
+  _errnoException
+} = require('util');
+
+const uv = process.binding('uv');
+const keys = Object.keys(uv);
+
+keys.forEach((key) => {
+  if (!key.startsWith('UV_'))
+    return;
+
+  assert.doesNotThrow(() => {
+    const err = _errnoException(uv[key], 'test');
+    const name = uv.errname(uv[key]);
+    assert.strictEqual(getSystemErrorName(uv[key]), name);
+    assert.strictEqual(err.code, name);
+    assert.strictEqual(err.code, err.errno);
+    assert.strictEqual(err.message, `test ${name}`);
+  });
+});
+
+[0, 1, 'test', {}, [], Infinity, -Infinity, NaN].forEach((key) => {
+  common.expectsError(
+    () => _errnoException(key),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "err" argument must be of type negative number'
+    });
+});

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -7,6 +7,7 @@ const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
+const { getSystemErrorName } = require('util');
 
 // Make sure that all Providers are tested.
 {
@@ -214,7 +215,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
       // Use a long string to make sure the write happens asynchronously.
       const err = handle.writeLatin1String(wreq, 'hi'.repeat(100000));
       if (err)
-        throw new Error(`write failed: ${process.binding('uv').errname(err)}`);
+        throw new Error(`write failed: ${getSystemErrorName(err)}`);
       testInitialized(wreq, 'WriteWrap');
     });
     req.address = common.localhostIPv4;

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -54,8 +54,8 @@ const typeMap = {
   'http.ServerResponse': 'http.html#http_class_http_serverresponse',
 
   'ClientHttp2Stream': 'http2.html#http2_class_clienthttp2stream',
-  'HTTP2 Headers Object': 'http2.html#http2_headers_object',
-  'HTTP2 Settings Object': 'http2.html#http2_settings_object',
+  'HTTP/2 Headers Object': 'http2.html#http2_headers_object',
+  'HTTP/2 Settings Object': 'http2.html#http2_settings_object',
   'http2.Http2ServerRequest': 'http2.html#http2_class_http2_http2serverrequest',
   'http2.Http2ServerResponse':
     'http2.html#http2_class_http2_http2serverresponse',


### PR DESCRIPTION
- Only two commits from https://github.com/nodejs/node/pull/18546 are backported.
- Only the lazy loading util part of https://github.com/nodejs/node/pull/18358 is backported since ERR_INVALID_ARG_VALUE does not exist on v8.x
- `util: implement util.getSystemErrorName()` is semver-minor

src: expose uv.errmap to binding
Refs: https://github.com/nodejs/node/pull/17338

util: implement util.getSystemErrorName()
Refs: https://github.com/nodejs/node/pull/18186

errors: lazy load util in internal/errors.js
Refs: https://github.com/nodejs/node/pull/18358

util: skip type checks in internal getSystemErrorName
errors: move error creation helpers to errors.js
Refs: https://github.com/nodejs/node/pull/18546

