### PR TITLE
doc: remove warning against readable/readable.read()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -955,9 +955,6 @@ readable.on('readable', () => {
 });
 ```
 
-Avoid the use of the `'readable'` event and the `readable.read()` method in
-favor of using either `readable.pipe()` or the `'data'` event.
-
 A Readable stream in object mode will always return a single item from
 a call to [`readable.read(size)`][stream-read], regardless of the value of the
 `size` argument.


### PR DESCRIPTION
Remove suggestion to avoid `readable` event and `readabe.read()` method.
No explanation was provided for this suggestion.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
