### PR TITLE
[v8.x] node_crypto: Use <cmath> definitions of isnan and isinf

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -44,9 +44,9 @@
 #include "StartComAndWoSignData.inc"
 
 #include <algorithm>
+#include <cmath>
 #include <errno.h>
 #include <limits.h>  // INT_MAX
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <vector>
@@ -5623,7 +5623,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   }
 
   raw_keylen = args[3]->NumberValue();
-  if (raw_keylen < 0.0 || isnan(raw_keylen) || isinf(raw_keylen) ||
+  if (raw_keylen < 0.0 || std::isnan(raw_keylen) || std::isinf(raw_keylen) ||
       raw_keylen > INT_MAX) {
     type_error = "Bad key length";
     goto err;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5623,7 +5623,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   }
 
   raw_keylen = args[3]->NumberValue();
-  if (raw_keylen < 0.0 || std::isnan(raw_keylen) || std::isinf(raw_keylen) ||
+  if (raw_keylen < 0.0 || isnan(raw_keylen) || isinf(raw_keylen) ||
       raw_keylen > INT_MAX) {
     type_error = "Bad key length";
     goto err;


### PR DESCRIPTION
Unless you specify C++11, `std::isnan` and `std::isinf` are not guaranteed to be available. Instead, explicitly use the `cmath` functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
