### PR TITLE
deps: cherry-pick 15c0c3a8ba and 43e2fb1c3d from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.4',
+    'v8_embedder_string': '-node.5',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/profiler/cpu-profiler.cc
+++ b/deps/v8/src/profiler/cpu-profiler.cc
@@ -165,13 +165,16 @@ void ProfilerEventsProcessor::Run() {
 
     if (nextSampleTime > now) {
 #if V8_OS_WIN
-      // Do not use Sleep on Windows as it is very imprecise.
-      // Could be up to 16ms jitter, which is unacceptable for the purpose.
-      while (base::TimeTicks::HighResolutionNow() < nextSampleTime) {
-      }
-#else
-      base::OS::Sleep(nextSampleTime - now);
+      if (nextSampleTime - now < base::TimeDelta::FromMilliseconds(100)) {
+        // Do not use Sleep on Windows as it is very imprecise, with up to 16ms
+        // jitter, which is unacceptable for short profile intervals.
+        while (base::TimeTicks::HighResolutionNow() < nextSampleTime) {
+        }
+      } else  // NOLINT
 #endif
+      {
+        base::OS::Sleep(nextSampleTime - now);
+      }
     }
 
     // Schedule next sample. sampler_ is nullptr in tests.


### PR DESCRIPTION
These changes avoid a busy wait loop in V8 CPU Profiler thread for windows (except for short intervals).

It would be good if this is also backported to Node.js v9 and LTS releases as this busy loop effectively disallows the use of cpu-profiler in windows production setups.

Original commit message 15c0c3a8ba:
```
[profiler] use Sleep() on windows for long profile intervals.

See nodejs/diagnostics#170

R=franzih@chromium.org

Change-Id: Iecc3bb27707b0d2afbb23fd9823d5cd4d725be6e
Reviewed-on: https://chromium-review.googlesource.com/931102
Reviewed-by: Franziska Hinkelmann <franzih@chromium.org>
Commit-Queue: Yang Guo <yangguo@chromium.org>
Cr-Commit-Position: refs/heads/master@{#51466}
```

Original commit message 43e2fb1c3d:
```
[profiler] fix sleeping on windows for long intervals.
R=franzih@chromium.org

Change-Id: I5717db794fc797e7c3b0b8f122ddb6dc0702a99e
Reviewed-on: https://chromium-review.googlesource.com/941126
Reviewed-by: Franziska Hinkelmann <franzih@chromium.org>
Commit-Queue: Yang Guo <yangguo@chromium.org>
Cr-Commit-Position: refs/heads/master@{#51755}

```

Refs: nodejs/diagnostics#170
Refs: https://github.com/v8/v8/commit/15c0c3a8ba69d5b2cc521f7b380d59f76834eb53
Refs: https://github.com/v8/v8/commit/43e2fb1c3df10f01ecf8519b6835ca2c7377d1ca

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
