### PR TITLE
src: move `Environment` ctor/dtor into env.cc

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -319,67 +319,6 @@ inline Environment* Environment::GetThreadLocalEnv() {
   return static_cast<Environment*>(uv_key_get(&thread_local_env));
 }
 
-inline Environment::Environment(IsolateData* isolate_data,
-                                v8::Local<v8::Context> context)
-    : isolate_(context->GetIsolate()),
-      isolate_data_(isolate_data),
-      immediate_info_(context->GetIsolate()),
-      tick_info_(context->GetIsolate()),
-      timer_base_(uv_now(isolate_data->event_loop())),
-      printed_error_(false),
-      trace_sync_io_(false),
-      abort_on_uncaught_exception_(false),
-      emit_napi_warning_(true),
-      emit_env_nonstring_warning_(true),
-      makecallback_cntr_(0),
-      should_abort_on_uncaught_toggle_(isolate_, 1),
-#if HAVE_INSPECTOR
-      inspector_agent_(new inspector::Agent(this)),
-#endif
-      handle_cleanup_waiting_(0),
-      http_parser_buffer_(nullptr),
-      fs_stats_field_array_(isolate_, kFsStatsFieldsLength),
-      context_(context->GetIsolate(), context) {
-  // We'll be creating new objects so make sure we've entered the context.
-  v8::HandleScope handle_scope(isolate());
-  v8::Context::Scope context_scope(context);
-  set_as_external(v8::External::New(isolate(), this));
-
-  AssignToContext(context, ContextInfo(""));
-
-  destroy_async_id_list_.reserve(512);
-  performance_state_.reset(new performance::performance_state(isolate()));
-  performance_state_->milestones[
-      performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT] =
-          PERFORMANCE_NOW();
-  performance_state_->milestones[
-    performance::NODE_PERFORMANCE_MILESTONE_NODE_START] =
-        performance::performance_node_start;
-  performance_state_->milestones[
-    performance::NODE_PERFORMANCE_MILESTONE_V8_START] =
-        performance::performance_v8_start;
-
-  // By default, always abort when --abort-on-uncaught-exception was passed.
-  should_abort_on_uncaught_toggle_[0] = 1;
-}
-
-inline Environment::~Environment() {
-  v8::HandleScope handle_scope(isolate());
-
-#if HAVE_INSPECTOR
-  // Destroy inspector agent before erasing the context. The inspector
-  // destructor depends on the context still being accessible.
-  inspector_agent_.reset();
-#endif
-
-  context()->SetAlignedPointerInEmbedderData(
-      ContextEmbedderIndex::kEnvironment, nullptr);
-
-  delete[] heap_statistics_buffer_;
-  delete[] heap_space_statistics_buffer_;
-  delete[] http_parser_buffer_;
-}
-
 inline v8::Isolate* Environment::isolate() const {
   return isolate_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -85,6 +85,66 @@ void InitThreadLocalOnce() {
   CHECK_EQ(0, uv_key_create(&Environment::thread_local_env));
 }
 
+Environment::Environment(IsolateData* isolate_data,
+                         Local<Context> context)
+    : isolate_(context->GetIsolate()),
+      isolate_data_(isolate_data),
+      immediate_info_(context->GetIsolate()),
+      tick_info_(context->GetIsolate()),
+      timer_base_(uv_now(isolate_data->event_loop())),
+      printed_error_(false),
+      trace_sync_io_(false),
+      abort_on_uncaught_exception_(false),
+      emit_napi_warning_(true),
+      makecallback_cntr_(0),
+      should_abort_on_uncaught_toggle_(isolate_, 1),
+#if HAVE_INSPECTOR
+      inspector_agent_(new inspector::Agent(this)),
+#endif
+      handle_cleanup_waiting_(0),
+      http_parser_buffer_(nullptr),
+      fs_stats_field_array_(isolate_, kFsStatsFieldsLength),
+      context_(context->GetIsolate(), context) {
+  // We'll be creating new objects so make sure we've entered the context.
+  v8::HandleScope handle_scope(isolate());
+  v8::Context::Scope context_scope(context);
+  set_as_external(v8::External::New(isolate(), this));
+
+  AssignToContext(context, ContextInfo(""));
+
+  destroy_async_id_list_.reserve(512);
+  performance_state_.reset(new performance::performance_state(isolate()));
+  performance_state_->milestones[
+      performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT] =
+          PERFORMANCE_NOW();
+  performance_state_->milestones[
+    performance::NODE_PERFORMANCE_MILESTONE_NODE_START] =
+        performance::performance_node_start;
+  performance_state_->milestones[
+    performance::NODE_PERFORMANCE_MILESTONE_V8_START] =
+        performance::performance_v8_start;
+
+  // By default, always abort when --abort-on-uncaught-exception was passed.
+  should_abort_on_uncaught_toggle_[0] = 1;
+}
+
+Environment::~Environment() {
+  v8::HandleScope handle_scope(isolate());
+
+#if HAVE_INSPECTOR
+  // Destroy inspector agent before erasing the context. The inspector
+  // destructor depends on the context still being accessible.
+  inspector_agent_.reset();
+#endif
+
+  context()->SetAlignedPointerInEmbedderData(
+      ContextEmbedderIndex::kEnvironment, nullptr);
+
+  delete[] heap_statistics_buffer_;
+  delete[] heap_space_statistics_buffer_;
+  delete[] http_parser_buffer_;
+}
+
 void Environment::Start(int argc,
                         const char* const* argv,
                         int exec_argc,

--- a/src/env.h
+++ b/src/env.h
@@ -561,8 +561,8 @@ class Environment {
   static uv_key_t thread_local_env;
   static inline Environment* GetThreadLocalEnv();
 
-  inline Environment(IsolateData* isolate_data, v8::Local<v8::Context> context);
-  inline ~Environment();
+  Environment(IsolateData* isolate_data, v8::Local<v8::Context> context);
+  ~Environment();
 
   void Start(int argc,
              const char* const* argv,


### PR DESCRIPTION
Splitting out from https://github.com/nodejs/node/pull/18936:

This makes it easier to use methods from other headers
in the constructor and destructor.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (presumably)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

