### PR TITLE
doc: fix n-api example string

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -246,7 +246,7 @@ napi_value Method(napi_env env, napi_callback_info args) {
   napi_value greeting;
   napi_status status;
 
-  status = napi_create_string_utf8(env, "hello", 6, &greeting);
+  status = napi_create_string_utf8(env, "hello", NAPI_AUTO_LENGTH, &greeting);
   if (status != napi_ok) return nullptr;
   return greeting;
 }


### PR DESCRIPTION
- using a length of 6 for `"hello"` includes a terminating null yielding
  `"hello\u0000"`
- length of 5 would work,
but comparing to the N-API docs gives `NAPI_AUTO_LENGTH` instead

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
