### PR TITLE
http2: simplify timeout tracking

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1630,10 +1630,6 @@ inline Http2Stream* Http2Session::SubmitRequest(
   return stream;
 }
 
-inline void Http2Session::SetChunksSinceLastWrite(size_t n) {
-  chunks_sent_since_last_write_ = n;
-}
-
 // Callback used to receive inbound data from the i/o stream
 void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   Http2Scope h2scope(this);
@@ -2016,7 +2012,6 @@ inline int Http2Stream::DoWrite(WriteWrap* req_wrap,
   CHECK(!this->IsDestroyed());
   CHECK_EQ(send_handle, nullptr);
   Http2Scope h2scope(this);
-  session_->SetChunksSinceLastWrite();
   if (!IsWritable()) {
     req_wrap->Done(UV_EOF);
     return 0;
@@ -2518,8 +2513,6 @@ void Http2Stream::RespondFD(const FunctionCallbackInfo<Value>& args) {
   int64_t offset = args[2]->IntegerValue(context).ToChecked();
   int64_t length = args[3]->IntegerValue(context).ToChecked();
   int options = args[4]->IntegerValue(context).ToChecked();
-
-  stream->session()->SetChunksSinceLastWrite();
 
   Headers list(isolate, context, headers);
   args.GetReturnValue().Set(stream->SubmitFile(fd, *list, list.length(),

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -884,8 +884,6 @@ class Http2Session : public AsyncWrap, public StreamListener {
   // Write data to the session
   inline ssize_t Write(const uv_buf_t* bufs, size_t nbufs);
 
-  inline void SetChunksSinceLastWrite(size_t n = 0);
-
   size_t self_size() const override { return sizeof(*this); }
 
   inline void GetTrailers(Http2Stream* stream, uint32_t* flags);


### PR DESCRIPTION
Splitting out from https://github.com/nodejs/node/pull/18936:

There’s no need to reset the chunk counter for every write.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
