### PR TITLE
src: fix deprecation id for non-string env value

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2667,7 +2667,7 @@ static void EnvSetter(Local<Name> property,
           "Assigning any value other than a string, number, or boolean to a "
           "process.env property is deprecated. Please make sure to convert the "
           "value to a string before setting process.env with it.",
-          "DEP00XX").IsNothing())
+          "DEP0104").IsNothing())
       return;
   }
 #ifdef __POSIX__

--- a/test/parallel/test-process-env-deprecation.js
+++ b/test/parallel/test-process-env-deprecation.js
@@ -9,7 +9,7 @@ common.expectWarning(
   'Assigning any value other than a string, number, or boolean to a ' +
   'process.env property is deprecated. Please make sure to convert the value ' +
   'to a string before setting process.env with it.',
-  'DEP00XX'
+  'DEP0104'
 );
 
 process.env.ABC = undefined;


### PR DESCRIPTION
This is a follow-up of https://github.com/nodejs/node/pull/18990. A new
deprecation id was assigned in it, but it was not reflected in code and
test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
