### PR TITLE
test: shared lib build doesn't handle SIGPIPE

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -203,6 +203,9 @@
       'sources': [
         'src/node_main.cc'
       ],
+      'includes': [
+        'node.gypi'
+      ],
       'include_dirs': [
         'src',
         'deps/v8/include',
@@ -220,9 +223,6 @@
         }],
         [ 'node_intermediate_lib_type=="static_library" and '
             'node_shared=="false"', {
-          'includes': [
-            'node.gypi'
-          ],
           'xcode_settings': {
             'OTHER_LDFLAGS': [
               '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)'
@@ -469,22 +469,8 @@
               ],
             }],
           ],
-          'defines!': [
-            'NODE_PLATFORM="win"',
-          ],
-          'defines': [
-            'FD_SETSIZE=1024',
-            # we need to use node's preferred "win32" rather than gyp's preferred "win"
-            'NODE_PLATFORM="win32"',
-            # Stop <windows.h> from defining macros that conflict with
-            # std::min() and std::max().  We don't use <windows.h> (much)
-            # but we still inherit it from uv.h.
-            'NOMINMAX',
-            '_UNICODE=1',
-          ],
           'libraries': [ '-lpsapi.lib' ]
         }, { # POSIX
-          'defines': [ '__POSIX__' ],
           'sources': [ 'src/backtrace_posix.cc' ],
         }],
         [ 'node_use_etw=="true"', {

--- a/node.gypi
+++ b/node.gypi
@@ -37,6 +37,24 @@
         'NODE_SHARED_MODE',
       ],
     }],
+    [ 'OS=="win"', {
+      'defines!': [
+        'NODE_PLATFORM="win"',
+      ],
+      'defines': [
+        'FD_SETSIZE=1024',
+        # we need to use node's preferred "win32" rather than gyp's preferred "win"
+        'NODE_PLATFORM="win32"',
+        # Stop <windows.h> from defining macros that conflict with
+        # std::min() and std::max().  We don't use <windows.h> (much)
+        # but we still inherit it from uv.h.
+        'NOMINMAX',
+        '_UNICODE=1',
+      ],
+    }, { # POSIX
+      'defines': [ '__POSIX__' ],
+    }],
+
     [ 'node_enable_d8=="true"', {
       'dependencies': [ 'deps/v8/src/d8.gyp:d8' ],
     }],


### PR DESCRIPTION
For shared lib build, we leave the signal handling for embedding users.
In these two test cases:
- `parallel/test-process-external-stdio-close-spawn`
- `parallel/test-process-external-stdio-close`

The pipe is used for stdout and is destroied before child process uses
it for logging. So the node executble that uses shared lib build
receives SIGPIPE and the child process ends. Need to modify these two
test cases to check the `SIGPIPE` instead.

Refs: https://github.com/nodejs/node/issues/18535

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
