### PR TITLE
test: fix test-abort-backtrace in shared lib build

### DIFF
--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -19,7 +19,8 @@ if (process.argv[2] === 'child') {
     }
 
     if (!common.isWindows) {
-      if (!frames.some((frame) => frame.includes(`[${process.execPath}]`))) {
+      const { getBinaryPath } = require('../common/shared-lib-util');
+      if (!frames.some((frame) => frame.includes(`[${getBinaryPath()}]`))) {
         assert.fail(`Some frames should include the binary name:\n${stderr}`);
       }
     }

--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -28,7 +28,7 @@ exports.addLibraryPath = function(env) {
     path.dirname(process.execPath);
 };
 
-// Get the full path of shared lib
+// Get the full path of shared lib.
 exports.getSharedLibPath = function() {
   if (common.isWindows) {
     return path.join(path.dirname(process.execPath), 'node.dll');
@@ -40,4 +40,10 @@ exports.getSharedLibPath = function() {
                      'lib.target',
                      `libnode.${process.config.variables.shlib_suffix}`);
   }
+};
+
+// Get the binary path of stack frames.
+exports.getBinaryPath = function() {
+  return process.config.variables.node_shared ?
+    exports.getSharedLibPath() : process.execPath;
 };


### PR DESCRIPTION
When using shared lib build, the binary path in the stack frames points
to shared lib. Change the checking criteria in the test case to match
that.

Refs: https://github.com/nodejs/node/issues/18535

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
