### PR TITLE
test: do not check text for engine-generated error

### DIFF
--- a/test/parallel/test-tls-wrap-event-emmiter.js
+++ b/test/parallel/test-tls-wrap-event-emmiter.js
@@ -15,5 +15,5 @@ const TlsSocket = require('tls').TLSSocket;
 const EventEmitter = require('events').EventEmitter;
 assert.throws(
   () => { new TlsSocket(new EventEmitter()); },
-  /^TypeError: (.+) is not a function$/
+  TypeError
 );


### PR DESCRIPTION
In test-tls-wrap-event-emitter, the text of a TypeError is checked as
part of the test. However, this text is generated by the JavaScript
engine (V8) and not Node.js. Thus, we should not check the text as JS
engine error messages can change without it being considered a breaking
change for Node.js.

A side effect is that node-chakracore will no longer need to patch this
test to pass.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
