### PR TITLE
test: remove flaky status for test-npm-install

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -15,7 +15,6 @@ test-postmortem-metadata: PASS,FLAKY
 [$system==macos]
 
 [$arch==arm || $arch==arm64]
-test-npm-install:      PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 


### PR DESCRIPTION
I haven't seen test-npm-install fail on arm in a long time. There is no
open issue for it being unreliable. Remove flaky designation in
parallel.status file. (If it turns out it is flaky, it's easy enough to
open an issue and restore the flaky designation.)

Ref: https://github.com/nodejs/node/issues/13498

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
