### PR TITLE
[v9.x backport] fs: support "as" and "as+" new modes in fs.open()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2008,10 +2008,16 @@ The file is created if it does not exist.
 
 * `'ax'` - Like `'a'` but fails if `path` exists.
 
+* `'as'` - Open file for appending in synchronous mode.
+The file is created if it does not exist.
+
 * `'a+'` - Open file for reading and appending.
 The file is created if it does not exist.
 
 * `'ax+'` - Like `'a+'` but fails if `path` exists.
+
+* `'as+'` - Open file for reading and appending in synchronous mode.
+The file is created if it does not exist.
 
 `mode` sets the file mode (permission and sticky bits), but only if the file was
 created. It defaults to `0o666` (readable and writable).

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -47,10 +47,14 @@ function stringToFlags(flags) {
     case 'a' : return O_APPEND | O_CREAT | O_WRONLY;
     case 'ax' : // Fall through.
     case 'xa' : return O_APPEND | O_CREAT | O_WRONLY | O_EXCL;
+    case 'as' : // Fall through.
+    case 'sa' : return O_APPEND | O_CREAT | O_WRONLY | O_SYNC;
 
     case 'a+' : return O_APPEND | O_CREAT | O_RDWR;
     case 'ax+': // Fall through.
     case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
+    case 'as+': // Fall through.
+    case 'sa+': return O_APPEND | O_CREAT | O_RDWR | O_SYNC;
   }
 
   throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'flags', flags);

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -56,8 +56,12 @@ assert.strictEqual(stringToFlags('wx+'), O_TRUNC | O_CREAT | O_RDWR | O_EXCL);
 assert.strictEqual(stringToFlags('xw+'), O_TRUNC | O_CREAT | O_RDWR | O_EXCL);
 assert.strictEqual(stringToFlags('ax'), O_APPEND | O_CREAT | O_WRONLY | O_EXCL);
 assert.strictEqual(stringToFlags('xa'), O_APPEND | O_CREAT | O_WRONLY | O_EXCL);
+assert.strictEqual(stringToFlags('as'), O_APPEND | O_CREAT | O_WRONLY | O_SYNC);
+assert.strictEqual(stringToFlags('sa'), O_APPEND | O_CREAT | O_WRONLY | O_SYNC);
 assert.strictEqual(stringToFlags('ax+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
 assert.strictEqual(stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
+assert.strictEqual(stringToFlags('as+'), O_APPEND | O_CREAT | O_RDWR | O_SYNC);
+assert.strictEqual(stringToFlags('sa+'), O_APPEND | O_CREAT | O_RDWR | O_SYNC);
 
 ('+ +a +r +w rw wa war raw r++ a++ w++ x +x x+ rx rx+ wxx wax xwx xxx')
   .split(' ')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Original PR-URL: https://github.com/nodejs/node/pull/18801
