### PR TITLE
async_hooks: don't set hook_fields[kTotals] to 0

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -74,12 +74,11 @@ class AsyncHook {
       return this;
 
     const prev_kTotals = hook_fields[kTotals];
-    hook_fields[kTotals] = 0;
 
     // createHook() has already enforced that the callbacks are all functions,
     // so here simply increment the count of whether each callbacks exists or
     // not.
-    hook_fields[kTotals] += hook_fields[kInit] += +!!this[init_symbol];
+    hook_fields[kTotals] = hook_fields[kInit] += +!!this[init_symbol];
     hook_fields[kTotals] += hook_fields[kBefore] += +!!this[before_symbol];
     hook_fields[kTotals] += hook_fields[kAfter] += +!!this[after_symbol];
     hook_fields[kTotals] += hook_fields[kDestroy] += +!!this[destroy_symbol];

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -101,9 +101,8 @@ class AsyncHook {
       return this;
 
     const prev_kTotals = hook_fields[kTotals];
-    hook_fields[kTotals] = 0;
 
-    hook_fields[kTotals] += hook_fields[kInit] -= +!!this[init_symbol];
+    hook_fields[kTotals] = hook_fields[kInit] -= +!!this[init_symbol];
     hook_fields[kTotals] += hook_fields[kBefore] -= +!!this[before_symbol];
     hook_fields[kTotals] += hook_fields[kAfter] -= +!!this[after_symbol];
     hook_fields[kTotals] += hook_fields[kDestroy] -= +!!this[destroy_symbol];


### PR DESCRIPTION
This commit removes the setting of hook_field[kTotals] to szero in
AsyncHook's enable function.

As far as I can tell this would not be required if the setting of
this field is done with the assignment operator instead of using the
addition assignment operator.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
