### PR TITLE
assert: do not use EOL in ERR_ASSERTION messages

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -35,7 +35,6 @@ const {
 const { openSync, closeSync, readSync } = require('fs');
 const { parseExpressionAt } = require('internal/deps/acorn/dist/acorn');
 const { inspect } = require('util');
-const { EOL } = require('os');
 const { NativeModule } = require('internal/bootstrap_loaders');
 
 // Escape control characters but not \n and \t to keep the line breaks and
@@ -189,7 +188,7 @@ function getErrMessage(call) {
         .slice(args[0].start, args[args.length - 1].end)
         .replace(escapeSequencesRegExp, escapeFn);
       message = 'The expression evaluated to a falsy value:' +
-        `${EOL}${EOL}  assert${ok}(${message})${EOL}`;
+        `\n\n  assert${ok}(${message})\n`;
     }
     // Make sure to always set the cache! No matter if the message is
     // undefined or not

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -27,7 +27,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { EOL } = require('os');
 const EventEmitter = require('events');
 const { errorCache } = require('internal/errors');
 const { writeFileSync, unlinkSync } = require('fs');
@@ -422,8 +421,8 @@ common.expectsError(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert.ok(typeof 123 === 'string')${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               'assert.ok(typeof 123 === \'string\')\n'
     }
   );
   Error.stackTraceLimit = tmpLimit;
@@ -592,8 +591,8 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     generatedMessage: true,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert.ok(null)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert.ok(null)\n'
   }
 );
 common.expectsError(
@@ -602,8 +601,8 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     generatedMessage: true,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert(typeof 123 === 'string')${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert(typeof 123 === \'string\')\n'
   }
 );
 
@@ -623,8 +622,8 @@ common.expectsError(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert(Buffer.from('test') instanceof Error)${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               'assert(Buffer.from(\'test\') instanceof Error)\n'
     }
   );
   common.expectsError(
@@ -632,8 +631,8 @@ common.expectsError(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert(Buffer.from('test') instanceof Error)${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               'assert(Buffer.from(\'test\') instanceof Error)\n'
     }
   );
   fs.close = tmp;
@@ -652,12 +651,12 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert((() => 'string')()${EOL}` +
-             `      // eslint-disable-next-line${EOL}` +
-             `      ===${EOL}` +
-             `      123 instanceof${EOL}` +
-             `          Buffer)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert((() => \'string\')()\n' +
+             '      // eslint-disable-next-line\n' +
+             '      ===\n' +
+             '      123 instanceof\n' +
+             '          Buffer)\n'
   }
 );
 
@@ -666,8 +665,8 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert(null, undefined)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert(null, undefined)\n'
   }
 );
 


### PR DESCRIPTION
On Windows if an error is thrown from a script that uses `\n`
to break lines - which is very common in the JavaScript ecosystem,
and is the case in our own code base -
then the error messages would contain mixed line feeds:
the part coming from the source code breaks with `\n` while the
message itself break with `\r\n`.

Since we do not use `\r\n` in util.inspect(), we should use `\n`
in error messages as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @BridgeAR 