### PR TITLE
[9.x] src: fix util abort

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -37,7 +37,6 @@ using v8::Value;
 
 #define V(_, ucname) \
   static void ucname(const FunctionCallbackInfo<Value>& args) {               \
-    CHECK_EQ(1, args.Length());                                               \
     args.GetReturnValue().Set(args[0]->ucname());                             \
   }
 
@@ -45,7 +44,6 @@ using v8::Value;
 #undef V
 
 static void IsAnyArrayBuffer(const FunctionCallbackInfo<Value>& args) {
-  CHECK_EQ(1, args.Length());
   args.GetReturnValue().Set(
     args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer());
 }

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -43,9 +43,10 @@ assert.strictEqual(false, util.isArray(Object.create(Array.prototype)));
 
 // isRegExp
 assert.strictEqual(true, util.isRegExp(/regexp/));
-assert.strictEqual(true, util.isRegExp(RegExp()));
+assert.strictEqual(true, util.isRegExp(RegExp(), 'foo'));
 assert.strictEqual(true, util.isRegExp(new RegExp()));
 assert.strictEqual(true, util.isRegExp(context('RegExp')()));
+assert.strictEqual(false, util.isRegExp());
 assert.strictEqual(false, util.isRegExp({}));
 assert.strictEqual(false, util.isRegExp([]));
 assert.strictEqual(false, util.isRegExp(new Date()));
@@ -53,7 +54,7 @@ assert.strictEqual(false, util.isRegExp(Object.create(RegExp.prototype)));
 
 // isDate
 assert.strictEqual(true, util.isDate(new Date()));
-assert.strictEqual(true, util.isDate(new Date(0)));
+assert.strictEqual(true, util.isDate(new Date(0), 'foo'));
 assert.strictEqual(true, util.isDate(new (context('Date'))()));
 assert.strictEqual(false, util.isDate(Date()));
 assert.strictEqual(false, util.isDate({}));


### PR DESCRIPTION
This makes sure util.isRegExp and util.isDate will not abort in case
more than one argument is passed to the function.

This got fixed in #18415 in 10.x. So this is a direct fix for 9.x instead of a backport.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
