### PR TITLE
src: avoid duplicate Before/AtExitCallback structs

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -232,25 +232,25 @@ void Environment::PrintSyncTrace() const {
 }
 
 void Environment::RunBeforeExitCallbacks() {
-  for (BeforeExitCallback before_exit : before_exit_functions_) {
+  for (ExitCallback before_exit : before_exit_functions_) {
     before_exit.cb_(before_exit.arg_);
   }
   before_exit_functions_.clear();
 }
 
 void Environment::BeforeExit(void (*cb)(void* arg), void* arg) {
-  before_exit_functions_.push_back(BeforeExitCallback{cb, arg});
+  before_exit_functions_.push_back(ExitCallback{cb, arg});
 }
 
 void Environment::RunAtExitCallbacks() {
-  for (AtExitCallback at_exit : at_exit_functions_) {
+  for (ExitCallback at_exit : at_exit_functions_) {
     at_exit.cb_(at_exit.arg_);
   }
   at_exit_functions_.clear();
 }
 
 void Environment::AtExit(void (*cb)(void* arg), void* arg) {
-  at_exit_functions_.push_back(AtExitCallback{cb, arg});
+  at_exit_functions_.push_back(ExitCallback{cb, arg});
 }
 
 void Environment::AddPromiseHook(promise_hook_func fn, void* arg) {

--- a/src/env.h
+++ b/src/env.h
@@ -823,17 +823,13 @@ class Environment {
   static const int kFsStatsFieldsLength = 2 * 14;
   AliasedBuffer<double, v8::Float64Array> fs_stats_field_array_;
 
-  struct BeforeExitCallback {
+  struct ExitCallback {
     void (*cb_)(void* arg);
     void* arg_;
   };
-  std::list<BeforeExitCallback> before_exit_functions_;
+  std::list<ExitCallback> before_exit_functions_;
 
-  struct AtExitCallback {
-    void (*cb_)(void* arg);
-    void* arg_;
-  };
-  std::list<AtExitCallback> at_exit_functions_;
+  std::list<ExitCallback> at_exit_functions_;
 
   struct PromiseHookCallback {
     promise_hook_func cb_;


### PR DESCRIPTION
Currently, BeforeExitCallback and AtExitCallback are identical apart for
the name of the struct. This commit introduces an ExitCallback struct
with can be used in both cases to avoid the duplication.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
