### PR TITLE
[v9.x backport] http2: callback valid check before closing request

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1763,6 +1763,8 @@ class Http2Stream extends Duplex {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'number');
     if (code < 0 || code > kMaxInt)
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'code');
+    if (callback !== undefined && typeof callback !== 'function')
+      throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
     // Unenroll the timeout.
     unenroll(this);
@@ -1780,8 +1782,6 @@ class Http2Stream extends Duplex {
     state.rstCode = code;
 
     if (callback !== undefined) {
-      if (typeof callback !== 'function')
-        throw new errors.TypeError('ERR_INVALID_CALLBACK');
       this.once('close', callback);
     }
 


### PR DESCRIPTION
Do not close the request if callback is not a function, and
throw ERR_INVALID_CALLBACK TypeError

PR-URL: https://github.com/nodejs/node/pull/19061
Fixes: https://github.com/nodejs/node/issues/18855
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Shingo Inoue <leko.noor@gmail.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
