### PR TITLE
path: remove redundant function

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -50,7 +50,7 @@ function isWindowsDeviceRoot(code) {
 }
 
 // Resolves . and .. elements in a path with directory names
-function normalizeStringWin32(path, allowAboveRoot) {
+function normalizeString(path, allowAboveRoot, separator) {
   var res = '';
   var lastSegmentLength = 0;
   var lastSlash = -1;
@@ -72,14 +72,14 @@ function normalizeStringWin32(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== CHAR_DOT ||
             res.charCodeAt(res.length - 2) !== CHAR_DOT) {
           if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('\\');
+            const lastSlashIndex = res.lastIndexOf(separator);
             if (lastSlashIndex !== res.length - 1) {
               if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
                 res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('\\');
+                lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
               }
               lastSlash = i;
               dots = 0;
@@ -95,82 +95,14 @@ function normalizeStringWin32(path, allowAboveRoot) {
         }
         if (allowAboveRoot) {
           if (res.length > 0)
-            res += '\\..';
+            res += `${separator}..`;
           else
             res = '..';
           lastSegmentLength = 2;
         }
       } else {
         if (res.length > 0)
-          res += '\\' + path.slice(lastSlash + 1, i);
-        else
-          res = path.slice(lastSlash + 1, i);
-        lastSegmentLength = i - lastSlash - 1;
-      }
-      lastSlash = i;
-      dots = 0;
-    } else if (code === CHAR_DOT && dots !== -1) {
-      ++dots;
-    } else {
-      dots = -1;
-    }
-  }
-  return res;
-}
-
-// Resolves . and .. elements in a path with directory names
-function normalizeStringPosix(path, allowAboveRoot) {
-  var res = '';
-  var lastSegmentLength = 0;
-  var lastSlash = -1;
-  var dots = 0;
-  var code;
-  for (var i = 0; i <= path.length; ++i) {
-    if (i < path.length)
-      code = path.charCodeAt(i);
-    else if (code === CHAR_FORWARD_SLASH)
-      break;
-    else
-      code = CHAR_FORWARD_SLASH;
-    if (code === CHAR_FORWARD_SLASH) {
-      if (lastSlash === i - 1 || dots === 1) {
-        // NOOP
-      } else if (lastSlash !== i - 1 && dots === 2) {
-        if (res.length < 2 || lastSegmentLength !== 2 ||
-            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
-            res.charCodeAt(res.length - 2) !== CHAR_DOT) {
-          if (res.length > 2) {
-            const lastSlashIndex = res.lastIndexOf('/');
-            if (lastSlashIndex !== res.length - 1) {
-              if (lastSlashIndex === -1) {
-                res = '';
-                lastSegmentLength = 0;
-              } else {
-                res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf('/');
-              }
-              lastSlash = i;
-              dots = 0;
-              continue;
-            }
-          } else if (res.length === 2 || res.length === 1) {
-            res = '';
-            lastSegmentLength = 0;
-            lastSlash = i;
-            dots = 0;
-            continue;
-          }
-        }
-        if (allowAboveRoot) {
-          if (res.length > 0)
-            res += '/..';
-          else
-            res = '..';
-          lastSegmentLength = 2;
-        }
-      } else {
-        if (res.length > 0)
-          res += '/' + path.slice(lastSlash + 1, i);
+          res += separator + path.slice(lastSlash + 1, i);
         else
           res = path.slice(lastSlash + 1, i);
         lastSegmentLength = i - lastSlash - 1;
@@ -340,7 +272,7 @@ const win32 = {
     // fails)
 
     // Normalize the tail path
-    resolvedTail = normalizeStringWin32(resolvedTail, !resolvedAbsolute);
+    resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\');
 
     return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
            '.';
@@ -432,7 +364,7 @@ const win32 = {
 
     var tail;
     if (rootEnd < len)
-      tail = normalizeStringWin32(path.slice(rootEnd), !isAbsolute);
+      tail = normalizeString(path.slice(rootEnd), !isAbsolute, '\\');
     else
       tail = '';
     if (tail.length === 0 && !isAbsolute)
@@ -1163,7 +1095,7 @@ const posix = {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeStringPosix(resolvedPath, !resolvedAbsolute);
+    resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/');
 
     if (resolvedAbsolute) {
       if (resolvedPath.length > 0)
@@ -1189,7 +1121,7 @@ const posix = {
       path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
 
     // Normalize the path
-    path = normalizeStringPosix(path, !isAbsolute);
+    path = normalizeString(path, !isAbsolute, '/');
 
     if (path.length === 0 && !isAbsolute)
       path = '.';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Benchmark results:

```                                                                                                  confidence improvement accuracy (*)   (**)  (***)
 path/basename-posix.js n=1000000 pathext=''                                                                       -0.34 %       ±1.24% ±1.66% ±2.17%
 path/basename-posix.js n=1000000 pathext='/'                                                                       0.15 %       ±0.69% ±0.92% ±1.19%
 path/basename-posix.js n=1000000 pathext='/foo'                                                           ***      2.91 %       ±0.41% ±0.55% ±0.72%
 path/basename-posix.js n=1000000 pathext='/foo/.bar.baz'                                                  ***      1.26 %       ±0.31% ±0.41% ±0.54%
 path/basename-posix.js n=1000000 pathext='/foo/.bar.baz|.baz'                                                      0.15 %       ±0.20% ±0.27% ±0.35%
 path/basename-posix.js n=1000000 pathext='/foo/bar/baz/asdf/quux.html'                                      *      0.29 %       ±0.24% ±0.32% ±0.41%
 path/basename-posix.js n=1000000 pathext='/foo/bar/baz/asdf/quux.html|.html'                                *      0.22 %       ±0.21% ±0.28% ±0.36%
 path/basename-posix.js n=1000000 pathext='foo'                                                            ***      4.71 %       ±0.47% ±0.63% ±0.82%
 path/basename-posix.js n=1000000 pathext='foo/bar.'                                                        **      4.42 %       ±2.96% ±3.99% ±5.29%
 path/basename-posix.js n=1000000 pathext='foo/bar.|.'                                                     ***     -0.83 %       ±0.31% ±0.42% ±0.55%
 path/basename-win32.js n=1000000 pathext=''                                                                        0.04 %       ±1.15% ±1.53% ±1.99%
 path/basename-win32.js n=1000000 pathext='\\\\foo\\\\bar\\\\baz\\\\asdf\\\\quux.html'                     ***      1.34 %       ±0.66% ±0.88% ±1.16%
 path/basename-win32.js n=1000000 pathext='\\\\foo\\\\bar\\\\baz\\\\asdf\\\\quux.html|.html'                 *     -0.26 %       ±0.20% ±0.26% ±0.34%
 path/basename-win32.js n=1000000 pathext='C:\\\\'                                                                  0.07 %       ±0.55% ±0.73% ±0.95%
 path/basename-win32.js n=1000000 pathext='C:\\\\foo'                                                       **     -0.41 %       ±0.30% ±0.40% ±0.51%
 path/basename-win32.js n=1000000 pathext='D:\\\\foo\\\\.bar.baz'                                                   0.11 %       ±0.31% ±0.42% ±0.54%
 path/basename-win32.js n=1000000 pathext='E:\\\\foo\\\\.bar.baz|.baz'                                     ***      0.70 %       ±0.22% ±0.29% ±0.37%
 path/basename-win32.js n=1000000 pathext='foo'                                                              *     -0.56 %       ±0.43% ±0.57% ±0.74%
 path/basename-win32.js n=1000000 pathext='foo\\\\bar.'                                                      *     -0.42 %       ±0.34% ±0.45% ±0.59%
 path/basename-win32.js n=1000000 pathext='foo\\\\bar.|.'                                                          -0.12 %       ±0.30% ±0.40% ±0.53%
 path/dirname-posix.js n=1000000 path=''                                                                           -0.09 %       ±1.23% ±1.64% ±2.14%
 path/dirname-posix.js n=1000000 path='/'                                                                           0.39 %       ±0.71% ±0.94% ±1.23%
 path/dirname-posix.js n=1000000 path='/foo'                                                                        0.85 %       ±1.01% ±1.35% ±1.75%
 path/dirname-posix.js n=1000000 path='/foo/bar'                                                                   -0.51 %       ±0.67% ±0.89% ±1.16%
 path/dirname-posix.js n=1000000 path='/foo/bar/baz/asdf/quux'                                             ***      0.78 %       ±0.32% ±0.43% ±0.56%
 path/dirname-posix.js n=1000000 path='foo'                                                                        -0.60 %       ±1.19% ±1.59% ±2.06%
 path/dirname-posix.js n=1000000 path='foo/bar'                                                             **     -0.89 %       ±0.56% ±0.74% ±0.97%
 path/dirname-win32.js n=1000000 path=''                                                                            0.13 %       ±0.87% ±1.16% ±1.51%
 path/dirname-win32.js n=1000000 path='\\\\'                                                                        0.37 %       ±0.90% ±1.20% ±1.57%
 path/dirname-win32.js n=1000000 path='\\\\foo'                                                            ***     -1.80 %       ±0.43% ±0.57% ±0.74%
 path/dirname-win32.js n=1000000 path='C:\\\\foo\\\\bar'                                                           -0.06 %       ±0.41% ±0.55% ±0.72%
 path/dirname-win32.js n=1000000 path='D:\\\\foo\\\\bar\\\\baz\\\\asdf\\\\quux'                                     0.35 %       ±0.90% ±1.21% ±1.58%
 path/dirname-win32.js n=1000000 path='foo'                                                                        -0.51 %       ±0.72% ±0.96% ±1.25%
 path/dirname-win32.js n=1000000 path='foo\\\\bar'                                                          **     -0.80 %       ±0.47% ±0.62% ±0.81%
 path/extname-posix.js n=1000000 path=''                                                                            0.17 %       ±1.09% ±1.45% ±1.88%
 path/extname-posix.js n=1000000 path='/'                                                                          -0.20 %       ±0.61% ±0.81% ±1.05%
 path/extname-posix.js n=1000000 path='/foo'                                                                        0.11 %       ±0.55% ±0.73% ±0.95%
 path/extname-posix.js n=1000000 path='/foo/bar/baz/asdf/quux.foobarbazasdfquux'                                   -0.19 %       ±0.22% ±0.29% ±0.38%
 path/extname-posix.js n=1000000 path='/foo/bar/baz/asdf/quux'                                                      0.16 %       ±0.44% ±0.59% ±0.76%
 path/extname-posix.js n=1000000 path='foo/.bar.baz'                                                                0.27 %       ±0.49% ±0.66% ±0.87%
 path/extname-posix.js n=1000000 path='foo/bar/...baz.quux'                                                ***     -0.79 %       ±0.28% ±0.37% ±0.48%
 path/extname-posix.js n=1000000 path='foo/bar/..baz.quux'                                                 ***     -0.54 %       ±0.25% ±0.34% ±0.44%
 path/extname-posix.js n=1000000 path='index.html'                                                          **     -0.37 %       ±0.28% ±0.37% ±0.48%
 path/extname-posix.js n=1000000 path='index'                                                                       0.01 %       ±0.34% ±0.45% ±0.58%
 path/extname-win32.js n=1000000 path=''                                                                            0.34 %       ±1.26% ±1.68% ±2.19%
 path/extname-win32.js n=1000000 path='\\\\'                                                                       -0.25 %       ±0.75% ±1.00% ±1.30%
 path/extname-win32.js n=1000000 path='\\\\foo\\\\bar\\\\baz\\\\asdf\\\\quux.foobarbazasdfquux'                    -0.09 %       ±0.13% ±0.17% ±0.22%
 path/extname-win32.js n=1000000 path='C:\\\\foo'                                                                   0.12 %       ±0.41% ±0.54% ±0.71%
 path/extname-win32.js n=1000000 path='D:\\\\foo\\\\bar\\\\baz\\\\asdf\\\\quux'                                     0.21 %       ±0.50% ±0.67% ±0.87%
 path/extname-win32.js n=1000000 path='foo\\\\.bar.baz'                                                    ***      0.81 %       ±0.27% ±0.36% ±0.47%
 path/extname-win32.js n=1000000 path='foo\\\\bar\\\\...baz.quux'                                          ***     -0.68 %       ±0.23% ±0.30% ±0.40%
 path/extname-win32.js n=1000000 path='foo\\\\bar\\\\..baz.quux'                                             *     -0.45 %       ±0.39% ±0.51% ±0.67%
 path/extname-win32.js n=1000000 path='index.html'                                                          **     -0.35 %       ±0.22% ±0.30% ±0.39%
 path/extname-win32.js n=1000000 path='index'                                                                       0.18 %       ±0.29% ±0.39% ±0.51%
 path/format-posix.js n=10000000 props='/|/home/user/dir|index.html|.html|index'                                    0.10 %       ±0.46% ±0.61% ±0.79%
 path/format-win32.js n=10000000 props='C:\\\\|C:\\\\path\\\\dir|index.html|.html|index'                            0.07 %       ±0.33% ±0.44% ±0.57%
 path/isAbsolute-posix.js n=1000000 path='.'                                                                       -0.00 %       ±1.90% ±2.53% ±3.29%
 path/isAbsolute-posix.js n=1000000 path=''                                                                         0.89 %       ±1.47% ±1.96% ±2.55%
 path/isAbsolute-posix.js n=1000000 path='/baz/..'                                                                  0.40 %       ±2.21% ±2.94% ±3.83%
 path/isAbsolute-posix.js n=1000000 path='/foo/bar'                                                                -0.81 %       ±2.25% ±2.99% ±3.90%
 path/isAbsolute-posix.js n=1000000 path='bar/baz'                                                                  0.25 %       ±2.25% ±2.99% ±3.90%
 path/isAbsolute-win32.js n=1000000 path='.'                                                                        1.84 %       ±2.79% ±3.76% ±4.96%
 path/isAbsolute-win32.js n=1000000 path=''                                                                         0.60 %       ±1.19% ±1.59% ±2.07%
 path/isAbsolute-win32.js n=1000000 path='//server'                                                                 0.35 %       ±0.72% ±0.96% ±1.26%
 path/isAbsolute-win32.js n=1000000 path='bar\\\\baz'                                                              -0.24 %       ±0.57% ±0.76% ±0.98%
 path/isAbsolute-win32.js n=1000000 path='C:\\\\baz\\\\..'                                                          0.33 %       ±0.70% ±0.93% ±1.22%
 path/isAbsolute-win32.js n=1000000 path='C:baz\\\\..'                                                       *      0.68 %       ±0.59% ±0.79% ±1.03%
 path/join-posix.js n=1000000 paths='/foo|bar||baz/asdf|quux|..'                                           ***     -0.82 %       ±0.10% ±0.14% ±0.18%
 path/join-win32.js n=1000000 paths='C:\\\\foo|bar||baz\\\\asdf|quux|..'                                   ***     -0.44 %       ±0.18% ±0.24% ±0.31%
 path/makeLong-win32.js n=1000000 path='\\\\\\\\?\\\\foo'                                                  ***     -1.70 %       ±0.33% ±0.43% ±0.57%
 path/makeLong-win32.js n=1000000 path='\\\\\\\\foo\\\\bar'                                                ***     -1.24 %       ±0.23% ±0.31% ±0.41%
 path/makeLong-win32.js n=1000000 path='C:\\\\foo'                                                         ***      1.08 %       ±0.24% ±0.33% ±0.42%
 path/makeLong-win32.js n=1000000 path='foo\\\\bar'                                                        ***     -0.90 %       ±0.46% ±0.61% ±0.79%
 path/normalize-posix.js n=1000000 path='.'                                                                ***     -5.53 %       ±0.37% ±0.49% ±0.64%
 path/normalize-posix.js n=1000000 path=''                                                                          0.33 %       ±0.90% ±1.19% ±1.55%
 path/normalize-posix.js n=1000000 path='/../'                                                             ***     -3.85 %       ±0.49% ±0.65% ±0.84%
 path/normalize-posix.js n=1000000 path='/foo'                                                             ***     -4.60 %       ±0.42% ±0.56% ±0.73%
 path/normalize-posix.js n=1000000 path='/foo/bar'                                                         ***     -4.47 %       ±0.28% ±0.37% ±0.48%
 path/normalize-posix.js n=1000000 path='/foo/bar//baz/asdf/quux/..'                                       ***     -2.00 %       ±0.40% ±0.53% ±0.69%
 path/normalize-win32.js n=1000000 path='.'                                                                ***     -2.63 %       ±0.36% ±0.48% ±0.62%
 path/normalize-win32.js n=1000000 path=''                                                                         -0.62 %       ±0.90% ±1.20% ±1.57%
 path/normalize-win32.js n=1000000 path='C:\\\\..\\\\'                                                     ***     -7.19 %       ±0.63% ±0.84% ±1.10%
 path/normalize-win32.js n=1000000 path='C:\\\\foo'                                                          *     -0.62 %       ±0.58% ±0.78% ±1.02%
 path/normalize-win32.js n=1000000 path='C:\\\\foo\\\\bar'                                                 ***     -5.07 %       ±0.35% ±0.47% ±0.61%
 path/normalize-win32.js n=1000000 path='C:\\\\foo\\\\bar\\\\\\\\baz\\\\asdf\\\\quux\\\\..'                        -0.23 %       ±0.27% ±0.36% ±0.47%
 path/parse-posix.js n=1000000 path=''                                                                              0.83 %       ±1.49% ±1.98% ±2.58%
 path/parse-posix.js n=1000000 path='/'                                                                             0.11 %       ±1.17% ±1.56% ±2.03%
 path/parse-posix.js n=1000000 path='/foo'                                                                 ***     -1.03 %       ±0.34% ±0.45% ±0.58%
 path/parse-posix.js n=1000000 path='/foo/bar.baz'                                                         ***     -0.87 %       ±0.22% ±0.30% ±0.39%
 path/parse-posix.js n=1000000 path='/foo/bar/baz/asdf/.quux'                                              ***     -1.08 %       ±0.24% ±0.32% ±0.42%
 path/parse-posix.js n=1000000 path='foo/.bar.baz'                                                                  0.03 %       ±0.49% ±0.65% ±0.86%
 path/parse-posix.js n=1000000 path='foo/bar'                                                              ***     -1.43 %       ±0.38% ±0.51% ±0.67%
 path/parse-win32.js n=1000000 path=''                                                                       *     -3.35 %       ±2.84% ±3.79% ±4.94%
 path/parse-win32.js n=1000000 path='\\\\foo'                                                               **     -0.55 %       ±0.33% ±0.44% ±0.57%
 path/parse-win32.js n=1000000 path='\\\\foo\\\\bar\\\\baz\\\\asdf\\\\.quux'                               ***     -2.92 %       ±0.27% ±0.36% ±0.48%
 path/parse-win32.js n=1000000 path='C:\\\\'                                                                        0.20 %       ±0.76% ±1.01% ±1.31%
 path/parse-win32.js n=1000000 path='C:\\\\foo'                                                                    -0.19 %       ±0.38% ±0.51% ±0.67%
 path/parse-win32.js n=1000000 path='E:\\\\foo\\\\bar.baz'                                                 ***     -0.89 %       ±0.24% ±0.33% ±0.43%
 path/parse-win32.js n=1000000 path='foo\\\\.bar.baz'                                                              -0.40 %       ±0.43% ±0.58% ±0.75%
 path/parse-win32.js n=1000000 path='foo\\\\bar'                                                           ***     -0.91 %       ±0.35% ±0.46% ±0.60%
 path/relative-posix.js n=1000000 paths='/|/'                                                                *      0.92 %       ±0.90% ±1.20% ±1.57%
 path/relative-posix.js n=1000000 paths='/|/var'                                                           ***     -2.89 %       ±0.33% ±0.44% ±0.58%
 path/relative-posix.js n=1000000 paths='/data/orandea/test/aaa|/data/orandea/impl/bbb'                    ***     -2.13 %       ±0.79% ±1.07% ±1.41%
 path/relative-posix.js n=1000000 paths='/foo/bar/baz/quux|/'                                              ***     -1.17 %       ±0.46% ±0.62% ±0.82%
 path/relative-posix.js n=1000000 paths='/foo/bar/baz/quux|/foo/bar/baz/quux'                                       0.10 %       ±0.48% ±0.65% ±0.84%
 path/relative-posix.js n=1000000 paths='/foo/bar/baz/quux|/var/log'                                        **     -1.43 %       ±0.92% ±1.24% ±1.64%
 path/relative-posix.js n=1000000 paths='/var|/bin'                                                        ***     -3.01 %       ±0.24% ±0.32% ±0.41%
 path/relative-win32.js n=1000000 paths='C:\\\\|D:\\\\'                                                    ***     -3.38 %       ±0.48% ±0.65% ±0.84%
 path/relative-win32.js n=1000000 paths='C:\\\\foo\\\\bar\\\\baz\\\\quux|C:\\\\'                             *     -0.87 %       ±0.67% ±0.89% ±1.16%
 path/relative-win32.js n=1000000 paths='C:\\\\foo\\\\bar\\\\baz|C:\\\\foo\\\\bar\\\\baz'                           0.22 %       ±0.63% ±0.84% ±1.10%
 path/relative-win32.js n=1000000 paths='C:\\\\foo\\\\BAR\\\\BAZ|C:\\\\foo\\\\bar\\\\baz'                          -1.40 %       ±1.44% ±1.92% ±2.51%
 path/relative-win32.js n=1000000 paths='C:\\\\orandea\\\\test\\\\aaa|C:\\\\orandea\\\\impl\\\\bbb'        ***     -0.71 %       ±0.29% ±0.39% ±0.51%
 path/resolve-posix.js n=1000000 paths=''                                                                           0.07 %       ±0.32% ±0.42% ±0.55%
 path/resolve-posix.js n=1000000 paths='|'                                                                         -0.42 %       ±0.48% ±0.64% ±0.84%
 path/resolve-posix.js n=1000000 paths='a/b/c/|../../..'                                                           -0.17 %       ±0.55% ±0.73% ±0.95%
 path/resolve-posix.js n=1000000 paths='foo/bar|/tmp/file/|..|a/../subfile'                                         0.03 %       ±0.26% ±0.35% ±0.46%
 path/resolve-win32.js n=1000000 paths=''                                                                   **     -0.70 %       ±0.51% ±0.69% ±0.90%
 path/resolve-win32.js n=1000000 paths='|'                                                                   *     -0.48 %       ±0.40% ±0.54% ±0.70%
 path/resolve-win32.js n=1000000 paths='c:/blah\\\\blah|d:/games|c:../a'                                   ***     -1.27 %       ±0.29% ±0.38% ±0.50%
 path/resolve-win32.js n=1000000 paths='c:/ignore|d:\\\\a/b\\\\c/d|\\\\e.exe'                              ***      3.50 %       ±0.52% ±0.69% ±0.90%
```


