### PR TITLE
crypto: consistently use bool over int

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3281,7 +3281,7 @@ bool CipherBase::Update(const char* data,
                         unsigned char** out,
                         int* out_len) {
   if (ctx_ == nullptr)
-    return 0;
+    return false;
 
   // on first update:
   if (kind_ == kDecipher && IsAuthenticatedMode() && auth_tag_len_ > 0) {


### PR DESCRIPTION
Just a tiny change to make the use of bool over int consistent.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)