### PR TITLE
src: add `jsEngine` property to `process`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -10,6 +10,7 @@
     'component%': 'static_library',   # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
     'python%': 'python',
+    'node_engine%': 'v8',
 
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,
@@ -81,6 +82,7 @@
   },
 
   'target_defaults': {
+    'defines': ['NODE_ENGINE="<(node_engine)"'],
     'default_configuration': 'Release',
     'configurations': {
       'Debug': {

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1205,6 +1205,20 @@ console.log(process.getgroups());         // [ 27, 30, 46, 1000 ]
 This function is only available on POSIX platforms (i.e. not Windows or
 Android).
 
+## process.jsEngine
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `process.jsEngine` property returns the JavaScript engine type. It will
+return `v8` when the V8 engine is being used.
+
+```js
+console.log(`Engine: ${process.jsEngine}`);
+```
+
 ## process.kill(pid[, signal])
 <!-- YAML
 added: v0.0.6

--- a/src/node.cc
+++ b/src/node.cc
@@ -2932,6 +2932,11 @@ void SetupProcessObject(Environment* env,
                              ProcessTitleSetter,
                              env->as_external()).FromJust());
 
+  // process.jsEngine
+  READONLY_PROPERTY(process,
+                    "jsEngine",
+                    FIXED_ONE_BYTE_STRING(env->isolate(), NODE_ENGINE));
+
   // process.version
   READONLY_PROPERTY(process,
                     "version",

--- a/test/parallel/test-process-jsEngine.js
+++ b/test/parallel/test-process-jsEngine.js
@@ -1,0 +1,5 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(process.jsEngine, 'v8');


### PR DESCRIPTION
Module owners currently have no documented way to determine which
engine is being used to execute their code, preventing seamless usage
of Node-ChakraCore. The most common issue is usage of V8-specific
launch options when spawning child processes.

Refs: https://github.com/nodejs/node-chakracore/issues/10
Refs: https://github.com/nodejs/node-chakracore/issues/486

I just wanted to gauge interest in exposing this property to modules so that they can be more targeted in when they take a dependency on V8 options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
