### PR TITLE
n-api: resolve promise in test

### DIFF
--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -45,7 +45,9 @@ common.crashOnUnhandledRejection();
   test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
 }
 
-assert.strictEqual(test_promise.isPromise(test_promise.createPromise()), true);
+const promiseTypeTestPromise = test_promise.createPromise();
+assert.strictEqual(test_promise.isPromise(promiseTypeTestPromise), true);
+test_promise.concludeCurrentPromise(undefined, true);
 
 const rejectPromise = Promise.reject(-1);
 const expected_reason = -1;


### PR DESCRIPTION
The last promise created by the test for the purposes of making sure
that its type is indeed a promise needs to be resolved so as to avoid
having it left in the pending state at the end of the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
