### PR TITLE
test: fix compiler warnings in callback-scope

### DIFF
--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -41,7 +41,8 @@ static void Callback(uv_work_t* req, int ignored) {
 
   v8::Local<v8::Promise::Resolver> local =
       v8::Local<v8::Promise::Resolver>::New(isolate, persistent);
-  local->Resolve(v8::Undefined(isolate));
+  local->Resolve(isolate->GetCurrentContext(),
+                 v8::Undefined(isolate)).ToChecked();
   delete req;
 }
 
@@ -49,7 +50,8 @@ static void TestResolveAsync(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
 
   if (persistent.IsEmpty()) {
-    persistent.Reset(isolate, v8::Promise::Resolver::New(isolate));
+    persistent.Reset(isolate, v8::Promise::Resolver::New(
+        isolate->GetCurrentContext()).ToLocalChecked());
 
     uv_work_t* req = new uv_work_t;
 


### PR DESCRIPTION
Currently there are two compiler warnings generated from the addons test
callback-scope:
```console
../binding.cc:44:10:
warning: 'Resolve' is deprecated [-Wdeprecated-declarations]
      local->Resolve(v8::Undefined(isolate));
             ^
../../../../deps/v8/include/v8.h:3893:45:
note: 'Resolve' has been explicitly marked deprecated here
V8_DEPRECATED("Use maybe version", void Resolve(Local<Value> value));
             ^
```
```console
../binding.cc:52:54:
warning: 'New' is deprecated [-Wdeprecated-declarations]
    persistent.Reset(isolate, v8::Promise::Resolver::New(isolate));
                                                     ^
../../../../deps/v8/include/v8.h:3880:42:
note: 'New' has been explicitly marked deprecated here
Local<Resolver> New(Isolate* isolate));
```
This commit updates the test to use non-deprecated functions.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
