### PR TITLE
Revert "util: use blue on non-windows systems for number/bigint"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -347,11 +347,10 @@ inspect.colors = Object.assign(Object.create(null), {
 });
 
 // Don't use 'blue' not visible on cmd.exe
-const windows = process.platform === 'win32';
 inspect.styles = Object.assign(Object.create(null), {
   'special': 'cyan',
-  'number': windows ? 'yellow' : 'blue',
-  'bigint': windows ? 'yellow' : 'blue',
+  'number': 'yellow',
+  'bigint': 'yellow',
   'boolean': 'yellow',
   'undefined': 'grey',
   'null': 'bold',

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -34,8 +34,7 @@ assert.deepStrictEqual(list, new BufferList());
 
 const tmp = util.inspect.defaultOptions.colors;
 util.inspect.defaultOptions = { colors: true };
-const color = util.inspect.colors[util.inspect.styles.number];
 assert.strictEqual(
   util.inspect(list),
-  `BufferList { length: \u001b[${color[0]}m0\u001b[${color[1]}m }`);
+  'BufferList { length: \u001b[33m0\u001b[39m }');
 util.inspect.defaultOptions = { colors: tmp };


### PR DESCRIPTION
This reverts commit 1708af369ba4cdfbc9f3eadd657508498b8489a3.

Numbers are much more difficult to read in blue and it would be good
to have a consistent output throughout all OS.

Refs: https://github.com/nodejs/node/pull/18925
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
