### PR TITLE
test: fix assertion argument order

### DIFF
--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -25,7 +25,7 @@ async function runTests() {
          'Waiting for the debugger to disconnect...');
   await session.send({ method: 'Profiler.stop' });
   session.disconnect();
-  assert.strictEqual(0, (await child.expectShutdown()).exitCode);
+  assert.strictEqual((await child.expectShutdown()).exitCode, 0);
 }
 
 common.crashOnUnhandledRejection();


### PR DESCRIPTION
Fix the assertion argument order so that it will report "actual" and
"expected" correctly when the test fails.

Ref: https://github.com/nodejs/node/issues/19263

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
