### PR TITLE
Fs stats added in versions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -421,24 +421,36 @@ Stats {
 ```
 
 ### stats.isBlockDevice()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
 Returns `true` if the `fs.Stats` object describes a block device.
 
 ### stats.isCharacterDevice()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
 Returns `true` if the `fs.Stats` object describes a character device.
 
 ### stats.isDirectory()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
 Returns `true` if the `fs.Stats` object describes a file system directory.
 
 ### stats.isFIFO()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
@@ -446,18 +458,27 @@ Returns `true` if the `fs.Stats` object describes a first-in-first-out (FIFO)
 pipe.
 
 ### stats.isFile()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
 Returns `true` if the `fs.Stats` object describes a regular file.
 
 ### stats.isSocket()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 
 Returns `true` if the `fs.Stats` object describes a socket.
 
 ### stats.isSymbolicLink()
+<!-- YAML
+added: v0.1.10
+-->
 
 * Returns: {boolean}
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -541,6 +541,9 @@ The file system block size for i/o operations.
 The number of blocks allocated for this file.
 
 ### stats.atimeMs
+<!-- YAML
+added: v8.1.0
+-->
 
 * Value: {number}
 
@@ -548,6 +551,9 @@ The timestamp indicating the last time this file was accessed expressed in
 milliseconds since the POSIX Epoch.
 
 ### stats.mtimeMs
+<!-- YAML
+added: v8.1.0
+-->
 
 * Value: {number}
 
@@ -555,6 +561,9 @@ The timestamp indicating the last time this file was modified expressed in
 milliseconds since the POSIX Epoch.
 
 ### stats.ctimeMs
+<!-- YAML
+added: v8.1.0
+-->
 
 * Value: {number}
 
@@ -562,6 +571,9 @@ The timestamp indicating the last time the file status was changed expressed
 in milliseconds since the POSIX Epoch.
 
 ### stats.birthtimeMs
+<!-- YAML
+added: v8.1.0
+-->
 
 * Value: {number}
 
@@ -569,24 +581,36 @@ The timestamp indicating the creation time of this file expressed in
 milliseconds since the POSIX Epoch.
 
 ### stats.atime
+<!-- YAML
+added: v0.11.13
+-->
 
 * Value: {Date}
 
 The timestamp indicating the last time this file was accessed.
 
 ### stats.mtime
+<!-- YAML
+added: v0.11.13
+-->
 
 * Value: {Date}
 
 The timestamp indicating the last time this file was modified.
 
 ### stats.ctime
+<!-- YAML
+added: v0.11.13
+-->
 
 * Value: {Date}
 
 The timestamp indicating the last time the file status was changed.
 
 ### stats.birthtime
+<!-- YAML
+added: v0.11.13
+-->
 
 * Value: {Date}
 


### PR DESCRIPTION
Almost all fs.Stats entries now have the `added in` version documented

Fixes:: https://github.com/nodejs/node/issues/19178

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

**Affected core subsystem(s)**
doc
