### PR TITLE
url: use existing handlers instead of duplicated code

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -248,20 +248,6 @@ function onParseProtocolComplete(flags, protocol, username, password,
   ctx.port = port;
 }
 
-function onParseHostComplete(flags, protocol, username, password,
-                             host, port, path, query, fragment) {
-  const ctx = this[context];
-  if ((flags & URL_FLAGS_HAS_HOST) !== 0) {
-    ctx.host = host;
-    ctx.flags |= URL_FLAGS_HAS_HOST;
-  } else {
-    ctx.host = null;
-    ctx.flags &= ~URL_FLAGS_HAS_HOST;
-  }
-  if (port !== null)
-    ctx.port = port;
-}
-
 function onParseHostnameComplete(flags, protocol, username, password,
                                  host, port, path, query, fragment) {
   const ctx = this[context];
@@ -277,6 +263,13 @@ function onParseHostnameComplete(flags, protocol, username, password,
 function onParsePortComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
   this[context].port = port;
+}
+
+function onParseHostComplete(flags, protocol, username, password,
+                             host, port, path, query, fragment) {
+  onParseHostnameComplete.apply(this, arguments);
+  if (port !== null)
+    onParsePortComplete.apply(this, arguments);
 }
 
 function onParsePathComplete(flags, protocol, username, password,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Benchmark results:

```
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='auth'                                         -0.26 %       ±1.12% ±1.49% ±1.94%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='dot'                                           1.78 %       ±1.91% ±2.55% ±3.33%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='file'                                          0.17 %       ±1.47% ±1.96% ±2.54%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='idn'                                           1.29 %       ±1.77% ±2.36% ±3.08%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='javascript'                                    0.61 %       ±1.37% ±1.82% ±2.38%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='long'                                         -0.56 %       ±1.55% ±2.06% ±2.69%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='percent'                                       0.50 %       ±1.57% ±2.09% ±2.72%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='short'                                         0.24 %       ±1.68% ±2.23% ±2.90%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='legacy' type='ws'                                           -0.35 %       ±1.32% ±1.76% ±2.29%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='auth'                                          0.08 %       ±0.83% ±1.11% ±1.45%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='dot'                                           0.40 %       ±1.17% ±1.56% ±2.05%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='file'                                         -0.40 %       ±0.96% ±1.28% ±1.66%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='idn'                                           0.11 %       ±1.20% ±1.60% ±2.09%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='javascript'                                   -0.03 %       ±1.36% ±1.81% ±2.35%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='long'                                          0.13 %       ±0.49% ±0.65% ±0.84%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='percent'                                       0.19 %       ±1.02% ±1.35% ±1.76%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='short'                                         0.33 %       ±0.63% ±0.83% ±1.08%
 url/legacy-vs-whatwg-url-get-prop.js n=100000 method='whatwg' type='ws'                                            0.12 %       ±1.44% ±1.91% ±2.49%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='auth'                                             0.43 %       ±1.01% ±1.35% ±1.75%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='dot'                                              0.03 %       ±1.01% ±1.34% ±1.74%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='file'                                            -0.05 %       ±1.19% ±1.58% ±2.07%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='idn'                                             -1.05 %       ±1.61% ±2.15% ±2.81%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='javascript'                                *     -0.83 %       ±0.66% ±0.88% ±1.16%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='long'                                            -0.09 %       ±0.51% ±0.68% ±0.89%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='percent'                                         -0.28 %       ±1.19% ±1.58% ±2.06%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='short'                                            0.33 %       ±1.55% ±2.06% ±2.68%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='legacy' type='ws'                                              -0.77 %       ±1.23% ±1.64% ±2.13%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='auth'                                            -0.25 %       ±1.08% ±1.44% ±1.88%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='dot'                                              0.22 %       ±0.91% ±1.22% ±1.59%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='file'                                             0.65 %       ±0.88% ±1.18% ±1.53%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='idn'                                             -0.60 %       ±0.94% ±1.25% ±1.64%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='javascript'                                      -0.07 %       ±0.67% ±0.89% ±1.17%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='long'                                             0.05 %       ±0.35% ±0.46% ±0.61%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='percent'                                         -0.37 %       ±1.37% ±1.82% ±2.37%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='short'                                           -0.44 %       ±0.90% ±1.20% ±1.56%
 url/legacy-vs-whatwg-url-parse.js n=100000 method='whatwg' type='ws'                                              -0.28 %       ±0.75% ±1.00% ±1.31%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='altspaces'                          0.23 %       ±0.52% ±0.69% ±0.90%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='encodefake'                         0.65 %       ±1.04% ±1.40% ±1.84%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='encodelast'                        -0.19 %       ±1.15% ±1.53% ±2.00%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='encodemany'                         0.16 %       ±1.18% ±1.58% ±2.07%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='manyblankpairs'                     0.04 %       ±0.12% ±0.16% ±0.21%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='manypairs'                         -0.39 %       ±0.80% ±1.07% ±1.39%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='multicharsep'                       0.13 %       ±0.94% ±1.25% ±1.62%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='multivalue'                        -0.85 %       ±0.99% ±1.32% ±1.72%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='multivaluemany'                    -0.74 %       ±2.95% ±3.95% ±5.19%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' type='noencode'                           0.06 %       ±1.26% ±1.69% ±2.21%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='altspaces'                          0.29 %       ±0.31% ±0.41% ±0.53%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='encodefake'                         0.01 %       ±0.23% ±0.31% ±0.40%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='encodelast'                         0.14 %       ±1.00% ±1.34% ±1.75%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='encodemany'                         0.29 %       ±0.53% ±0.70% ±0.92%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='manyblankpairs'                    -0.81 %       ±2.27% ±3.02% ±3.93%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='manypairs'                         -0.13 %       ±0.25% ±0.33% ±0.43%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='multicharsep'                       0.17 %       ±0.41% ±0.54% ±0.71%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='multivalue'                         0.03 %       ±0.52% ±0.69% ±0.90%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='multivaluemany'                     0.00 %       ±0.12% ±0.16% ±0.21%
 url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' type='noencode'                          -0.03 %       ±0.49% ±0.65% ±0.85%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='altspaces'                     -0.37 %       ±0.46% ±0.61% ±0.79%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='encodefake'                     0.10 %       ±0.32% ±0.43% ±0.56%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='encodelast'                    -0.10 %       ±0.29% ±0.39% ±0.51%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='encodemany'                    -0.19 %       ±0.34% ±0.45% ±0.59%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='manyblankpairs'                 0.03 %       ±0.46% ±0.61% ±0.79%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='manypairs'                      0.27 %       ±1.04% ±1.38% ±1.79%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='multicharsep'                  -0.19 %       ±0.32% ±0.42% ±0.55%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='multivalue'                     0.04 %       ±0.27% ±0.36% ±0.47%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='multivaluemany'                 0.09 %       ±0.17% ±0.23% ±0.30%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' type='noencode'                       0.07 %       ±0.88% ±1.19% ±1.56%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='altspaces'                      0.14 %       ±0.17% ±0.23% ±0.29%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='encodefake'                    -0.11 %       ±0.28% ±0.38% ±0.49%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='encodelast'                     0.00 %       ±0.18% ±0.24% ±0.31%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='encodemany'                     0.09 %       ±0.21% ±0.29% ±0.37%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='manyblankpairs'                -0.70 %       ±1.22% ±1.63% ±2.12%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='manypairs'                      0.09 %       ±0.24% ±0.32% ±0.41%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='multicharsep'                   0.15 %       ±0.20% ±0.27% ±0.35%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='multivalue'                     0.08 %       ±0.18% ±0.23% ±0.31%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='multivaluemany'                -0.03 %       ±0.12% ±0.16% ±0.20%
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' type='noencode'                       0.23 %       ±0.26% ±0.35% ±0.45%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='auth'                                        -0.32 %       ±0.62% ±0.82% ±1.07%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='dot'                                         -0.27 %       ±0.66% ±0.89% ±1.16%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='file'                                         0.09 %       ±0.63% ±0.84% ±1.09%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='idn'                                         -0.00 %       ±0.71% ±0.95% ±1.24%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='javascript'                                  -0.16 %       ±0.50% ±0.67% ±0.87%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='long'                                         0.21 %       ±0.37% ±0.50% ±0.65%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='percent'                                      0.22 %       ±0.47% ±0.62% ±0.81%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='short'                                        0.04 %       ±0.59% ±0.78% ±1.02%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='legacy' type='ws'                                          -0.08 %       ±0.34% ±0.45% ±0.59%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='auth'                                        -0.50 %       ±0.98% ±1.30% ±1.69%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='dot'                                         -0.25 %       ±0.78% ±1.04% ±1.35%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='file'                                        -0.02 %       ±0.76% ±1.02% ±1.32%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='idn'                                          0.85 %       ±1.27% ±1.69% ±2.21%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='javascript'                                  -0.22 %       ±1.01% ±1.34% ±1.75%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='long'                                         0.04 %       ±0.61% ±0.82% ±1.07%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='percent'                                      0.54 %       ±1.11% ±1.48% ±1.92%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='short'                                 *     -0.58 %       ±0.57% ±0.76% ±0.99%
 url/legacy-vs-whatwg-url-serialize.js n=100000 method='whatwg' type='ws'                                           0.27 %       ±1.21% ±1.61% ±2.11%
 url/url-format.js n=25000000 type='file'                                                                          -0.01 %       ±0.13% ±0.17% ±0.23%
 url/url-format.js n=25000000 type='slashes'                                                                        0.06 %       ±0.22% ±0.29% ±0.38%
 url/url-parse.js n=10000000 type='escaped'                                                                        -0.71 %       ±1.39% ±1.85% ±2.41%
 url/url-parse.js n=10000000 type='normal'                                                                         -0.46 %       ±1.93% ±2.57% ±3.34%
 url/url-resolve.js n=100000 path='down' href='auth'                                                               -0.73 %       ±1.54% ±2.05% ±2.67%
 url/url-resolve.js n=100000 path='down' href='dot'                                                                -0.10 %       ±0.99% ±1.32% ±1.71%
 url/url-resolve.js n=100000 path='down' href='file'                                                                0.98 %       ±1.45% ±1.93% ±2.51%
 url/url-resolve.js n=100000 path='down' href='idn'                                                                 0.17 %       ±2.18% ±2.90% ±3.78%
 url/url-resolve.js n=100000 path='down' href='javascript'                                                         -0.17 %       ±1.45% ±1.94% ±2.53%
 url/url-resolve.js n=100000 path='down' href='long'                                                               -0.27 %       ±0.65% ±0.86% ±1.12%
 url/url-resolve.js n=100000 path='down' href='noscheme'                                                            0.07 %       ±0.93% ±1.24% ±1.62%
 url/url-resolve.js n=100000 path='down' href='percent'                                                             0.28 %       ±1.38% ±1.83% ±2.39%
 url/url-resolve.js n=100000 path='down' href='short'                                                               0.66 %       ±1.73% ±2.30% ±2.99%
 url/url-resolve.js n=100000 path='down' href='ws'                                                                 -0.16 %       ±1.70% ±2.27% ±2.95%
 url/url-resolve.js n=100000 path='foo/bar' href='auth'                                                            -0.75 %       ±1.64% ±2.18% ±2.83%
 url/url-resolve.js n=100000 path='foo/bar' href='dot'                                                      **     -2.54 %       ±1.89% ±2.53% ±3.31%
 url/url-resolve.js n=100000 path='foo/bar' href='file'                                                             0.32 %       ±1.53% ±2.04% ±2.66%
 url/url-resolve.js n=100000 path='foo/bar' href='idn'                                                             -0.42 %       ±2.66% ±3.54% ±4.61%
 url/url-resolve.js n=100000 path='foo/bar' href='javascript'                                                       0.05 %       ±1.15% ±1.54% ±2.01%
 url/url-resolve.js n=100000 path='foo/bar' href='long'                                                            -0.54 %       ±0.67% ±0.89% ±1.16%
 url/url-resolve.js n=100000 path='foo/bar' href='noscheme'                                                 **      1.27 %       ±0.86% ±1.16% ±1.52%
 url/url-resolve.js n=100000 path='foo/bar' href='percent'                                                          0.23 %       ±1.36% ±1.81% ±2.35%
 url/url-resolve.js n=100000 path='foo/bar' href='short'                                                            0.09 %       ±1.30% ±1.73% ±2.25%
 url/url-resolve.js n=100000 path='foo/bar' href='ws'                                                        *      1.70 %       ±1.57% ±2.10% ±2.74%
 url/url-resolve.js n=100000 path='sibling' href='auth'                                                             1.48 %       ±1.72% ±2.30% ±3.02%
 url/url-resolve.js n=100000 path='sibling' href='dot'                                                              0.65 %       ±1.61% ±2.15% ±2.80%
 url/url-resolve.js n=100000 path='sibling' href='file'                                                            -0.12 %       ±1.11% ±1.47% ±1.92%
 url/url-resolve.js n=100000 path='sibling' href='idn'                                                             -0.18 %       ±2.07% ±2.76% ±3.61%
 url/url-resolve.js n=100000 path='sibling' href='javascript'                                                      -0.01 %       ±0.70% ±0.93% ±1.22%
 url/url-resolve.js n=100000 path='sibling' href='long'                                                      *      0.75 %       ±0.64% ±0.85% ±1.11%
 url/url-resolve.js n=100000 path='sibling' href='noscheme'                                                        -0.22 %       ±0.67% ±0.90% ±1.16%
 url/url-resolve.js n=100000 path='sibling' href='percent'                                                          0.88 %       ±1.84% ±2.45% ±3.19%
 url/url-resolve.js n=100000 path='sibling' href='short'                                                           -0.06 %       ±1.19% ±1.58% ±2.06%
 url/url-resolve.js n=100000 path='sibling' href='ws'                                                              -1.02 %       ±1.83% ±2.44% ±3.19%
 url/url-resolve.js n=100000 path='up' href='auth'                                                           *      1.68 %       ±1.58% ±2.12% ±2.80%
 url/url-resolve.js n=100000 path='up' href='dot'                                                                  -0.80 %       ±1.30% ±1.73% ±2.26%
 url/url-resolve.js n=100000 path='up' href='file'                                                                  0.07 %       ±1.15% ±1.53% ±1.99%
 url/url-resolve.js n=100000 path='up' href='idn'                                                           **     -2.67 %       ±1.83% ±2.45% ±3.22%
 url/url-resolve.js n=100000 path='up' href='javascript'                                                           -0.05 %       ±0.89% ±1.19% ±1.55%
 url/url-resolve.js n=100000 path='up' href='long'                                                                 -0.70 %       ±1.04% ±1.39% ±1.80%
 url/url-resolve.js n=100000 path='up' href='noscheme'                                                       *      1.11 %       ±1.05% ±1.41% ±1.85%
 url/url-resolve.js n=100000 path='up' href='percent'                                                               0.28 %       ±1.48% ±1.98% ±2.58%
 url/url-resolve.js n=100000 path='up' href='short'                                                                -0.06 %       ±1.19% ±1.59% ±2.07%
 url/url-resolve.js n=100000 path='up' href='ws'                                                                   -0.24 %       ±1.38% ±1.83% ±2.39%
 url/url-resolve.js n=100000 path='withscheme' href='auth'                                                          0.15 %       ±1.44% ±1.91% ±2.49%
 url/url-resolve.js n=100000 path='withscheme' href='dot'                                                          -0.58 %       ±1.00% ±1.33% ±1.74%
 url/url-resolve.js n=100000 path='withscheme' href='file'                                                         -0.21 %       ±1.43% ±1.90% ±2.47%
 url/url-resolve.js n=100000 path='withscheme' href='idn'                                                           0.02 %       ±1.69% ±2.25% ±2.94%
 url/url-resolve.js n=100000 path='withscheme' href='javascript'                                                   -0.53 %       ±0.98% ±1.31% ±1.71%
 url/url-resolve.js n=100000 path='withscheme' href='long'                                                          0.36 %       ±0.66% ±0.88% ±1.14%
 url/url-resolve.js n=100000 path='withscheme' href='noscheme'                                                      0.46 %       ±0.93% ±1.25% ±1.63%
 url/url-resolve.js n=100000 path='withscheme' href='percent'                                                      -0.83 %       ±1.16% ±1.55% ±2.02%
 url/url-resolve.js n=100000 path='withscheme' href='short'                                                        -0.16 %       ±1.42% ±1.89% ±2.46%
 url/url-resolve.js n=100000 path='withscheme' href='ws'                                                            0.38 %       ±0.83% ±1.10% ±1.43%
 url/url-searchparams-iteration.js n=1000000 method='forEach'                                                       0.11 %       ±0.82% ±1.09% ±1.42%
 url/url-searchparams-iteration.js n=1000000 method='iterator'                                                     -1.49 %       ±1.64% ±2.19% ±2.85%
 url/url-searchparams-read.js n=20000000 param='nonexistent' method='get'                                    *     -0.47 %       ±0.47% ±0.63% ±0.83%
 url/url-searchparams-read.js n=20000000 param='nonexistent' method='getAll'                                       -0.08 %       ±0.48% ±0.64% ±0.84%
 url/url-searchparams-read.js n=20000000 param='nonexistent' method='has'                                           0.05 %       ±0.23% ±0.30% ±0.40%
 url/url-searchparams-read.js n=20000000 param='one' method='get'                                                   0.02 %       ±0.18% ±0.24% ±0.31%
 url/url-searchparams-read.js n=20000000 param='one' method='getAll'                                               -0.21 %       ±0.39% ±0.53% ±0.68%
 url/url-searchparams-read.js n=20000000 param='one' method='has'                                                  -0.06 %       ±0.15% ±0.20% ±0.27%
 url/url-searchparams-read.js n=20000000 param='three' method='get'                                                 0.09 %       ±0.18% ±0.24% ±0.31%
 url/url-searchparams-read.js n=20000000 param='three' method='getAll'                                              0.25 %       ±0.31% ±0.42% ±0.54%
 url/url-searchparams-read.js n=20000000 param='three' method='has'                                                -0.13 %       ±0.55% ±0.73% ±0.95%
 url/url-searchparams-read.js n=20000000 param='two' method='get'                                                  -0.27 %       ±0.89% ±1.19% ±1.55%
 url/url-searchparams-read.js n=20000000 param='two' method='getAll'                                                0.30 %       ±0.32% ±0.43% ±0.56%
 url/url-searchparams-read.js n=20000000 param='two' method='has'                                            *     -0.17 %       ±0.16% ±0.21% ±0.28%
 url/url-searchparams-sort.js n=1000000 type='almostsorted'                                                        -0.02 %       ±0.32% ±0.43% ±0.55%
 url/url-searchparams-sort.js n=1000000 type='empty'                                                                0.30 %       ±0.93% ±1.23% ±1.61%
 url/url-searchparams-sort.js n=1000000 type='long'                                                                 0.02 %       ±0.20% ±0.27% ±0.35%
 url/url-searchparams-sort.js n=1000000 type='random'                                                               0.01 %       ±0.10% ±0.14% ±0.18%
 url/url-searchparams-sort.js n=1000000 type='reversed'                                                             0.01 %       ±0.06% ±0.09% ±0.11%
 url/url-searchparams-sort.js n=1000000 type='short'                                                                0.08 %       ±0.16% ±0.21% ±0.27%
 url/url-searchparams-sort.js n=1000000 type='sorted'                                                              -0.02 %       ±0.25% ±0.33% ±0.43%
 url/usvstring.js n=50000000 input='allinvalid'                                                                    -0.66 %       ±1.35% ±1.82% ±2.42%
 url/usvstring.js n=50000000 input='nonstring'                                                                     -0.39 %       ±2.22% ±2.96% ±3.87%
 url/usvstring.js n=50000000 input='someinvalid'                                                                    0.05 %       ±0.12% ±0.15% ±0.20%
 url/usvstring.js n=50000000 input='valid'                                                                         -0.07 %       ±0.07% ±0.10% ±0.13%
 url/usvstring.js n=50000000 input='validsurr'                                                                     -0.03 %       ±0.05% ±0.07% ±0.09%
 url/whatwg-url-idna.js n=5000000 to='ascii' input='all'                                                            0.05 %       ±0.25% ±0.33% ±0.43%
 url/whatwg-url-idna.js n=5000000 to='ascii' input='empty'                                                         -0.63 %       ±1.54% ±2.08% ±2.75%
 url/whatwg-url-idna.js n=5000000 to='ascii' input='none'                                                           0.06 %       ±0.77% ±1.02% ±1.33%
 url/whatwg-url-idna.js n=5000000 to='ascii' input='nonstring'                                                      0.75 %       ±1.48% ±1.97% ±2.58%
 url/whatwg-url-idna.js n=5000000 to='ascii' input='some'                                                           0.33 %       ±0.79% ±1.05% ±1.38%
 url/whatwg-url-idna.js n=5000000 to='unicode' input='all'                                                         -0.20 %       ±0.35% ±0.47% ±0.62%
 url/whatwg-url-idna.js n=5000000 to='unicode' input='empty'                                                        0.13 %       ±2.24% ±2.98% ±3.88%
 url/whatwg-url-idna.js n=5000000 to='unicode' input='none'                                                        -0.04 %       ±0.10% ±0.14% ±0.18%
 url/whatwg-url-idna.js n=5000000 to='unicode' input='nonstring'                                                    1.08 %       ±1.56% ±2.10% ±2.77%
 url/whatwg-url-idna.js n=5000000 to='unicode' input='some'                                                        -0.00 %       ±0.35% ±0.47% ±0.61%
 url/whatwg-url-properties.js n=300000 prop='hash' input='auth'                                                     0.76 %       ±1.04% ±1.38% ±1.80%
 url/whatwg-url-properties.js n=300000 prop='hash' input='dot'                                                      0.08 %       ±1.47% ±1.95% ±2.55%
 url/whatwg-url-properties.js n=300000 prop='hash' input='file'                                                    -0.01 %       ±1.32% ±1.75% ±2.28%
 url/whatwg-url-properties.js n=300000 prop='hash' input='idn'                                                      0.94 %       ±1.05% ±1.40% ±1.82%
 url/whatwg-url-properties.js n=300000 prop='hash' input='javascript'                                              -0.91 %       ±1.41% ±1.87% ±2.44%
 url/whatwg-url-properties.js n=300000 prop='hash' input='long'                                                    -0.24 %       ±1.22% ±1.62% ±2.11%
 url/whatwg-url-properties.js n=300000 prop='hash' input='percent'                                                 -0.46 %       ±1.28% ±1.70% ±2.22%
 url/whatwg-url-properties.js n=300000 prop='hash' input='short'                                                   -0.43 %       ±1.61% ±2.14% ±2.78%
 url/whatwg-url-properties.js n=300000 prop='hash' input='ws'                                                      -0.15 %       ±1.04% ±1.38% ±1.80%
 url/whatwg-url-properties.js n=300000 prop='host' input='auth'                                             **     -1.73 %       ±1.01% ±1.35% ±1.75%
 url/whatwg-url-properties.js n=300000 prop='host' input='dot'                                             ***     -2.83 %       ±1.08% ±1.44% ±1.89%
 url/whatwg-url-properties.js n=300000 prop='host' input='file'                                                    -0.62 %       ±1.30% ±1.73% ±2.25%
 url/whatwg-url-properties.js n=300000 prop='host' input='idn'                                                     -0.39 %       ±1.01% ±1.34% ±1.76%
 url/whatwg-url-properties.js n=300000 prop='host' input='javascript'                                               0.17 %       ±1.49% ±1.98% ±2.58%
 url/whatwg-url-properties.js n=300000 prop='host' input='long'                                            ***     -2.28 %       ±0.84% ±1.12% ±1.46%
 url/whatwg-url-properties.js n=300000 prop='host' input='percent'                                         ***     -2.15 %       ±0.76% ±1.01% ±1.31%
 url/whatwg-url-properties.js n=300000 prop='host' input='short'                                           ***     -2.38 %       ±1.12% ±1.49% ±1.94%
 url/whatwg-url-properties.js n=300000 prop='host' input='ws'                                              ***     -2.94 %       ±1.61% ±2.15% ±2.82%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='auth'                                                -0.37 %       ±0.90% ±1.20% ±1.56%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='dot'                                                  0.15 %       ±1.17% ±1.55% ±2.02%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='file'                                                -0.21 %       ±0.99% ±1.32% ±1.72%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='idn'                                                  0.24 %       ±0.79% ±1.05% ±1.36%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='javascript'                                          -0.95 %       ±1.76% ±2.35% ±3.07%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='long'                                                 0.50 %       ±0.93% ±1.23% ±1.61%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='percent'                                              0.25 %       ±0.91% ±1.21% ±1.58%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='short'                                               -0.36 %       ±0.79% ±1.05% ±1.36%
 url/whatwg-url-properties.js n=300000 prop='hostname' input='ws'                                                  -0.21 %       ±1.05% ±1.40% ±1.82%
 url/whatwg-url-properties.js n=300000 prop='href' input='auth'                                                    -0.16 %       ±1.09% ±1.45% ±1.89%
 url/whatwg-url-properties.js n=300000 prop='href' input='dot'                                                     -0.11 %       ±0.95% ±1.27% ±1.66%
 url/whatwg-url-properties.js n=300000 prop='href' input='file'                                                     0.18 %       ±0.89% ±1.19% ±1.55%
 url/whatwg-url-properties.js n=300000 prop='href' input='idn'                                                     -0.68 %       ±1.85% ±2.48% ±3.26%
 url/whatwg-url-properties.js n=300000 prop='href' input='javascript'                                              -0.33 %       ±1.22% ±1.63% ±2.12%
 url/whatwg-url-properties.js n=300000 prop='href' input='long'                                                     0.02 %       ±0.90% ±1.19% ±1.55%
 url/whatwg-url-properties.js n=300000 prop='href' input='percent'                                                 -0.70 %       ±2.15% ±2.86% ±3.73%
 url/whatwg-url-properties.js n=300000 prop='href' input='short'                                                    0.33 %       ±2.01% ±2.68% ±3.49%
 url/whatwg-url-properties.js n=300000 prop='href' input='ws'                                                      -0.45 %       ±1.64% ±2.19% ±2.87%
 url/whatwg-url-properties.js n=300000 prop='origin' input='auth'                                                  -0.68 %       ±0.84% ±1.12% ±1.47%
 url/whatwg-url-properties.js n=300000 prop='origin' input='dot'                                                    0.35 %       ±0.64% ±0.86% ±1.12%
 url/whatwg-url-properties.js n=300000 prop='origin' input='file'                                                  -0.02 %       ±0.81% ±1.08% ±1.41%
 url/whatwg-url-properties.js n=300000 prop='origin' input='idn'                                                   -0.01 %       ±0.68% ±0.91% ±1.19%
 url/whatwg-url-properties.js n=300000 prop='origin' input='javascript'                                             1.05 %       ±1.17% ±1.57% ±2.05%
 url/whatwg-url-properties.js n=300000 prop='origin' input='long'                                                  -0.40 %       ±0.67% ±0.90% ±1.17%
 url/whatwg-url-properties.js n=300000 prop='origin' input='percent'                                                0.03 %       ±0.70% ±0.93% ±1.21%
 url/whatwg-url-properties.js n=300000 prop='origin' input='short'                                                 -0.51 %       ±0.67% ±0.89% ±1.15%
 url/whatwg-url-properties.js n=300000 prop='origin' input='ws'                                                    -0.51 %       ±0.54% ±0.72% ±0.94%
 url/whatwg-url-properties.js n=300000 prop='password' input='auth'                                                 0.08 %       ±1.18% ±1.57% ±2.04%
 url/whatwg-url-properties.js n=300000 prop='password' input='dot'                                                 -0.13 %       ±1.01% ±1.35% ±1.76%
 url/whatwg-url-properties.js n=300000 prop='password' input='file'                                                 0.79 %       ±1.84% ±2.46% ±3.22%
 url/whatwg-url-properties.js n=300000 prop='password' input='idn'                                                  0.82 %       ±1.43% ±1.91% ±2.48%
 url/whatwg-url-properties.js n=300000 prop='password' input='javascript'                                   **     -1.55 %       ±1.15% ±1.54% ±2.02%
 url/whatwg-url-properties.js n=300000 prop='password' input='long'                                                 0.30 %       ±1.15% ±1.53% ±2.00%
 url/whatwg-url-properties.js n=300000 prop='password' input='percent'                                             -0.54 %       ±0.96% ±1.28% ±1.67%
 url/whatwg-url-properties.js n=300000 prop='password' input='short'                                                0.11 %       ±1.59% ±2.12% ±2.78%
 url/whatwg-url-properties.js n=300000 prop='password' input='ws'                                                   0.04 %       ±1.33% ±1.77% ±2.31%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='auth'                                                 0.14 %       ±1.28% ±1.71% ±2.23%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='dot'                                                 -1.07 %       ±1.34% ±1.79% ±2.33%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='file'                                                -0.77 %       ±1.17% ±1.55% ±2.02%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='idn'                                                  0.09 %       ±0.86% ±1.15% ±1.49%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='javascript'                                           0.34 %       ±1.48% ±1.98% ±2.58%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='long'                                          *      1.25 %       ±1.10% ±1.47% ±1.93%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='percent'                                       *     -1.29 %       ±1.10% ±1.46% ±1.90%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='short'                                         *      1.61 %       ±1.59% ±2.11% ±2.76%
 url/whatwg-url-properties.js n=300000 prop='pathname' input='ws'                                                  -0.53 %       ±1.91% ±2.55% ±3.32%
 url/whatwg-url-properties.js n=300000 prop='port' input='auth'                                                     0.38 %       ±0.99% ±1.31% ±1.71%
 url/whatwg-url-properties.js n=300000 prop='port' input='dot'                                                     -0.02 %       ±1.24% ±1.65% ±2.15%
 url/whatwg-url-properties.js n=300000 prop='port' input='file'                                                     0.08 %       ±1.41% ±1.87% ±2.44%
 url/whatwg-url-properties.js n=300000 prop='port' input='idn'                                                      0.39 %       ±1.29% ±1.72% ±2.24%
 url/whatwg-url-properties.js n=300000 prop='port' input='javascript'                                               0.71 %       ±1.36% ±1.81% ±2.35%
 url/whatwg-url-properties.js n=300000 prop='port' input='long'                                                    -0.59 %       ±1.10% ±1.47% ±1.92%
 url/whatwg-url-properties.js n=300000 prop='port' input='percent'                                                 -0.08 %       ±0.91% ±1.21% ±1.57%
 url/whatwg-url-properties.js n=300000 prop='port' input='short'                                                   -0.46 %       ±1.02% ±1.36% ±1.78%
 url/whatwg-url-properties.js n=300000 prop='port' input='ws'                                                *      1.18 %       ±1.16% ±1.55% ±2.02%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='auth'                                                -0.00 %       ±0.98% ±1.30% ±1.70%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='dot'                                                  0.24 %       ±1.13% ±1.51% ±1.96%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='file'                                                 0.71 %       ±1.60% ±2.13% ±2.78%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='idn'                                                 -0.21 %       ±0.87% ±1.16% ±1.51%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='javascript'                                           0.21 %       ±1.30% ±1.73% ±2.25%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='long'                                                -0.09 %       ±0.97% ±1.29% ±1.68%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='percent'                                              0.52 %       ±1.00% ±1.32% ±1.73%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='short'                                                0.79 %       ±1.05% ±1.40% ±1.82%
 url/whatwg-url-properties.js n=300000 prop='protocol' input='ws'                                            *     -1.17 %       ±0.94% ±1.25% ±1.63%
 url/whatwg-url-properties.js n=300000 prop='search' input='auth'                                                   1.44 %       ±2.00% ±2.68% ±3.51%
 url/whatwg-url-properties.js n=300000 prop='search' input='dot'                                                   -0.66 %       ±1.40% ±1.87% ±2.45%
 url/whatwg-url-properties.js n=300000 prop='search' input='file'                                                  -1.08 %       ±1.68% ±2.25% ±2.93%
 url/whatwg-url-properties.js n=300000 prop='search' input='idn'                                                   -0.04 %       ±1.63% ±2.17% ±2.83%
 url/whatwg-url-properties.js n=300000 prop='search' input='javascript'                                             0.57 %       ±1.72% ±2.29% ±2.98%
 url/whatwg-url-properties.js n=300000 prop='search' input='long'                                                  -0.02 %       ±1.60% ±2.13% ±2.77%
 url/whatwg-url-properties.js n=300000 prop='search' input='percent'                                               -1.18 %       ±1.30% ±1.74% ±2.28%
 url/whatwg-url-properties.js n=300000 prop='search' input='short'                                                 -0.72 %       ±1.16% ±1.55% ±2.02%
 url/whatwg-url-properties.js n=300000 prop='search' input='ws'                                                     1.96 %       ±2.29% ±3.06% ±4.01%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='auth'                                            -0.10 %       ±1.84% ±2.44% ±3.18%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='dot'                                             -0.75 %       ±1.68% ±2.23% ±2.91%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='file'                                             0.52 %       ±1.58% ±2.10% ±2.73%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='idn'                                             -0.10 %       ±1.68% ±2.24% ±2.91%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='javascript'                                       0.36 %       ±2.11% ±2.80% ±3.65%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='long'                                             1.35 %       ±2.05% ±2.73% ±3.55%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='percent'                                          1.00 %       ±1.81% ±2.40% ±3.13%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='short'                                           -1.67 %       ±1.84% ±2.45% ±3.21%
 url/whatwg-url-properties.js n=300000 prop='searchParams' input='ws'                                               0.58 %       ±1.40% ±1.86% ±2.43%
 url/whatwg-url-properties.js n=300000 prop='username' input='auth'                                                -0.50 %       ±1.31% ±1.76% ±2.30%
 url/whatwg-url-properties.js n=300000 prop='username' input='dot'                                                 -0.14 %       ±1.26% ±1.69% ±2.20%
 url/whatwg-url-properties.js n=300000 prop='username' input='file'                                          *     -1.56 %       ±1.28% ±1.71% ±2.25%
 url/whatwg-url-properties.js n=300000 prop='username' input='idn'                                                  0.69 %       ±1.83% ±2.44% ±3.18%
 url/whatwg-url-properties.js n=300000 prop='username' input='javascript'                                           0.25 %       ±1.30% ±1.73% ±2.26%
 url/whatwg-url-properties.js n=300000 prop='username' input='long'                                                 0.28 %       ±2.03% ±2.70% ±3.52%
 url/whatwg-url-properties.js n=300000 prop='username' input='percent'                                             -0.71 %       ±1.32% ±1.76% ±2.32%
 url/whatwg-url-properties.js n=300000 prop='username' input='short'                                                0.80 %       ±1.79% ±2.39% ±3.11%
 url/whatwg-url-properties.js n=300000 prop='username' input='ws'                                                   0.70 %       ±1.33% ±1.77% ±2.30%
```
