### PR TITLE
vm: migrate isContext to internal/errors

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -26,10 +26,13 @@ const {
   kParsingContext,
 
   makeContext,
-  isContext,
+  isContext: _isContext,
 } = process.binding('contextify');
 
-const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_MISSING_ARGS
+} = require('internal/errors').codes;
 
 // The binding provides a few useful primitives:
 // - Script(code, { filename = "evalmachine.anonymous",
@@ -95,6 +98,19 @@ function getContextOptions(options) {
     return contextOptions;
   }
   return {};
+}
+
+function isContext(sandbox) {
+  if (arguments.length < 1) {
+    throw new ERR_MISSING_ARGS('sandbox');
+  }
+
+  if (typeof sandbox !== 'object' && typeof sandbox !== 'function' ||
+      sandbox === null) {
+    throw new ERR_INVALID_ARG_TYPE('sandbox', 'object', sandbox);
+  }
+
+  return _isContext(sandbox);
 }
 
 let defaultContextNameIndex = 1;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -252,10 +252,8 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
 void ContextifyContext::IsContext(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!args[0]->IsObject()) {
-    env->ThrowTypeError("sandbox must be an object");
-    return;
-  }
+  CHECK(args[0]->IsObject());
+
   Local<Object> sandbox = args[0].As<Object>();
 
   Maybe<bool> result =

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const vm = require('vm');
@@ -44,9 +44,12 @@ assert.strictEqual(3, context.foo);
 assert.strictEqual('lala', context.thing);
 
 // Issue GH-227:
-assert.throws(() => {
+common.expectsError(() => {
   vm.runInNewContext('', null, 'some.js');
-}, /^TypeError: sandbox must be an object$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError
+});
 
 // Issue GH-1140:
 // Test runInContext signature

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -20,13 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
-const assert = require('assert');
+const common = require('../common');
 const vm = require('vm');
 
-assert.throws(function() {
+common.expectsError(() => {
   vm.createContext('string is not supported');
-}, /^TypeError: sandbox must be an object$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError
+});
 
 // Should not throw.
 vm.createContext({ a: 1 });

--- a/test/parallel/test-vm-is-context.js
+++ b/test/parallel/test-vm-is-context.js
@@ -20,13 +20,27 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-assert.throws(function() {
-  vm.isContext('string is not supported');
-}, /^TypeError: sandbox must be an object$/);
+for (const valToTest of [
+  'string', null, undefined, 8.9, Symbol('sym'), true
+]) {
+  common.expectsError(() => {
+    vm.isContext(valToTest);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  });
+}
+
+common.expectsError(() => {
+  vm.isContext();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  type: TypeError
+});
 
 assert.strictEqual(vm.isContext({}), false);
 assert.strictEqual(vm.isContext([]), false);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/18106

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
