### PR TITLE
doc: improve style guide text

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -14,9 +14,8 @@
   "color" vs. "colour", etc.
 * Use [serial commas][].
 * Avoid personal pronouns in reference documentation ("I", "you", "we").
-  * Pronouns are acceptable in more colloquial documentation, like guides.
-  * Use gender-neutral pronouns and mass nouns. Non-comprehensive
-    examples:
+  * Personal pronouns are acceptable in colloquial documentation such as guides.
+  * Use gender-neutral pronouns and gender-neutral plural nouns.
     * OK: "they", "their", "them", "folks", "people", "developers"
     * NOT OK: "his", "hers", "him", "her", "guys", "dudes"
 * When combining wrapping elements (parentheses and quotes), terminal


### PR DESCRIPTION
* Specify that personal pronouns are OK in colloquial documentation
  rather than just pronouns. Pronouns are OK in all documentation. (For
  example, "it" is a pronoun and is acceptable in all types of
  documentation.) Specify "personal pronouns" for clarity.
* more colloquial -> colloquial
* like -> such as
* Remove "mass nouns" as no mass nouns are given as examples. Plural
  nouns seems to be what was meant, so use that instead.
* Repeat "gender-neutral" to make it clear that it refers to both terms
  and not merely the first term it appears before.
* Remove "non-comprehensive examples". Examples are, by definition,
  non-comprehensive. No need to announce that the examples are examples.
  It is obvious.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
