### PR TITLE
doc: do not announce obvious examples

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -23,8 +23,6 @@ resized.
 The `Buffer` class is a global within Node.js, making it unlikely that one
 would need to ever use `require('buffer').Buffer`.
 
-Examples:
-
 ```js
 // Creates a zero-filled Buffer of length 10.
 const buf1 = Buffer.alloc(10);
@@ -485,8 +483,6 @@ changes:
 Creates a new `Buffer` containing the given JavaScript string `string`. If
 provided, the `encoding` parameter identifies the character encoding of `string`.
 
-Examples:
-
 ```js
 const buf1 = new Buffer('this is a tést');
 const buf2 = new Buffer('7468697320697320612074c3a97374', 'hex');
@@ -895,8 +891,6 @@ added: v5.10.0
 Creates a new `Buffer` containing the given JavaScript string `string`. If
 provided, the `encoding` parameter identifies the character encoding of `string`.
 
-Examples:
-
 ```js
 const buf1 = Buffer.from('this is a tést');
 const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
@@ -1048,8 +1042,6 @@ Comparison is based on the actual sequence of bytes in each `Buffer`.
 * `1` is returned if `target` should come *before* `buf` when sorted.
 * `-1` is returned if `target` should come *after* `buf` when sorted.
 
-Examples:
-
 ```js
 const buf1 = Buffer.from('ABC');
 const buf2 = Buffer.from('BCD');
@@ -1073,8 +1065,6 @@ console.log([buf1, buf2, buf3].sort(Buffer.compare));
 The optional `targetStart`, `targetEnd`, `sourceStart`, and `sourceEnd`
 arguments can be used to limit the comparison to specific ranges within `target`
 and `buf` respectively.
-
-Examples:
 
 ```js
 const buf1 = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -1185,8 +1175,6 @@ changes:
 Returns `true` if both `buf` and `otherBuffer` have exactly the same bytes,
 `false` otherwise.
 
-Examples:
-
 ```js
 const buf1 = Buffer.from('ABC');
 const buf2 = Buffer.from('414243', 'hex');
@@ -1277,8 +1265,6 @@ added: v5.3.0
 
 Equivalent to [`buf.indexOf() !== -1`][`buf.indexOf()`].
 
-Examples:
-
 ```js
 const buf = Buffer.from('this is a buffer');
 
@@ -1326,8 +1312,6 @@ If `value` is:
     To compare a partial `Buffer`, use [`buf.slice()`].
   * a number, `value` will be interpreted as an unsigned 8-bit integer
   value between `0` and `255`.
-
-Examples:
 
 ```js
 const buf = Buffer.from('this is a buffer');
@@ -1427,8 +1411,6 @@ changes:
 Identical to [`buf.indexOf()`], except `buf` is searched from back to front
 instead of front to back.
 
-Examples:
-
 ```js
 const buf = Buffer.from('this buffer is a buffer');
 
@@ -1513,8 +1495,6 @@ can result in undefined and inconsistent behavior. Applications that wish to
 modify the length of a `Buffer` should therefore treat `length` as read-only and
 use [`buf.slice()`] to create a new `Buffer`.
 
-Examples:
-
 ```js
 let buf = Buffer.allocUnsafe(10);
 
@@ -1556,8 +1536,6 @@ Reads a 64-bit double from `buf` at the specified `offset` with specified
 endian format (`readDoubleBE()` returns big endian, `readDoubleLE()` returns
 little endian).
 
-Examples:
-
 ```js
 const buf = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -1590,8 +1568,6 @@ Reads a 32-bit float from `buf` at the specified `offset` with specified
 endian format (`readFloatBE()` returns big endian, `readFloatLE()` returns
 little endian).
 
-Examples:
-
 ```js
 const buf = Buffer.from([1, 2, 3, 4]);
 
@@ -1622,8 +1598,6 @@ changes:
 Reads a signed 8-bit integer from `buf` at the specified `offset`.
 
 Integers read from a `Buffer` are interpreted as two's complement signed values.
-
-Examples:
 
 ```js
 const buf = Buffer.from([-1, 5]);
@@ -1656,8 +1630,6 @@ the specified endian format (`readInt16BE()` returns big endian,
 
 Integers read from a `Buffer` are interpreted as two's complement signed values.
 
-Examples:
-
 ```js
 const buf = Buffer.from([0, 5]);
 
@@ -1689,8 +1661,6 @@ the specified endian format (`readInt32BE()` returns big endian,
 
 Integers read from a `Buffer` are interpreted as two's complement signed values.
 
-Examples:
-
 ```js
 const buf = Buffer.from([0, 0, 0, 5]);
 
@@ -1721,8 +1691,6 @@ Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as a two's complement signed value. Supports up to 48
 bits of accuracy.
 
-Examples:
-
 ```js
 const buf = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
 
@@ -1750,8 +1718,6 @@ changes:
 * Returns: {integer}
 
 Reads an unsigned 8-bit integer from `buf` at the specified `offset`.
-
-Examples:
 
 ```js
 const buf = Buffer.from([1, -2]);
@@ -1781,8 +1747,6 @@ changes:
 Reads an unsigned 16-bit integer from `buf` at the specified `offset` with
 specified endian format (`readUInt16BE()` returns big endian, `readUInt16LE()`
 returns little endian).
-
-Examples:
 
 ```js
 const buf = Buffer.from([0x12, 0x34, 0x56]);
@@ -1817,8 +1781,6 @@ Reads an unsigned 32-bit integer from `buf` at the specified `offset` with
 specified endian format (`readUInt32BE()` returns big endian,
 `readUInt32LE()` returns little endian).
 
-Examples:
-
 ```js
 const buf = Buffer.from([0x12, 0x34, 0x56, 0x78]);
 
@@ -1848,8 +1810,6 @@ changes:
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as an unsigned integer. Supports up to 48
 bits of accuracy.
-
-Examples:
 
 ```js
 const buf = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
@@ -1915,8 +1875,6 @@ console.log(buf2.toString('ascii', 0, buf2.length));
 Specifying negative indexes causes the slice to be generated relative to the
 end of `buf` rather than the beginning.
 
-Examples:
-
 ```js
 const buf = Buffer.from('buffer');
 
@@ -1942,8 +1900,6 @@ added: v5.10.0
 
 Interprets `buf` as an array of unsigned 16-bit integers and swaps the byte-order
 *in-place*. Throws a `RangeError` if [`buf.length`] is not a multiple of 2.
-
-Examples:
 
 ```js
 const buf1 = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
@@ -1972,8 +1928,6 @@ added: v5.10.0
 Interprets `buf` as an array of unsigned 32-bit integers and swaps the byte-order
 *in-place*. Throws a `RangeError` if [`buf.length`] is not a multiple of 4.
 
-Examples:
-
 ```js
 const buf1 = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
 
@@ -2000,8 +1954,6 @@ added: v6.3.0
 
 Interprets `buf` as an array of 64-bit numbers and swaps the byte-order *in-place*.
 Throws a `RangeError` if [`buf.length`] is not a multiple of 8.
-
-Examples:
 
 ```js
 const buf1 = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
@@ -2069,8 +2021,6 @@ Decodes `buf` to a string according to the specified character encoding in
 The maximum length of a string instance (in UTF-16 code units) is available
 as [`buffer.constants.MAX_STRING_LENGTH`][].
 
-Examples:
-
 ```js
 const buf1 = Buffer.allocUnsafe(26);
 
@@ -2103,8 +2053,6 @@ added: v1.1.0
 
 Creates and returns an [iterator] for `buf` values (bytes). This function is
 called automatically when a `Buffer` is used in a `for..of` statement.
-
-Examples:
 
 ```js
 const buf = Buffer.from('buffer');
@@ -2179,8 +2127,6 @@ format (`writeDoubleBE()` writes big endian, `writeDoubleLE()` writes little
 endian). `value` *should* be a valid 64-bit double. Behavior is undefined when
 `value` is anything other than a 64-bit double.
 
-Examples:
-
 ```js
 const buf = Buffer.allocUnsafe(8);
 
@@ -2214,8 +2160,6 @@ Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeFloatBE()` writes big endian, `writeFloatLE()` writes little
 endian). `value` *should* be a valid 32-bit float. Behavior is undefined when
 `value` is anything other than a 32-bit float.
-
-Examples:
 
 ```js
 const buf = Buffer.allocUnsafe(4);
@@ -2251,8 +2195,6 @@ a signed 8-bit integer.
 
 `value` is interpreted and written as a two's complement signed integer.
 
-Examples:
-
 ```js
 const buf = Buffer.allocUnsafe(2);
 
@@ -2284,8 +2226,6 @@ endian). `value` *should* be a valid signed 16-bit integer. Behavior is undefine
 when `value` is anything other than a signed 16-bit integer.
 
 `value` is interpreted and written as a two's complement signed integer.
-
-Examples:
 
 ```js
 const buf = Buffer.allocUnsafe(4);
@@ -2319,8 +2259,6 @@ when `value` is anything other than a signed 32-bit integer.
 
 `value` is interpreted and written as a two's complement signed integer.
 
-Examples:
-
 ```js
 const buf = Buffer.allocUnsafe(8);
 
@@ -2350,8 +2288,6 @@ changes:
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`.
 Supports up to 48 bits of accuracy. Behavior is undefined when `value` is
 anything other than a signed integer.
-
-Examples:
 
 ```js
 const buf = Buffer.allocUnsafe(6);
@@ -2385,8 +2321,6 @@ Writes `value` to `buf` at the specified `offset`. `value` *should* be a
 valid unsigned 8-bit integer. Behavior is undefined when `value` is anything
 other than an unsigned 8-bit integer.
 
-Examples:
-
 ```js
 const buf = Buffer.allocUnsafe(4);
 
@@ -2418,8 +2352,6 @@ Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeUInt16BE()` writes big endian, `writeUInt16LE()` writes little
 endian). `value` should be a valid unsigned 16-bit integer. Behavior is
 undefined when `value` is anything other than an unsigned 16-bit integer.
-
-Examples:
 
 ```js
 const buf = Buffer.allocUnsafe(4);
@@ -2457,8 +2389,6 @@ format (`writeUInt32BE()` writes big endian, `writeUInt32LE()` writes little
 endian). `value` should be a valid unsigned 32-bit integer. Behavior is
 undefined when `value` is anything other than an unsigned 32-bit integer.
 
-Examples:
-
 ```js
 const buf = Buffer.allocUnsafe(4);
 
@@ -2493,8 +2423,6 @@ changes:
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`.
 Supports up to 48 bits of accuracy. Behavior is undefined when `value` is
 anything other than an unsigned integer.
-
-Examples:
 
 ```js
 const buf = Buffer.allocUnsafe(6);


### PR DESCRIPTION
Remove "Examples:" labels that announce things that are clearly
examples.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
