### PR TITLE
util,doc,test: accept optional context parameter in util.promisify

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1393,7 +1393,7 @@ unavailable.
 [`process.on('message')`]: process.html#process_event_message
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`stdio`]: #child_process_options_stdio
-[`util.promisify()`]: util.html#util_util_promisify_original
+[`util.promisify()`]: util.html#util_util_promisify_original_options
 [Default Windows Shell]: #child_process_default_windows_shell
 [Shell Requirements]: #child_process_shell_requirements
 [synchronous counterparts]: #child_process_synchronous_process_creation

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -660,7 +660,7 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [`dns.reverse()`]: #dns_dns_reverse_ip_callback
 [`dns.setServers()`]: #dns_dns_setservers_servers
 [`socket.connect()`]: net.html#net_socket_connect_options_connectlistener
-[`util.promisify()`]: util.html#util_util_promisify_original
+[`util.promisify()`]: util.html#util_util_promisify_original_options
 [DNS error codes]: #dns_error_codes
 [Implementation considerations section]: #dns_implementation_considerations
 [rfc5952]: https://tools.ietf.org/html/rfc5952#section-6

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4737,7 +4737,7 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`kqueue`]: https://www.freebsd.org/cgi/man.cgi?kqueue
 [`net.Socket`]: net.html#net_class_net_socket
 [`stat()`]: fs.html#fs_fs_stat_path_callback
-[`util.promisify()`]: util.html#util_util_promisify_original
+[`util.promisify()`]: util.html#util_util_promisify_original_options
 [Caveats]: #fs_caveats
 [Common System Errors]: errors.html#errors_common_system_errors
 [FS Constants]: #fs_fs_constants_1

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -237,5 +237,5 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 [`setImmediate()`]: timers.html#timers_setimmediate_callback_args
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
-[`util.promisify()`]: util.html#util_util_promisify_original
+[`util.promisify()`]: util.html#util_util_promisify_original_options
 [the Node.js Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -660,13 +660,15 @@ Otherwise, returns `false`.
 See [`assert.deepStrictEqual()`][] for more information about deep strict
 equality.
 
-## util.promisify(original[, context])
+## util.promisify(original[, options])
 <!-- YAML
 added: v8.0.0
 -->
 
 * `original` {Function}
-* `context` {any}
+* `options` {Object} Optional. Can be passed to change the default behaviour.
+  Can have the following fields:
+  * `context` {any} Context to which to bind the returning function to.
 * Returns: {Function}
 
 Takes a function following the common error-first callback style, i.e. taking
@@ -1987,7 +1989,7 @@ Deprecated predecessor of `console.log`.
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 [`TypedArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 [`util.inspect()`]: #util_util_inspect_object_options
-[`util.promisify()`]: #util_util_promisify_original
+[`util.promisify()`]: #util_util_promisify_original_options
 [`util.types.isAnyArrayBuffer()`]: #util_util_types_isanyarraybuffer_value
 [`util.types.isArrayBuffer()`]: #util_util_types_isarraybuffer_value
 [`util.types.isDate()`]: #util_util_types_isdate_value

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -660,17 +660,20 @@ Otherwise, returns `false`.
 See [`assert.deepStrictEqual()`][] for more information about deep strict
 equality.
 
-## util.promisify(original)
+## util.promisify(original[, context])
 <!-- YAML
 added: v8.0.0
 -->
 
 * `original` {Function}
+* `context` {any}
 * Returns: {Function}
 
 Takes a function following the common error-first callback style, i.e. taking
 a `(err, value) => ...` callback as the last argument, and returns a version
 that returns promises.
+
+If `context` is passed, the context of the returned function is bound to it.
 
 ```js
 const util = require('util');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -292,7 +292,7 @@ function getIdentificationOf(obj) {
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
-function promisify(original) {
+function promisify(original, context) {
   if (typeof original !== 'function')
     throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
 
@@ -314,7 +314,7 @@ function promisify(original) {
   function fn(...args) {
     const promise = createPromise();
     try {
-      original.call(this, ...args, (err, ...values) => {
+      original.call(context || this, ...args, (err, ...values) => {
         if (err) {
           promiseReject(promise, err);
         } else if (argumentNames !== undefined && values.length > 1) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -292,9 +292,15 @@ function getIdentificationOf(obj) {
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
-function promisify(original, context) {
+function promisify(original, options = {}) {
   if (typeof original !== 'function')
     throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
+
+  if (Object.prototype.toString.call(options) !== '[object Object]') {
+    throw new ERR_INVALID_ARG_TYPE('options', 'object');
+  }
+
+  const { context } = options;
 
   if (original[kCustomPromisifiedSymbol]) {
     const fn = original[kCustomPromisifiedSymbol];

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -297,7 +297,7 @@ function promisify(original, options = {}) {
     throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
 
   if (typeof options !== 'object' || options == null) {
-    throw new ERR_INVALID_ARG_TYPE('options', 'Object');
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
 
   const { context } = options;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -296,8 +296,8 @@ function promisify(original, options = {}) {
   if (typeof original !== 'function')
     throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
 
-  if (Object.prototype.toString.call(options) !== '[object Object]') {
-    throw new ERR_INVALID_ARG_TYPE('options', 'object');
+  if (typeof options !== 'object' || options == null) {
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object');
   }
 
   const { context } = options;

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -195,3 +195,14 @@ const stat = promisify(fs.stat);
                `Received type ${typeof input}`
     });
 });
+
+{
+  function factory() {
+    this.getContext = function(callback) {
+      callback(null, this);
+    };
+  }
+  const instance = new factory();
+  const a = promisify(instance.getContext, instance);
+  a().then((context) => assert.strictEqual(context, instance));
+}

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -203,6 +203,16 @@ const stat = promisify(fs.stat);
     };
   }
   const instance = new factory();
-  const a = promisify(instance.getContext, instance);
+  const a = promisify(instance.getContext, { context: instance });
   a().then((context) => assert.strictEqual(context, instance));
+}
+
+{
+  function fn(callback) {
+    callback(null);
+  }
+  common.expectsError(
+    () => promisify(fn, []),
+    { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
+  );
 }

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -212,7 +212,7 @@ const stat = promisify(fs.stat);
     callback(null);
   }
   common.expectsError(
-    () => promisify(fn, []),
+    () => promisify(fn, ''),
     { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
   );
 }


### PR DESCRIPTION
This commit accepts an optional `context` parameter in `util.promisify`.

The purpose of this is to allow preserving of scope and/or context of the original function passed, which is currently lost.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
