### PR TITLE
module: fix `e.stack` error when throwing undefined or null

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -105,7 +105,6 @@ class ModuleJob {
     try {
       module.evaluate();
     } catch (e) {
-      e.stack;
       this.hadError = true;
       this.error = e;
       throw e;

--- a/test/es-module/test-esm-throw-undefined.mjs
+++ b/test/es-module/test-esm-throw-undefined.mjs
@@ -4,12 +4,12 @@ import common from '../common/index.js';
 import assert from 'assert';
 
 async function doTest() {
-  try {
-    await import('../fixtures/es-module-loaders/throw-undefined');
-    assert(false);
-  } catch (e) {
-    assert.strictEqual(e, undefined);
-  }
+  await assert.rejects(
+    async () => {
+      await import('../fixtures/es-module-loaders/throw-undefined');
+    },
+    (e) => e === undefined
+  );
 }
 
 doTest().then(common.mustCall());

--- a/test/es-module/test-esm-throw-undefined.mjs
+++ b/test/es-module/test-esm-throw-undefined.mjs
@@ -1,0 +1,15 @@
+// Flags: --experimental-modules
+/* eslint-disable node-core/required-modules */
+import common from '../common/index.js';
+import assert from 'assert';
+
+async function doTest() {
+  try {
+    await import('../fixtures/es-module-loaders/throw-undefined');
+    assert(false);
+  } catch (e) {
+    assert.strictEqual(e, undefined);
+  }
+}
+
+doTest().then(common.mustCall());

--- a/test/es-module/test-esm-throw-undefined.mjs
+++ b/test/es-module/test-esm-throw-undefined.mjs
@@ -12,4 +12,5 @@ async function doTest() {
   );
 }
 
-doTest().then(common.mustCall());
+common.crashOnUnhandledRejection();
+doTest();

--- a/test/fixtures/es-module-loaders/throw-undefined.mjs
+++ b/test/fixtures/es-module-loaders/throw-undefined.mjs
@@ -1,0 +1,3 @@
+'use strict';
+
+throw undefined;


### PR DESCRIPTION
Fix #19281

I just deleted one `e.stack` line. There's another `e.stack` line in DefaultResolve.js, with a comment. Seems that shouldn't be deleted.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
