### PR TITLE
lib: define printErr() in script string

### DIFF
--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -22,11 +22,6 @@ scriptFiles.forEach(function(s) {
   script += process.binding('natives')[s] + '\n';
 });
 
-// eslint-disable-next-line no-unused-vars
-function printErr(err) {
-  console.error(err);
-}
-
 const tickArguments = [];
 if (process.platform === 'darwin') {
   tickArguments.push('--mac');
@@ -37,6 +32,7 @@ tickArguments.push.apply(tickArguments, process.argv.slice(1));
 script = `(function(module, require) {
   arguments = ${JSON.stringify(tickArguments)};
   function write (s) { process.stdout.write(s) }
+  function printErr(err) { console.error(err); }
   ${script}
 })`;
 vm.runInThisContext(script)(module, require);


### PR DESCRIPTION
This commit moves the `printErr()` function, used by the tick profiler processer, into the code string passed to `vm.runInThisContext()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: https://github.com/nodejs/node/issues/19260