### PR TITLE
test: fix path in doctool/test-doctool-json

### DIFF
--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const common = require('../common');
-// The doctool currently uses js-yaml from the tool/eslint/ tree.
+// The doctool currently uses js-yaml from the tool/node_modules/eslint/ tree.
 try {
-  require('../../tools/eslint/node_modules/js-yaml');
+  require('../../tools/node_modules/eslint/node_modules/js-yaml');
 } catch (e) {
   common.skip('missing js-yaml (eslint not present)');
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This seems to slip in https://github.com/nodejs/node/pull/17820