### PR TITLE
buffer: improve write(U)Int functions

### DIFF
--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -34,6 +34,7 @@ const INT32 = 0x7fffffff;
 const INT48 = 0x7fffffffffff;
 const UINT8 = 0xff;
 const UINT16 = 0xffff;
+const UINT32 = 0xffffffff;
 
 const mod = {
   writeInt8: INT8,
@@ -44,8 +45,8 @@ const mod = {
   writeUInt8: UINT8,
   writeUInt16BE: UINT16,
   writeUInt16LE: UINT16,
-  writeUInt32BE: INT32,
-  writeUInt32LE: INT32,
+  writeUInt32BE: UINT32,
+  writeUInt32LE: UINT32,
   writeUIntLE: INT8,
   writeUIntBE: INT16,
   writeIntLE: INT32,

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -481,9 +481,12 @@ function writeU_Int48LE(buf, value, offset, min, max) {
 
   const newVal = Math.floor(value * 2 ** -32);
   buf[offset++] = value;
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 24);
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
   buf[offset++] = newVal;
   buf[offset++] = (newVal >>> 8);
   return offset;
@@ -495,9 +498,12 @@ function writeU_Int40LE(buf, value, offset, min, max) {
 
   const newVal = value;
   buf[offset++] = value;
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 24);
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
   buf[offset++] = Math.floor(newVal * 2 ** -32);
   return offset;
 }
@@ -507,9 +513,12 @@ function writeU_Int32LE(buf, value, offset, min, max) {
   checkInt(value, min, max, buf, offset, 3);
 
   buf[offset++] = value;
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 24);
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
   return offset;
 }
 
@@ -522,8 +531,10 @@ function writeU_Int24LE(buf, value, offset, min, max) {
   checkInt(value, min, max, buf, offset, 2);
 
   buf[offset++] = value;
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = (value >>> 16);
+  value = value >>> 8;
+  buf[offset++] = value;
+  value = value >>> 8;
+  buf[offset++] = value;
   return offset;
 }
 
@@ -582,11 +593,14 @@ function writeU_Int48BE(buf, value, offset, min, max) {
   const newVal = Math.floor(value * 2 ** -32);
   buf[offset++] = (newVal >>> 8);
   buf[offset++] = newVal;
-  buf[offset++] = (value >>> 24);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = value;
-  return offset;
+  buf[offset + 3] = value;
+  value = value >>> 8;
+  buf[offset + 2] = value;
+  value = value >>> 8;
+  buf[offset + 1] = value;
+  value = value >>> 8;
+  buf[offset] = value;
+  return offset + 4;
 }
 
 function writeU_Int40BE(buf, value, offset, min, max) {
@@ -594,22 +608,28 @@ function writeU_Int40BE(buf, value, offset, min, max) {
   checkInt(value, min, max, buf, offset, 4);
 
   buf[offset++] = Math.floor(value * 2 ** -32);
-  buf[offset++] = (value >>> 24);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = value;
-  return offset;
+  buf[offset + 3] = value;
+  value = value >>> 8;
+  buf[offset + 2] = value;
+  value = value >>> 8;
+  buf[offset + 1] = value;
+  value = value >>> 8;
+  buf[offset] = value;
+  return offset + 4;
 }
 
 function writeU_Int32BE(buf, value, offset, min, max) {
   value = +value;
   checkInt(value, min, max, buf, offset, 3);
 
-  buf[offset++] = (value >>> 24);
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = value;
-  return offset;
+  buf[offset + 3] = value;
+  value = value >>> 8;
+  buf[offset + 2] = value;
+  value = value >>> 8;
+  buf[offset + 1] = value;
+  value = value >>> 8;
+  buf[offset] = value;
+  return offset + 4;
 }
 
 function writeUInt32BE(value, offset) {
@@ -620,10 +640,12 @@ function writeU_Int24BE(buf, value, offset, min, max) {
   value = +value;
   checkInt(value, min, max, buf, offset, 2);
 
-  buf[offset++] = (value >>> 16);
-  buf[offset++] = (value >>> 8);
-  buf[offset++] = value;
-  return offset;
+  buf[offset + 2] = value;
+  value = value >>> 8;
+  buf[offset + 1] = value;
+  value = value >>> 8;
+  buf[offset] = value;
+  return offset + 3;
 }
 
 function writeU_Int16BE(buf, value, offset, min, max) {


### PR DESCRIPTION
This improves the performance of some buffer write functions.

```
 buffers/buffer-write.js millions=5 type='Int32BE' buffer='fast'         ***      5.83 %       ±1.13% ±1.51% ±1.97%
 buffers/buffer-write.js millions=5 type='Int32BE' buffer='slow'         ***      6.40 %       ±3.04% ±4.05% ±5.30%
 buffers/buffer-write.js millions=5 type='Int32LE' buffer='fast'         ***     11.19 %       ±1.90% ±2.54% ±3.32%
 buffers/buffer-write.js millions=5 type='Int32LE' buffer='slow'         ***     13.35 %       ±2.47% ±3.28% ±4.28%
 buffers/buffer-write.js millions=5 type='IntBE' buffer='fast'                   -0.36 %       ±1.59% ±2.12% ±2.76%
 buffers/buffer-write.js millions=5 type='IntBE' buffer='slow'                    0.15 %       ±0.97% ±1.29% ±1.67%
 buffers/buffer-write.js millions=5 type='IntLE' buffer='fast'                    1.68 %       ±2.23% ±2.98% ±3.92%
 buffers/buffer-write.js millions=5 type='IntLE' buffer='slow'                    0.31 %       ±1.34% ±1.78% ±2.31%
 buffers/buffer-write.js millions=5 type='UInt32BE' buffer='fast'        ***      7.28 %       ±1.42% ±1.89% ±2.47%
 buffers/buffer-write.js millions=5 type='UInt32BE' buffer='slow'        ***      7.66 %       ±1.49% ±1.99% ±2.59%
 buffers/buffer-write.js millions=5 type='UInt32LE' buffer='fast'        ***      3.53 %       ±1.04% ±1.38% ±1.80%
 buffers/buffer-write.js millions=5 type='UInt32LE' buffer='slow'        ***      5.49 %       ±2.12% ±2.84% ±3.74%
 buffers/buffer-write.js millions=5 type='UIntBE' buffer='fast'                   0.76 %       ±2.48% ±3.32% ±4.36%
 buffers/buffer-write.js millions=5 type='UIntBE' buffer='slow'                   0.35 %       ±3.25% ±4.34% ±5.66%
 buffers/buffer-write.js millions=5 type='UIntLE' buffer='fast'                  -1.21 %       ±2.70% ±3.63% ±4.78%
 buffers/buffer-write.js millions=5 type='UIntLE' buffer='slow'                   1.50 %       ±2.20% ±2.96% ±3.92%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
