### PR TITLE
build: do not cd on vcbuild help

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -1,7 +1,5 @@
 @if not defined DEBUG_HELPER @ECHO OFF
 
-cd %~dp0
-
 if /i "%1"=="help" goto help
 if /i "%1"=="--help" goto help
 if /i "%1"=="-help" goto help
@@ -10,6 +8,8 @@ if /i "%1"=="?" goto help
 if /i "%1"=="-?" goto help
 if /i "%1"=="--?" goto help
 if /i "%1"=="/?" goto help
+
+cd %~dp0
 
 @rem Process arguments.
 set config=Release


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

`vcbuild help` just outputs help info and exits. If a user calls this command not from a project root, the directory change can be unexpected and unwanted.