### PR TITLE
assert: improve assert()/assert.ok() performance

### DIFF
--- a/benchmark/assert/ok.js
+++ b/benchmark/assert/ok.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e9]
+});
+
+function main({ n }) {
+  var i;
+  bench.start();
+  for (i = 0; i < n; ++i) {
+    if (i % 2 === 0)
+      assert(true);
+    else
+      assert(true, 'foo bar baz');
+  }
+  bench.end(n);
+}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -206,13 +206,11 @@ function getErrMessage(call) {
   }
 }
 
-function innerOk(args, fn) {
-  var [value, message] = args;
-
+function innerOk(fn, argLen, value, message) {
   if (!value) {
     let generatedMessage = false;
 
-    if (args.length === 0) {
+    if (argLen === 0) {
       generatedMessage = true;
       message = 'No value argument passed to `assert.ok()`';
     } else if (message == null) {
@@ -253,7 +251,7 @@ function innerOk(args, fn) {
 // Pure assertion tests whether a value is truthy, as determined
 // by !!value.
 function ok(...args) {
-  innerOk(args, ok);
+  innerOk(ok, args.length, ...args);
 }
 assert.ok = ok;
 
@@ -563,7 +561,7 @@ assert.ifError = function ifError(err) {
 
 // Expose a strict only variant of assert
 function strict(...args) {
-  innerOk(args, strict);
+  innerOk(strict, args.length, ...args);
 }
 assert.strict = Object.assign(strict, assert, {
   equal: assert.strictEqual,


### PR DESCRIPTION
With included benchmark:

```
                            confidence improvement accuracy (*)    (**)   (***)
 assert/ok.js n=1000000000        ***    841.57 %       ±8.15% ±11.30% ±15.66%

Be aware that when doing many comparisions the risk of a false-positive
result increases. In this case there are 1 comparisions, you can thus
expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

CI: https://ci.nodejs.org/job/node-test-pull-request/13637/


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
