### PR TITLE
url: Fix error type in constructor

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -311,8 +311,7 @@ class URL {
   constructor(input, base) {
     // toUSVString is not needed.
     input = `${input}`;
-    if (base !== undefined &&
-        (!base[searchParams] || !base[searchParams][searchParams])) {
+    if (base !== undefined) {
       base = new URL(base);
     }
     parse(this, input, base);

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -22,6 +22,8 @@ const failureTests = tests.filter((test) => test.failure).concat([
   { input: null },
   { input: new Date() },
   { input: new RegExp() },
+  { input: 'test', base: null },
+  { input: 'http://nodejs.org', base: null },
   { input: () => {} }
 ]);
 


### PR DESCRIPTION
Currently whatwg URLs fail with an incorrect error when null is passed as the base. Adding a check before accessing a symbol for the URL makes the URL error correctly.

Add test for it.

Fixes: https://github.com/nodejs/node/issues/19254

cc @targos @nodejs/url 

