### PR TITLE
child_process: better spawn error message

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -385,8 +385,11 @@ function _convertCustomFds(options) {
 }
 
 function normalizeSpawnArguments(file, args, options) {
-  if (typeof file !== 'string' || file.length === 0)
+  if (typeof file !== 'string')
     throw new ERR_INVALID_ARG_TYPE('file', 'string', file);
+
+  if (file.length === 0)
+    throw new ERR_INVALID_ARG_VALUE('file', file, 'cannot be empty');
 
   if (Array.isArray(args)) {
     args = args.slice(0);

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -30,10 +30,10 @@ const invalidcmd = 'hopefully_you_dont_have_this_on_your_machine';
 const empty = fixtures.path('empty.js');
 
 const invalidArgValueError =
-  common.expectsError({ code: 'ERR_INVALID_ARG_VALUE', type: TypeError }, 13);
+  common.expectsError({ code: 'ERR_INVALID_ARG_VALUE', type: TypeError }, 14);
 
 const invalidArgTypeError =
-  common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 11);
+  common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 10);
 
 assert.throws(function() {
   const child = spawn(invalidcmd, 'this is not an array');
@@ -53,7 +53,7 @@ assert.throws(function() {
 
 assert.throws(function() {
   spawn('');
-}, invalidArgTypeError);
+}, invalidArgValueError);
 
 assert.throws(function() {
   const file = { toString() { return null; } };


### PR DESCRIPTION
Throw `ERR_INVALID_ARG_VALUE` when filename passed to spawn is empty.

Fixes: https://github.com/nodejs/node/issues/19235

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
