### PR TITLE
test: remove unused deprecation code

### DIFF
--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -4,8 +4,7 @@ const assert = require('assert');
 
 common.expectWarning(
   'DeprecationWarning',
-  'process.assert() is deprecated. Please use the `assert` module instead.',
-  'DEP0100'
+  'process.assert() is deprecated. Please use the `assert` module instead.'
 );
 
 assert.strictEqual(process.assert(1, 'error'), undefined);

--- a/test/parallel/test-process-env-deprecation.js
+++ b/test/parallel/test-process-env-deprecation.js
@@ -8,8 +8,7 @@ common.expectWarning(
   'DeprecationWarning',
   'Assigning any value other than a string, number, or boolean to a ' +
   'process.env property is deprecated. Please make sure to convert the value ' +
-  'to a string before setting process.env with it.',
-  'DEP0104'
+  'to a string before setting process.env with it.'
 );
 
 process.env.ABC = undefined;


### PR DESCRIPTION
Currently there are two tests that specify a third argument, a
deprecation code string, when calling common.expectWarning. The
function only takes two arguments and this third argument is not used.

This commit removes the deprecation code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
