### PR TITLE
src: give enable_count_ default value of one

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -324,7 +324,7 @@ void Environment::AddPromiseHook(promise_hook_func fn, void* arg) {
     it->enable_count_++;
     return;
   }
-  promise_hooks_.push_back(PromiseHookCallback{fn, arg, 1});
+  promise_hooks_.push_back(PromiseHookCallback{fn, arg});
 
   if (promise_hooks_.size() == 1) {
     isolate_->SetPromiseHook(EnvPromiseHook);

--- a/src/env.h
+++ b/src/env.h
@@ -835,7 +835,7 @@ class Environment {
   struct PromiseHookCallback {
     promise_hook_func cb_;
     void* arg_;
-    size_t enable_count_;
+    size_t enable_count_ = 1;
   };
   std::vector<PromiseHookCallback> promise_hooks_;
 


### PR DESCRIPTION
Currently the value for `enable_count_` is only specified once and set to
one. This commit suggests giving `enable_count_` a default value of one.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
