### PR TITLE
src: simplify Environment::HandleCleanup

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -341,7 +341,7 @@ inline uv_idle_t* Environment::immediate_idle_handle() {
 inline void Environment::RegisterHandleCleanup(uv_handle_t* handle,
                                                HandleCleanupCb cb,
                                                void *arg) {
-  handle_cleanup_queue_.PushBack(new HandleCleanup(handle, cb, arg));
+  handle_cleanup_queue_.push_back(HandleCleanup{handle, cb, arg});
 }
 
 inline void Environment::FinishHandleCleanup(uv_handle_t* handle) {

--- a/src/env.h
+++ b/src/env.h
@@ -530,26 +530,6 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };
 
-  typedef void (*HandleCleanupCb)(Environment* env,
-                                  uv_handle_t* handle,
-                                  void* arg);
-
-  class HandleCleanup {
-   private:
-    friend class Environment;
-
-    HandleCleanup(uv_handle_t* handle, HandleCleanupCb cb, void* arg)
-        : handle_(handle),
-          cb_(cb),
-          arg_(arg) {
-    }
-
-    uv_handle_t* handle_;
-    HandleCleanupCb cb_;
-    void* arg_;
-    ListNode<HandleCleanup> handle_cleanup_queue_;
-  };
-
   static inline Environment* GetCurrent(v8::Isolate* isolate);
   static inline Environment* GetCurrent(v8::Local<v8::Context> context);
   static inline Environment* GetCurrent(
@@ -570,7 +550,22 @@ class Environment {
              int exec_argc,
              const char* const* exec_argv,
              bool start_profiler_idle_notifier);
+
+  typedef void (*HandleCleanupCb)(Environment* env,
+                                  uv_handle_t* handle,
+                                  void* arg);
+  struct HandleCleanup {
+    uv_handle_t* handle_;
+    HandleCleanupCb cb_;
+    void* arg_;
+  };
+
+  void RegisterHandleCleanups();
   void CleanupHandles();
+  inline void RegisterHandleCleanup(uv_handle_t* handle,
+                                    HandleCleanupCb cb,
+                                    void *arg);
+  inline void FinishHandleCleanup(uv_handle_t* handle);
 
   inline void AssignToContext(v8::Local<v8::Context> context,
                               const ContextInfo& info);
@@ -585,12 +580,6 @@ class Environment {
   static inline Environment* from_immediate_check_handle(uv_check_t* handle);
   inline uv_check_t* immediate_check_handle();
   inline uv_idle_t* immediate_idle_handle();
-
-  // Register clean-up cb to be called on environment destruction.
-  inline void RegisterHandleCleanup(uv_handle_t* handle,
-                                    HandleCleanupCb cb,
-                                    void *arg);
-  inline void FinishHandleCleanup(uv_handle_t* handle);
 
   inline AsyncHooks* async_hooks();
   inline ImmediateInfo* immediate_info();
@@ -809,8 +798,7 @@ class Environment {
   friend int GenDebugSymbols();
   HandleWrapQueue handle_wrap_queue_;
   ReqWrapQueue req_wrap_queue_;
-  ListHead<HandleCleanup,
-           &HandleCleanup::handle_cleanup_queue_> handle_cleanup_queue_;
+  std::list<HandleCleanup> handle_cleanup_queue_;
   int handle_cleanup_waiting_;
 
   double* heap_statistics_buffer_ = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -4410,6 +4410,7 @@ Environment* CreateEnvironment(IsolateData* isolate_data,
 
 
 void FreeEnvironment(Environment* env) {
+  env->CleanupHandles();
   delete env;
 }
 

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -118,7 +118,6 @@ class EnvironmentTestFixture : public NodeTestFixture {
     }
 
     ~Env() {
-      environment_->CleanupHandles();
       node::FreeEnvironment(environment_);
       node::FreeIsolateData(isolate_data_);
       context_->Exit();


### PR DESCRIPTION
#### src: call CleanupHandles in FreeEnvironment

CleanupHandles() has not been called in our own code base anymore
after the v8 debug agent has been removed. It used to be in the
~Environment() destructor but then removed to avoid firing other
events after the exit event, given that we were not going to
clean up handles for the one environment per process setup.
Call it in FreeEnvironment so that embedders can clean up
the handles in the loop when creating multiple environments.

#### src: simplify Environment::HandleCleanup

- Make the HandleCleanup a struct, and make the queue a
  std::list, iterate over it in CleanupHandles() and clear
  it after that.
- Put the handle cleanup registration into a method and
  document that they will not be called in the one environemt
  per process setup.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
