### PR TITLE
doc: documented `make docopen`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -206,15 +206,14 @@ To read the documentation:
 $ man doc/node.1
 ```
 
-If you prefer to read the documentation in the browser and have `python` 
-installed, you can run:
+If you prefer to read the documentation in the browser,
+run the following once `make doc` is done:
 
 ```console
-$ cd out/doc/api/
-$ python -m SimpleHTTPServer
+$ make doconly
 ```
 
-and navigate to `http://localhost:8000` in your browser.
+This will open up a browser tab/window with the documentation.
 
 To test if Node.js was built correctly:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -210,7 +210,7 @@ If you prefer to read the documentation in the browser,
 run the following once `make doc` is done:
 
 ```console
-$ make doconly
+$ make docopen
 ```
 
 This will open up a browser tab/window with the documentation.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -206,6 +206,16 @@ To read the documentation:
 $ man doc/node.1
 ```
 
+If you prefer to read the documentation in the browser and have `python` 
+installed, you can run:
+
+```console
+$ cd out/doc/api/
+$ python -m SimpleHTTPServer
+```
+
+and navigate to `http://localhost:8000` in your browser.
+
 To test if Node.js was built correctly:
 
 ```console

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -206,14 +206,14 @@ To read the documentation:
 $ man doc/node.1
 ```
 
-If you prefer to read the documentation in the browser,
-run the following once `make doc` is done:
+If you prefer to read the documentation in a browser,
+run the following after `make doc` is finished:
 
 ```console
 $ make docopen
 ```
 
-This will open up a browser tab/window with the documentation.
+This will open a browser with the documentation.
 
 To test if Node.js was built correctly:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -206,14 +206,15 @@ To read the documentation:
 $ man doc/node.1
 ```
 
-If you prefer to read the documentation in the browser,
-run the following once `make doc` is done:
+If you prefer to read the documentation in the browser and have `python` 
+installed, you can run:
 
 ```console
-$ make docopen
+$ cd out/doc/api/
+$ python -m SimpleHTTPServer
 ```
 
-This will open up a browser tab/window with the documentation.
+and navigate to `http://localhost:8000` in your browser.
 
 To test if Node.js was built correctly:
 


### PR DESCRIPTION
Documented `make docopen` as a way to read documentation in the browser.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
