### PR TITLE
[6.x] Revert "fs: fix options.end of fs.ReadStream()"

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1919,8 +1919,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = typeof this.fd !== 'number' && options.start === undefined ?
-    0 : options.start;
+  this.start = options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -132,20 +132,6 @@ stream.on('end', function() {
   assert.strictEqual('x', stream.data);
 });
 
-{
-  // Verify that end works when start is not specified.
-  const stream = new fs.createReadStream(rangeFile, { end: 1 });
-  stream.data = '';
-
-  stream.on('data', function(chunk) {
-    stream.data += chunk;
-  });
-
-  stream.on('end', common.mustCall(function() {
-    assert.strictEqual('xy', stream.data);
-  }));
-}
-
 // pause and then resume immediately.
 const pauseRes = fs.createReadStream(rangeFile);
 pauseRes.pause();


### PR DESCRIPTION
This reverts commit df038ad90fbc0d47f5937a7f6b2b6a55f3c98d57.

Some people were relying on the behavior of this.start being able to be
undefined, whereas after the change it is being set to 0.

Fixes: https://github.com/nodejs/node/issues/19240:
Refs: https://github.com/nodejs/node/pull/18121

/cc @wankdanker @MoonBall @nodejs/lts 