### PR TITLE
[8.x] Revert "fs: fix options.end of fs.ReadStream()"

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1950,8 +1950,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = typeof this.fd !== 'number' && options.start === undefined ?
-    0 : options.start;
+  this.start = options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -158,20 +158,6 @@ assert.throws(function() {
 }
 
 {
-  // Verify that end works when start is not specified.
-  const stream = new fs.createReadStream(rangeFile, { end: 1 });
-  stream.data = '';
-
-  stream.on('data', function(chunk) {
-    stream.data += chunk;
-  });
-
-  stream.on('end', common.mustCall(function() {
-    assert.strictEqual('xy', stream.data);
-  }));
-}
-
-{
   // pause and then resume immediately.
   const pauseRes = fs.createReadStream(rangeFile);
   pauseRes.pause();


### PR DESCRIPTION
This reverts commit b343cb60e1dce2d25432f9efb7bb6e65f8333ee8.

Some people were relying on the behavior of this.start being able to be
undefined, whereas after the change it is being set to 0.

Refs: https://github.com/nodejs/node/issues/19240
Refs: https://github.com/nodejs/node/pull/18121
