### PR TITLE
doc: add note to readable stream async iterator docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1197,10 +1197,9 @@ print(fs.createReadStream('file')).catch(console.log);
 
 If the loop terminates with a `break` or a `throw`, the stream will be
 destroyed. In other terms, iterating over a stream will consume the stream
-fully. 
-The stream will be read in chunks of size equal to the `highWaterMark` option.
-In the code example above, data will be in a single chunk if the file has less
-then 64kb of data because no `highWaterMark` option is provided to
+fully. The stream will be read in chunks of size equal to the `highWaterMark`
+option. In the code example above, data will be in a single chunk if the file
+has less then 64kb of data because no `highWaterMark` option is provided to
 [`fs.createReadStream()`][].
 
 ### Duplex and Transform Streams

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1198,9 +1198,10 @@ print(fs.createReadStream('file')).catch(console.log);
 If the loop terminates with a `break` or a `throw`, the stream will be
 destroyed. In other terms, iterating over a stream will consume the stream
 fully. 
-Note that by default, async reading of the contents of the file will be
-performed by chunks of size equal to `highWaterMark` value (default is 64kb
-for [`fs.createReadStream()`][]).
+The stream will be read in chunks of size equal to the `highWaterMark` option.
+In the code example above, data will be in a single chunk if the file has less
+then 64kb of data because no `highWaterMark` option is provided to
+[`fs.createReadStream()`][].
 
 ### Duplex and Transform Streams
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1197,7 +1197,9 @@ print(fs.createReadStream('file')).catch(console.log);
 
 If the loop terminates with a `break` or a `throw`, the stream will be
 destroyed. In other terms, iterating over a stream will consume the stream
-fully.
+fully. 
+Note that by default file iteration would be by the chunks of the size equal 
+to `highWaterMark` value (default is 64kb for [`fs.createReadStream()`][]).
 
 ### Duplex and Transform Streams
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1198,8 +1198,9 @@ print(fs.createReadStream('file')).catch(console.log);
 If the loop terminates with a `break` or a `throw`, the stream will be
 destroyed. In other terms, iterating over a stream will consume the stream
 fully. 
-Note that by default file iteration would be by the chunks of the size equal 
-to `highWaterMark` value (default is 64kb for [`fs.createReadStream()`][]).
+Note that by default, async reading of the contents of the file will be
+performed by chunks of size equal to `highWaterMark` value (default is 64kb
+for [`fs.createReadStream()`][]).
 
 ### Duplex and Transform Streams
 


### PR DESCRIPTION
While I was working on https://github.com/nodejs/node/pull/18904 I noticed that [async iterator in readable streams](https://nodejs.org/download/nightly/v10.0.0-nightly20180205d4b605b990/docs/api/stream.html#stream_readable_asynciterator) iterates by the chunks of the size equal to stream `highWaterMark` value when reading a file. So I think it worth to mention in docs because for me it seemed confusing at first.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
stream, doc
