### PR TITLE
node_api: add napi_fatal_exception

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -541,6 +541,19 @@ This API returns true if an exception is pending.
 
 This API can be called even if there is a pending JavaScript exception.
 
+#### napi_fatal_exception
+<!-- YAML
+added: TBA
+-->
+```C
+napi_fatal_exception(napi_env env);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+
+Trigger an `uncaughtException` in JavaScript. Useful if an async
+callback throws an exception with no way to recover.
+
 ### Fatal Errors
 
 In the event of an unrecoverable error in a native module, a fatal error can be

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -543,7 +543,7 @@ This API can be called even if there is a pending JavaScript exception.
 
 #### napi_fatal_exception
 <!-- YAML
-added: TBA
+added: REPLACEME
 -->
 ```C
 napi_fatal_exception(napi_env env);

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -546,10 +546,11 @@ This API can be called even if there is a pending JavaScript exception.
 added: REPLACEME
 -->
 ```C
-napi_fatal_exception(napi_env env);
+napi_status napi_fatal_exception(napi_env env, napi_value err);
 ```
 
 - `[in] env`: The environment that the API is invoked under.
+- `[in] err`: The error you want to pass to `uncaughtException`.
 
 Trigger an `uncaughtException` in JavaScript. Useful if an async
 callback throws an exception with no way to recover.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3354,10 +3354,11 @@ class Work : public node::AsyncResource {
       // report it as a fatal exception. (There is no JavaScript on the
       // callstack that can possibly handle it.)
       if (!env->last_exception.IsEmpty()) {
-        v8::TryCatch try_catch(env->isolate);
-        env->isolate->ThrowException(
-          v8::Local<v8::Value>::New(env->isolate, env->last_exception));
-        node::FatalException(env->isolate, try_catch);
+        v8::Local<v8::Value> err = v8::Local<v8::Value>::New(
+          env->isolate, env->last_exception);
+        v8::Local<v8::Message> msg = v8::Exception::CreateMessage(
+          env->isolate, err);
+        node::FatalException(env->isolate, err, msg);
       }
     }
   }

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -112,7 +112,7 @@ NAPI_EXTERN napi_status
 napi_get_last_error_info(napi_env env,
                          const napi_extended_error_info** result);
 
-NAPI_EXTERN void napi_fatal_exception(napi_env env);
+NAPI_EXTERN napi_status napi_fatal_exception(napi_env env, napi_value err);
 
 NAPI_EXTERN NAPI_NO_RETURN void napi_fatal_error(const char* location,
                                                  size_t location_len,

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -112,6 +112,8 @@ NAPI_EXTERN napi_status
 napi_get_last_error_info(napi_env env,
                          const napi_extended_error_info** result);
 
+NAPI_EXTERN void napi_fatal_exception(napi_env env);
+
 NAPI_EXTERN NAPI_NO_RETURN void napi_fatal_error(const char* location,
                                                  size_t location_len,
                                                  const char* message,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -250,6 +250,11 @@ void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
+void FatalException(v8::Isolate* isolate,
+                    v8::Local<v8::Value> error,
+                    v8::Local<v8::Message> message);
+
+
 void SignalExit(int signo);
 #ifdef __POSIX__
 void RegisterSignalHandler(int signal,

--- a/test/addons-napi/test_async/test-uncaught.js
+++ b/test/addons-napi/test_async/test-uncaught.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const test_async = require(`./build/${common.buildType}/test_async`);
+
+process.on('uncaughtException', common.mustCall(function(err) {
+  try {
+    throw new Error('should not fail');
+  } catch (err) {
+    assert.strictEqual(err.message, 'should not fail');
+  }
+  assert.strictEqual(err.message, 'uncaught');
+}));
+
+// Successful async execution and completion callback.
+test_async.Test(5, {}, common.mustCall(function() {
+  throw new Error('uncaught');
+}));

--- a/test/addons-napi/test_fatal_exception/binding.gyp
+++ b/test/addons-napi/test_fatal_exception/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_fatal_exception",
+      "sources": [ "test_fatal_exception.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_fatal_exception/test.js
+++ b/test/addons-napi/test_fatal_exception/test.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const test_fatal = require(`./build/${common.buildType}/test_fatal_exception`);
+
+process.on('uncaughtException', common.mustCall(function(err) {
+  assert.strictEqual(err.message, 'fatal error');
+}));
+
+const err = new Error('fatal error');
+test_fatal.Test(err);

--- a/test/addons-napi/test_fatal_exception/test_fatal_exception.c
+++ b/test/addons-napi/test_fatal_exception/test_fatal_exception.c
@@ -1,0 +1,26 @@
+#include <node_api.h>
+#include "../common.h"
+
+napi_value Test(napi_env env, napi_callback_info info) {
+  napi_value err;
+  size_t argc = 1;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &err, NULL, NULL));
+
+  NAPI_CALL(env, napi_fatal_exception(env, err));
+
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("Test", Test),
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Adds `void napi_fatal_exception(napi_env env)` which triggers an `node::FatalException`. 
Currently there is no way of doing this when using async callbacks, which makes error handling quite tricky