### PR TITLE
src: simplify native_immediate_callbacks

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -369,7 +369,7 @@ void Environment::RunAndClearNativeImmediates() {
   size_t count = native_immediate_callbacks_.size();
   if (count > 0) {
     size_t ref_count = 0;
-    std::vector<NativeImmediateCallback> list;
+    std::list<NativeImmediateCallback> list;
     native_immediate_callbacks_.swap(list);
     auto drain_list = [&]() {
       v8::TryCatch try_catch(isolate());
@@ -381,8 +381,7 @@ void Environment::RunAndClearNativeImmediates() {
           FatalException(isolate(), try_catch);
           // Bail out, remove the already executed callbacks from list
           // and set up a new TryCatch for the other pending callbacks.
-          std::move_backward(it, list.end(), list.begin() + (list.end() - it));
-          list.resize(list.end() - it);
+          list.erase(list.begin(), it);
           return true;
         }
       }

--- a/src/env.h
+++ b/src/env.h
@@ -845,7 +845,7 @@ class Environment {
     std::unique_ptr<Persistent<v8::Object>> keep_alive_;
     bool refed_;
   };
-  std::vector<NativeImmediateCallback> native_immediate_callbacks_;
+  std::list<NativeImmediateCallback> native_immediate_callbacks_;
   void RunAndClearNativeImmediates();
   static void CheckImmediate(uv_check_t* handle);
 


### PR DESCRIPTION
- Use std::list instead of std::vector because we do not need
  random access.
- Use list.erase instead of moving elements then resizing to
  remove the first n elements in the list for simplicity and
  avoiding reallocation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
