### PR TITLE
util: add boxed BigInt formatting to util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -580,6 +580,13 @@ function formatValue(ctx, value, recurseTimes, ln) {
         if (keyLength === 0)
           return ctx.stylize(`[Boolean: ${formatted}]`, 'boolean');
         base = `[Boolean: ${formatted}]`;
+        // eslint-disable-next-line valid-typeof
+      } else if (typeof raw === 'bigint') {
+        // Make boxed primitive BigInts look like such
+        const formatted = formatPrimitive(stylizeNoColor, raw);
+        if (keyLength === 0)
+          return ctx.stylize(`[BigInt: ${formatted}]`, 'bigint');
+        base = `[BigInt: ${formatted}]`;
       } else if (typeof raw === 'symbol') {
         const formatted = formatPrimitive(stylizeNoColor, raw);
         return ctx.stylize(`[Symbol: ${formatted}]`, 'symbol');

--- a/test/parallel/test-util-inspect-bigint.js
+++ b/test/parallel/test-util-inspect-bigint.js
@@ -8,3 +8,5 @@ const assert = require('assert');
 const { inspect } = require('util');
 
 assert.strictEqual(inspect(1n), '1n');
+assert.strictEqual(inspect(Object(-1n)), '[BigInt: -1n]');
+assert.strictEqual(inspect(Object(13n)), '[BigInt: 13n]');


### PR DESCRIPTION
Before:
```
> Object(7n)
BigInt {}
```
After:
```
> Object(7n)
[BigInt: 7n]
```
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
