### PR TITLE
crypto: doc-only deprecate createCipher/Decipher

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1254,7 +1254,11 @@ This property is deprecated. Please use `crypto.setFips()` and
 ### crypto.createCipher(algorithm, password[, options])
 <!-- YAML
 added: v0.1.94
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated: Use [`crypto.createCipheriv()`][] instead.
+
 - `algorithm` {string}
 - `password` {string | Buffer | TypedArray | DataView}
 - `options` {Object} [`stream.transform` options][]
@@ -1334,7 +1338,11 @@ called.
 ### crypto.createDecipher(algorithm, password[, options])
 <!-- YAML
 added: v0.1.94
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated: Use [`crypto.createDecipheriv()`][] instead.
+
 - `algorithm` {string}
 - `password` {string | Buffer | TypedArray | DataView}
 - `options` {Object} [`stream.transform` options][]

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -959,11 +959,23 @@ Type: Runtime
 [`decipher.final()`][]. In the future, this API will likely be removed, and it
 is recommended to use [`decipher.final()`][] instead.
 
+<a id="DEP00XX"></a>
+### DEP00XX: crypto.createCipher and crypto.createDecipher
+
+Type: Documentation-only
+
+Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] should be
+avoided as they use a weak key derivation function (MD5 with no salt) and static
+initialization vectors. It is recommended to derive a key using
+[`crypto.pbkdf2()`][] and to use [`crypto.createCipheriv()`][] and
+[`crypto.createDecipheriv()`][] to obtain the [`Cipher`] object.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`Cipher`]: crypto.html#crypto_class_cipher
 [`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout
@@ -976,7 +988,11 @@ is recommended to use [`decipher.final()`][] instead.
 [`child_process`]: child_process.html
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args
+[`crypto.createCipher()`]: crypto.html#crypto_crypto_createcipher_algorithm_password_options
+[`crypto.createCipheriv()`]: crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv_options
 [`crypto.createCredentials()`]: crypto.html#crypto_crypto_createcredentials_details
+[`crypto.createDecipher()`]: crypto.html#crypto_crypto_createdecipher_algorithm_password_options
+[`crypto.createDecipheriv()`]: crypto.html#crypto_crypto_createdecipheriv_algorithm_key_iv_options
 [`crypto.DEFAULT_ENCODING`]: crypto.html#crypto_crypto_default_encoding
 [`crypto.fips`]: crypto.html#crypto_crypto_fips
 [`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -969,7 +969,7 @@ avoided as they use a weak key derivation function (MD5 with no salt) and static
 initialization vectors. It is recommended to derive a key using
 [`crypto.pbkdf2()`][] and to use [`crypto.createCipheriv()`][] and
 [`crypto.createDecipheriv()`][] to obtain the [`Cipher`][] and [`Decipher`][]
-object, respectively.
+objects respectively.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -968,7 +968,8 @@ Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] should be
 avoided as they use a weak key derivation function (MD5 with no salt) and static
 initialization vectors. It is recommended to derive a key using
 [`crypto.pbkdf2()`][] and to use [`crypto.createCipheriv()`][] and
-[`crypto.createDecipheriv()`][] to obtain the [`Cipher`] object.
+[`crypto.createDecipheriv()`][] to obtain the [`Cipher`][] and [`Decipher`][]
+object, respectively.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -976,6 +977,7 @@ initialization vectors. It is recommended to derive a key using
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
 [`Cipher`]: crypto.html#crypto_class_cipher
+[`Decipher`]: crypto.html#crypto_class_decipher
 [`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout


### PR DESCRIPTION
`createCipher` and `createDecipher` are cryptographically weak and can cause severe security issues when used improperly, there are hundreds of examples on GitHub alone. There was https://github.com/nodejs/node/pull/13941 but it was discontinued due to the author becoming inactive. Seeing that `crypto.createCipher` is widely used, the first step is to doc-only deprecate the pair of functions.

Another argument against having `create(De|C)ipher` is that they are unsupported in FIPS mode, not sure whether that's worth mentioning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)