### PR TITLE
test: fix flaky test-http2-settings-flood

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -12,7 +12,6 @@ test-inspector-bindings               : PASS, FLAKY
 test-inspector-debug-end              : PASS, FLAKY
 test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
 test-http2-ping-flood                 : PASS, FLAKY
-test-http2-settings-flood             : PASS, FLAKY
 
 [$system==linux]
 

--- a/test/sequential/test-http2-settings-flood.js
+++ b/test/sequential/test-http2-settings-flood.js
@@ -4,8 +4,10 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const http2 = require('http2');
 const net = require('net');
+
 const http2util = require('../common/http2');
 
 // Test that settings flooding causes the session to be torn down
@@ -14,13 +16,16 @@ const kSettings = new http2util.SettingsFrame();
 
 const server = http2.createServer();
 
+let interval;
+
 server.on('stream', common.mustNotCall());
 server.on('session', common.mustCall((session) => {
-  session.on('error', common.expectsError({
-    code: 'ERR_HTTP2_ERROR',
-    message:
-      'Flooding was detected in this HTTP/2 session, and it must be closed'
-  }));
+  session.on('error', (e) => {
+    assert.strictEqual(e.code, 'ERR_HTTP2_ERROR');
+    assert(e.message.includes('Flooding was detected'));
+    clearInterval(interval);
+  });
+
   session.on('close', common.mustCall(() => {
     server.close();
   }));
@@ -30,9 +35,7 @@ server.listen(0, common.mustCall(() => {
   const client = net.connect(server.address().port);
 
   // nghttp2 uses a limit of 10000 items in it's outbound queue.
-  // If this number is exceeded, a flooding error is raised. Set
-  // this lim higher to account for the ones that nghttp2 is
-  // successfully able to respond to.
+  // If this number is exceeded, a flooding error is raised.
   // TODO(jasnell): Unfortunately, this test is inherently flaky because
   // it is entirely dependent on how quickly the server is able to handle
   // the inbound frames and whether those just happen to overflow nghttp2's
@@ -40,8 +43,10 @@ server.listen(0, common.mustCall(() => {
   // from one system to another, and from one test run to another.
   client.on('connect', common.mustCall(() => {
     client.write(http2util.kClientMagic, () => {
-      for (let n = 0; n < 35000; n++)
-        client.write(kSettings.data);
+      interval = setInterval(() => {
+        for (let n = 0; n < 10000; n++)
+          client.write(kSettings.data);
+      }, 1);
     });
   }));
 


### PR DESCRIPTION
The test is unreliable on some Windows platforms in its current form.
Make it more robust by using `setInterval()` to repeat the flooding
until an error is triggered.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
