### PR TITLE
crypto: deprecate Decipher.finaltol

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -950,11 +950,21 @@ deprecated if the assigned value is not a string, boolean, or number. In the
 future, such assignment may result in a thrown error. Please convert the
 property to a string before assigning it to `process.env`.
 
+<a id="DEP00XX"></a>
+### DEP00XX: crypto.Decipher.finaltol
+
+Type: Runtime
+
+`Decipher.finaltol()` has never been documented and is currently an alias for
+[`Decipher.final()`][]. In the future, this API will likely be removed, and it
+is recommended to use [`Decipher.final()`][] instead.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`Decipher.final()`]: crypto.html#crypto_decipher_final_outputencoding
 [`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -951,20 +951,19 @@ future, such assignment may result in a thrown error. Please convert the
 property to a string before assigning it to `process.env`.
 
 <a id="DEP00XX"></a>
-### DEP00XX: crypto.Decipher.finaltol
+### DEP00XX: decipher.finaltol
 
 Type: Runtime
 
-`Decipher.finaltol()` has never been documented and is currently an alias for
-[`Decipher.final()`][]. In the future, this API will likely be removed, and it
-is recommended to use [`Decipher.final()`][] instead.
+`decipher.finaltol()` has never been documented and is currently an alias for
+[`decipher.final()`][]. In the future, this API will likely be removed, and it
+is recommended to use [`decipher.final()`][] instead.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
-[`Decipher.final()`]: crypto.html#crypto_decipher_final_outputencoding
 [`assert`]: assert.html
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout
@@ -981,6 +980,7 @@ is recommended to use [`Decipher.final()`][] instead.
 [`crypto.DEFAULT_ENCODING`]: crypto.html#crypto_crypto_default_encoding
 [`crypto.fips`]: crypto.html#crypto_crypto_fips
 [`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+[`decipher.final()`]: crypto.html#crypto_decipher_final_outputencoding
 [`decipher.setAuthTag()`]: crypto.html#crypto_decipher_setauthtag_buffer
 [`domain`]: domain.html
 [`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_publickey_encoding

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -30,7 +30,7 @@ const LazyTransform = require('internal/streams/lazy_transform');
 const { StringDecoder } = require('string_decoder');
 
 const { inherits } = require('util');
-const { normalizeEncoding } = require('internal/util');
+const { deprecate, normalizeEncoding } = require('internal/util');
 
 function rsaPublic(method, defaultPadding) {
   return function(options, buffer) {
@@ -217,6 +217,10 @@ Cipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;
 Cipheriv.prototype.setAAD = Cipher.prototype.setAAD;
 
 
+const finaltol = deprecate(Cipher.prototype.final,
+                           'crypto.Decipher.finaltol is deprecated. Use ' +
+                           'crypto.Decipher.final instead.', 'DEP00XX');
+
 function Decipher(cipher, password, options) {
   if (!(this instanceof Decipher))
     return new Decipher(cipher, password, options);
@@ -245,7 +249,7 @@ Decipher.prototype._transform = Cipher.prototype._transform;
 Decipher.prototype._flush = Cipher.prototype._flush;
 Decipher.prototype.update = Cipher.prototype.update;
 Decipher.prototype.final = Cipher.prototype.final;
-Decipher.prototype.finaltol = Cipher.prototype.final;
+Decipher.prototype.finaltol = finaltol;
 Decipher.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 Decipher.prototype.getAuthTag = Cipher.prototype.getAuthTag;
 Decipher.prototype.setAuthTag = Cipher.prototype.setAuthTag;
@@ -288,7 +292,7 @@ Decipheriv.prototype._transform = Cipher.prototype._transform;
 Decipheriv.prototype._flush = Cipher.prototype._flush;
 Decipheriv.prototype.update = Cipher.prototype.update;
 Decipheriv.prototype.final = Cipher.prototype.final;
-Decipheriv.prototype.finaltol = Cipher.prototype.final;
+Decipheriv.prototype.finaltol = finaltol;
 Decipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 Decipheriv.prototype.getAuthTag = Cipher.prototype.getAuthTag;
 Decipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -9,7 +9,9 @@ const tls = require('tls');
 
 common.expectWarning('DeprecationWarning', [
   'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
-  'crypto.createCredentials is deprecated. Use tls.createSecureContext instead.'
+  'crypto.createCredentials is deprecated. Use tls.createSecureContext ' +
+  'instead.',
+  'crypto.Decipher.finaltol is deprecated. Use crypto.Decipher.final instead.'
 ]);
 
 // Accessing the deprecated function is enough to trigger the warning event.
@@ -18,3 +20,15 @@ common.expectWarning('DeprecationWarning', [
 // mapped to the correct non-deprecated function.
 assert.strictEqual(crypto.Credentials, tls.SecureContext);
 assert.strictEqual(crypto.createCredentials, tls.createSecureContext);
+
+{
+  const cipher = crypto.createCipheriv('aes-128-cbc', '0000000000000000',
+                                       '0000000000000000');
+  const ciphertext = cipher.update('Node.js', 'utf8', 'hex') +
+                     cipher.final('hex');
+  const decipher = crypto.createDecipheriv('aes-128-cbc', '0000000000000000',
+                                           '0000000000000000');
+  const plaintext = decipher.update(ciphertext, 'hex', 'utf8') +
+                    decipher.finaltol('utf8');
+  assert.strictEqual(plaintext, 'Node.js');
+}


### PR DESCRIPTION
Ever since eaf13431003b92521e3277dd7fa5dd223407052f, `Decipher.finaltol()` has been an undocumented alias for `Decipher.final()`. Sadly, @bnoordhuis [comment](https://github.com/nodejs/node/commit/eaf13431003b92521e3277dd7fa5dd223407052f#diff-801e3948990f4965a8ea4aca4a423864R2562) ("remove someday") was lost at some point in the last six years, but I believe the time has finally come.

The function has never been documented, it has no advantage over `.final()`, there is exactly one test which uses it, and there seems to be [absolutely no usage on GitHub](https://github.com/search?l=JavaScript&q=finaltol+NOT+0123456789abcdef0123456789abcdef+NOT+LazyTransform+NOT+fileoverview&type=Code&utf8=%E2%9C%93).

cc @danbev

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
