### PR TITLE
[v6.x backport] test: make common.mustNotCall show file:linenumber

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -94,6 +94,12 @@ Path to the 'fixtures' directory.
 
 Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
 
+### getCallSite(func)
+* `func` [&lt;Function>]
+* return [&lt;String>]
+
+Returns the file name and line number for the provided Function.
+
 ### globalCheck
 * [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 

--- a/test/parallel/test-common-must-not-call.js
+++ b/test/parallel/test-common-must-not-call.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+
+const message = 'message';
+const testFunction = common.mustNotCall(message);
+
+const validateError = common.mustCall((e) => {
+  const prefix = `${message} at `;
+  assert.ok(e.message.startsWith(prefix));
+  if (process.platform === 'win32') {
+    e.message = e.message.substring(2); // remove 'C:'
+  }
+  const [ fileName, lineNumber ] = e.message
+                                    .substring(prefix.length).split(':');
+  assert.strictEqual(path.basename(fileName), 'test-common-must-not-call.js');
+  assert.strictEqual(lineNumber, '8');
+});
+
+try {
+  testFunction();
+} catch (e) {
+  validateError(e);
+}


### PR DESCRIPTION
When a test fails via `common.mustNotCall` it is sometimes hard to
determine exactly what was called. This modification stores the
caller's file and line number by using the V8 Error API to capture
a stack at the time `common.mustNotCall()` is called. In the event
of failure, this information is printed.

This change also exposes a new function in test/common, `getCallSite()`
which accepts a `function` and returns a `String` with the file name and
line number for the function.

Ref: https://github.com/nodejs/node/pull/17257

PR-URL: https://github.com/nodejs/node/pull/17257
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
Reviewed-By: Khaidi Chu <i@2333.moe>

**NOTE**: This commit also includes `common.canCreateSymlink()`, for which the documentation has been backported, but not the implementation. If desired, this can be removed - it came along for the ride when cherry-picking.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
