### PR TITLE
fs: fix memory leak in WriteString

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1356,7 +1356,6 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
 
   const auto enc = ParseEncoding(env->isolate(), args[3], UTF8);
 
-  std::unique_ptr<char[]> delete_on_return;
   Local<Value> value = args[1];
   char* buf = nullptr;
   size_t len;
@@ -1384,24 +1383,41 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  if (buf == nullptr) {
+  if (is_async) {  // write(fd, string, pos, enc, req)
+    CHECK_NE(req_wrap, nullptr);
     len = StringBytes::StorageSize(env->isolate(), value, enc);
-    buf = new char[len];
-    // SYNC_CALL returns on error.  Make sure to always free the memory.
-    if (!is_async) delete_on_return.reset(buf);
+    FSReqBase::FSReqBuffer& stack_buffer =
+        req_wrap->Init("write", len, enc);
     // StorageSize may return too large a char, so correct the actual length
     // by the write size
-    len = StringBytes::Write(env->isolate(), buf, len, args[1], enc);
-  }
-
-  uv_buf_t uvbuf = uv_buf_init(buf, len);
-
-  if (is_async) {  // write(fd, string, pos, enc, req)
-    AsyncCall(env, req_wrap, args, "write", UTF8, AfterInteger,
-              uv_fs_write, fd, &uvbuf, 1, pos);
+    len = StringBytes::Write(env->isolate(), *stack_buffer, len, args[1], enc);
+    uv_buf_t uvbuf = uv_buf_init(*stack_buffer, len);
+    int err = uv_fs_write(env->event_loop(), req_wrap->req(),
+                          fd, &uvbuf, 1, pos, AfterInteger);
+    req_wrap->Dispatched();
+    if (err < 0) {
+      uv_fs_t* uv_req = req_wrap->req();
+      uv_req->result = err;
+      uv_req->path = nullptr;
+      AfterInteger(uv_req);  // after may delete req_wrap if there is an error
+      req_wrap = nullptr;
+    } else {
+      req_wrap->SetReturnValue(args);
+    }
   } else {  // write(fd, string, pos, enc, undefined, ctx)
     CHECK_EQ(argc, 6);
     fs_req_wrap req_wrap;
+    std::unique_ptr<char[]> delete_on_return;
+    if (buf == nullptr) {
+      len = StringBytes::StorageSize(env->isolate(), value, enc);
+      buf = new char[len];
+      // Make sure to always free the memory.
+      delete_on_return.reset(buf);
+      // StorageSize may return too large a char, so correct the actual length
+      // by the write size
+      len = StringBytes::Write(env->isolate(), buf, len, args[1], enc);
+    }
+    uv_buf_t uvbuf = uv_buf_init(buf, len);
     int bytesWritten = SyncCall(env, args[5], &req_wrap, "write",
                                 uv_fs_write, fd, &uvbuf, 1, pos);
     args.GetReturnValue().Set(bytesWritten);

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -55,7 +55,6 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
     encoding_ = encoding;
 
     buffer_.AllocateSufficientStorage(len + 1);
-    buffer_.SetLengthAndZeroTerminate(len);
     has_data_ = false;  // so that the data does not show up in error messages
     return buffer_;
   }


### PR DESCRIPTION
In the async case, if the buffer was copied instead of being moved
then the buf will not get deleted after the request is done.
This was introduced when the FSReqWrap:: Ownership was removed in 4b9ba9b,
and ReleaseEarly was no longer called upon destruction of FSReqWrap.

Create a custom Init function so we can use the MaybeStackBuffer in
the FSReqBase to copy the string in the async case. The data will
then get destructed when the FSReqBase is destructed.

Fixes: https://github.com/nodejs/node/issues/19356

Before this patch, running `valgrind --leak-check=yes ./node --expose_externalize_string test/parallel/test-fs-write.js` produces:

```
==25808== 21 bytes in 3 blocks are definitely lost in loss record 7 of 51
==25808==    at 0x4C2E80F: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==25808==    by 0x8238CA: node::fs::WriteString(v8::FunctionCallbackInfo<v8::Value> const&) (in /home/ubuntu/projects/node/out/Release/node)
==25808==    by 0x97873B: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) (in /home/ubuntu/projects/node/out/Release/node)
==25808==    by 0x9CFEA4: v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) (in /home/ubuntu/projects/node/out/Release/node)
==25808==    by 0x9CF5D5: v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) (in /home/ubuntu/projects/node/out/Release/node)
==25808==    by 0x21191EE0427C: ???
==25808==    by 0x21191EE13616: ???
==25808==    by 0x21191EE0BF02: ???
==25808==    by 0x21191EE13616: ???
==25808==    by 0x21191EE13616: ???
==25808==    by 0x21191EE0BF02: ???
==25808==    by 0x21191EE13616: ???
```

After this patch, this leak is gone.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
