### PR TITLE
doc: fix punctuation issue in async_hooks.md

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -284,7 +284,7 @@ The `TCPSERVERWRAP` is the server which receives the connections.
 The `TCPWRAP` is the new connection from the client. When a new
 connection is made, the `TCPWrap` instance is immediately constructed. This
 happens outside of any JavaScript stack. (An `executionAsyncId()` of `0` means
-that it is being executed from C++ with no JavaScript stack above it). With only
+that it is being executed from C++ with no JavaScript stack above it.) With only
 that information, it would be impossible to link resources together in
 terms of what caused them to be created, so `triggerAsyncId` is given the task
 of propagating what resource is responsible for the new resource's existence.


### PR DESCRIPTION
Move period incorrectly placed outside of parentheses to inside the
parentheses. The parenthetical in this case is a full sentence.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
