### PR TITLE
src: make AsyncWrap constructors delegate

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -229,7 +229,7 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
 class PromiseWrap : public AsyncWrap {
  public:
   PromiseWrap(Environment* env, Local<Object> object, bool silent)
-      : AsyncWrap(env, object, silent) {
+      : AsyncWrap(env, object, PROVIDER_PROMISE, -1, silent) {
     MakeWeak(this);
   }
   size_t self_size() const override { return sizeof(*this); }
@@ -586,32 +586,23 @@ AsyncWrap::AsyncWrap(Environment* env,
                      Local<Object> object,
                      ProviderType provider,
                      double execution_async_id)
+    : AsyncWrap(env, object, provider, execution_async_id, false) {}
+
+AsyncWrap::AsyncWrap(Environment* env,
+                     Local<Object> object,
+                     ProviderType provider,
+                     double execution_async_id,
+                     bool silent)
     : BaseObject(env, object),
       provider_type_(provider) {
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
   // Shift provider value over to prevent id collision.
-  persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider);
-
-  // Use AsyncReset() call to execute the init() callbacks.
-  AsyncReset(execution_async_id);
-}
-
-
-// This is specifically used by the PromiseWrap constructor.
-AsyncWrap::AsyncWrap(Environment* env,
-                     Local<Object> object,
-                     bool silent)
-    : BaseObject(env, object),
-      provider_type_(PROVIDER_PROMISE) {
-  CHECK_GE(object->InternalFieldCount(), 1);
-
-  // Shift provider value over to prevent id collision.
   persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider_type_);
 
   // Use AsyncReset() call to execute the init() callbacks.
-  AsyncReset(-1, silent);
+  AsyncReset(execution_async_id, silent);
 }
 
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -172,8 +172,11 @@ class AsyncWrap : public BaseObject {
  private:
   friend class PromiseWrap;
 
-  // This is specifically used by the PromiseWrap constructor.
-  AsyncWrap(Environment* env, v8::Local<v8::Object> promise, bool silent);
+  AsyncWrap(Environment* env,
+            v8::Local<v8::Object> promise,
+            ProviderType provider,
+            double execution_async_id,
+            bool silent);
   inline AsyncWrap();
   const ProviderType provider_type_;
   // Because the values may be Reset(), cannot be made const.


### PR DESCRIPTION
Currently, there is an AsyncWrap constructor that is only used by
PromiseWrap. This constructor has a body which is very similar
to the other AsyncWrap constructor.

This commit suggests updating the private constructor that is used
by PromiseWrap and also have the second constructor delegate to this
one to avoid the code duplication.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
