### PR TITLE
async_hooks: remove async_wrap from async_hooks.js

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -5,13 +5,12 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
-const async_wrap = process.binding('async_wrap');
 const internal_async_hooks = require('internal/async_hooks');
 
 // Get functions
 // For userland AsyncResources, make sure to emit a destroy event when the
 // resource gets gced.
-const { registerDestroyHook } = async_wrap;
+const { registerDestroyHook } = internal_async_hooks;
 const {
   executionAsyncId,
   triggerAsyncId,
@@ -38,7 +37,7 @@ const {
 // Get constants
 const {
   kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
-} = async_wrap.constants;
+} = internal_async_hooks.constants;
 
 // Listener API //
 

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -65,11 +65,12 @@ const active_hooks = {
   tmp_fields: null
 };
 
+const { registerDestroyHook } = async_wrap;
 
 // Each constant tracks how many callbacks there are for any given step of
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
-const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
+const { kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
         kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
         kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
@@ -435,6 +436,9 @@ module.exports = {
     init_symbol, before_symbol, after_symbol, destroy_symbol,
     promise_resolve_symbol
   },
+  constants: {
+    kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve
+  },
   enableHooks,
   disableHooks,
   clearDefaultTriggerAsyncId,
@@ -452,4 +456,5 @@ module.exports = {
   emitBefore: emitBeforeScript,
   emitAfter: emitAfterScript,
   emitDestroy: emitDestroyScript,
+  registerDestroyHook,
 };


### PR DESCRIPTION
This commit removes the builtin async_wrap module from
lib/async_hooks.js.

The motivation for this is that lib/async_hooks.js requires
lib/internal/async_hooks which also binds async_wrap. Instead of
lib/async_hooks.js also binding async_wrap it now only has to require
the internal async_hooks and access it's exports.

There might be a very good reason for doing it the current way but the
reason is not obvious to me. Hopefully someone can shed some light on
this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
