### PR TITLE
build: remove implied support for win 2012 not R2

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -42,7 +42,7 @@ platforms in production.
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
 | macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
-| Windows      | Tier 1       | >= Windows 7/2008 R2             | x86, x64             | vs2017           |
+| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |


### PR DESCRIPTION
Raising this primarily for the discussion of whether to remove the implied support for Win 2012 not R2. The basis for this is that CI does not run on Win 2012 not R2, and some failures have been deemed specific to this platform. 

See: 
- https://github.com/nodejs/node/issues/18177
- https://github.com/nodejs/node/issues/18454

/cc @gibfahn 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
