### PR TITLE
module: skip preserveSymlinks for main

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -69,7 +69,9 @@ function resolve(specifier, parentURL) {
     throw e;
   }
 
-  if (!preserveSymlinks) {
+  const isMain = parentURL === undefined;
+
+  if (!preserveSymlinks || isMain) {
     const real = realpathSync(getPathFromURL(url), {
       [internalFS.realpathCacheKey]: realpathCache
     });
@@ -83,7 +85,6 @@ function resolve(specifier, parentURL) {
 
   let format = extensionFormatMap[ext];
   if (!format) {
-    const isMain = parentURL === undefined;
     if (isMain)
       format = 'cjs';
     else

--- a/test/es-module/test-esm-symlink-main.js
+++ b/test/es-module/test-esm-symlink-main.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const { spawn } = require('child_process');
@@ -17,7 +18,8 @@ try {
   common.skip('insufficient privileges for symlinks');
 }
 
-spawn(process.execPath, ['--experimental-modules', '--preserve-symlinks', symlinkPath],
+spawn(process.execPath,
+      ['--experimental-modules', '--preserve-symlinks', symlinkPath],
       { stdio: 'inherit' }).on('exit', (code) => {
   assert.strictEqual(code, 0);
 });

--- a/test/es-module/test-esm-symlink-main.js
+++ b/test/es-module/test-esm-symlink-main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const entry = path.resolve(__dirname, '../fixtures/es-modules/symlink.js');
+const { spawn } = require('child_process');
+
+spawn(process.execPath, ['--experimental-modules', '--preserve-symlinks', entry],
+      { stdio: 'inherit' }).on('exit', (code) => {
+  assert.strictEqual(code, 0);
+});

--- a/test/es-module/test-esm-symlink-main.js
+++ b/test/es-module/test-esm-symlink-main.js
@@ -2,10 +2,22 @@
 
 const assert = require('assert');
 const path = require('path');
-const entry = path.resolve(__dirname, '../fixtures/es-modules/symlink.js');
 const { spawn } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+tmpdir.refresh();
 
-spawn(process.execPath, ['--experimental-modules', '--preserve-symlinks', entry],
+const realPath = path.resolve(__dirname, '../fixtures/es-modules/symlink.mjs');
+const symlinkPath = path.resolve(tmpdir.path, 'symlink.js');
+
+try {
+  fs.symlinkSync(realPath, symlinkPath);
+} catch (err) {
+  if (err.code !== 'EPERM') throw err;
+  common.skip('insufficient privileges for symlinks');
+}
+
+spawn(process.execPath, ['--experimental-modules', '--preserve-symlinks', symlinkPath],
       { stdio: 'inherit' }).on('exit', (code) => {
   assert.strictEqual(code, 0);
 });

--- a/test/fixtures/es-modules/symlink.js
+++ b/test/fixtures/es-modules/symlink.js
@@ -1,0 +1,1 @@
+symlink.mjs

--- a/test/fixtures/es-modules/symlink.js
+++ b/test/fixtures/es-modules/symlink.js
@@ -1,1 +1,0 @@
-symlink.mjs

--- a/test/fixtures/es-modules/symlink.mjs
+++ b/test/fixtures/es-modules/symlink.mjs
@@ -1,0 +1,1 @@
+export var symlinked = true;


### PR DESCRIPTION
The CommonJS module resolver specifically skips --preserveSymlinks for the main entry point into Node.

From discussion in https://github.com/nodejs/node/issues/19383, it seems like this should probably be carried over into the ES module resolver in order to ensure full backwards-compatibility.

The alternative here might be to have --preserveSymlinks act on the main in the CJS resolver too instead of this PR.

//cc @nodejs/modules 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
