### PR TITLE
http2: destroy() stream, upon errnoException

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1677,7 +1677,7 @@ class Http2Stream extends Duplex {
     req.async = false;
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
-      throw errnoException(err, 'write', req.error);
+      return this.destroy(errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 
@@ -1720,7 +1720,7 @@ class Http2Stream extends Duplex {
     }
     const err = handle.writev(req, chunks);
     if (err)
-      throw errnoException(err, 'write', req.error);
+      return this.destroy(errnoException(err, 'write', req.error), cb);
     trackWriteState(this, req.bytes);
   }
 


### PR DESCRIPTION
First steps towards #19060

Attempting to move `lib/net` and `lib/http2/core` towards similar API, for all work of reading and writing from underlying stream.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
