### PR TITLE
async_hooks: add copyHooks function

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -212,11 +212,15 @@ function storeActiveHooks() {
   // Don't want to make the assumption that kInit to kDestroy are indexes 0 to
   // 4. So do this the long way.
   active_hooks.tmp_fields = [];
-  active_hooks.tmp_fields[kInit] = async_hook_fields[kInit];
-  active_hooks.tmp_fields[kBefore] = async_hook_fields[kBefore];
-  active_hooks.tmp_fields[kAfter] = async_hook_fields[kAfter];
-  active_hooks.tmp_fields[kDestroy] = async_hook_fields[kDestroy];
-  active_hooks.tmp_fields[kPromiseResolve] = async_hook_fields[kPromiseResolve];
+  copyHooks(active_hooks.tmp_fields, async_hook_fields);
+}
+
+function copyHooks(destination, source) {
+  destination[kInit] = source[kInit];
+  destination[kBefore] = source[kBefore];
+  destination[kAfter] = source[kAfter];
+  destination[kDestroy] = source[kDestroy];
+  destination[kPromiseResolve] = source[kPromiseResolve];
 }
 
 
@@ -224,11 +228,7 @@ function storeActiveHooks() {
 // during hook callback execution.
 function restoreActiveHooks() {
   active_hooks.array = active_hooks.tmp_array;
-  async_hook_fields[kInit] = active_hooks.tmp_fields[kInit];
-  async_hook_fields[kBefore] = active_hooks.tmp_fields[kBefore];
-  async_hook_fields[kAfter] = active_hooks.tmp_fields[kAfter];
-  async_hook_fields[kDestroy] = active_hooks.tmp_fields[kDestroy];
-  async_hook_fields[kPromiseResolve] = active_hooks.tmp_fields[kPromiseResolve];
+  copyHooks(async_hook_fields, active_hooks.tmp_fields);
 
   active_hooks.tmp_array = null;
   active_hooks.tmp_fields = null;


### PR DESCRIPTION
This commit introduces a copyHooks function that can be used by
storeActiveHooks and restoreActiveHooks to remove some code duplication.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
