### PR TITLE
n-api: separate out async_hooks test

### DIFF
--- a/test/addons-napi/test_make_callback/test-async-hooks.js
+++ b/test/addons-napi/test_make_callback/test-async-hooks.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const binding = require(`./build/${common.buildType}/binding`);
+const makeCallback = binding.makeCallback;
+
+// Check async hooks integration using async context.
+const hook_result = {
+  id: null,
+  init_called: false,
+  before_called: false,
+  after_called: false,
+  destroy_called: false,
+};
+const test_hook = async_hooks.createHook({
+  init: (id, type) => {
+    if (type === 'test') {
+      hook_result.id = id;
+      hook_result.init_called = true;
+    }
+  },
+  before: (id) => {
+    if (id === hook_result.id) hook_result.before_called = true;
+  },
+  after: (id) => {
+    if (id === hook_result.id) hook_result.after_called = true;
+  },
+  destroy: (id) => {
+    if (id === hook_result.id) hook_result.destroy_called = true;
+  },
+});
+
+test_hook.enable();
+makeCallback(process, function() {});
+
+assert.strictEqual(hook_result.init_called, true);
+assert.strictEqual(hook_result.before_called, true);
+assert.strictEqual(hook_result.after_called, true);
+setImmediate(() => {
+  assert.strictEqual(hook_result.destroy_called, true);
+  test_hook.disable();
+});

--- a/test/addons-napi/test_make_callback/test.js
+++ b/test/addons-napi/test_make_callback/test.js
@@ -2,7 +2,6 @@
 
 const common = require('../../common');
 const assert = require('assert');
-const async_hooks = require('async_hooks');
 const vm = require('vm');
 const binding = require(`./build/${common.buildType}/binding`);
 const makeCallback = binding.makeCallback;
@@ -81,40 +80,3 @@ function endpoint($Object) {
 }
 
 assert.strictEqual(Object, makeCallback(process, forward, endpoint));
-
-// Check async hooks integration using async context.
-const hook_result = {
-  id: null,
-  init_called: false,
-  before_called: false,
-  after_called: false,
-  destroy_called: false,
-};
-const test_hook = async_hooks.createHook({
-  init: (id, type) => {
-    if (type === 'test') {
-      hook_result.id = id;
-      hook_result.init_called = true;
-    }
-  },
-  before: (id) => {
-    if (id === hook_result.id) hook_result.before_called = true;
-  },
-  after: (id) => {
-    if (id === hook_result.id) hook_result.after_called = true;
-  },
-  destroy: (id) => {
-    if (id === hook_result.id) hook_result.destroy_called = true;
-  },
-});
-
-test_hook.enable();
-makeCallback(process, function() {});
-
-assert.strictEqual(hook_result.init_called, true);
-assert.strictEqual(hook_result.before_called, true);
-assert.strictEqual(hook_result.after_called, true);
-setImmediate(() => {
-  assert.strictEqual(hook_result.destroy_called, true);
-  test_hook.disable();
-});


### PR DESCRIPTION
Place the test_make_callback async_hooks-related test into its own file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
