### PR TITLE
test: fix flaky test-http2-ping-flood

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -11,7 +11,6 @@ test-inspector-async-call-stack       : PASS, FLAKY
 test-inspector-bindings               : PASS, FLAKY
 test-inspector-debug-end              : PASS, FLAKY
 test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
-test-http2-ping-flood                 : PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
The test is unreliable on some Windows platforms in its current form.
Make it more robust by using `setInterval()` to repeat the flooding
until an error is triggered.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
