### PR TITLE
vm: move options checks from C++ to JS

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -579,6 +579,9 @@ console.log(globalVar);
 added: v0.3.1
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/19398
+    description: The `sandbox` option can no longer be a function.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/19016
     description: The `codeGeneration` option is supported now.
 -->

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -88,12 +88,7 @@
     };
   }
 
-  // Minimal sandbox helper
   const ContextifyScript = process.binding('contextify').ContextifyScript;
-  function runInThisContext(code, options) {
-    const script = new ContextifyScript(code, options);
-    return script.runInThisContext();
-  }
 
   // Set up NativeModule
   function NativeModule(id) {
@@ -205,11 +200,9 @@
     this.loading = true;
 
     try {
-      const fn = runInThisContext(source, {
-        filename: this.filename,
-        lineOffset: 0,
-        displayErrors: true
-      });
+      const script = new ContextifyScript(source, this.filename);
+      // Arguments: timeout, displayErrors, breakOnSigint
+      const fn = script.runInThisContext(-1, true, false);
       const requireFn = this.id.startsWith('internal/deps/') ?
         NativeModule.requireForDeps :
         NativeModule.require;

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -55,6 +55,10 @@ class Module {
 
     let context;
     if (options.context !== undefined) {
+      if (typeof options.context !== 'object' || options.context === null) {
+        throw new ERR_INVALID_ARG_TYPE('options.context', 'object',
+                                       options.context);
+      }
       if (isContext(options.context)) {
         context = options.context;
       } else {

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -24,63 +24,109 @@
 const {
   ContextifyScript,
   kParsingContext,
-
   makeContext,
   isContext: _isContext,
 } = process.binding('contextify');
 
 const {
   ERR_INVALID_ARG_TYPE,
-  ERR_MISSING_ARGS
+  ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
-
-// The binding provides a few useful primitives:
-// - Script(code, { filename = "evalmachine.anonymous",
-//                  displayErrors = true } = {})
-//   with methods:
-//   - runInThisContext({ displayErrors = true } = {})
-//   - runInContext(sandbox, { displayErrors = true, timeout = undefined } = {})
-// - makeContext(sandbox)
-// - isContext(sandbox)
-// From this we build the entire documented API.
+const { isUint8Array } = require('internal/util/types');
 
 class Script extends ContextifyScript {
-  constructor(code, options) {
+  constructor(code, options = {}) {
+    code = `${code}`;
+    if (typeof options === 'string') {
+      options = { filename: options };
+    }
+    if (typeof options !== 'object' || options === null) {
+      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+    }
+
+    const {
+      filename = 'evalmachine.<anonymous>',
+      lineOffset = 0,
+      columnOffset = 0,
+      cachedData,
+      produceCachedData = false,
+      [kParsingContext]: parsingContext
+    } = options;
+
+    if (typeof filename !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE('options.filename', 'string', filename);
+    }
+    validateInteger(lineOffset, 'options.lineOffset');
+    validateInteger(columnOffset, 'options.columnOffset');
+    if (cachedData !== undefined && !isUint8Array(cachedData)) {
+      throw new ERR_INVALID_ARG_TYPE('options.cachedData',
+                                     ['Buffer', 'Uint8Array'], cachedData);
+    }
+    if (typeof produceCachedData !== 'boolean') {
+      throw new ERR_INVALID_ARG_TYPE('options.produceCachedData', 'boolean',
+                                     produceCachedData);
+    }
+
     // Calling `ReThrow()` on a native TryCatch does not generate a new
     // abort-on-uncaught-exception check. A dummy try/catch in JS land
     // protects against that.
     try {
-      super(code, options);
+      super(code,
+            filename,
+            lineOffset,
+            columnOffset,
+            cachedData,
+            produceCachedData,
+            parsingContext);
     } catch (e) {
       throw e; /* node-do-not-add-exception-line */
     }
   }
+
+  runInThisContext(options) {
+    const { breakOnSigint, args } = getRunInContextArgs(options);
+    if (breakOnSigint && process.listenerCount('SIGINT') > 0) {
+      return sigintHandlersWrap(super.runInThisContext, this, args);
+    } else {
+      return super.runInThisContext(...args);
+    }
+  }
+
+  runInContext(contextifiedSandbox, options) {
+    validateContext(contextifiedSandbox);
+    const { breakOnSigint, args } = getRunInContextArgs(options);
+    if (breakOnSigint && process.listenerCount('SIGINT') > 0) {
+      return sigintHandlersWrap(super.runInContext, this,
+                                [contextifiedSandbox, ...args]);
+    } else {
+      return super.runInContext(contextifiedSandbox, ...args);
+    }
+  }
+
+  runInNewContext(sandbox, options) {
+    const context = createContext(sandbox, getContextOptions(options));
+    return this.runInContext(context, options);
+  }
 }
 
-const realRunInThisContext = Script.prototype.runInThisContext;
-const realRunInContext = Script.prototype.runInContext;
-
-Script.prototype.runInThisContext = function(options) {
-  if (options && options.breakOnSigint && process.listenerCount('SIGINT') > 0) {
-    return sigintHandlersWrap(realRunInThisContext, this, [options]);
-  } else {
-    return realRunInThisContext.call(this, options);
+function validateContext(sandbox) {
+  if (typeof sandbox !== 'object' || sandbox === null) {
+    throw new ERR_INVALID_ARG_TYPE('contextifiedSandbox', 'Object', sandbox);
   }
-};
-
-Script.prototype.runInContext = function(contextifiedSandbox, options) {
-  if (options && options.breakOnSigint && process.listenerCount('SIGINT') > 0) {
-    return sigintHandlersWrap(realRunInContext, this,
-                              [contextifiedSandbox, options]);
-  } else {
-    return realRunInContext.call(this, contextifiedSandbox, options);
+  if (!_isContext(sandbox)) {
+    throw new ERR_INVALID_ARG_TYPE('contextifiedSandbox', 'vm.Context',
+                                   sandbox);
   }
-};
+}
 
-Script.prototype.runInNewContext = function(sandbox, options) {
-  const context = createContext(sandbox, getContextOptions(options));
-  return this.runInContext(context, options);
-};
+function validateInteger(prop, propName) {
+  if (!Number.isInteger(prop)) {
+    throw new ERR_INVALID_ARG_TYPE(propName, 'integer', prop);
+  }
+  if ((prop >> 0) !== prop) {
+    throw new ERR_OUT_OF_RANGE(propName, '32-bit integer', prop);
+  }
+}
 
 function validateString(prop, propName) {
   if (prop !== undefined && typeof prop !== 'string')
@@ -95,6 +141,39 @@ function validateBool(prop, propName) {
 function validateObject(prop, propName) {
   if (prop !== undefined && (typeof prop !== 'object' || prop === null))
     throw new ERR_INVALID_ARG_TYPE(propName, 'Object', prop);
+}
+
+function getRunInContextArgs(options = {}) {
+  if (typeof options !== 'object' || options === null) {
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+  }
+
+  let timeout = options.timeout;
+  if (timeout === undefined) {
+    timeout = -1;
+  } else if (!Number.isInteger(timeout) || timeout <= 0) {
+    throw new ERR_INVALID_ARG_TYPE('options.timeout', 'a positive integer',
+                                   timeout);
+  }
+
+  const {
+    displayErrors = true,
+    breakOnSigint = false
+  } = options;
+
+  if (typeof displayErrors !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE('options.displayErrors', 'boolean',
+                                   displayErrors);
+  }
+  if (typeof breakOnSigint !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE('options.breakOnSigint', 'boolean',
+                                   breakOnSigint);
+  }
+
+  return {
+    breakOnSigint,
+    args: [timeout, displayErrors, breakOnSigint]
+  };
 }
 
 function getContextOptions(options) {
@@ -123,57 +202,43 @@ function getContextOptions(options) {
 }
 
 function isContext(sandbox) {
-  if (arguments.length < 1) {
-    throw new ERR_MISSING_ARGS('sandbox');
+  if (typeof sandbox !== 'object' || sandbox === null) {
+    throw new ERR_INVALID_ARG_TYPE('sandbox', 'Object', sandbox);
   }
-
-  if (typeof sandbox !== 'object' && typeof sandbox !== 'function' ||
-      sandbox === null) {
-    throw new ERR_INVALID_ARG_TYPE('sandbox', 'object', sandbox);
-  }
-
   return _isContext(sandbox);
 }
 
 let defaultContextNameIndex = 1;
-function createContext(sandbox, options) {
-  if (sandbox === undefined) {
-    sandbox = {};
-  } else if (isContext(sandbox)) {
+function createContext(sandbox = {}, options = {}) {
+  if (isContext(sandbox)) {
     return sandbox;
   }
 
-  if (options !== undefined) {
-    if (typeof options !== 'object' || options === null) {
-      throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
-    }
-    validateObject(options.codeGeneration, 'options.codeGeneration');
-    options = {
-      name: options.name,
-      origin: options.origin,
-      codeGeneration: typeof options.codeGeneration === 'object' ? {
-        strings: options.codeGeneration.strings,
-        wasm: options.codeGeneration.wasm,
-      } : undefined,
-    };
-    if (options.codeGeneration !== undefined) {
-      validateBool(options.codeGeneration.strings,
-                   'options.codeGeneration.strings');
-      validateBool(options.codeGeneration.wasm,
-                   'options.codeGeneration.wasm');
-    }
-    if (options.name === undefined) {
-      options.name = `VM Context ${defaultContextNameIndex++}`;
-    } else if (typeof options.name !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('options.name', 'string', options.name);
-    }
-    validateString(options.origin, 'options.origin');
-  } else {
-    options = {
-      name: `VM Context ${defaultContextNameIndex++}`
-    };
+  if (typeof options !== 'object' || options === null) {
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
-  makeContext(sandbox, options);
+
+  const {
+    name = `VM Context ${defaultContextNameIndex++}`,
+    origin,
+    codeGeneration
+  } = options;
+
+  if (typeof name !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('options.name', 'string', options.name);
+  }
+  validateString(origin, 'options.origin');
+  validateObject(codeGeneration, 'options.codeGeneration');
+
+  let strings = true;
+  let wasm = true;
+  if (codeGeneration !== undefined) {
+    ({ strings = true, wasm = true } = codeGeneration);
+    validateBool(strings, 'options.codeGeneration.strings');
+    validateBool(wasm, 'options.codeGeneration.wasm');
+  }
+
+  makeContext(sandbox, name, origin, strings, wasm);
   return sandbox;
 }
 
@@ -200,6 +265,7 @@ function sigintHandlersWrap(fn, thisArg, argsArray) {
 }
 
 function runInContext(code, contextifiedSandbox, options) {
+  validateContext(contextifiedSandbox);
   if (typeof options === 'string') {
     options = {
       filename: options,
@@ -226,6 +292,9 @@ function runInNewContext(code, sandbox, options) {
 }
 
 function runInThisContext(code, options) {
+  if (typeof options === 'string') {
+    options = { filename: options };
+  }
   return createScript(code, options).runInThisContext(options);
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -239,7 +239,6 @@ struct PackageConfig {
   V(port_string, "port")                                                      \
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
-  V(produce_cached_data_string, "produceCachedData")                          \
   V(promise_string, "promise")                                                \
   V(pubkey_string, "pubkey")                                                  \
   V(query_string, "query")                                                    \

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -9,6 +9,13 @@
 namespace node {
 namespace contextify {
 
+struct ContextOptions {
+  v8::Local<v8::String> name;
+  v8::Local<v8::String> origin;
+  v8::Local<v8::Boolean> allow_code_gen_strings;
+  v8::Local<v8::Boolean> allow_code_gen_wasm;
+};
+
 class ContextifyContext {
  protected:
   Environment* const env_;
@@ -17,11 +24,11 @@ class ContextifyContext {
  public:
   ContextifyContext(Environment* env,
                     v8::Local<v8::Object> sandbox_obj,
-                    v8::Local<v8::Object> options_obj);
+                    const ContextOptions& options);
 
   v8::Local<v8::Value> CreateDataWrapper(Environment* env);
   v8::Local<v8::Context> CreateV8Context(Environment* env,
-      v8::Local<v8::Object> sandbox_obj, v8::Local<v8::Object> options_obj);
+      v8::Local<v8::Object> sandbox_obj, const ContextOptions& options);
   static void Init(Environment* env, v8::Local<v8::Object> target);
 
   static bool AllowWasmCodeGeneration(

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -24,60 +24,85 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-// Test 1: vm.runInNewContext
-const sandbox = {};
-let result = vm.runInNewContext(
-  'foo = "bar"; this.typeofProcess = typeof process; typeof Object;',
-  sandbox
-);
-assert.deepStrictEqual(sandbox, {
-  foo: 'bar',
-  typeofProcess: 'undefined',
-});
-assert.strictEqual(result, 'function');
+// vm.runInNewContext
+{
+  const sandbox = {};
+  const result = vm.runInNewContext(
+    'foo = "bar"; this.typeofProcess = typeof process; typeof Object;',
+    sandbox
+  );
+  assert.deepStrictEqual(sandbox, {
+    foo: 'bar',
+    typeofProcess: 'undefined',
+  });
+  assert.strictEqual(result, 'function');
+}
 
-// Test 2: vm.runInContext
-const sandbox2 = { foo: 'bar' };
-const context = vm.createContext(sandbox2);
-result = vm.runInContext(
-  'baz = foo; this.typeofProcess = typeof process; typeof Object;',
-  context
-);
-assert.deepStrictEqual(sandbox2, {
-  foo: 'bar',
-  baz: 'bar',
-  typeofProcess: 'undefined'
-});
-assert.strictEqual(result, 'function');
+// vm.runInContext
+{
+  const sandbox = { foo: 'bar' };
+  const context = vm.createContext(sandbox);
+  const result = vm.runInContext(
+    'baz = foo; this.typeofProcess = typeof process; typeof Object;',
+    context
+  );
+  assert.deepStrictEqual(sandbox, {
+    foo: 'bar',
+    baz: 'bar',
+    typeofProcess: 'undefined'
+  });
+  assert.strictEqual(result, 'function');
+}
 
-// Test 3: vm.runInThisContext
-result = vm.runInThisContext(
-  'vmResult = "foo"; Object.prototype.toString.call(process);'
-);
-assert.strictEqual(global.vmResult, 'foo');
-assert.strictEqual(result, '[object process]');
-delete global.vmResult;
+// vm.runInThisContext
+{
+  const result = vm.runInThisContext(
+    'vmResult = "foo"; Object.prototype.toString.call(process);'
+  );
+  assert.strictEqual(global.vmResult, 'foo');
+  assert.strictEqual(result, '[object process]');
+  delete global.vmResult;
+}
 
-// Test 4: vm.runInNewContext
-result = vm.runInNewContext(
-  'vmResult = "foo"; typeof process;'
-);
-assert.strictEqual(global.vmResult, undefined);
-assert.strictEqual(result, 'undefined');
+// vm.runInNewContext
+{
+  const result = vm.runInNewContext(
+    'vmResult = "foo"; typeof process;'
+  );
+  assert.strictEqual(global.vmResult, undefined);
+  assert.strictEqual(result, 'undefined');
+}
 
-// Test 5: vm.createContext
-const sandbox3 = {};
-const context2 = vm.createContext(sandbox3);
-assert.strictEqual(sandbox3, context2);
+// vm.createContext
+{
+  const sandbox = {};
+  const context = vm.createContext(sandbox);
+  assert.strictEqual(sandbox, context);
+}
 
-// Test 6: invalid arguments
+// Run script with filename
+{
+  const script = 'throw new Error("boom")';
+  const filename = 'test-boom-error';
+  const context = vm.createContext();
+
+  function checkErr(err) {
+    return err.stack.startsWith('test-boom-error:1');
+  }
+
+  assert.throws(() => vm.runInContext(script, context, filename), checkErr);
+  assert.throws(() => vm.runInNewContext(script, context, filename), checkErr);
+  assert.throws(() => vm.runInThisContext(script, filename), checkErr);
+}
+
+// Invalid arguments
 [null, 'string'].forEach((input) => {
   common.expectsError(() => {
     vm.createContext({}, input);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type object. ' +
+    message: 'The "options" argument must be of type Object. ' +
              `Received type ${typeof input}`
   });
 });

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 const spawnSync = require('child_process').spawnSync;
@@ -84,8 +84,12 @@ function testRejectSlice() {
 testRejectSlice();
 
 // It should throw on non-Buffer cachedData
-assert.throws(() => {
+common.expectsError(() => {
   new vm.Script('function abc() {}', {
     cachedData: 'ohai'
   });
-}, /^TypeError: options\.cachedData must be a Buffer instance$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: /must be one of type Buffer or Uint8Array/
+});

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -64,19 +64,25 @@ try {
 // This is outside of catch block to confirm catch block ran.
 assert.strictEqual(gh1140Exception.toString(), 'Error');
 
-// GH-558, non-context argument segfaults / raises assertion
-const nonContextualSandboxErrorMsg =
-  /^TypeError: contextifiedSandbox argument must be an object\.$/;
-const contextifiedSandboxErrorMsg =
-    /^TypeError: sandbox argument must have been converted to a context\.$/;
+const nonContextualSandboxError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: /must be of type Object/
+};
+const contextifiedSandboxError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: /must be of type vm\.Context/
+};
+
 [
-  [undefined, nonContextualSandboxErrorMsg],
-  [null, nonContextualSandboxErrorMsg], [0, nonContextualSandboxErrorMsg],
-  [0.0, nonContextualSandboxErrorMsg], ['', nonContextualSandboxErrorMsg],
-  [{}, contextifiedSandboxErrorMsg], [[], contextifiedSandboxErrorMsg]
+  [undefined, nonContextualSandboxError],
+  [null, nonContextualSandboxError], [0, nonContextualSandboxError],
+  [0.0, nonContextualSandboxError], ['', nonContextualSandboxError],
+  [{}, contextifiedSandboxError], [[], contextifiedSandboxError]
 ].forEach((e) => {
-  assert.throws(() => { script.runInContext(e[0]); }, e[1]);
-  assert.throws(() => { vm.runInContext('', e[0]); }, e[1]);
+  common.expectsError(() => { script.runInContext(e[0]); }, e[1]);
+  common.expectsError(() => { vm.runInContext('', e[0]); }, e[1]);
 });
 
 // Issue GH-693:

--- a/test/parallel/test-vm-is-context.js
+++ b/test/parallel/test-vm-is-context.js
@@ -35,13 +35,6 @@ for (const valToTest of [
   });
 }
 
-common.expectsError(() => {
-  vm.isContext();
-}, {
-  code: 'ERR_MISSING_ARGS',
-  type: TypeError
-});
-
 assert.strictEqual(vm.isContext({}), false);
 assert.strictEqual(vm.isContext([]), false);
 

--- a/test/parallel/test-vm-options-validation.js
+++ b/test/parallel/test-vm-options-validation.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const common = require('../common');
+const vm = require('vm');
+
+const invalidArgType = {
+  type: TypeError,
+  code: 'ERR_INVALID_ARG_TYPE'
+};
+
+const outOfRange = {
+  type: RangeError,
+  code: 'ERR_OUT_OF_RANGE'
+};
+
+common.expectsError(() => {
+  new vm.Script('void 0', 42);
+}, invalidArgType);
+
+[null, {}, [1], 'bad', true, 0.1].forEach((value) => {
+  common.expectsError(() => {
+    new vm.Script('void 0', { lineOffset: value });
+  }, invalidArgType);
+
+  common.expectsError(() => {
+    new vm.Script('void 0', { columnOffset: value });
+  }, invalidArgType);
+});
+
+common.expectsError(() => {
+  new vm.Script('void 0', { lineOffset: Number.MAX_SAFE_INTEGER });
+}, outOfRange);
+
+common.expectsError(() => {
+  new vm.Script('void 0', { columnOffset: Number.MAX_SAFE_INTEGER });
+}, outOfRange);
+
+common.expectsError(() => {
+  new vm.Script('void 0', { filename: 123 });
+}, invalidArgType);
+
+common.expectsError(() => {
+  new vm.Script('void 0', { produceCachedData: 1 });
+}, invalidArgType);
+
+[[0], {}, true, 'bad', 42].forEach((value) => {
+  common.expectsError(() => {
+    new vm.Script('void 0', { cachedData: value });
+  }, invalidArgType);
+});
+
+{
+  const script = new vm.Script('void 0');
+  const sandbox = vm.createContext();
+
+  function assertErrors(options) {
+    common.expectsError(() => {
+      script.runInThisContext(options);
+    }, invalidArgType);
+
+    common.expectsError(() => {
+      script.runInContext(sandbox, options);
+    }, invalidArgType);
+
+    common.expectsError(() => {
+      script.runInNewContext({}, options);
+    }, invalidArgType);
+  }
+
+  [null, 'bad', 42].forEach(assertErrors);
+  [{}, [1], 'bad', null, -1, 0, NaN].forEach((value) => {
+    assertErrors({ timeout: value });
+  });
+  [{}, [1], 'bad', 1, null].forEach((value) => {
+    assertErrors({ displayErrors: value });
+    assertErrors({ breakOnSigint: value });
+  });
+}

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -24,25 +24,15 @@ require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-// Test 1: Timeout of 100ms executing endless loop
+// Timeout of 100ms executing endless loop
 assert.throws(function() {
   vm.runInThisContext('while(true) {}', { timeout: 100 });
 }, /^Error: Script execution timed out\.$/);
 
-// Test 2: Timeout must be >= 0ms
-assert.throws(function() {
-  vm.runInThisContext('', { timeout: -1 });
-}, /^RangeError: timeout must be a positive number$/);
-
-// Test 3: Timeout of 0ms
-assert.throws(function() {
-  vm.runInThisContext('', { timeout: 0 });
-}, /^RangeError: timeout must be a positive number$/);
-
-// Test 4: Timeout of 1000ms, script finishes first
+// Timeout of 1000ms, script finishes first
 vm.runInThisContext('', { timeout: 1000 });
 
-// Test 5: Nested vm timeouts, inner timeout propagates out
+// Nested vm timeouts, inner timeout propagates out
 assert.throws(function() {
   const context = {
     log: console.log,
@@ -54,7 +44,7 @@ assert.throws(function() {
   throw new Error('Test 5 failed');
 }, /Script execution timed out\./);
 
-// Test 6: Nested vm timeouts, outer timeout is shorter and fires first.
+// Nested vm timeouts, outer timeout is shorter and fires first.
 assert.throws(function() {
   const context = {
     runInVM: function(timeout) {
@@ -65,7 +55,7 @@ assert.throws(function() {
   throw new Error('Test 6 failed');
 }, /Script execution timed out\./);
 
-// Test 7: Nested vm timeouts, inner script throws an error.
+// Nested vm timeouts, inner script throws an error.
 assert.throws(function() {
   const context = {
     runInVM: function(timeout) {


### PR DESCRIPTION
~I tried to keep the type checking as it was done in C++ (not very strict for some options).~ -> Now all options are checked more strictly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
