### PR TITLE
test: refactor test-fs-readfile-tostring-fail

### DIFF
--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -30,11 +30,10 @@ for (let i = 0; i < 201; i++) {
 
 stream.end();
 stream.on('finish', common.mustCall(function() {
-  // make sure that the toString does not throw an error
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
-    assert(/^(Array buffer allocation failed|"toString\(\)" failed)$/
-             .test(err.message));
+    assert.ok(/^(Array buffer allocation failed|"toString\(\)" failed)$/
+              .test(err.message));
     assert.strictEqual(buf, undefined);
   }));
 }));


### PR DESCRIPTION
The test uses both `assert()` and `assert.ok()`. Use just `assert.ok()`.

Remove a comment that does not appear to match the code and does not
seem to explain much beyond the bare code itself.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
