### PR TITLE
[v8.x] fs: fix `createReadStream(…, {end: n})` for non-seekable fds 

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1950,8 +1950,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = typeof this.fd !== 'number' && options.start === undefined ?
-    0 : options.start;
+  this.start = options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;
@@ -1973,6 +1972,12 @@ function ReadStream(path, options) {
 
     this.pos = this.start;
   }
+
+  // Backwards compatibility: Make sure `end` is a number regardless of `start`.
+  // TODO(addaleax): Make the above typecheck not depend on `start` instead.
+  // (That is a semver-major change).
+  if (typeof this.end !== 'number')
+    this.end = Infinity;
 
   if (typeof this.fd !== 'number')
     this.open();
@@ -2028,6 +2033,8 @@ ReadStream.prototype._read = function(n) {
 
   if (this.pos !== undefined)
     toRead = Math.min(this.end - this.pos + 1, toRead);
+  else
+    toRead = Math.min(this.end - this.bytesRead + 1, toRead);
 
   // already read everything we were supposed to read!
   // treat as EOF.

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -21,7 +21,9 @@
 
 'use strict';
 const common = require('../common');
+const tmpdir = require('../common/tmpdir');
 
+const child_process = require('child_process');
 const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
@@ -169,6 +171,31 @@ assert.throws(function() {
   stream.on('end', common.mustCall(function() {
     assert.strictEqual('xy', stream.data);
   }));
+}
+
+if (!common.isWindows) {
+  // Verify that end works when start is not specified, and we do not try to
+  // use positioned reads. This makes sure that this keeps working for
+  // non-seekable file descriptors.
+  tmpdir.refresh();
+  const filename = `${tmpdir.path}/foo.pipe`;
+  const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
+  if (!mkfifoResult.error) {
+    child_process.exec(`echo "xyz foobar" > '${filename}'`);
+    const stream = new fs.createReadStream(filename, { end: 1 });
+    stream.data = '';
+
+    stream.on('data', function(chunk) {
+      stream.data += chunk;
+    });
+
+    stream.on('end', common.mustCall(function() {
+      assert.strictEqual('xy', stream.data);
+      fs.unlinkSync(filename);
+    }));
+  } else {
+    common.printSkipMessage('mkfifo not available');
+  }
 }
 
 {

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -21,7 +21,6 @@
 
 'use strict';
 const common = require('../common');
-const tmpdir = require('../common/tmpdir');
 
 const child_process = require('child_process');
 const assert = require('assert');
@@ -177,8 +176,8 @@ if (!common.isWindows) {
   // Verify that end works when start is not specified, and we do not try to
   // use positioned reads. This makes sure that this keeps working for
   // non-seekable file descriptors.
-  tmpdir.refresh();
-  const filename = `${tmpdir.path}/foo.pipe`;
+  common.refreshTmpDir();
+  const filename = `${common.tmpDir}/foo.pipe`;
   const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
   if (!mkfifoResult.error) {
     child_process.exec(`echo "xyz foobar" > '${filename}'`);


### PR DESCRIPTION
Backport #19329 to v8.x

The test file needed to be updated.

Fixes: #19240