### PR TITLE
[v6.x] fs: fix `createReadStream(…, {end: n})` for non-seekable fds 

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1919,8 +1919,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = typeof this.fd !== 'number' && options.start === undefined ?
-    0 : options.start;
+  this.start = options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;
@@ -1942,6 +1941,12 @@ function ReadStream(path, options) {
 
     this.pos = this.start;
   }
+
+  // Backwards compatibility: Make sure `end` is a number regardless of `start`.
+  // TODO(addaleax): Make the above typecheck not depend on `start` instead.
+  // (That is a semver-major change).
+  if (typeof this.end !== 'number')
+    this.end = Infinity;
 
   if (typeof this.fd !== 'number')
     this.open();
@@ -1996,6 +2001,8 @@ ReadStream.prototype._read = function(n) {
 
   if (this.pos !== undefined)
     toRead = Math.min(this.end - this.pos + 1, toRead);
+  else
+    toRead = Math.min(this.end - this.bytesRead + 1, toRead);
 
   // already read everything we were supposed to read!
   // treat as EOF.

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -174,8 +174,8 @@ if (!common.isWindows) {
   // Verify that end works when start is not specified, and we do not try to
   // use positioned reads. This makes sure that this keeps working for
   // non-seekable file descriptors.
-  tmpdir.refresh();
-  const filename = `${tmpdir.path}/foo.pipe`;
+  common.refreshTmpDir();
+  const filename = `${common.tmpDir}/foo.pipe`;
   const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
   if (!mkfifoResult.error) {
     child_process.exec(`echo "xyz foobar" > '${filename}'`);


### PR DESCRIPTION
Backport #19329 to v6.x

The test file needed to be updated & has merge conflicts from neighbouring tests resolved.

Fixes: #19240