### PR TITLE
[v9.x backport] test: http2 client setNextStreamID errors

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -948,7 +948,7 @@ class Http2Session extends EventEmitter {
     if (typeof id !== 'number')
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'id', 'number');
     if (id <= 0 || id > kMaxStreams)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE');
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'id');
     this[kHandle].setNextStreamID(id);
   }
 

--- a/test/parallel/test-http2-client-setNextStreamID-errors.js
+++ b/test/parallel/test-http2-client-setNextStreamID-errors.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respond();
+  stream.end('ok');
+});
+
+const types = {
+  boolean: true,
+  function: () => {},
+  number: 1,
+  object: {},
+  array: [],
+  null: null,
+  symbol: Symbol('test')
+};
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  client.on('connect', () => {
+    const outOfRangeNum = 2 ** 31;
+    common.expectsError(
+      () => client.setNextStreamID(outOfRangeNum),
+      {
+        type: RangeError,
+        code: 'ERR_OUT_OF_RANGE',
+        message: 'The "id" argument is out of range'
+      }
+    );
+
+    // should throw if something other than number is passed to setNextStreamID
+    Object.entries(types).forEach(([type, value]) => {
+      if (type === 'number') {
+        return;
+      }
+
+      common.expectsError(
+        () => client.setNextStreamID(value),
+        {
+          type: TypeError,
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: 'The "id" argument must be of type number'
+        }
+      );
+    });
+
+    server.close();
+    client.close();
+  });
+}));


### PR DESCRIPTION
This also fixes the error thrown (was 'The "%s" argument is out of range').

Original PR: https://github.com/nodejs/node/pull/18848

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)