### PR TITLE
net: emit error on invalid address family

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1042,6 +1042,11 @@ The `inspector` module is not available for use.
 While using the `inspector` module, an attempt was made to use the inspector
 before it was connected.
 
+<a id="ERR_INVALID_ADDRESS_FAMILY"></a>
+### ERR_INVALID_ADDRESS_FAMILY
+
+The provided address family is not understood by the Node.js API.
+
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -737,6 +737,7 @@ E('ERR_INSPECTOR_ALREADY_CONNECTED',
 E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available', Error);
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected', Error);
+E('ERR_INVALID_ADDRESS_FAMILY', 'Invalid address family: %s', RangeError);
 E('ERR_INVALID_ARG_TYPE', invalidArgType, TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
   const util = lazyUtil();

--- a/lib/net.js
+++ b/lib/net.js
@@ -54,6 +54,7 @@ const {
 } = require('internal/async_hooks');
 const errors = require('internal/errors');
 const {
+  ERR_INVALID_ADDRESS_FAMILY,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_FD_TYPE,
   ERR_INVALID_IP_ADDRESS,
@@ -1113,6 +1114,12 @@ function lookupAndConnect(self, options) {
         // immediately calls net.Socket.connect() on it (that's us).
         // There are no event listeners registered yet so defer the
         // error event to the next tick.
+        err.host = options.host;
+        err.port = options.port;
+        err.message = err.message + ' ' + options.host + ':' + options.port;
+        process.nextTick(connectErrorNT, self, err);
+      } else if (addressType !== 4 && addressType !== 6) {
+        err = new ERR_INVALID_ADDRESS_FAMILY(addressType);
         err.host = options.host;
         err.port = options.port;
         err.message = err.message + ' ' + options.host + ':' + options.port;

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -29,5 +29,14 @@ function connectDoesNotThrow(input) {
     lookup: input
   };
 
-  net.connect(opts);
+  return net.connect(opts);
+}
+
+{
+  // Verify that an error is emitted when an invalid address family is returned.
+  const s = connectDoesNotThrow((host, options, cb) => {
+    cb(null, '127.0.0.1', 100);
+  });
+
+  s.on('error', common.expectsError({ code: 'ERR_INVALID_ADDRESS_FAMILY' }));
 }


### PR DESCRIPTION
This commit adds proper error handling to `net.connect()` when a custom `lookup()` function returns an invalid address family.

Fixes: https://github.com/nodejs/node/issues/19407

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
