### PR TITLE
test: update assert messages to show expected and actual values

### DIFF
--- a/test/fixtures/readfile_pipe_test.txt
+++ b/test/fixtures/readfile_pipe_test.txt
@@ -1,0 +1,5 @@
+xxxx xxxx xxxx xxxx
+xxxx xxxx xxxx xxxx
+xxxx xxxx xxxx xxxx
+xxxx xxxx xxxx xxxx
+xxxx xxxx xxxx xxxx

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -28,9 +28,8 @@ if (common.isWindows || common.isAIX)
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');
+const path = require('path');
 const fs = require('fs');
-
-const dataExpected = fs.readFileSync(__filename, 'utf8');
 
 if (process.argv[2] === 'child') {
   fs.readFile('/dev/stdin', function(er, data) {
@@ -40,13 +39,28 @@ if (process.argv[2] === 'child') {
   return;
 }
 
+const tmpdir = require('../common/tmpdir');
+
+const filename = path.join(tmpdir.path, '/readfile_pipe_test.txt');
+const dataExpected = `xxxxxxxxxx xxxxxxxxxx
+xxxxxxxxxx xxxxxxxxxx
+xxxxxxxxxx xxxxxxxxxx
+xxxxxxxxxx xxxxxxxxxx
+xxxxxxxxxx xxxxxxxxxx`
+tmpdir.refresh();
+fs.writeFileSync(filename, dataExpected);
+
 const exec = require('child_process').exec;
 const f = JSON.stringify(__filename);
 const node = JSON.stringify(process.execPath);
-const cmd = `cat ${f} | ${node} ${f} child`;
+const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(cmd, function(err, stdout, stderr) {
   assert.ifError(err);
-  assert.strictEqual(stdout, dataExpected, `expected to read ${dataExpected} but got: ${stdout}`);
-  assert.strictEqual(stderr, '', `expected not to read anything from stderr but got: ${stderr}`);
+  assert.strictEqual(stdout, dataExpected, `expected to read: '${dataExpected}' but got: '${stdout}'`);
+  assert.strictEqual(stderr, '', `expected not to read anything from stderr but got: '${stderr}'`);
   console.log('ok');
+});
+
+process.on('exit', function() {
+  fs.unlinkSync(filename);
 });

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -46,7 +46,7 @@ const node = JSON.stringify(process.execPath);
 const cmd = `cat ${f} | ${node} ${f} child`;
 exec(cmd, function(err, stdout, stderr) {
   assert.ifError(err);
-  assert.strictEqual(stdout, dataExpected, 'it reads the file and outputs it');
-  assert.strictEqual(stderr, '', 'it does not write to stderr');
+  assert.strictEqual(stdout, dataExpected, `expected to read ${dataExpected} but got: ${stdout}`);
+  assert.strictEqual(stderr, '', `expected not to read anything from stderr but got: ${stderr}`);
   console.log('ok');
 });

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -46,7 +46,7 @@ const dataExpected = `xxxxxxxxxx xxxxxxxxxx
 xxxxxxxxxx xxxxxxxxxx
 xxxxxxxxxx xxxxxxxxxx
 xxxxxxxxxx xxxxxxxxxx
-xxxxxxxxxx xxxxxxxxxx`
+xxxxxxxxxx xxxxxxxxxx`;
 tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
@@ -56,8 +56,14 @@ const node = JSON.stringify(process.execPath);
 const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(cmd, function(err, stdout, stderr) {
   assert.ifError(err);
-  assert.strictEqual(stdout, dataExpected, `expected to read: '${dataExpected}' but got: '${stdout}'`);
-  assert.strictEqual(stderr, '', `expected not to read anything from stderr but got: '${stderr}'`);
+  assert.strictEqual(
+    stdout,
+    dataExpected,
+    `expected to read: '${dataExpected}' but got: '${stdout}'`);
+  assert.strictEqual(
+    stderr,
+    '',
+    `expected not to read anything from stderr but got: '${stderr}'`);
   console.log('ok');
 });
 

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -28,7 +28,6 @@ if (common.isWindows || common.isAIX)
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
@@ -39,16 +38,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
 
-const filename = path.join(tmpdir.path, '/readfile_pipe_test.txt');
-const dataExpected = `xxxxxxxxxx xxxxxxxxxx
-xxxxxxxxxx xxxxxxxxxx
-xxxxxxxxxx xxxxxxxxxx
-xxxxxxxxxx xxxxxxxxxx
-xxxxxxxxxx xxxxxxxxxx`;
-tmpdir.refresh();
-fs.writeFileSync(filename, dataExpected);
+const filename = fixtures.path('readfile_pipe_test.txt');
+const dataExpected = fs.readFileSync(filename).toString();
 
 const exec = require('child_process').exec;
 const f = JSON.stringify(__filename);
@@ -65,8 +58,4 @@ exec(cmd, function(err, stdout, stderr) {
     '',
     `expected not to read anything from stderr but got: '${stderr}'`);
   console.log('ok');
-});
-
-process.on('exit', function() {
-  fs.unlinkSync(filename);
 });


### PR DESCRIPTION
The test-fs-readfile-pipe unit test has been updated to display the actual and expected values when the assertion fires.  The test has also been updated to use a string of regularly formatted x characters as test data so that differences between the actual and expected values are easier to spot.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
