### PR TITLE
console: don't swallow stack overflow

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -21,14 +21,15 @@
 
 'use strict';
 
-const { ERR_CONSOLE_WRITABLE_STREAM } = require('internal/errors').codes;
+const {
+  isStackOverflowError,
+  codes: { ERR_CONSOLE_WRITABLE_STREAM },
+} = require('internal/errors');
 const util = require('util');
 const kCounts = Symbol('counts');
 
 // Track amount of indentation required via `console.group()`.
 const kGroupIndent = Symbol('groupIndent');
-
-let MAX_STACK_MESSAGE;
 
 function Console(stdout, stderr, ignoreErrors = true) {
   if (!(this instanceof Console)) {
@@ -113,17 +114,9 @@ function write(ignoreErrors, stream, string, errorhandler, groupIndent) {
 
     stream.write(string, errorhandler);
   } catch (e) {
-    if (MAX_STACK_MESSAGE === undefined) {
-      try {
-        // eslint-disable-next-line no-unused-vars
-        function a() { a(); }
-      } catch (err) {
-        MAX_STACK_MESSAGE = err.message;
-      }
-    }
     // console is a debugging utility, so it swallowing errors is not desirable
     // even in edge cases such as low stack space.
-    if (e.message === MAX_STACK_MESSAGE && e.name === 'RangeError')
+    if (isStackOverflowError(e))
       throw e;
     // Sorry, there's no proper way to pass along the error here.
   } finally {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -566,11 +566,33 @@ function dnsException(err, syscall, hostname) {
   return ex;
 }
 
+let MAX_STACK_MESSAGE;
+/**
+ * Returns true if `err` is a `RangeError` with an engine-specific message.
+ * "Maximum call stack size exceeded" in V8.
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function isStackOverflowError(err) {
+  if (MAX_STACK_MESSAGE === undefined) {
+    try {
+      function overflowStack() { overflowStack(); }
+      overflowStack();
+    } catch (err) {
+      MAX_STACK_MESSAGE = err.message;
+    }
+  }
+
+  return err.name === 'RangeError' && err.message === MAX_STACK_MESSAGE;
+}
+
 module.exports = exports = {
   dnsException,
   errnoException,
   exceptionWithHostPort,
   uvException,
+  isStackOverflowError,
   message,
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),

--- a/test/parallel/test-console-no-swallow-stack-overflow.js
+++ b/test/parallel/test-console-no-swallow-stack-overflow.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const { Console } = require('console');
+const { Writable } = require('stream');
+
+for (const method of ['dir', 'log', 'warn']) {
+  common.expectsError(() => {
+    const out = new Writable({
+      write: common.mustCall(function write(...args) {
+        // Exceeds call stack.
+        return write(...args);
+      }),
+    });
+    const c = new Console(out, out, true);
+
+    c[method]('Hello, world!');
+  }, { name: 'RangeError' });
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

`console.log` unintentionally swallows stack overflows from V8. [`MAX_STACK_MESSAGE` is never set](https://github.com/nodejs/node/blob/master/lib/console.js#L119) as `a` is not called. The original code was intentionally platform-agnostic, so this logic avoids platform-specific logic as well.
