### PR TITLE
n-api: allow escape of undefined

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2615,8 +2615,13 @@ napi_status napi_escape_handle(napi_env env,
   v8impl::EscapableHandleScopeWrapper* s =
       v8impl::V8EscapableHandleScopeFromJsEscapableHandleScope(scope);
   if (!s->escape_called()) {
-    *result = v8impl::JsValueFromV8LocalValue(
-        s->Escape(v8impl::V8LocalValueFromJsValue(escapee)));
+    v8::Local<v8::Value> escapee_object =
+        v8impl::V8LocalValueFromJsValue(escapee);
+    if (escapee_object->IsUndefined()) {
+      *result = escapee;
+    } else {
+      *result = v8impl::JsValueFromV8LocalValue(s->Escape(escapee_object));
+    }
     return napi_clear_last_error(env);
   }
   return napi_set_last_error(env, napi_escape_called_twice);

--- a/test/addons-napi/test_handle_scope/test.js
+++ b/test/addons-napi/test_handle_scope/test.js
@@ -17,3 +17,5 @@ assert.throws(
     testHandleScope.NewScopeWithException(() => { throw new RangeError(); });
   },
   RangeError);
+
+assert.ok(testHandleScope.NewScopeEscapeUndefined() === undefined);

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -68,12 +68,25 @@ napi_value NewScopeWithException(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+napi_value NewScopeEscapeUndefined(napi_env env, napi_callback_info info) {
+  napi_escapable_handle_scope scope;
+  napi_value escapee = NULL;
+  napi_value undefined_object = NULL;
+
+  NAPI_CALL(env, napi_open_escapable_handle_scope(env, &scope));
+  NAPI_CALL(env, napi_get_undefined(env, &undefined_object));
+  NAPI_CALL(env, napi_escape_handle(env, scope, undefined_object, &escapee));
+  NAPI_CALL(env, napi_close_escapable_handle_scope(env, scope));
+  return escapee;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("NewScope", NewScope),
     DECLARE_NAPI_PROPERTY("NewScopeEscape", NewScopeEscape),
     DECLARE_NAPI_PROPERTY("NewScopeEscapeTwice", NewScopeEscapeTwice),
     DECLARE_NAPI_PROPERTY("NewScopeWithException", NewScopeWithException),
+    DECLARE_NAPI_PROPERTY("NewScopeEscapeUndefined", NewScopeEscapeUndefined),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
The node-addon-api module was calling escape on undefined
which would fail. Instead of forcing a check in all consumers
of napi_escape_handle accept undefined and simply return
it as it does not need to be escaped.

Refs: https://github.com/nodejs/node-addon-api/issues/233

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
