### PR TITLE
child_process: fix channel disconnect logic & cleanup pending handles

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -266,6 +266,22 @@ function closePendingHandle(target) {
   target._pendingMessage = null;
 }
 
+function closeHandleQueue(target) {
+  const queue = target._handleQueue;
+  target._handleQueue = null;
+
+  const ex = new errors.Error('ERR_IPC_CHANNEL_CLOSED');
+
+  for (var i = 0; i < queue.length; i++) {
+    const args = queue[i];
+
+    if (args.callback && !args.options.swallowErrors) {
+      process.nextTick(args.callback, ex);
+    }
+
+    args.handle.close();
+  }
+}
 
 ChildProcess.prototype.spawn = function(options) {
   var ipc;
@@ -505,11 +521,14 @@ function setupChannel(target, channel) {
 
     } else {
       this.buffering = false;
+
+      // The channel is closed, so get rid of remaining handles manually.
+      if (target._pendingMessage)
+        closePendingHandle(target);
+      if (target._handleQueue)
+        closeHandleQueue(target);
+
       target.disconnect();
-      channel.onread = nop;
-      channel.close();
-      target.channel = null;
-      maybeClose(target);
     }
   };
 
@@ -763,16 +782,17 @@ function setupChannel(target, channel) {
     // This marks the fact that the channel is actually disconnected.
     this.channel = null;
 
-    if (this._pendingMessage)
-      closePendingHandle(this);
-
     var fired = false;
     function finish() {
       if (fired) return;
       fired = true;
 
+      channel.onread = nop;
       channel.close();
+
       target.emit('disconnect');
+
+      maybeClose(target);
     }
 
     // If a message is being read, then wait for it to complete.

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -104,8 +104,8 @@ if (process.argv[2] === 'child') {
     }
   });
 
-  process.on('exit', function() {
+  child.on('close', common.mustCall(function() {
     assert.strictEqual(childFlag, false);
     assert.strictEqual(parentFlag, false);
-  });
+  }));
 }


### PR DESCRIPTION
- Fix close not being emitted when calling process.disconnect()
  from a parent process.
- When there are pending handles that would never be closed
  because the other side has closed the channel, they are now
  closed 'manually'.
- Extend child disconnect test case to also check that 'close'
  was emitted.

Fixes: https://github.com/nodejs/node/issues/19433
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
