### PR TITLE
errors: improve invalid args

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -87,8 +87,9 @@ function ClientRequest(options, cb) {
     // Explicitly pass through this statement as agent will not be used
     // when createConnection is provided.
   } else if (typeof agent.addRequest !== 'function') {
-    throw new ERR_INVALID_ARG_TYPE('Agent option',
-                                   ['Agent-like Object', 'undefined', 'false']);
+    throw new ERR_INVALID_ARG_TYPE('options.agent',
+                                   ['Agent-like Object', 'undefined', 'false'],
+                                   agent);
   }
   this.agent = agent;
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -540,7 +540,7 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 
 OutgoingMessage.prototype.getHeader = function getHeader(name) {
   if (typeof name !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('name', 'string');
+    throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
   }
 
   if (!this[outHeadersKey]) return;
@@ -576,7 +576,7 @@ OutgoingMessage.prototype.getHeaders = function getHeaders() {
 
 OutgoingMessage.prototype.hasHeader = function hasHeader(name) {
   if (typeof name !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('name', 'string');
+    throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
   }
 
   return !!(this[outHeadersKey] && this[outHeadersKey][name.toLowerCase()]);
@@ -585,7 +585,7 @@ OutgoingMessage.prototype.hasHeader = function hasHeader(name) {
 
 OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
   if (typeof name !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('name', 'string');
+    throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
   }
 
   if (this._header) {
@@ -656,7 +656,8 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   }
 
   if (!fromEnd && typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-    throw new ERR_INVALID_ARG_TYPE('first argument', ['string', 'Buffer']);
+    throw new ERR_INVALID_ARG_TYPE('first argument',
+                                   ['string', 'Buffer'], chunk);
   }
 
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -755,7 +755,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   var uncork;
   if (chunk) {
     if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('first argument', ['string', 'Buffer']);
+      throw new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
     }
     if (!this._header) {
       if (typeof chunk === 'string')

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -294,7 +294,8 @@ function chunkInvalid(state, chunk) {
       typeof chunk !== 'string' &&
       chunk !== undefined &&
       !state.objectMode) {
-    er = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer', 'Uint8Array']);
+    er = new ERR_INVALID_ARG_TYPE(
+      'chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
   }
   return er;
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -255,7 +255,7 @@ function validChunk(stream, state, chunk, cb) {
   if (chunk === null) {
     er = new ERR_STREAM_NULL_VALUES();
   } else if (typeof chunk !== 'string' && !state.objectMode) {
-    er = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer']);
+    er = new ERR_INVALID_ARG_TYPE('chunk', ['string', 'Buffer'], chunk);
   }
   if (er) {
     stream.emit('error', er);

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -58,11 +58,14 @@ function SecureContext(secureProtocol, secureOptions, context) {
 }
 
 function validateKeyCert(value, type) {
-  if (typeof value !== 'string' && !isArrayBufferView(value))
+  if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(
+      // TODO(BridgeAR): Change this to `options.${type}`
       type,
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      value
     );
+  }
 }
 
 exports.SecureContext = SecureContext;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -667,7 +667,7 @@ TLSSocket.prototype._start = function() {
 
 TLSSocket.prototype.setServername = function(name) {
   if (typeof name !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('name', 'string');
+    throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
   }
 
   if (this._tlsOptions.isServer) {
@@ -877,7 +877,7 @@ function Server(options, listener) {
   } else if (options == null || typeof options === 'object') {
     options = options || {};
   } else {
-    throw new ERR_INVALID_ARG_TYPE('options', 'Object');
+    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -908,7 +908,8 @@ function Server(options, listener) {
   this[kSNICallback] = options.SNICallback;
 
   if (typeof this[kHandshakeTimeout] !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('timeout', 'number');
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.handshakeTimeout', 'number', options.handshakeTimeout);
   }
 
   if (this.sessionTimeout) {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -141,7 +141,7 @@ function showEmitBeforeAfterWarning() {
 class AsyncResource {
   constructor(type, opts = {}) {
     if (typeof type !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('type', 'string');
+      throw new ERR_INVALID_ARG_TYPE('type', 'string', type);
 
     if (typeof opts === 'number') {
       opts = { triggerAsyncId: opts, requireManualDestroy: false };

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -416,16 +416,20 @@ Buffer.isBuffer = function isBuffer(b) {
   return b instanceof Buffer;
 };
 
-Buffer.compare = function compare(a, b) {
-  if (!isUint8Array(a) || !isUint8Array(b)) {
-    throw new ERR_INVALID_ARG_TYPE(['buf1', 'buf2'], ['Buffer', 'Uint8Array']);
+Buffer.compare = function compare(buf1, buf2) {
+  if (!isUint8Array(buf1)) {
+    throw new ERR_INVALID_ARG_TYPE('buf1', ['Buffer', 'Uint8Array'], buf1);
   }
 
-  if (a === b) {
+  if (!isUint8Array(buf2)) {
+    throw new ERR_INVALID_ARG_TYPE('buf2', ['Buffer', 'Uint8Array'], buf2);
+  }
+
+  if (buf1 === buf2) {
     return 0;
   }
 
-  return _compare(a, b);
+  return _compare(buf1, buf2);
 };
 
 Buffer.isEncoding = function isEncoding(encoding) {
@@ -437,7 +441,8 @@ Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 Buffer.concat = function concat(list, length) {
   var i;
   if (!Array.isArray(list)) {
-    throw new ERR_INVALID_ARG_TYPE('list', ['Array', 'Buffer', 'Uint8Array']);
+    throw new ERR_INVALID_ARG_TYPE(
+      'list', ['Array', 'Buffer', 'Uint8Array'], list);
   }
 
   if (list.length === 0)
@@ -645,14 +650,15 @@ Buffer.prototype.toString = function toString(encoding, start, end) {
   return stringSlice(this, encoding, start, end);
 };
 
-Buffer.prototype.equals = function equals(b) {
-  if (!isUint8Array(b)) {
-    throw new ERR_INVALID_ARG_TYPE('otherBuffer', ['Buffer', 'Uint8Array'], b);
+Buffer.prototype.equals = function equals(otherBuffer) {
+  if (!isUint8Array(otherBuffer)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'otherBuffer', ['Buffer', 'Uint8Array'], otherBuffer);
   }
-  if (this === b)
+  if (this === otherBuffer)
     return true;
 
-  return _compare(this, b) === 0;
+  return _compare(this, otherBuffer) === 0;
 };
 
 // Override how buffers are presented by util.inspect().

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -461,7 +461,10 @@ Buffer.concat = function concat(list, length) {
   for (i = 0; i < list.length; i++) {
     var buf = list[i];
     if (!isUint8Array(buf)) {
-      throw new ERR_INVALID_ARG_TYPE('list', ['Array', 'Buffer', 'Uint8Array']);
+      // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
+      // Instead, find the proper error code for this.
+      throw new ERR_INVALID_ARG_TYPE(
+        `list[${i}]`, ['Array', 'Buffer', 'Uint8Array'], list[i]);
     }
     _copy(buf, buffer, pos);
     pos += buf.length;

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -75,7 +75,7 @@ function newHandle(type, lookup) {
   if (lookup === undefined)
     lookup = dns.lookup;
   else if (typeof lookup !== 'function')
-    throw new ERR_INVALID_ARG_TYPE('lookup', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('lookup', 'Function', lookup);
 
   if (type === 'udp4') {
     const handle = new UDP();
@@ -299,19 +299,19 @@ Socket.prototype.sendto = function(buffer,
                                    address,
                                    callback) {
   if (typeof offset !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number');
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
   }
 
   if (typeof length !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('length', 'number');
+    throw new ERR_INVALID_ARG_TYPE('length', 'number', length);
   }
 
   if (typeof port !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('port', 'number');
+    throw new ERR_INVALID_ARG_TYPE('port', 'number', port);
   }
 
   if (typeof address !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('address', 'string');
+    throw new ERR_INVALID_ARG_TYPE('address', 'string', address);
   }
 
   this.send(buffer, offset, length, port, address, callback);
@@ -323,7 +323,7 @@ function sliceBuffer(buffer, offset, length) {
     buffer = Buffer.from(buffer);
   } else if (!isUint8Array(buffer)) {
     throw new ERR_INVALID_ARG_TYPE('buffer',
-                                   ['Buffer', 'Uint8Array', 'string']);
+                                   ['Buffer', 'Uint8Array', 'string'], buffer);
   }
 
   offset = offset >>> 0;
@@ -415,13 +415,14 @@ Socket.prototype.send = function(buffer,
       list = [ Buffer.from(buffer) ];
     } else if (!isUint8Array(buffer)) {
       throw new ERR_INVALID_ARG_TYPE('buffer',
-                                     ['Buffer', 'Uint8Array', 'string']);
+                                     ['Buffer', 'Uint8Array', 'string'],
+                                     buffer);
     } else {
       list = [ buffer ];
     }
   } else if (!(list = fixBufferList(buffer))) {
     throw new ERR_INVALID_ARG_TYPE('buffer list arguments',
-                                   ['Buffer', 'string']);
+                                   ['Buffer', 'string'], buffer);
   }
 
   port = port >>> 0;
@@ -437,7 +438,7 @@ Socket.prototype.send = function(buffer,
     callback = address;
     address = undefined;
   } else if (address && typeof address !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('address', ['string', 'falsy']);
+    throw new ERR_INVALID_ARG_TYPE('address', ['string', 'falsy'], address);
   }
 
   this._healthCheck();
@@ -602,7 +603,8 @@ Socket.prototype.setMulticastInterface = function(interfaceAddress) {
   this._healthCheck();
 
   if (typeof interfaceAddress !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('interfaceAddress', 'string');
+    throw new ERR_INVALID_ARG_TYPE(
+      'interfaceAddress', 'string', interfaceAddress);
   }
 
   const err = this._handle.setMulticastInterface(interfaceAddress);

--- a/lib/events.js
+++ b/lib/events.js
@@ -197,7 +197,7 @@ function _addListener(target, type, listener, prepend) {
 
   if (typeof listener !== 'function') {
     const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function');
+    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
   }
 
   events = target._events;
@@ -287,7 +287,7 @@ function _onceWrap(target, type, listener) {
 EventEmitter.prototype.once = function once(type, listener) {
   if (typeof listener !== 'function') {
     const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function');
+    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
   }
   this.on(type, _onceWrap(this, type, listener));
   return this;
@@ -297,7 +297,7 @@ EventEmitter.prototype.prependOnceListener =
     function prependOnceListener(type, listener) {
       if (typeof listener !== 'function') {
         const errors = lazyErrors();
-        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function');
+        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
       }
       this.prependListener(type, _onceWrap(this, type, listener));
       return this;
@@ -310,7 +310,7 @@ EventEmitter.prototype.removeListener =
 
       if (typeof listener !== 'function') {
         const errors = lazyErrors();
-        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function');
+        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
       }
 
       events = this._events;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -751,6 +751,10 @@ fs.ftruncate = function(fd, len = 0, callback) {
     len = 0;
   }
   validateUint32(fd, 'fd');
+  // TODO(BridgeAR): This does not seem right.
+  // There does not seem to be any validation before and if there is any, it
+  // should work similar to validateUint32 or not have a upper cap at all.
+  // This applies to all usage of `validateLen`.
   validateLen(len);
   len = Math.max(0, len);
   const req = new FSReqWrap();
@@ -1012,7 +1016,7 @@ fs.fchmod = function(fd, mode, callback) {
   mode = modeNum(mode);
   validateUint32(fd, 'fd');
   validateUint32(mode, 'mode');
-  // values for mode < 0 are already checked via the validateUint32 function
+  // Values for mode < 0 are already checked via the validateUint32 function
   if (mode > 0o777)
     throw new ERR_OUT_OF_RANGE('mode');
 
@@ -1025,7 +1029,8 @@ fs.fchmodSync = function(fd, mode) {
   mode = modeNum(mode);
   validateUint32(fd, 'fd');
   validateUint32(mode, 'mode');
-  if (mode < 0 || mode > 0o777)
+  // Values for mode < 0 are already checked via the validateUint32 function
+  if (mode > 0o777)
     throw new ERR_OUT_OF_RANGE('mode');
   const ctx = {};
   binding.fchmod(fd, mode, undefined, ctx);

--- a/lib/fs/promises.js
+++ b/lib/fs/promises.js
@@ -364,7 +364,7 @@ async function fchmod(handle, mode) {
   mode = modeNum(mode);
   validateFileHandle(handle);
   validateUint32(mode, 'mode');
-  if (mode < 0 || mode > 0o777)
+  if (mode > 0o777)
     throw new ERR_OUT_OF_RANGE('mode');
   return binding.fchmod(handle.fd, mode, kUsePromises);
 }

--- a/lib/fs/promises.js
+++ b/lib/fs/promises.js
@@ -112,7 +112,7 @@ class FileHandle {
 
 function validateFileHandle(handle) {
   if (!(handle instanceof FileHandle))
-    throw new ERR_INVALID_ARG_TYPE('filehandle', 'FileHandle');
+    throw new ERR_INVALID_ARG_TYPE('filehandle', 'FileHandle', handle);
 }
 
 async function writeFileHandle(filehandle, data, options) {

--- a/lib/internal/crypto/certificate.js
+++ b/lib/internal/crypto/certificate.js
@@ -17,7 +17,8 @@ function verifySpkac(spkac) {
   if (!isArrayBufferView(spkac)) {
     throw new ERR_INVALID_ARG_TYPE(
       'spkac',
-      ['Buffer', 'TypedArray', 'DataView']
+      ['Buffer', 'TypedArray', 'DataView'],
+      spkac
     );
   }
   return certVerifySpkac(spkac);
@@ -28,7 +29,8 @@ function exportPublicKey(spkac, encoding) {
   if (!isArrayBufferView(spkac)) {
     throw new ERR_INVALID_ARG_TYPE(
       'spkac',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      spkac
     );
   }
   return certExportPublicKey(spkac);
@@ -39,7 +41,8 @@ function exportChallenge(spkac, encoding) {
   if (!isArrayBufferView(spkac)) {
     throw new ERR_INVALID_ARG_TYPE(
       'spkac',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      spkac
     );
   }
   return certExportChallenge(spkac);

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -67,13 +67,14 @@ function Cipher(cipher, password, options) {
     return new Cipher(cipher, password, options);
 
   if (typeof cipher !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('cipher', 'string');
+    throw new ERR_INVALID_ARG_TYPE('cipher', 'string', cipher);
 
   password = toBuf(password);
   if (!isArrayBufferView(password)) {
     throw new ERR_INVALID_ARG_TYPE(
       'password',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      password
     );
   }
 
@@ -110,7 +111,8 @@ Cipher.prototype.update = function update(data, inputEncoding, outputEncoding) {
   if (typeof data !== 'string' && !isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE(
       'data',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
     );
   }
 
@@ -155,7 +157,8 @@ Cipher.prototype.getAuthTag = function getAuthTag() {
 Cipher.prototype.setAuthTag = function setAuthTag(tagbuf) {
   if (!isArrayBufferView(tagbuf)) {
     throw new ERR_INVALID_ARG_TYPE('buffer',
-                                   ['Buffer', 'TypedArray', 'DataView']);
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   tagbuf);
   }
   // Do not do a normal falsy check because the method returns
   // undefined if it succeeds. Returns false specifically if it
@@ -168,7 +171,8 @@ Cipher.prototype.setAuthTag = function setAuthTag(tagbuf) {
 Cipher.prototype.setAAD = function setAAD(aadbuf) {
   if (!isArrayBufferView(aadbuf)) {
     throw new ERR_INVALID_ARG_TYPE('buffer',
-                                   ['Buffer', 'TypedArray', 'DataView']);
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   aadbuf);
   }
   if (this._handle.setAAD(aadbuf) === false)
     throw new ERR_CRYPTO_INVALID_STATE('setAAD');
@@ -180,13 +184,14 @@ function Cipheriv(cipher, key, iv, options) {
     return new Cipheriv(cipher, key, iv, options);
 
   if (typeof cipher !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('cipher', 'string');
+    throw new ERR_INVALID_ARG_TYPE('cipher', 'string', cipher);
 
   key = toBuf(key);
   if (!isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
       'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      key
     );
   }
 
@@ -194,7 +199,8 @@ function Cipheriv(cipher, key, iv, options) {
   if (iv !== null && !isArrayBufferView(iv)) {
     throw new ERR_INVALID_ARG_TYPE(
       'iv',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      iv
     );
   }
 
@@ -226,13 +232,14 @@ function Decipher(cipher, password, options) {
     return new Decipher(cipher, password, options);
 
   if (typeof cipher !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('cipher', 'string');
+    throw new ERR_INVALID_ARG_TYPE('cipher', 'string', cipher);
 
   password = toBuf(password);
   if (!isArrayBufferView(password)) {
     throw new ERR_INVALID_ARG_TYPE(
       'password',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      password
     );
   }
 
@@ -261,13 +268,14 @@ function Decipheriv(cipher, key, iv, options) {
     return new Decipheriv(cipher, key, iv, options);
 
   if (typeof cipher !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('cipher', 'string');
+    throw new ERR_INVALID_ARG_TYPE('cipher', 'string', cipher);
 
   key = toBuf(key);
   if (!isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
       'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      key
     );
   }
 
@@ -275,7 +283,8 @@ function Decipheriv(cipher, key, iv, options) {
   if (iv !== null && !isArrayBufferView(iv)) {
     throw new ERR_INVALID_ARG_TYPE(
       'iv',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      iv
     );
   }
 

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -197,12 +197,13 @@ ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   if (typeof key !== 'string' && !isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
       'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      key
     );
   }
 
   if (typeof curve !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('curve', 'string');
+    throw new ERR_INVALID_ARG_TYPE('curve', 'string', curve);
   }
 
   const encoding = getDefaultEncoding();

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -39,13 +39,11 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
     );
   }
 
-  if (keyEncoding) {
-    if (typeof keyEncoding !== 'string' ||
-        (!Buffer.isEncoding(keyEncoding) && keyEncoding !== 'buffer')) {
-      genEncoding = generator;
-      generator = keyEncoding;
-      keyEncoding = false;
-    }
+  if (keyEncoding && !Buffer.isEncoding(keyEncoding) &&
+      keyEncoding !== 'buffer') {
+    genEncoding = generator;
+    generator = keyEncoding;
+    keyEncoding = false;
   }
 
   const encoding = getDefaultEncoding();

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -34,7 +34,8 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
       !isArrayBufferView(sizeOrKey)) {
     throw new ERR_INVALID_ARG_TYPE(
       'sizeOrKey',
-      ['number', 'string', 'Buffer', 'TypedArray', 'DataView']
+      ['number', 'string', 'Buffer', 'TypedArray', 'DataView'],
+      sizeOrKey
     );
   }
 
@@ -169,7 +170,7 @@ function ECDH(curve) {
     return new ECDH(curve);
 
   if (typeof curve !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('curve', 'string');
+    throw new ERR_INVALID_ARG_TYPE('curve', 'string', curve);
 
   this._handle = new _ECDH(curve);
 }

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -29,7 +29,7 @@ function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
   if (typeof algorithm !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string');
+    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string', algorithm);
   this._handle = new _Hash(algorithm);
   this[kState] = {
     [kFinalized]: false
@@ -56,7 +56,7 @@ Hash.prototype.update = function update(data, encoding) {
 
   if (typeof data !== 'string' && !isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE('data',
-                                   ['string', 'TypedArray', 'DataView']);
+                                   ['string', 'TypedArray', 'DataView'], data);
   }
 
   if (!this._handle.update(data, encoding || getDefaultEncoding()))
@@ -84,9 +84,10 @@ function Hmac(hmac, key, options) {
   if (!(this instanceof Hmac))
     return new Hmac(hmac, key, options);
   if (typeof hmac !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('hmac', 'string');
+    throw new ERR_INVALID_ARG_TYPE('hmac', 'string', hmac);
   if (typeof key !== 'string' && !isArrayBufferView(key)) {
-    throw new ERR_INVALID_ARG_TYPE('key', ['string', 'TypedArray', 'DataView']);
+    throw new ERR_INVALID_ARG_TYPE('key',
+                                   ['string', 'TypedArray', 'DataView'], key);
   }
   this._handle = new _Hmac();
   this._handle.init(hmac, toBuf(key));

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -37,22 +37,24 @@ function pbkdf2Sync(password, salt, iterations, keylen, digest) {
 function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
   if (digest !== null && typeof digest !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null']);
+    throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);
 
   password = toBuf(password);
   salt = toBuf(salt);
 
   if (!isArrayBufferView(password)) {
     throw new ERR_INVALID_ARG_TYPE('password',
-                                   ['string', 'Buffer', 'TypedArray']);
+                                   ['string', 'Buffer', 'TypedArray'],
+                                   password);
   }
 
   if (!isArrayBufferView(salt)) {
-    throw new ERR_INVALID_ARG_TYPE('salt', ['string', 'Buffer', 'TypedArray']);
+    throw new ERR_INVALID_ARG_TYPE('salt',
+                                   ['string', 'Buffer', 'TypedArray'], salt);
   }
 
   if (typeof iterations !== 'number')
-    throw new ERR_INVALID_ARG_TYPE('iterations', 'number');
+    throw new ERR_INVALID_ARG_TYPE('iterations', 'number', iterations);
 
   if (iterations < 0)
     throw new ERR_OUT_OF_RANGE('iterations',
@@ -60,7 +62,7 @@ function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
                                iterations);
 
   if (typeof keylen !== 'number')
-    throw new ERR_INVALID_ARG_TYPE('keylen', 'number');
+    throw new ERR_INVALID_ARG_TYPE('keylen', 'number', keylen);
 
   if (keylen < 0 ||
       !Number.isFinite(keylen) ||

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -51,7 +51,7 @@ function randomBytes(size, cb) {
 
 function randomFillSync(buf, offset = 0, size) {
   if (!isArrayBufferView(buf)) {
-    throw new ERR_INVALID_ARG_TYPE('buf', 'ArrayBufferView');
+    throw new ERR_INVALID_ARG_TYPE('buf', 'ArrayBufferView', buf);
   }
 
   const elementSize = buf.BYTES_PER_ELEMENT || 1;
@@ -72,7 +72,7 @@ function randomFillSync(buf, offset = 0, size) {
 
 function randomFill(buf, offset, size, cb) {
   if (!isArrayBufferView(buf)) {
-    throw new ERR_INVALID_ARG_TYPE('buf', 'ArrayBufferView');
+    throw new ERR_INVALID_ARG_TYPE('buf', 'ArrayBufferView', buf);
   }
 
   const elementSize = buf.BYTES_PER_ELEMENT || 1;

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -13,37 +13,44 @@ const {
 
 const { kMaxLength } = require('buffer');
 const kMaxUint32 = Math.pow(2, 32) - 1;
+const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
 
-function assertOffset(offset, length) {
-  if (typeof offset !== 'number' || Number.isNaN(offset)) {
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number');
+function assertOffset(offset, elementSize, length) {
+  if (typeof offset !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
   }
 
-  if (offset > kMaxUint32 || offset < 0) {
-    throw new ERR_INVALID_ARG_TYPE('offset', 'uint32');
+  offset *= elementSize;
+
+  const maxLength = Math.min(length, kMaxPossibleLength);
+  if (Number.isNaN(offset) || offset > maxLength || offset < 0) {
+    throw new ERR_OUT_OF_RANGE('offset', `>= 0 && <= ${maxLength}`, offset);
   }
 
-  if (offset > kMaxLength || offset > length) {
-    throw new ERR_OUT_OF_RANGE('offset');
-  }
+  return offset;
 }
 
-function assertSize(size, offset = 0, length = Infinity) {
-  if (typeof size !== 'number' || Number.isNaN(size)) {
-    throw new ERR_INVALID_ARG_TYPE('size', 'number');
+function assertSize(size, elementSize, offset, length) {
+  if (typeof size !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('size', 'number', size);
   }
 
-  if (size > kMaxUint32 || size < 0) {
-    throw new ERR_INVALID_ARG_TYPE('size', 'uint32');
+  size *= elementSize;
+
+  if (Number.isNaN(size) || size > kMaxPossibleLength || size < 0) {
+    throw new ERR_OUT_OF_RANGE('size',
+                               `>= 0 && <= ${kMaxPossibleLength}`, size);
   }
 
-  if (size + offset > length || size > kMaxLength) {
-    throw new ERR_OUT_OF_RANGE('size');
+  if (size + offset > length) {
+    throw new ERR_OUT_OF_RANGE('size + offset', `<= ${length}`, size + offset);
   }
+
+  return size;
 }
 
 function randomBytes(size, cb) {
-  assertSize(size);
+  assertSize(size, 1, 0, Infinity);
   if (cb !== undefined && typeof cb !== 'function')
     throw new ERR_INVALID_CALLBACK();
   return _randomBytes(size, cb);
@@ -56,16 +63,13 @@ function randomFillSync(buf, offset = 0, size) {
 
   const elementSize = buf.BYTES_PER_ELEMENT || 1;
 
-  offset *= elementSize;
-  assertOffset(offset, buf.byteLength);
+  offset = assertOffset(offset, elementSize, buf.byteLength);
 
   if (size === undefined) {
     size = buf.byteLength - offset;
   } else {
-    size *= elementSize;
+    size = assertSize(size, elementSize, offset, buf.byteLength);
   }
-
-  assertSize(size, offset, buf.byteLength);
 
   return _randomFill(buf, offset, size);
 }
@@ -83,19 +87,18 @@ function randomFill(buf, offset, size, cb) {
     size = buf.bytesLength;
   } else if (typeof size === 'function') {
     cb = size;
-    offset *= elementSize;
     size = buf.byteLength - offset;
   } else if (typeof cb !== 'function') {
     throw new ERR_INVALID_CALLBACK();
   }
+
+  offset = assertOffset(offset, elementSize, buf.byteLength);
+
   if (size === undefined) {
     size = buf.byteLength - offset;
   } else {
-    size *= elementSize;
+    size = assertSize(size, elementSize, offset, buf.byteLength);
   }
-
-  assertOffset(offset, buf.byteLength);
-  assertSize(size, offset, buf.byteLength);
 
   return _randomFill(buf, offset, size, cb);
 }

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -25,7 +25,7 @@ function Sign(algorithm, options) {
   if (!(this instanceof Sign))
     return new Sign(algorithm, options);
   if (typeof algorithm !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string');
+    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string', algorithm);
   this._handle = new _Sign();
   this._handle.init(algorithm);
 
@@ -45,7 +45,8 @@ Sign.prototype.update = function update(data, encoding) {
   if (!isArrayBufferView(data)) {
     throw new ERR_INVALID_ARG_TYPE(
       'data',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      data
     );
   }
   this._handle.update(data);
@@ -82,7 +83,8 @@ Sign.prototype.sign = function sign(options, encoding) {
   if (!isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
       'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      key
     );
   }
 
@@ -100,7 +102,7 @@ function Verify(algorithm, options) {
   if (!(this instanceof Verify))
     return new Verify(algorithm, options);
   if (typeof algorithm !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string');
+    throw new ERR_INVALID_ARG_TYPE('algorithm', 'string', algorithm);
   this._handle = new _Verify();
   this._handle.init(algorithm);
 
@@ -139,7 +141,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   if (!isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
       'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      key
     );
   }
 
@@ -147,7 +150,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   if (!isArrayBufferView(signature)) {
     throw new ERR_INVALID_ARG_TYPE(
       'signature',
-      ['string', 'Buffer', 'TypedArray', 'DataView']
+      ['string', 'Buffer', 'TypedArray', 'DataView'],
+      signature
     );
   }
 

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -54,10 +54,10 @@ const getCurves = cachedResult(() => filterDuplicateStrings(_getCurves()));
 
 function setEngine(id, flags) {
   if (typeof id !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('id', 'string');
+    throw new ERR_INVALID_ARG_TYPE('id', 'string', id);
 
   if (flags && typeof flags !== 'number')
-    throw new ERR_INVALID_ARG_TYPE('flags', 'number');
+    throw new ERR_INVALID_ARG_TYPE('flags', 'number', flags);
   flags = flags >>> 0;
 
   // Use provided engine for everything by default
@@ -68,17 +68,19 @@ function setEngine(id, flags) {
     throw new ERR_CRYPTO_ENGINE_UNKNOWN(id);
 }
 
-function timingSafeEqual(a, b) {
-  if (!isArrayBufferView(a)) {
-    throw new ERR_INVALID_ARG_TYPE('a', ['Buffer', 'TypedArray', 'DataView']);
+function timingSafeEqual(buf1, buf2) {
+  if (!isArrayBufferView(buf1)) {
+    throw new ERR_INVALID_ARG_TYPE('buf1',
+                                   ['Buffer', 'TypedArray', 'DataView'], buf1);
   }
-  if (!isArrayBufferView(b)) {
-    throw new ERR_INVALID_ARG_TYPE('b', ['Buffer', 'TypedArray', 'DataView']);
+  if (!isArrayBufferView(buf2)) {
+    throw new ERR_INVALID_ARG_TYPE('buf2',
+                                   ['Buffer', 'TypedArray', 'DataView'], buf2);
   }
-  if (a.length !== b.length) {
+  if (buf1.length !== buf2.length) {
     throw new ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH();
   }
-  return _timingSafeEqual(a, b);
+  return _timingSafeEqual(buf1, buf2);
 }
 
 module.exports = {

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -51,7 +51,7 @@ function validateDecoder(obj) {
 
 function validateArgument(prop, expected, propName, expectedName) {
   if (typeof prop !== expected)
-    throw new ERR_INVALID_ARG_TYPE(propName, expectedName);
+    throw new ERR_INVALID_ARG_TYPE(propName, expectedName, prop);
 }
 
 const CONVERTER_FLAGS_FLUSH = 0x1;
@@ -391,7 +391,8 @@ function makeTextDecoderICU() {
         input = lazyBuffer().from(input);
       } else if (!isArrayBufferView(input)) {
         throw new ERR_INVALID_ARG_TYPE('input',
-                                       ['ArrayBuffer', 'ArrayBufferView']);
+                                       ['ArrayBuffer', 'ArrayBufferView'],
+                                       input);
       }
       validateArgument(options, 'object', 'options', 'Object');
 
@@ -460,7 +461,8 @@ function makeTextDecoderJS() {
                                   input.byteLength);
       } else {
         throw new ERR_INVALID_ARG_TYPE('input',
-                                       ['ArrayBuffer', 'ArrayBufferView']);
+                                       ['ArrayBuffer', 'ArrayBufferView'],
+                                       input);
       }
       validateArgument(options, 'object', 'options', 'Object');
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -319,7 +319,7 @@ function createErrDiff(actual, expected, operator) {
 class AssertionError extends Error {
   constructor(options) {
     if (typeof options !== 'object' || options === null) {
-      throw new codes.ERR_INVALID_ARG_TYPE('options', 'Object');
+      throw new codes.ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
     var {
       actual,
@@ -959,10 +959,10 @@ function invalidArgType(name, expected, actual) {
     msg = `The "${name}" ${type} ${determiner} ${oneOf(expected, 'type')}`;
   }
 
-  // if actual value received, output it
-  if (arguments.length >= 3) {
-    msg += `. Received type ${actual !== null ? typeof actual : 'null'}`;
-  }
+  // If actual value received, output it
+  // TODO(BridgeAR): Improve the output by showing `null` and similar.
+  if (arguments.length === 3)
+    msg += `. Received type ${typeof actual}`;
   return msg;
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -936,7 +936,8 @@ function sysError(code, syscall, path, dest,
 messages.set('ERR_SYSTEM_ERROR', sysError);
 
 function invalidArgType(name, expected, actual) {
-  internalAssert(name, 'name is required');
+  internalAssert(typeof name === 'string');
+  internalAssert(arguments.length === 3);
 
   // determiner: 'must be' or 'must not be'
   let determiner;
@@ -948,21 +949,16 @@ function invalidArgType(name, expected, actual) {
   }
 
   let msg;
-  if (Array.isArray(name)) {
-    var names = name.map((val) => `"${val}"`).join(', ');
-    msg = `The ${names} arguments ${determiner} ${oneOf(expected, 'type')}`;
-  } else if (name.endsWith(' argument')) {
-    // for the case like 'first argument'
+  if (name.endsWith(' argument')) {
+    // For cases like 'first argument'
     msg = `The ${name} ${determiner} ${oneOf(expected, 'type')}`;
   } else {
     const type = name.includes('.') ? 'property' : 'argument';
     msg = `The "${name}" ${type} ${determiner} ${oneOf(expected, 'type')}`;
   }
 
-  // If actual value received, output it
   // TODO(BridgeAR): Improve the output by showing `null` and similar.
-  if (arguments.length === 3)
-    msg += `. Received type ${typeof actual}`;
+  msg += `. Received type ${typeof actual}`;
   return msg;
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -752,7 +752,7 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
     inspected = inspected.slice(0, 128) + '...';
   }
   return `The argument '${name}' ${reason}. Received ${inspected}`;
-}, TypeError, RangeError); // Some are currently falsy implemented as "Error"
+}, TypeError, RangeError);
 E('ERR_INVALID_ARRAY_LENGTH',
   (name, len, actual) => {
     internalAssert(typeof actual === 'number', 'actual must be a number');
@@ -762,7 +762,7 @@ E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s', RangeError);
 E('ERR_INVALID_BUFFER_SIZE',
   'Buffer size must be a multiple of %s', RangeError);
 E('ERR_INVALID_CALLBACK', 'Callback must be a function', TypeError);
-E('ERR_INVALID_CHAR', invalidChar, TypeError); //Check falsy "Error" entries.
+E('ERR_INVALID_CHAR', invalidChar, TypeError);
 
 // This should probably be a `TypeError`.
 E('ERR_INVALID_CURSOR_POS',

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -372,12 +372,8 @@ function validateOffsetLengthWrite(offset, length, byteLength) {
   }
 }
 
-function validatePath(path, propName) {
+function validatePath(path, propName = 'path') {
   let err;
-
-  if (propName === undefined) {
-    propName = 'path';
-  }
 
   if (typeof path !== 'string' && !isUint8Array(path)) {
     err = new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -323,7 +323,8 @@ function toUnixTimestamp(time, name = 'time') {
 
 function validateBuffer(buffer) {
   if (!isUint8Array(buffer)) {
-    const err = new ERR_INVALID_ARG_TYPE('buffer', ['Buffer', 'Uint8Array']);
+    const err = new ERR_INVALID_ARG_TYPE('buffer',
+                                         ['Buffer', 'Uint8Array'], buffer);
     Error.captureStackTrace(err, validateBuffer);
     throw err;
   }
@@ -379,7 +380,7 @@ function validatePath(path, propName) {
   }
 
   if (typeof path !== 'string' && !isUint8Array(path)) {
-    err = new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL']);
+    err = new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);
   } else {
     err = nullCheck(path, propName, false);
   }

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -77,11 +77,16 @@ function isUint32(n) { return n === (n >>> 0); }
 function modeNum(m, def) {
   if (typeof m === 'number')
     return m;
-  if (typeof m === 'string')
-    return parseInt(m, 8);
-  if (def)
-    return modeNum(def);
-  return undefined;
+  if (typeof m === 'string') {
+    const parsed = parseInt(m, 8);
+    if (Number.isNaN(parsed))
+      return m;
+    return parsed;
+  }
+  // TODO(BridgeAR): Only return `def` in case `m == null`
+  if (def !== undefined)
+    return def;
+  return m;
 }
 
 // Check if the path contains null types if it is a string nor Uint8Array,
@@ -333,8 +338,14 @@ function validateBuffer(buffer) {
 function validateLen(len) {
   let err;
 
-  if (!isInt32(len))
-    err = new ERR_INVALID_ARG_TYPE('len', 'integer');
+  if (!isInt32(len)) {
+    if (typeof value !== 'number') {
+      err = new ERR_INVALID_ARG_TYPE('len', 'number', len);
+    } else {
+      // TODO(BridgeAR): Improve this error message.
+      err = new ERR_OUT_OF_RANGE('len', 'an integer', len);
+    }
+  }
 
   if (err !== undefined) {
     Error.captureStackTrace(err, validateLen);
@@ -388,12 +399,16 @@ function validatePath(path, propName = 'path') {
 }
 
 function validateUint32(value, propName) {
-  let err;
-
-  if (!isUint32(value))
-    err = new ERR_INVALID_ARG_TYPE(propName, 'integer');
-
-  if (err !== undefined) {
+  if (!isUint32(value)) {
+    let err;
+    if (typeof value !== 'number') {
+      err = new ERR_INVALID_ARG_TYPE(propName, 'number', value);
+    } else if (!Number.isInteger(value)) {
+      err = new ERR_OUT_OF_RANGE(propName, 'an integer', value);
+    } else {
+      // 2 ** 32 === 4294967296
+      err = new ERR_OUT_OF_RANGE(propName, '>= 0 && < 4294967296', value);
+    }
     Error.captureStackTrace(err, validateUint32);
     throw err;
   }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -438,7 +438,7 @@ class Http2ServerResponse extends Stream {
 
   setTrailer(name, value) {
     if (typeof name !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('name', 'string');
+      throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
 
     name = name.trim().toLowerCase();
     assertValidHeader(name, value);
@@ -456,7 +456,7 @@ class Http2ServerResponse extends Stream {
 
   getHeader(name) {
     if (typeof name !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('name', 'string');
+      throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
 
     name = name.trim().toLowerCase();
     return this[kHeaders][name];
@@ -472,7 +472,7 @@ class Http2ServerResponse extends Stream {
 
   hasHeader(name) {
     if (typeof name !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('name', 'string');
+      throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
 
     name = name.trim().toLowerCase();
     return Object.prototype.hasOwnProperty.call(this[kHeaders], name);
@@ -480,7 +480,7 @@ class Http2ServerResponse extends Stream {
 
   removeHeader(name) {
     if (typeof name !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('name', 'string');
+      throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
 
     if (this[kStream].headersSent)
       throw new ERR_HTTP2_HEADERS_SENT();
@@ -491,7 +491,7 @@ class Http2ServerResponse extends Stream {
 
   setHeader(name, value) {
     if (typeof name !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('name', 'string');
+      throw new ERR_INVALID_ARG_TYPE('name', 'string', name);
 
     if (this[kStream].headersSent)
       throw new ERR_HTTP2_HEADERS_SENT();

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -13,6 +13,7 @@ const {
   ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED,
   ERR_HTTP2_STATUS_INVALID,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
   ERR_INVALID_HTTP_TOKEN
 } = require('internal/errors').codes;
@@ -312,8 +313,10 @@ class Http2ServerRequest extends Readable {
   }
 
   set method(method) {
-    if (typeof method !== 'string' || method.trim() === '')
-      throw new ERR_INVALID_ARG_TYPE('method', 'string');
+    if (typeof method !== 'string')
+      throw new ERR_INVALID_ARG_TYPE('method', 'string', method);
+    if (method.trim() === '')
+      throw new ERR_INVALID_ARG_VALUE('method', method);
 
     this[kHeaders][HTTP2_HEADER_METHOD] = method;
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -984,7 +984,7 @@ class Http2Session extends EventEmitter {
       throw new ERR_HTTP2_INVALID_SESSION();
 
     if (typeof id !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('id', 'number');
+      throw new ERR_INVALID_ARG_TYPE('id', 'number', id);
     if (id <= 0 || id > kMaxStreams)
       throw new ERR_OUT_OF_RANGE('id', `> 0 and <= ${kMaxStreams}`, id);
     this[kHandle].setNextStreamID(id);
@@ -1003,7 +1003,8 @@ class Http2Session extends EventEmitter {
     }
     if (payload && !isArrayBufferView(payload)) {
       throw new ERR_INVALID_ARG_TYPE('payload',
-                                     ['Buffer', 'TypedArray', 'DataView']);
+                                     ['Buffer', 'TypedArray', 'DataView'],
+                                     payload);
     }
     if (payload && payload.length !== 8) {
       throw new ERR_HTTP2_PING_LENGTH();
@@ -1122,13 +1123,14 @@ class Http2Session extends EventEmitter {
 
     if (opaqueData !== undefined && !isArrayBufferView(opaqueData)) {
       throw new ERR_INVALID_ARG_TYPE('opaqueData',
-                                     ['Buffer', 'TypedArray', 'DataView']);
+                                     ['Buffer', 'TypedArray', 'DataView'],
+                                     opaqueData);
     }
     if (typeof code !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE('code', 'number');
+      throw new ERR_INVALID_ARG_TYPE('code', 'number', code);
     }
     if (typeof lastStreamID !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE('lastStreamID', 'number');
+      throw new ERR_INVALID_ARG_TYPE('lastStreamID', 'number', lastStreamID);
     }
 
     const goawayFn = submitGoaway.bind(this, code, lastStreamID, opaqueData);
@@ -1321,14 +1323,15 @@ class ServerHttp2Session extends Http2Session {
       // be invalid.
       if (typeof origin !== 'string') {
         throw new ERR_INVALID_ARG_TYPE('originOrStream',
-                                       ['string', 'number', 'URL', 'object']);
+                                       ['string', 'number', 'URL', 'object'],
+                                       originOrStream);
       } else if (origin === 'null' || origin.length === 0) {
         throw new ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
       }
     }
 
     if (typeof alt !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('alt', 'string');
+      throw new ERR_INVALID_ARG_TYPE('alt', 'string', alt);
     if (!kQuotedString.test(alt))
       throw new ERR_INVALID_CHAR('alt');
 
@@ -1794,7 +1797,7 @@ class Http2Stream extends Duplex {
   // but no DATA and HEADERS frames may be sent.
   close(code = NGHTTP2_NO_ERROR, callback) {
     if (typeof code !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('code', 'number');
+      throw new ERR_INVALID_ARG_TYPE('code', 'number', code);
     if (code < 0 || code > kMaxInt)
       throw new ERR_OUT_OF_RANGE('code');
     if (callback !== undefined && typeof callback !== 'function')
@@ -2313,7 +2316,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     if (typeof fd !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('fd', 'number');
+      throw new ERR_INVALID_ARG_TYPE('fd', 'number', fd);
 
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
           `${sessionName(session[kType])}]: initiating response from fd`);
@@ -2767,7 +2770,8 @@ function getPackedSettings(settings) {
 
 function getUnpackedSettings(buf, options = {}) {
   if (!isArrayBufferView(buf)) {
-    throw new ERR_INVALID_ARG_TYPE('buf', ['Buffer', 'TypedArray', 'DataView']);
+    throw new ERR_INVALID_ARG_TYPE('buf',
+                                   ['Buffer', 'TypedArray', 'DataView'], buf);
   }
   if (buf.length % 6 !== 0)
     throw new ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH();

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -482,7 +482,7 @@ function assertIsObject(value, name, types = 'Object') {
       (value === null ||
        typeof value !== 'object' ||
        Array.isArray(value))) {
-    const err = new ERR_INVALID_ARG_TYPE(name, types);
+    const err = new ERR_INVALID_ARG_TYPE(name, types, value);
     Error.captureStackTrace(err, assertIsObject);
     throw err;
   }

--- a/lib/internal/modules/esm/Loader.js
+++ b/lib/internal/modules/esm/Loader.js
@@ -49,16 +49,16 @@ class Loader {
   async resolve(specifier, parentURL) {
     const isMain = parentURL === undefined;
     if (!isMain && typeof parentURL !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('parentURL', 'string');
+      throw new ERR_INVALID_ARG_TYPE('parentURL', 'string', parentURL);
 
     const { url, format } =
       await this._resolve(specifier, parentURL, defaultResolve);
 
     if (typeof url !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('url', 'string');
+      throw new ERR_INVALID_ARG_TYPE('url', 'string', url);
 
     if (typeof format !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('format', 'string');
+      throw new ERR_INVALID_ARG_TYPE('format', 'string', format);
 
     if (format === 'builtin')
       return { url: `node:${url}`, format };

--- a/lib/internal/modules/esm/ModuleMap.js
+++ b/lib/internal/modules/esm/ModuleMap.js
@@ -9,23 +9,23 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 class ModuleMap extends SafeMap {
   get(url) {
     if (typeof url !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('url', 'string');
+      throw new ERR_INVALID_ARG_TYPE('url', 'string', url);
     }
     return super.get(url);
   }
   set(url, job) {
     if (typeof url !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('url', 'string');
+      throw new ERR_INVALID_ARG_TYPE('url', 'string', url);
     }
     if (job instanceof ModuleJob !== true) {
-      throw new ERR_INVALID_ARG_TYPE('job', 'ModuleJob');
+      throw new ERR_INVALID_ARG_TYPE('job', 'ModuleJob', job);
     }
     debug(`Storing ${url} in ModuleMap`);
     return super.set(url, job);
   }
   has(url) {
     if (typeof url !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('url', 'string');
+      throw new ERR_INVALID_ARG_TYPE('url', 'string', url);
     }
     return super.has(url);
   }

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -157,7 +157,7 @@ function setupKillAndExit() {
 
     // eslint-disable-next-line eqeqeq
     if (pid != (pid | 0)) {
-      throw new ERR_INVALID_ARG_TYPE('pid', 'number');
+      throw new ERR_INVALID_ARG_TYPE('pid', 'number', pid);
     }
 
     // preserve null signal
@@ -255,7 +255,7 @@ function setupUncaughtExceptionCapture(exceptionHandlerState) {
       return;
     }
     if (typeof fn !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'null']);
+      throw new ERR_INVALID_ARG_TYPE('fn', ['Function', 'null'], fn);
     }
     if (exceptionHandlerState.captureFn !== null) {
       throw new ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET();

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -7,6 +7,7 @@ const {
     ERR_CPU_USAGE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARRAY_LENGTH,
+    ERR_INVALID_OPT_VALUE,
     ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET,
     ERR_UNKNOWN_SIGNAL
   }
@@ -41,11 +42,24 @@ function setup_cpuUsage() {
     // If a previous value was passed in, ensure it has the correct shape.
     if (prevValue) {
       if (!previousValueIsValid(prevValue.user)) {
-        throw new ERR_INVALID_ARG_TYPE('preValue.user', 'number');
+        if (typeof prevValue !== 'object')
+          throw new ERR_INVALID_ARG_TYPE('prevValue', 'object', prevValue);
+
+        if (typeof prevValue.user !== 'number') {
+          throw new ERR_INVALID_ARG_TYPE('prevValue.user',
+                                         'number', prevValue.user);
+        }
+        throw new ERR_INVALID_OPT_VALUE.RangeError('prevValue.user',
+                                                   prevValue.user);
       }
 
       if (!previousValueIsValid(prevValue.system)) {
-        throw new ERR_INVALID_ARG_TYPE('preValue.system', 'number');
+        if (typeof prevValue.system !== 'number') {
+          throw new ERR_INVALID_ARG_TYPE('prevValue.system',
+                                         'number', prevValue.system);
+        }
+        throw new ERR_INVALID_OPT_VALUE.RangeError('prevValue.system',
+                                                   prevValue.system);
       }
     }
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -68,15 +68,15 @@ function setup_cpuUsage() {
       user: cpuValues[0],
       system: cpuValues[1]
     };
-
-    // Ensure that a previously passed in value is valid. Currently, the native
-    // implementation always returns numbers <= Number.MAX_SAFE_INTEGER.
-    function previousValueIsValid(num) {
-      return Number.isFinite(num) &&
-          num <= Number.MAX_SAFE_INTEGER &&
-          num >= 0;
-    }
   };
+
+  // Ensure that a previously passed in value is valid. Currently, the native
+  // implementation always returns numbers <= Number.MAX_SAFE_INTEGER.
+  function previousValueIsValid(num) {
+    return Number.isFinite(num) &&
+        num <= Number.MAX_SAFE_INTEGER &&
+        num >= 0;
+  }
 }
 
 // The 3 entries filled in by the original process.hrtime contains

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -122,9 +122,9 @@ function setupProcessWarnings() {
       code = undefined;
     }
     if (code !== undefined && typeof code !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('code', 'string');
+      throw new ERR_INVALID_ARG_TYPE('code', 'string', code);
     if (type !== undefined && typeof type !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('type', 'string');
+      throw new ERR_INVALID_ARG_TYPE('type', 'string', type);
     if (warning === undefined || typeof warning === 'string') {
       // eslint-disable-next-line no-restricted-syntax
       warning = new Error(warning);
@@ -134,7 +134,7 @@ function setupProcessWarnings() {
       Error.captureStackTrace(warning, ctor || process.emitWarning);
     }
     if (!(warning instanceof Error)) {
-      throw new ERR_INVALID_ARG_TYPE('warning', ['Error', 'string']);
+      throw new ERR_INVALID_ARG_TYPE('warning', ['Error', 'string'], warning);
     }
     if (warning.name === 'DeprecationWarning') {
       if (process.noDeprecation)

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -379,7 +379,7 @@ Object.defineProperties(URL.prototype, {
     // eslint-disable-next-line func-name-matching
     value: function format(options) {
       if (options && typeof options !== 'object')
-        throw new ERR_INVALID_ARG_TYPE('options', 'Object');
+        throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
       options = util._extend({
         fragment: true,
         unicode: false,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -49,7 +49,7 @@ function deprecate(fn, msg, code) {
   }
 
   if (code !== undefined && typeof code !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('code', 'string');
+    throw new ERR_INVALID_ARG_TYPE('code', 'string', code);
 
   let warned = false;
   function deprecated(...args) {
@@ -294,7 +294,7 @@ const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
 function promisify(original) {
   if (typeof original !== 'function')
-    throw new ERR_INVALID_ARG_TYPE('original', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
 
   if (original[kCustomPromisifiedSymbol]) {
     const fn = original[kCustomPromisifiedSymbol];

--- a/lib/internal/vm/Module.js
+++ b/lib/internal/vm/Module.js
@@ -58,7 +58,8 @@ class Module {
       if (isContext(options.context)) {
         context = options.context;
       } else {
-        throw new ERR_INVALID_ARG_TYPE('options.context', 'vm.Context');
+        throw new ERR_INVALID_ARG_TYPE('options.context',
+                                       'vm.Context', options.context);
       }
     }
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -36,7 +36,7 @@ const {
 
 function assertPath(path) {
   if (typeof path !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('path', 'string');
+    throw new ERR_INVALID_ARG_TYPE('path', 'string', path);
   }
 }
 
@@ -747,7 +747,7 @@ const win32 = {
 
   basename: function basename(path, ext) {
     if (ext !== undefined && typeof ext !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('ext', 'string');
+      throw new ERR_INVALID_ARG_TYPE('ext', 'string', ext);
     assertPath(path);
     var start = 0;
     var end = -1;
@@ -1295,7 +1295,7 @@ const posix = {
 
   basename: function basename(path, ext) {
     if (ext !== undefined && typeof ext !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('ext', 'string');
+      throw new ERR_INVALID_ARG_TYPE('ext', 'string', ext);
     assertPath(path);
 
     var start = 0;

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -383,7 +383,7 @@ class PerformanceObserver extends AsyncResource {
   observe(options) {
     const errors = lazyErrors();
     if (typeof options !== 'object' || options == null) {
-      throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object');
+      throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
     if (!Array.isArray(options.entryTypes)) {
       throw new errors.ERR_INVALID_OPT_VALUE('entryTypes', options);
@@ -420,7 +420,7 @@ class Performance extends PerformanceObserverEntryList {
   set maxEntries(val) {
     if (typeof val !== 'number' || val >>> 0 !== val) {
       const errors = lazyErrors();
-      throw new errors.ERR_INVALID_ARG_TYPE('val', 'number');
+      throw new errors.ERR_INVALID_ARG_TYPE('val', 'number', val);
     }
     this[kMaxCount] = Math.max(1, val >>> 0);
   }
@@ -533,7 +533,7 @@ class Performance extends PerformanceObserverEntryList {
   timerify(fn) {
     if (typeof fn !== 'function') {
       const errors = lazyErrors();
-      throw new errors.ERR_INVALID_ARG_TYPE('fn', 'Function');
+      throw new errors.ERR_INVALID_ARG_TYPE('fn', 'Function', fn);
     }
     if (fn[kTimerified])
       return fn[kTimerified];

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -73,7 +73,8 @@ StringDecoder.prototype.write = function write(buf) {
     return buf;
   if (!ArrayBuffer.isView(buf))
     throw new ERR_INVALID_ARG_TYPE('buf',
-                                   ['Buffer', 'Uint8Array', 'ArrayBufferView']);
+                                   ['Buffer', 'Uint8Array', 'ArrayBufferView'],
+                                   buf);
   return decode(this[kNativeDecoder], buf);
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -323,7 +323,7 @@ Object.defineProperty(inspect, 'defaultOptions', {
   },
   set(options) {
     if (options === null || typeof options !== 'object') {
-      throw new ERR_INVALID_ARG_TYPE('options', 'Object');
+      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
     return _extend(inspectDefaultOptions, options);
   }
@@ -1024,13 +1024,14 @@ function log() {
 function inherits(ctor, superCtor) {
 
   if (ctor === undefined || ctor === null)
-    throw new ERR_INVALID_ARG_TYPE('ctor', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('ctor', 'Function', ctor);
 
   if (superCtor === undefined || superCtor === null)
-    throw new ERR_INVALID_ARG_TYPE('superCtor', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('superCtor', 'Function', superCtor);
 
   if (superCtor.prototype === undefined) {
-    throw new ERR_INVALID_ARG_TYPE('superCtor.prototype', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('superCtor.prototype',
+                                   'Function', superCtor.prototype);
   }
   ctor.super_ = superCtor;
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
@@ -1088,7 +1089,7 @@ function callbackifyOnRejected(reason, cb) {
 
 function callbackify(original) {
   if (typeof original !== 'function') {
-    throw new ERR_INVALID_ARG_TYPE('original', 'Function');
+    throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
   }
 
   // We DO NOT return the promise as it gives the user a false sense that
@@ -1097,7 +1098,7 @@ function callbackify(original) {
   function callbackified(...args) {
     const maybeCb = args.pop();
     if (typeof maybeCb !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE('last argument', 'Function');
+      throw new ERR_INVALID_ARG_TYPE('last argument', 'Function', maybeCb);
     }
     const cb = (...args) => { Reflect.apply(maybeCb, this, args); };
     // In true node style we process the callback on `nextTick` with all the

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -67,7 +67,7 @@ const heapSpaceStatisticsBuffer =
 
 function setFlagsFromString(flags) {
   if (typeof flags !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('flags', 'string');
+    throw new ERR_INVALID_ARG_TYPE('flags', 'string', flags);
   _setFlagsFromString(flags);
 }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -169,12 +169,16 @@ function flushCallback(level, strategy, callback) {
 // 4. Throws ERR_OUT_OF_RANGE for infinite numbers
 function checkFiniteNumber(number, name) {
   // Common case
-  if (number === undefined || Number.isNaN(number)) {
+  if (number === undefined) {
     return false;
   }
 
   if (Number.isFinite(number)) {
-    return true;  // is a valid number
+    return true; // Is a valid number
+  }
+
+  if (Number.isNaN(number)) {
+    return false;
   }
 
   // Other non-numbers

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -127,7 +127,8 @@ function zlibBufferSync(engine, buffer) {
     } else {
       throw new ERR_INVALID_ARG_TYPE(
         'buffer',
-        ['string', 'Buffer', 'TypedArray', 'DataView', 'ArrayBuffer']
+        ['string', 'Buffer', 'TypedArray', 'DataView', 'ArrayBuffer'],
+        buffer
       );
     }
   }

--- a/test/es-module/test-esm-loader-modulemap.js
+++ b/test/es-module/test-esm-loader-modulemap.js
@@ -24,7 +24,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "url" argument must be of type string'
+    message: 'The "url" argument must be of type string. Received type number'
   }
 );
 
@@ -33,7 +33,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "url" argument must be of type string'
+    message: 'The "url" argument must be of type string. Received type number'
   }
 );
 
@@ -42,7 +42,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "job" argument must be of type ModuleJob'
+    message: 'The "job" argument must be of type ModuleJob. ' +
+             'Received type string'
   }
 );
 
@@ -51,6 +52,6 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "url" argument must be of type string'
+    message: 'The "url" argument must be of type string. Received type number'
   }
 );

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -317,10 +317,6 @@ try {
 
 {
   // Verify that throws() and doesNotThrow() throw on non-function block.
-  function typeName(value) {
-    return value === null ? 'null' : typeof value;
-  }
-
   const testBlockTypeError = (method, block) => {
     common.expectsError(
       () => method(block),
@@ -328,7 +324,7 @@ try {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "block" argument must be of type Function. Received ' +
-                `type ${typeName(block)}`
+                 `type ${typeof block}`
       }
     );
   };
@@ -369,15 +365,15 @@ assert.throws(() => {
 {
   // Bad args to AssertionError constructor should throw TypeError.
   const args = [1, true, false, '', null, Infinity, Symbol('test'), undefined];
-  const re = /^The "options" argument must be of type Object$/;
   args.forEach((input) => {
     assert.throws(
       () => new assert.AssertionError(input),
-      common.expectsError({
+      {
         code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: re
-      }));
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        message: 'The "options" argument must be of type Object. ' +
+                 `Received type ${typeof input}`
+      });
   });
 }
 

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -28,15 +28,16 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-const errMsg = common.expectsError({
+assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "buf1", "buf2" arguments must be one of ' +
-             'type Buffer or Uint8Array'
-}, 2);
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
-
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), errMsg);
+  message: 'The "buf2" argument must be one of type Buffer or Uint8Array. ' +
+           'Received type string'
+});
+assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "buf1" argument must be one of type Buffer or Uint8Array. ' +
+           'Received type string'
+});
 
 common.expectsError(() => Buffer.alloc(1).compare('abc'), {
   code: 'ERR_INVALID_ARG_TYPE',

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -54,6 +54,24 @@ assert.strictEqual(flatLongLen.toString(), check);
   });
 });
 
+[[42], ['hello', Buffer.from('world')]].forEach((value) => {
+  assert.throws(() => {
+    Buffer.concat(value);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "list[0]" argument must be one of type Array, Buffer, ' +
+             `or Uint8Array. Received type ${typeof value[0]}`
+  });
+});
+
+assert.throws(() => {
+  Buffer.concat([Buffer.from('hello'), 3]);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "list[1]" argument must be one of type Array, Buffer, ' +
+           'or Uint8Array. Received type number'
+});
+
 // eslint-disable-next-line node-core/crypto-check
 const random10 = common.hasCrypto ?
   require('crypto').randomBytes(10) :

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -44,23 +44,15 @@ assert.notStrictEqual(flatOne, one[0]);
 assert.strictEqual(flatLong.toString(), check);
 assert.strictEqual(flatLongLen.toString(), check);
 
-assertWrongList();
-assertWrongList(null);
-assertWrongList(Buffer.from('hello'));
-assertWrongList([42]);
-assertWrongList(['hello', 'world']);
-assertWrongList(['hello', Buffer.from('world')]);
-
-function assertWrongList(value) {
-  common.expectsError(() => {
+[undefined, null, Buffer.from('hello')].forEach((value) => {
+  assert.throws(() => {
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "list" argument must be one of type ' +
-             'Array, Buffer, or Uint8Array'
+    message: 'The "list" argument must be one of type Array, Buffer, ' +
+             `or Uint8Array. Received type ${typeof value}`
   });
-}
+});
 
 // eslint-disable-next-line node-core/crypto-check
 const random10 = common.hasCrypto ?

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -6,7 +6,7 @@ const { ChildProcess } = require('child_process');
 assert.strictEqual(typeof ChildProcess, 'function');
 
 function typeName(value) {
-  return value === null ? 'null' : typeof value;
+  return typeof value;
 }
 
 {

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -78,39 +78,26 @@ function stripLineEndings(obj) {
   return obj.replace(/\n/g, '');
 }
 
-// direct call Certificate() should return instance
+// Direct call Certificate() should return instance
 assert(Certificate() instanceof Certificate);
 
-[1, {}, [], Infinity, true, 'test', undefined, null].forEach((i) => {
-  common.expectsError(
-    () => Certificate.verifySpkac(i),
+[1, {}, [], Infinity, true, 'test', undefined, null].forEach((val) => {
+  assert.throws(
+    () => Certificate.verifySpkac(val),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
       message: 'The "spkac" argument must be one of type Buffer, TypedArray, ' +
-               'or DataView'
+               `or DataView. Received type ${typeof val}`
     }
   );
 });
 
-[1, {}, [], Infinity, true, undefined, null].forEach((i) => {
-  common.expectsError(
-    () => Certificate.exportPublicKey(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "spkac" argument must be one of type string, Buffer,' +
-               ' TypedArray, or DataView'
-    }
-  );
-
-  common.expectsError(
-    () => Certificate.exportChallenge(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "spkac" argument must be one of type string, Buffer,' +
-               ' TypedArray, or DataView'
-    }
-  );
+[1, {}, [], Infinity, true, undefined, null].forEach((val) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "spkac" argument must be one of type string, Buffer,' +
+             ` TypedArray, or DataView. Received type ${typeof val}`
+  };
+  assert.throws(() => Certificate.exportPublicKey(val), errObj);
+  assert.throws(() => Certificate.exportChallenge(val), errObj);
 });

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -81,7 +81,8 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "cipher" argument must be of type string'
+      message: 'The "cipher" argument must be of type string. ' +
+               'Received type object'
     });
 
   common.expectsError(
@@ -90,7 +91,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "password" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 
   common.expectsError(
@@ -99,7 +100,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "data" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 
   common.expectsError(
@@ -108,7 +109,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "buffer" argument must be one of type Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 
   common.expectsError(
@@ -117,7 +118,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "buffer" argument must be one of type Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 }
 
@@ -132,7 +133,8 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "cipher" argument must be of type string'
+      message: 'The "cipher" argument must be of type string. ' +
+               'Received type object'
     });
 
   common.expectsError(
@@ -141,7 +143,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "password" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 }
 

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -92,7 +92,8 @@ function testCipher3(key, iv) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "cipher" argument must be of type string'
+      message: 'The "cipher" argument must be of type string. ' +
+               'Received type object'
     });
 
   common.expectsError(
@@ -101,7 +102,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "key" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 
   common.expectsError(
@@ -110,7 +111,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "iv" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type number'
     });
 }
 
@@ -128,7 +129,8 @@ function testCipher3(key, iv) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "cipher" argument must be of type string'
+      message: 'The "cipher" argument must be of type string. ' +
+               'Received type object'
     });
 
   common.expectsError(
@@ -137,7 +139,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "key" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type object'
     });
 
   common.expectsError(
@@ -146,7 +148,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "iv" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView'
+               'TypedArray, or DataView. Received type number'
     });
 }
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -49,14 +49,14 @@ assert.strictEqual(dh2.verifyError, 0);
   () => { },
   /abc/,
   {}
-].forEach((i) => {
+].forEach((input) => {
   common.expectsError(
-    () => crypto.createDiffieHellman(i),
+    () => crypto.createDiffieHellman(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "sizeOrKey" argument must be one of type number, string, ' +
-               'Buffer, TypedArray, or DataView'
+               `Buffer, TypedArray, or DataView. Received type ${typeof input}`
     }
   );
 });
@@ -380,5 +380,6 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "curve" argument must be of type string'
+    message: 'The "curve" argument must be of type string. ' +
+             'Received type undefined'
   });

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -12,7 +12,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "id" argument must be of type string'
+    message: 'The "id" argument must be of type string. Received type boolean'
   });
 
 common.expectsError(
@@ -20,7 +20,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "flags" argument must be of type number'
+    message: 'The "flags" argument must be of type number. Received type string'
   });
 
 common.expectsError(

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -152,7 +152,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "algorithm" argument must be of type string'
+    message: 'The "algorithm" argument must be of type string. ' +
+             'Received type undefined'
   }
 );
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -18,7 +18,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "hmac" argument must be of type string'
+    message: 'The "hmac" argument must be of type string. Received type object'
   });
 
 common.expectsError(
@@ -27,7 +27,7 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "key" argument must be one of type string, TypedArray, or ' +
-             'DataView'
+             'DataView. Received type object'
   });
 
 {

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -82,7 +82,8 @@ common.expectsError(
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "keylen" argument must be of type number'
+      message: 'The "keylen" argument must be of type number. ' +
+               `Received type ${typeof notNumber}`
     });
 });
 
@@ -107,7 +108,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "digest" argument must be one of type string or null'
+    message: 'The "digest" argument must be one of type string or null. ' +
+             'Received type undefined'
   });
 
 common.expectsError(
@@ -115,58 +117,57 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "digest" argument must be one of type string or null'
+    message: 'The "digest" argument must be one of type string or null. ' +
+             'Received type undefined'
   });
 
-[1, {}, [], true, undefined, null].forEach((i) => {
+[1, {}, [], true, undefined, null].forEach((input) => {
+  const msgPart2 = `Buffer, or TypedArray. Received type ${typeof input}`;
   common.expectsError(
-    () => crypto.pbkdf2(i, 'salt', 8, 8, 'sha256', common.mustNotCall()),
+    () => crypto.pbkdf2(input, 'salt', 8, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "password" argument must be one of type string, ' +
-               'Buffer, or TypedArray'
+      message: `The "password" argument must be one of type string, ${msgPart2}`
     }
   );
 
   common.expectsError(
-    () => crypto.pbkdf2('pass', i, 8, 8, 'sha256', common.mustNotCall()),
+    () => crypto.pbkdf2('pass', input, 8, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "salt" argument must be one of type string, ' +
-               'Buffer, or TypedArray'
+      message: `The "salt" argument must be one of type string, ${msgPart2}`
     }
   );
 
   common.expectsError(
-    () => crypto.pbkdf2Sync(i, 'salt', 8, 8, 'sha256'),
+    () => crypto.pbkdf2Sync(input, 'salt', 8, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "password" argument must be one of type string, ' +
-               'Buffer, or TypedArray'
+      message: `The "password" argument must be one of type string, ${msgPart2}`
     }
   );
 
   common.expectsError(
-    () => crypto.pbkdf2Sync('pass', i, 8, 8, 'sha256'),
+    () => crypto.pbkdf2Sync('pass', input, 8, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "salt" argument must be one of type string, ' +
-               'Buffer, or TypedArray'
+      message: `The "salt" argument must be one of type string, ${msgPart2}`
     }
   );
 });
 
 ['test', {}, [], true, undefined, null].forEach((i) => {
+  const received = `Received type ${typeof i}`;
   common.expectsError(
     () => crypto.pbkdf2('pass', 'salt', i, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "iterations" argument must be of type number'
+      message: `The "iterations" argument must be of type number. ${received}`
     }
   );
 
@@ -175,7 +176,7 @@ common.expectsError(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "iterations" argument must be of type number'
+      message: `The "iterations" argument must be of type number. ${received}`
     }
   );
 });

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -265,7 +265,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError [ERR_OUT_OF_RANGE]',
     message: 'The value of "size" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. Received 4294967296'
+             `It must be >= 0 && <= ${kMaxPossibleLength}. Received 4294967296`
   }
 );
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -80,43 +80,18 @@ process.setMaxListeners(256);
 }
 
 {
-  const buf = new Uint16Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf);
-  const after = Buffer.from(buf.buffer).toString('hex');
-  assert.notStrictEqual(before, after);
-}
-
-{
-  const buf = new Uint32Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf);
-  const after = Buffer.from(buf.buffer).toString('hex');
-  assert.notStrictEqual(before, after);
-}
-
-{
-  const buf = new Float32Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf);
-  const after = Buffer.from(buf.buffer).toString('hex');
-  assert.notStrictEqual(before, after);
-}
-
-{
-  const buf = new Float64Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf);
-  const after = Buffer.from(buf.buffer).toString('hex');
-  assert.notStrictEqual(before, after);
-}
-
-{
-  const buf = new DataView(new ArrayBuffer(10));
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf);
-  const after = Buffer.from(buf.buffer).toString('hex');
-  assert.notStrictEqual(before, after);
+  [
+    new Uint16Array(10),
+    new Uint32Array(10),
+    new Float32Array(10),
+    new Float64Array(10),
+    new DataView(new ArrayBuffer(10))
+  ].forEach((buf) => {
+    const before = Buffer.from(buf.buffer).toString('hex');
+    crypto.randomFillSync(buf);
+    const after = Buffer.from(buf.buffer).toString('hex');
+    assert.notStrictEqual(before, after);
+  });
 }
 
 {
@@ -140,53 +115,20 @@ process.setMaxListeners(256);
 }
 
 {
-  const buf = new Uint16Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
-    const after = Buffer.from(buf.buffer).toString('hex');
-    assert.notStrictEqual(before, after);
-  }));
-}
-
-{
-  const buf = new Uint32Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
-    const after = Buffer.from(buf.buffer).toString('hex');
-    assert.notStrictEqual(before, after);
-  }));
-}
-
-{
-  const buf = new Float32Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
-    const after = Buffer.from(buf.buffer).toString('hex');
-    assert.notStrictEqual(before, after);
-  }));
-}
-
-{
-  const buf = new Float64Array(10);
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
-    const after = Buffer.from(buf.buffer).toString('hex');
-    assert.notStrictEqual(before, after);
-  }));
-}
-
-{
-  const buf = new DataView(new ArrayBuffer(10));
-  const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
-    const after = Buffer.from(buf.buffer).toString('hex');
-    assert.notStrictEqual(before, after);
-  }));
+  [
+    new Uint16Array(10),
+    new Uint32Array(10),
+    new Float32Array(10),
+    new Float64Array(10),
+    new DataView(new ArrayBuffer(10))
+  ].forEach((buf) => {
+    const before = Buffer.from(buf.buffer).toString('hex');
+    crypto.randomFill(buf, common.mustCall((err, buf) => {
+      assert.ifError(err);
+      const after = Buffer.from(buf.buffer).toString('hex');
+      assert.notStrictEqual(before, after);
+    }));
+  });
 }
 
 {

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -27,42 +27,49 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
+const { kMaxLength } = require('buffer');
+
+const kMaxUint32 = Math.pow(2, 32) - 1;
+const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
 // bump, we register a lot of exit listeners
 process.setMaxListeners(256);
 
-[crypto.randomBytes, crypto.pseudoRandomBytes].forEach(function(f) {
-  [-1, undefined, null, false, true, {}, []].forEach(function(value) {
-
-    common.expectsError(
-      () => f(value),
-      {
+{
+  [crypto.randomBytes, crypto.pseudoRandomBytes].forEach((f) => {
+    [undefined, null, false, true, {}, []].forEach((value) => {
+      const errObj = {
         code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: /^The "size" argument must be of type (number|uint32)$/
-      }
-    );
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        message: 'The "size" argument must be of type number. ' +
+                `Received type ${typeof value}`
+      };
+      assert.throws(() => f(value), errObj);
+      assert.throws(() => f(value, common.mustNotCall()), errObj);
+    });
 
-    common.expectsError(
-      () => f(value, common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: /^The "size" argument must be of type (number|uint32)$/
-      }
-    );
-  });
+    [-1, NaN, 2 ** 32].forEach((value) => {
+      const errObj = {
+        code: 'ERR_OUT_OF_RANGE',
+        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        message: 'The value of "size" is out of range. It must be >= 0 && <= ' +
+                 `${kMaxPossibleLength}. Received ${value}`
+      };
+      assert.throws(() => f(value), errObj);
+      assert.throws(() => f(value, common.mustNotCall()), errObj);
+    });
 
-  [0, 1, 2, 4, 16, 256, 1024, 101.2].forEach(function(len) {
-    f(len, common.mustCall(function(ex, buf) {
-      assert.strictEqual(ex, null);
-      assert.strictEqual(buf.length, Math.floor(len));
-      assert.ok(Buffer.isBuffer(buf));
-    }));
+    [0, 1, 2, 4, 16, 256, 1024, 101.2].forEach((len) => {
+      f(len, common.mustCall((ex, buf) => {
+        assert.strictEqual(ex, null);
+        assert.strictEqual(buf.length, Math.floor(len));
+        assert.ok(Buffer.isBuffer(buf));
+      }));
+    });
   });
-});
+}
 
 {
   const buf = Buffer.alloc(10);
@@ -181,252 +188,84 @@ process.setMaxListeners(256);
 }
 
 {
-  const bufs = [
+  [
     Buffer.alloc(10),
     new Uint8Array(new Array(10).fill(0))
-  ];
-
-  const max = require('buffer').kMaxLength + 1;
-
-  for (const buf of bufs) {
+  ].forEach((buf) => {
     const len = Buffer.byteLength(buf);
     assert.strictEqual(len, 10, `Expected byteLength of 10, got ${len}`);
 
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 'test'),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type number'
-      }
-    );
+    const typeErrObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "offset" argument must be of type number. ' +
+               'Received type string'
+    };
 
-    common.expectsError(
-      () => crypto.randomFillSync(buf, NaN),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type number'
-      }
-    );
+    assert.throws(() => crypto.randomFillSync(buf, 'test'), typeErrObj);
 
-    common.expectsError(
+    assert.throws(
       () => crypto.randomFill(buf, 'test', common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type number'
-      }
-    );
+      typeErrObj);
 
-    common.expectsError(
-      () => crypto.randomFill(buf, NaN, common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type number'
-      }
-    );
+    typeErrObj.message = 'The "size" argument must be of type number. ' +
+                     'Received type string';
+    assert.throws(() => crypto.randomFillSync(buf, 0, 'test'), typeErrObj);
 
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 11),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "offset" is out of range.'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, max),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "offset" is out of range.'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFill(buf, 11, common.mustNotCall()),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "offset" is out of range.'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFill(buf, max, common.mustNotCall()),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "offset" is out of range.'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 0, 'test'),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "size" argument must be of type number'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 0, NaN),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "size" argument must be of type number'
-      }
-    );
-
-    common.expectsError(
+    assert.throws(
       () => crypto.randomFill(buf, 0, 'test', common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "size" argument must be of type number'
-      }
+      typeErrObj
     );
 
-    common.expectsError(
-      () => crypto.randomFill(buf, 0, NaN, common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "size" argument must be of type number'
-      }
-    );
-
-    {
-      const size = (-1 >>> 0) + 1;
-
-      common.expectsError(
-        () => crypto.randomFillSync(buf, 0, -10),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "size" argument must be of type uint32'
-        }
-      );
-
-      common.expectsError(
-        () => crypto.randomFillSync(buf, 0, size),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "size" argument must be of type uint32'
-        }
-      );
-
-      common.expectsError(
-        () => crypto.randomFill(buf, 0, -10, common.mustNotCall()),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "size" argument must be of type uint32'
-        }
-      );
-
-      common.expectsError(
-        () => crypto.randomFill(buf, 0, size, common.mustNotCall()),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "size" argument must be of type uint32'
-        }
-      );
-    }
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, -10),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type uint32'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFill(buf, -10, common.mustNotCall()),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "offset" argument must be of type uint32'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 1, 10),
-      {
+    [NaN, kMaxPossibleLength + 1, -10, (-1 >>> 0) + 1].forEach((offsetSize) => {
+      const errObj = {
         code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "size" is out of range.'
-      }
-    );
+        name: 'RangeError [ERR_OUT_OF_RANGE]',
+        message: 'The value of "offset" is out of range. ' +
+                 `It must be >= 0 && <= 10. Received ${offsetSize}`
+      };
 
-    common.expectsError(
+      assert.throws(() => crypto.randomFillSync(buf, offsetSize), errObj);
+
+      assert.throws(
+        () => crypto.randomFill(buf, offsetSize, common.mustNotCall()),
+        errObj);
+
+      errObj.message = 'The value of "size" is out of range. It must be >= ' +
+                       `0 && <= ${kMaxPossibleLength}. Received ${offsetSize}`;
+      assert.throws(() => crypto.randomFillSync(buf, 1, offsetSize), errObj);
+
+      assert.throws(
+        () => crypto.randomFill(buf, 1, offsetSize, common.mustNotCall()),
+        errObj
+      );
+    });
+
+    const rangeErrObj = {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      message: 'The value of "size + offset" is out of range. ' +
+               'It must be <= 10. Received 11'
+    };
+    assert.throws(() => crypto.randomFillSync(buf, 1, 10), rangeErrObj);
+
+    assert.throws(
       () => crypto.randomFill(buf, 1, 10, common.mustNotCall()),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "size" is out of range.'
-      }
+      rangeErrObj
     );
-
-    common.expectsError(
-      () => crypto.randomFillSync(buf, 0, 12),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "size" is out of range.'
-      }
-    );
-
-    common.expectsError(
-      () => crypto.randomFill(buf, 0, 12, common.mustNotCall()),
-      {
-        code: 'ERR_OUT_OF_RANGE',
-        type: RangeError,
-        message: 'The value of "size" is out of range.'
-      }
-    );
-
-    {
-      // Offset is too big
-      const offset = (-1 >>> 0) + 1;
-      common.expectsError(
-        () => crypto.randomFillSync(buf, offset, 10),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "offset" argument must be of type uint32'
-        }
-      );
-
-      common.expectsError(
-        () => crypto.randomFill(buf, offset, 10, common.mustNotCall()),
-        {
-          code: 'ERR_INVALID_ARG_TYPE',
-          type: TypeError,
-          message: 'The "offset" argument must be of type uint32'
-        }
-      );
-    }
-  }
+  });
 }
 
 // https://github.com/nodejs/node-v0.x-archive/issues/5126,
 // "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData() length
 // exceeds max acceptable value"
-common.expectsError(
+assert.throws(
   () => crypto.randomBytes((-1 >>> 0) + 1),
   {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "size" argument must be of type uint32'
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "size" is out of range. ' +
+             'It must be >= 0 && <= 2147483647. Received 4294967296'
   }
 );
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -315,105 +315,51 @@ common.expectsError(
   }));
 }
 
-[1, [], {}, undefined, null, true, Infinity].forEach((i) => {
-  common.expectsError(
-    () => crypto.createSign(),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "algorithm" argument must be of type string'
-    }
-  );
-  common.expectsError(
-    () => crypto.createVerify(),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "algorithm" argument must be of type string'
-    }
-  );
-});
-
 {
   const sign = crypto.createSign('SHA1');
   const verify = crypto.createVerify('SHA1');
 
-  [1, [], {}, undefined, null, true, Infinity].forEach((i) => {
-    common.expectsError(
-      () => sign.update(i),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "data" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
-    common.expectsError(
-      () => verify.update(i),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "data" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
-    common.expectsError(
-      () => sign._write(i, 'utf8', () => {}),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "data" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
-    common.expectsError(
-      () => verify._write(i, 'utf8', () => {}),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "data" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
+  [1, [], {}, undefined, null, true, Infinity].forEach((input) => {
+    const type = typeof input;
+    const errObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "algorithm" argument must be of type string. ' +
+               `Received type ${type}`
+    };
+    assert.throws(() => crypto.createSign(input), errObj);
+    assert.throws(() => crypto.createVerify(input), errObj);
+
+    errObj.message = 'The "data" argument must be one of type string, ' +
+                     `Buffer, TypedArray, or DataView. Received type ${type}`;
+    assert.throws(() => sign.update(input), errObj);
+    assert.throws(() => verify.update(input), errObj);
+    assert.throws(() => sign._write(input, 'utf8', () => {}), errObj);
+    assert.throws(() => verify._write(input, 'utf8', () => {}), errObj);
   });
 
   [
     Uint8Array, Uint16Array, Uint32Array, Float32Array, Float64Array
-  ].forEach((i) => {
+  ].forEach((clazz) => {
     // These should all just work
-    sign.update(new i());
-    verify.update(new i());
+    sign.update(new clazz());
+    verify.update(new clazz());
   });
 
-  [1, {}, [], Infinity].forEach((i) => {
-    common.expectsError(
-      () => sign.sign(i),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "key" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
+  [1, {}, [], Infinity].forEach((input) => {
+    const type = typeof input;
+    const errObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "key" argument must be one of type string, Buffer, ' +
+               `TypedArray, or DataView. Received type ${type}`
+    };
 
-    common.expectsError(
-      () => verify.verify(i),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "key" argument must be one of type string, Buffer, ' +
-                 'TypedArray, or DataView'
-      }
-    );
+    assert.throws(() => sign.sign(input), errObj);
+    assert.throws(() => verify.verify(input), errObj);
 
-    common.expectsError(
-      () => verify.verify('test', i),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "signature" argument must be one of type string, ' +
-                 'Buffer, TypedArray, or DataView'
-      }
-    );
+    errObj.message = 'The "signature" argument must be one of type string, ' +
+                     `Buffer, TypedArray, or DataView. Received type ${type}`;
+    assert.throws(() => verify.verify('test', input), errObj);
   });
 }

--- a/test/parallel/test-dgram-custom-lookup.js
+++ b/test/parallel/test-dgram-custom-lookup.js
@@ -40,7 +40,8 @@ const dns = require('dns');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "lookup" argument must be of type Function'
+      message: 'The "lookup" argument must be of type Function. ' +
+               `Received type ${typeof value}`
     });
   });
 }

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -10,47 +10,27 @@ const onMessage = common.mustCall((err, bytes) => {
   assert.strictEqual(bytes, buf.length);
 }, 6);
 
-const expectedError = { code: 'ERR_INVALID_ARG_TYPE',
-                        type: TypeError,
-                        message:
-  /^The "address" argument must be one of type string or falsy$/
-};
-
 const client = dgram.createSocket('udp4').bind(0, () => {
   const port = client.address().port;
 
-  // valid address: false
-  client.send(buf, port, false, onMessage);
+  // Check valid addresses
+  [false, '', null, 0, undefined].forEach((address) => {
+    client.send(buf, port, address, onMessage);
+  });
 
-  // valid address: empty string
-  client.send(buf, port, '', onMessage);
-
-  // valid address: null
-  client.send(buf, port, null, onMessage);
-
-  // valid address: 0
-  client.send(buf, port, 0, onMessage);
-
-  // valid address: undefined
-  client.send(buf, port, undefined, onMessage);
-
-  // valid address: not provided
+  // Valid address: not provided
   client.send(buf, port, onMessage);
 
-  // invalid address: object
-  common.expectsError(() => {
-    client.send(buf, port, []);
-  }, expectedError);
-
-  // invalid address: nonzero number
-  common.expectsError(() => {
-    client.send(buf, port, 1);
-  }, expectedError);
-
-  // invalid address: true
-  common.expectsError(() => {
-    client.send(buf, port, true);
-  }, expectedError);
+  // Check invalid addresses
+  [[], 1, true].forEach((invalidInput) => {
+    const expectedError = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "address" argument must be one of type string or falsy. ' +
+               `Received type ${typeof invalidInput}`
+    };
+    assert.throws(() => client.send(buf, port, invalidInput), expectedError);
+  });
 });
 
 client.unref();

--- a/test/parallel/test-dgram-sendto.js
+++ b/test/parallel/test-dgram-sendto.js
@@ -1,47 +1,37 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const assert = require('assert');
 const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 
-const errorMessageOffset =
-  /^The "offset" argument must be of type number$/;
-
-common.expectsError(() => {
-  socket.sendto();
-}, {
+const errObj = {
   code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: errorMessageOffset
-});
+  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  message: 'The "offset" argument must be of type number. Received type ' +
+           'undefined'
+};
+assert.throws(() => socket.sendto(), errObj);
 
-common.expectsError(() => {
-  socket.sendto('buffer', 1, 'offset', 'port', 'address', 'cb');
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: /^The "length" argument must be of type number$/
-});
+errObj.message = 'The "length" argument must be of type number. Received ' +
+                 'type string';
+assert.throws(
+  () => socket.sendto('buffer', 1, 'offset', 'port', 'address', 'cb'),
+  errObj);
 
-common.expectsError(() => {
-  socket.sendto('buffer', 'offset', 1, 'port', 'address', 'cb');
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: errorMessageOffset
-});
+errObj.message = 'The "offset" argument must be of type number. Received ' +
+                 'type string';
+assert.throws(
+  () => socket.sendto('buffer', 'offset', 1, 'port', 'address', 'cb'),
+  errObj);
 
-common.expectsError(() => {
-  socket.sendto('buffer', 1, 1, 10, false, 'cb');
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: /^The "address" argument must be of type string$/
-});
+errObj.message = 'The "address" argument must be of type string. Received ' +
+                 'type boolean';
+assert.throws(
+  () => socket.sendto('buffer', 1, 1, 10, false, 'cb'),
+  errObj);
 
-common.expectsError(() => {
-  socket.sendto('buffer', 1, 1, false, 'address', 'cb');
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: /^The "port" argument must be of type number$/
-});
+errObj.message = 'The "port" argument must be of type number. Received ' +
+                 'type boolean';
+assert.throws(
+  () => socket.sendto('buffer', 1, 1, false, 'address', 'cb'),
+  errObj);

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -92,5 +92,6 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type Function'
+  message: 'The "listener" argument must be of type Function. ' +
+           'Received type object'
 });

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -52,12 +52,12 @@ e.emit('e');
 // Verify that the listener must be a function
 common.expectsError(() => {
   const ee = new EventEmitter();
-
   ee.once('foo', null);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type Function'
+  message: 'The "listener" argument must be of type Function. ' +
+           'Received type object'
 });
 
 {

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -21,12 +21,12 @@ myEE.emit('foo');
 // Verify that the listener must be a function
 common.expectsError(() => {
   const ee = new EventEmitter();
-
   ee.prependOnceListener('foo', null);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type Function'
+  message: 'The "listener" argument must be of type Function. ' +
+           'Received type object'
 });
 
 // Test fallback if prependListener is undefined.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -146,12 +146,12 @@ function listener2() {}
 // Verify that the removed listener must be a function
 common.expectsError(() => {
   const ee = new EventEmitter();
-
   ee.removeListener('foo', null);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type Function'
+  message: 'The "listener" argument must be of type Function. ' +
+           'Received type object'
 });
 
 {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -97,7 +97,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "path" argument must be one of type string, Buffer, or URL'
+    message: 'The "path" argument must be one of type string, Buffer, or URL.' +
+             ' Received type number'
   }
 );
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -62,22 +62,14 @@ assert.strictEqual(typeof fs.R_OK, 'number');
 assert.strictEqual(typeof fs.W_OK, 'number');
 assert.strictEqual(typeof fs.X_OK, 'number');
 
-fs.access(__filename, common.mustCall((err) => {
-  assert.ifError(err);
-}));
-
-fs.access(__filename, fs.R_OK, common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.access(__filename, common.mustCall(assert.ifError));
+fs.access(__filename, fs.R_OK, common.mustCall(assert.ifError));
+fs.access(readOnlyFile, fs.F_OK | fs.R_OK, common.mustCall(assert.ifError));
 
 fs.access(doesNotExist, common.mustCall((err) => {
   assert.notStrictEqual(err, null, 'error should exist');
   assert.strictEqual(err.code, 'ENOENT');
   assert.strictEqual(err.path, doesNotExist);
-}));
-
-fs.access(readOnlyFile, fs.F_OK | fs.R_OK, common.mustCall((err) => {
-  assert.ifError(err);
 }));
 
 fs.access(readOnlyFile, fs.W_OK, common.mustCall(function(err) {

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -25,7 +25,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "path" argument must be one of type string, Buffer, or URL'
+    message: 'The "path" argument must be one of type string, Buffer, or URL.' +
+             ' Received type boolean'
   }
 );
 

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -114,7 +114,8 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "mode" argument must be of type integer'
+        message: 'The "mode" argument must be of type number. ' +
+                 'Received type object'
       }
     );
 
@@ -150,7 +151,8 @@ if (fs.lchmod) {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "fd" argument must be of type integer'
+    message: 'The "fd" argument must be of type number. ' +
+             `Received type ${typeof input}`
   };
   assert.throws(() => fs.fchmod(input, 0o000), errObj);
   assert.throws(() => fs.fchmodSync(input, 0o000), errObj);

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -146,40 +146,25 @@ if (fs.lchmod) {
   }));
 }
 
-['', false, null, undefined, {}, []].forEach((i) => {
-  common.expectsError(
-    () => fs.fchmod(i, 0o000),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchmodSync(i, 0o000),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "fd" argument must be of type integer'
+  };
+  assert.throws(() => fs.fchmod(input, 0o000), errObj);
+  assert.throws(() => fs.fchmodSync(input, 0o000), errObj);
 });
 
-[false, 1, {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.chmod(i, 1, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
-  common.expectsError(
-    () => fs.chmodSync(i, 1),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "path" argument must be one of type string, Buffer, or URL.' +
+             ` Received type ${typeof input}`
+  };
+  assert.throws(() => fs.chmod(input, 1, common.mustNotCall()), errObj);
+  assert.throws(() => fs.chmodSync(input, 1), errObj);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -11,7 +11,8 @@ const fs = require('fs');
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "fd" argument must be of type integer'
+    message: 'The "fd" argument must be of type number. ' +
+             `Received type ${typeof input}`
   };
   assert.throws(() => fs.close(input), errObj);
   assert.throws(() => fs.closeSync(input), errObj);

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -3,24 +3,16 @@
 // This tests that the errors thrown from fs.close and fs.closeSync
 // include the desired properties
 
-const common = require('../common');
+require('../common');
+const assert = require('assert');
 const fs = require('fs');
 
-['', false, null, undefined, {}, []].forEach((i) => {
-  common.expectsError(
-    () => fs.close(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.closeSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "fd" argument must be of type integer'
+  };
+  assert.throws(() => fs.close(input), errObj);
+  assert.throws(() => fs.closeSync(input), errObj);
 });

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -1,45 +1,66 @@
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 const fs = require('fs');
 
 // This test ensures that input for fchmod is valid, testing for valid
 // inputs for fd and mode
 
 // Check input type
-['', false, null, undefined, {}, [], Infinity, -1].forEach((i) => {
-  common.expectsError(
-    () => fs.fchmod(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchmodSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+[false, null, undefined, {}, [], ''].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "fd" argument must be of type number. Received type ' +
+             typeof input
+  };
+  assert.throws(() => fs.fchmod(input), errObj);
+  assert.throws(() => fs.fchmodSync(input), errObj);
+  errObj.message = errObj.message.replace('fd', 'mode');
+  assert.throws(() => fs.fchmod(1, input), errObj);
+  assert.throws(() => fs.fchmodSync(1, input), errObj);
+});
 
-  common.expectsError(
-    () => fs.fchmod(1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "mode" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchmodSync(1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "mode" argument must be of type integer'
-    }
-  );
+[-1, 2 ** 32].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "fd" is out of range. It must be >= 0 && < ' +
+             `${2 ** 32}. Received ${input}`
+  };
+  assert.throws(() => fs.fchmod(input), errObj);
+  assert.throws(() => fs.fchmodSync(input), errObj);
+  errObj.message = errObj.message.replace('fd', 'mode');
+  assert.throws(() => fs.fchmod(1, input), errObj);
+  assert.throws(() => fs.fchmodSync(1, input), errObj);
+});
+
+[NaN, Infinity].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "fd" is out of range. It must be an integer. ' +
+             `Received ${input}`
+  };
+  assert.throws(() => fs.fchmod(input), errObj);
+  assert.throws(() => fs.fchmodSync(input), errObj);
+  errObj.message = errObj.message.replace('fd', 'mode');
+  assert.throws(() => fs.fchmod(1, input), errObj);
+  assert.throws(() => fs.fchmodSync(1, input), errObj);
+});
+
+[1.5].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "fd" is out of range. It must be an integer. ' +
+             `Received ${input}`
+  };
+  assert.throws(() => fs.fchmod(input), errObj);
+  assert.throws(() => fs.fchmodSync(input), errObj);
+  errObj.message = errObj.message.replace('fd', 'mode');
+  assert.throws(() => fs.fchmod(1, input), errObj);
+  assert.throws(() => fs.fchmodSync(1, input), errObj);
 });
 
 // Check for mode values range

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -1,57 +1,46 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
+const assert = require('assert');
 const fs = require('fs');
 
-['', false, null, undefined, {}, [], Infinity, -1].forEach((i) => {
-  common.expectsError(
-    () => fs.fchown(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchownSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+function test(input, errObj) {
+  assert.throws(() => fs.fchown(input), errObj);
+  assert.throws(() => fs.fchownSync(input), errObj);
+  errObj.message = errObj.message.replace('fd', 'uid');
+  assert.throws(() => fs.fchown(1, input), errObj);
+  assert.throws(() => fs.fchownSync(1, input), errObj);
+  errObj.message = errObj.message.replace('uid', 'gid');
+  assert.throws(() => fs.fchown(1, 1, input), errObj);
+  assert.throws(() => fs.fchownSync(1, 1, input), errObj);
+}
 
-  common.expectsError(
-    () => fs.fchown(1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "uid" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchownSync(1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "uid" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "fd" argument must be of type number. Received type ' +
+             typeof input
+  };
+  test(input, errObj);
+});
 
-  common.expectsError(
-    () => fs.fchown(1, 1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "gid" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fchownSync(1, 1, i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "gid" argument must be of type integer'
-    }
-  );
+[Infinity, NaN].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "fd" is out of range. It must be an integer. ' +
+             `Received ${input}`
+  };
+  test(input, errObj);
+});
+
+[-1, 2 ** 32].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "fd" is out of range. It must be ' +
+             `>= 0 && < 4294967296. Received ${input}`
+  };
+  test(input, errObj);
 });

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -50,37 +50,15 @@ fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
   }));
 }));
 
-['', false, null, undefined, {}, []].forEach((i) => {
-  common.expectsError(
-    () => fs.fdatasync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fdatasyncSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fsync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fsyncSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "fd" argument must be of type number. Received type ' +
+             typeof input
+  };
+  assert.throws(() => fs.fdatasync(input), errObj);
+  assert.throws(() => fs.fdatasyncSync(input), errObj);
+  assert.throws(() => fs.fsync(input), errObj);
+  assert.throws(() => fs.fsyncSync(input), errObj);
 });

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -14,7 +14,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array.' +
+             ' Received type number'
   }
 );
 
@@ -26,8 +27,11 @@ common.expectsError(
             expected.length,
             0,
             common.mustNotCall());
-  }, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError,
-       message: 'The "fd" argument must be of type integer' });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "fd" argument must be of type integer'
+  });
 });
 
 common.expectsError(() => {
@@ -56,7 +60,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array.' +
+             ' Received type number'
   }
 );
 
@@ -67,8 +72,11 @@ common.expectsError(
                 0,
                 expected.length,
                 0);
-  }, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError,
-       message: 'The "fd" argument must be of type integer' });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "fd" argument must be of type integer'
+  });
 });
 
 common.expectsError(() => {

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -30,7 +30,8 @@ common.expectsError(
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "fd" argument must be of type integer'
+    message: 'The "fd" argument must be of type number. ' +
+             `Received type ${typeof value}`
   });
 });
 
@@ -75,7 +76,8 @@ common.expectsError(
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "fd" argument must be of type integer'
+    message: 'The "fd" argument must be of type number. ' +
+             `Received type ${typeof value}`
   });
 });
 

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -60,7 +60,8 @@ common.expectsError(
   () => { fs.readFile(() => {}, common.mustNotCall()); },
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "path" argument must be one of type string, Buffer, or URL',
+    message: 'The "path" argument must be one of type string, Buffer, or URL.' +
+             ' Received type function',
     type: TypeError
   }
 );

--- a/test/parallel/test-fs-rename-type-check.js
+++ b/test/parallel/test-fs-rename-type-check.js
@@ -1,43 +1,41 @@
 'use strict';
 
 const common = require('../common');
+const assert = require('assert');
 const fs = require('fs');
 
-[false, 1, [], {}, null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.rename(i, 'does-not-exist', common.mustNotCall()),
+[false, 1, [], {}, null, undefined].forEach((input) => {
+  const type = `of type string, Buffer, or URL. Received type ${typeof input}`;
+  assert.throws(
+    () => fs.rename(input, 'does-not-exist', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "oldPath" argument must be one of type string, Buffer, or URL'
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: `The "oldPath" argument must be one ${type}`
     }
   );
-  common.expectsError(
-    () => fs.rename('does-not-exist', i, common.mustNotCall()),
+  assert.throws(
+    () => fs.rename('does-not-exist', input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "newPath" argument must be one of type string, Buffer, or URL'
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: `The "newPath" argument must be one ${type}`
     }
   );
-  common.expectsError(
-    () => fs.renameSync(i, 'does-not-exist'),
+  assert.throws(
+    () => fs.renameSync(input, 'does-not-exist'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "oldPath" argument must be one of type string, Buffer, or URL'
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: `The "oldPath" argument must be one ${type}`
     }
   );
-  common.expectsError(
-    () => fs.renameSync('does-not-exist', i),
+  assert.throws(
+    () => fs.renameSync('does-not-exist', input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "newPath" argument must be one of type string, Buffer, or URL'
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: `The "newPath" argument must be one ${type}`
     }
   );
 });

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -138,7 +138,8 @@ fs.stat(__filename, common.mustCall(function(err, s) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "fd" argument must be of type integer'
+        message: 'The "fd" argument must be of type number. ' +
+                 `Received type ${typeof input}`
       }
     );
   });

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -131,52 +131,46 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   });
 }));
 
-['', false, null, undefined, {}, []].forEach((i) => {
-  common.expectsError(
-    () => fs.fstat(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.fstatSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  ['fstat', 'fstatSync'].forEach((fnName) => {
+    assert.throws(
+      () => fs[fnName](input),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        message: 'The "fd" argument must be of type integer'
+      }
+    );
+  });
 });
 
-[false, 1, {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.lstat(i, common.mustNotCall()),
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  assert.throws(
+    () => fs.lstat(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
     }
   );
-  common.expectsError(
-    () => fs.lstatSync(i),
+  assert.throws(
+    () => fs.lstatSync(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
     }
   );
-  common.expectsError(
-    () => fs.stat(i, common.mustNotCall()),
+  assert.throws(
+    () => fs.stat(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
     }
   );
-  common.expectsError(
-    () => fs.statSync(i),
+  assert.throws(
+    () => fs.statSync(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]'
     }
   );
 });

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -35,7 +35,7 @@ let fileTime;
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-// test creating and reading symbolic link
+// Test creating and reading symbolic link
 const linkData = fixtures.path('/cycles/root.js');
 const linkPath = path.join(tmpdir.path, 'symlink1.js');
 
@@ -58,63 +58,29 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   }));
 }));
 
-[false, 1, {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.symlink(i, '', common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "target" argument must be one of type string, Buffer, or URL'
-    }
-  );
-  common.expectsError(
-    () => fs.symlink('', i, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "path" argument must be one of type string, Buffer, or URL'
-    }
-  );
-  common.expectsError(
-    () => fs.symlinkSync(i, ''),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "target" argument must be one of type string, Buffer, or URL'
-    }
-  );
-  common.expectsError(
-    () => fs.symlinkSync('', i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message:
-        'The "path" argument must be one of type string, Buffer, or URL'
-    }
-  );
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  const errObj = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "target" argument must be one of type string, Buffer, or ' +
+             `URL. Received type ${typeof input}`
+  };
+  assert.throws(() => fs.symlink(input, '', common.mustNotCall()), errObj);
+  assert.throws(() => fs.symlinkSync(input, ''), errObj);
+
+  errObj.message = errObj.message.replace('target', 'path');
+  assert.throws(() => fs.symlink('', input, common.mustNotCall()), errObj);
+  assert.throws(() => fs.symlinkSync('', input), errObj);
 });
 
-common.expectsError(
-  () => fs.symlink('', '', '🍏', common.mustNotCall()),
-  {
-    code: 'ERR_FS_INVALID_SYMLINK_TYPE',
-    type: Error,
-    message:
-      'Symlink type must be one of "dir", "file", or "junction". Received "🍏"'
-  }
-);
-common.expectsError(
-  () => fs.symlinkSync('', '', '🍏'),
-  {
-    code: 'ERR_FS_INVALID_SYMLINK_TYPE',
-    type: Error,
-    message:
-      'Symlink type must be one of "dir", "file", or "junction". Received "🍏"'
-  }
-);
+const errObj = {
+  code: 'ERR_FS_INVALID_SYMLINK_TYPE',
+  name: 'Error [ERR_FS_INVALID_SYMLINK_TYPE]',
+  message:
+    'Symlink type must be one of "dir", "file", or "junction". Received "🍏"'
+};
+assert.throws(() => fs.symlink('', '', '🍏', common.mustNotCall()), errObj);
+assert.throws(() => fs.symlinkSync('', '', '🍏'), errObj);
 
 process.on('exit', function() {
   assert.notStrictEqual(linkTime, fileTime);

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -36,7 +36,7 @@ let stat;
 const msg = 'Using fs.truncate with a file descriptor is deprecated.' +
             ' Please use fs.ftruncate with a file descriptor instead.';
 
-// truncateSync
+// Check truncateSync
 fs.writeFileSync(filename, data);
 stat = fs.statSync(filename);
 assert.strictEqual(stat.size, 1024 * 16);
@@ -49,7 +49,7 @@ fs.truncateSync(filename);
 stat = fs.statSync(filename);
 assert.strictEqual(stat.size, 0);
 
-// ftruncateSync
+// Check ftruncateSync
 fs.writeFileSync(filename, data);
 const fd = fs.openSync(filename, 'r+');
 
@@ -64,18 +64,16 @@ fs.ftruncateSync(fd);
 stat = fs.statSync(filename);
 assert.strictEqual(stat.size, 0);
 
-// truncateSync
+// Check truncateSync
 common.expectWarning('DeprecationWarning', msg);
 fs.truncateSync(fd);
 
 fs.closeSync(fd);
 
-// async tests
+// Async tests
 testTruncate(common.mustCall(function(er) {
   assert.ifError(er);
-  testFtruncate(common.mustCall(function(er) {
-    assert.ifError(er);
-  }));
+  testFtruncate(common.mustCall(assert.ifError));
 }));
 
 function testTruncate(cb) {
@@ -104,7 +102,6 @@ function testTruncate(cb) {
     });
   });
 }
-
 
 function testFtruncate(cb) {
   fs.writeFile(filename, data, function(er) {
@@ -135,7 +132,6 @@ function testFtruncate(cb) {
     });
   });
 }
-
 
 // Make sure if the size of the file is smaller than the length then it is
 // filled with zeroes.

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -184,7 +184,8 @@ function testFtruncate(cb) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "len" argument must be of type integer'
+        message: 'The "len" argument must be of type number. ' +
+                 `Received type ${typeof input}`
       }
     );
   });
@@ -213,7 +214,8 @@ function testFtruncate(cb) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "fd" argument must be of type integer'
+        message: 'The "fd" argument must be of type number. ' +
+                 `Received type ${typeof input}`
       }
     );
   });

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -182,12 +182,12 @@ function testFtruncate(cb) {
   const fd = fs.openSync(file5, 'r+');
   process.on('exit', () => fs.closeSync(fd));
 
-  ['', false, null, {}, []].forEach((i) => {
-    common.expectsError(
-      () => fs.ftruncate(fd, i),
+  ['', false, null, {}, []].forEach((input) => {
+    assert.throws(
+      () => fs.ftruncate(fd, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "len" argument must be of type integer'
       }
     );
@@ -210,21 +210,15 @@ function testFtruncate(cb) {
   }));
 }
 
-['', false, null, undefined, {}, []].forEach((i) => {
-  common.expectsError(
-    () => fs.ftruncate(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
-  common.expectsError(
-    () => fs.ftruncateSync(i),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "fd" argument must be of type integer'
-    }
-  );
+['', false, null, undefined, {}, []].forEach((input) => {
+  ['ftruncate', 'ftruncateSync'].forEach((fnName) => {
+    assert.throws(
+      () => fs[fnName](input),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        message: 'The "fd" argument must be of type integer'
+      }
+    );
+  });
 });

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -101,8 +101,10 @@ function testIt(atime, mtime, callback) {
     common.expectsError(
       () => fs.futimesSync(-1, atime, mtime),
       {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError
+        code: 'ERR_OUT_OF_RANGE',
+        type: RangeError,
+        message: 'The value of "fd" is out of range. ' +
+                'It must be >= 0 && < 4294967296. Received -1'
       }
     );
     tests_run++;
@@ -130,8 +132,10 @@ function testIt(atime, mtime, callback) {
         common.expectsError(
           () => fs.futimes(-1, atime, mtime, common.mustNotCall()),
           {
-            code: 'ERR_INVALID_ARG_TYPE',
-            type: TypeError,
+            code: 'ERR_OUT_OF_RANGE',
+            type: RangeError,
+            message: 'The value of "fd" is out of range. ' +
+                    'It must be >= 0 && < 4294967296. Received -1'
           }
         );
 

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -111,10 +111,10 @@ function testIt(atime, mtime, callback) {
   //
   // test async code paths
   //
-  fs.utimes(tmpdir.path, atime, mtime, common.mustCall(function(err) {
+  fs.utimes(tmpdir.path, atime, mtime, common.mustCall((err) => {
     expect_ok('utimes', tmpdir.path, err, atime, mtime);
 
-    fs.utimes('foobarbaz', atime, mtime, common.mustCall(function(err) {
+    fs.utimes('foobarbaz', atime, mtime, common.mustCall((err) => {
       expect_errno('utimes', 'foobarbaz', err, 'ENOENT');
 
       // don't close this fd
@@ -124,7 +124,7 @@ function testIt(atime, mtime, callback) {
         fd = fs.openSync(tmpdir.path, 'r');
       }
 
-      fs.futimes(fd, atime, mtime, common.mustCall(function(err) {
+      fs.futimes(fd, atime, mtime, common.mustCall((err) => {
         expect_ok('futimes', fd, err, atime, mtime);
 
         common.expectsError(
@@ -148,19 +148,19 @@ function testIt(atime, mtime, callback) {
 
 const stats = fs.statSync(tmpdir.path);
 
-// run tests
+// Run tests
 const runTest = common.mustCall(testIt, 1);
 
-runTest(new Date('1982-09-10 13:37'), new Date('1982-09-10 13:37'), function() {
-  runTest(new Date(), new Date(), function() {
-    runTest(123456.789, 123456.789, function() {
-      runTest(stats.mtime, stats.mtime, function() {
-        runTest('123456', -1, function() {
+runTest(new Date('1982-09-10 13:37'), new Date('1982-09-10 13:37'), () => {
+  runTest(new Date(), new Date(), () => {
+    runTest(123456.789, 123456.789, () => {
+      runTest(stats.mtime, stats.mtime, () => {
+        runTest('123456', -1, () => {
           runTest(
             new Date('2017-04-08T17:59:38.008Z'),
             new Date('2017-04-08T17:59:38.008Z'),
-            common.mustCall(function() {
-              // done
+            common.mustCall(() => {
+              // Done
             })
           );
         });
@@ -169,7 +169,7 @@ runTest(new Date('1982-09-10 13:37'), new Date('1982-09-10 13:37'), function() {
   });
 });
 
-process.on('exit', function() {
+process.on('exit', () => {
   assert.strictEqual(tests_ok, tests_run - 2);
 });
 

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 
-// tests if `filename` is provided to watcher on supported platforms
+// Tests if `filename` is provided to watcher on supported platforms
 
 const fs = require('fs');
 const assert = require('assert');
@@ -41,7 +41,7 @@ tmpdir.refresh();
 for (const testCase of cases) {
   if (testCase.shouldSkip) continue;
   fs.mkdirSync(testCase.dirPath);
-  // long content so it's actually flushed.
+  // Long content so it's actually flushed.
   const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
   fs.writeFileSync(testCase.filePath, content1);
 
@@ -65,13 +65,13 @@ for (const testCase of cases) {
       assert.strictEqual(eventType, 'change');
     assert.strictEqual(argFilename, testCase.fileName);
 
-    watcher.start();  // starting a started watcher should be a noop
-    // end of test case
+    watcher.start(); // Starting a started watcher should be a noop
+    // End of test case
     watcher.close();
-    watcher.close(); // closing a closed watcher should be a noop
+    watcher.close(); // Closing a closed watcher should be a noop
   }));
 
-  // long content so it's actually flushed. toUpperCase so there's real change.
+  // Long content so it's actually flushed. toUpperCase so there's real change.
   const content2 = Date.now() + testCase.fileName.toUpperCase().repeat(1e4);
   interval = setInterval(() => {
     fs.writeFileSync(testCase.filePath, '');

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -79,14 +79,14 @@ for (const testCase of cases) {
   }, 100);
 }
 
-[false, 1, {}, [], null, undefined].forEach((i) => {
+[false, 1, {}, [], null, undefined].forEach((input) => {
   common.expectsError(
-    () => fs.watch(i, common.mustNotCall()),
+    () => fs.watch(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "filename" argument must be one of ' +
-               'type string, Buffer, or URL'
+      message: 'The "filename" argument must be one of type string, Buffer, ' +
+               `or URL. Received type ${typeof input}`
     }
   );
 });

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -52,8 +52,8 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "Agent option" argument must be one of type ' +
-                 'Agent-like Object, undefined, or false'
+        message: 'The "options.agent" property must be one of type Agent-like' +
+                 ` Object, undefined, or false. Received type ${typeof agent}`
       }
     );
   });

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -71,7 +71,8 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_INVALID_ARG_TYPE',
           type: TypeError,
-          message: 'The "name" argument must be of type string'
+          message: 'The "name" argument must be of type string. ' +
+                   'Received type undefined'
         }
       );
       common.expectsError(
@@ -79,7 +80,8 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_INVALID_ARG_TYPE',
           type: TypeError,
-          message: 'The "name" argument must be of type string'
+          message: 'The "name" argument must be of type string. ' +
+                   'Received type undefined'
         }
       );
 
@@ -122,7 +124,8 @@ const s = http.createServer(common.mustCall((req, res) => {
           {
             code: 'ERR_INVALID_ARG_TYPE',
             type: TypeError,
-            message: 'The "name" argument must be of type string'
+            message: 'The "name" argument must be of type string. ' +
+                     `Received type ${typeof val}`
           }
         );
       });

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -79,7 +79,8 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The first argument must be one of type string or Buffer'
+  message: 'The first argument must be one of type string or Buffer. ' +
+           'Received type undefined'
 });
 
 common.expectsError(() => {
@@ -88,7 +89,8 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The first argument must be one of type string or Buffer'
+  message: 'The first argument must be one of type string or Buffer. ' +
+           'Received type number'
 });
 
 // addTrailers()

--- a/test/parallel/test-http2-client-setNextStreamID-errors.js
+++ b/test/parallel/test-http2-client-setNextStreamID-errors.js
@@ -48,7 +48,8 @@ server.listen(0, common.mustCall(() => {
         {
           type: TypeError,
           code: 'ERR_INVALID_ARG_TYPE',
-          message: 'The "id" argument must be of type number'
+          message: 'The "id" argument must be of type number. Received type ' +
+                   typeof value
         }
       );
     });

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -45,12 +45,12 @@ server.listen(0, common.mustCall(function() {
     // change the request method
     request.method = 'POST';
     assert.strictEqual(request.method, 'POST');
-    common.expectsError(
+    assert.throws(
       () => request.method = '   ',
       {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "method" argument must be of type string'
+        code: 'ERR_INVALID_ARG_VALUE',
+        name: 'TypeError [ERR_INVALID_ARG_VALUE]',
+        message: "The argument 'method' is invalid. Received '   '"
       }
     );
     assert.throws(
@@ -58,7 +58,8 @@ server.listen(0, common.mustCall(function() {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "method" argument must be of type string'
+        message: 'The "method" argument must be of type string. ' +
+                 'Received type boolean'
       }
     );
 

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -41,7 +41,7 @@ server.listen(0, common.mustCall(function() {
     request.url = '/one';
     assert.strictEqual(request.url, '/one');
 
-    // third-party plugins for packages like express use query params to
+    // Third-party plugins for packages like express use query params to
     // change the request method
     request.method = 'POST';
     assert.strictEqual(request.method, 'POST');

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -53,11 +53,11 @@ server.listen(0, common.mustCall(function() {
         message: 'The "method" argument must be of type string'
       }
     );
-    common.expectsError(
+    assert.throws(
       () => request.method = true,
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "method" argument must be of type string'
       }
     );

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -41,30 +41,17 @@ server.listen(0, common.mustCall(function() {
     response.removeHeader(denormalised);
     assert.strictEqual(response.hasHeader(denormalised), false);
 
-    common.expectsError(
-      () => response.hasHeader(),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "name" argument must be of type string'
-      }
-    );
-    common.expectsError(
-      () => response.getHeader(),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "name" argument must be of type string'
-      }
-    );
-    common.expectsError(
-      () => response.removeHeader(),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        type: TypeError,
-        message: 'The "name" argument must be of type string'
-      }
-    );
+    ['hasHeader', 'getHeader', 'removeHeader'].forEach((fnName) => {
+      assert.throws(
+        () => response[fnName](),
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+          message: 'The "name" argument must be of type string. Received ' +
+                   'type undefined'
+        }
+      );
+    });
 
     [
       ':status',
@@ -95,11 +82,12 @@ server.listen(0, common.mustCall(function() {
       message: 'Invalid value "undefined" for header "foo-bar"'
     });
     common.expectsError(
-      () => response.setHeader(), // header name undefined
+      () => response.setHeader(), // Header name undefined
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "name" argument must be of type string'
+        message: 'The "name" argument must be of type string. Received type ' +
+                 'undefined'
       }
     );
     common.expectsError(

--- a/test/parallel/test-http2-compat-serverresponse-trailers.js
+++ b/test/parallel/test-http2-compat-serverresponse-trailers.js
@@ -40,11 +40,12 @@ server.listen(0, common.mustCall(() => {
       }
     );
     common.expectsError(
-      () => response.setTrailer(), // trailer name undefined
+      () => response.setTrailer(), // Trailer name undefined
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "name" argument must be of type string'
+        message: 'The "name" argument must be of type string. Received type ' +
+                 'undefined'
       }
     );
     common.expectsError(

--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -4,19 +4,19 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const http2 = require('http2');
 
-const invalidOptions = [() => {}, 1, 'test', null];
-const invalidArgTypeError = {
-  type: TypeError,
-  code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "options" argument must be of type Object'
-};
-
 // Error if options are not passed to createSecureServer
+const invalidOptions = [() => {}, 1, 'test', null];
 invalidOptions.forEach((invalidOption) => {
-  common.expectsError(
+  assert.throws(
     () => http2.createSecureServer(invalidOption),
-    invalidArgTypeError
+    {
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "options" argument must be of type Object. Received ' +
+               `type ${typeof invalidOption}`
+    }
   );
 });

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -99,14 +99,15 @@ http2.getPackedSettings({ enablePush: false });
     0x00, 0x00, 0x00, 0x64, 0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
     0x00, 0x02, 0x00, 0x00, 0x00, 0x01]);
 
-  [1, true, '', [], {}, NaN].forEach((i) => {
+  [1, true, '', [], {}, NaN].forEach((input) => {
     common.expectsError(() => {
-      http2.getUnpackedSettings(i);
+      http2.getUnpackedSettings(input);
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message:
-        'The "buf" argument must be one of type Buffer, TypedArray, or DataView'
+        'The "buf" argument must be one of type Buffer, TypedArray, or ' +
+        `DataView. Received type ${typeof input}`
     });
   });
 

--- a/test/parallel/test-http2-invalidargtypes-errors.js
+++ b/test/parallel/test-http2-invalidargtypes-errors.js
@@ -13,7 +13,8 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "code" argument must be of type number'
+      message: 'The "code" argument must be of type number. ' +
+               'Received type string'
     }
   );
   stream.respond();

--- a/test/parallel/test-http2-misc-util.js
+++ b/test/parallel/test-http2-misc-util.js
@@ -35,7 +35,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "test" argument must be of type Object'
+    message: 'The "test" argument must be of type Object. Received type string'
   });
 
 common.expectsError(
@@ -43,7 +43,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "test" argument must be of type Date'
+    message: 'The "test" argument must be of type Date. Received type string'
   });
 
 assertIsObject({}, 'test');

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -81,14 +81,14 @@ server.listen(0, common.mustCall(() => {
 
     // should throw if payload is not of type ArrayBufferView
     {
-      [1, true, {}, []].forEach((invalidPayload) =>
+      [1, true, {}, []].forEach((payload) =>
         common.expectsError(
-          () => client.ping(invalidPayload),
+          () => client.ping(payload),
           {
             type: TypeError,
             code: 'ERR_INVALID_ARG_TYPE',
-            message: 'The "payload" argument must be one of type' +
-                     ' Buffer, TypedArray, or DataView'
+            message: 'The "payload" argument must be one of type Buffer, ' +
+                     `TypedArray, or DataView. Received type ${typeof payload}`
           }
         )
       );

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -79,7 +79,7 @@ server.listen(0, common.mustCall(() => {
       message: 'HTTP2 ping cancelled'
     })));
 
-    // should throw if payload is not of type ArrayBufferView
+    // Should throw if payload is not of type ArrayBufferView
     {
       [1, true, {}, []].forEach((payload) =>
         common.expectsError(
@@ -94,7 +94,7 @@ server.listen(0, common.mustCall(() => {
       );
     }
 
-    // should throw if payload length is not 8
+    // Should throw if payload length is not 8
     {
       const shortPayload = Buffer.from('abcdefg');
       const longPayload = Buffer.from('abcdefghi');
@@ -110,7 +110,7 @@ server.listen(0, common.mustCall(() => {
       );
     }
 
-    // should throw error is callback is not of type function
+    // Should throw error is callback is not of type function
     {
       const payload = Buffer.from('abcdefgh');
       [1, true, {}, []].forEach((invalidCallback) =>

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -43,7 +43,8 @@ server.on('stream', common.mustCall((stream) => {
       {
         type: TypeError,
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "fd" argument must be of type number'
+        message: 'The "fd" argument must be of type number. Received type ' +
+                 typeof types[type]
       }
     );
   });

--- a/test/parallel/test-http2-server-shutdown-options-errors.js
+++ b/test/parallel/test-http2-server-shutdown-options-errors.js
@@ -18,30 +18,32 @@ const types = [
 server.on('stream', common.mustCall((stream) => {
   const session = stream.session;
 
-  types.forEach((i) => {
+  types.forEach((input) => {
     common.expectsError(
-      () => session.goaway(i),
+      () => session.goaway(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "code" argument must be of type number'
+        message: 'The "code" argument must be of type number. Received type ' +
+                 typeof input
       }
     );
     common.expectsError(
-      () => session.goaway(0, i),
+      () => session.goaway(0, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "lastStreamID" argument must be of type number'
+        message: 'The "lastStreamID" argument must be of type number. ' +
+                 `Received type ${typeof input}`
       }
     );
     common.expectsError(
-      () => session.goaway(0, 0, i),
+      () => session.goaway(0, 0, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "opaqueData" argument must be one of type Buffer, ' +
-                 'TypedArray, or DataView'
+                 `TypedArray, or DataView. Received type ${typeof input}`
       }
     );
   });

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -13,8 +13,8 @@ const {
   Object.create(null),
   new Date(),
   new (class Foo {})()
-].forEach((i) => {
-  assertIsObject(i, 'foo', 'Object');
+].forEach((input) => {
+  assertIsObject(input, 'foo', 'Object');
 });
 
 [
@@ -39,5 +39,5 @@ assertWithinRange('foo', 1, 0, 2);
 common.expectsError(() => assertWithinRange('foo', 1, 2, 3),
                     {
                       code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-                      message: /^Invalid value for setting "foo": 1$/
+                      message: 'Invalid value for setting "foo": 1'
                     });

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -25,11 +25,12 @@ const {
   Infinity,
   [],
   [{}]
-].forEach((i) => {
-  common.expectsError(() => assertIsObject(i, 'foo', 'Object'),
+].forEach((input) => {
+  common.expectsError(() => assertIsObject(input, 'foo', 'Object'),
                       {
                         code: 'ERR_INVALID_ARG_TYPE',
-                        message: /^The "foo" argument must be of type Object$/
+                        message: 'The "foo" argument must be of type Object. ' +
+                                 `Received type ${typeof input}`
                       });
 });
 

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -6,6 +6,7 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const https = require('https');
 
 function toArrayBuffer(buf) {
@@ -38,8 +39,6 @@ const caArrBuff = toArrayBuffer(caCert);
 const keyDataView = toDataView(keyBuff);
 const certDataView = toDataView(certBuff);
 const caArrDataView = toDataView(caCert);
-const invalidKeyRE = /^The "key" argument must be one of type string, Buffer, TypedArray, or DataView$/;
-const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, TypedArray, or DataView$/;
 
 // Checks to ensure https.createServer doesn't throw an error
 // Format ['key', 'cert']
@@ -63,50 +62,59 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [false, [certStr, certStr2]],
   [[{ pem: keyBuff }], false],
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
-].forEach((params) => {
-  https.createServer({
-    key: params[0],
-    cert: params[1]
-  });
+].forEach(([key, cert]) => {
+  https.createServer({ key, cert });
 });
 
 // Checks to ensure https.createServer predictably throws an error
 // Format ['key', 'cert', 'expected message']
 [
-  [true, certBuff, invalidKeyRE],
-  [keyBuff, true, invalidCertRE],
-  [true, certStr, invalidKeyRE],
-  [keyStr, true, invalidCertRE],
-  [true, certArrBuff, invalidKeyRE],
-  [keyArrBuff, true, invalidCertRE],
-  [true, certDataView, invalidKeyRE],
-  [keyDataView, true, invalidCertRE],
-  [true, true, invalidCertRE],
-  [true, false, invalidKeyRE],
-  [false, true, invalidCertRE],
-  [true, false, invalidKeyRE],
-  [{ pem: keyBuff }, false, invalidKeyRE],
-  [false, { pem: keyBuff }, invalidCertRE],
-  [1, false, invalidKeyRE],
-  [false, 1, invalidCertRE],
-  [[keyBuff, true], [certBuff, certBuff2], invalidKeyRE],
-  [[true, keyStr2], [certStr, certStr2], invalidKeyRE],
-  [[keyBuff, keyBuff2], [true, certBuff2], invalidCertRE],
-  [[keyStr, keyStr2], [certStr, true], invalidCertRE],
-  [[true, false], [certBuff, certBuff2], invalidKeyRE],
-  [[keyStr, keyStr2], [true, false], invalidCertRE],
-  [[keyStr, keyStr2], true, invalidCertRE],
-  [true, [certBuff, certBuff2], invalidKeyRE]
-].forEach((params) => {
-  common.expectsError(() => {
-    https.createServer({
-      key: params[0],
-      cert: params[1]
-    });
+  [true, certBuff],
+  [true, certStr],
+  [true, certArrBuff],
+  [true, certDataView],
+  [true, false],
+  [true, false],
+  [{ pem: keyBuff }, false, 'pem'],
+  [1, false],
+  [[keyBuff, true], [certBuff, certBuff2], 1],
+  [[true, keyStr2], [certStr, certStr2], 0],
+  [[true, false], [certBuff, certBuff2], 0],
+  [true, [certBuff, certBuff2]]
+].forEach(([key, cert, index]) => {
+  const type = typeof (index === undefined ? key : key[index]);
+  assert.throws(() => {
+    https.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: params[2]
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "key" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
+  });
+});
+
+[
+  [keyBuff, true],
+  [keyStr, true],
+  [keyArrBuff, true],
+  [keyDataView, true],
+  [true, true],
+  [false, true],
+  [false, { pem: keyBuff }, 'pem'],
+  [false, 1],
+  [[keyBuff, keyBuff2], [true, certBuff2], 0],
+  [[keyStr, keyStr2], [certStr, true], 1],
+  [[keyStr, keyStr2], [true, false], 0],
+  [[keyStr, keyStr2], true],
+].forEach(([key, cert, index]) => {
+  const type = typeof (index === undefined ? cert : cert[index]);
+  assert.throws(() => {
+    https.createServer({ key, cert });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "cert" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
   });
 });
 
@@ -120,12 +128,8 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, caArrBuff],
   [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
-].forEach((params) => {
-  https.createServer({
-    key: params[0],
-    cert: params[1],
-    ca: params[2]
-  });
+].forEach(([key, cert, ca]) => {
+  https.createServer({ key, cert, ca });
 });
 
 // Checks to ensure https.createServer throws an error for CA assignment
@@ -135,17 +139,15 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, {}],
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
-  [keyBuff, certBuff, [caCert, true]]
-].forEach((params) => {
-  common.expectsError(() => {
-    https.createServer({
-      key: params[0],
-      cert: params[1],
-      ca: params[2]
-    });
+  [keyBuff, certBuff, [caCert, true], 1]
+].forEach(([key, cert, ca, index]) => {
+  const type = typeof (index ? ca[index] : ca);
+  assert.throws(() => {
+    https.createServer({ key, cert, ca });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "ca" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
   });
 });

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -47,7 +47,7 @@ common.expectsError(
     type: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "source" argument must be one of type Buffer ' +
-             'or Uint8Array. Received type null'
+             'or Uint8Array. Received type object'
   }
 );
 

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -90,36 +90,6 @@ common.expectsError(() => {
   message: /.+ does not match \S/
 });
 
-// // Test ERR_INVALID_ARG_TYPE
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', 'b']),
-                   'The "a" argument must be of type b');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', ['b']]),
-                   'The "a" argument must be of type b');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', ['b', 'c']]),
-                   'The "a" argument must be one of type b or c');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE',
-                                  ['a', ['b', 'c', 'd']]),
-                   'The "a" argument must be one of type b, c, or d');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', 'b', 'c']),
-                   'The "a" argument must be of type b. Received type string');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE',
-                                  ['a', 'b', undefined]),
-                   'The "a" argument must be of type b. Received type ' +
-                   'undefined');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE',
-                                  ['a', 'b', null]),
-                   'The "a" argument must be of type b. Received type null');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', 'not b']),
-                   'The "a" argument must not be of type b');
-assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a.b', 'not c']),
-                   'The "a.b" property must not be of type c');
-assert.strictEqual(
-  errors.message('ERR_INVALID_ARG_TYPE', ['first argument', 'c']),
-  'The first argument must be of type c');
-assert.strictEqual(
-  errors.message('ERR_INVALID_ARG_TYPE', [['a', 'b', 'c'], 'not d']),
-  'The "a", "b", "c" arguments must not be of type d');
-
 // Test ERR_INVALID_FD_TYPE
 assert.strictEqual(errors.message('ERR_INVALID_FD_TYPE', ['a']),
                    'Unsupported fd type: a');

--- a/test/parallel/test-net-connect-buffer.js
+++ b/test/parallel/test-net-connect-buffer.js
@@ -62,16 +62,16 @@ tcp.listen(0, common.mustCall(function() {
     undefined,
     1,
     1.0,
-    1 / 0,
     +Infinity,
     -Infinity,
     [],
     {}
-  ].forEach((v) => {
-    common.expectsError(() => socket.write(v), {
+  ].forEach((value) => {
+    common.expectsError(() => socket.write(value), {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "chunk" argument must be one of type string or Buffer'
+      message: 'The "chunk" argument must be one of type string or Buffer. ' +
+               `Received type ${typeof value}`
     });
   });
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -220,10 +220,6 @@ function checkFormat(path, testCases) {
     assert.strictEqual(path.format(testCase[0]), testCase[1]);
   });
 
-  function typeName(value) {
-    return value === null ? 'null' : typeof value;
-  }
-
   [null, undefined, 1, true, false, 'string'].forEach((pathObject) => {
     common.expectsError(() => {
       path.format(pathObject);
@@ -231,7 +227,7 @@ function checkFormat(path, testCases) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "pathObject" argument must be of type Object. ' +
-               `Received type ${typeName(pathObject)}`
+               `Received type ${typeof pathObject}`
     });
   });
 }

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -70,12 +70,13 @@ const {
 }
 
 {
-  [1, {}, [], null, undefined, Infinity].forEach((i) => {
-    common.expectsError(() => performance.timerify(i),
+  [1, {}, [], null, undefined, Infinity].forEach((input) => {
+    common.expectsError(() => performance.timerify(input),
                         {
                           code: 'ERR_INVALID_ARG_TYPE',
                           type: TypeError,
-                          message: 'The "fn" argument must be of type Function'
+                          message: 'The "fn" argument must be of type ' +
+                                   `Function. Received type ${typeof input}`
                         });
   });
 }

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -37,14 +37,14 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
   });
   const observer = new PerformanceObserver(common.mustNotCall());
 
-  [1, null, undefined].forEach((i) => {
-    //observer.observe(i);
+  [1, null, undefined].forEach((input) => {
     common.expectsError(
-      () => observer.observe(i),
+      () => observer.observe(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "options" argument must be of type Object'
+        message: 'The "options" argument must be of type Object. ' +
+                 `Received type ${typeof input}`
       });
   });
 

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 const assert = require('assert');
-const common = require('../common');
 const result = process.cpuUsage();
 
 // Validate the result of calling with no previous value argument.
@@ -31,65 +31,80 @@ for (let i = 0; i < 10; i++) {
   assert(diffUsage.user >= 0);
   assert(diffUsage.system >= 0);
 }
-const invalidUserArgument = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "preValue.user" property must be of type number'
-}, 8);
-
-const invalidSystemArgument = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "preValue.system" property must be of type number'
-}, 2);
-
 
 // Ensure that an invalid shape for the previous value argument throws an error.
-assert.throws(() => {
-  process.cpuUsage(1);
-}, invalidUserArgument);
+assert.throws(
+  () => process.cpuUsage(1),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "prevValue" argument must be of type object. ' +
+             'Received type number'
+  }
+);
 
-assert.throws(() => {
-  process.cpuUsage({});
-}, invalidUserArgument);
+// Check invalid types.
+[
+  {},
+  { user: 'a' },
+  { user: null, system: 'c' },
+].forEach((value) => {
+  assert.throws(
+    () => process.cpuUsage(value),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "prevValue.user" property must be of type number. ' +
+               `Received type ${typeof value.user}`
+    }
+  );
+});
 
-assert.throws(() => {
-  process.cpuUsage({ user: 'a' });
-}, invalidUserArgument);
+[
+  { user: 3, system: 'b' },
+  { user: 3, system: null }
+].forEach((value) => {
+  assert.throws(
+    () => process.cpuUsage(value),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "prevValue.system" property must be of type number. ' +
+               `Received type ${typeof value.system}`
+    }
+  );
+});
 
-assert.throws(() => {
-  process.cpuUsage({ system: 'b' });
-}, invalidUserArgument);
+// Check invalid values.
+[
+  { user: -1, system: 2 },
+  { user: Number.POSITIVE_INFINITY, system: 4 }
+].forEach((value) => {
+  assert.throws(
+    () => process.cpuUsage(value),
+    {
+      code: 'ERR_INVALID_OPT_VALUE',
+      name: 'RangeError [ERR_INVALID_OPT_VALUE]',
+      message: `The value "${value.user}" is invalid ` +
+               'for option "prevValue.user"'
+    }
+  );
+});
 
-assert.throws(() => {
-  process.cpuUsage({ user: null, system: 'c' });
-}, invalidUserArgument);
-
-assert.throws(() => {
-  process.cpuUsage({ user: 'd', system: null });
-}, invalidUserArgument);
-
-assert.throws(() => {
-  process.cpuUsage({ user: -1, system: 2 });
-}, invalidUserArgument);
-
-assert.throws(() => {
-  process.cpuUsage({ user: 3, system: -2 });
-}, invalidSystemArgument);
-
-assert.throws(() => {
-  process.cpuUsage({
-    user: Number.POSITIVE_INFINITY,
-    system: 4
-  });
-}, invalidUserArgument);
-
-assert.throws(() => {
-  process.cpuUsage({
-    user: 5,
-    system: Number.NEGATIVE_INFINITY
-  });
-}, invalidSystemArgument);
+[
+  { user: 3, system: -2 },
+  { user: 5, system: Number.NEGATIVE_INFINITY }
+].forEach((value) => {
+  assert.throws(
+    () => process.cpuUsage(value),
+    {
+      code: 'ERR_INVALID_OPT_VALUE',
+      name: 'RangeError [ERR_INVALID_OPT_VALUE]',
+      message: `The value "${value.system}" is invalid ` +
+               'for option "prevValue.system"'
+    }
+  );
+});
 
 // Ensure that the return value is the expected shape.
 function validateResult(result) {

--- a/test/parallel/test-process-exception-capture-errors.js
+++ b/test/parallel/test-process-exception-capture-errors.js
@@ -6,7 +6,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "fn" argument must be one of type Function or null'
+    message: 'The "fn" argument must be one of type Function or null. ' +
+             'Received type number'
   }
 );
 

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -38,24 +38,14 @@ const assert = require('assert');
 //
 // process.pid, String(process.pid): ourself
 
-const invalidPidArgument = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "pid" argument must be of type number'
-}, 6);
-
-assert.throws(function() { process.kill('SIGTERM'); },
-              invalidPidArgument);
-assert.throws(function() { process.kill(null); },
-              invalidPidArgument);
-assert.throws(function() { process.kill(undefined); },
-              invalidPidArgument);
-assert.throws(function() { process.kill(+'not a number'); },
-              invalidPidArgument);
-assert.throws(function() { process.kill(1 / 0); },
-              invalidPidArgument);
-assert.throws(function() { process.kill(-1 / 0); },
-              invalidPidArgument);
+['SIGTERM', null, undefined, NaN, Infinity, -Infinity].forEach((val) => {
+  assert.throws(() => process.kill(val), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "pid" argument must be of type number. ' +
+             `Received type ${typeof val}`
+  });
+});
 
 // Test that kill throws an error for unknown signal names
 common.expectsError(() => process.kill(0, 'test'), {

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -26,7 +26,8 @@ common.expectsError(() => tls.createServer({ handshakeTimeout: 'abcd' }),
                     {
                       code: 'ERR_INVALID_ARG_TYPE',
                       type: TypeError,
-                      message: 'The "timeout" argument must be of type number'
+                      message: 'The "timeout" argument must ' +
+                               'be of type number'
                     }
 );
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -26,8 +26,8 @@ common.expectsError(() => tls.createServer({ handshakeTimeout: 'abcd' }),
                     {
                       code: 'ERR_INVALID_ARG_TYPE',
                       type: TypeError,
-                      message: 'The "timeout" argument must ' +
-                               'be of type number'
+                      message: 'The "options.handshakeTimeout" property must ' +
+                               'be of type number. Received type string'
                     }
 );
 

--- a/test/parallel/test-tls-error-servername.js
+++ b/test/parallel/test-tls-error-servername.js
@@ -27,7 +27,8 @@ const client = connect({
     client.setServername(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "name" argument must be of type string'
+    message: 'The "name" argument must be of type string. ' +
+             `Received type ${typeof value}`
   });
 });
 

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -43,7 +43,8 @@ common.expectsError(() => tls.createServer('this is not valid'),
                     {
                       code: 'ERR_INVALID_ARG_TYPE',
                       type: TypeError,
-                      message: 'The "options" argument must be of type Object'
+                      message: 'The "options" argument must be of type ' +
+                               'Object. Received type string'
                     }
 );
 

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -38,8 +38,6 @@ const caArrBuff = toArrayBuffer(caCert);
 const keyDataView = toDataView(keyBuff);
 const certDataView = toDataView(certBuff);
 const caArrDataView = toDataView(caCert);
-const invalidKeyRE = /^The "key" argument must be one of type string, Buffer, TypedArray, or DataView$/;
-const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, TypedArray, or DataView$/;
 
 // Checks to ensure tls.createServer doesn't throw an error
 // Format ['key', 'cert']
@@ -70,37 +68,51 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
 // Checks to ensure tls.createServer predictably throws an error
 // Format ['key', 'cert', 'expected message']
 [
-  [true, certBuff, invalidKeyRE],
-  [keyBuff, true, invalidCertRE],
-  [true, certStr, invalidKeyRE],
-  [keyStr, true, invalidCertRE],
-  [true, certArrBuff, invalidKeyRE],
-  [keyArrBuff, true, invalidCertRE],
-  [true, certDataView, invalidKeyRE],
-  [keyDataView, true, invalidCertRE],
-  [true, true, invalidCertRE],
-  [true, false, invalidKeyRE],
-  [false, true, invalidCertRE],
-  [true, false, invalidKeyRE],
-  [{ pem: keyBuff }, false, invalidKeyRE],
-  [false, { pem: keyBuff }, invalidCertRE],
-  [1, false, invalidKeyRE],
-  [false, 1, invalidCertRE],
-  [[keyBuff, true], [certBuff, certBuff2], invalidKeyRE],
-  [[true, keyStr2], [certStr, certStr2], invalidKeyRE],
-  [[keyBuff, keyBuff2], [true, certBuff2], invalidCertRE],
-  [[keyStr, keyStr2], [certStr, true], invalidCertRE],
-  [[true, false], [certBuff, certBuff2], invalidKeyRE],
-  [[keyStr, keyStr2], [true, false], invalidCertRE],
-  [[keyStr, keyStr2], true, invalidCertRE],
-  [true, [certBuff, certBuff2], invalidKeyRE]
-].forEach(([key, cert, message]) => {
+  [true, certBuff],
+  [true, certStr],
+  [true, certArrBuff],
+  [true, certDataView],
+  [true, false],
+  [true, false],
+  [{ pem: keyBuff }, false, 'pem'],
+  [[keyBuff, true], [certBuff, certBuff2], 1],
+  [[true, keyStr2], [certStr, certStr2], 0],
+  [[true, false], [certBuff, certBuff2], 0],
+  [true, [certBuff, certBuff2]]
+].forEach(([key, cert, index]) => {
+  const type = typeof (index === undefined ? key : key[index]);
   common.expectsError(() => {
     tls.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message
+    message: 'The "key" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
+  });
+});
+
+[
+  [keyBuff, true],
+  [keyStr, true],
+  [keyArrBuff, true],
+  [keyDataView, true],
+  [true, true],
+  [false, true],
+  [false, { pem: keyBuff }, 'pem'],
+  [false, 1],
+  [[keyBuff, keyBuff2], [true, certBuff2], 0],
+  [[keyStr, keyStr2], [certStr, true], 1],
+  [[keyStr, keyStr2], [true, false], 0],
+  [[keyStr, keyStr2], true]
+].forEach(([key, cert, index]) => {
+  const type = typeof (index === undefined ? cert : cert[index]);
+  common.expectsError(() => {
+    tls.createServer({ key, cert });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "cert" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
   });
 });
 
@@ -125,32 +137,16 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, {}],
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
-  [keyBuff, certBuff, [caCert, true]]
-].forEach(([key, cert, ca]) => {
+  [keyBuff, certBuff, [caCert, true], 1]
+].forEach(([key, cert, ca, index]) => {
+  const type = typeof (index === undefined ? ca : ca[index]);
   common.expectsError(() => {
     tls.createServer({ key, cert, ca });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
-  });
-});
-
-// Checks to ensure tls.createServer throws an error for CA assignment
-// Format ['key', 'cert', 'ca']
-[
-  [keyBuff, certBuff, true],
-  [keyBuff, certBuff, {}],
-  [keyBuff, certBuff, 1],
-  [keyBuff, certBuff, true],
-  [keyBuff, certBuff, [caCert, true]]
-].forEach(([key, cert, ca]) => {
-  common.expectsError(() => {
-    tls.createServer({ key, cert, ca });
-  }, {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
+    message: 'The "ca" argument must be one of type string, Buffer, ' +
+             `TypedArray, or DataView. Received type ${type}`
   });
 });
 

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -5,7 +5,7 @@ const url = require('url');
 
 const throwsObjsAndReportTypes = new Map([
   [undefined, 'undefined'],
-  [null, 'null'],
+  [null, 'object'],
   [true, 'boolean'],
   [false, 'boolean'],
   [0, 'number'],

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -21,15 +21,17 @@ assert.strictEqual(
 );
 
 {
-  const expectedErr = common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "options" argument must be of type Object'
-  }, 4);
-  assert.throws(() => url.format(myURL, true), expectedErr);
-  assert.throws(() => url.format(myURL, 1), expectedErr);
-  assert.throws(() => url.format(myURL, 'test'), expectedErr);
-  assert.throws(() => url.format(myURL, Infinity), expectedErr);
+  [true, 1, 'test', Infinity].forEach((value) => {
+    assert.throws(
+      () => url.format(myURL, value),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+        message: 'The "options" argument must be of type Object. ' +
+                 `Received type ${typeof value}`
+      }
+    );
+  });
 }
 
 // Any falsy value other than undefined will be treated as false.

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -6,7 +6,7 @@ const url = require('url');
 // https://github.com/joyent/node/issues/568
 [
   [undefined, 'undefined'],
-  [null, 'null'],
+  [null, 'object'],
   [true, 'boolean'],
   [false, 'boolean'],
   [0.0, 'number'],

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -236,7 +236,8 @@ const values = [
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "original" argument must be of type Function'
+      message: 'The "original" argument must be of type Function. ' +
+               `Received type ${typeof value}`
     });
   });
 }
@@ -257,7 +258,8 @@ const values = [
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The last argument must be of type Function'
+      message: 'The last argument must be of type Function. ' +
+               `Received type ${typeof value}`
     });
   });
 }

--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -7,6 +7,7 @@ const util = require('util');
   common.expectsError(() => util.deprecate(() => {}, 'message', notString), {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "code" argument must be of type string'
+    message: 'The "code" argument must be of type string. ' +
+             `Received type ${typeof notString}`
   });
 });

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -2,15 +2,15 @@
 
 const common = require('../common');
 const assert = require('assert');
-const inherits = require('util').inherits;
+const { inherits } = require('util');
 
-// super constructor
+// Super constructor
 function A() {
   this._a = 'a';
 }
 A.prototype.a = function() { return this._a; };
 
-// one level of inheritance
+// One level of inheritance
 function B(value) {
   A.call(this);
   this._b = value;
@@ -25,7 +25,7 @@ assert.strictEqual(b.a(), 'a');
 assert.strictEqual(b.b(), 'b');
 assert.strictEqual(b.constructor, B);
 
-// two levels of inheritance
+// Two levels of inheritance
 function C() {
   B.call(this, 'b');
   this._c = 'c';
@@ -40,7 +40,7 @@ const c = new C();
 assert.strictEqual(c.getValue(), 'abc');
 assert.strictEqual(c.constructor, C);
 
-// inherits can be called after setting prototype properties
+// Inherits can be called after setting prototype properties
 function D() {
   C.call(this);
   this._d = 'd';

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -74,13 +74,14 @@ assert.strictEqual(e.d(), 'd');
 assert.strictEqual(e.e(), 'e');
 assert.strictEqual(e.constructor, E);
 
-// should throw with invalid arguments
+// Should throw with invalid arguments
 common.expectsError(function() {
   inherits(A, {});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor.prototype" property must be of type Function'
+  message: 'The "superCtor.prototype" property must be of type Function. ' +
+           'Received type undefined'
 });
 
 common.expectsError(function() {
@@ -88,7 +89,8 @@ common.expectsError(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor" argument must be of type Function'
+  message: 'The "superCtor" argument must be of type Function. ' +
+           'Received type object'
 });
 
 common.expectsError(function() {
@@ -96,5 +98,5 @@ common.expectsError(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "ctor" argument must be of type Function'
+  message: 'The "ctor" argument must be of type Function. Received type object'
 });

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1134,7 +1134,8 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type Object'
+    message: 'The "options" argument must be of type Object. ' +
+             'Received type object'
   }
   );
 
@@ -1143,7 +1144,8 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type Object'
+    message: 'The "options" argument must be of type Object. ' +
+             'Received type string'
   }
   );
 }

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -191,6 +191,7 @@ const stat = promisify(fs.stat);
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "original" argument must be of type Function'
+      message: 'The "original" argument must be of type Function. ' +
+               `Received type ${typeof input}`
     });
 });

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -2,13 +2,14 @@
 const common = require('../common');
 const v8 = require('v8');
 
-[ 1, undefined ].forEach((i) => {
+[1, undefined].forEach((value) => {
   common.expectsError(
-    () => v8.setFlagsFromString(i),
+    () => v8.setFlagsFromString(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "flags" argument must be of type string'
+      message: 'The "flags" argument must be of type string. ' +
+               `Received type ${typeof value}`
     }
   );
 });

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -71,54 +71,35 @@ const context2 = vm.createContext(sandbox3);
 assert.strictEqual(sandbox3, context2);
 
 // Test 6: invalid arguments
-common.expectsError(() => {
-  vm.createContext({}, null);
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options" argument must be of type object. Received type null'
+[null, 'string'].forEach((input) => {
+  common.expectsError(() => {
+    vm.createContext({}, input);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "options" argument must be of type object. ' +
+             `Received type ${typeof input}`
+  });
 });
 
-common.expectsError(() => {
-  vm.createContext({}, 'string');
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options" argument must be of type object. Received type string'
+['name', 'origin'].forEach((propertyName) => {
+  common.expectsError(() => {
+    vm.createContext({}, { [propertyName]: null });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: `The "options.${propertyName}" property must be of type string. ` +
+             'Received type object'
+  });
 });
 
-common.expectsError(() => {
-  vm.createContext({}, { name: null });
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options.name" property must be of type string. ' +
-           'Received type null'
-});
-
-common.expectsError(() => {
-  vm.createContext({}, { origin: null });
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options.origin" property must be of type string. ' +
-           'Received type null'
-});
-
-common.expectsError(() => {
-  vm.runInNewContext('', {}, { contextName: null });
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options.contextName" property must be of type string. ' +
-           'Received type null'
-});
-
-common.expectsError(() => {
-  vm.runInNewContext('', {}, { contextOrigin: null });
-}, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "options.contextOrigin" property must be of type string. ' +
-           'Received type null'
+['contextName', 'contextOrigin'].forEach((propertyName) => {
+  common.expectsError(() => {
+    vm.runInNewContext('', {}, { [propertyName]: null });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: `The "options.${propertyName}" property must be of type string. ` +
+             'Received type object'
+  });
 });

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -6,14 +6,24 @@
 const common = require('../common');
 const zlib = require('zlib');
 
-[undefined, null, true, false, 0, 1, [1, 2, 3], { foo: 'bar' }].forEach((i) => {
+[
+  undefined,
+  null,
+  true,
+  false,
+  0,
+  1,
+  [1, 2, 3],
+  { foo: 'bar' }
+].forEach((input) => {
   common.expectsError(
-    () => zlib.deflateSync(i),
+    () => zlib.deflateSync(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "buffer" argument must be one of type string, Buffer, ' +
-               'TypedArray, DataView, or ArrayBuffer'
+               'TypedArray, DataView, or ArrayBuffer. ' +
+               `Received type ${typeof input}`
     }
   );
 });

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -33,7 +33,8 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message:
-      'The "a" argument must be one of type Buffer, TypedArray, or DataView'
+      'The "buf1" argument must be one of type Buffer, TypedArray, or ' +
+      'DataView. Received type string'
   }
 );
 
@@ -43,6 +44,7 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message:
-      'The "b" argument must be one of type Buffer, TypedArray, or DataView'
+      'The "buf2" argument must be one of type Buffer, TypedArray, or ' +
+      'DataView. Received type string'
   }
 );


### PR DESCRIPTION
This is a step towards better error messages. There were a couple of cases that were not handled properly right now.

This fixes all `ERR_INVALID_ARG_TYPE` errors that do not show the input value. This is from now on mandatory.

I plan on having follow-up PRs for this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
