### PR TITLE
test: improve tty.getColorDepth coverage

### DIFF
--- a/test/pseudo-tty/test-tty-get-color-depth.js
+++ b/test/pseudo-tty/test-tty-get-color-depth.js
@@ -5,9 +5,6 @@ const assert = require('assert').strict;
 /* eslint-disable no-restricted-properties */
 const { WriteStream } = require('tty');
 
-const NODE_DISABLE_COLORS = process.env.NODE_DISABLE_COLORS;
-delete process.env.NODE_DISABLE_COLORS;
-
 const fd = common.getTTYfd();
 const writeStream = new WriteStream(fd);
 
@@ -65,5 +62,3 @@ const writeStream = new WriteStream(fd);
   assert.equal(writeStream.getColorDepth({}), depth2);
   Object.defineProperty(process, 'platform', platform);
 }
-
-process.env.NODE_DISABLE_COLORS = NODE_DISABLE_COLORS;

--- a/test/pseudo-tty/test-tty-get-color-depth.js
+++ b/test/pseudo-tty/test-tty-get-color-depth.js
@@ -5,32 +5,65 @@ const assert = require('assert').strict;
 /* eslint-disable no-restricted-properties */
 const { WriteStream } = require('tty');
 
+const NODE_DISABLE_COLORS = process.env.NODE_DISABLE_COLORS;
+delete process.env.NODE_DISABLE_COLORS;
+
 const fd = common.getTTYfd();
 const writeStream = new WriteStream(fd);
 
 {
   const depth = writeStream.getColorDepth();
-
   assert.equal(typeof depth, 'number');
   assert(depth >= 1 && depth <= 24);
-
-  if (depth === 1) {
-    // Terminal does not support colors, compare to a value that would.
-    assert.notEqual(writeStream.getColorDepth({ COLORTERM: '1' }), depth);
-  } else {
-    // Terminal supports colors, compare to a value that would not.
-    assert.notEqual(writeStream.getColorDepth({ TERM: 'dumb' }), depth);
-  }
 }
 
-// Deactivate colors
+// Check different environment variables.
+[
+  [{ COLORTERM: '1' }, 4],
+  [{ TMUX: '1' }, 8],
+  [{ CI: '1' }, 1],
+  [{ CI: '1', TRAVIS: '1' }, 8],
+  [{ CI: '1', CIRCLECI: '1' }, 8],
+  [{ CI: '1', APPVEYOR: '1' }, 8],
+  [{ CI: '1', GITLAB_CI: '1' }, 8],
+  [{ CI: '1', CI_NAME: 'codeship' }, 8],
+  [{ TEAMCITY_VERSION: '1.0.0' }, 1],
+  [{ TEAMCITY_VERSION: '9.11.0' }, 4],
+  [{ TERM_PROGRAM: 'iTerm.app' }, 8],
+  [{ TERM_PROGRAM: 'iTerm.app', TERM_PROGRAM_VERSION: '3.0' }, 24],
+  [{ TERM_PROGRAM: 'iTerm.app', TERM_PROGRAM_VERSION: '2.0' }, 8],
+  [{ TERM_PROGRAM: 'HyperTerm' }, 24],
+  [{ TERM_PROGRAM: 'Hyper' }, 24],
+  [{ TERM_PROGRAM: 'MacTerm' }, 24],
+  [{ TERM_PROGRAM: 'Apple_Terminal' }, 8],
+  [{ TERM: 'xterm-256' }, 8],
+  [{ TERM: 'ansi' }, 4],
+  [{ TERM: 'ANSI' }, 4],
+  [{ TERM: 'color' }, 4],
+  [{ TERM: 'linux' }, 4],
+  [{ TERM: 'fail' }, 1],
+  [{ NODE_DISABLE_COLORS: '1' }, 1],
+  [{ TERM: 'dumb' }, 1],
+  [{ TERM: 'dumb', COLORTERM: '1' }, 4],
+].forEach(([env, depth], i) => {
+  const actual = writeStream.getColorDepth(env);
+  assert.equal(
+    actual,
+    depth,
+    `i: ${i}, expected: ${depth}, actual: ${actual}, env: ${env}`
+  );
+});
+
+// OS settings
 {
-  const tmp = process.env.NODE_DISABLE_COLORS;
-  process.env.NODE_DISABLE_COLORS = 1;
+  const platform = Object.getOwnPropertyDescriptor(process, 'platform');
+  const [ value, depth1, depth2 ] = process.platform !== 'win32' ?
+    ['win32', 1, 4] : ['linux', 4, 1];
 
-  const depth = writeStream.getColorDepth();
-
-  assert.equal(depth, 1);
-
-  process.env.NODE_DISABLE_COLORS = tmp;
+  assert.equal(writeStream.getColorDepth({}), depth1);
+  Object.defineProperty(process, 'platform', { value });
+  assert.equal(writeStream.getColorDepth({}), depth2);
+  Object.defineProperty(process, 'platform', platform);
 }
+
+process.env.NODE_DISABLE_COLORS = NODE_DISABLE_COLORS;


### PR DESCRIPTION
The `tty.getColorDepth` function has only a very basic coverage. This almost fully covers that function (there are some parts that can not really be tested).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
