### PR TITLE
n-api: re-write test_make_callback

### DIFF
--- a/test/addons-napi/test_make_callback/binding.c
+++ b/test/addons-napi/test_make_callback/binding.c
@@ -1,13 +1,13 @@
 #include <node_api.h>
 #include "../common.h"
-#include <vector>
 
-namespace {
+#define MAX_ARGUMENTS 10
 
+static
 napi_value MakeCallback(napi_env env, napi_callback_info info) {
-  const int kMaxArgs = 10;
-  size_t argc = kMaxArgs;
-  napi_value args[kMaxArgs];
+  size_t argc = MAX_ARGUMENTS;
+  size_t n;
+  napi_value args[MAX_ARGUMENTS];
   // NOLINTNEXTLINE (readability/null_usage)
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
@@ -16,9 +16,9 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   napi_value recv = args[0];
   napi_value func = args[1];
 
-  std::vector<napi_value> argv;
-  for (size_t n = 2; n < argc; n += 1) {
-    argv.push_back(args[n]);
+  napi_value argv[MAX_ARGUMENTS - 2];
+  for (n = 2; n < argc; n += 1) {
+    argv[n - 2] = args[n];
   }
 
   napi_valuetype func_type;
@@ -35,7 +35,7 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   napi_value result;
   if (func_type == napi_function) {
     NAPI_CALL(env, napi_make_callback(
-        env, context, recv, func, argv.size(), argv.data(), &result));
+        env, context, recv, func, argc - 2, argv, &result));
   } else {
     NAPI_ASSERT(env, false, "Unexpected argument type");
   }
@@ -45,6 +45,7 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   return result;
 }
 
+static
 napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
   NAPI_CALL(env, napi_create_function(
@@ -53,7 +54,5 @@ napi_value Init(napi_env env, napi_value exports) {
   NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
   return exports;
 }
-
-}  // anonymous namespace
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_make_callback/binding.gyp
+++ b/test/addons-napi/test_make_callback/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.c' ]
     }
   ]
 }


### PR DESCRIPTION
This re-writes the test in C by dropping std::vector<napi_value> in
favour of a C99 variable length array, and by dropping the anonymous
namespace in favour of static function declarations.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
