### PR TITLE
doc: move who-to-cc to COLABORATOR_GUIDE.md

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -836,7 +836,7 @@ LTS working group and the Release team.
 | `lib/domains`                            | @nodejs/domains                                                       |
 | `lib/fs`, `src/{fs,file}`                | @nodejs/fs                                                            |
 | `lib/{_}http{*}`                         | @nodejs/http                                                          |
-| `lib/inspector.js`, `src/inspector_*`    | @nodejs/v8-inspector                                                  |
+| `lib/inspector.js`, `src/inspector_*`    | @nodejs/V8-inspector                                                  |
 | `lib/internal/url`, `src/node_url`       | @nodejs/url                                                           |
 | `lib/net`                                | @bnoordhuis, @indutny, @nodejs/streams                                |
 | `lib/repl`                               | @nodejs/repl                                                          |
@@ -859,7 +859,7 @@ LTS working group and the Release team.
 | upgrading http-parser                    | @nodejs/http, @nodejs/http2                                           |
 | upgrading libuv                          | @nodejs/libuv                                                         |
 | upgrading npm                            | @fishrock123, @MylesBorins                                            |
-| upgrading V8                             | @nodejs/v8, @nodejs/post-mortem                                       |
+| upgrading V8                             | @nodejs/V8, @nodejs/post-mortem                                       |
 | Embedded use or delivery of Node.js      | @nodejs/delivery-channels                                             |
 
 When things need extra attention, are controversial, or `semver-major`:

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -35,6 +35,7 @@
     - [How are LTS Branches Managed?](#how-are-lts-branches-managed)
     - [How can I help?](#how-can-i-help)
     - [How is an LTS release cut?](#how-is-an-lts-release-cut)
+* [Who to CC in the issue tracker](#who-to-cc-in-the-issue-tracker)
 
 This document contains information for Collaborators of the Node.js
 project regarding managing the project's code, documentation, and issue tracker.
@@ -53,7 +54,7 @@ requests they feel qualified to handle. Make sure this is done while being
 mindful of these guidelines, the opinions of other Collaborators, and guidance
 of the [TSC][]. They may also notify other qualified parties for more input on
 an issue or a pull request.
-[See "Who to CC in issues"](./doc/onboarding-extras.md#who-to-cc-in-issues)
+See [Who to CC in the issue tracker](#who-to-cc-in-the-issue-tracker).
 
 ### Welcoming First-Time Contributors
 
@@ -118,7 +119,7 @@ Collaborator, an additional Collaborator is required for sign-off.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.
-[See "Who to CC in issues"](./doc/onboarding-extras.md#who-to-cc-in-issues).
+See [Who to CC in the issue tracker](#who-to-cc-in-the-issue-tracker).
 
 If you are unsure about the modification and are not prepared to take
 full responsibility for the change, defer to another Collaborator.
@@ -817,6 +818,54 @@ When the LTS working group determines that a new LTS release is required,
 selected commits will be picked from the staging branch to be included in the
 release. This process of making a release will be a collaboration between the
 LTS working group and the Release team.
+
+## Who to CC in the issue tracker
+
+| Subsystem                                | Maintainers                                                           |
+| ---                                      | ---                                                                   |
+| `benchmark/*`                            | @nodejs/benchmarking, @mscdex                                         |
+| `bootstrap_node.js`                      | @nodejs/process                                                       |
+| `doc/*`, `*.md`                          | @nodejs/documentation                                                 |
+| `lib/assert`                             | @nodejs/testing                                                       |
+| `lib/async_hooks`                        | @nodejs/async\_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
+| `lib/buffer`                             | @nodejs/buffer                                                        |
+| `lib/child_process`                      | @nodejs/child\_process                                                |
+| `lib/cluster`                            | @nodejs/cluster                                                       |
+| `lib/{crypto,tls,https}`                 | @nodejs/crypto                                                        |
+| `lib/dgram`                              | @nodejs/dgram                                                         |
+| `lib/domains`                            | @nodejs/domains                                                       |
+| `lib/fs`, `src/{fs,file}`                | @nodejs/fs                                                            |
+| `lib/{_}http{*}`                         | @nodejs/http                                                          |
+| `lib/inspector.js`, `src/inspector_*`    | @nodejs/v8-inspector                                                  |
+| `lib/internal/url`, `src/node_url`       | @nodejs/url                                                           |
+| `lib/net`                                | @bnoordhuis, @indutny, @nodejs/streams                                |
+| `lib/repl`                               | @nodejs/repl                                                          |
+| `lib/{_}stream{*}`                       | @nodejs/streams                                                       |
+| `lib/timers`                             | @nodejs/timers                                                        |
+| `lib/util`                               | @nodejs/util                                                          |
+| `lib/zlib`                               | @nodejs/zlib                                                          |
+| `src/async-wrap.*`                       | @nodejs/async\_hooks                                                  |
+| `src/node_api.*`                         | @nodejs/n-api                                                         |
+| `src/node_crypto.*`                      | @nodejs/crypto                                                        |
+| `test/*`                                 | @nodejs/testing                                                       |
+| `tools/node_modules/eslint`, `.eslintrc` | @nodejs/linting                                                       |
+| build                                    | @nodejs/build                                                         |
+| `src/module_wrap.*`, `lib/internal/loader/*`, `lib/internal/vm/Module.js` | @nodejs/modules                      |
+| GYP                                      | @nodejs/gyp                                                           |
+| performance                              | @nodejs/performance                                                   |
+| platform specific                        | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |
+| python code                              | @nodejs/python                                                        |
+| upgrading c-ares                         | @rvagg                                                                |
+| upgrading http-parser                    | @nodejs/http, @nodejs/http2                                           |
+| upgrading libuv                          | @nodejs/libuv                                                         |
+| upgrading npm                            | @fishrock123, @MylesBorins                                            |
+| upgrading V8                             | @nodejs/v8, @nodejs/post-mortem                                       |
+| Embedded use or delivery of Node.js      | @nodejs/delivery-channels                                             |
+
+When things need extra attention, are controversial, or `semver-major`:
+@nodejs/tsc
+
+If you cannot find who to cc for a file, `git shortlog -n -s <file>` may help.
 
 [backporting guide]: doc/guides/backporting-to-release-lines.md
 [contributing]: ./doc/guides/contributing/pull-requests.md#commit-message-guidelines

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -1,53 +1,5 @@
 # Additional Onboarding Information
 
-## Who to CC in issues
-
-| Subsystem                                | Maintainers                                                           |
-| ---                                      | ---                                                                   |
-| `benchmark/*`                            | @nodejs/benchmarking, @mscdex                                         |
-| `bootstrap_node.js`                      | @nodejs/process                                                       |
-| `doc/*`, `*.md`                          | @nodejs/documentation                                                 |
-| `lib/assert`                             | @nodejs/testing                                                       |
-| `lib/async_hooks`                        | @nodejs/async\_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
-| `lib/buffer`                             | @nodejs/buffer                                                        |
-| `lib/child_process`                      | @nodejs/child\_process                                                |
-| `lib/cluster`                            | @nodejs/cluster                                                       |
-| `lib/{crypto,tls,https}`                 | @nodejs/crypto                                                        |
-| `lib/dgram`                              | @nodejs/dgram                                                         |
-| `lib/domains`                            | @nodejs/domains                                                       |
-| `lib/fs`, `src/{fs,file}`                | @nodejs/fs                                                            |
-| `lib/{_}http{*}`                         | @nodejs/http                                                          |
-| `lib/inspector.js`, `src/inspector_*`    | @nodejs/v8-inspector                                                  |
-| `lib/internal/url`, `src/node_url`       | @nodejs/url                                                           |
-| `lib/net`                                | @bnoordhuis, @indutny, @nodejs/streams                                |
-| `lib/repl`                               | @nodejs/repl                                                          |
-| `lib/{_}stream{*}`                       | @nodejs/streams                                                       |
-| `lib/timers`                             | @nodejs/timers                                                        |
-| `lib/util`                               | @nodejs/util                                                          |
-| `lib/zlib`                               | @nodejs/zlib                                                          |
-| `src/async-wrap.*`                       | @nodejs/async\_hooks                                                  |
-| `src/node_api.*`                         | @nodejs/n-api                                                         |
-| `src/node_crypto.*`                      | @nodejs/crypto                                                        |
-| `test/*`                                 | @nodejs/testing                                                       |
-| `tools/node_modules/eslint`, `.eslintrc` | @nodejs/linting                                                       |
-| build                                    | @nodejs/build                                                         |
-| `src/module_wrap.*`, `lib/internal/loader/*`, `lib/internal/vm/Module.js` | @nodejs/modules                      |
-| GYP                                      | @nodejs/gyp                                                           |
-| performance                              | @nodejs/performance                                                   |
-| platform specific                        | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |
-| python code                              | @nodejs/python                                                        |
-| upgrading c-ares                         | @rvagg                                                                |
-| upgrading http-parser                    | @nodejs/http, @nodejs/http2                                           |
-| upgrading libuv                          | @nodejs/libuv                                                         |
-| upgrading npm                            | @fishrock123, @MylesBorins                                            |
-| upgrading V8                             | @nodejs/v8, @nodejs/post-mortem                                       |
-| Embedded use or delivery of Node.js      | @nodejs/delivery-channels                                             |
-
-When things need extra attention, are controversial, or `semver-major`:
-@nodejs/tsc
-
-If you cannot find who to cc for a file, `git shortlog -n -s <file>` may help.
-
 ## Labels
 
 ### Subsystems

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -20,7 +20,7 @@ onboarding session.
 * Prior to the onboarding session, add the new Collaborator to
   [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators).
 * Ask them if they want to join any subsystem teams. See
-  [Who to CC for Issues][who-to-cc].
+  [Who to CC in the issue tracker][who-to-cc].
 
 ## Onboarding session
 
@@ -96,7 +96,7 @@ onboarding session.
     * no outstanding review comments exist and
     * at least one collaborator approved the PR.
 
-* [**See "Who to CC in issues"**][who-to-cc]
+* See [Who to CC in the issue tracker][who-to-cc].
   * This will come more naturally over time
   * For many of the teams listed there, you can ask to be added if you are
     interested
@@ -253,4 +253,4 @@ needs to be pointed out separately during the onboarding.
 [two-factor authentication]: https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
 [Updating Node.js from Upstream]: ./onboarding-extras.md#updating-nodejs-from-upstream
 [using a TOTP mobile app]: https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/
-[who-to-cc]: ./onboarding-extras.md#who-to-cc-in-issues
+[who-to-cc]: ../COLLABORATOR_GUIDE.md#who-to-cc-in-the-issue-tracker


### PR DESCRIPTION
Put the "who to cc" information in the COLLABORATOR_GUIDE. The
onboarding-extras doc is a bit of miscellaneous collection. Rather than
stashing things in a junk drawer doc, put them where they are relevant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
