### PR TITLE
http: support server options on createServer

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -30,8 +30,8 @@ const server = require('_http_server');
 
 const { Server } = server;
 
-function createServer(requestListener) {
-  return new Server(requestListener);
+function createServer(opts, requestListener) {
+  return new Server(opts, requestListener);
 }
 
 function request(options, cb) {

--- a/test/parallel/test-http-server-options-incoming-message.js
+++ b/test/parallel/test-http-server-options-incoming-message.js
@@ -16,7 +16,7 @@ class MyIncomingMessage extends http.IncomingMessage {
   }
 }
 
-const server = http.Server({
+const server = http.createServer({
   IncomingMessage: MyIncomingMessage
 }, common.mustCall(function(req, res) {
   assert.strictEqual(req.getUserAgent(), 'node-test');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

The feature and docs were added in #15752, but it looks like the `http.createServer` call was missed.  I looked for someone else fixing this issue but did not find it.  

Also this is my first PR, and I tried to follow all the contribution instructions but I may have missed something, so any help with what else I am missing would be great.  Thanks in advance.