### PR TITLE
assert: add warning about `assert.doesNotReject`

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -321,10 +321,16 @@ added: REPLACEME
 * `message` {any}
 
 Awaits for the promise returned by function `block` to complete and not be
-rejected. See [`assert.rejects()`][] for more details.
+rejected.
+
+Please note: Using `assert.doesNotReject()` is actually not useful because there
+is little benefit by catching a rejection and then rejecting it again. Instead,
+consider adding a comment next to the specific code path that should not reject
+and keep error messages as expressive as possible.
 
 When `assert.doesNotReject()` is called, it will immediately call the `block`
-function, and awaits for completion.
+function, and awaits for completion. See [`assert.rejects()`][] for more
+details.
 
 Besides the async nature to await the completion behaves identically to
 [`assert.doesNotThrow()`][].


### PR DESCRIPTION
The usefulness of `assert.doesNotReject` is very limited and this
warns against the usage.

This keeps it in line with `assert.doesNotThrow`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
