### PR TITLE
assert: use error diffs in throws messages

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -365,13 +365,38 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function compareExceptionKey(actual, expected, key, msg) {
-  if (!isDeepStrictEqual(actual[key], expected[key])) {
+class Comparison {
+  constructor(obj, keys) {
+    for (const key of keys) {
+      if (key in obj)
+        this[key] = obj[key];
+    }
+  }
+}
+
+function compareExceptionKey(actual, expected, key, message, keys) {
+  if (!(key in actual) || !isDeepStrictEqual(actual[key], expected[key])) {
+    if (!message) {
+      // Create placeholder objects to create a nice output.
+      const a = new Comparison(actual, keys);
+      const b = new Comparison(expected, keys);
+
+      const tmpLimit = Error.stackTraceLimit;
+      Error.stackTraceLimit = 0;
+      const err = new AssertionError({
+        actual: a,
+        expected: b,
+        operator: 'deepStrictEqual',
+        stackStartFn: assert.throws,
+        errorDiff: ERR_DIFF_EQUAL
+      });
+      Error.stackTraceLimit = tmpLimit;
+      message = err.message;
+    }
     innerFail({
-      actual: actual[key],
-      expected: expected[key],
-      message: msg || `${key}: expected ${inspect(expected[key])}, ` +
-                      `not ${inspect(actual[key])}`,
+      actual,
+      expected,
+      message,
       operator: 'throws',
       stackStartFn: assert.throws
     });
@@ -388,16 +413,14 @@ function expectedException(actual, expected, msg) {
         'expected', ['Function', 'RegExp'], expected
       );
     }
-    // The name and message could be non enumerable. Therefore test them
-    // explicitly.
-    if ('name' in expected) {
-      compareExceptionKey(actual, expected, 'name', msg);
+    const keys = Object.keys(expected);
+    // Special handle errors to make sure the name and the message are compared
+    // as well.
+    if (expected instanceof Error) {
+      keys.push('name', 'message');
     }
-    if ('message' in expected) {
-      compareExceptionKey(actual, expected, 'message', msg);
-    }
-    for (const key of Object.keys(expected)) {
-      compareExceptionKey(actual, expected, key, msg);
+    for (const key of keys) {
+      compareExceptionKey(actual, expected, key, msg, keys);
     }
     return true;
   }

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -2,7 +2,13 @@ assert.js:*
   throw new AssertionError(obj);
   ^
 
-AssertionError [ERR_ASSERTION]: bar: expected true, not undefined
+AssertionError [ERR_ASSERTION]: Input A expected to deepStrictEqual input B:
++ expected - actual
+
+- Comparison {}
++ Comparison {
++   bar: true
++ }
     at Object.<anonymous> (*assert_throws_stack.js:*:*)
     at *
     at *

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -38,11 +38,7 @@ assert.throws(() => {
   assert.fail(typeof 1, 'object', new TypeError('another custom message'));
 }, {
   name: 'TypeError',
-  message: 'another custom message',
-  operator: undefined,
-  actual: undefined,
-  expected: undefined,
-  code: undefined
+  message: 'another custom message'
 });
 
 // No third arg (but a fourth arg)

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -33,8 +33,5 @@ assert.throws(() => {
   assert.fail(new TypeError('custom message'));
 }, {
   name: 'TypeError',
-  message: 'custom message',
-  operator: undefined,
-  actual: undefined,
-  expected: undefined
+  message: 'custom message'
 });


### PR DESCRIPTION
This switches the assert.throws output to the one used in strict mode
if a error object is used for comparison. From now on it will show
the complete difference between two objects instead of only showing
the first failing property.

It also fixes detecting properties with a undefined value and fails
in case the thrown error does not contain the value at all.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
