### PR TITLE
assert: improve error messages

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -54,9 +54,6 @@ const meta = [
 
 const escapeFn = (str) => meta[str.charCodeAt(0)];
 
-const ERR_DIFF_NOT_EQUAL = 1;
-const ERR_DIFF_EQUAL = 2;
-
 let warned = false;
 
 // The assert module provides functions that throw
@@ -321,8 +318,7 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'deepStrictEqual',
-      stackStartFn: deepStrictEqual,
-      errorDiff: ERR_DIFF_EQUAL
+      stackStartFn: deepStrictEqual
     });
   }
 };
@@ -335,8 +331,7 @@ function notDeepStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'notDeepStrictEqual',
-      stackStartFn: notDeepStrictEqual,
-      errorDiff: ERR_DIFF_NOT_EQUAL
+      stackStartFn: notDeepStrictEqual
     });
   }
 }
@@ -348,8 +343,7 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'strictEqual',
-      stackStartFn: strictEqual,
-      errorDiff: ERR_DIFF_EQUAL
+      stackStartFn: strictEqual
     });
   }
 };
@@ -361,8 +355,7 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'notStrictEqual',
-      stackStartFn: notStrictEqual,
-      errorDiff: ERR_DIFF_NOT_EQUAL
+      stackStartFn: notStrictEqual
     });
   }
 };
@@ -389,8 +382,7 @@ function compareExceptionKey(actual, expected, key, message, keys) {
         actual: a,
         expected: b,
         operator: 'deepStrictEqual',
-        stackStartFn: assert.throws,
-        errorDiff: ERR_DIFF_EQUAL
+        stackStartFn: assert.throws
       });
       Error.stackTraceLimit = tmpLimit;
       message = err.message;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -54,7 +54,6 @@ const meta = [
 
 const escapeFn = (str) => meta[str.charCodeAt(0)];
 
-const ERR_DIFF_DEACTIVATED = 0;
 const ERR_DIFF_NOT_EQUAL = 1;
 const ERR_DIFF_EQUAL = 2;
 
@@ -323,7 +322,7 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
       message,
       operator: 'deepStrictEqual',
       stackStartFn: deepStrictEqual,
-      errorDiff: this === strict ? ERR_DIFF_EQUAL : ERR_DIFF_DEACTIVATED
+      errorDiff: ERR_DIFF_EQUAL
     });
   }
 };
@@ -337,7 +336,7 @@ function notDeepStrictEqual(actual, expected, message) {
       message,
       operator: 'notDeepStrictEqual',
       stackStartFn: notDeepStrictEqual,
-      errorDiff: this === strict ? ERR_DIFF_NOT_EQUAL : ERR_DIFF_DEACTIVATED
+      errorDiff: ERR_DIFF_NOT_EQUAL
     });
   }
 }
@@ -350,7 +349,7 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
       message,
       operator: 'strictEqual',
       stackStartFn: strictEqual,
-      errorDiff: this === strict ? ERR_DIFF_EQUAL : ERR_DIFF_DEACTIVATED
+      errorDiff: ERR_DIFF_EQUAL
     });
   }
 };
@@ -363,7 +362,7 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
       message,
       operator: 'notStrictEqual',
       stackStartFn: notStrictEqual,
-      errorDiff: this === strict ? ERR_DIFF_NOT_EQUAL : ERR_DIFF_DEACTIVATED
+      errorDiff: ERR_DIFF_NOT_EQUAL
     });
   }
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -19,6 +19,13 @@ let green = '';
 let red = '';
 let white = '';
 
+const READABLE_OPERATOR = {
+  deepStrictEqual: 'Input A expected to strictly deep-equal input B',
+  notDeepStrictEqual: 'Input A expected to strictly not deep-equal input B',
+  strictEqual: 'Input A expected to strictly equal input B',
+  notStrictEqual: 'Input A expected to strictly not equal input B'
+};
+
 const {
   errmap,
   UV_EAI_MEMORY,
@@ -40,10 +47,34 @@ function lazyInternalUtil() {
   return internalUtil;
 }
 
+function copyError(source) {
+  const keys = Object.keys(source);
+  const target = Object.create(Object.getPrototypeOf(source));
+  for (const key of keys) {
+    target[key] = source[key];
+  }
+  Object.defineProperty(target, 'message', { value: source.message });
+  return target;
+}
+
 function inspectValue(val) {
+  // The util.inspect default values could be changed. This makes sure the
+  // error messages contain the necessary information nevertheless.
   return util.inspect(
     val,
-    { compact: false, customInspect: false }
+    {
+      compact: false,
+      customInspect: false,
+      depth: 1000,
+      maxArrayLength: Infinity,
+      // Assert compares only enumerable properties (with a few exceptions).
+      showHidden: false,
+      // Having a long line as error is better than wrapping the line for
+      // comparison.
+      breakLength: Infinity,
+      // Assert does not detect proxies currently.
+      showProxy: false
+    }
   ).split('\n');
 }
 
@@ -226,8 +257,8 @@ function createErrDiff(actual, expected, operator) {
   if (util === undefined) util = require('util');
   const actualLines = inspectValue(actual);
   const expectedLines = inspectValue(expected);
-  const msg = `Input A expected to ${operator} input B:\n` +
-        `${green}+ expected${white} ${red}- actual${white}`;
+  const msg = READABLE_OPERATOR[operator] +
+        `:\n${green}+ expected${white} ${red}- actual${white}`;
   const skippedMsg = ' ... Lines skipped';
 
   // Remove all ending lines that match (this optimizes the output for
@@ -259,6 +290,7 @@ function createErrDiff(actual, expected, operator) {
 
   const maxLines = Math.max(actualLines.length, expectedLines.length);
   var printedLines = 0;
+  var identical = 0;
   for (i = 0; i < maxLines; i++) {
     // Only extra expected lines exist
     const cur = i - lastPos;
@@ -318,11 +350,37 @@ function createErrDiff(actual, expected, operator) {
         res += `\n  ${actualLines[i]}`;
         printedLines++;
       }
+      identical++;
     }
     // Inspected object to big (Show ~20 rows max)
     if (printedLines > 20 && i < maxLines - 2) {
       return `${msg}${skippedMsg}\n${res}\n...${other}\n...`;
     }
+  }
+
+  // Strict equal with identical objects that are not identical by reference.
+  if (identical === maxLines) {
+    let base = 'Input object identical but not reference equal:';
+
+    if (operator !== 'strictEqual') {
+      // This code path should not be possible to reach.
+      // The output is identical but it is not clear why.
+      base = 'Input objects not identical:';
+    }
+
+    // We have to get the result again. The lines were all removed before.
+    const actualLines = inspectValue(actual);
+
+    // Only remove lines in case it makes sense to collapse those.
+    // TODO: Accept env to always show the full error.
+    if (actualLines.length > 30) {
+      actualLines[26] = '...';
+      while (actualLines.length > 27) {
+        actualLines.pop();
+      }
+    }
+
+    return `${base}\n\n  ${actualLines.join('\n  ')}\n`;
   }
   return `${msg}${skipped ? skippedMsg : ''}\n${res}${other}${end}`;
 }
@@ -358,13 +416,15 @@ class AssertionError extends Error {
         }
       }
       if (util === undefined) util = require('util');
+      // Prevent the error stack from being visible by duplicating the error
+      // in a very close way to the original in case both sides are actually
+      // instances of Error.
       if (typeof actual === 'object' && actual !== null &&
-        'stack' in actual && actual instanceof Error) {
-        actual = `${actual.name}: ${actual.message}`;
-      }
-      if (typeof expected === 'object' && expected !== null &&
-        'stack' in expected && expected instanceof Error) {
-        expected = `${expected.name}: ${expected.message}`;
+          typeof expected === 'object' && expected !== null &&
+          'stack' in actual && actual instanceof Error &&
+          'stack' in expected && expected instanceof Error) {
+        actual = copyError(actual);
+        expected = copyError(expected);
       }
 
       if (errorDiff === 0) {
@@ -379,15 +439,23 @@ class AssertionError extends Error {
         // In case the objects are equal but the operator requires unequal, show
         // the first object and say A equals B
         const res = inspectValue(actual);
+        const base = `Identical input passed to ${operator}:`;
 
-        if (res.length > 20) {
-          res[19] = '...';
-          while (res.length > 20) {
+        // Only remove lines in case it makes sense to collapse those.
+        // TODO: Accept env to always show the full error.
+        if (res.length > 30) {
+          res[26] = '...';
+          while (res.length > 27) {
             res.pop();
           }
         }
-        // Only print a single object.
-        super(`Identical input passed to ${operator}:\n${res.join('\n')}`);
+
+        // Only print a single input.
+        if (res.length === 1) {
+          super(`${base} ${res[0]}`);
+        } else {
+          super(`${base}\n\n  ${res.join('\n  ')}\n`);
+        }
       } else {
         super(createErrDiff(actual, expected, operator));
       }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -395,8 +395,7 @@ class AssertionError extends Error {
       expected,
       message,
       operator,
-      stackStartFn,
-      errorDiff = 0
+      stackStartFn
     } = options;
 
     if (message != null) {
@@ -427,15 +426,10 @@ class AssertionError extends Error {
         expected = copyError(expected);
       }
 
-      if (errorDiff === 0) {
-        let res = util.inspect(actual);
-        let other = util.inspect(expected);
-        if (res.length > 128)
-          res = `${res.slice(0, 125)}...`;
-        if (other.length > 128)
-          other = `${other.slice(0, 125)}...`;
-        super(`${res} ${operator} ${other}`);
-      } else if (errorDiff === 1) {
+      if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
+        super(createErrDiff(actual, expected, operator));
+      } else if (operator === 'notDeepStrictEqual' ||
+        operator === 'notStrictEqual') {
         // In case the objects are equal but the operator requires unequal, show
         // the first object and say A equals B
         const res = inspectValue(actual);
@@ -457,7 +451,13 @@ class AssertionError extends Error {
           super(`${base}\n\n  ${res.join('\n  ')}\n`);
         }
       } else {
-        super(createErrDiff(actual, expected, operator));
+        let res = util.inspect(actual);
+        let other = util.inspect(expected);
+        if (res.length > 128)
+          res = `${res.slice(0, 125)}...`;
+        if (other.length > 128)
+          other = `${other.slice(0, 125)}...`;
+        super(`${res} ${operator} ${other}`);
       }
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -49,6 +49,7 @@ const types = internalBinding('types');
 Object.assign(types, require('internal/util/types'));
 const {
   isAnyArrayBuffer,
+  isArgumentsObject,
   isDataView,
   isExternal,
   isMap,
@@ -538,9 +539,13 @@ function formatValue(ctx, value, recurseTimes, ln) {
   if (noIterator) {
     braces = ['{', '}'];
     if (prefix === 'Object ') {
-      // Object fast path
-      if (keyLength === 0)
+      if (isArgumentsObject(value)) {
+        braces[0] = '[Arguments] {';
+        if (keyLength === 0)
+          return '[Arguments] {}';
+      } else if (keyLength === 0) {
         return '{}';
+      }
     } else if (typeof value === 'function') {
       const name =
         `${constructor || tag}${value.name ? `: ${value.name}` : ''}`;

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -2,7 +2,7 @@ assert.js:*
   throw new AssertionError(obj);
   ^
 
-AssertionError [ERR_ASSERTION]: Input A expected to deepStrictEqual input B:
+AssertionError [ERR_ASSERTION]: Input A expected to strictly deep-equal input B:
 + expected - actual
 
 - Comparison {}

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -3,7 +3,11 @@ assert.js:*
   throw new AssertionError(obj);
   ^
 
-AssertionError [ERR_ASSERTION]: 1 strictEqual 2
+AssertionError [ERR_ASSERTION]: Input A expected to strictly equal input B:
++ expected - actual
+
+- 1
++ 2
     at Object.<anonymous> (*test*message*error_exit.js:*:*)
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)

--- a/test/parallel/test-assert-checktag.js
+++ b/test/parallel/test-assert-checktag.js
@@ -1,24 +1,6 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const util = require('util');
-
-// Template tag function turning an error message into a RegExp
-// for assert.throws()
-function re(literals, ...values) {
-  let result = literals[0];
-  const escapeRE = /[\\^$.*+?()[\]{}|=!<>:-]/g;
-  for (const [i, value] of values.entries()) {
-    const str = util.inspect(value);
-    // Need to escape special characters.
-    result += str.replace(escapeRE, '\\$&');
-    result += literals[i + 1];
-  }
-  return common.expectsError({
-    code: 'ERR_ASSERTION',
-    message: new RegExp(`^${result}$`)
-  });
-}
 
 // Turn off no-restricted-properties because we are testing deepEqual!
 /* eslint-disable no-restricted-properties */
@@ -35,10 +17,20 @@ function re(literals, ...values) {
 
   // For deepStrictEqual we check the runtime type,
   // then reveal the fakeness of the fake date
-  assert.throws(() => assert.deepStrictEqual(date, fake),
-                re`${date} deepStrictEqual Date {}`);
-  assert.throws(() => assert.deepStrictEqual(fake, date),
-                re`Date {} deepStrictEqual ${date}`);
+  assert.throws(
+    () => assert.deepStrictEqual(date, fake),
+    {
+      message: 'Input A expected to strictly deep-equal input B:\n' +
+               '+ expected - actual\n\n- 2016-01-01T00:00:00.000Z\n+ Date {}'
+    }
+  );
+  assert.throws(
+    () => assert.deepStrictEqual(fake, date),
+    {
+      message: 'Input A expected to strictly deep-equal input B:\n' +
+               '+ expected - actual\n\n- Date {}\n+ 2016-01-01T00:00:00.000Z'
+    }
+  );
 }
 
 {  // At the moment global has its own type tag

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -34,7 +34,7 @@ const { writeFileSync, unlinkSync } = require('fs');
 const { inspect } = require('util');
 const a = assert;
 
-const start = 'Input A expected to deepStrictEqual input B:';
+const start = 'Input A expected to strictly deep-equal input B:';
 const actExp = '+ expected - actual';
 
 assert.ok(a.AssertionError.prototype instanceof Error,
@@ -67,8 +67,21 @@ assert.throws(() => a.strictEqual(2, '2'),
 assert.throws(() => a.strictEqual(null, undefined),
               a.AssertionError, 'strictEqual(null, undefined)');
 
-assert.throws(() => a.notStrictEqual(2, 2),
-              a.AssertionError, 'notStrictEqual(2, 2)');
+assert.throws(
+  () => a.notStrictEqual(2, 2),
+  {
+    message: 'Identical input passed to notStrictEqual: 2',
+    name: 'AssertionError [ERR_ASSERTION]'
+  }
+);
+
+assert.throws(
+  () => a.notStrictEqual('a '.repeat(30), 'a '.repeat(30)),
+  {
+    message: `Identical input passed to notStrictEqual: '${'a '.repeat(30)}'`,
+    name: 'AssertionError [ERR_ASSERTION]'
+  }
+);
 
 a.notStrictEqual(2, '2');
 
@@ -245,8 +258,11 @@ function testAssertionMessage(actual, expected) {
   try {
     assert.strictEqual(actual, '');
   } catch (e) {
-    assert.strictEqual(e.message,
-                       [expected, 'strictEqual', '\'\''].join(' '));
+    assert.strictEqual(
+      e.message,
+      'Input A expected to strictly equal input B:\n+ expected - actual\n\n' +
+        `- ${expected}\n+ ''`
+    );
     assert.ok(e.generatedMessage, 'Message not marked as generated');
   }
 }
@@ -263,29 +279,34 @@ testAssertionMessage(-Infinity, '-Infinity');
 testAssertionMessage('', '""');
 testAssertionMessage('foo', '\'foo\'');
 testAssertionMessage([], '[]');
-testAssertionMessage([1, 2, 3], '[ 1, 2, 3 ]');
+testAssertionMessage([1, 2, 3], '[\n-   1,\n-   2,\n-   3\n- ]');
 testAssertionMessage(/a/, '/a/');
 testAssertionMessage(/abc/gim, '/abc/gim');
 testAssertionMessage(function f() {}, '[Function: f]');
 testAssertionMessage(function() {}, '[Function]');
 testAssertionMessage({}, '{}');
-testAssertionMessage(circular, '{ y: 1, x: [Circular] }');
-testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');
+testAssertionMessage(circular, '{\n-   y: 1,\n-   x: [Circular]\n- }');
+testAssertionMessage({ a: undefined, b: null },
+                     '{\n-   a: undefined,\n-   b: null\n- }');
 testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
-                     '{ a: NaN, b: Infinity, c: -Infinity }');
+                     '{\n-   a: NaN,\n-   b: Infinity,\n-   c: -Infinity\n- }');
 
 // https://github.com/nodejs/node-v0.x-archive/issues/5292
 try {
   assert.strictEqual(1, 2);
 } catch (e) {
-  assert.strictEqual(e.message.split('\n')[0], '1 strictEqual 2');
+  assert.strictEqual(
+    e.message,
+    'Input A expected to strictly equal input B:\n' +
+      '+ expected - actual\n\n- 1\n+ 2'
+  );
   assert.ok(e.generatedMessage, 'Message not marked as generated');
 }
 
 try {
   assert.strictEqual(1, 2, 'oh no');
 } catch (e) {
-  assert.strictEqual(e.message.split('\n')[0], 'oh no');
+  assert.strictEqual(e.message, 'oh no');
   assert.strictEqual(e.generatedMessage, false,
                      'Message incorrectly marked as generated');
 }
@@ -361,10 +382,11 @@ assert.throws(() => { throw new Error(); }, (err) => err instanceof Error);
 // Long values should be truncated for display.
 assert.throws(() => {
   assert.strictEqual('A'.repeat(1000), '');
-}, common.expectsError({
+}, {
   code: 'ERR_ASSERTION',
-  message: /^'A{124}\.\.\. strictEqual ''$/
-}));
+  message: 'Input A expected to strictly equal input B:\n' +
+           `+ expected - actual\n\n- '${'A'.repeat(1000)}'\n+ ''`
+});
 
 {
   // Bad args to AssertionError constructor should throw TypeError.
@@ -381,12 +403,13 @@ assert.throws(() => {
   });
 }
 
-common.expectsError(
+assert.throws(
   () => assert.strictEqual(new Error('foo'), new Error('foobar')),
   {
     code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: /^'Error: foo' strictEqual 'Error: foobar'$/
+    name: 'AssertionError [ERR_ASSERTION]',
+    message: 'Input A expected to strictly equal input B:\n' +
+             '+ expected - actual\n\n- [Error: foo]\n+ [Error: foobar]'
   }
 );
 
@@ -576,14 +599,15 @@ common.expectsError(
   });
 
   // notDeepEqual tests
-  message = 'Identical input passed to notDeepStrictEqual:\n[\n  1\n]';
+  message = 'Identical input passed to notDeepStrictEqual:\n\n' +
+            '  [\n    1\n  ]\n';
   assert.throws(
     () => assert.notDeepEqual([1], [1]),
     { message });
 
   message = 'Identical input passed to notDeepStrictEqual:' +
-        `\n[${'\n  1,'.repeat(18)}\n...`;
-  const data = Array(21).fill(1);
+        `\n\n  [${'\n    1,'.repeat(25)}\n  ...\n`;
+  const data = Array(31).fill(1);
   assert.throws(
     () => assert.notDeepEqual(data, data),
     { message });
@@ -873,3 +897,21 @@ assert.throws(
 // Should not throw.
 // eslint-disable-next-line no-restricted-syntax, no-throw-literal
 assert.throws(() => { throw null; }, 'foo');
+
+assert.throws(
+  () => assert.strictEqual([], []),
+  {
+    message: 'Input object identical but not reference equal:\n\n  []\n'
+  }
+);
+
+{
+  const args = (function() { return arguments; })('a');
+  assert.throws(
+    () => assert.strictEqual(args, { 0: 'a' }),
+    {
+      message: 'Input A expected to strictly equal input B:\n+ expected' +
+               " - actual\n\n- [Arguments] {\n+ {\n    '0': 'a'\n  }"
+    }
+  );
+}

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1399,3 +1399,8 @@ util.inspect(process);
                     'extra: true }';
   assert(out === expect || out === expectAlt);
 }
+
+{ // Test argument objects.
+  const args = (function() { return arguments; })('a');
+  assert.strictEqual(util.inspect(args), "[Arguments] { '0': 'a' }");
+}

--- a/test/pseudo-tty/test-assert-colors.js
+++ b/test/pseudo-tty/test-assert-colors.js
@@ -7,7 +7,7 @@ try {
   process.env.COLORTERM = '1';
   assert.deepStrictEqual([1, 2], [2, 2]);
 } catch (err) {
-  const expected = 'Input A expected to deepStrictEqual input B:\n' +
+  const expected = 'Input A expected to strictly deep-equal input B:\n' +
     '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m\n\n' +
     '  [\n' +
     '\u001b[31m-\u001b[39m   1,\n' +


### PR DESCRIPTION
This switches all assert error messages to use the new diffing output as in the `assert` strict mode.

It also makes sure not reference equal objects are now visualised as such. Before it would e.g. have been `[1, 2] strictEqual [1, 2]` and that would be quite confusing. That is now detected and [expressed](https://github.com/nodejs/node/compare/master...BridgeAR:improve-error-messages?expand=1#diff-81c8c31c5728ec9ed47700e55d9ceebfR870).

I also added support in util.inspect to visualize arguments to distinguish them from a regular object.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
