### PR TITLE
 src: ensure that `SetImmediate()`s have `HandleScope`s 

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -376,6 +376,9 @@ void Environment::RunAndClearNativeImmediates() {
     auto drain_list = [&]() {
       v8::TryCatch try_catch(isolate());
       for (auto it = list.begin(); it != list.end(); ++it) {
+#ifdef DEBUG
+        v8::SealHandleScope seal_handle_scope(isolate());
+#endif
         it->cb_(this, it->data_);
         if (it->refed_)
           ref_count++;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -178,6 +178,7 @@ inline void FileHandle::Close() {
       // it is being thrown from within the SetImmediate handler and
       // there is no JS stack to bubble it to. In other words, tearing
       // down the process is the only reasonable thing we can do here.
+      HandleScope handle_scope(env->isolate());
       env->ThrowUVException(detail->ret, "close", msg);
       delete detail;
     }, detail);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -520,6 +520,7 @@ void Http2Stream::EmitStatistics() {
         static_cast<Http2StreamPerformanceEntry*>(data) };
     if (!HasHttp2Observer(env))
       return;
+    HandleScope handle_scope(env->isolate());
     AliasedBuffer<double, v8::Float64Array>& buffer =
         env->http2_state()->stream_stats_buffer;
     buffer[IDX_STREAM_STATS_ID] = entry->id();
@@ -558,6 +559,7 @@ void Http2Session::EmitStatistics() {
         static_cast<Http2SessionPerformanceEntry*>(data) };
     if (!HasHttp2Observer(env))
       return;
+    HandleScope handle_scope(env->isolate());
     AliasedBuffer<double, v8::Float64Array>& buffer =
         env->http2_state()->session_stats_buffer;
     buffer[IDX_SESSION_STATS_TYPE] = entry->type();


### PR DESCRIPTION
* **src: simplify http2 perf tracking code**

  Use `unique_ptr`s and use the resulting simplification to
  reduce indentation in these functions.

* **src: ensure that `SetImmediate()`s have `HandleScope`s**

  Make sure that all native `SetImmediate()` functions have
  `HandleScope`s if they create handles.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: https://ci.nodejs.org/job/node-test-commit/17015/