### PR TITLE
net: allow IPC servers be accessible by all

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -259,6 +259,10 @@ added: v0.11.14
   * `backlog` {number} Common parameter of [`server.listen()`][]
     functions.
   * `exclusive` {boolean} **Default:** `false`
+  * `readableAll` {boolean} For IPC servers makes the pipe readable
+    for all users. **Default:** `false`
+  * `writableAll` {boolean} For IPC servers makes the pipe writable
+    for all users. **Default:** `false`
 * `callback` {Function} Common parameter of [`server.listen()`][]
   functions.
 * Returns: {net.Server}
@@ -283,6 +287,10 @@ server.listen({
   exclusive: true
 });
 ```
+
+Starting an IPC server as root may cause the server path to be inaccessible for
+unprivileged users. Using `readableAll` and `writableAll` will make the server
+accessible for all users.
 
 #### server.listen(path[, backlog][, callback])
 <!-- YAML

--- a/lib/net.js
+++ b/lib/net.js
@@ -1475,6 +1475,19 @@ Server.prototype.listen = function(...args) {
     backlog = options.backlog || backlogFromArgs;
     listenInCluster(this, pipeName, -1, -1,
                     backlog, undefined, options.exclusive);
+    let mode = 0;
+    if (options.readableAll === true)
+      mode |= PipeConstants.UV_READABLE;
+    if (options.writableAll === true)
+      mode |= PipeConstants.UV_WRITABLE;
+    if (mode !== 0) {
+      const err = this._handle.fchmod(mode);
+      if (err) {
+        this._handle.close();
+        this._handle = null;
+        throw errnoException(err, 'uv_pipe_chmod');
+      }
+    }
     return this;
   }
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -98,6 +98,8 @@ void PipeWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setPendingInstances", SetPendingInstances);
 #endif
 
+  env->SetProtoMethod(t, "fchmod", Fchmod);
+
   target->Set(pipeString, t->GetFunction());
   env->set_pipe_constructor_template(t);
 
@@ -114,6 +116,8 @@ void PipeWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, SOCKET);
   NODE_DEFINE_CONSTANT(constants, SERVER);
   NODE_DEFINE_CONSTANT(constants, IPC);
+  NODE_DEFINE_CONSTANT(constants, UV_READABLE);
+  NODE_DEFINE_CONSTANT(constants, UV_WRITABLE);
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "constants"),
               constants).FromJust();
@@ -182,6 +186,17 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
   uv_pipe_pending_instances(&wrap->handle_, instances);
 }
 #endif
+
+
+void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  PipeWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  CHECK(args[0]->IsInt32());
+  int mode = args[0].As<Int32>()->Value();
+  int err = uv_pipe_chmod(reinterpret_cast<uv_pipe_t*>(&wrap->handle_),
+                          mode);
+  args.GetReturnValue().Set(err);
+}
 
 
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -63,6 +63,7 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
   static void SetPendingInstances(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif
+  static void Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
 


### PR DESCRIPTION
Adds mappings to `uv_pipe_chmod` call by adding two new options to listen call. This allows the IPC server pipe to be made readable or writable by all users.

Fixes: https://github.com/nodejs/node/issues/19154

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
