### PR TITLE
tools: fix nits in tools/doc/preprocess.js

### DIFF
--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -5,7 +5,7 @@ module.exports = preprocess;
 const path = require('path');
 const fs = require('fs');
 
-const includeExpr = /^@include\s+([A-Za-z0-9-_]+)(?:\.)?([a-zA-Z]*)$/gmi;
+const includeExpr = /^@include\s+[\w-]+\.?[a-zA-Z]*$/gmi;
 const includeData = {};
 
 function preprocess(inputFile, input, cb) {
@@ -20,12 +20,12 @@ function stripComments(input) {
 function processIncludes(inputFile, input, cb) {
   const includes = input.match(includeExpr);
   if (includes === null) return cb(null, input);
-  var errState = null;
-  var incCount = includes.length;
-  if (incCount === 0) cb(null, input);
-  includes.forEach(function(include) {
-    var fname = include.replace(/^@include\s+/, '');
-    if (!fname.match(/\.md$/)) fname = `${fname}.md`;
+  let errState = null;
+  let incCount = includes.length;
+
+  includes.forEach((include) => {
+    let fname = include.replace(/^@include\s+/, '');
+    if (!/\.md$/.test(fname)) fname = `${fname}.md`;
 
     if (includeData.hasOwnProperty(fname)) {
       input = input.split(include).join(includeData[fname]);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

ES6 nits:
1. Replace remaining `var`s with `let`s.
1. Replace a common function with an arrow function in `.forEach()` argument.

RegExp nits:
1. Simplify `[A-Za-z0-9-_]` into `[\w-]`.
1. Remove capturing and not capturing parentheses in `includeExpr` RegExp: there is no need to group in its case + `includeExpr` is used only in `.match()` call that does not return capturing.
1. Replace `.match()` with `.test()` in a boolean context.

Logic nits:
1. Remove excess check: `.match()` with `g`  flag can only return `null` or non-empty array (it cannot return an array with `0` length) + `incCount` may be changed only after this check.

I've built the docs on Windows (using https://github.com/nodejs/node/issues/19330) before and after these changes and both doc sets are identical + `test/doctool/test-make-doc.js` is OK.