### PR TITLE
test: add deprecation code to expectWarning

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -108,11 +108,17 @@ Indicates if there is more than 1gb of total memory.
   returned function has not been called exactly `exact` number of times when the
   test is complete, then the test will fail.
 
-### expectWarning(name, expected)
+### expectWarning(name, expected, code)
 * `name` [&lt;string>]
 * `expected` [&lt;string>] | [&lt;Array>]
+* `code` [&lt;string>]
 
-Tests whether `name` and `expected` are part of a raised warning.
+Tests whether `name`, `expected`, and `code` are part of a raised warning. If
+an expected warning does not have a code then `common.noWarnCode` can be used
+to indicate this.
+
+### noWarnCode
+See `common.expectWarning()` for usage.
 
 ### fileExists(pathname)
 * pathname [&lt;string>]

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -6,7 +6,8 @@ const assert = require('assert');
 common.expectWarning(
   'DeprecationWarning',
   'assert.fail() with more than one argument is deprecated. ' +
-    'Please use assert.strictEqual() instead or only pass a message.'
+    'Please use assert.strictEqual() instead or only pass a message.',
+  'DEP0094'
 );
 
 // Two args only, operator defaults to '!='

--- a/test/parallel/test-buffer-pending-deprecation.js
+++ b/test/parallel/test-buffer-pending-deprecation.js
@@ -9,7 +9,7 @@ const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
 
-common.expectWarning('DeprecationWarning', bufferWarning);
+common.expectWarning('DeprecationWarning', bufferWarning, 'DEP0005');
 
 // This is used to make sure that a warning is only emitted once even though
 // `new Buffer()` is called twice.

--- a/test/parallel/test-child-process-custom-fds.js
+++ b/test/parallel/test-child-process-custom-fds.js
@@ -9,7 +9,7 @@ const oldSpawnSync = internalCp.spawnSync;
 {
   const msg = 'child_process: options.customFds option is deprecated. ' +
               'Use options.stdio instead.';
-  common.expectWarning('DeprecationWarning', msg);
+  common.expectWarning('DeprecationWarning', msg, 'DEP0006');
 
   const customFds = [-1, process.stdout.fd, process.stderr.fd];
   internalCp.spawnSync = common.mustCall(function(opts) {

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -336,13 +336,16 @@ const errMessages = {
 const ciphers = crypto.getCiphers();
 
 const expectedWarnings = common.hasFipsCrypto ?
-  [] : ['Use Cipheriv for counter mode of aes-192-gcm'];
+  [] : [['Use Cipheriv for counter mode of aes-192-gcm',
+         common.noWarnCode]];
 
 const expectedDeprecationWarnings = [0, 1, 2, 6, 9, 10, 11, 17]
-  .map((i) => `Permitting authentication tag lengths of ${i} bytes is ` +
-            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.');
+  .map((i) => [`Permitting authentication tag lengths of ${i} bytes is ` +
+            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.',
+               'DEP0090']);
 
-expectedDeprecationWarnings.push('crypto.DEFAULT_ENCODING is deprecated.');
+expectedDeprecationWarnings.push(['crypto.DEFAULT_ENCODING is deprecated.',
+                                  'DEP0091']);
 
 common.expectWarning({
   Warning: expectedWarnings,

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -236,7 +236,8 @@ testCipher2(Buffer.from('0123456789abcdef'));
   const data = Buffer.from('test-crypto-cipher-decipher');
 
   common.expectWarning('Warning',
-                       'Use Cipheriv for counter mode of aes-256-gcm');
+                       'Use Cipheriv for counter mode of aes-256-gcm',
+                       common.noWarnCode);
 
   const cipher = crypto.createCipher('aes-256-gcm', key);
   cipher.setAAD(aadbuf);

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -8,10 +8,12 @@ const crypto = require('crypto');
 const tls = require('tls');
 
 common.expectWarning('DeprecationWarning', [
-  'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
-  'crypto.createCredentials is deprecated. Use tls.createSecureContext ' +
-  'instead.',
-  'crypto.Decipher.finaltol is deprecated. Use crypto.Decipher.final instead.'
+  ['crypto.Credentials is deprecated. Use tls.SecureContext instead.',
+   'DEP0011'],
+  ['crypto.createCredentials is deprecated. Use tls.createSecureContext ' +
+  'instead.', 'DEP0010'],
+  ['crypto.Decipher.finaltol is deprecated. Use crypto.Decipher.final instead.',
+   'DEP0105']
 ]);
 
 // Accessing the deprecated function is enough to trigger the warning event.

--- a/test/parallel/test-fs-filehandle.js
+++ b/test/parallel/test-fs-filehandle.js
@@ -20,7 +20,8 @@ let fdnum;
 
 common.expectWarning(
   'Warning',
-  `Closing file descriptor ${fdnum} on garbage collection`
+  `Closing file descriptor ${fdnum} on garbage collection`,
+  common.noWarnCode
 );
 
 gc();  // eslint-disable-line no-undef

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -15,7 +15,7 @@ const msg = 'Using fs.truncate with a file descriptor is deprecated.' +
 ' Please use fs.ftruncate with a file descriptor instead.';
 
 
-common.expectWarning('DeprecationWarning', msg);
+common.expectWarning('DeprecationWarning', msg, 'DEP0081');
 fs.truncate(fd, 5, common.mustCall(function(err) {
   assert.ok(!err);
   assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -64,8 +64,8 @@ fs.ftruncateSync(fd);
 stat = fs.statSync(filename);
 assert.strictEqual(stat.size, 0);
 
-// Check truncateSync
-common.expectWarning('DeprecationWarning', msg);
+// truncateSync
+common.expectWarning('DeprecationWarning', msg, 'DEP0081');
 fs.truncateSync(fd);
 
 fs.closeSync(fd);

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -30,7 +30,7 @@ const server = new net.Server();
 const expectedWarning = 'Server.connections property is deprecated. ' +
                         'Use Server.getConnections method instead.';
 
-common.expectWarning('DeprecationWarning', expectedWarning);
+common.expectWarning('DeprecationWarning', expectedWarning, 'DEP0020');
 
 // test that server.connections property is no longer enumerable now that it
 // has been marked as deprecated

--- a/test/parallel/test-performance-warning.js
+++ b/test/parallel/test-performance-warning.js
@@ -20,10 +20,10 @@ performance.maxEntries = 1;
   );
 });
 
-common.expectWarning('Warning', [
-  'Possible perf_hooks memory leak detected. There are 2 entries in the ' +
+common.expectWarning('Warning', 'Possible perf_hooks memory leak detected. ' +
+  'There are 2 entries in the ' +
   'Performance Timeline. Use the clear methods to remove entries that are no ' +
   'longer needed or set performance.maxEntries equal to a higher value ' +
-  '(currently the maxEntries is 1).']);
+  '(currently the maxEntries is 1).', common.noWarnCode);
 
 performance.mark('test');

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -4,7 +4,8 @@ const assert = require('assert');
 
 common.expectWarning(
   'DeprecationWarning',
-  'process.assert() is deprecated. Please use the `assert` module instead.'
+  'process.assert() is deprecated. Please use the `assert` module instead.',
+  'DEP0100'
 );
 
 assert.strictEqual(process.assert(1, 'error'), undefined);

--- a/test/parallel/test-process-emit-warning-from-native.js
+++ b/test/parallel/test-process-emit-warning-from-native.js
@@ -12,7 +12,8 @@ const key = '0123456789';
 
 {
   common.expectWarning('Warning',
-                       'Use Cipheriv for counter mode of aes-256-gcm');
+                       'Use Cipheriv for counter mode of aes-256-gcm',
+                       common.noWarnCode);
 
   // Emits regular warning expected by expectWarning()
   crypto.createCipher('aes-256-gcm', key);

--- a/test/parallel/test-process-env-deprecation.js
+++ b/test/parallel/test-process-env-deprecation.js
@@ -8,7 +8,8 @@ common.expectWarning(
   'DeprecationWarning',
   'Assigning any value other than a string, number, or boolean to a ' +
   'process.env property is deprecated. Please make sure to convert the value ' +
-  'to a string before setting process.env with it.'
+  'to a string before setting process.env with it.',
+  'DEP0104'
 );
 
 process.env.ABC = undefined;

--- a/test/parallel/test-promises-unhandled-proxy-rejections.js
+++ b/test/parallel/test-promises-unhandled-proxy-rejections.js
@@ -1,16 +1,16 @@
 'use strict';
 const common = require('../common');
 
-const expectedDeprecationWarning = 'Unhandled promise rejections are ' +
+const expectedDeprecationWarning = ['Unhandled promise rejections are ' +
                                    'deprecated. In the future, promise ' +
                                    'rejections that are not handled will ' +
                                    'terminate the Node.js process with a ' +
-                                   'non-zero exit code.';
-const expectedPromiseWarning = 'Unhandled promise rejection. ' +
+                                   'non-zero exit code.', 'DEP0018'];
+const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). (rejection id: 1)';
+  'not handled with .catch(). (rejection id: 1)', common.noWarnCode];
 
 function throwErr() {
   throw new Error('Error from proxy');

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -1,17 +1,17 @@
 'use strict';
 const common = require('../common');
 
-const expectedValueWarning = 'Symbol()';
-const expectedDeprecationWarning = 'Unhandled promise rejections are ' +
+const expectedValueWarning = ['Symbol()', common.noWarnCode];
+const expectedDeprecationWarning = ['Unhandled promise rejections are ' +
                                    'deprecated. In the future, promise ' +
                                    'rejections that are not handled will ' +
                                    'terminate the Node.js process with a ' +
-                                   'non-zero exit code.';
-const expectedPromiseWarning = 'Unhandled promise rejection. ' +
+                                   'non-zero exit code.', common.noWarnCode];
+const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
   'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). (rejection id: 1)';
+  'not handled with .catch(). (rejection id: 1)', common.noWarnCode];
 
 common.expectWarning({
   DeprecationWarning: expectedDeprecationWarning,

--- a/test/parallel/test-repl-deprecations.js
+++ b/test/parallel/test-repl-deprecations.js
@@ -9,7 +9,7 @@ function testParseREPLKeyword() {
   const server = repl.start({ prompt: '> ' });
   const warn = 'REPLServer.parseREPLKeyword() is deprecated';
 
-  common.expectWarning('DeprecationWarning', warn);
+  common.expectWarning('DeprecationWarning', warn, 'DEP0075');
   assert.ok(server.parseREPLKeyword('clear'));
   assert.ok(!server.parseREPLKeyword('tacos'));
   server.close();

--- a/test/parallel/test-repl-memory-deprecation.js
+++ b/test/parallel/test-repl-memory-deprecation.js
@@ -9,7 +9,7 @@ function testMemory() {
   const server = repl.start({ prompt: '> ' });
   const warn = 'REPLServer.memory() is deprecated';
 
-  common.expectWarning('DeprecationWarning', warn);
+  common.expectWarning('DeprecationWarning', warn, 'DEP0082');
   assert.strictEqual(server.memory(), undefined);
   server.close();
 }

--- a/test/parallel/test-repl-turn-off-editor-mode.js
+++ b/test/parallel/test-repl-turn-off-editor-mode.js
@@ -8,7 +8,7 @@ function testTurnOffEditorMode() {
   const server = repl.start({ prompt: '> ' });
   const warn = 'REPLServer.turnOffEditorMode() is deprecated';
 
-  common.expectWarning('DeprecationWarning', warn);
+  common.expectWarning('DeprecationWarning', warn, 'DEP0078');
   server.turnOffEditorMode();
   server.close();
 }

--- a/test/parallel/test-require-deps-deprecation.js
+++ b/test/parallel/test-require-deps-deprecation.js
@@ -29,8 +29,8 @@ const deps = [
 ];
 
 common.expectWarning('DeprecationWarning', deprecatedModules.map((m) => {
-  return `Requiring Node.js-bundled '${m}' module is deprecated. ` +
-         'Please install the necessary module locally.';
+  return [`Requiring Node.js-bundled '${m}' module is deprecated. ` +
+         'Please install the necessary module locally.', 'DEP0084'];
 }));
 
 for (const m of deprecatedModules) {

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -41,7 +41,8 @@ const ciphers = 'DHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
 
 // Test will emit a warning because the DH parameter size is < 2048 bits
 common.expectWarning('SecurityWarning',
-                     'DH parameter is less than 2048 bits');
+                     'DH parameter is less than 2048 bits',
+                     common.noWarnCode);
 
 function loadDHParam(n) {
   const params = [`dh${n}.pem`];

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -48,7 +48,8 @@ const options = {
 };
 
 common.expectWarning('DeprecationWarning',
-                     '{ ecdhCurve: false } is deprecated.');
+                     '{ ecdhCurve: false } is deprecated.',
+                     'DEP0083');
 
 const server = tls.createServer(options, common.mustNotCall());
 

--- a/test/parallel/test-tls-legacy-deprecated.js
+++ b/test/parallel/test-tls-legacy-deprecated.js
@@ -8,7 +8,8 @@ const tls = require('tls');
 
 common.expectWarning(
   'DeprecationWarning',
-  'tls.createSecurePair() is deprecated. Please use tls.TLSSocket instead.'
+  'tls.createSecurePair() is deprecated. Please use tls.TLSSocket instead.',
+  'DEP0064'
 );
 
 tls.createSecurePair();

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -59,7 +59,8 @@ common.restoreStderr();
 {
   common.expectWarning('DeprecationWarning',
                        'tls.parseCertString() is deprecated. ' +
-                       'Please use querystring.parse() instead.');
+                       'Please use querystring.parse() instead.',
+                       'DEP0076');
 
   const ret = tls.parseCertString('foo=bar');
   assert.deepStrictEqual(ret, { __proto__: null, foo: 'bar' });

--- a/test/parallel/test-util-inspect-deprecated.js
+++ b/test/parallel/test-util-inspect-deprecated.js
@@ -11,7 +11,8 @@ const util = require('util');
   // `common.expectWarning` will expect the warning exactly one time only
   common.expectWarning(
     'DeprecationWarning',
-    'Custom inspection function on Objects via .inspect() is deprecated'
+    'Custom inspection function on Objects via .inspect() is deprecated',
+    'DEP0079'
   );
   util.inspect(target);  // should emit deprecation warning
   util.inspect(target);  // should not emit deprecation warning

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -142,10 +142,10 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
-  'util.print is deprecated. Use console.log instead.',
-  'util.puts is deprecated. Use console.log instead.',
-  'util.debug is deprecated. Use console.error instead.',
-  'util.error is deprecated. Use console.error instead.'
+  ['util.print is deprecated. Use console.log instead.', common.noWarnCode],
+  ['util.puts is deprecated. Use console.log instead.', common.noWarnCode],
+  ['util.debug is deprecated. Use console.error instead.', common.noWarnCode],
+  ['util.error is deprecated. Use console.error instead.', common.noWarnCode]
 ]);
 
 util.print('test');

--- a/test/parallel/test-warn-sigprof.js
+++ b/test/parallel/test-warn-sigprof.js
@@ -10,6 +10,7 @@ if (common.isWindows)
   common.skip('test does not apply to Windows');
 
 common.expectWarning('Warning',
-                     'process.on(SIGPROF) is reserved while debugging');
+                     'process.on(SIGPROF) is reserved while debugging',
+                     common.noWarnCode);
 
 process.on('SIGPROF', () => {});


### PR DESCRIPTION
This commit adds a deprecation code to expectWarning and updates the
function to check the passed code against the code property on the
warning object.

Not all warnings have a deprecation code so for those that don't an
explicit code of common.noWarnCode is required. Passing this skips the
assertion of the code.

This PR follows up on https://github.com/nodejs/node/pull/19317.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
