### PR TITLE
tools: fix logic nit in tools/doc/generate.js

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -65,8 +65,8 @@ function next(er, input) {
   switch (format) {
     case 'json':
       require('./json.js')(input, filename, (er, obj) => {
-        console.log(JSON.stringify(obj, null, 2));
         if (er) throw er;
+        console.log(JSON.stringify(obj, null, 2));
       });
       break;
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I am not sure if there is a reason to throw before (instead of) the output [for HTML format](https://github.com/nodejs/node/blob/5a4a1cba2445d71aadf4ebf4350090dfdb32d871/tools/doc/generate.js#L76-L77) and throw after (with) the output [for JSON format](https://github.com/nodejs/node/blob/5a4a1cba2445d71aadf4ebf4350090dfdb32d871/tools/doc/generate.js#L68-L69). Let me know if I miss something.