### PR TITLE
doc: add note about browsers and HTTP/2

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -25,8 +25,8 @@ be emitted either by client-side code or server-side code.
 ### Server-side example
 
 The following illustrates a simple HTTP/2 server using the Core API.
-Note the use of [`http2.createSecureServer()`][] since HTTPS is required
-for [most web browsers](https://caniuse.com/#feat=http2).
+Since no browsers support [unencrypted HTTP/2][HTTP2 Unencrypted],
+the use of [`http2.createSecureServer()`][] is preferred.
 
 ```js
 const http2 = require('http2');
@@ -253,7 +253,7 @@ and would instead register a handler for the `'stream'` event emitted by the
 ```js
 const http2 = require('http2');
 
-// Create a simple HTTP/2 server
+// Create an unencrypted HTTP/2 server
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {
@@ -1728,12 +1728,15 @@ changes:
 Returns a `net.Server` instance that creates and manages `Http2Session`
 instances.
 
+Since no browsers support [unencrypted HTTP/2][HTTP2 Unencrypted],
+the use of [`http2.createSecureServer()`][] is preferred.
+
 ```js
 const http2 = require('http2');
 
-// Create a simple HTTP/2 server
-// This will not work in most browsers,
-// Try http2.createSecureServer instead
+// Create an unencrypted HTTP/2 server.
+// Since no browsers support unencrypted HTTP/2,
+// the use of `http2.createSecureServer()` is preferred.
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {
@@ -3088,6 +3091,7 @@ following additional properties:
 [Compatibility API]: #http2_compatibility_api
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
+[HTTP2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
 [HTTP2 Headers Object]: #http2_headers_object
 [HTTP2 Settings Object]: #http2_settings_object
 [HTTPS]: https.html

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -24,8 +24,9 @@ be emitted either by client-side code or server-side code.
 
 ### Server-side example
 
-The following illustrates a simple, plain-text HTTP/2 server using the
-Core API:
+The following illustrates a simple HTTP/2 server using the Core API.
+Note the use of [`http2.createSecureServer()`][] since HTTPS is required
+for [most web browsers](https://caniuse.com/#feat=http2).
 
 ```js
 const http2 = require('http2');
@@ -252,7 +253,7 @@ and would instead register a handler for the `'stream'` event emitted by the
 ```js
 const http2 = require('http2');
 
-// Create a plain-text HTTP/2 server
+// Create a simple HTTP/2 server
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {
@@ -1730,7 +1731,9 @@ instances.
 ```js
 const http2 = require('http2');
 
-// Create a plain-text HTTP/2 server
+// Create a simple HTTP/2 server
+// This will not work in most browsers,
+// Try http2.createSecureServer instead
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -25,7 +25,7 @@ be emitted either by client-side code or server-side code.
 ### Server-side example
 
 The following illustrates a simple HTTP/2 server using the Core API.
-Since no browsers support [unencrypted HTTP/2][HTTP2 Unencrypted],
+Since no browsers support [unencrypted HTTP/2][HTTP/2 Unencrypted],
 the use of [`http2.createSecureServer()`][] is preferred.
 
 ```js
@@ -1728,7 +1728,7 @@ changes:
 Returns a `net.Server` instance that creates and manages `Http2Session`
 instances.
 
-Since no browsers support [unencrypted HTTP/2][HTTP2 Unencrypted],
+Since no browsers support [unencrypted HTTP/2][HTTP/2 Unencrypted],
 the use of [`http2.createSecureServer()`][] is preferred.
 
 ```js
@@ -3091,7 +3091,7 @@ following additional properties:
 [Compatibility API]: #http2_compatibility_api
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
-[HTTP2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
+[HTTP/2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
 [HTTP2 Headers Object]: #http2_headers_object
 [HTTP2 Settings Object]: #http2_settings_object
 [HTTPS]: https.html

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -25,9 +25,10 @@ be emitted either by client-side code or server-side code.
 ### Server-side example
 
 The following illustrates a simple HTTP/2 server using the Core API.
-Since there are no browsers known that support [unencrypted HTTP/2](HTTP/2 Unencrypted),
-the use of [`http2.createSecureServer()`][] is necessary when communicating with browser
-clients.
+Since there are no browsers known that support
+[unencrypted HTTP/2][HTTP/2 Unencrypted], the use of
+[`http2.createSecureServer()`][] is necessary when communicating
+with browser clients.
 
 ```js
 const http2 = require('http2');
@@ -1729,9 +1730,10 @@ changes:
 Returns a `net.Server` instance that creates and manages `Http2Session`
 instances.
 
-Since there are no browsers known that support [unencrypted HTTP/2](HTTP/2 Unencrypted),
-the use of [`http2.createSecureServer()`][] is necessary when communicating with browser
-clients.
+Since there are no browsers known that support
+[unencrypted HTTP/2][HTTP/2 Unencrypted], the use of
+[`http2.createSecureServer()`][] is necessary when communicating
+with browser clients.
 
 ```js
 const http2 = require('http2');

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -25,8 +25,9 @@ be emitted either by client-side code or server-side code.
 ### Server-side example
 
 The following illustrates a simple HTTP/2 server using the Core API.
-Since no browsers support [unencrypted HTTP/2][HTTP/2 Unencrypted],
-the use of [`http2.createSecureServer()`][] is preferred.
+Since there are no browsers known that support [unencrypted HTTP/2](HTTP/2 Unencrypted),
+the use of [`http2.createSecureServer()`][] is necessary when communicating with browser
+clients.
 
 ```js
 const http2 = require('http2');
@@ -1728,15 +1729,17 @@ changes:
 Returns a `net.Server` instance that creates and manages `Http2Session`
 instances.
 
-Since no browsers support [unencrypted HTTP/2][HTTP/2 Unencrypted],
-the use of [`http2.createSecureServer()`][] is preferred.
+Since there are no browsers known that support [unencrypted HTTP/2](HTTP/2 Unencrypted),
+the use of [`http2.createSecureServer()`][] is necessary when communicating with browser
+clients.
 
 ```js
 const http2 = require('http2');
 
 // Create an unencrypted HTTP/2 server.
-// Since no browsers support unencrypted HTTP/2,
-// the use of `http2.createSecureServer()` is preferred.
+// Since there are no browsers known that support
+// unencrypted HTTP/2, the use of `http2.createSecureServer()`
+// is necessary when communicating with browser clients.
 const server = http2.createServer();
 
 server.on('stream', (stream, headers) => {


### PR DESCRIPTION
The docs were not clear for new users of HTTP/2 requires TLS in most browsers.
This adds a couple notes to direct new users to `http2.createSecureServer()`.

Fixes #19406

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Affected core subsystem(s)
doc