### PR TITLE
[v9.x] doc: fix deprecation removed by mistake

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -783,6 +783,18 @@ Importing assert directly is not recommended as the exposed functions will use
 loose equality checks. Use `require('assert').strict` instead. The API is the
 same as the legacy assert but it will always use strict equality checks.
 
+<a id="DEP0098"></a>
+### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs
+
+Type: Runtime
+
+The embedded API provided by AsyncHooks exposes emit{Before,After} methods
+which are very easy to use incorrectly which can lead to unrecoverable errors.
+
+Use [`asyncResource.runInAsyncScope()`][] API instead which provides a much
+safer, and more convenient, alternative. See
+https://github.com/nodejs/node/pull/18513 for more details.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
@@ -792,6 +804,7 @@ same as the legacy assert but it will always use strict equality checks.
 [`Server.getConnections()`]: net.html#net_server_getconnections_callback
 [`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`asyncResource.runInAsyncScope()`]: async_hooks.html#async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`child_process`]: child_process.html
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args


### PR DESCRIPTION
In https://github.com/nodejs/node/commit/bae5de1949b8fed3b6f0653e7c1e9d860666e5af,
a deprecation (DEP0089) was added to the docs and another one (DEP0098)
was removed by mistake. This commit restores it.

Fixes https://github.com/nodejs/node/pull/19428#issuecomment-374002269

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
