### PR TITLE
[v6.x] test: check reading zero-length env vars

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2799,6 +2799,7 @@ static void EnvGetter(Local<Name> property,
 #else  // _WIN32
   String::Value key(property);
   WCHAR buffer[32767];  // The maximum size allowed for environment variables.
+  SetLastError(ERROR_SUCCESS);
   DWORD result = GetEnvironmentVariableW(reinterpret_cast<WCHAR*>(*key),
                                          buffer,
                                          arraysize(buffer));
@@ -2846,6 +2847,7 @@ static void EnvQuery(Local<Name> property,
 #else  // _WIN32
   String::Value key(property);
   WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
+  SetLastError(ERROR_SUCCESS);
   if (GetEnvironmentVariableW(key_ptr, nullptr, 0) > 0 ||
       GetLastError() == ERROR_SUCCESS) {
     rc = 0;

--- a/test/parallel/test-process-env-windows-error-reset.js
+++ b/test/parallel/test-process-env-windows-error-reset.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// This checks that after accessing a missing env var, a subsequent
+// env read will succeed even for empty variables.
+
+{
+  process.env.FOO = '';
+  process.env.NONEXISTENT_ENV_VAR;
+  const foo = process.env.FOO;
+
+  assert.strictEqual(foo, '');
+}
+
+{
+  process.env.FOO = '';
+  process.env.NONEXISTENT_ENV_VAR;
+  const hasFoo = 'FOO' in process.env;
+
+  assert.strictEqual(hasFoo, true);
+}


### PR DESCRIPTION
~~Backport the test from https://github.com/nodejs/node/pull/18463 (6acb1a3df59222ae44e2848b76c91a72f7942360) to make sure nothing accidentally introduces this bug to Node 6.~~ Backport https://github.com/nodejs/node/pull/18463 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
