### PR TITLE
[4.x] http: make socketPath work with no agent

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -126,7 +126,13 @@ function ClientRequest(options, cb) {
   if (self.socketPath) {
     self._last = true;
     self.shouldKeepAlive = false;
-    self.onSocket(self.agent.createConnection({ path: self.socketPath }));
+    var opts = { path: self.socketPath };
+    var socket = self.agent
+      ? self.agent.createConnection(opts)
+      : options.createConnection
+        ? options.createConnection(opts)
+        : net.createConnection(opts);
+    self.onSocket(socket);
   } else if (self.agent) {
     // If there is an agent we should default to Connection:keep-alive,
     // but only if the Agent will actually reuse the connection!

--- a/test/parallel/test-http-client-unix-socket-no-agent.js
+++ b/test/parallel/test-http-client-unix-socket-no-agent.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+
+const http = require('http');
+const net = require('net');
+
+let requests = 0;
+const server = http.createServer((req, res) => {
+  if (++requests === 2)
+    server.close();
+  res.end();
+});
+
+common.refreshTmpDir();
+
+server.listen(common.PIPE, common.mustCall(() => {
+  http.get({
+    createConnection: net.createConnection,
+    socketPath: common.PIPE
+  });
+  http.get({ agent: 0, socketPath: common.PIPE });
+}));


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/19425.

Currently `Agent.prototype.createConnection()` is called uncoditionally
if the `socketPath` option is used. This throws an error if no agent is
used, preventing, for example, the `socketPath` and `createConnection`
options to be used together.

This commit fixes the issue by falling back to the `createConnection`
option or `net.createConnection()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
