### PR TITLE
[v8.x backport] tools: add .mjs linting for Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -536,7 +536,7 @@ if defined lint_js_ci goto lint-js-ci
 if not defined lint_js goto exit
 if not exist tools\eslint goto no-lint
 echo running lint-js
-%config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.md benchmark doc lib test tools
+%config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.mjs,.md benchmark doc lib test tools
 goto exit
 
 :lint-js-ci


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Backport of https://github.com/nodejs/node/pull/18569

It seems we cannot CI-check this (we do not lint on Windows machines), but I've checked the command locally.