### PR TITLE
[v8.x backport] tools: non-Ascii linter for /lib only

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -593,20 +593,20 @@ Validate that the commit message is properly formatted using
 $ git rev-list upstream/master...HEAD | xargs core-validate-commit
 ```
 
+Optional: When landing your own commits, force push the amended commit to the
+branch you used to open the pull request. If your branch is called `bugfix`,
+then the command would be `git push --force-with-lease origin master:bugfix`.
+When the pull request is closed, this will cause the pull request to
+show the purple merged status rather than the red closed status that is
+usually used for pull requests that weren't merged.
+
 Time to push it:
 
 ```text
 $ git push upstream master
 ```
-* Optional: Force push the amended commit to the branch you used to
-open the pull request. If your branch is called `bugfix`, then the
-command would be `git push --force-with-lease origin master:bugfix`.
-When the pull request is closed, this will cause the pull request to
-show the purple merged status rather than the red closed status that is
-usually used for pull requests that weren't merged. Only do this when
-landing your own contributions.
 
-* Close the pull request with a "Landed in `<commit hash>`" comment. If
+Close the pull request with a "Landed in `<commit hash>`" comment. If
 your pull request shows the purple merged status then you should still
 add the "Landed in <commit hash>..<commit hash>" comment if you added
 multiple commits.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@
   <a title="CII Best Practices" href="https://bestpractices.coreinfrastructure.org/projects/29"><img src="https://bestpractices.coreinfrastructure.org/projects/29/badge"></a>
 </p>
 
-Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. Node.js
-uses an event-driven, non-blocking I/O model that makes it lightweight and
-efficient. The Node.js package ecosystem, [npm][], is the largest ecosystem of
-open source libraries in the world.
+Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. For
+more information on using Node.js, see the
+[Node.js Website][].
 
 The Node.js project is supported by the
 [Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
@@ -593,7 +592,6 @@ Previous releases may also have been signed with one of the following GPG keys:
 * [Contributing to the project][]
 * [Working Groups][]
 
-[npm]: https://www.npmjs.com
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Help]: https://github.com/nodejs/help

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ For more information about the governance of the Node.js project, see
 **Franziska Hinkelmann** &lt;franziska.hinkelmann@gmail.com&gt; (she/her)
 * [Fishrock123](https://github.com/Fishrock123) -
 **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
+* [gibfahn](https://github.com/gibfahn) -
+**Gibson Fahnestock** &lt;gibfahn@gmail.com&gt; (he/him)
 * [indutny](https://github.com/indutny) -
 **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
 * [jasnell](https://github.com/jasnell) -

--- a/README.md
+++ b/README.md
@@ -257,8 +257,6 @@ For more information about the governance of the Node.js project, see
 **Matteo Collina** &lt;matteo.collina@gmail.com&gt; (he/him)
 * [mhdawson](https://github.com/mhdawson) -
 **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt; (he/him)
-* [mscdex](https://github.com/mscdex) -
-**Brian White** &lt;mscdex@mscdex.net&gt;
 * [MylesBorins](https://github.com/MylesBorins) -
 **Myles Borins** &lt;myles.borins@gmail.com&gt; (he/him)
 * [ofrobots](https://github.com/ofrobots) -
@@ -284,6 +282,8 @@ For more information about the governance of the Node.js project, see
 **Isaac Z. Schlueter** &lt;i@izs.me&gt;
 * [joshgav](https://github.com/joshgav) -
 **Josh Gavant** &lt;josh.gavant@outlook.com&gt;
+* [mscdex](https://github.com/mscdex) -
+**Brian White** &lt;mscdex@mscdex.net&gt;
 * [nebrius](https://github.com/nebrius) -
 **Bryan Hughes** &lt;bryan@nebri.us&gt;
 * [orangemocha](https://github.com/orangemocha) -

--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -2,22 +2,15 @@
 
 const assert = require('assert');
 const http = require('http');
-const fs = require('fs');
 const { fork } = require('child_process');
 const common = require('../common.js');
-const { PIPE, tmpDir } = require('../../test/common');
+const { PIPE } = require('../../test/common');
+const tmpdir = require('../../test/common/tmpdir');
 process.env.PIPE_NAME = PIPE;
 
-try {
-  fs.accessSync(tmpDir, fs.F_OK);
-} catch (e) {
-  fs.mkdirSync(tmpDir);
-}
+tmpdir.refresh();
 
 var server;
-try {
-  fs.unlinkSync(process.env.PIPE_NAME);
-} catch (e) { /* ignore */ }
 
 server = http.createServer(function(req, res) {
   const headers = {

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const common = require('../common.js');
-const icu = process.binding('icu');
+let icu;
+try {
+  icu = process.binding('icu');
+} catch (err) {}
 const punycode = require('punycode');
 
 const bench = common.createBenchmark(main, {
-  method: ['punycode', 'icu'],
+  method: ['punycode'].concat(icu !== undefined ? ['icu'] : []),
   n: [1024],
   val: [
     'افغانستا.icom.museum',
@@ -69,8 +72,11 @@ function main(conf) {
       runPunycode(n, val);
       break;
     case 'icu':
-      runICU(n, val);
-      break;
+      if (icu !== undefined) {
+        runICU(n, val);
+        break;
+      }
+      // fallthrough
     default:
       throw new Error('Unexpected method');
   }

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const common = require('../common.js');
 
-const { refreshTmpDir, tmpDir } = require('../../test/common');
-const benchmarkDirectory = path.join(tmpDir, 'nodejs-benchmark-module');
+const tmpdir = require('../../test/common/tmpdir');
+const benchmarkDirectory = path.join(tmpdir.path, 'nodejs-benchmark-module');
 
 const bench = common.createBenchmark(main, {
   thousands: [50],
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const n = +conf.thousands * 1e3;
 
-  refreshTmpDir();
+  tmpdir.refresh();
   try { fs.mkdirSync(benchmarkDirectory); } catch (e) {}
 
   for (var i = 0; i <= n; i++) {
@@ -35,7 +35,7 @@ function main(conf) {
   else
     measureDir(n, conf.useCache === 'true');
 
-  refreshTmpDir();
+  tmpdir.refresh();
 }
 
 function measureFull(n, useCache) {

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -45,11 +45,11 @@ function main(conf) {
   };
 
   server = tls.createServer(options, onConnection);
-  setTimeout(done, dur * 1000);
   var conn;
   server.listen(common.PORT, function() {
     const opt = { port: common.PORT, rejectUnauthorized: false };
     conn = tls.connect(opt, function() {
+      setTimeout(done, dur * 1000);
       bench.start();
       conn.on('drain', write);
       write();

--- a/common.gypi
+++ b/common.gypi
@@ -282,7 +282,7 @@
         ],
       }],
       [ 'OS in "linux freebsd openbsd solaris aix"', {
-        'cflags': [ '-pthread', ],
+        'cflags': [ '-pthread' ],
         'ldflags': [ '-pthread' ],
       }],
       [ 'OS in "linux freebsd openbsd solaris android aix"', {
@@ -295,6 +295,7 @@
             'standalone_static_library': 1,
           }],
           ['OS=="openbsd"', {
+            'cflags': [ '-I/usr/local/include' ],
             'ldflags': [ '-Wl,-z,wxneeded' ],
           }],
         ],

--- a/configure
+++ b/configure
@@ -61,7 +61,7 @@ parser = optparse.OptionParser()
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
             'android', 'aix')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
-              'ppc64', 'x32','x64', 'x86', 's390', 's390x')
+              'ppc64', 'x32','x64', 'x86', 'x86_64', 's390', 's390x')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
 valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
 valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
@@ -861,6 +861,9 @@ def configure_node(o):
   # the Makefile resets this to x86 afterward
   if target_arch == 'x86':
     target_arch = 'ia32'
+  # x86_64 is common across linuxes, allow it as an alias for x64
+  if target_arch == 'x86_64':
+    target_arch = 'x64'
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
   o['variables']['node_byteorder'] = sys.byteorder

--- a/configure
+++ b/configure
@@ -881,7 +881,6 @@ def configure_node(o):
     configure_mips(o)
 
   if flavor == 'aix':
-    o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
@@ -990,6 +989,13 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  if options.shared:
+    o['variables']['node_target_type'] = 'shared_library'
+  elif options.enable_static:
+    o['variables']['node_target_type'] = 'static_library'
+  else:
+    o['variables']['node_target_type'] = 'executable'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
@@ -1487,8 +1493,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
-  'NODE_TARGET_TYPE': variables['node_target_type'] if options.enable_static \
-      else '',
+  'NODE_TARGET_TYPE': variables['node_target_type'],
 }
 
 if options.prefix:

--- a/deps/node-inspect/CHANGELOG.md
+++ b/deps/node-inspect/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.11.3
+
+* [`93caa0f`](https://github.com/nodejs/node-inspect/commit/93caa0f5267c7ab452b258d3b03329a0bb5ac7f7) **docs:** Add missing oc in protocol
+* [`2d87cbe`](https://github.com/nodejs/node-inspect/commit/2d87cbe76aa968dfc1ac69d9571af1be81abd8e0) **fix:** Make --inspect-port=0 work
+* [`ebfd02e`](https://github.com/nodejs/node-inspect/commit/ebfd02ece9b642586023f7791da71defeb13d746) **chore:** Bump tap to 10.7
+* [`c07adb1`](https://github.com/nodejs/node-inspect/commit/c07adb17b164c1cf3da8d38659ea9f5d7ff42e9c) **test:** Use useful break location
+* [`94f0bf9`](https://github.com/nodejs/node-inspect/commit/94f0bf97d24c376baf3ecced2088d81715a73464) **fix:** Fix `takeHeapSnapshot()` truncation bug
+
+
 ### 1.11.2
 
 * [`42e0cd1`](https://github.com/nodejs/node-inspect/commit/42e0cd111d89ed09faba1c0ec45089b0b44de011) **fix:** look for generic hint text

--- a/deps/node-inspect/README.md
+++ b/deps/node-inspect/README.md
@@ -10,7 +10,7 @@ node has two options:
 1. `node --debug <file>`: Start `file` with remote debugging enabled.
 2. `node debug <file>`: Start an interactive CLI debugger for `<file>`.
 
-But for the Chrome inspector protol,
+But for the Chrome inspector protocol,
 there's only one: `node --inspect <file>`.
 
 This project tries to provide the missing second option

--- a/deps/node-inspect/lib/_inspect.js
+++ b/deps/node-inspect/lib/_inspect.js
@@ -42,18 +42,9 @@ const [ InspectClient, createRepl ] =
 
 const debuglog = util.debuglog('inspect');
 
-const DEBUG_PORT_PATTERN = /^--(?:debug|inspect)(?:-port|-brk)?=(\d{1,5})$/;
-function getDefaultPort() {
-  for (const arg of process.execArgv) {
-    const match = arg.match(DEBUG_PORT_PATTERN);
-    if (match) {
-      return +match[1];
-    }
-  }
-  return 9229;
-}
-
 function portIsFree(host, port, timeout = 2000) {
+  if (port === 0) return Promise.resolve();  // Binding to a random port.
+
   const retryDelay = 150;
   let didTimeOut = false;
 
@@ -110,9 +101,11 @@ function runScript(script, scriptArgs, inspectHost, inspectPort, childPrint) {
         let output = '';
         function waitForListenHint(text) {
           output += text;
-          if (/Debugger listening on/.test(output)) {
+          if (/Debugger listening on ws:\/\/\[?(.+?)\]?:(\d+)\//.test(output)) {
+            const host = RegExp.$1;
+            const port = Number.parseInt(RegExp.$2);
             child.stderr.removeListener('data', waitForListenHint);
-            resolve(child);
+            resolve([child, port, host]);
           }
         }
 
@@ -160,10 +153,11 @@ class NodeInspector {
                                        options.port,
                                        this.childPrint.bind(this));
     } else {
-      this._runScript = () => Promise.resolve(null);
+      this._runScript =
+          () => Promise.resolve([null, options.port, options.host]);
     }
 
-    this.client = new InspectClient(options.port, options.host);
+    this.client = new InspectClient();
 
     this.domainNames = ['Debugger', 'HeapProfiler', 'Profiler', 'Runtime'];
     this.domainNames.forEach((domain) => {
@@ -223,9 +217,8 @@ class NodeInspector {
 
   run() {
     this.killChild();
-    const { host, port } = this.options;
 
-    return this._runScript().then((child) => {
+    return this._runScript().then(([child, port, host]) => {
       this.child = child;
 
       let connectionAttempts = 0;
@@ -233,7 +226,7 @@ class NodeInspector {
         ++connectionAttempts;
         debuglog('connection attempt #%d', connectionAttempts);
         this.stdout.write('.');
-        return this.client.connect()
+        return this.client.connect(port, host)
           .then(() => {
             debuglog('connection established');
             this.stdout.write(' ok');
@@ -288,7 +281,7 @@ class NodeInspector {
 
 function parseArgv([target, ...args]) {
   let host = '127.0.0.1';
-  let port = getDefaultPort();
+  let port = 9229;
   let isRemote = false;
   let script = target;
   let scriptArgs = args;

--- a/deps/node-inspect/lib/internal/inspect_client.js
+++ b/deps/node-inspect/lib/internal/inspect_client.js
@@ -164,12 +164,12 @@ function decodeFrameHybi17(data) {
 }
 
 class Client extends EventEmitter {
-  constructor(port, host) {
+  constructor() {
     super();
     this.handleChunk = this._handleChunk.bind(this);
 
-    this._port = port;
-    this._host = host;
+    this._port = undefined;
+    this._host = undefined;
 
     this.reset();
   }
@@ -284,7 +284,9 @@ class Client extends EventEmitter {
     });
   }
 
-  connect() {
+  connect(port, host) {
+    this._port = port;
+    this._host = host;
     return this._discoverWebsocketPath()
       .then((urlPath) => this._connectWebsocket(urlPath));
   }

--- a/deps/node-inspect/package.json
+++ b/deps/node-inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-inspect",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Node Inspect",
   "license": "MIT",
   "main": "lib/_inspect.js",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "^3.10.2",
     "nlm": "^3.0.0",
-    "tap": "^7.1.2"
+    "tap": "^10.7.0"
   },
   "author": {
     "name": "Jan Krems",

--- a/deps/node-inspect/test/cli/break.test.js
+++ b/deps/node-inspect/test/cli/break.test.js
@@ -134,7 +134,7 @@ test('sb before loading file', (t) => {
 
   return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
-    .then(() => cli.command('sb("other.js", 3)'))
+    .then(() => cli.command('sb("other.js", 2)'))
     .then(() => {
       t.match(
         cli.output,
@@ -145,7 +145,7 @@ test('sb before loading file', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        `break in ${otherScript}:3`,
+        `break in ${otherScript}:2`,
         'found breakpoint in file that was not loaded yet');
     })
     .then(() => cli.quit())

--- a/deps/node-inspect/test/cli/heap-profiler.test.js
+++ b/deps/node-inspect/test/cli/heap-profiler.test.js
@@ -1,0 +1,34 @@
+'use strict';
+const { test } = require('tap');
+const { readFileSync, unlinkSync } = require('fs');
+
+const startCLI = require('./start-cli');
+const filename = 'node.heapsnapshot';
+
+function cleanup() {
+  try {
+    unlinkSync(filename);
+  } catch (_) {
+    // Ignore.
+  }
+}
+
+cleanup();
+
+test('Heap profiler take snapshot', (t) => {
+  const cli = startCLI(['examples/empty.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  // Check that the snapshot is valid JSON.
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('takeHeapSnapshot()'))
+    .then(() => JSON.parse(readFileSync(filename, 'utf8')))
+    .then(() => cleanup())
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});

--- a/deps/node-inspect/test/cli/launch.test.js
+++ b/deps/node-inspect/test/cli/launch.test.js
@@ -26,6 +26,46 @@ test('custom port', (t) => {
     });
 });
 
+test('random port', (t) => {
+  const script = Path.join('examples', 'three-lines.js');
+
+  const cli = startCLI(['--port=0', script]);
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(cli.output, 'debug>', 'prints a prompt');
+      t.match(
+        cli.output,
+        /< Debugger listening on /,
+        'forwards child output');
+    })
+    .then(() => cli.quit())
+    .then((code) => {
+      t.equal(code, 0, 'exits with success');
+    });
+});
+
+test('random port with --inspect-port=0', (t) => {
+  const script = Path.join('examples', 'three-lines.js');
+
+  const cli = startCLI([script], ['--inspect-port=0']);
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(cli.output, 'debug>', 'prints a prompt');
+      t.match(
+        cli.output,
+        /< Debugger listening on /,
+        'forwards child output');
+    })
+    .then(() => cli.quit())
+    .then((code) => {
+      t.equal(code, 0, 'exits with success');
+    });
+});
+
 test('examples/three-lines.js', (t) => {
   const script = Path.join('examples', 'three-lines.js');
   const cli = startCLI([script]);

--- a/deps/node-inspect/test/cli/start-cli.js
+++ b/deps/node-inspect/test/cli/start-cli.js
@@ -16,8 +16,8 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
   'exception', 'other', 'promiseRejection',
 ].join('|') + ') in', 'i');
 
-function startCLI(args) {
-  const child = spawn(process.execPath, [CLI, ...args]);
+function startCLI(args, flags = []) {
+  const child = spawn(process.execPath, [...flags, CLI, ...args]);
   let isFirstStdoutChunk = true;
 
   const outputBuffer = [];

--- a/deps/v8/src/v8.gyp
+++ b/deps/v8/src/v8.gyp
@@ -2044,9 +2044,10 @@
                 '-L/usr/local/lib -lexecinfo',
             ]},
             'sources': [
+              'base/debug/stack_trace_posix.cc',
               'base/platform/platform-openbsd.cc',
               'base/platform/platform-posix.h',
-              'base/platform/platform-posix.cc'
+              'base/platform/platform-posix.cc',
               'base/platform/platform-posix-time.h',
               'base/platform/platform-posix-time.cc',
             ],

--- a/deps/v8/test/cctest/test-lockers.cc
+++ b/deps/v8/test/cctest/test-lockers.cc
@@ -55,6 +55,244 @@ using ::v8::Value;
 using ::v8::V8;
 
 
+namespace {
+
+class DeoptimizeCodeThread : public v8::base::Thread {
+ public:
+  DeoptimizeCodeThread(v8::Isolate* isolate, v8::Local<v8::Context> context,
+                       const char* trigger)
+      : Thread(Options("DeoptimizeCodeThread")),
+        isolate_(isolate),
+        context_(isolate, context),
+        source_(trigger) {}
+
+  void Run() {
+    v8::Locker locker(isolate_);
+    isolate_->Enter();
+    v8::HandleScope handle_scope(isolate_);
+    v8::Local<v8::Context> context =
+        v8::Local<v8::Context>::New(isolate_, context_);
+    v8::Context::Scope context_scope(context);
+    CHECK_EQ(isolate_, v8::Isolate::GetCurrent());
+    // This code triggers deoptimization of some function that will be
+    // used in a different thread.
+    CompileRun(source_);
+    isolate_->Exit();
+  }
+
+ private:
+  v8::Isolate* isolate_;
+  Persistent<v8::Context> context_;
+  // The code that triggers the deoptimization.
+  const char* source_;
+};
+
+void UnlockForDeoptimization(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  // Gets the pointer to the thread that will trigger the deoptimization of the
+  // code.
+  DeoptimizeCodeThread* deoptimizer =
+      reinterpret_cast<DeoptimizeCodeThread*>(isolate->GetData(0));
+  {
+    // Exits and unlocks the isolate.
+    isolate->Exit();
+    v8::Unlocker unlocker(isolate);
+    // Starts the deoptimizing thread.
+    deoptimizer->Start();
+    // Waits for deoptimization to finish.
+    deoptimizer->Join();
+  }
+  // The deoptimizing thread has finished its work, and the isolate
+  // will now be used by the current thread.
+  isolate->Enter();
+}
+
+void UnlockForDeoptimizationIfReady(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  bool* ready_to_deoptimize = reinterpret_cast<bool*>(isolate->GetData(1));
+  if (*ready_to_deoptimize) {
+    // The test should enter here only once, so put the flag back to false.
+    *ready_to_deoptimize = false;
+    // Gets the pointer to the thread that will trigger the deoptimization of
+    // the code.
+    DeoptimizeCodeThread* deoptimizer =
+        reinterpret_cast<DeoptimizeCodeThread*>(isolate->GetData(0));
+    {
+      // Exits and unlocks the thread.
+      isolate->Exit();
+      v8::Unlocker unlocker(isolate);
+      // Starts the thread that deoptimizes the function.
+      deoptimizer->Start();
+      // Waits for the deoptimizing thread to finish.
+      deoptimizer->Join();
+    }
+    // The deoptimizing thread has finished its work, and the isolate
+    // will now be used by the current thread.
+    isolate->Enter();
+  }
+}
+}  // namespace
+
+TEST(LazyDeoptimizationMultithread) {
+  i::FLAG_allow_natives_syntax = true;
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  {
+    v8::Locker locker(isolate);
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    const char* trigger_deopt = "obj = { y: 0, x: 1 };";
+
+    // We use the isolate to pass arguments to the UnlockForDeoptimization
+    // function. Namely, we pass a pointer to the deoptimizing thread.
+    DeoptimizeCodeThread deoptimize_thread(isolate, context, trigger_deopt);
+    isolate->SetData(0, &deoptimize_thread);
+    v8::Context::Scope context_scope(context);
+
+    // Create the function templace for C++ code that is invoked from
+    // JavaScript code.
+    Local<v8::FunctionTemplate> fun_templ =
+        v8::FunctionTemplate::New(isolate, UnlockForDeoptimization);
+    Local<Function> fun = fun_templ->GetFunction(context).ToLocalChecked();
+    CHECK(context->Global()
+              ->Set(context, v8_str("unlock_for_deoptimization"), fun)
+              .FromJust());
+
+    // Optimizes a function f, which will be deoptimized in another
+    // thread.
+    CompileRun(
+        "var b = false; var obj = { x: 1 };"
+        "function f() { g(); return obj.x; }"
+        "function g() { if (b) { unlock_for_deoptimization(); } }"
+        "%NeverOptimizeFunction(g);"
+        "f(); f(); %OptimizeFunctionOnNextCall(f);"
+        "f();");
+
+    // Trigger the unlocking.
+    Local<Value> v = CompileRun("b = true; f();");
+
+    // Once the isolate has been unlocked, the thread will wait for the
+    // other thread to finish its task. Once this happens, this thread
+    // continues with its execution, that is, with the execution of the
+    // function g, which then returns to f. The function f should have
+    // also been deoptimized. If the replacement did not happen on this
+    // thread's stack, then the test will fail here.
+    CHECK(v->IsNumber());
+    CHECK_EQ(1, static_cast<int>(v->NumberValue(context).FromJust()));
+  }
+  isolate->Dispose();
+}
+
+TEST(LazyDeoptimizationMultithreadWithNatives) {
+  i::FLAG_allow_natives_syntax = true;
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  {
+    v8::Locker locker(isolate);
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    const char* trigger_deopt = "%DeoptimizeFunction(f);";
+
+    // We use the isolate to pass arguments to the UnlockForDeoptimization
+    // function. Namely, we pass a pointer to the deoptimizing thread.
+    DeoptimizeCodeThread deoptimize_thread(isolate, context, trigger_deopt);
+    isolate->SetData(0, &deoptimize_thread);
+    bool ready_to_deopt = false;
+    isolate->SetData(1, &ready_to_deopt);
+    v8::Context::Scope context_scope(context);
+
+    // Create the function templace for C++ code that is invoked from
+    // JavaScript code.
+    Local<v8::FunctionTemplate> fun_templ =
+        v8::FunctionTemplate::New(isolate, UnlockForDeoptimizationIfReady);
+    Local<Function> fun = fun_templ->GetFunction(context).ToLocalChecked();
+    CHECK(context->Global()
+              ->Set(context, v8_str("unlock_for_deoptimization"), fun)
+              .FromJust());
+
+    // Optimizes a function f, which will be deoptimized in another
+    // thread.
+    CompileRun(
+        "var obj = { x: 1 };"
+        "function f() { g(); return obj.x;}"
+        "function g() { "
+        "  unlock_for_deoptimization(); }"
+        "%NeverOptimizeFunction(g);"
+        "f(); f(); %OptimizeFunctionOnNextCall(f);");
+
+    // Trigger the unlocking.
+    ready_to_deopt = true;
+    isolate->SetData(1, &ready_to_deopt);
+    Local<Value> v = CompileRun("f();");
+
+    // Once the isolate has been unlocked, the thread will wait for the
+    // other thread to finish its task. Once this happens, this thread
+    // continues with its execution, that is, with the execution of the
+    // function g, which then returns to f. The function f should have
+    // also been deoptimized. Otherwise, the test will fail here.
+    CHECK(v->IsNumber());
+    CHECK_EQ(1, static_cast<int>(v->NumberValue(context).FromJust()));
+  }
+  isolate->Dispose();
+}
+
+TEST(EagerDeoptimizationMultithread) {
+  i::FLAG_allow_natives_syntax = true;
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  {
+    v8::Locker locker(isolate);
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    const char* trigger_deopt = "f({y: 0, x: 1});";
+
+    // We use the isolate to pass arguments to the UnlockForDeoptimization
+    // function. Namely, we pass a pointer to the deoptimizing thread.
+    DeoptimizeCodeThread deoptimize_thread(isolate, context, trigger_deopt);
+    isolate->SetData(0, &deoptimize_thread);
+    bool ready_to_deopt = false;
+    isolate->SetData(1, &ready_to_deopt);
+    v8::Context::Scope context_scope(context);
+
+    // Create the function templace for C++ code that is invoked from
+    // JavaScript code.
+    Local<v8::FunctionTemplate> fun_templ =
+        v8::FunctionTemplate::New(isolate, UnlockForDeoptimizationIfReady);
+    Local<Function> fun = fun_templ->GetFunction(context).ToLocalChecked();
+    CHECK(context->Global()
+              ->Set(context, v8_str("unlock_for_deoptimization"), fun)
+              .FromJust());
+
+    // Optimizes a function f, which will be deoptimized by another thread.
+    CompileRun(
+        "function f(obj) { unlock_for_deoptimization(); return obj.x; }"
+        "f({x: 1}); f({x: 1});"
+        "%OptimizeFunctionOnNextCall(f);"
+        "f({x: 1});");
+
+    // Trigger the unlocking.
+    ready_to_deopt = true;
+    isolate->SetData(1, &ready_to_deopt);
+    Local<Value> v = CompileRun("f({x: 1});");
+
+    // Once the isolate has been unlocked, the thread will wait for the
+    // other thread to finish its task. Once this happens, this thread
+    // continues with its execution, that is, with the execution of the
+    // function g, which then returns to f. The function f should have
+    // also been deoptimized. Otherwise, the test will fail here.
+    CHECK(v->IsNumber());
+    CHECK_EQ(1, static_cast<int>(v->NumberValue(context).FromJust()));
+  }
+  isolate->Dispose();
+}
+
 // Migrating an isolate
 class KangarooThread : public v8::base::Thread {
  public:

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -276,7 +276,7 @@ added: v0.1.21
 * `expected` {any}
 * `message` {any}
 * `operator` {string} **Default:** '!='
-* `stackStartFunction` {function} **Default:** `assert.fail`
+* `stackStartFunction` {Function} **Default:** `assert.fail`
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -86,7 +86,7 @@ added: v8.1.0
   * `before` {Function} The [`before` callback][].
   * `after` {Function} The [`after` callback][].
   * `destroy` {Function} The [`destroy` callback][].
-* Returns: `{AsyncHook}` Instance used for disabling and enabling hooks
+* Returns: {AsyncHook} Instance used for disabling and enabling hooks
 
 Registers functions to be called for different lifetime events of each async
 operation.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -44,7 +44,7 @@ implemented on top of [`child_process.spawn()`][] or [`child_process.spawnSync()
   * [`child_process.exec()`][]: spawns a shell and runs a command within that shell,
     passing the `stdout` and `stderr` to a callback function when complete.
   * [`child_process.execFile()`][]: similar to [`child_process.exec()`][] except that
-    it spawns the command directly without first spawning a shell.
+    it spawns the command directly without first spawning a shell by default.
   * [`child_process.fork()`][]: spawns a new Node.js process and invokes a
     specified module with an IPC communication channel established that allows
     sending messages between parent and child.
@@ -78,7 +78,7 @@ when the child process terminates.
 The importance of the distinction between [`child_process.exec()`][] and
 [`child_process.execFile()`][] can vary based on platform. On Unix-type operating
 systems (Unix, Linux, macOS) [`child_process.execFile()`][] can be more efficient
-because it does not spawn a shell. On Windows, however, `.bat` and `.cmd`
+because it does not spawn a shell by default. On Windows, however, `.bat` and `.cmd`
 files are not executable on their own without a terminal, and therefore cannot
 be launched using [`child_process.execFile()`][]. When running on Windows, `.bat`
 and `.cmd` files can be invoked using [`child_process.spawn()`][] with the `shell`
@@ -266,6 +266,10 @@ changes:
     normally be created on Windows systems. **Default:** `false`.
   * `windowsVerbatimArguments` {boolean} No quoting or escaping of arguments is
     done on Windows. Ignored on Unix. **Default:** `false`.
+  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
+    `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
+    shell can be specified as a string. See [Shell Requirements][] and
+    [Default Windows Shell][]. **Default:** `false` (no shell).
 * `callback` {Function} Called with the output when process terminates.
   * `error` {Error}
   * `stdout` {string|Buffer}
@@ -273,7 +277,7 @@ changes:
 * Returns: {ChildProcess}
 
 The `child_process.execFile()` function is similar to [`child_process.exec()`][]
-except that it does not spawn a shell. Rather, the specified executable `file`
+except that it does not spawn a shell by default. Rather, the specified executable `file`
 is spawned directly as a new process making it slightly more efficient than
 [`child_process.exec()`][].
 
@@ -311,6 +315,10 @@ async function getVersion() {
 }
 getVersion();
 ```
+
+*Note*: If the `shell` option is enabled, do not pass unsanitized user input
+to this function. Any input containing shell metacharacters may be used to
+trigger arbitrary command execution.
 
 ### child_process.fork(modulePath[, args][, options])
 <!-- YAML
@@ -703,6 +711,10 @@ changes:
   * `encoding` {string} The encoding used for all stdio inputs and outputs. **Default:** `'buffer'`
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
+  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
+    `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
+    shell can be specified as a string. See [Shell Requirements][] and
+    [Default Windows Shell][]. **Default:** `false` (no shell).
 * Returns: {Buffer|string} The stdout from the command.
 
 The `child_process.execFileSync()` method is generally identical to
@@ -718,6 +730,10 @@ exited.
 If the process times out or has a non-zero exit code, this method ***will***
 throw an [`Error`][] that will include the full result of the underlying
 [`child_process.spawnSync()`][].
+
+*Note*: If the `shell` option is enabled, do not pass unsanitized user input
+to this function. Any input containing shell metacharacters may be used to
+trigger arbitrary command execution.
 
 ### child_process.execSync(command[, options])
 <!-- YAML

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -267,7 +267,7 @@ changes:
     description: This method now returns a reference to `worker`.
 -->
 
-* Returns: {Worker} A reference to `worker`.
+* Returns: {cluster.Worker} A reference to `worker`.
 
 In a worker, this function will close all servers, wait for the `'close'` event on
 those servers, and then disconnect the IPC channel.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -752,7 +752,7 @@ changes:
     `'ipc'` entry. When this option is provided, it overrides `silent`.
   * `uid` {number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {number} Sets the group identity of the process. (See setgid(2).)
-  * `inspectPort` {number|function} Sets inspector port of worker.
+  * `inspectPort` {number|Function} Sets inspector port of worker.
     This can be a number, or a function that takes no arguments and returns a
     number. By default each worker gets its own port, incremented from the
     master's `process.debugPort`.

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -78,8 +78,8 @@ const { Console } = console;
 ```
 
 ### new Console(stdout[, stderr])
-* `stdout` {Writable}
-* `stderr` {Writable}
+* `stdout` {stream.Writable}
+* `stderr` {stream.Writable}
 
 Creates a new `Console` with one or two writable stream instances. `stdout` is a
 writable stream to print log or info output. `stderr` is used for warning or

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -371,6 +371,14 @@ received _authentication tag_. If no tag is provided, or if the cipher text
 has been tampered with, [`decipher.final()`][] will throw, indicating that the
 cipher text should be discarded due to failed authentication.
 
+Note that this Node.js version does not verify the length of GCM authentication
+tags. Such a check *must* be implemented by applications and is crucial to the
+authenticity of the encrypted data, otherwise, an attacker can use an
+arbitrarily short authentication tag to increase the chances of successfully
+passing authentication (up to 0.39%). It is highly recommended to associate one
+of the values 16, 15, 14, 13, 12, 8 or 4 bytes with each key, and to only permit
+authentication tags of that length, see [NIST SP 800-38D][].
+
 The `decipher.setAuthTag()` method must be called before
 [`decipher.final()`][].
 
@@ -2288,6 +2296,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [HTML5's `keygen` element]: https://www.w3.org/TR/html5/forms.html#the-keygen-element
 [NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
 [NIST SP 800-132]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
+[NIST SP 800-38D]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [Nonce-Disrespecting Adversaries]: https://github.com/nonce-disrespect/nonce-disrespect
 [OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
 [RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -997,11 +997,6 @@ While using `N-API`, `Constructor.prototype` was not an object.
 An attempt was made to use features that require [ICU][], but Node.js was not
 compiled with ICU support.
 
-<a id="ERR_OUTOFMEMORY"></a>
-### ERR_OUTOFMEMORY
-
-An operation caused an out-of-memory condition.
-
 <a id="ERR_SOCKET_ALREADY_BOUND"></a>
 ### ERR_SOCKET_ALREADY_BOUND
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -577,7 +577,7 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `mode` {integer} **Default:** `fs.constants.F_OK`
-* Returns: `undefined`
+* Returns: {undefined}
 
 Synchronously tests a user's permissions for the file or directory specified by
 `path`. The `mode` argument is an optional integer that specifies the

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1880,6 +1880,49 @@ const req = http.request(options, (res) => {
 });
 ```
 
+In a successful request, the following events will be emitted in the following
+order:
+
+* `socket`
+* `response`
+  * `data` any number of times, on the `res` object
+    (`data` will not be emitted at all if the response body is empty, for
+    instance, in most redirects)
+  * `end` on the `res` object
+* `close`
+
+In the case of a connection error, the following events will be emitted:
+
+* `socket`
+* `error`
+* `close`
+
+If `req.abort()` is called before the connection succeeds, the following events
+will be emitted in the following order:
+
+* `socket`
+* (`req.abort()` called here)
+* `abort`
+* `close`
+* `error` with an error with message `Error: socket hang up` and code
+  `ECONNRESET`
+
+If `req.abort()` is called after the response is received, the following events
+will be emitted in the following order:
+
+* `socket`
+* `response`
+  * `data` any number of times, on the `res` object
+* (`req.abort()` called here)
+* `abort`
+* `close`
+  * `aborted` on the `res` object
+  * `end` on the `res` object
+  * `close` on the `res` object
+
+Note that setting the `timeout` option or using the `setTimeout` function will
+not abort the request or do anything besides add a `timeout` event.
+
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'request'`]: #http_event_request
 [`'response'`]: #http_event_response

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1045,7 +1045,7 @@ added: v8.4.0
 * `options` {Object}
   * `endStream` {boolean} Set to `true` to indicate that the response will not
     include payload data.
-  * `getTrailers` {function} Callback function invoked to collect trailer
+  * `getTrailers` {Function} Callback function invoked to collect trailer
     headers.
 * Returns: {undefined}
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -589,7 +589,7 @@ client.
 added: v8.4.0
 -->
 
-* Extends: {Duplex}
+* Extends: {stream.Duplex}
 
 Each instance of the `Http2Stream` class represents a bidirectional HTTP/2
 communications stream over an `Http2Session` instance. Any single `Http2Session`
@@ -1308,7 +1308,7 @@ an `Http2Session` object. If no listener is registered for this event, an
 added: v8.5.0
 -->
 
-* `socket` {http2.ServerHttp2Stream}
+* `socket` {ServerHttp2Stream}
 
 If an `ServerHttp2Stream` emits an `'error'` event, it will be forwarded here.
 The stream will already be destroyed when this event is triggered.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -323,7 +323,7 @@ Interface's `input` *as if it were provided by the user*.
 added: v0.7.7
 -->
 
-* `stream` {Writable}
+* `stream` {stream.Writable}
 * `dir` {number}
   * `-1` - to the left from cursor
   * `1` - to the right from cursor
@@ -338,7 +338,7 @@ in a specified direction identified by `dir`.
 added: v0.7.7
 -->
 
-* `stream` {Writable}
+* `stream` {stream.Writable}
 
 The `readline.clearScreenDown()` method clears the given [TTY][] stream from
 the current position of the cursor down.
@@ -362,9 +362,9 @@ changes:
 -->
 
 * `options` {Object}
-  * `input` {Readable} The [Readable][] stream to listen to. This option is
+  * `input` {stream.Readable} The [Readable][] stream to listen to. This option is
     *required*.
-  * `output` {Writable} The [Writable][] stream to write readline data to.
+  * `output` {stream.Writable} The [Writable][] stream to write readline data to.
   * `completer` {Function} An optional function used for Tab autocompletion.
   * `terminal` {boolean} `true` if the `input` and `output` streams should be
     treated like a TTY, and have ANSI/VT100 escape codes written to it.
@@ -444,7 +444,7 @@ function completer(linePartial, callback) {
 added: v0.7.7
 -->
 
-* `stream` {Writable}
+* `stream` {stream.Writable}
 * `x` {number}
 * `y` {number}
 
@@ -456,7 +456,7 @@ given [TTY][] `stream`.
 added: v0.7.7
 -->
 
-* `stream` {Readable}
+* `stream` {stream.Readable}
 * `interface` {readline.Interface}
 
 The `readline.emitKeypressEvents()` method causes the given [Readable][]
@@ -482,7 +482,7 @@ if (process.stdin.isTTY)
 added: v0.7.7
 -->
 
-* `stream` {Writable}
+* `stream` {stream.Writable}
 * `dx` {number}
 * `dy` {number}
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -388,9 +388,9 @@ changes:
 * `options` {Object|string}
   * `prompt` {string} The input prompt to display. Defaults to `> `
     (with a trailing space).
-  * `input` {Readable} The Readable stream from which REPL input will be read.
+  * `input` {stream.Readable} The Readable stream from which REPL input will be read.
     Defaults to `process.stdin`.
-  * `output` {Writable} The Writable stream to which REPL output will be
+  * `output` {stream.Writable} The Writable stream to which REPL output will be
     written. Defaults to `process.stdout`.
   * `terminal` {boolean} If `true`, specifies that the `output` should be
     treated as a TTY terminal, and have ANSI/VT100 escape codes written to it.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -572,8 +572,8 @@ The Readable can switch back to paused mode using one of the following:
 
 * If there are no pipe destinations, by calling the
   [`stream.pause()`][stream-pause] method.
-* If there are pipe destinations, by removing any [`'data'`][] event
-  handlers, and removing all pipe destinations by calling the
+* If there are pipe destinations, by removing all pipe destinations.
+  Multiple pipe destinations may be removed by calling the
   [`stream.unpipe()`][] method.
 
 The important concept to remember is that a Readable will not generate data
@@ -1411,7 +1411,7 @@ write succeeded.
 
 All calls to `writable.write()` that occur between the time `writable._write()`
 is called and the `callback` is called will cause the written data to be
-buffered. Once the `callback` is invoked, the stream will emit a [`'drain'`][]
+buffered. When the `callback` is invoked, the stream might emit a [`'drain'`][]
 event. If a stream implementation is capable of processing multiple chunks of
 data at once, the `writable._writev()` method should be implemented.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -394,7 +394,7 @@ changes:
 -->
 
 * `encoding` {string} The new default encoding
-* Returns: `this`
+* Returns: {this}
 
 The `writable.setDefaultEncoding()` method sets the default `encoding` for a
 [Writable][] stream.
@@ -525,7 +525,7 @@ A Writable stream in object mode will always ignore the `encoding` argument.
 added: v8.0.0
 -->
 
-* Returns: `this`
+* Returns: {this}
 
 Destroy the stream, and emit the passed error. After this call, the
 writable stream has ended. Implementors should not override this method,
@@ -810,7 +810,7 @@ readable.isPaused(); // === false
 added: v0.9.4
 -->
 
-* Returns: `this`
+* Returns: {this}
 
 The `readable.pause()` method will cause a stream in flowing mode to stop
 emitting [`'data'`][] events, switching out of flowing mode. Any data that
@@ -950,7 +950,7 @@ event has been emitted will return `null`. No runtime error will be raised.
 added: v0.9.4
 -->
 
-* Returns: `this`
+* Returns: {this}
 
 The `readable.resume()` method causes an explicitly paused Readable stream to
 resume emitting [`'data'`][] events, switching the stream into flowing mode.
@@ -973,7 +973,7 @@ added: v0.9.4
 -->
 
 * `encoding` {string} The encoding to use.
-* Returns: `this`
+* Returns: {this}
 
 The `readable.setEncoding()` method sets the character encoding for
 data read from the Readable stream.

--- a/doc/node.1
+++ b/doc/node.1
@@ -37,9 +37,9 @@ node \- Server-side JavaScript runtime
 .RI [ script.js \ |
 .B -e
 .RI \&" script \&"
-.R |
+.RI |
 .B -
-.R ]
+.RI ]
 .B [--]
 .RI [ arguments ]
 .br

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -6,3 +6,4 @@ rules:
   buffer-constructor: error
   no-let-in-for-declaration: error
   lowercase-name-for-primitive: error
+  non-ascii-character: error

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -453,6 +453,7 @@ function socketOnData(d) {
     socket.removeListener('data', socketOnData);
     socket.removeListener('end', socketOnEnd);
     parser.finish();
+    freeParser(parser, req, socket);
 
     var bodyHead = d.slice(bytesParsed, d.length);
 
@@ -475,7 +476,6 @@ function socketOnData(d) {
       // Got Upgrade header or CONNECT method, but have no handler.
       socket.destroy();
     }
-    freeParser(parser, req, socket);
   } else if (parser.incoming && parser.incoming.complete &&
              // When the status code is 100 (Continue), the server will
              // send a final response after this client sends a request

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -645,8 +645,8 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
       if (((state.pipesCount === 1 && state.pipes === dest) ||
            (state.pipesCount > 1 && state.pipes.indexOf(dest) !== -1)) &&
           !cleanedUp) {
-        debug('false write response, pause', src._readableState.awaitDrain);
-        src._readableState.awaitDrain++;
+        debug('false write response, pause', state.awaitDrain);
+        state.awaitDrain++;
         increasedAwaitDrain = true;
       }
       src.pause();

--- a/lib/console.js
+++ b/lib/console.js
@@ -81,7 +81,7 @@ function createWriteErrorHandler(stream) {
       // If there was an error, it will be emitted on `stream` as
       // an `error` event. Adding a `once` listener will keep that error
       // from becoming an uncaught exception, but since the handler is
-      // removed after the event, non-console.* writes won’t be affected.
+      // removed after the event, non-console.* writes won't be affected.
       // we are only adding noop if there is no one else listening for 'error'
       if (stream.listenerCount('error') === 0) {
         stream.on('error', noop);
@@ -114,7 +114,7 @@ function write(ignoreErrors, stream, string, errorhandler, groupIndent) {
     // even in edge cases such as low stack space.
     if (e.message === 'Maximum call stack size exceeded')
       throw e;
-    // Sorry, there’s no proper way to pass along the error here.
+    // Sorry, there's no proper way to pass along the error here.
   } finally {
     stream.removeListener('error', noop);
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1950,8 +1950,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = typeof this.fd !== 'number' && options.start === undefined ?
-    0 : options.start;
+  this.start = options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;
@@ -1973,6 +1972,12 @@ function ReadStream(path, options) {
 
     this.pos = this.start;
   }
+
+  // Backwards compatibility: Make sure `end` is a number regardless of `start`.
+  // TODO(addaleax): Make the above typecheck not depend on `start` instead.
+  // (That is a semver-major change).
+  if (typeof this.end !== 'number')
+    this.end = Infinity;
 
   if (typeof this.fd !== 'number')
     this.open();
@@ -2028,6 +2033,8 @@ ReadStream.prototype._read = function(n) {
 
   if (this.pos !== undefined)
     toRead = Math.min(this.end - this.pos + 1, toRead);
+  else
+    toRead = Math.min(this.end - this.bytesRead + 1, toRead);
 
   // already read everything we were supposed to read!
   // treat as EOF.

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -34,7 +34,7 @@ const { async_id_symbol, async_hook_fields, async_id_fields } = async_wrap;
 // case of a fatal exception this stack is emptied after calling each hook's
 // after() callback.
 const { pushAsyncIds: pushAsyncIds_, popAsyncIds: popAsyncIds_ } = async_wrap;
-// For performance reasons, only track Proimses when a hook is enabled.
+// For performance reasons, only track Promises when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;
 // Properties in active_hooks are used to keep track of the set of hooks being
 // executed in case another hook is enabled/disabled. The new set of hooks is

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -11,16 +11,17 @@ const async_wrap = process.binding('async_wrap');
  * the various asynchronous states of the application. These are:
  *  kExecutionAsyncId: The async_id assigned to the resource responsible for the
  *    current execution stack.
- *  kTriggerAsyncId: The trigger_async_id of the resource responsible for
- *    the current execution stack.
+ *  kTriggerAsyncId: The async_id of the resource that caused (or 'triggered')
+ *    the resource corresponding to the current execution stack.
  *  kAsyncIdCounter: Incremental counter tracking the next assigned async_id.
  *  kDefaultTriggerAsyncId: Written immediately before a resource's constructor
- *    that sets the value of the init()'s triggerAsyncId. The order of
- *    retrieving the triggerAsyncId value is passing directly to the
- *    constructor -> value set in kDefaultTriggerAsyncId -> executionAsyncId of
- *    the current resource.
+ *    that sets the value of the init()'s triggerAsyncId. The precedence order
+ *    of retrieving the triggerAsyncId value is:
+ *    1. the value passed directly to the constructor
+ *    2. value set in kDefaultTriggerAsyncId
+ *    3. executionAsyncId of the current resource.
  *
- * async_ids_fast_stack is a Float64Array that contains part of the async ID
+ * async_ids_stack is a Float64Array that contains part of the async ID
  * stack. Each pushAsyncIds() call adds two doubles to it, and each
  * popAsyncIds() call removes two doubles from it.
  * It has a fixed size, so if that is exceeded, calls to the native
@@ -28,10 +29,10 @@ const async_wrap = process.binding('async_wrap');
  */
 const { async_id_symbol, async_hook_fields, async_id_fields } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a std::stack on
-// Environment::AsyncHooks::ids_stack_ tracks the resource responsible for the
-// current execution stack. This is unwound as each resource exits. In the case
-// of a fatal exception this stack is emptied after calling each hook's after()
-// callback.
+// Environment::AsyncHooks::async_ids_stack_ tracks the resource responsible for
+// the current execution stack. This is unwound as each resource exits. In the
+// case of a fatal exception this stack is emptied after calling each hook's
+// after() callback.
 const { pushAsyncIds: pushAsyncIds_, popAsyncIds: popAsyncIds_ } = async_wrap;
 // For performance reasons, only track Proimses when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -58,11 +58,7 @@
     NativeModule.require('internal/trace_events_async_hooks').setup();
     NativeModule.require('internal/inspector_async_hook').setup();
 
-    // Do not initialize channel in debugger agent, it deletes env variable
-    // and the main thread won't see it.
-    if (process.argv[1] !== '--debug-agent')
-      _process.setupChannel();
-
+    _process.setupChannel();
     _process.setupRawDebug();
 
     const browserGlobals = !process._noBrowserGlobals;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -264,7 +264,6 @@ E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function');
 E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
 E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
-E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1537,7 +1537,7 @@ function processRespondWithFD(fd, headers, offset = 0, length = -1,
     return;
   }
   // exact length of the file doesn't matter here, since the
-  // stream is closing anyway — just use 1 to signify that
+  // stream is closing anyway - just use 1 to signify that
   // a write does exist
   trackWriteState(this, 1);
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1276,7 +1276,7 @@ class Http2Stream extends Duplex {
     process.nextTick(emit, this, 'timeout');
   }
 
-  // true if the Http2Stream was aborted abornomally.
+  // true if the Http2Stream was aborted abnormally.
   get aborted() {
     return this[kState].aborted;
   }

--- a/lib/internal/streams/BufferList.js
+++ b/lib/internal/streams/BufferList.js
@@ -61,8 +61,6 @@ module.exports = class BufferList {
   concat(n) {
     if (this.length === 0)
       return Buffer.alloc(0);
-    if (this.length === 1)
-      return this.head.data;
     const ret = Buffer.allocUnsafe(n >>> 0);
     var p = this.head;
     var i = 0;

--- a/lib/internal/test/unicode.js
+++ b/lib/internal/test/unicode.js
@@ -3,4 +3,6 @@
 // This module exists entirely for regression testing purposes.
 // See `test/parallel/test-internal-unicode.js`.
 
+/* eslint-disable non-ascii-character */
 module.exports = '✓';
+/* eslint-enable non-ascii-character */

--- a/lib/net.js
+++ b/lib/net.js
@@ -767,13 +767,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     // Retain chunks
     if (err === 0) req._chunks = chunks;
   } else {
-    var enc;
-    if (data instanceof Buffer) {
-      enc = 'buffer';
-    } else {
-      enc = encoding;
-    }
-    err = createWriteReq(req, this._handle, data, enc);
+    err = createWriteReq(req, this._handle, data, encoding);
   }
 
   if (err)

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -751,7 +751,8 @@ Interface.prototype._ttyWrite = function(s, key) {
   key = key || {};
   this._previousKey = key;
 
-  // Ignore escape key - Fixes #2876
+  // Ignore escape key, fixes
+  // https://github.com/nodejs/node-v0.x-archive/issues/2876.
   if (key.name === 'escape') return;
 
   if (key.ctrl && key.shift) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -45,7 +45,7 @@ try {
   try {
     Stream._isUint8Array = process.binding('util').isUint8Array;
   } catch (e) {
-    // This throws for Node < 4.2.0 because there’s no util binding and
+    // This throws for Node < 4.2.0 because there's no util binding and
     // returns undefined for Node < 7.4.0.
   }
 }

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -209,8 +209,11 @@ function utf8Text(buf, i) {
 // character.
 function utf8End(buf) {
   const r = (buf && buf.length ? this.write(buf) : '');
-  if (this.lastNeed)
+  if (this.lastNeed) {
+    this.lastNeed = 0;
+    this.lastTotal = 0;
     return r + '\ufffd';
+  }
   return r;
 }
 
@@ -245,6 +248,8 @@ function utf16End(buf) {
   const r = (buf && buf.length ? this.write(buf) : '');
   if (this.lastNeed) {
     const end = this.lastTotal - this.lastNeed;
+    this.lastNeed = 0;
+    this.lastTotal = 0;
     return r + this.lastChar.toString('utf16le', 0, end);
   }
   return r;
@@ -268,8 +273,12 @@ function base64Text(buf, i) {
 
 function base64End(buf) {
   const r = (buf && buf.length ? this.write(buf) : '');
-  if (this.lastNeed)
-    return r + this.lastChar.toString('base64', 0, 3 - this.lastNeed);
+  if (this.lastNeed) {
+    const end = 3 - this.lastNeed;
+    this.lastNeed = 0;
+    this.lastTotal = 0;
+    return r + this.lastChar.toString('base64', 0, end);
+  }
   return r;
 }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -89,6 +89,7 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // TimerWrap C++ handle, which makes the call after the duration to process the
 // list it is attached to.
 //
+/* eslint-disable non-ascii-character */
 //
 // ╔════ > Object Map
 // ║
@@ -110,6 +111,7 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // ║
 // ╚════ > Linked List
 //
+/* eslint-enable non-ascii-character */
 //
 // With this, virtually constant-time insertion (append), removal, and timeout
 // is possible in the JavaScript layer. Any one list of timers is able to be

--- a/lib/url.js
+++ b/lib/url.js
@@ -880,7 +880,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
 
   // if the path is allowed to go above the root, restore leading ..s
   if (!mustEndAbs && !removeAllDots) {
-    for (; up--; up) {
+    while (up--) {
       srcPath.unshift('..');
     }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,9 +77,7 @@ var Debug;
 
 /* eslint-disable */
 const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c]/;
-const keyEscapeSequencesRegExp = /[\x00-\x1f\x27]/;
 const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c]/g;
-const keyEscapeSequencesReplacer = /[\x00-\x1f\x27]/g;
 /* eslint-enable */
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const colorRegExp = /\u001b\[\d\d?m/g;
@@ -117,34 +115,6 @@ function strEscape(str) {
   for (var i = 0; i < str.length; i++) {
     const point = str.charCodeAt(i);
     if (point === 39 || point === 92 || point < 32) {
-      if (last === i) {
-        result += meta[point];
-      } else {
-        result += `${str.slice(last, i)}${meta[point]}`;
-      }
-      last = i + 1;
-    }
-  }
-  if (last === 0) {
-    result = str;
-  } else if (last !== i) {
-    result += str.slice(last);
-  }
-  return `'${result}'`;
-}
-
-// Escape control characters and single quotes.
-// Note: for performance reasons this is not combined with strEscape
-function keyEscape(str) {
-  if (str.length < 5000 && !keyEscapeSequencesRegExp.test(str))
-    return `'${str}'`;
-  if (str.length > 100)
-    return `'${str.replace(keyEscapeSequencesReplacer, escapeFn)}'`;
-  var result = '';
-  var last = 0;
-  for (var i = 0; i < str.length; i++) {
-    const point = str.charCodeAt(i);
-    if (point === 39 || point < 32) {
       if (last === i) {
         result += meta[point];
       } else {
@@ -851,7 +821,7 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
   } else if (keyStrRegExp.test(key)) {
     name = ctx.stylize(key, 'name');
   } else {
-    name = ctx.stylize(keyEscape(key), 'string');
+    name = ctx.stylize(strEscape(key), 'string');
   }
 
   return `${name}: ${str}`;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -339,7 +339,7 @@ Zlib.prototype.flush = function flush(kind, callback) {
     this._scheduledFlushFlag = maxFlush(kind, this._scheduledFlushFlag);
 
     // If a callback was passed, always register a new `drain` + flush handler,
-    // mostly because that’s simpler and flush callbacks piling up is a rare
+    // mostly because that's simpler and flush callbacks piling up is a rare
     // thing anyway.
     if (!alreadyHadFlushScheduled || callback) {
       const drainHandler = () => this.flush(this._scheduledFlushFlag, callback);

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -554,12 +554,12 @@ void AsyncWrap::Initialize(Local<Object> target,
   // this way to allow JS and C++ to read/write each value as quickly as
   // possible. The fields are represented as follows:
   //
-  // kAsyncUid: Maintains the state of the next unique id to be assigned.
+  // kAsyncIdCounter: Maintains the state of the next unique id to be assigned.
   //
   // kDefaultTriggerAsyncId: Write the id of the resource responsible for a
   //   handle's creation just before calling the new handle's constructor.
   //   After the new handle is constructed kDefaultTriggerAsyncId is set back
-  //   to 0.
+  //   to -1.
   FORCE_SET_TARGET_FIELD(target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3449,7 +3449,7 @@ void CipherBase::Init(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<unsigned char*>(key),
                     reinterpret_cast<unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
 }
 
 
@@ -3518,7 +3518,7 @@ void CipherBase::InitIv(const char* cipher_type,
                     nullptr,
                     reinterpret_cast<const unsigned char*>(key),
                     reinterpret_cast<const unsigned char*>(iv),
-                    kind_ == kCipher);
+                    encrypt);
 }
 
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -92,6 +92,16 @@ class URLHost {
   Value value_;
   HostType type_ = HostType::H_FAILED;
 
+  inline void Reset() {
+    using string = std::string;
+    switch (type_) {
+      case HostType::H_DOMAIN: value_.domain.~string(); break;
+      case HostType::H_OPAQUE: value_.opaque.~string(); break;
+      default: break;
+    }
+    type_ = HostType::H_FAILED;
+  }
+
   // Setting the string members of the union with = is brittle because
   // it relies on them being initialized to a state that requires no
   // destruction of old data.
@@ -101,23 +111,20 @@ class URLHost {
   // These helpers are the easiest solution but we might want to consider
   // just not forcing strings into an union.
   inline void SetOpaque(std::string&& string) {
+    Reset();
     type_ = HostType::H_OPAQUE;
     new(&value_.opaque) std::string(std::move(string));
   }
 
   inline void SetDomain(std::string&& string) {
+    Reset();
     type_ = HostType::H_DOMAIN;
     new(&value_.domain) std::string(std::move(string));
   }
 };
 
 URLHost::~URLHost() {
-  using string = std::string;
-  switch (type_) {
-    case HostType::H_DOMAIN: value_.domain.~string(); break;
-    case HostType::H_OPAQUE: value_.opaque.~string(); break;
-    default: break;
-  }
+  Reset();
 }
 
 #define ARGS(XX)                                                              \

--- a/test/abort/test-http-parser-consume.js
+++ b/test/abort/test-http-parser-consume.js
@@ -11,12 +11,12 @@ if (process.argv[2] === 'child') {
     const rr = get({ port: server.address().port }, common.mustCall(() => {
       // This bad input (0) should abort the parser and the process
       rr.parser.consume(0);
-      // This line should be unreachanble.
+      // This line should be unreachable.
       assert.fail('this should be unreachable');
     }));
   }));
 } else {
-  // super-proces
+  // super-process
   const child = spawn(process.execPath, [__filename, 'child']);
   child.stdout.on('data', common.mustNotCall());
 

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -7,12 +7,13 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../../common/tmpdir');
+tmpdir.refresh();
 
 // make a path that is more than 260 chars long.
 // Any given folder cannot have a name longer than 260 characters,
 // so create 10 nested folders each with 30 character long names.
-let addonDestinationDir = path.resolve(common.tmpDir);
+let addonDestinationDir = path.resolve(tmpdir.path);
 
 for (let i = 0; i < 10; i++) {
   addonDestinationDir = path.join(addonDestinationDir, 'x'.repeat(30));

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -1,8 +1,4 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
@@ -10,13 +6,6 @@
         ['node_use_openssl=="true"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
-          'conditions': [
-            ['OS=="win" and node_target_type=="static_library"', {
-	      'libraries': [
-                '../../../../$(Configuration)/lib/<(OPENSSL_PRODUCT)'
-              ],
-            }],
-          ],
         }]
       ]
     },

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -12,10 +12,11 @@ const assert = require('assert');
 // This test should pass in Node.js v4 and v5. This test will pass in Node.js
 // with https://github.com/nodejs/node/pull/5950 reverted.
 
-common.refreshTmpDir();
+const tmpdir = require('../../common/tmpdir');
+tmpdir.refresh();
 
 const addonPath = path.join(__dirname, 'build', common.buildType);
-const addonLink = path.join(common.tmpDir, 'addon');
+const addonLink = path.join(tmpdir.path, 'addon');
 
 try {
   fs.symlinkSync(addonPath, addonLink);

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -1,22 +1,9 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
-      'conditions': [
-        ['node_target_type=="static_library"', {
-          'conditions': [
-            ['OS=="win"', {
-	      'libraries': ['../../../../$(Configuration)/lib/zlib.lib'],
-            }],
-          ],
-        }],
-      ],
     },
   ]
 }

--- a/test/async-hooks/hook-checks.js
+++ b/test/async-hooks/hook-checks.js
@@ -11,7 +11,7 @@ require('../common');
  * @param {Object} activity including timestamps for each life time event,
  *                 i.e. init, before ...
  * @param {Object} hooks the expected life time event invocations with a count
- *                       indicating how oftn they should have been invoked,
+ *                       indicating how often they should have been invoked,
  *                       i.e. `{ init: 1, before: 2, after: 2 }`
  * @param {String} stage the name of the stage in the test at which we are
  *                       checking the invocations

--- a/test/async-hooks/test-graph.pipeconnect.js
+++ b/test/async-hooks/test-graph.pipeconnect.js
@@ -6,7 +6,8 @@ const verifyGraph = require('./verify-graph');
 
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/async-hooks/test-internal-nexttick-default-trigger.js
+++ b/test/async-hooks/test-internal-nexttick-default-trigger.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 // This tests ensures that the triggerId of both the internal and external
-// nexTick function sets the triggerAsyncId correctly.
+// nextTick function sets the triggerAsyncId correctly.
 
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -8,7 +8,8 @@ const { checkInvocations } = require('./hook-checks');
 
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -53,7 +53,7 @@ function onlisten() {
 const awaitOnconnectCalls = new Set(['server', 'client']);
 function maybeOnconnect(source) {
   // both server and client must call onconnect. On most OS's waiting for
-  // the client is sufficient, but on CertOS 5 the sever needs to respond too.
+  // the client is sufficient, but on CentOS 5 the sever needs to respond too.
   assert.ok(awaitOnconnectCalls.size > 0);
   awaitOnconnectCalls.delete(source);
   if (awaitOnconnectCalls.size > 0) return;

--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -32,7 +32,7 @@ function pruneTickObjects(activities) {
       foundTickObject = true;
 
       // point all triggerAsyncIds that point to the tickObject
-      // to its triggerAsyncId and findally remove it from the activities
+      // to its triggerAsyncId and finally remove it from the activities
       const tickObject = activities[tickObjectIdx];
       const newTriggerId = tickObject.triggerAsyncId;
       const oldTriggerId = tickObject.uid;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -61,10 +61,6 @@ class NodeTestFixture : public ::testing::Test {
  protected:
   v8::Isolate* isolate_;
 
-  ~NodeTestFixture() {
-    TearDown();
-  }
-
   virtual void SetUp() {
     CHECK_EQ(0, uv_loop_init(&current_loop));
     platform_ = new node::NodePlatform(8, &current_loop, nullptr);
@@ -76,7 +72,6 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void TearDown() {
-    if (platform_ == nullptr) return;
     platform_->Shutdown();
     while (uv_loop_alive(&current_loop)) {
       uv_run(&current_loop, UV_RUN_ONCE);

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -5,16 +5,7 @@
 
 using node::AliasedBuffer;
 
-class AliasBufferTest : public NodeTestFixture {
- protected:
-  void SetUp() override {
-    NodeTestFixture::SetUp();
-  }
-
-  void TearDown() override {
-    NodeTestFixture::TearDown();
-  }
-};
+class AliasBufferTest : public NodeTestFixture {};
 
 template<class NativeT>
 void CreateOracleValues(NativeT* buf, size_t count) {

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -10,6 +10,7 @@ This directory contains modules used to test the Node.js implementation.
 * [DNS module](#dns-module)
 * [Duplex pair helper](#duplex-pair-helper)
 * [Fixtures module](#fixtures-module)
+* [tmpdir module](#tmpdir-module)
 * [WPT module](#wpt-module)
 
 ## Benchmark Module
@@ -312,11 +313,6 @@ A port number for tests to use if one is needed.
 
 Logs '1..0 # Skipped: ' + `msg`
 
-### refreshTmpDir()
-* return [&lt;String>]
-
-Deletes the testing 'tmp' directory and recreates it.
-
 ### restoreStderr()
 
 Restore the original `process.stderr.write`. Used to restore `stderr` to its
@@ -368,11 +364,6 @@ Platform normalizes the `pwd` command.
 * return [&lt;Object>]
 
 Synchronous version of `spawnPwd`.
-
-### tmpDir
-* [&lt;String>]
-
-The realpath of the 'tmp' directory.
 
 ## Countdown Module
 
@@ -491,6 +482,19 @@ Returns the result of
 
 Returns the result of
 `fs.readFileSync(path.join(fixtures.fixturesDir, 'keys', arg), 'enc')`.
+
+## tmpdir Module
+
+The `tmpdir` module supports the use of a temporary directory for testing.
+
+### path
+* [&lt;String>]
+
+The realpath of the testing temporary directory.
+
+### refresh()
+
+Deletes and recreates the testing temporary directory.
 
 ## WPT Module
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -30,15 +30,10 @@ const stream = require('stream');
 const util = require('util');
 const Timer = process.binding('timer_wrap').Timer;
 const { fixturesDir } = require('./fixtures');
-
-const testRoot = process.env.NODE_TEST_DIR ?
-  fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
+const tmpdir = require('./tmpdir');
 
 const noop = () => {};
 
-// Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
-// gets tools to ignore it by default or by simple rules, especially eslint.
-let tmpDirName = '.tmp';
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';
@@ -120,63 +115,6 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
     },
   }).enable();
 }
-
-function rimrafSync(p) {
-  let st;
-  try {
-    st = fs.lstatSync(p);
-  } catch (e) {
-    if (e.code === 'ENOENT')
-      return;
-  }
-
-  try {
-    if (st && st.isDirectory())
-      rmdirSync(p, null);
-    else
-      fs.unlinkSync(p);
-  } catch (e) {
-    if (e.code === 'ENOENT')
-      return;
-    if (e.code === 'EPERM')
-      return rmdirSync(p, e);
-    if (e.code !== 'EISDIR')
-      throw e;
-    rmdirSync(p, e);
-  }
-}
-
-function rmdirSync(p, originalEr) {
-  try {
-    fs.rmdirSync(p);
-  } catch (e) {
-    if (e.code === 'ENOTDIR')
-      throw originalEr;
-    if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
-      const enc = exports.isLinux ? 'buffer' : 'utf8';
-      fs.readdirSync(p, enc).forEach((f) => {
-        if (f instanceof Buffer) {
-          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
-          rimrafSync(buf);
-        } else {
-          rimrafSync(path.join(p, f));
-        }
-      });
-      fs.rmdirSync(p);
-    }
-  }
-}
-
-exports.refreshTmpDir = function() {
-  rimrafSync(exports.tmpDir);
-  fs.mkdirSync(exports.tmpDir);
-};
-
-if (process.env.TEST_THREAD_ID) {
-  exports.PORT += process.env.TEST_THREAD_ID * 100;
-  tmpDirName += `.${process.env.TEST_THREAD_ID}`;
-}
-exports.tmpDir = path.join(testRoot, tmpDirName);
 
 let opensslCli = null;
 let inFreeBSDJail = null;
@@ -271,7 +209,7 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 });
 
 {
-  const localRelative = path.relative(process.cwd(), `${exports.tmpDir}/`);
+  const localRelative = path.relative(process.cwd(), `${tmpdir.path}/`);
   const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : localRelative;
   const pipeName = `node-test.${process.pid}.sock`;
   exports.PIPE = path.join(pipePrefix, pipeName);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -82,7 +82,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
   const async_wrap = process.binding('async_wrap');
 
   process.on('exit', () => {
-    // itterate through handles to make sure nothing crashes
+    // iterate through handles to make sure nothing crashes
     for (const k in initHandles)
       util.inspect(initHandles[k]);
   });

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -1,0 +1,67 @@
+/* eslint-disable required-modules */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function rimrafSync(p) {
+  let st;
+  try {
+    st = fs.lstatSync(p);
+  } catch (e) {
+    if (e.code === 'ENOENT')
+      return;
+  }
+
+  try {
+    if (st && st.isDirectory())
+      rmdirSync(p, null);
+    else
+      fs.unlinkSync(p);
+  } catch (e) {
+    if (e.code === 'ENOENT')
+      return;
+    if (e.code === 'EPERM')
+      return rmdirSync(p, e);
+    if (e.code !== 'EISDIR')
+      throw e;
+    rmdirSync(p, e);
+  }
+}
+
+function rmdirSync(p, originalEr) {
+  try {
+    fs.rmdirSync(p);
+  } catch (e) {
+    if (e.code === 'ENOTDIR')
+      throw originalEr;
+    if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
+      const enc = process.platform === 'linux' ? 'buffer' : 'utf8';
+      fs.readdirSync(p, enc).forEach((f) => {
+        if (f instanceof Buffer) {
+          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
+          rimrafSync(buf);
+        } else {
+          rimrafSync(path.join(p, f));
+        }
+      });
+      fs.rmdirSync(p);
+    }
+  }
+}
+
+const testRoot = process.env.NODE_TEST_DIR ?
+  fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
+
+// Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
+// gets tools to ignore it by default or by simple rules, especially eslint.
+let tmpdirName = '.tmp';
+if (process.env.TEST_THREAD_ID) {
+  tmpdirName += `.${process.env.TEST_THREAD_ID}`;
+}
+exports.path = path.join(testRoot, tmpdirName);
+
+exports.refresh = () => {
+  rimrafSync(exports.path);
+  fs.mkdirSync(exports.path);
+};

--- a/test/es-module/test-esm-preserve-symlinks.js
+++ b/test/es-module/test-esm-preserve-symlinks.js
@@ -7,8 +7,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const entry = path.join(tmpDir, 'entry.js');
 const real = path.join(tmpDir, 'real.js');

--- a/test/es-module/test-esm-symlink.js
+++ b/test/es-module/test-esm-symlink.js
@@ -6,8 +6,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const entry = path.join(tmpDir, 'entry.mjs');
 const real = path.join(tmpDir, 'index.mjs');

--- a/test/fixtures/net-fd-passing-receiver.js
+++ b/test/fixtures/net-fd-passing-receiver.js
@@ -45,7 +45,7 @@ receiver = net.createServer(function(socket) {
   });
 });
 
-/* To signal the test runne we're up and listening */
+/* To signal the test runner we're up and listening */
 receiver.on('listening', function() {
   console.log('ready');
 });

--- a/test/known_issues/test-cwd-enoent-file.js
+++ b/test/known_issues/test-cwd-enoent-file.js
@@ -17,8 +17,9 @@ const fs = require('fs');
 if (process.argv[2] === 'child') {
   // Do nothing.
 } else {
-  common.refreshTmpDir();
-  const dir = fs.mkdtempSync(`${common.tmpDir}/`);
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const dir = fs.mkdtempSync(`${tmpdir.path}/`);
   process.chdir(dir);
   fs.rmdirSync(dir);
   assert.throws(process.cwd,

--- a/test/known_issues/test-module-deleted-extensions.js
+++ b/test/known_issues/test-module-deleted-extensions.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const file = path.join(common.tmpDir, 'test-extensions.foo.bar');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, 'test-extensions.foo.bar');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(file, '', 'utf8');
 require.extensions['.foo.bar'] = (module, path) => {};
 delete require.extensions['.foo.bar'];
@@ -14,4 +15,4 @@ require.extensions['.bar'] = common.mustCall((module, path) => {
   assert.strictEqual(module.id, file);
   assert.strictEqual(path, file);
 });
-require(path.join(common.tmpDir, 'test-extensions'));
+require(path.join(tmpdir.path, 'test-extensions'));

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -586,7 +586,7 @@ testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');
 testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
                      '{ a: NaN, b: Infinity, c: -Infinity }');
 
-// #2893
+// https://github.com/nodejs/node-v0.x-archive/issues/2893
 {
   let threw = false;
   try {
@@ -601,7 +601,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
   assert.ok(threw);
 }
 
-// #5292
+// https://github.com/nodejs/node-v0.x-archive/issues/5292
 try {
   assert.strictEqual(1, 2);
 } catch (e) {

--- a/test/parallel/test-async-hooks-http-agent.js
+++ b/test/parallel/test-async-hooks-http-agent.js
@@ -8,7 +8,7 @@ const http = require('http');
 // Checks that an http.Agent properly asyncReset()s a reused socket handle, and
 // re-assigns the fresh async id to the reused `net.Socket` instance.
 
-// Make sure a single socket is transpartently reused for 2 requests.
+// Make sure a single socket is transparently reused for 2 requests.
 const agent = new http.Agent({
   keepAlive: true,
   keepAliveMsecs: Infinity,

--- a/test/parallel/test-async-hooks-promise-enable-disable.js
+++ b/test/parallel/test-async-hooks-promise-enable-disable.js
@@ -11,13 +11,13 @@ let p_inits = 0;
 common.crashOnUnhandledRejection();
 
 // Not useful to place common.mustCall() around 'exit' event b/c it won't be
-// able to check it anway.
+// able to check it anyway.
 process.on('exit', (code) => {
   if (code !== 0)
     return;
   if (p_er !== null)
     throw p_er;
-  // Expecint exactly 2 PROMISE types to reach init.
+  // Expecting exactly 2 PROMISE types to reach init.
   assert.strictEqual(p_inits, EXPECTED_INITS);
 });
 

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -8,7 +8,7 @@ if (process.argv[2] === 'async') {
     throw new Error();
   }
   (async function() { await fn(); })();
-  // While the above should error, just in case it dosn't the script shouldn't
+  // While the above should error, just in case it doesn't the script shouldn't
   // fork itself indefinitely so return early.
   return;
 }

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const runBenchmark = require('../common/benchmark');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 runBenchmark('fs', [
   'n=1',
@@ -16,4 +17,4 @@ runBenchmark('fs', [
   'statSyncType=fstatSync',
   'encodingType=buf',
   'filesize=1024'
-], { NODE_TMPDIR: common.tmpDir, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+], { NODE_TMPDIR: tmpdir.path, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -636,7 +636,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  // #1210 Test UTF-8 string includes null character
+  // https://github.com/nodejs/node-v0.x-archive/pull/1210
+  // Test UTF-8 string includes null character
   let buf = Buffer.from('\0');
   assert.strictEqual(buf.length, 1);
   buf = Buffer.from('\0\0');
@@ -660,7 +661,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  // #243 Test write() with maxLength
+  // https://github.com/nodejs/node-v0.x-archive/issues/243
+  // Test write() with maxLength
   const buf = Buffer.allocUnsafe(4);
   buf.fill(0xFF);
   assert.strictEqual(buf.write('abcd', 1, 2, 'utf8'), 2);
@@ -886,12 +888,14 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
   assert.strictEqual(buf.readIntBE(0, 5), -0x0012000000);
 }
 
-// Regression test for #5482: should throw but not assert in C++ land.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
+// should throw but not assert in C++ land.
 assert.throws(() => Buffer.from('', 'buffer'),
               /^TypeError: "encoding" must be a valid string encoding$/);
 
-// Regression test for #6111. Constructing a buffer from another buffer
-// should a) work, and b) not corrupt the source buffer.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/6111.
+// Constructing a buffer from another buffer should a) work, and b) not corrupt
+// the source buffer.
 {
   const a = [...Array(128).keys()]; // [0, 1, 2, 3, ... 126, 127]
   const b = Buffer.from(a);

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -344,7 +344,7 @@ Buffer.alloc(8, '');
           return 0;
         } else {
           elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
+          // Once buffer.js calls the C++ implementation of fill, return -1
           return -1;
         }
       }
@@ -377,7 +377,7 @@ assert.throws(() => {
           return 1;
         } else {
           elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
+          // Once buffer.js calls the C++ implementation of fill, return -1
           return -1;
         }
       }

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -137,7 +137,7 @@ assert.strictEqual(
 );
 
 
-// test usc2 encoding
+// test ucs2 encoding
 let twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 
 assert(twoByteString.includes('\u0395', 4, 'ucs2'));

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -553,7 +553,7 @@ assert.strictEqual(511, longBufferString.lastIndexOf(pattern, 1534));
 // "yolo swag swag yolo swag yolo yolo swag" ..., goes on for about 5MB.
 // This is hard to search because it all looks similar, but never repeats.
 
-// countBits returns the number of bits in the binary reprsentation of n.
+// countBits returns the number of bits in the binary representation of n.
 function countBits(n) {
   let count;
   for (count = 0; n > 0; count++) {

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -20,11 +20,11 @@ function read(buff, funx, args, expected) {
 
 }
 
-// testing basic functionality of readDoubleBE() and readDOubleLE()
+// testing basic functionality of readDoubleBE() and readDoubleLE()
 read(buf, 'readDoubleBE', [1], -3.1827727774563287e+295);
 read(buf, 'readDoubleLE', [1], -6.966010051009108e+144);
 
-// testing basic functionality of readFLoatBE() and readFloatLE()
+// testing basic functionality of readFloatBE() and readFloatLE()
 read(buf, 'readFloatBE', [1], -1.6691549692541768e+37);
 read(buf, 'readFloatLE', [1], -7861303808);
 

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -6,6 +6,7 @@ const uv = process.binding('uv');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
+const execOpts = { encoding: 'utf8', shell: true };
 
 {
   execFile(
@@ -37,4 +38,11 @@ const fixture = fixtures.path('exit.js');
 
   child.kill();
   child.emit('close', code, null);
+}
+
+{
+  // Verify the shell option works properly
+  execFile(process.execPath, [fixture, 0], execOpts, common.mustCall((err) => {
+    assert.ifError(err);
+  }));
 }

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -24,9 +24,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const tmpdir = require('../common/tmpdir');
 const msg = { test: 'this' };
 const nodePath = process.execPath;
-const copyPath = path.join(common.tmpDir, 'node-copy.exe');
+const copyPath = path.join(tmpdir.path, 'node-copy.exe');
 
 if (process.env.FORK) {
   assert(process.send);
@@ -34,7 +35,7 @@ if (process.env.FORK) {
   process.send(msg);
   process.exit();
 } else {
-  common.refreshTmpDir();
+  tmpdir.refresh();
   try {
     fs.unlinkSync(copyPath);
   } catch (e) {

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -32,7 +32,7 @@ if (process.argv[2] === 'child') {
   //send non-internal message containing PREFIX at a non prefix position
   process.send(normal);
 
-  //send inernal message
+  //send internal message
   process.send(internal);
 
   process.exit(0);

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -14,7 +14,7 @@ const fixtures = require('../common/fixtures');
 const subScript = fixtures.path('child-process-persistent.js');
 
 {
-  // Test `send` return value on `fork` that opens and IPC by deafult.
+  // Test `send` return value on `fork` that opens and IPC by default.
   const n = fork(subScript);
   // `subprocess.send` should always return `true` for the first send.
   const rv = n.send({ h: 'w' }, (err) => { if (err) assert.fail(err); });
@@ -31,12 +31,12 @@ const subScript = fixtures.path('child-process-persistent.js');
   const server = net.createServer(common.mustNotCall()).listen(0, () => {
     const handle = server._handle;
 
-    // Sending a handle and not giving the tickQueue time to acknoladge should
+    // Sending a handle and not giving the tickQueue time to acknowledge should
     // create the internal backlog, but leave it empty.
     const rv1 = s.send('one', handle, (err) => { if (err) assert.fail(err); });
     assert.strictEqual(rv1, true);
-    // Since the first `send` included a handle (should be unackoladged),
-    // we can safly queue up only one more message.
+    // Since the first `send` included a handle (should be unacknowledged),
+    // we can safely queue up only one more message.
     const rv2 = s.send('two', (err) => { if (err) assert.fail(err); });
     assert.strictEqual(rv2, true);
     // The backlog should now be indicate to backoff.

--- a/test/parallel/test-cli-node-options-disallowed.js
+++ b/test/parallel/test-cli-node-options-disallowed.js
@@ -8,8 +8,9 @@ if (process.config.variables.node_without_node_options)
 const assert = require('assert');
 const exec = require('child_process').execFile;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 disallow('--version');
 disallow('-v');

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -8,8 +8,9 @@ if (process.config.variables.node_without_node_options)
 const assert = require('assert');
 const exec = require('child_process').execFile;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 expect(`-r ${require.resolve('../fixtures/printA.js')}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -33,7 +33,8 @@ const net = require('net');
 
 if (cluster.isMaster && process.argv.length !== 3) {
   // cluster.isMaster
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   const PIPE_NAME = common.PIPE;
   const worker = cluster.fork({ PIPE_NAME });
 

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -32,7 +32,8 @@ const cluster = require('cluster');
 const http = require('http');
 
 if (cluster.isMaster) {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   const worker = cluster.fork();
   worker.on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, 'DONE');

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -6,6 +6,8 @@ const net = require('net');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 if (common.isWindows)
   common.skip('On Windows named pipes live in their own ' +
               'filesystem and don\'t have a ~100 byte limit');
@@ -20,8 +22,8 @@ assert.strictEqual(path.resolve(socketDir, socketName).length > 100, true,
 
 if (cluster.isMaster) {
   // ensure that the worker exits peacefully
-  common.refreshTmpDir();
-  process.chdir(common.tmpDir);
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
   fs.mkdirSync(socketDir);
   cluster.fork().on('exit', common.mustCall(function(statusCode) {
     assert.strictEqual(statusCode, 0);

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -42,7 +42,7 @@ if (cluster.isMaster) {
     worker.send(msg);
   });
 } else {
-  // GH #7998
+  // https://github.com/nodejs/node-v0.x-archive/issues/7998
   cluster.worker.on('message', (message) => {
     process.send(message === msg);
   });

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -411,7 +411,8 @@ fileStream.on('close', common.mustCall(function() {
   );
 }));
 
-// Issue #2227: unknown digest method should throw an error.
+// Unknown digest method should throw an error:
+// https://github.com/nodejs/node-v0.x-archive/issues/2227
 assert.throws(function() {
   crypto.createHash('xyzzy');
 }, /^Error: Digest method not supported$/);

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -70,7 +70,8 @@ testCipher1(Buffer.from('MySecretKey123'));
 testCipher2('0123456789abcdef');
 testCipher2(Buffer.from('0123456789abcdef'));
 
-// Base64 padding regression test, see #4837.
+// Base64 padding regression test, see
+// https://github.com/nodejs/node-v0.x-archive/issues/4837.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');
   const s = c.update('test', 'utf8', 'base64') + c.final('base64');
@@ -78,7 +79,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
 }
 
 // Calling Cipher.final() or Decipher.final() twice should error but
-// not assert. See #4886.
+// not assert. See https://github.com/nodejs/node-v0.x-archive/issues/4886.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');
   try { c.final('xxx'); } catch (e) { /* Ignore. */ }
@@ -90,14 +91,16 @@ testCipher2(Buffer.from('0123456789abcdef'));
   try { d.final('xxx'); } catch (e) { /* Ignore. */ }
 }
 
-// Regression test for #5482: string to Cipher#update() should not assert.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
+// string to Cipher#update() should not assert.
 {
   const c = crypto.createCipher('aes192', '0123456789abcdef');
   c.update('update');
   c.final();
 }
 
-// #5655 regression tests, 'utf-8' and 'utf8' are identical.
+// https://github.com/nodejs/node-v0.x-archive/issues/5655 regression tests,
+// 'utf-8' and 'utf8' are identical.
 {
   let c = crypto.createCipher('aes192', '0123456789abcdef');
   c.update('update', '');  // Defaults to "utf8".

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -14,7 +14,7 @@ common.expectWarning('DeprecationWarning', [
 
 // Accessing the deprecated function is enough to trigger the warning event.
 // It does not need to be called. So the assert serves the purpose of both
-// triggering the warning event and confirming that the deprected function is
+// triggering the warning event and confirming that the deprecated function is
 // mapped to the correct non-deprecated function.
 assert.strictEqual(crypto.Credentials, tls.SecureContext);
 assert.strictEqual(crypto.createCredentials, tls.createSecureContext);

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -91,7 +91,7 @@ testHelper(
 // to try to call the fips setter, to try to detect this situation, as
 // that would throw an error:
 // ("Error: Cannot set FIPS mode in a non-FIPS build.").
-// Due to this uncertanty the following tests are skipped when configured
+// Due to this uncertainty the following tests are skipped when configured
 // with --shared-openssl.
 if (!sharedOpenSSL()) {
   // OpenSSL config file should be able to turn on FIPS mode

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -105,7 +105,8 @@ fileStream.on('close', common.mustCall(function() {
                      'Test SHA1 of sample.png');
 }));
 
-// Issue #2227: unknown digest method should throw an error.
+// Issue https://github.com/nodejs/node-v0.x-archive/issues/2227: unknown digest
+// method should throw an error.
 assert.throws(function() {
   crypto.createHash('xyzzy');
 }, /Digest method not supported/);

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -260,8 +260,9 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
   }
 }
 
-// #5126, "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData()
-// length exceeds max acceptable value"
+// https://github.com/nodejs/node-v0.x-archive/issues/5126,
+// "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData() length
+// exceeds max acceptable value"
 assert.throws(function() {
   crypto.randomBytes((-1 >>> 0) + 1);
 }, /^TypeError: size must be a number >= 0$/);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -255,11 +255,12 @@ const modSize = 1024;
       padding: crypto.constants.RSA_PKCS1_PSS_PADDING
     });
 
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
-  const sigfile = path.join(common.tmpDir, 's5.sig');
+  const sigfile = path.join(tmpdir.path, 's5.sig');
   fs.writeFileSync(sigfile, s5);
-  const msgfile = path.join(common.tmpDir, 's5.msg');
+  const msgfile = path.join(tmpdir.path, 's5.msg');
   fs.writeFileSync(msgfile, msg);
 
   const cmd =

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -159,8 +159,8 @@ testImmutability(tls.getCiphers);
 testImmutability(crypto.getHashes);
 testImmutability(crypto.getCurves);
 
-// Regression tests for #5725: hex input that's not a power of two should
-// throw, not assert in C++ land.
+// Regression tests for https://github.com/nodejs/node-v0.x-archive/pull/5725:
+// hex input that's not a power of two should throw, not assert in C++ land.
 assert.throws(function() {
   crypto.createCipher('aes192', 'test').update('0', 'hex');
 }, (err) => {

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -8,10 +8,11 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
 const abspathFile = fixtures.path('a.js');
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -8,8 +8,10 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -8,8 +8,10 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const dgram = require('dgram');
 
-// should not hang, see #1282
+// should not hang, see https://github.com/nodejs/node-v0.x-archive/issues/1282
 dgram.createSocket('udp4');
 dgram.createSocket('udp6');
 

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -24,7 +24,8 @@ require('../common');
 const assert = require('assert');
 const dns = require('dns');
 
-// Should not raise assertion error. Issue #7070
+// Should not raise assertion error.
+// Issue https://github.com/nodejs/node-v0.x-archive/issues/7070
 assert.throws(() => dns.resolveNs([]), // bad name
               /^Error: "name" argument must be a string$/);
 assert.throws(() => dns.resolveNs(''), // bad callback

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'child') {
       // is not properly flushed in V8's Isolate::Throw right before the
       // process aborts due to an uncaught exception, and thus the error
       // message representing the error that was thrown cannot be read by the
-      // parent process. So instead of parsing the child process' stdandard
+      // parent process. So instead of parsing the child process' standard
       // error, the parent process will check that in the case
       // --abort-on-uncaught-exception was passed, the process did not exit
       // with exit code RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE.

--- a/test/parallel/test-eslint-prefer-assert-methods.js
+++ b/test/parallel/test-eslint-prefer-assert-methods.js
@@ -9,31 +9,46 @@ const rule = require('../../tools/eslint-rules/prefer-assert-methods');
 
 new RuleTester().run('prefer-assert-methods', rule, {
   valid: [
-    'assert.strictEqual(foo, bar)',
-    'assert(foo === bar && baz)'
+    'assert.strictEqual(foo, bar);',
+    'assert(foo === bar && baz);',
+    'assert.notStrictEqual(foo, bar);',
+    'assert(foo !== bar && baz);',
+    'assert.equal(foo, bar);',
+    'assert(foo == bar && baz);',
+    'assert.notEqual(foo, bar);',
+    'assert(foo != bar && baz);',
+    'assert.ok(foo);',
+    'assert.ok(foo != bar);',
+    'assert.ok(foo === bar && baz);'
   ],
   invalid: [
     {
-      code: 'assert(foo == bar)',
-      errors: [{ message: "'assert.equal' should be used instead of '=='" }]
+      code: 'assert(foo == bar);',
+      errors: [{
+        message: "'assert.equal' should be used instead of '=='"
+      }],
+      output: 'assert.equal(foo, bar);'
     },
     {
-      code: 'assert(foo === bar)',
+      code: 'assert(foo === bar);',
       errors: [{
         message: "'assert.strictEqual' should be used instead of '==='"
-      }]
+      }],
+      output: 'assert.strictEqual(foo, bar);'
     },
     {
-      code: 'assert(foo != bar)',
+      code: 'assert(foo != bar);',
       errors: [{
         message: "'assert.notEqual' should be used instead of '!='"
-      }]
+      }],
+      output: 'assert.notEqual(foo, bar);'
     },
     {
-      code: 'assert(foo !== bar)',
+      code: 'assert(foo !== bar);',
       errors: [{
         message: "'assert.notStrictEqual' should be used instead of '!=='"
-      }]
-    },
+      }],
+      output: 'assert.notStrictEqual(foo, bar);'
+    }
   ]
 });

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -119,10 +119,10 @@ function listener2() {}
 
   // listener4 will still be called although it is removed by listener 3.
   ee.emit('hello');
-  // This is so because the interal listener array at time of emit
+  // This is so because the internal listener array at time of emit
   // was [listener3,listener4]
 
-  // Interal listener array [listener3]
+  // Internal listener array [listener3]
   ee.emit('hello');
 }
 

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -20,13 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.tmpDir, 'write.txt');
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+const fn = path.join(tmpdir.path, 'write.txt');
+tmpdir.refresh();
 const file = fs.createWriteStream(fn, {
   highWaterMark: 10
 });

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
 
-const filepath = path.join(common.tmpDir, 'write.txt');
+
+const filepath = path.join(tmpdir.path, 'write.txt');
 
 const EXPECTED = '012345678910';
 
@@ -58,7 +60,7 @@ function removeTestFile() {
 }
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // drain at 0, return false at 10.
 const file = fs.createWriteStream(filepath, {

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -25,8 +25,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
 
-const filepath = path.join(common.tmpDir, 'write_pos.txt');
+
+const filepath = path.join(tmpdir.path, 'write_pos.txt');
 
 
 const cb_expected = 'write open close write open close write open close ';
@@ -51,7 +53,7 @@ process.on('exit', function() {
 });
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 
 function run_test_1() {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -3,16 +3,18 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
-const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
-const readWriteFile = path.join(common.tmpDir, 'read_write_file');
+
+const tmpdir = require('../common/tmpdir');
+const doesNotExist = path.join(tmpdir.path, '__this_should_not_exist');
+const readOnlyFile = path.join(tmpdir.path, 'read_only_file');
+const readWriteFile = path.join(tmpdir.path, 'read_write_file');
 
 function createFileWithPerms(file, mode) {
   fs.writeFileSync(file, '');
   fs.chmodSync(file, mode);
 }
 
-common.refreshTmpDir();
+tmpdir.refresh();
 createFileWithPerms(readOnlyFile, 0o444);
 createFileWithPerms(readWriteFile, 0o666);
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -28,7 +28,7 @@ createFileWithPerms(readWriteFile, 0o666);
  * The change of user id is done after creating the fixtures files for the same
  * reason: the test may be run as the superuser within a directory in which
  * only the superuser can create files, and thus it may need superuser
- * priviledges to create them.
+ * privileges to create them.
  *
  * There's not really any point in resetting the process' user id to 0 after
  * changing it to 'nobody', since in the case that the test runs without

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -36,10 +36,11 @@ const data = '南越国是前203年至前111年存在于岭南地区的一个国
              '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
              '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test that empty file will be created and have content added
-const filename = join(common.tmpDir, 'append-sync.txt');
+const filename = join(tmpdir.path, 'append-sync.txt');
 
 fs.appendFileSync(filename, data);
 
@@ -48,7 +49,7 @@ const fileData = fs.readFileSync(filename);
 assert.strictEqual(Buffer.byteLength(data), fileData.length);
 
 // test that appends data to a non empty file
-const filename2 = join(common.tmpDir, 'append-sync2.txt');
+const filename2 = join(tmpdir.path, 'append-sync2.txt');
 fs.writeFileSync(filename2, currentFileData);
 
 fs.appendFileSync(filename2, data);
@@ -59,7 +60,7 @@ assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
                    fileData2.length);
 
 // test that appendFileSync accepts buffers
-const filename3 = join(common.tmpDir, 'append-sync3.txt');
+const filename3 = join(tmpdir.path, 'append-sync3.txt');
 fs.writeFileSync(filename3, currentFileData);
 
 const buf = Buffer.from(data, 'utf8');
@@ -70,7 +71,7 @@ const fileData3 = fs.readFileSync(filename3);
 assert.strictEqual(buf.length + currentFileData.length, fileData3.length);
 
 // test that appendFile accepts numbers.
-const filename4 = join(common.tmpDir, 'append-sync4.txt');
+const filename4 = join(tmpdir.path, 'append-sync4.txt');
 fs.writeFileSync(filename4, currentFileData, { mode: m });
 
 fs.appendFileSync(filename4, num, { mode: m });
@@ -87,7 +88,7 @@ assert.strictEqual(Buffer.byteLength(String(num)) + currentFileData.length,
                    fileData4.length);
 
 // test that appendFile accepts file descriptors
-const filename5 = join(common.tmpDir, 'append-sync5.txt');
+const filename5 = join(tmpdir.path, 'append-sync5.txt');
 fs.writeFileSync(filename5, currentFileData);
 
 const filename5fd = fs.openSync(filename5, 'a+', 0o600);

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -25,7 +25,9 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-const filename = join(common.tmpDir, 'append.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = join(tmpdir.path, 'append.txt');
 
 const currentFileData = 'ABCD';
 
@@ -40,7 +42,7 @@ const s = '南越国是前203年至前111年存在于岭南地区的一个国家
 
 let ncallbacks = 0;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // test that empty file will be created and have content added
 fs.appendFile(filename, s, function(e) {
@@ -56,7 +58,7 @@ fs.appendFile(filename, s, function(e) {
 });
 
 // test that appends data to a non empty file
-const filename2 = join(common.tmpDir, 'append2.txt');
+const filename2 = join(tmpdir.path, 'append2.txt');
 fs.writeFileSync(filename2, currentFileData);
 
 fs.appendFile(filename2, s, function(e) {
@@ -73,7 +75,7 @@ fs.appendFile(filename2, s, function(e) {
 });
 
 // test that appendFile accepts buffers
-const filename3 = join(common.tmpDir, 'append3.txt');
+const filename3 = join(tmpdir.path, 'append3.txt');
 fs.writeFileSync(filename3, currentFileData);
 
 const buf = Buffer.from(s, 'utf8');
@@ -91,7 +93,7 @@ fs.appendFile(filename3, buf, function(e) {
 });
 
 // test that appendFile accepts numbers.
-const filename4 = join(common.tmpDir, 'append4.txt');
+const filename4 = join(tmpdir.path, 'append4.txt');
 fs.writeFileSync(filename4, currentFileData);
 
 const m = 0o600;
@@ -115,7 +117,7 @@ fs.appendFile(filename4, n, { mode: m }, function(e) {
 });
 
 // test that appendFile accepts file descriptors
-const filename5 = join(common.tmpDir, 'append5.txt');
+const filename5 = join(tmpdir.path, 'append5.txt');
 fs.writeFileSync(filename5, currentFileData);
 
 fs.open(filename5, 'a+', function(e, fd) {
@@ -146,7 +148,7 @@ fs.open(filename5, 'a+', function(e, fd) {
 
 // test that a missing callback emits a warning, even if the last argument is a
 // function.
-const filename6 = join(common.tmpDir, 'append6.txt');
+const filename6 = join(tmpdir.path, 'append6.txt');
 const warn = 'Calling an asynchronous function without callback is deprecated.';
 common.expectWarning('DeprecationWarning', warn);
 fs.appendFile(filename6, console.log);

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -6,16 +6,17 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 assert.doesNotThrow(() => {
-  fs.access(Buffer.from(common.tmpDir), common.mustCall((err) => {
+  fs.access(Buffer.from(tmpdir.path), common.mustCall((err) => {
     assert.ifError(err);
   }));
 });
 
 assert.doesNotThrow(() => {
-  const buf = Buffer.from(path.join(common.tmpDir, 'a.txt'));
+  const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
   fs.open(buf, 'w+', common.mustCall((err, fd) => {
     assert.ifError(err);
     assert(fd);

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 // This test ensures that writeSync does support inputs which
 // are then correctly converted into string buffers.
@@ -8,10 +8,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const filePath = path.join(common.tmpDir, 'test_buffer_type');
+const tmpdir = require('../common/tmpdir');
+
+const filePath = path.join(tmpdir.path, 'test_buffer_type');
 const v = [true, false, 0, 1, Infinity, () => {}, {}, [], undefined, null];
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 v.forEach((value) => {
   const fd = fs.openSync(filePath, 'w');

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -71,10 +71,11 @@ if (common.isWindows) {
   mode_sync = 0o644;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file1 = path.join(common.tmpDir, 'a.js');
-const file2 = path.join(common.tmpDir, 'a1.js');
+const file1 = path.join(tmpdir.path, 'a.js');
+const file2 = path.join(tmpdir.path, 'a1.js');
 
 // Create file1.
 fs.closeSync(fs.openSync(file1, 'w'));
@@ -121,7 +122,7 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
 
 // lchmod
 if (fs.lchmod) {
-  const link = path.join(common.tmpDir, 'symbolic-link');
+  const link = path.join(tmpdir.path, 'symbolic-link');
 
   fs.symlinkSync(file2, link);
 

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -1,11 +1,12 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const src = fixtures.path('a.js');
-const dest = path.join(common.tmpDir, 'copyfile.out');
+const dest = path.join(tmpdir.path, 'copyfile.out');
 const { COPYFILE_EXCL, UV_FS_COPYFILE_EXCL } = fs.constants;
 
 function verify(src, dest) {
@@ -19,7 +20,7 @@ function verify(src, dest) {
   assert.strictEqual(srcStat.size, destStat.size);
 }
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Verify that flags are defined.
 assert.strictEqual(typeof COPYFILE_EXCL, 'number');

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -23,15 +23,16 @@
 const common = require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const fs = require('fs');
 const path = require('path');
 
 const fileFixture = fixtures.path('a.js');
-const fileTemp = path.join(common.tmpDir, 'a.js');
+const fileTemp = path.join(tmpdir.path, 'a.js');
 
 // Copy fixtures to temp.
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.copyFileSync(fileFixture, fileTemp);
 
 fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -4,11 +4,12 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test creating and reading hard link
-const srcPath = path.join(common.tmpDir, 'hardlink-target.txt');
-const dstPath = path.join(common.tmpDir, 'link1.js');
+const srcPath = path.join(tmpdir.path, 'hardlink-target.txt');
+const dstPath = path.join(tmpdir.path, 'link1.js');
 fs.writeFileSync(srcPath, 'hello world');
 
 function callback(err) {

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -28,12 +28,14 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
+const tmpdir = require('../common/tmpdir');
+
 // make a path that will be at least 260 chars long.
-const fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-const fileName = path.join(common.tmpDir, 'x'.repeat(fileNameLen));
+const fileNameLen = Math.max(260 - tmpdir.path.length - 1, 1);
+const fileName = path.join(tmpdir.path, 'x'.repeat(fileNameLen));
 const fullPath = path.resolve(fileName);
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 console.log({
   filenameLength: fileName.length,

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -8,12 +8,13 @@ const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
 const { sep } = require('path');
 const warn = 'Calling an asynchronous function without callback is deprecated.';
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function testMakeCallback(cb) {
   return function() {
     // fs.mkdtemp() calls makeCallback() on its third argument
-    fs.mkdtemp(`${common.tmpDir}${sep}`, {}, cb);
+    fs.mkdtemp(`${tmpdir.path}${sep}`, {}, cb);
   };
 }
 

--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const d = path.join(common.tmpDir, 'dir');
+const tmpdir = require('../common/tmpdir');
+const d = path.join(tmpdir.path, 'dir');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Make sure the directory does not exist
 assert(!common.fileExists(d));

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -24,10 +24,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
-  const pathname = `${common.tmpDir}/test1`;
+  const pathname = `${tmpdir.path}/test1`;
 
   fs.mkdir(pathname, common.mustCall(function(err) {
     assert.strictEqual(err, null);
@@ -36,7 +37,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = `${common.tmpDir}/test2`;
+  const pathname = `${tmpdir.path}/test2`;
 
   fs.mkdir(pathname, 0o777, common.mustCall(function(err) {
     assert.strictEqual(err, null);
@@ -45,7 +46,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = `${common.tmpDir}/test3`;
+  const pathname = `${tmpdir.path}/test3`;
 
   fs.mkdirSync(pathname);
 

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -5,14 +5,15 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const tmpFolder = fs.mkdtempSync(path.join(common.tmpDir, 'foo.'));
+const tmpFolder = fs.mkdtempSync(path.join(tmpdir.path, 'foo.'));
 
 assert.strictEqual(path.basename(tmpFolder).length, 'foo.XXXXXX'.length);
 assert(common.fileExists(tmpFolder));
 
-const utf8 = fs.mkdtempSync(path.join(common.tmpDir, '\u0222abc.'));
+const utf8 = fs.mkdtempSync(path.join(tmpdir.path, '\u0222abc.'));
 assert.strictEqual(Buffer.byteLength(path.basename(utf8)),
                    Buffer.byteLength('\u0222abc.XXXXXX'));
 assert(common.fileExists(utf8));
@@ -23,13 +24,13 @@ function handler(err, folder) {
   assert.strictEqual(this, null);
 }
 
-fs.mkdtemp(path.join(common.tmpDir, 'bar.'), common.mustCall(handler));
+fs.mkdtemp(path.join(tmpdir.path, 'bar.'), common.mustCall(handler));
 
 // Same test as above, but making sure that passing an options object doesn't
 // affect the way the callback function is handled.
-fs.mkdtemp(path.join(common.tmpDir, 'bar.'), {}, common.mustCall(handler));
+fs.mkdtemp(path.join(tmpdir.path, 'bar.'), {}, common.mustCall(handler));
 
 // Making sure that not passing a callback doesn't crash, as a default function
 // is passed internally.
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-')));
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-'), {}));
+assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-')));
+assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-'), {}));

--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const tempFile = path.join(common.tmpDir, 'fs-non-number-arguments-throw');
+const tmpdir = require('../common/tmpdir');
+const tempFile = path.join(tmpdir.path, 'fs-non-number-arguments-throw');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(tempFile, 'abc\ndef');
 
 // a sanity check when using numbers instead of strings

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -84,8 +84,9 @@ assert.throws(
 );
 
 if (common.isLinux || common.isOSX) {
-  common.refreshTmpDir();
-  const file = path.join(common.tmpDir, 'a.js');
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const file = path.join(tmpdir.path, 'a.js');
   fs.copyFileSync(fixtures.path('a.js'), file);
   fs.open(file, O_DSYNC, common.mustCall(assert.ifError));
 }

--- a/test/parallel/test-fs-open-numeric-flags.js
+++ b/test/parallel/test-fs-open-numeric-flags.js
@@ -1,14 +1,15 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // O_WRONLY without O_CREAT shall fail with ENOENT
-const pathNE = path.join(common.tmpDir, 'file-should-not-exist');
+const pathNE = path.join(tmpdir.path, 'file-should-not-exist');
 assert.throws(
   () => fs.openSync(pathNE, fs.constants.O_WRONLY),
   (e) => e.code === 'ENOENT'

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -14,7 +14,8 @@ const path = require('path');
 
 const errHandler = (e) => assert.ifError(e);
 const options = Object.freeze({});
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
   assert.doesNotThrow(() =>
@@ -31,8 +32,8 @@ common.refreshTmpDir();
 }
 
 if (common.canCreateSymLink()) {
-  const sourceFile = path.resolve(common.tmpDir, 'test-readlink');
-  const linkFile = path.resolve(common.tmpDir, 'test-readlink-link');
+  const sourceFile = path.resolve(tmpdir.path, 'test-readlink');
+  const linkFile = path.resolve(tmpdir.path, 'test-readlink-link');
 
   fs.writeFileSync(sourceFile, '');
   fs.symlinkSync(sourceFile, linkFile);
@@ -44,7 +45,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'writeFile');
+  const fileName = path.resolve(tmpdir.path, 'writeFile');
   assert.doesNotThrow(() => fs.writeFileSync(fileName, 'ABCD', options));
   assert.doesNotThrow(() =>
     fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler))
@@ -52,7 +53,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'appendFile');
+  const fileName = path.resolve(tmpdir.path, 'appendFile');
   assert.doesNotThrow(() => fs.appendFileSync(fileName, 'ABCD', options));
   assert.doesNotThrow(() =>
     fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler))
@@ -82,7 +83,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const tempFileName = path.resolve(common.tmpDir, 'mkdtemp-');
+  const tempFileName = path.resolve(tmpdir.path, 'mkdtemp-');
   assert.doesNotThrow(() => fs.mkdtempSync(tempFileName, options));
   assert.doesNotThrow(() =>
     fs.mkdtemp(tempFileName, options, common.mustCall(errHandler))
@@ -90,7 +91,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'streams');
+  const fileName = path.resolve(tmpdir.path, 'streams');
   assert.doesNotThrow(() => {
     fs.WriteStream(fileName, options).once('open', common.mustCall(() => {
       assert.doesNotThrow(() => fs.ReadStream(fileName, options));

--- a/test/parallel/test-fs-promisified.js
+++ b/test/parallel/test-fs-promisified.js
@@ -20,9 +20,10 @@ const exists = promisify(fs.exists);
   }));
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 {
-  const filename = path.join(common.tmpDir, 'write-promise.txt');
+  const filename = path.join(tmpdir.path, 'write-promise.txt');
   const fd = fs.openSync(filename, 'w');
   write(fd, Buffer.from('foobar')).then(common.mustCall((obj) => {
     assert.strictEqual(typeof obj.bytesWritten, 'number');

--- a/test/parallel/test-fs-read-stream-fd.js
+++ b/test/parallel/test-fs-read-stream-fd.js
@@ -20,15 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
-const file = path.join(common.tmpDir, '/read_stream_fd_test.txt');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, '/read_stream_fd_test.txt');
 const input = 'hello world';
 
 let output = '';
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(file, input);
 
 const fd = fs.openSync(file, 'r');

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -176,8 +176,9 @@ if (!common.isWindows) {
   // Verify that end works when start is not specified, and we do not try to
   // use positioned reads. This makes sure that this keeps working for
   // non-seekable file descriptors.
-  common.refreshTmpDir();
-  const filename = `${common.tmpDir}/foo.pipe`;
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const filename = `${tmpdir.path}/foo.pipe`;
   const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
   if (!mkfifoResult.error) {
     child_process.exec(`echo "xyz foobar" > '${filename}'`);

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -8,9 +8,10 @@ const path = require('path');
 const fs = require('fs');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const filename = '\uD83D\uDC04';
-const root = Buffer.from(`${common.tmpDir}${path.sep}`);
+const root = Buffer.from(`${tmpdir.path}${path.sep}`);
 const filebuff = Buffer.from(filename, 'ucs2');
 const fullpath = Buffer.concat([root, filebuff]);
 
@@ -22,7 +23,7 @@ try {
   throw e;
 }
 
-fs.readdir(common.tmpDir, 'ucs2', common.mustCall((err, list) => {
+fs.readdir(tmpdir.path, 'ucs2', common.mustCall((err, list) => {
   assert.ifError(err);
   assert.strictEqual(1, list.length);
   const fn = list[0];

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -4,11 +4,13 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const readdirDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+
+const readdirDir = tmpdir.path;
 const files = ['empty', 'files', 'for', 'just', 'testing'];
 
 // Make sure tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Create the necessary files
 files.forEach(function(currentFile) {

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -18,9 +18,11 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = path.join(tmpdir.path, '/readfile_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 
 // Test that unlink succeeds immediately after readFile completes.
 
@@ -28,10 +28,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const fileName = path.resolve(common.tmpDir, 'test.bin');
+const tmpdir = require('../common/tmpdir');
+
+const fileName = path.resolve(tmpdir.path, 'test.bin');
 const buf = Buffer.alloc(512 * 1024, 42);
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.writeFileSync(fileName, buf);
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -15,9 +15,11 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = path.join(tmpdir.path, '/readfilesync_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const assert = require('assert');
 const fs = require('fs');
@@ -31,9 +32,9 @@ let async_completed = 0;
 let async_expected = 0;
 const unlink = [];
 let skipSymlinks = false;
-const tmpDir = common.tmpDir;
+const tmpDir = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 let root = '/';
 let assertEqualPath = assert.strictEqual;
@@ -400,6 +401,8 @@ function test_up_multiple(cb) {
     cleanup();
   }
   setup();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   fs.mkdirSync(tmp('a'), 0o755);
   fs.mkdirSync(tmp('a/b'), 0o755);
   fs.symlinkSync('..', tmp('a/d'), 'dir');

--- a/test/parallel/test-fs-sir-writes-alot.js
+++ b/test/parallel/test-fs-sir-writes-alot.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const join = require('path').join;
 
-const filename = join(common.tmpDir, 'out.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const filename = join(tmpdir.path, 'out.txt');
+
+tmpdir.refresh();
 
 const fd = fs.openSync(filename, 'w');
 

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -23,15 +23,16 @@
 const common = require('../common');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 test1(fs.createReadStream(__filename));
 test2(fs.createReadStream(__filename));
 test3(fs.createReadStream(__filename));
 
-test1(fs.createWriteStream(`${common.tmpDir}/dummy1`));
-test2(fs.createWriteStream(`${common.tmpDir}/dummy2`));
-test3(fs.createWriteStream(`${common.tmpDir}/dummy3`));
+test1(fs.createWriteStream(`${tmpdir.path}/dummy1`));
+test2(fs.createWriteStream(`${tmpdir.path}/dummy2`));
+test3(fs.createWriteStream(`${tmpdir.path}/dummy3`));
 
 function test1(stream) {
   stream.destroy();

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -28,12 +28,14 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const linkPath1 = path.join(common.tmpDir, 'junction1');
-const linkPath2 = path.join(common.tmpDir, 'junction2');
+const tmpdir = require('../common/tmpdir');
+
+const linkPath1 = path.join(tmpdir.path, 'junction1');
+const linkPath2 = path.join(tmpdir.path, 'junction2');
 const linkTarget = fixtures.fixturesDir;
 const linkData = fixtures.fixturesDir;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Test fs.symlink()
 fs.symlink(linkData, linkPath1, 'junction', common.mustCall(function(err) {

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -26,11 +26,13 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 // test creating and reading symbolic link
 const linkData = fixtures.path('cycles/');
-const linkPath = path.join(common.tmpDir, 'cycles_link');
+const linkPath = path.join(tmpdir.path, 'cycles_link');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   assert.ifError(err);

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -32,11 +32,12 @@ const fs = require('fs');
 let linkTime;
 let fileTime;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test creating and reading symbolic link
 const linkData = fixtures.path('/cycles/root.js');
-const linkPath = path.join(common.tmpDir, 'symlink1.js');
+const linkPath = path.join(tmpdir.path, 'symlink1.js');
 
 fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   assert.ifError(err);

--- a/test/parallel/test-fs-syncwritestream.js
+++ b/test/parallel/test-fs-syncwritestream.js
@@ -21,9 +21,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'stdout');
+const filename = path.join(tmpdir.path, 'stdout');
 const stdoutFd = fs.openSync(filename, 'w');
 
 const proc = spawn(process.execPath, [__filename, 'child'], {

--- a/test/parallel/test-fs-truncate-GH-6233.js
+++ b/test/parallel/test-fs-truncate-GH-6233.js
@@ -24,9 +24,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const filename = `${common.tmpDir}/truncate-file.txt`;
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const filename = `${tmpdir.path}/truncate-file.txt`;
+
+tmpdir.refresh();
 
 // Synchronous test.
 {

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -3,8 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
+tmpdir.refresh();
 const filename = path.resolve(tmp, 'truncate-file.txt');
 
 fs.writeFileSync(filename, 'hello world', 'utf8');

--- a/test/parallel/test-fs-truncate-sync.js
+++ b/test/parallel/test-fs-truncate-sync.js
@@ -1,11 +1,12 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const filename = path.resolve(tmp, 'truncate-sync-file.txt');
 

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -24,11 +24,12 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
 const filename = path.resolve(tmp, 'truncate-file.txt');
 const data = Buffer.alloc(1024 * 16, 'x');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 let stat;
 

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -25,7 +25,8 @@ const assert = require('assert');
 const util = require('util');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 let tests_ok = 0;
 let tests_run = 0;
@@ -73,8 +74,8 @@ function testIt(atime, mtime, callback) {
   // test synchronized code paths, these functions throw on failure
   //
   function syncTests() {
-    fs.utimesSync(common.tmpDir, atime, mtime);
-    expect_ok('utimesSync', common.tmpDir, undefined, atime, mtime);
+    fs.utimesSync(tmpdir.path, atime, mtime);
+    expect_ok('utimesSync', tmpdir.path, undefined, atime, mtime);
     tests_run++;
 
     // some systems don't have futimes
@@ -109,17 +110,17 @@ function testIt(atime, mtime, callback) {
   //
   // test async code paths
   //
-  fs.utimes(common.tmpDir, atime, mtime, common.mustCall(function(err) {
-    expect_ok('utimes', common.tmpDir, err, atime, mtime);
+  fs.utimes(tmpdir.path, atime, mtime, common.mustCall(function(err) {
+    expect_ok('utimes', tmpdir.path, err, atime, mtime);
 
     fs.utimes('foobarbaz', atime, mtime, common.mustCall(function(err) {
       expect_errno('utimes', 'foobarbaz', err, 'ENOENT');
 
       // don't close this fd
       if (common.isWindows) {
-        fd = fs.openSync(common.tmpDir, 'r+');
+        fd = fs.openSync(tmpdir.path, 'r+');
       } else {
-        fd = fs.openSync(common.tmpDir, 'r');
+        fd = fs.openSync(tmpdir.path, 'r');
       }
 
       fs.futimes(fd, atime, mtime, common.mustCall(function(err) {
@@ -139,7 +140,7 @@ function testIt(atime, mtime, callback) {
   tests_run++;
 }
 
-const stats = fs.statSync(common.tmpDir);
+const stats = fs.statSync(tmpdir.path);
 
 // run tests
 const runTest = common.mustCall(testIt, 6);
@@ -168,7 +169,7 @@ process.on('exit', function() {
 
 
 // Ref: https://github.com/nodejs/node/issues/13255
-const path = `${common.tmpDir}/test-utimes-precision`;
+const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
 // test Y2K38 for all platforms [except 'arm', and 'SunOS']

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -22,10 +22,11 @@ if (common.isAIX)
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const fn = '新建文夹件.txt';
-const a = path.join(common.tmpDir, fn);
+const a = path.join(tmpdir.path, fn);
 
 const watchers = new Set();
 
@@ -42,7 +43,7 @@ function unregisterWatcher(watcher) {
 }
 
 const watcher1 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   { encoding: 'hex' },
   (event, filename) => {
     if (['e696b0e5bbbae69687e5a4b9e4bbb62e747874', null].includes(filename))
@@ -52,7 +53,7 @@ const watcher1 = fs.watch(
 registerWatcher(watcher1);
 
 const watcher2 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   (event, filename) => {
     if ([fn, null].includes(filename))
       done(watcher2);
@@ -61,7 +62,7 @@ const watcher2 = fs.watch(
 registerWatcher(watcher2);
 
 const watcher3 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   { encoding: 'buffer' },
   (event, filename) => {
     if (filename instanceof Buffer && filename.toString('utf8') === fn)

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -9,10 +9,12 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const testDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+
+const testDir = tmpdir.path;
 const filenameOne = 'watch.txt';
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const testsubdir = fs.mkdtempSync(testDir + path.sep);
 const relativePathOne = path.join(path.basename(testsubdir), filenameOne);

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -14,7 +14,7 @@ class WatchTestCase {
     this.field = field;
     this.shouldSkip = !shouldInclude;
   }
-  get dirPath() { return join(common.tmpDir, this.dirName); }
+  get dirPath() { return join(tmpdir.path, this.dirName); }
   get filePath() { return join(this.dirPath, this.fileName); }
 }
 
@@ -35,7 +35,8 @@ const cases = [
   )
 ];
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 for (const testCase of cases) {
   if (testCase.shouldSkip) continue;

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -5,6 +5,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 // Basic usage tests.
 assert.throws(function() {
   fs.watchFile('./some-file');
@@ -18,7 +20,7 @@ assert.throws(function() {
   fs.watchFile(new Object(), common.mustNotCall());
 }, /Path must be a string/);
 
-const enoentFile = path.join(common.tmpDir, 'non-existent-file');
+const enoentFile = path.join(tmpdir.path, 'non-existent-file');
 const expectedStatObject = new fs.Stats(
   0,                                        // dev
   0,                                        // mode
@@ -36,7 +38,7 @@ const expectedStatObject = new fs.Stats(
   Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
 );
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // If the file initially didn't exist, and gets created at a later point of
 // time, the callback should be invoked again with proper values in stat object
@@ -67,7 +69,7 @@ fs.watchFile(enoentFile, { interval: 0 }, common.mustCall(function(curr, prev) {
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {
-  const dir = path.join(common.tmpDir, 'watch');
+  const dir = path.join(tmpdir.path, 'watch');
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -26,11 +26,12 @@ const path = require('path');
 const fs = require('fs');
 const expected = Buffer.from('hello');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // fs.write with all parameters provided:
 {
-  const filename = path.join(common.tmpDir, 'write1.txt');
+  const filename = path.join(tmpdir.path, 'write1.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -50,7 +51,7 @@ common.refreshTmpDir();
 
 // fs.write with a buffer, without the length parameter:
 {
-  const filename = path.join(common.tmpDir, 'write2.txt');
+  const filename = path.join(tmpdir.path, 'write2.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -70,7 +71,7 @@ common.refreshTmpDir();
 
 // fs.write with a buffer, without the offset and length parameters:
 {
-  const filename = path.join(common.tmpDir, 'write3.txt');
+  const filename = path.join(tmpdir.path, 'write3.txt');
   fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.ifError(err);
 
@@ -90,7 +91,7 @@ common.refreshTmpDir();
 
 // fs.write with the offset passed as undefined followed by the callback:
 {
-  const filename = path.join(common.tmpDir, 'write4.txt');
+  const filename = path.join(tmpdir.path, 'write4.txt');
   fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.ifError(err);
 
@@ -110,7 +111,7 @@ common.refreshTmpDir();
 
 // fs.write with offset and length passed as undefined followed by the callback:
 {
-  const filename = path.join(common.tmpDir, 'write5.txt');
+  const filename = path.join(tmpdir.path, 'write5.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -130,7 +131,7 @@ common.refreshTmpDir();
 
 // fs.write with a Uint8Array, without the offset and length parameters:
 {
-  const filename = path.join(common.tmpDir, 'write6.txt');
+  const filename = path.join(tmpdir.path, 'write6.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 

--- a/test/parallel/test-fs-write-file-buffer.js
+++ b/test/parallel/test-fs-write-file-buffer.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const join = require('path').join;
 const util = require('util');
 const fs = require('fs');
@@ -46,9 +46,10 @@ let data = [
 
 data = data.join('\n');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const buf = Buffer.from(data, 'base64');
-fs.writeFileSync(join(common.tmpDir, 'test.jpg'), buf);
+fs.writeFileSync(join(tmpdir.path, 'test.jpg'), buf);
 
 util.log('Done!');

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -8,7 +8,8 @@ const path = require('path');
 if (!common.isWindows)
   common.skip('This test is for Windows only.');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const DATA_VALUE = 'hello';
 
@@ -17,7 +18,7 @@ const DATA_VALUE = 'hello';
 const RESERVED_CHARACTERS = '<>"|?*';
 
 [...RESERVED_CHARACTERS].forEach((ch) => {
-  const pathname = path.join(common.tmpDir, `somefile_${ch}`);
+  const pathname = path.join(tmpdir.path, `somefile_${ch}`);
   assert.throws(
     () => {
       fs.writeFileSync(pathname, DATA_VALUE);
@@ -28,7 +29,7 @@ const RESERVED_CHARACTERS = '<>"|?*';
 
 // Test for ':' (NTFS data streams).
 // Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx
-const pathname = path.join(common.tmpDir, 'foo:bar');
+const pathname = path.join(tmpdir.path, 'foo:bar');
 fs.writeFileSync(pathname, DATA_VALUE);
 
 let content = '';

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -46,10 +46,11 @@ if (common.isWindows) {
   mode = 0o755;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // Test writeFileSync
-const file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
+const file1 = path.join(tmpdir.path, 'testWriteFileSync.txt');
 
 fs.writeFileSync(file1, '123', { mode });
 
@@ -59,7 +60,7 @@ assert.strictEqual(content, '123');
 assert.strictEqual(fs.statSync(file1).mode & 0o777, mode);
 
 // Test appendFileSync
-const file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
+const file2 = path.join(tmpdir.path, 'testAppendFileSync.txt');
 
 fs.appendFileSync(file2, 'abc', { mode });
 
@@ -69,7 +70,7 @@ assert.strictEqual(content, 'abc');
 assert.strictEqual(fs.statSync(file2).mode & mode, mode);
 
 // Test writeFileSync with file descriptor
-const file3 = path.join(common.tmpDir, 'testWriteFileSyncFd.txt');
+const file3 = path.join(tmpdir.path, 'testWriteFileSyncFd.txt');
 
 const fd = fs.openSync(file3, 'w+', mode);
 fs.writeFileSync(fd, '123');

--- a/test/parallel/test-fs-write-file-uint8array.js
+++ b/test/parallel/test-fs-write-file-uint8array.js
@@ -4,9 +4,10 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = join(common.tmpDir, 'test.txt');
+const filename = join(tmpdir.path, 'test.txt');
 
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
           '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -25,9 +25,10 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = join(common.tmpDir, 'test.txt');
+const filename = join(tmpdir.path, 'test.txt');
 
 const n = 220;
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
@@ -48,7 +49,7 @@ fs.writeFile(filename, s, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts buffers
-const filename2 = join(common.tmpDir, 'test2.txt');
+const filename2 = join(tmpdir.path, 'test2.txt');
 const buf = Buffer.from(s, 'utf8');
 
 fs.writeFile(filename2, buf, common.mustCall(function(e) {
@@ -62,7 +63,7 @@ fs.writeFile(filename2, buf, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts numbers.
-const filename3 = join(common.tmpDir, 'test3.txt');
+const filename3 = join(tmpdir.path, 'test3.txt');
 
 const m = 0o600;
 fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
@@ -82,7 +83,7 @@ fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts file descriptors
-const filename4 = join(common.tmpDir, 'test4.txt');
+const filename4 = join(tmpdir.path, 'test4.txt');
 
 fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
   assert.ifError(e);

--- a/test/parallel/test-fs-write-stream-autoclose-option.js
+++ b/test/parallel/test-fs-write-stream-autoclose-option.js
@@ -4,8 +4,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write-autoclose-opt1.txt');
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const file = path.join(tmpdir.path, 'write-autoclose-opt1.txt');
+tmpdir.refresh();
 let stream = fs.createWriteStream(file, { flags: 'w+', autoClose: false });
 stream.write('Test1');
 stream.end();

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const file = path.join(tmpdir.path, 'write.txt');
+
+tmpdir.refresh();
 
 const stream = fs.WriteStream(file);
 const _fs_close = fs.close;

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const s = fs.createWriteStream(path.join(common.tmpDir, 'rw'));
+const s = fs.createWriteStream(path.join(tmpdir.path, 'rw'));
 
 s.close(common.mustCall());
 s.close(common.mustCall());

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -1,17 +1,18 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
+const tmpdir = require('../common/tmpdir');
 const firstEncoding = 'base64';
 const secondEncoding = 'latin1';
 
 const examplePath = fixtures.path('x.txt');
-const dummyPath = path.join(common.tmpDir, 'x.txt');
+const dummyPath = path.join(tmpdir.path, 'x.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const exampleReadStream = fs.createReadStream(examplePath, {
   encoding: firstEncoding

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -25,17 +25,18 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
-  const file = path.join(common.tmpDir, 'write-end-test0.txt');
+  const file = path.join(tmpdir.path, 'write-end-test0.txt');
   const stream = fs.createWriteStream(file);
   stream.end();
   stream.on('close', common.mustCall());
 }
 
 {
-  const file = path.join(common.tmpDir, 'write-end-test1.txt');
+  const file = path.join(tmpdir.path, 'write-end-test1.txt');
   const stream = fs.createWriteStream(file);
   stream.end('a\n', 'utf8');
   stream.on('close', common.mustCall(function() {

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -24,9 +24,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const stream = fs.createWriteStream(`${common.tmpDir}/out`, {
+const stream = fs.createWriteStream(`${tmpdir.path}/out`, {
   highWaterMark: 10
 });
 const err = new Error('BAM');

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
@@ -10,9 +10,11 @@ const numberError =
 const booleanError =
   /^TypeError: "options" must be a string or an object, got boolean instead\.$/;
 
-const example = path.join(common.tmpDir, 'dummy');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const example = path.join(tmpdir.path, 'dummy');
+
+tmpdir.refresh();
 
 assert.doesNotThrow(() => {
   fs.createWriteStream(example, undefined);

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const file = path.join(tmpdir.path, 'write.txt');
+
+tmpdir.refresh();
 
 {
   const stream = fs.WriteStream(file);

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -4,9 +4,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const fn = path.join(common.tmpDir, 'write-string-coerce.txt');
+const fn = path.join(tmpdir.path, 'write-string-coerce.txt');
 const data = true;
 const expected = String(data);
 

--- a/test/parallel/test-fs-write-sync.js
+++ b/test/parallel/test-fs-write-sync.js
@@ -20,13 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const filename = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
+const filename = path.join(tmpdir.path, 'write.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // fs.writeSync with all parameters provided:
 {

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -24,13 +24,15 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.tmpDir, 'write.txt');
-const fn2 = path.join(common.tmpDir, 'write2.txt');
-const fn3 = path.join(common.tmpDir, 'write3.txt');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const fn = path.join(tmpdir.path, 'write.txt');
+const fn2 = path.join(tmpdir.path, 'write2.txt');
+const fn3 = path.join(tmpdir.path, 'write3.txt');
 const expected = 'ümlaut.';
 const constants = fs.constants;
-
-common.refreshTmpDir();
 
 fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   assert.ifError(err);

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
 
 const agent = new http.Agent();
 
@@ -33,7 +35,7 @@ assert.strictEqual(
 );
 
 // unix socket
-const socketPath = path.join(common.tmpDir, 'foo', 'bar');
+const socketPath = path.join(tmpdir.path, 'foo', 'bar');
 assert.strictEqual(
   agent.getName({
     socketPath

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -89,7 +89,7 @@ function remoteClose() {
       process.nextTick(common.mustCall(() => {
         assert.strictEqual(agent.sockets[name], undefined);
         assert.strictEqual(agent.freeSockets[name].length, 1);
-        // waitting remote server close the socket
+        // waiting remote server close the socket
         setTimeout(common.mustCall(() => {
           assert.strictEqual(agent.sockets[name], undefined);
           assert.strictEqual(agent.freeSockets[name], undefined,
@@ -102,7 +102,7 @@ function remoteClose() {
 }
 
 function remoteError() {
-  // remove server will destroy ths socket
+  // remote server will destroy the socket
   const req = get('/error', common.mustNotCall());
   req.on('error', common.mustCall((err) => {
     assert(err);

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -37,7 +37,9 @@ if (process.argv[2] === 'shasum') {
 const http = require('http');
 const cp = require('child_process');
 
-const filename = require('path').join(common.tmpDir, 'big');
+const tmpdir = require('../common/tmpdir');
+
+const filename = require('path').join(tmpdir.path, 'big');
 let server;
 
 function executeRequest(cb) {
@@ -59,7 +61,7 @@ function executeRequest(cb) {
 }
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const ddcmd = common.ddCommand(filename, 10240);
 

--- a/test/parallel/test-http-client-abort-keep-alive-queued-unix-socket.js
+++ b/test/parallel/test-http-client-abort-keep-alive-queued-unix-socket.js
@@ -16,7 +16,8 @@ class Agent extends http.Agent {
 const server = http.createServer((req, res) => res.end());
 
 const socketPath = common.PIPE;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(socketPath, common.mustCall(() => {
   const agent = new Agent({

--- a/test/parallel/test-http-client-abort-unix-socket.js
+++ b/test/parallel/test-http-client-abort-unix-socket.js
@@ -12,7 +12,8 @@ class Agent extends http.Agent {
   }
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(() => {
   const req = http.get({

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -34,7 +34,8 @@ const server = http.createServer(function(req, res) {
   });
 });
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, function() {
   const req = http.request({

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -27,7 +27,8 @@ const domain = require('domain');
 
 let d;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // first fire up a simple HTTP server
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -30,30 +30,41 @@ const http = require('http');
 const https = require('https');
 
 const host = '*'.repeat(256);
+const MAX_TRIES = 5;
 
-function do_not_call() {
-  throw new Error('This function should not have been called.');
-}
-
-function test(mod) {
-
+function tryGet(mod, tries) {
   // Bad host name should not throw an uncatchable exception.
   // Ensure that there is time to attach an error listener.
-  const req1 = mod.get({ host: host, port: 42 }, do_not_call);
-  req1.on('error', common.mustCall(function(err) {
+  const req = mod.get({ host: host, port: 42 }, common.mustNotCall());
+  req.on('error', common.mustCall(function(err) {
+    if (err.code === 'EAGAIN' && tries < MAX_TRIES) {
+      tryGet(mod, ++tries);
+      return;
+    }
     assert.strictEqual(err.code, 'ENOTFOUND');
   }));
   // http.get() called req1.end() for us
+}
 
-  const req2 = mod.request({
+function tryRequest(mod, tries) {
+  const req = mod.request({
     method: 'GET',
     host: host,
     port: 42
-  }, do_not_call);
-  req2.on('error', common.mustCall(function(err) {
+  }, common.mustNotCall());
+  req.on('error', common.mustCall(function(err) {
+    if (err.code === 'EAGAIN' && tries < MAX_TRIES) {
+      tryRequest(mod, ++tries);
+      return;
+    }
     assert.strictEqual(err.code, 'ENOTFOUND');
   }));
-  req2.end();
+  req.end();
+}
+
+function test(mod) {
+  tryGet(mod, 0);
+  tryRequest(mod, 0);
 }
 
 if (common.hasCrypto) {

--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -51,7 +51,6 @@ const server = net.createServer(function(socket) {
 
     if (postBody.includes('\r\n')) {
       socket.write(fullResponse);
-      // omg, I wrote the response twice, what a terrible HTTP server I am.
       socket.end(fullResponse);
     }
   });

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -32,7 +32,8 @@ const Countdown = require('../common/countdown');
 
 http.globalAgent.maxSockets = 1;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const image = fixtures.readSync('/person.jpg');
 
@@ -68,7 +69,7 @@ server.listen(0, function() {
 
       http.get(opts, function(res) {
         console.error(`recv ${x}`);
-        const s = fs.createWriteStream(`${common.tmpDir}/${x}.jpg`);
+        const s = fs.createWriteStream(`${tmpdir.path}/${x}.jpg`);
         res.pipe(s);
 
         s.on('finish', function() {
@@ -85,13 +86,13 @@ server.listen(0, function() {
 
 function checkFiles() {
   // Should see 1.jpg, 2.jpg, ..., 100.jpg in tmpDir
-  const files = fs.readdirSync(common.tmpDir);
+  const files = fs.readdirSync(tmpdir.path);
   assert(total <= files.length);
 
   for (let i = 0; i < total; i++) {
     const fn = `${i}.jpg`;
     assert.ok(files.includes(fn), `couldn't find '${fn}'`);
-    const stat = fs.statSync(`${common.tmpDir}/${fn}`);
+    const stat = fs.statSync(`${tmpdir.path}/${fn}`);
     assert.strictEqual(
       image.length, stat.size,
       `size doesn't match on '${fn}'. Got ${stat.size} bytes`);

--- a/test/parallel/test-http-parser-freed-before-upgrade.js
+++ b/test/parallel/test-http-parser-freed-before-upgrade.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+
+server.on('upgrade', common.mustCall((request, socket) => {
+  assert.strictEqual(socket.parser, null);
+  socket.write([
+    'HTTP/1.1 101 Switching Protocols',
+    'Connection: Upgrade',
+    'Upgrade: WebSocket',
+    '\r\n'
+  ].join('\r\n'));
+}));
+
+server.listen(common.mustCall(() => {
+  const request = http.get({
+    port: server.address().port,
+    headers: {
+      Connection: 'Upgrade',
+      Upgrade: 'WebSocket'
+    }
+  });
+
+  request.on('upgrade', common.mustCall((response, socket) => {
+    assert.strictEqual(socket.parser, null);
+    socket.destroy();
+    server.close();
+  }));
+}));

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -29,9 +29,10 @@ const NUMBER_OF_STREAMS = 2;
 
 const countdown = new Countdown(NUMBER_OF_STREAMS, () => server.close());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file = path.join(common.tmpDir, 'http-pipe-fs-test.txt');
+const file = path.join(tmpdir.path, 'http-pipe-fs-test.txt');
 
 const server = http.createServer(common.mustCall(function(req, res) {
   const stream = fs.createWriteStream(file);

--- a/test/parallel/test-http-unix-socket-keep-alive.js
+++ b/test/parallel/test-http-unix-socket-keep-alive.js
@@ -5,7 +5,8 @@ const http = require('http');
 
 const server = http.createServer((req, res) => res.end());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(() =>
   asyncLoop(makeKeepAliveRequest, 10, common.mustCall(() =>

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -34,7 +34,8 @@ const server = http.createServer(function(req, res) {
   res.end();
 });
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(function() {
 

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -11,9 +11,10 @@ const path = require('path');
 
 // piping should work as expected with createWriteStream
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const loc = fixtures.path('url-tests.js');
-const fn = path.join(common.tmpDir, 'http2-url-tests.js');
+const fn = path.join(tmpdir.path, 'http2-url-tests.js');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -12,9 +12,10 @@ const Countdown = require('../common/countdown');
 
 // piping should work as expected with createWriteStream
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const loc = fixtures.path('url-tests.js');
-const fn = path.join(common.tmpDir, 'http2-url-tests.js');
+const fn = path.join(tmpdir.path, 'http2-url-tests.js');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-server-push-disabled.js
+++ b/test/parallel/test-http2-server-push-disabled.js
@@ -42,7 +42,7 @@ server.listen(0, common.mustCall(() => {
                                options);
   const req = client.request({ ':path': '/' });
 
-  // Because push stream sre disabled, this must not be called.
+  // Because push streams are disabled, this must not be called.
   client.on('stream', common.mustNotCall());
 
   req.resume();

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -5,6 +5,8 @@
 // to pass to the internal binding layer.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const { mapToHeaders } = require('internal/http2/util');
 

--- a/test/parallel/test-http2-util-update-options-buffer.js
+++ b/test/parallel/test-http2-util-update-options-buffer.js
@@ -1,7 +1,9 @@
 // Flags: --expose-internals
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 // Test coverage for the updateOptionsBuffer method used internally
 // by the http2 implementation.

--- a/test/parallel/test-https-agent-secure-protocol.js
+++ b/test/parallel/test-https-agent-secure-protocol.js
@@ -42,7 +42,7 @@ server.listen(0, common.mustCall(function() {
       }, common.mustCall(function(res) {
         res.resume();
         globalAgent.once('free', common.mustCall(function() {
-          // Verify that two keep-alived connections are created
+          // Verify that two keep-alive connections are created
           // due to the different secureProtocol settings:
           const keys = Object.keys(globalAgent.freeSockets);
           assert.strictEqual(keys.length, 2);

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -61,7 +61,7 @@ server_http.listen(0, function() {
 });
 
 // Then try https server (requires functions to be
-// mirroed in tls.js's CryptoStream)
+// mirrored in tls.js's CryptoStream)
 
 const server_https = https.createServer(options, function(req, res) {
   console.log('got HTTPS request');

--- a/test/parallel/test-https-unix-socket-self-signed.js
+++ b/test/parallel/test-https-unix-socket-self-signed.js
@@ -4,7 +4,8 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const fixtures = require('../common/fixtures');
 const https = require('https');

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -7,9 +7,10 @@ const fs = require('fs');
 const path = require('path');
 const SyncWriteStream = require('internal/fs').SyncWriteStream;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
+const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
 
 // Verify constructing the instance with default options.
 {

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -31,7 +31,7 @@ const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
   assert.strictEqual(stream.listenerCount('end'), 1);
 }
 
-// Verfiy that the file will be written synchronously.
+// Verify that the file will be written synchronously.
 {
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);
@@ -54,7 +54,7 @@ const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
   assert.strictEqual(stream.destroySoon(), true);
 }
 
-// Verfit that the 'end' event listener will also destroy the stream.
+// Verify that the 'end' event listener will also destroy the stream.
 {
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);

--- a/test/parallel/test-module-circular-symlinks.js
+++ b/test/parallel/test-module-circular-symlinks.js
@@ -29,8 +29,9 @@ const fs = require('fs');
 //         └── node_modules
 //         └── moduleA -> {tmpDir}/node_modules/moduleA
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const node_modules = path.join(tmpDir, 'node_modules');
 const moduleA = path.join(node_modules, 'moduleA');

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -10,10 +10,11 @@ const pkgName = 'foo';
 if (process.argv[2] === 'child') {
   console.log(require(pkgName).string);
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
   // Copy node binary into a test $PREFIX directory.
-  const prefixPath = path.join(common.tmpDir, 'install');
+  const prefixPath = path.join(tmpdir.path, 'install');
   fs.mkdirSync(prefixPath);
   let testExecPath;
   if (common.isWindows) {
@@ -43,7 +44,7 @@ if (process.argv[2] === 'child') {
   delete env['NODE_PATH'];
 
   // Test empty global path.
-  const noPkgHomeDir = path.join(common.tmpDir, 'home-no-pkg');
+  const noPkgHomeDir = path.join(tmpdir.path, 'home-no-pkg');
   fs.mkdirSync(noPkgHomeDir);
   env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
   assert.throws(

--- a/test/parallel/test-module-symlinked-peer-modules.js
+++ b/test/parallel/test-module-symlinked-peer-modules.js
@@ -13,9 +13,10 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const tmpDir = common.tmpDir;
+const tmpDir = tmpdir.path;
 
 // Creates the following structure
 // {tmpDir}

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -8,7 +8,8 @@ const net = require('net');
 const path = require('path');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function testClients(getSocketOpt, getConnectOpt, getConnectCb) {
   const cloneOptions = (index) =>

--- a/test/parallel/test-net-connect-options-path.js
+++ b/test/parallel/test-net-connect-options-path.js
@@ -5,7 +5,8 @@ const net = require('net');
 // This file tests the option handling of net.connect,
 // net.createConnect, and new Socket().connect
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const CLIENT_VARIANTS = 12;
 

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -25,5 +25,5 @@ const net = require('net');
 
 const server = net.createServer(function(socket) {
 });
-server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCESS or EADDRNOTAVAIL
+server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCES or EADDRNOTAVAIL
 server.on('error', common.mustCall());

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -128,7 +128,8 @@ function pingPongTest(port, host) {
 }
 
 /* All are run at once, so run on different ports */
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 pingPongTest(common.PIPE);
 pingPongTest(0);
 pingPongTest(0, 'localhost');

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -37,7 +37,7 @@ if (common.isWindows) {
   emptyTxt = fixtures.path('empty.txt');
 } else {
   common.refreshTmpDir();
-  // Keep the file name very short so tht we don't exceed the 108 char limit
+  // Keep the file name very short so that we don't exceed the 108 char limit
   // on CI for a POSIX socket. Even though this isn't actually a socket file,
   // the error will be different from the one we are expecting if we exceed the
   // limit.

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -36,12 +36,13 @@ if (common.isWindows) {
   // file instead
   emptyTxt = fixtures.path('empty.txt');
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   // Keep the file name very short so that we don't exceed the 108 char limit
   // on CI for a POSIX socket. Even though this isn't actually a socket file,
   // the error will be different from the one we are expecting if we exceed the
   // limit.
-  emptyTxt = `${common.tmpDir}0.txt`;
+  emptyTxt = `${tmpdir.path}0.txt`;
 
   function cleanup() {
     try {

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -8,7 +8,8 @@ const uv = process.binding('uv');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function closeServer() {
   return common.mustCall(function() {

--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -3,7 +3,8 @@
 const common = require('../common');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function closeServer() {
   return common.mustCall(function() {

--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -39,7 +39,7 @@ const server = net.createServer(common.mustCall(function(socket) {
 
 server.listen(0, function() {
   const client = net.connect(this.address().port, function() {
-    // cliend.end() will close both the readable and writable side
+    // client.end() will close both the readable and writable side
     // of the duplex because allowHalfOpen defaults to false.
     // Then 'end' will be emitted when it receives a FIN packet from
     // the other side.

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -9,10 +9,11 @@ const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
-common.refreshTmpDir();
-const npmSandbox = path.join(common.tmpDir, 'npm-sandbox');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const npmSandbox = path.join(tmpdir.path, 'npm-sandbox');
 fs.mkdirSync(npmSandbox);
-const installDir = path.join(common.tmpDir, 'install-dir');
+const installDir = path.join(tmpdir.path, 'install-dir');
 fs.mkdirSync(installDir);
 
 const npmPath = path.join(

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -113,7 +113,7 @@ is.string(arch);
 assert.ok(arch.length > 0);
 
 if (!common.isSunOS) {
-  // not implemeneted yet
+  // not implemented yet
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);
   assert.ok(os.totalmem() > 0);

--- a/test/parallel/test-pipe-address.js
+++ b/test/parallel/test-pipe-address.js
@@ -4,7 +4,8 @@ const assert = require('assert');
 const net = require('net');
 const server = net.createServer(common.mustNotCall());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(function() {
   assert.strictEqual(server.address(), common.PIPE);

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -27,9 +27,10 @@ const http = require('http');
 const path = require('path');
 const cp = require('child_process');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir || '/tmp', 'big');
+const filename = path.join(tmpdir.path || '/tmp', 'big');
 let count = 0;
 
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-pipe-stream.js
+++ b/test/parallel/test-pipe-stream.js
@@ -3,7 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function test(clazz, cb) {
   let have_ping = false;

--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -4,7 +4,8 @@ const net = require('net');
 
 // This test should end immediately after `unref` is called
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const s = net.Server();
 s.listen(common.PIPE);

--- a/test/parallel/test-pipe-writev.js
+++ b/test/parallel/test-pipe-writev.js
@@ -7,7 +7,8 @@ if (common.isWindows)
 const assert = require('assert');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = net.createServer((connection) => {
   connection.on('error', (err) => {

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
 
 process.chdir('..');
 assert.notStrictEqual(process.cwd(), __dirname);
@@ -18,10 +20,10 @@ if (process.versions.icu) {
   // ICU is unavailable, use characters that can't be decomposed
   dirName = 'weird \ud83d\udc04 characters \ud83d\udc05';
 }
-const dir = path.resolve(common.tmpDir, dirName);
+const dir = path.resolve(tmpdir.path, dirName);
 
 // Make sure that the tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.mkdirSync(dir);
 process.chdir(dir);
@@ -29,7 +31,7 @@ assert.strictEqual(process.cwd().normalize(), dir.normalize());
 
 process.chdir('..');
 assert.strictEqual(process.cwd().normalize(),
-                   path.resolve(common.tmpDir).normalize());
+                   path.resolve(tmpdir.path).normalize());
 
 const errMessage = /^TypeError: Bad argument\.$/;
 assert.throws(function() { process.chdir({}); },

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -14,9 +14,10 @@ if (process.argv[2] === 'child') {
   // The console.log() output is part of the test here.
   console.log(process.execPath);
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
-  const symlinkedNode = path.join(common.tmpDir, 'symlinked-node');
+  const symlinkedNode = path.join(tmpdir.path, 'symlinked-node');
   fs.symlinkSync(process.execPath, symlinkedNode);
 
   const proc = child_process.spawnSync(symlinkedNode, [__filename, 'child']);

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -12,10 +12,11 @@ const fork = require('child_process').fork;
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const warnmod = require.resolve(fixtures.path('warnings.js'));
-const warnpath = path.join(common.tmpDir, 'warnings.txt');
+const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { env: Object.assign({}, process.env,
                                    { NODE_REDIRECT_WARNINGS: warnpath }) })

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -12,10 +12,11 @@ const fork = require('child_process').fork;
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const warnmod = fixtures.path('warnings.js');
-const warnpath = path.join(common.tmpDir, 'warnings.txt');
+const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { execArgv: [`--redirect-warnings=${warnpath}`] })
   .on('exit', common.mustCall(() => {

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -293,7 +293,7 @@ asyncTest('While inside setImmediate, catching a rejected promise derived ' +
   });
 });
 
-// State adapation tests
+// State adaptation tests
 asyncTest('catching a promise which is asynchronously rejected (via ' +
           'resolution to an asynchronously-rejected promise) prevents' +
           ' unhandledRejection', function(done) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -812,7 +812,7 @@ function isWarned(emitter) {
     assert.strictEqual(isWarned(process.stdout._events), false);
   }
 
-  // can create a new readline Interface with a null output arugument
+  // can create a new readline Interface with a null output argument
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(

--- a/test/parallel/test-regress-GH-3739.js
+++ b/test/parallel/test-regress-GH-3739.js
@@ -5,10 +5,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-let dir = path.resolve(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+
+let dir = path.resolve(tmpdir.path);
 
 // Make sure that the tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Make a long path.
 for (let i = 0; i < 50; i++) {

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -31,8 +31,9 @@ stream._write = function(c, e, cb) {
 };
 stream.readable = stream.writable = true;
 
-common.refreshTmpDir();
-const replHistoryPath = path.join(common.tmpDir, '.node_repl_history');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 
 const checkResults = common.mustCall(function(err, r) {
   assert.ifError(err);

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -11,11 +11,12 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // Mock os.homedir()
 os.homedir = function() {
-  return common.tmpDir;
+  return tmpdir.path;
 };
 
 // Create an input stream specialized for testing an array of actions
@@ -55,16 +56,16 @@ const CLEAR = { ctrl: true, name: 'u' };
 
 // File paths
 const historyFixturePath = fixtures.path('.node_repl_history');
-const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
-const historyPathFail = path.join(common.tmpDir, '.node_repl\u0000_history');
+const historyPath = path.join(tmpdir.path, '.fixture_copy_repl_history');
+const historyPathFail = path.join(tmpdir.path, '.node_repl\u0000_history');
 const oldHistoryPathObj = fixtures.path('old-repl-history-file-obj.json');
 const oldHistoryPathFaulty = fixtures.path('old-repl-history-file-faulty.json');
 const oldHistoryPath = fixtures.path('old-repl-history-file.json');
 const enoentHistoryPath = fixtures.path('enoent-repl-history-file.json');
 const emptyHistoryPath = fixtures.path('.empty-repl-history-file');
-const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
+const defaultHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 const emptyHiddenHistoryPath = fixtures.path('.empty-hidden-repl-history-file');
-const devNullHistoryPath = path.join(common.tmpDir,
+const devNullHistoryPath = path.join(tmpdir.path,
                                      '.dev-null-repl-history-file');
 // Common message bits
 const prompt = '> ';

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -25,7 +25,8 @@ const assert = require('assert');
 const join = require('path').join;
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const repl = require('repl');
 
@@ -39,7 +40,7 @@ const testFile = [
   'var top = function() {',
   'var inner = {one:1};'
 ];
-const saveFileName = join(common.tmpDir, 'test.save.js');
+const saveFileName = join(tmpdir.path, 'test.save.js');
 
 // input some data
 putIn.run(testFile);
@@ -91,7 +92,7 @@ testMe.complete('inner.o', function(error, data) {
 // clear the REPL
 putIn.run(['.clear']);
 
-let loadFile = join(common.tmpDir, 'file.does.not.exist');
+let loadFile = join(tmpdir.path, 'file.does.not.exist');
 
 // should not break
 putIn.write = function(data) {
@@ -103,7 +104,7 @@ putIn.write = function(data) {
 putIn.run([`.load ${loadFile}`]);
 
 // throw error on loading directory
-loadFile = common.tmpDir;
+loadFile = tmpdir.path;
 putIn.write = function(data) {
   assert.strictEqual(data, `Failed to load:${loadFile} is not a valid file\n`);
   putIn.write = () => {};
@@ -115,7 +116,7 @@ putIn.run(['.clear']);
 
 // NUL (\0) is disallowed in filenames in UNIX-like operating systems and
 // Windows so we can use that to test failed saves
-const invalidFileName = join(common.tmpDir, '\0\0\0\0\0');
+const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
 
 // should not break
 putIn.write = function(data) {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -304,7 +304,7 @@ function error_test() {
     { client: client_unix,
       send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
       expect: `true\n${prompt_unix}` },
-    // the following test's result depends on the RegEx's match from the above
+    // the following test's result depends on the RegExp's match from the above
     { client: client_unix,
       send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
             'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -22,10 +22,11 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 
 common.globalCheck = false;
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const net = require('net');
 const repl = require('repl');

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -6,15 +6,17 @@ if (!common.isWindows)
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 // make a path that is more than 260 chars long.
-const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
-const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));
+const dirNameLen = Math.max(260 - tmpdir.path.length, 1);
+const dirName = path.join(tmpdir.path, 'x'.repeat(dirNameLen));
 const fullDirPath = path.resolve(dirName);
 
 const indexFile = path.join(fullDirPath, 'index.js');
 const otherFile = path.join(fullDirPath, 'other.js');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.mkdirSync(fullDirPath);
 fs.writeFileSync(indexFile, 'require("./other");');
@@ -23,4 +25,4 @@ fs.writeFileSync(otherFile, '');
 require(indexFile);
 require(otherFile);
 
-common.refreshTmpDir();
+tmpdir.refresh();

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -38,7 +38,8 @@ function copyDir(source, target) {
 copyDir(fixtureSource, tmpDirTarget);
 
 // Move to tmp dir and do everything with relative paths there so that the test
-// doesn't incorrectly fail due to a symlink somewhere else in the absolte path.
+// doesn't incorrectly fail due to a symlink somewhere else in the absolute
+// path.
 process.chdir(common.tmpDir);
 
 const linkDir = path.join(dirName,

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -14,12 +14,13 @@ const process = require('process');
 // Setup: Copy fixtures to tmp directory.
 
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const dirName = 'module-require-symlink';
 const fixtureSource = fixtures.path(dirName);
-const tmpDirTarget = path.join(common.tmpDir, dirName);
+const tmpDirTarget = path.join(tmpdir.path, dirName);
 
 // Copy fixtureSource to linkTarget recursively.
-common.refreshTmpDir();
+tmpdir.refresh();
 
 function copyDir(source, target) {
   fs.mkdirSync(target);
@@ -40,7 +41,7 @@ copyDir(fixtureSource, tmpDirTarget);
 // Move to tmp dir and do everything with relative paths there so that the test
 // doesn't incorrectly fail due to a symlink somewhere else in the absolute
 // path.
-process.chdir(common.tmpDir);
+process.chdir(tmpdir.path);
 
 const linkDir = path.join(dirName,
                           'node_modules',

--- a/test/parallel/test-require-unicode.js
+++ b/test/parallel/test-require-unicode.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const dirname = path.join(common.tmpDir, '\u4e2d\u6587\u76ee\u5f55');
+const dirname = path.join(tmpdir.path, '\u4e2d\u6587\u76ee\u5f55');
 fs.mkdirSync(dirname);
 fs.writeFileSync(path.join(dirname, 'file.js'), 'module.exports = 42;');
 fs.writeFileSync(path.join(dirname, 'package.json'),

--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -1,13 +1,14 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const { join } = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 
 const stdoutScript = fixtures.path('echo-close-check.js');
-const tmpFile = join(common.tmpDir, 'stdin.txt');
+const tmpFile = join(tmpdir.path, 'stdin.txt');
 
 const cmd = `"${process.argv[0]}" "${stdoutScript}" < "${tmpFile}"`;
 
@@ -24,7 +25,7 @@ const string = 'abc\nümlaut.\nsomething else\n' +
                '有效的改善了岭南地区落后的政治、##济现状。\n';
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 console.log(`${cmd}\n\n`);
 

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -5,12 +5,13 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const scriptString = fixtures.path('print-chars.js');
 const scriptBuffer = fixtures.path('print-chars-from-buffer.js');
-const tmpFile = path.join(common.tmpDir, 'stdout.txt');
+const tmpFile = path.join(tmpdir.path, 'stdout.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 function test(size, useBuffer, cb) {
   const cmd = `"${process.argv[0]}" "${

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -14,14 +14,19 @@ assert.strictEqual(emptyList.join(','), '');
 
 assert.deepStrictEqual(emptyList.concat(0), Buffer.alloc(0));
 
+const buf = Buffer.from('foo');
+
 // Test buffer list with one element.
 const list = new BufferList();
-list.push('foo');
+list.push(buf);
 
-assert.strictEqual(list.concat(1), 'foo');
+const copy = list.concat(3);
+
+assert.notStrictEqual(copy, buf);
+assert.deepStrictEqual(copy, buf);
 
 assert.strictEqual(list.join(','), 'foo');
 
 const shifted = list.shift();
-assert.strictEqual(shifted, 'foo');
+assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());

--- a/test/parallel/test-stream-transform-final-sync.js
+++ b/test/parallel/test-stream-transform-final-sync.js
@@ -7,7 +7,7 @@ let state = 0;
 
 /*
 What you do
-var stream = new tream.Transform({
+var stream = new stream.Transform({
   transform: function transformCallback(chunk, _, next) {
     // part 1
     this.push(chunk);

--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -7,7 +7,7 @@ let state = 0;
 
 /*
 What you do
-var stream = new tream.Transform({
+var stream = new stream.Transform({
   transform: function transformCallback(chunk, _, next) {
     // part 1
     this.push(chunk);

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -175,7 +175,7 @@ const Transform = require('_stream_transform');
 }
 
 {
-  // Verify assymetric transform (expand)
+  // Verify asymmetric transform (expand)
   const pt = new Transform();
 
   // emit each chunk 2 times.
@@ -207,7 +207,7 @@ const Transform = require('_stream_transform');
 }
 
 {
-  // Verify assymetric trasform (compress)
+  // Verify asymmetric transform (compress)
   const pt = new Transform();
 
   // each output is the first char of 3 consecutive chunks,
@@ -262,7 +262,7 @@ const Transform = require('_stream_transform');
 // this tests for a stall when data is written to a full stream
 // that has empty transforms.
 {
-  // Verify compex transform behavior
+  // Verify complex transform behavior
   let count = 0;
   let saved = null;
   const pt = new Transform({ highWaterMark: 3 });

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -65,7 +65,7 @@ writeChunks(inputChunks, () => {
   // trigger writing out the buffer
   w.uncork();
 
-  // buffered bytes shoud be seen in current tick
+  // buffered bytes should be seen in current tick
   assert.strictEqual(seenChunks.length, 4);
 
   // did the chunks match

--- a/test/parallel/test-string-decoder-end.js
+++ b/test/parallel/test-string-decoder-end.js
@@ -39,6 +39,46 @@ for (let i = 1; i <= 16; i++) {
 
 encodings.forEach(testEncoding);
 
+testEnd('utf8', Buffer.of(0xE2), Buffer.of(0x61), '\uFFFDa');
+testEnd('utf8', Buffer.of(0xE2), Buffer.of(0x82), '\uFFFD\uFFFD');
+testEnd('utf8', Buffer.of(0xE2), Buffer.of(0xE2), '\uFFFD\uFFFD');
+testEnd('utf8', Buffer.of(0xE2, 0x82), Buffer.of(0x61), '\uFFFDa');
+testEnd('utf8', Buffer.of(0xE2, 0x82), Buffer.of(0xAC), '\uFFFD\uFFFD');
+testEnd('utf8', Buffer.of(0xE2, 0x82), Buffer.of(0xE2), '\uFFFD\uFFFD');
+testEnd('utf8', Buffer.of(0xE2, 0x82, 0xAC), Buffer.of(0x61), '€a');
+
+testEnd('utf16le', Buffer.of(0x3D), Buffer.of(0x61, 0x00), 'a');
+testEnd('utf16le', Buffer.of(0x3D), Buffer.of(0xD8, 0x4D, 0xDC), '\u4DD8');
+testEnd('utf16le', Buffer.of(0x3D, 0xD8), Buffer.of(), '\uD83D');
+testEnd('utf16le', Buffer.of(0x3D, 0xD8), Buffer.of(0x61, 0x00), '\uD83Da');
+testEnd(
+  'utf16le',
+  Buffer.of(0x3D, 0xD8),
+  Buffer.of(0x4D, 0xDC),
+  '\uD83D\uDC4D'
+);
+testEnd('utf16le', Buffer.of(0x3D, 0xD8, 0x4D), Buffer.of(), '\uD83D');
+testEnd(
+  'utf16le',
+  Buffer.of(0x3D, 0xD8, 0x4D),
+  Buffer.of(0x61, 0x00),
+  '\uD83Da'
+);
+testEnd('utf16le', Buffer.of(0x3D, 0xD8, 0x4D), Buffer.of(0xDC), '\uD83D');
+testEnd(
+  'utf16le',
+  Buffer.of(0x3D, 0xD8, 0x4D, 0xDC),
+  Buffer.of(0x61, 0x00),
+  '👍a'
+);
+
+testEnd('base64', Buffer.of(0x61), Buffer.of(), 'YQ==');
+testEnd('base64', Buffer.of(0x61), Buffer.of(0x61), 'YQ==YQ==');
+testEnd('base64', Buffer.of(0x61, 0x61), Buffer.of(), 'YWE=');
+testEnd('base64', Buffer.of(0x61, 0x61), Buffer.of(0x61), 'YWE=YQ==');
+testEnd('base64', Buffer.of(0x61, 0x61, 0x61), Buffer.of(), 'YWFh');
+testEnd('base64', Buffer.of(0x61, 0x61, 0x61), Buffer.of(0x61), 'YWFhYQ==');
+
 function testEncoding(encoding) {
   bufs.forEach((buf) => {
     testBuf(encoding, buf);
@@ -65,4 +105,15 @@ function testBuf(encoding, buf) {
 
   assert.strictEqual(res1, res3, 'one byte at a time should match toString');
   assert.strictEqual(res2, res3, 'all bytes at once should match toString');
+}
+
+function testEnd(encoding, incomplete, next, expected) {
+  let res = '';
+  const s = new SD(encoding);
+  res += s.write(incomplete);
+  res += s.end();
+  res += s.write(next);
+  res += s.end();
+
+  assert.strictEqual(res, expected);
 }

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -82,7 +82,7 @@ assert.strictEqual(c_bin.toString('latin1'), ucs2_control);
 assert.strictEqual(c_ucs.toString('latin1'), ucs2_control);
 
 
-// now let's test BASE64 and HEX ecoding/decoding
+// now let's test BASE64 and HEX encoding/decoding
 const RADIOS = 2;
 const PRE_HALF_APEX = Math.ceil(EXTERN_APEX / 2) - RADIOS;
 const PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -71,7 +71,8 @@ const check_unref = setInterval(() => {
     setInterval(() => timeout.unref(), SHORT_TIME);
 }
 
-// Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
+// Should not assert on args.Holder()->InternalFieldCount() > 0.
+// See https://github.com/nodejs/node-v0.x-archive/issues/4261.
 {
   const t = setInterval(() => {}, 1);
   process.nextTick(t.unref.bind({}));

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -31,7 +31,7 @@ const testCases = [
     errorCode: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
   },
   // Test 1: for the fix of node#2061
-  // agent6-cert.pem is signed by intermidate cert of ca3.
+  // agent6-cert.pem is signed by intermediate cert of ca3.
   // The server has a cert chain of agent6->ca3->ca1(root) but
   // tls.connect should be failed with an error of
   // UNABLE_TO_GET_ISSUER_CERT_LOCALLY since the root CA of ca1 is not

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -33,7 +33,8 @@ const options = {
   cert: fixtures.readKey('agent1-cert.pem')
 };
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = tls.Server(options, common.mustCall(function(socket) {
   server.close();

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Test that the usage of eliptic curves are not permitted if disabled during
+// Test that the usage of elliptic curves are not permitted if disabled during
 // server initialization.
 
 'use strict';

--- a/test/parallel/test-tls-net-connect-prefer-path.js
+++ b/test/parallel/test-tls-net-connect-prefer-path.js
@@ -8,7 +8,8 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const tls = require('tls');
 const net = require('net');

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -286,8 +286,8 @@ function runTest(port, testIndex) {
   let renegotiated = false;
   const server = tls.Server(serverOptions, function handleConnection(c) {
     c.on('error', function(e) {
-      // child.kill() leads ECONNRESET errro in the TLS connection of
-      // openssl s_client via spawn(). A Test result is already
+      // child.kill() leads ECONNRESET error in the TLS connection of
+      // openssl s_client via spawn(). A test result is already
       // checked by the data of client.stdout before child.kill() so
       // these tls errors can be ignored.
     });

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -69,11 +69,11 @@ function doTest(testOptions, callback) {
   server.on('newSession', function(id, data, cb) {
     ++newSessionCount;
     // Emulate asynchronous store
-    setTimeout(function() {
+    setImmediate(() => {
       assert.ok(!session);
       session = { id, data };
       cb();
-    }, 1000);
+    });
   });
   server.on('resumeSession', function(id, callback) {
     ++resumeCount;
@@ -89,9 +89,9 @@ function doTest(testOptions, callback) {
     }
 
     // Just to check that async really works there
-    setTimeout(function() {
+    setImmediate(() => {
       callback(null, data);
-    }, 100);
+    });
   });
 
   server.listen(0, function() {
@@ -132,7 +132,7 @@ function doTest(testOptions, callback) {
         }
         assert.strictEqual(code, 0);
         server.close(common.mustCall(function() {
-          setTimeout(callback, 100);
+          setImmediate(callback);
         }));
       }));
     }

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -63,7 +63,7 @@ server.listen(0, function() {
   client.on('close', function() {
     // readyState is deprecated but we want to make
     // sure this isn't triggering an assert in lib/net.js
-    // See issue #1069.
+    // See https://github.com/nodejs/node-v0.x-archive/issues/1069.
     assert.strictEqual('closed', client.readyState);
 
     // Confirming the buffer string is encoded in ASCII

--- a/test/parallel/test-tls-wrap-econnreset-pipe.js
+++ b/test/parallel/test-tls-wrap-econnreset-pipe.js
@@ -8,7 +8,8 @@ const assert = require('assert');
 const tls = require('tls');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = net.createServer((c) => {
   c.end();

--- a/test/parallel/test-trace-events-all.js
+++ b/test/parallel/test-trace-events-all.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled', '-e', CODE ]);

--- a/test/parallel/test-trace-events-async-hooks.js
+++ b/test/parallel/test-trace-events-async-hooks.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-binding.js
+++ b/test/parallel/test-trace-events-binding.js
@@ -20,8 +20,9 @@ const CODE = `
 `;
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-category-used.js
+++ b/test/parallel/test-trace-events-category-used.js
@@ -7,8 +7,9 @@ const CODE = `console.log(
   process.binding("trace_events").categoryGroupEnabled("custom")
 );`;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const procEnabled = cp.spawn(
   process.execPath,

--- a/test/parallel/test-trace-events-none.js
+++ b/test/parallel/test-trace-events-none.js
@@ -7,8 +7,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc_no_categories = cp.spawn(
   process.execPath,

--- a/test/parallel/test-trace-events-process-exit.js
+++ b/test/parallel/test-trace-events-process-exit.js
@@ -4,10 +4,12 @@ const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-v8.js
+++ b/test/parallel/test-trace-events-v8.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -558,25 +558,31 @@ assert.doesNotThrow(() => {
   assert.strictEqual(util.inspect(x).includes('inspect'), true);
 }
 
-// util.inspect should not display the escaped value of a key.
+// util.inspect should display the escaped value of a key.
 {
   const w = {
     '\\': 1,
     '\\\\': 2,
     '\\\\\\': 3,
     '\\\\\\\\': 4,
+    '\n': 5,
+    '\r': 6
   };
 
   const y = ['a', 'b', 'c'];
-  y['\\\\\\'] = 'd';
+  y['\\\\'] = 'd';
+  y['\n'] = 'e';
+  y['\r'] = 'f';
 
   assert.strictEqual(
     util.inspect(w),
-    '{ \'\\\': 1, \'\\\\\': 2, \'\\\\\\\': 3, \'\\\\\\\\\': 4 }'
+    '{ \'\\\\\': 1, \'\\\\\\\\\': 2, \'\\\\\\\\\\\\\': 3, ' +
+    '\'\\\\\\\\\\\\\\\\\': 4, \'\\n\': 5, \'\\r\': 6 }'
   );
   assert.strictEqual(
     util.inspect(y),
-    '[ \'a\', \'b\', \'c\', \'\\\\\\\': \'d\' ]'
+    '[ \'a\', \'b\', \'c\', \'\\\\\\\\\': \'d\', ' +
+    '\'\\n\': \'e\', \'\\r\': \'f\' ]'
   );
 }
 

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -29,7 +29,8 @@ const zlib = require('zlib');
 const path = require('path');
 const fixtures = require('../common/fixtures');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const gunzip = zlib.createGunzip();
 
@@ -37,7 +38,7 @@ const fs = require('fs');
 
 const fixture = fixtures.path('person.jpg.gz');
 const unzippedFixture = fixtures.path('person.jpg');
-const outputFile = path.resolve(common.tmpDir, 'person.jpg');
+const outputFile = path.resolve(tmpdir.path, 'person.jpg');
 const expect = fs.readFileSync(unzippedFixture);
 const inp = fs.createReadStream(fixture);
 const out = fs.createWriteStream(outputFile);

--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -20,15 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filepath = path.join(common.tmpDir, 'large.txt');
+const filepath = path.join(tmpdir.path, 'large.txt');
 const fd = fs.openSync(filepath, 'w+');
 const offset = 5 * 1024 * 1024 * 1024; // 5GB
 const message = 'Large File';

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -25,7 +25,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const FILENAME = path.join(common.tmpDir, 'watch-me');
+const tmpdir = require('../common/tmpdir');
+
+const FILENAME = path.join(tmpdir.path, 'watch-me');
 const TIMEOUT = 1300;
 
 let nevents = 0;

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -25,12 +25,14 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 let watchSeenOne = 0;
 let watchSeenTwo = 0;
 let watchSeenThree = 0;
 let watchSeenFour = 0;
 
-const testDir = common.tmpDir;
+const testDir = tmpdir.path;
 
 const filenameOne = 'watch.txt';
 const filepathOne = path.join(testDir, filenameOne);

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -24,7 +24,9 @@ const common = require('../common');
 const path = require('path');
 const fs = require('fs');
 
-const testDir = common.tmpDir;
+const tmpdir = require('tmpdir');
+
+const testDir = tmpdir.path;
 const testsubdir = path.join(testDir, 'testsubdir');
 const filepath = path.join(testsubdir, 'watch.txt');
 

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -22,8 +22,10 @@
 'use strict';
 // Flags: --expose_gc
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
+
+const tmpdir = require('../common/tmpdir');
 
 function newBuffer(size, value) {
   const buffer = Buffer.allocUnsafe(size);
@@ -36,7 +38,7 @@ function newBuffer(size, value) {
 }
 
 const fs = require('fs');
-const testFileName = require('path').join(common.tmpDir, 'GH-814_testFile.txt');
+const testFileName = require('path').join(tmpdir.path, 'GH-814_testFile.txt');
 const testFileFD = fs.openSync(testFileName, 'w');
 console.log(testFileName);
 

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -22,11 +22,12 @@
 'use strict';
 // Flags: --expose_gc
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const fs = require('fs');
-const testFileName = require('path').join(common.tmpDir, 'GH-814_test.txt');
+const tmpdir = require('../common/tmpdir');
+const testFileName = require('path').join(tmpdir.path, 'GH-814_test.txt');
 const testFD = fs.openSync(testFileName, 'w');
 console.error(`${testFileName}\n`);
 

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -28,6 +28,8 @@ if (!common.opensslCli)
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const tmpdir = require('../common/tmpdir');
+
 doTest();
 
 // This test consists of three TLS requests --
@@ -65,7 +67,7 @@ function doTest() {
 
   const sessionFileName = (function() {
     const ticketFileName = 'tls-session-ticket.txt';
-    const tmpPath = join(common.tmpDir, ticketFileName);
+    const tmpPath = join(tmpdir.path, ticketFileName);
     fs.writeFileSync(tmpPath, fixtures.readSync(ticketFileName));
     return tmpPath;
   }());

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 // Make sure that all Providers are tested.
 {
@@ -145,7 +146,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 }
 
 {
-  common.refreshTmpDir();
+  tmpdir.refresh();
 
   const server = net.createServer(common.mustCall((socket) => {
     server.close();

--- a/test/sequential/test-benchmark-tls.js
+++ b/test/sequential/test-benchmark-tls.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.enoughTestMem)
+  common.skip('Insufficient memory for TLS benchmark test');
+
+// Because the TLS benchmarks use hardcoded ports, this should be in sequential
+// rather than parallel to make sure it does not conflict with tests that choose
+// random available ports.
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('tls',
+             [
+               'concurrency=1',
+               'dur=0.1',
+               'n=1',
+               'size=2',
+               'type=asc'
+             ],
+             {
+               NODEJS_BENCHMARK_ZERO_ALLOWED: 1,
+               duration: 0
+             });

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -94,7 +94,8 @@ ret = execFileSync(process.execPath, args, { encoding: 'utf8' });
 
 assert.strictEqual(ret, `${msg}\n`);
 
-// Verify that the cwd option works - GH #7824
+// Verify that the cwd option works.
+// See https://github.com/nodejs/node-v0.x-archive/issues/7824.
 {
   const cwd = common.rootDir;
   const cmd = common.isWindows ? 'echo %cd%' : 'pwd';
@@ -103,7 +104,8 @@ assert.strictEqual(ret, `${msg}\n`);
   assert.strictEqual(response.toString().trim(), cwd);
 }
 
-// Verify that stderr is not accessed when stdio = 'ignore' - GH #7966
+// Verify that stderr is not accessed when stdio = 'ignore'.
+// See https://github.com/nodejs/node-v0.x-archive/issues/7966.
 {
   assert.throws(function() {
     execSync('exit -1', { stdio: 'ignore' });

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -29,6 +29,7 @@ const TIMER = 200;
 const SLEEP = 2000;
 
 const start = Date.now();
+const execOpts = { encoding: 'utf8', shell: true };
 let err;
 let caught = false;
 
@@ -124,3 +125,8 @@ assert.strictEqual(ret, `${msg}\n`);
     return true;
   });
 }
+
+// Verify the shell option works properly
+assert.doesNotThrow(() => {
+  execFileSync(process.execPath, [], execOpts);
+});

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -13,9 +13,10 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file = path.join(common.tmpDir, 'toobig.txt');
+const file = path.join(tmpdir.path, 'toobig.txt');
 const stream = fs.createWriteStream(file, {
   flags: 'a'
 });

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -26,14 +26,16 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 const expectFilePath = common.isWindows ||
                        common.isLinux ||
                        common.isOSX ||
                        common.isAIX;
 
-const testDir = common.tmpDir;
+const testDir = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 {
   const filepath = path.join(testDir, 'watch.txt');

--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -8,7 +8,8 @@ const fs = require('fs');
 const http2 = require('http2');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // This test assesses whether long-running writes can complete
 // or timeout because the session or stream are not aware that the
@@ -29,7 +30,7 @@ let offsetTimeout = common.platformTimeout(100);
 let didReceiveData = false;
 
 const content = Buffer.alloc(writeSize, 0x44);
-const filepath = path.join(common.tmpDir, 'http2-large-write.tmp');
+const filepath = path.join(tmpdir.path, 'http2-large-write.tmp');
 fs.writeFileSync(filepath, content, 'binary');
 const fd = fs.openSync(filepath, 'r');
 

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -27,9 +27,10 @@ async function testContextCreatedAndDestroyed() {
     const { name } = contextCreated.params.context;
     if (common.isSunOS || common.isWindows) {
       // uv_get_process_title() is unimplemented on Solaris-likes, it returns
-      // an empy string.  On the Windows CI buildbots it returns "Administrator:
-      // Windows PowerShell[42]" because of a GetConsoleTitle() quirk. Not much
-      // we can do about either, just verify that it contains the PID.
+      // an empty string.  On the Windows CI buildbots it returns
+      // "Administrator: Windows PowerShell[42]" because of a GetConsoleTitle()
+      // quirk. Not much we can do about either, just verify that it contains
+      // the PID.
       strictEqual(name.includes(`[${process.pid}]`), true);
     } else {
       strictEqual(`${process.argv0}[${process.pid}]`, name);

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -250,7 +250,8 @@ try {
 
   assert.deepStrictEqual(children, {
     'common/index.js': {
-      'common/fixtures.js': {}
+      'common/fixtures.js': {},
+      'common/tmpdir.js': {}
     },
     'fixtures/not-main-module.js': {},
     'fixtures/a.js': {

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -222,7 +222,8 @@ try {
 }
 
 {
-  // #1357 Loading JSON files with require()
+  // Loading JSON files with require()
+  // See https://github.com/nodejs/node-v0.x-archive/issues/1357.
   const json = require('../fixtures/packages/main/package.json');
   assert.deepStrictEqual(json, {
     name: 'package-name',
@@ -337,7 +338,8 @@ process.on('exit', function() {
 });
 
 
-// #1440 Loading files with a byte order marker.
+// Loading files with a byte order marker.
+// See https://github.com/nodejs/node-v0.x-archive/issues/1440.
 assert.strictEqual(require('../fixtures/utf8-bom.js'), 42);
 assert.strictEqual(require('../fixtures/utf8-bom.json'), 42);
 

--- a/test/sequential/test-readline-interface.js
+++ b/test/sequential/test-readline-interface.js
@@ -24,7 +24,7 @@
 const common = require('../common');
 
 // These test cases are in `sequential` rather than the analogous test file in
-// `parallel` because they become unrelaible under load. The unreliability under
+// `parallel` because they become unreliable under load. The unreliability under
 // load was determined empirically when the test cases were in `parallel` by
 // running:
 //   tools/test.py -j 96 --repeat 192 test/parallel/test-readline-interface.js

--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -25,9 +25,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'watched');
+const filename = path.join(tmpdir.path, 'watched');
 fs.writeFileSync(filename, 'quis custodiet ipsos custodes');
 
 fs.watchFile(filename, { interval: 50 }, common.mustCall(function(curr, prev) {

--- a/test/tick-processor/tick-processor-base.js
+++ b/test/tick-processor/tick-processor-base.js
@@ -1,12 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const cp = require('child_process');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const LOG_FILE = path.join(common.tmpDir, 'tick-processor.log');
+const LOG_FILE = path.join(tmpdir.path, 'tick-processor.log');
 const RETRY_TIMEOUT = 150;
 
 function runTest(test) {

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -13,13 +13,13 @@ const jsPrimitives = {
   'undefined': 'Undefined'
 };
 const jsGlobalTypes = [
-  'Error', 'Object', 'Function', 'Array', 'TypedArray', 'Uint8Array',
-  'Uint16Array', 'Uint32Array', 'Int8Array', 'Int16Array', 'Int32Array',
-  'Uint8ClampedArray', 'Float32Array', 'Float64Array', 'Date', 'RegExp',
-  'ArrayBuffer', 'DataView', 'Promise', 'EvalError', 'RangeError',
-  'ReferenceError', 'SyntaxError', 'TypeError', 'URIError', 'Proxy', 'Map',
-  'Set', 'WeakMap', 'WeakSet', 'Generator', 'GeneratorFunction',
-  'AsyncFunction', 'SharedArrayBuffer'
+  'Array', 'ArrayBuffer', 'AsyncFunction', 'DataView', 'Date', 'Error',
+  'EvalError', 'Float32Array', 'Float64Array', 'Function', 'Generator',
+  'GeneratorFunction', 'Int16Array', 'Int32Array', 'Int8Array', 'Map', 'Object',
+  'Promise', 'Proxy', 'RangeError', 'ReferenceError', 'RegExp', 'Set',
+  'SharedArrayBuffer', 'SyntaxError', 'TypeError', 'TypedArray', 'URIError',
+  'Uint16Array', 'Uint32Array', 'Uint8Array', 'Uint8ClampedArray', 'WeakMap',
+  'WeakSet'
 ];
 const typeMap = {
   'Iterable':
@@ -27,15 +27,25 @@ const typeMap = {
   'Iterator':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterator_protocol`,
 
+  'this': `${jsDocPrefix}Reference/Operators/this`,
+
+  'AsyncHook': 'async_hooks.html#async_hooks_async_hooks_createhook_callbacks',
+
   'Buffer': 'buffer.html#buffer_class_buffer',
 
   'ChildProcess': 'child_process.html#child_process_class_childprocess',
 
   'cluster.Worker': 'cluster.html#cluster_class_worker',
 
+  'crypto.constants': 'crypto.html#crypto_crypto_constants_1',
+
   'dgram.Socket': 'dgram.html#dgram_class_dgram_socket',
 
+  'Domain': 'domain.html#domain_class_domain',
+
   'EventEmitter': 'events.html#events_class_eventemitter',
+
+  'fs.Stats': 'fs.html#fs_class_fs_stats',
 
   'http.Agent': 'http.html#http_class_http_agent',
   'http.ClientRequest': 'http.html#http_class_http_clientrequest',
@@ -43,17 +53,41 @@ const typeMap = {
   'http.Server': 'http.html#http_class_http_server',
   'http.ServerResponse': 'http.html#http_class_http_serverresponse',
 
+  'ClientHttp2Stream': 'http2.html#http2_class_clienthttp2stream',
+  'HTTP2 Headers Object': 'http2.html#http2_headers_object',
+  'HTTP2 Settings Object': 'http2.html#http2_settings_object',
+  'http2.Http2ServerRequest': 'http2.html#http2_class_http2_http2serverrequest',
+  'http2.Http2ServerResponse':
+    'http2.html#http2_class_http2_http2serverresponse',
+  'Http2Server': 'http2.html#http2_class_http2server',
+  'Http2Session': 'http2.html#http2_class_http2session',
+  'Http2Stream': 'http2.html#http2_class_http2stream',
+  'ServerHttp2Stream': 'http2.html#http2_class_serverhttp2stream',
+
   'Handle': 'net.html#net_server_listen_handle_backlog_callback',
+  'net.Server': 'net.html#net_class_net_server',
   'net.Socket': 'net.html#net_class_net_socket',
 
+  'os.constants.dlopen': 'os.html#os_dlopen_constants',
+
+  'PerformanceObserver':
+    'perf_hooks.html#perf_hooks_class_performanceobserver_callback',
+  'PerformanceObserverEntryList':
+    'perf_hooks.html#perf_hooks_class_performanceobserverentrylist',
+
+  'readline.Interface': 'readline.html#readline_class_interface',
+
   'Stream': 'stream.html#stream_stream',
+  'stream.Duplex': 'stream.html#stream_class_stream_duplex',
   'stream.Readable': 'stream.html#stream_class_stream_readable',
   'stream.Writable': 'stream.html#stream_class_stream_writable',
-  'stream.Duplex': 'stream.html#stream_class_stream_duplex',
 
-  'tls.TLSSocket': 'tls.html#tls_class_tls_tlssocket',
-
+  'Immediate': 'timers.html#timers_class_immediate',
+  'Timeout': 'timers.html#timers_class_timeout',
   'Timer': 'timers.html#timers_timers',
+
+  'tls.Server': 'tls.html#tls_class_tls_server',
+  'tls.TLSSocket': 'tls.html#tls_class_tls_tlssocket',
 
   'URL': 'url.html#url_the_whatwg_url_api',
   'URLSearchParams': 'url.html#url_class_urlsearchparams'

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -16,13 +16,18 @@ const utils = require('./rules-utils.js');
 const msg = 'Please add a hasCrypto check to allow this test to be skipped ' +
             'when Node is built "--without-ssl".';
 
+const cryptoModules = ['crypto', 'http2'];
+const requireModules = cryptoModules.concat(['tls', 'https']);
+const bindingModules = cryptoModules.concat(['tls_wrap']);
+
 module.exports = function(context) {
   const missingCheckNodes = [];
   const requireNodes = [];
   var hasSkipCall = false;
 
   function testCryptoUsage(node) {
-    if (utils.isRequired(node, ['crypto', 'tls', 'https', 'http2'])) {
+    if (utils.isRequired(node, requireModules) ||
+        utils.isBinding(node, bindingModules)) {
       requireNodes.push(node);
     }
   }

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -1,0 +1,61 @@
+/**
+ * @fileOverview Any non-ASCII characters in lib/ will increase the size
+ *               of the compiled node binary. This linter rule ensures that
+ *               any such character is reported.
+ * @author Sarat Addepalli <sarat.addepalli@gmail.com>
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const nonAsciiRegexPattern = /[^\r\n\x20-\x7e]/;
+const suggestions = {
+  '’': '\'',
+  '‛': '\'',
+  '‘': '\'',
+  '“': '"',
+  '‟': '"',
+  '”': '"',
+  '«': '"',
+  '»': '"',
+  '—': '-'
+};
+
+module.exports = (context) => {
+
+  const reportIfError = (node, sourceCode) => {
+
+    const matches = sourceCode.text.match(nonAsciiRegexPattern);
+
+    if (!matches) return;
+
+    const offendingCharacter = matches[0];
+    const offendingCharacterPosition = matches.index;
+    const suggestion = suggestions[offendingCharacter];
+
+    let message = `Non-ASCII character '${offendingCharacter}' detected.`;
+
+    message = suggestion ?
+      `${message} Consider replacing with: ${suggestion}` :
+      message;
+
+    context.report({
+      node,
+      message,
+      loc: sourceCode.getLocFromIndex(offendingCharacterPosition),
+      fix: (fixer) => {
+        return fixer.replaceText(
+          node,
+          suggestion ? `${suggestion}` : ''
+        );
+      }
+    });
+  };
+
+  return {
+    Program: (node) => reportIfError(node, context.getSourceCode())
+  };
+};

--- a/tools/eslint-rules/prefer-assert-methods.js
+++ b/tools/eslint-rules/prefer-assert-methods.js
@@ -1,3 +1,7 @@
+/**
+ * @fileoverview Prohibit the use of assert operators ( ===, !==, ==, != )
+ */
+
 'use strict';
 
 const astSelector = 'ExpressionStatement[expression.type="CallExpression"]' +
@@ -21,7 +25,19 @@ module.exports = function(context) {
       const arg = node.expression.arguments[0];
       const assertMethod = preferedAssertMethod[arg.operator];
       if (assertMethod) {
-        context.report(node, parseError(assertMethod, arg.operator));
+        context.report({
+          node,
+          message: parseError(assertMethod, arg.operator),
+          fix: (fixer) => {
+            const sourceCode = context.getSourceCode();
+            const left = sourceCode.getText(arg.left);
+            const right = sourceCode.getText(arg.right);
+            return fixer.replaceText(
+              node,
+              `assert.${assertMethod}(${left}, ${right});`
+            );
+          }
+        });
       }
     }
   };

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -13,6 +13,18 @@ module.exports.isRequired = function(node, modules) {
 };
 
 /**
+ * Returns true if any of the passed in modules are used in
+ * binding calls.
+ */
+module.exports.isBinding = function(node, modules) {
+  if (node.callee.object) {
+    return node.callee.object.name === 'process' &&
+           node.callee.property.name === 'binding' &&
+           modules.includes(node.arguments[0].value);
+  }
+};
+
+/**
  * Returns true is the node accesses any property in the properties
  * array on the 'common' object.
  */

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -536,7 +536,7 @@ if defined lint_js_ci goto lint-js-ci
 if not defined lint_js goto exit
 if not exist tools\eslint goto no-lint
 echo running lint-js
-%config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.md benchmark doc lib test tools
+%config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.mjs,.md benchmark doc lib test tools
 goto exit
 
 :lint-js-ci

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -105,7 +105,7 @@ if /i "%1"=="build-release" set build_release=1&set sign=1&goto arg-ok
 if /i "%1"=="upload"        set upload=1&goto arg-ok
 if /i "%1"=="small-icu"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
-if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
+if /i "%1"=="intl-none"     set i18n_arg=none&goto arg-ok
 if /i "%1"=="without-intl"  set i18n_arg=none&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok


### PR DESCRIPTION
Non-ASCII characters in /lib get compiled into the node binary,
and may bloat the binary size unnecessarily. A linter rule may
help prevent this.

PR-URL: https://github.com/nodejs/node/pull/18043
Fixes: https://github.com/nodejs/node/issues/11209
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Teddy Katz <teddy.katz@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
