### PR TITLE
[v9.x backport] test: introduce SetUpTestCase/TearDownTestCase

### DIFF
--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -3,4 +3,5 @@
 uv_loop_t NodeTestFixture::current_loop;
 std::unique_ptr<node::NodePlatform> NodeTestFixture::platform;
 std::unique_ptr<v8::ArrayBuffer::Allocator> NodeTestFixture::allocator;
+std::unique_ptr<v8::TracingController> NodeTestFixture::tracing_controller;
 v8::Isolate::CreateParams NodeTestFixture::params;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -100,9 +100,7 @@ class EnvironmentTestFixture : public NodeTestFixture {
  public:
   class Env {
    public:
-    Env(const v8::HandleScope& handle_scope,
-        const Argv& argv,
-        NodeTestFixture* test_fixture) {
+    Env(const v8::HandleScope& handle_scope, const Argv& argv) {
       auto isolate = handle_scope.GetIsolate();
       context_ = node::NewContext(isolate);
       CHECK(!context_.IsEmpty());

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -32,7 +32,7 @@ class EnvironmentTest : public EnvironmentTestFixture {
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, argv, this};
+  Env env {handle_scope, argv};
 
   AtExit(*env, at_exit_callback1);
   RunAtExit(*env);
@@ -42,7 +42,7 @@ TEST_F(EnvironmentTest, AtExitWithEnvironment) {
 TEST_F(EnvironmentTest, AtExitWithArgument) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env {handle_scope, argv, this};
+  Env env {handle_scope, argv};
 
   std::string arg{"some args"};
   AtExit(*env, at_exit_callback1, static_cast<void*>(&arg));
@@ -53,8 +53,8 @@ TEST_F(EnvironmentTest, AtExitWithArgument) {
 TEST_F(EnvironmentTest, MultipleEnvironmentsPerIsolate) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env1 {handle_scope, argv, this};
-  Env env2 {handle_scope, argv, this};
+  Env env1 {handle_scope, argv};
+  Env env2 {handle_scope, argv};
 
   AtExit(*env1, at_exit_callback1);
   AtExit(*env2, at_exit_callback2);

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -70,7 +70,7 @@ TEST_F(DebugSymbolsTest, ExternalStringDataOffset) {
 TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   v8::Local<v8::Object> object = v8::Object::New(isolate_);
   node::BaseObject obj(*env, object);
@@ -87,7 +87,7 @@ TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
 TEST_F(DebugSymbolsTest, EnvironmentHandleWrapQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto expected = reinterpret_cast<uintptr_t>((*env)->handle_wrap_queue());
   auto calculated = reinterpret_cast<uintptr_t>(*env) +
@@ -98,7 +98,7 @@ TEST_F(DebugSymbolsTest, EnvironmentHandleWrapQueue) {
 TEST_F(DebugSymbolsTest, EnvironmentReqWrapQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto expected = reinterpret_cast<uintptr_t>((*env)->req_wrap_queue());
   auto calculated = reinterpret_cast<uintptr_t>(*env) +
@@ -109,7 +109,7 @@ TEST_F(DebugSymbolsTest, EnvironmentReqWrapQueue) {
 TEST_F(DebugSymbolsTest, HandleWrapList) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   uv_tcp_t handle;
 
@@ -138,7 +138,7 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
 TEST_F(DebugSymbolsTest, ReqWrapList) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
-  Env env{handle_scope, argv, this};
+  Env env{handle_scope, argv};
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
   obj_template->InstanceTemplate()->SetInternalFieldCount(1);


### PR DESCRIPTION
This commit add SetUpTestCase and TearDownTestCase functions that will
be called once per test case. Currently we only have SetUp/TearDown
which are called for each test.

This commit moves the initialization and configuration of Node and V8 to
be done on a per test case basis, but gives each test a new Isolate.

PR-URL: https://github.com/nodejs/node/pull/18558
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
