### PR TITLE
repl: fix tab completion of inspector module

### DIFF
--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -104,7 +104,7 @@ const builtinLibs = [
   'stream', 'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ];
 
-if (typeof process.binding('inspector').connect === 'function') {
+if (typeof process.binding('inspector').open === 'function') {
   builtinLibs.push('inspector');
   builtinLibs.sort();
 }

--- a/test/parallel/test-module-cjs-helpers.js
+++ b/test/parallel/test-module-cjs-helpers.js
@@ -1,0 +1,11 @@
+'use strict';
+// Flags: --expose-internals
+
+require('../common');
+const assert = require('assert');
+const { builtinLibs } = require('internal/modules/cjs/helpers');
+
+const hasInspector = process.config.variables.v8_enable_inspector === 1;
+
+const expectedLibs = hasInspector ? 32 : 31;
+assert.strictEqual(builtinLibs.length, expectedLibs);


### PR DESCRIPTION
Correctly check for the presence of the inspector module before adding
it to the builtin libs list.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
