### PR TITLE
stream: give error message if `write()` cb called twice

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -37,11 +37,11 @@ const { getHighWaterMark } = require('internal/streams/state');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_METHOD_NOT_IMPLEMENTED,
+  ERR_MULTIPLE_CALLBACK,
   ERR_STREAM_CANNOT_PIPE,
   ERR_STREAM_DESTROYED,
   ERR_STREAM_NULL_VALUES,
   ERR_STREAM_WRITE_AFTER_END,
-  ERR_STREAM_WRITE_CALLBACK_TWICE,
   ERR_UNKNOWN_ENCODING
 } = require('internal/errors').codes;
 
@@ -447,7 +447,7 @@ function onwrite(stream, er) {
   var cb = state.writecb;
 
   if (typeof cb !== 'function')
-    throw new ERR_STREAM_WRITE_CALLBACK_TWICE();
+    throw new ERR_MULTIPLE_CALLBACK();
 
   onwriteStateUpdate(state);
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -41,6 +41,7 @@ const {
   ERR_STREAM_DESTROYED,
   ERR_STREAM_NULL_VALUES,
   ERR_STREAM_WRITE_AFTER_END,
+  ERR_STREAM_WRITE_CALLBACK_TWICE,
   ERR_UNKNOWN_ENCODING
 } = require('internal/errors').codes;
 
@@ -444,6 +445,9 @@ function onwrite(stream, er) {
   var state = stream._writableState;
   var sync = state.sync;
   var cb = state.writecb;
+
+  if (typeof cb !== 'function')
+    throw new ERR_STREAM_WRITE_CALLBACK_TWICE();
 
   onwriteStateUpdate(state);
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -852,7 +852,6 @@ E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
   'stream.unshift() after end event', Error);
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
 E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
-E('ERR_STREAM_WRITE_CALLBACK_TWICE', '_write() callback called twice', Error);
 E('ERR_TLS_CERT_ALTNAME_INVALID',
   'Hostname/IP does not match certificate\'s altnames: %s', Error);
 E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -852,6 +852,7 @@ E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
   'stream.unshift() after end event', Error);
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
 E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
+E('ERR_STREAM_WRITE_CALLBACK_TWICE', '_write() callback called twice', Error);
 E('ERR_TLS_CERT_ALTNAME_INVALID',
   'Hostname/IP does not match certificate\'s altnames: %s', Error);
 E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);

--- a/test/parallel/test-stream-writable-write-cb-twice.js
+++ b/test/parallel/test-stream-writable-write-cb-twice.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common');
+const { Writable } = require('stream');
+
+{
+  // Sync + Sync
+  const writable = new Writable({
+    write: common.mustCall((buf, enc, cb) => {
+      cb();
+      common.expectsError(cb, {
+        code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+        type: Error
+      });
+    })
+  });
+  writable.write('hi');
+}
+
+{
+  // Sync + Async
+  const writable = new Writable({
+    write: common.mustCall((buf, enc, cb) => {
+      cb();
+      process.nextTick(() => {
+        common.expectsError(cb, {
+          code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+          type: Error
+        });
+      });
+    })
+  });
+  writable.write('hi');
+}
+
+{
+  // Async + Async
+  const writable = new Writable({
+    write: common.mustCall((buf, enc, cb) => {
+      process.nextTick(cb);
+      process.nextTick(() => {
+        common.expectsError(cb, {
+          code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+          type: Error
+        });
+      });
+    })
+  });
+  writable.write('hi');
+}

--- a/test/parallel/test-stream-writable-write-cb-twice.js
+++ b/test/parallel/test-stream-writable-write-cb-twice.js
@@ -8,7 +8,7 @@ const { Writable } = require('stream');
     write: common.mustCall((buf, enc, cb) => {
       cb();
       common.expectsError(cb, {
-        code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+        code: 'ERR_MULTIPLE_CALLBACK',
         type: Error
       });
     })
@@ -23,7 +23,7 @@ const { Writable } = require('stream');
       cb();
       process.nextTick(() => {
         common.expectsError(cb, {
-          code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+          code: 'ERR_MULTIPLE_CALLBACK',
           type: Error
         });
       });
@@ -39,7 +39,7 @@ const { Writable } = require('stream');
       process.nextTick(cb);
       process.nextTick(() => {
         common.expectsError(cb, {
-          code: 'ERR_STREAM_WRITE_CALLBACK_TWICE',
+          code: 'ERR_MULTIPLE_CALLBACK',
           type: Error
         });
       });


### PR DESCRIPTION
Otherwise, this condition would result in an error that just reads
`cb is not a function`, and which additionally could have lost
stack trace context through a `process.nextTick()` call.

    $ ./node benchmark/compare.js --new ./node --old ./node-master --filter writable --runs 200 streams | Rscript benchmark/compare.R
    [00:09:36|% 100| 1/1 files | 400/400 runs | 1/1 configs]: Done
                                               confidence improvement accuracy (*)   (**)  (***)
     streams/writable-manywrites.js n=2000000                -0.28 %       ±3.51% ±4.62% ±5.92%

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
