### PR TITLE
tools: make metadata parsing less permissive

### DIFF
--- a/tools/doc/common.js
+++ b/tools/doc/common.js
@@ -13,31 +13,28 @@ function arrify(value) {
 }
 
 function extractAndParseYAML(text) {
-  text = text.trim();
-
-  text = text.replace(/^<!-- YAML/, '')
+  text = text.trim()
+             .replace(/^<!-- YAML/, '')
              .replace(/-->$/, '');
 
   // js-yaml.safeLoad() throws on error
   const meta = yaml.safeLoad(text);
 
-  const added = meta.added;
-  if (added) {
+  if (meta.added) {
     // Since semver-minors can trickle down to previous major versions,
     // features may have been added in multiple versions.
-    meta.added = arrify(added);
+    meta.added = arrify(meta.added);
   }
 
-  const deprecated = meta.deprecated;
-  if (deprecated) {
+  if (meta.deprecated) {
     // Treat deprecated like added for consistency.
-    meta.deprecated = arrify(deprecated);
+    meta.deprecated = arrify(meta.deprecated);
   }
 
   meta.changes = meta.changes || [];
-  meta.changes.forEach((entry) => {
+  for (const entry of meta.changes) {
     entry.description = entry.description.replace(/^\^\s*/, '');
-  });
+  }
 
   return meta;
 }

--- a/tools/doc/common.js
+++ b/tools/doc/common.js
@@ -21,14 +21,14 @@ function extractAndParseYAML(text) {
   // js-yaml.safeLoad() throws on error
   const meta = yaml.safeLoad(text);
 
-  const added = meta.added || meta.Added;
+  const added = meta.added;
   if (added) {
     // Since semver-minors can trickle down to previous major versions,
     // features may have been added in multiple versions.
     meta.added = arrify(added);
   }
 
-  const deprecated = meta.deprecated || meta.Deprecated;
+  const deprecated = meta.deprecated;
   if (deprecated) {
     // Treat deprecated like added for consistency.
     meta.deprecated = arrify(deprecated);


### PR DESCRIPTION
This change slightly shortens `extractAndParseYAML` and removes support for parsing `Added:` and `Deprecated:` in favor of the lowercase variants. We are consistent about that in our API docs, so the tooling should be consistent as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)