### PR TITLE
[8.x] Backport 18513, 18694

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -684,6 +684,18 @@ Type: Runtime
 cause a lot of issues. See https://github.com/nodejs/node/issues/14328 for more
 details.
 
+<a id="DEP0098"></a>
+### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs
+
+Type: Runtime
+
+The embedded API provided by AsyncHooks exposes emit{Before,After} methods
+which are very easy to use incorrectly which can lead to unrecoverable errors.
+
+Use [`asyncResource.runInAsyncScope()`][] API instead which provides a much
+safer, and more convenient, alternative. See
+https://github.com/nodejs/node/pull/18513 for more details.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
@@ -694,6 +706,7 @@ details.
 [`Server.getConnections()`]: net.html#net_server_getconnections_callback
 [`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`asyncResource.runInAsyncScope()`]: async_hooks.html#async_hooks_asyncresource_runinasyncscope_fn_thisarg_args
 [`child_process`]: child_process.html
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -143,6 +143,17 @@ function triggerAsyncId() {
 
 const destroyedSymbol = Symbol('destroyed');
 
+let emitBeforeAfterWarning = true;
+function showEmitBeforeAfterWarning() {
+  if (emitBeforeAfterWarning) {
+    process.emitWarning(
+      'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
+      'asyncResource.runInAsyncScope instead',
+      'DeprecationWarning', 'DEP00XX');
+    emitBeforeAfterWarning = false;
+  }
+}
+
 class AsyncResource {
   constructor(type, opts = {}) {
     if (typeof type !== 'string')
@@ -178,13 +189,26 @@ class AsyncResource {
   }
 
   emitBefore() {
+    showEmitBeforeAfterWarning();
     emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
     return this;
   }
 
   emitAfter() {
+    showEmitBeforeAfterWarning();
     emitAfter(this[async_id_symbol]);
     return this;
+  }
+
+  runInAsyncScope(fn, thisArg, ...args) {
+    emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
+    let ret;
+    try {
+      ret = Reflect.apply(fn, thisArg, args);
+    } finally {
+      emitAfter(this[async_id_symbol]);
+    }
+    return ret;
   }
 
   emitDestroy() {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -149,7 +149,7 @@ function showEmitBeforeAfterWarning() {
     process.emitWarning(
       'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
       'asyncResource.runInAsyncScope instead',
-      'DeprecationWarning', 'DEP00XX');
+      'DeprecationWarning', 'DEP0098');
     emitBeforeAfterWarning = false;
   }
 }

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -143,17 +143,6 @@ function triggerAsyncId() {
 
 const destroyedSymbol = Symbol('destroyed');
 
-let emitBeforeAfterWarning = true;
-function showEmitBeforeAfterWarning() {
-  if (emitBeforeAfterWarning) {
-    process.emitWarning(
-      'asyncResource.emitBefore and emitAfter are deprecated. Please use ' +
-      'asyncResource.runInAsyncScope instead',
-      'DeprecationWarning', 'DEP0098');
-    emitBeforeAfterWarning = false;
-  }
-}
-
 class AsyncResource {
   constructor(type, opts = {}) {
     if (typeof type !== 'string')
@@ -189,13 +178,11 @@ class AsyncResource {
   }
 
   emitBefore() {
-    showEmitBeforeAfterWarning();
     emitBefore(this[async_id_symbol], this[trigger_async_id_symbol]);
     return this;
   }
 
   emitAfter() {
-    showEmitBeforeAfterWarning();
     emitAfter(this[async_id_symbol]);
     return this;
   }

--- a/test/async-hooks/test-embedder.api.async-resource.runInAsyncScope.js
+++ b/test/async-hooks/test-embedder.api.async-resource.runInAsyncScope.js
@@ -1,0 +1,11 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// Ensure that asyncResource.makeCallback returns the callback return value.
+const a = new async_hooks.AsyncResource('foobar');
+const ret = a.runInAsyncScope(() => {
+  return 1729;
+});
+assert.strictEqual(ret, 1729);

--- a/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
+++ b/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// This test verifies that the async ID stack can grow indefinitely.
+
+function recurse(n) {
+  const a = new async_hooks.AsyncResource('foobar');
+  a.runInAsyncScope(() => {
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+    if (n >= 0)
+      recurse(n - 1);
+    assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+    assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  });
+}
+
+recurse(1000);

--- a/test/parallel/test-emit-after-uncaught-exception-runInAsyncScope.js
+++ b/test/parallel/test-emit-after-uncaught-exception-runInAsyncScope.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+const id_obj = {};
+let collect = true;
+
+const hook = async_hooks.createHook({
+  before(id) { if (collect) id_obj[id] = true; },
+  after(id) { delete id_obj[id]; },
+}).enable();
+
+process.once('uncaughtException', common.mustCall((er) => {
+  assert.strictEqual(er.message, 'bye');
+  collect = false;
+}));
+
+setImmediate(common.mustCall(() => {
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(Object.keys(id_obj).length, 0);
+    hook.disable();
+  }));
+
+  // Create a stack of async ids that will need to be emitted in the case of
+  // an uncaught exception.
+  const ar1 = new async_hooks.AsyncResource('Mine');
+  ar1.runInAsyncScope(() => {
+    const ar2 = new async_hooks.AsyncResource('Mine');
+    ar2.runInAsyncScope(() => {
+      throw new Error('bye');
+    });
+  });
+
+  // TODO(trevnorris): This test shows that the after() hooks are always called
+  // correctly, but it doesn't solve where the emitDestroy() is missed because
+  // of the uncaught exception. Simple solution is to always call emitDestroy()
+  // before the emitAfter(), but how to codify this?
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
8.x backport of #18513, #18694. @nodejs/lts this probably requires extra scrutiny as it backports a semver-minor deprecation – because async_hooks is experimental – to an LTS release. 

I don't have too strong feelings that the deprecation *must* be backported to 8.x, but the rest of the commit (addition of the `runInAsyncScope` API) would be good to backport so that users have a consistent async_hooks API available across node versions. I'd be open to dropping the deprecation, if people feel strongly.

There are very few, but non-zero, users of the async hooks embedder API at this point.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/13814/