### PR TITLE
path: fix regression in posix.normalize

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -368,11 +368,12 @@ const win32 = {
     }
 
     var tail;
-    if (rootEnd < len)
+    if (rootEnd < len) {
       tail = normalizeString(path.slice(rootEnd), !isAbsolute, '\\',
                              isPathSeparator);
-    else
+    } else {
       tail = '';
+    }
     if (tail.length === 0 && !isAbsolute)
       tail = '.';
     if (tail.length > 0 && isPathSeparator(path.charCodeAt(len - 1)))

--- a/lib/path.js
+++ b/lib/path.js
@@ -44,13 +44,17 @@ function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
 }
 
+function isPosixPathSeparator(code) {
+  return code === CHAR_FORWARD_SLASH;
+}
+
 function isWindowsDeviceRoot(code) {
   return code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z ||
          code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z;
 }
 
 // Resolves . and .. elements in a path with directory names
-function normalizeString(path, allowAboveRoot, separator) {
+function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
   var res = '';
   var lastSegmentLength = 0;
   var lastSlash = -1;
@@ -272,7 +276,8 @@ const win32 = {
     // fails)
 
     // Normalize the tail path
-    resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\');
+    resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\',
+                                   isPathSeparator);
 
     return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
            '.';
@@ -364,7 +369,8 @@ const win32 = {
 
     var tail;
     if (rootEnd < len)
-      tail = normalizeString(path.slice(rootEnd), !isAbsolute, '\\');
+      tail = normalizeString(path.slice(rootEnd), !isAbsolute, '\\',
+                             isPathSeparator);
     else
       tail = '';
     if (tail.length === 0 && !isAbsolute)
@@ -1095,7 +1101,8 @@ const posix = {
     // handle relative paths to be safe (might happen when process.cwd() fails)
 
     // Normalize the path
-    resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/');
+    resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/',
+                                   isPosixPathSeparator);
 
     if (resolvedAbsolute) {
       if (resolvedPath.length > 0)
@@ -1121,7 +1128,7 @@ const posix = {
       path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
 
     // Normalize the path
-    path = normalizeString(path, !isAbsolute, '/');
+    path = normalizeString(path, !isAbsolute, '/', isPosixPathSeparator);
 
     if (path.length === 0 && !isAbsolute)
       path = '.';

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -39,6 +39,7 @@ assert.strictEqual(
   path.win32.normalize('../.../../foobar/../../../bar/../../baz'),
   '..\\..\\..\\..\\baz'
 );
+assert.strictEqual(path.win32.normalize('foo/bar\\baz'), 'foo\\bar\\baz');
 
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
                    'fixtures/b/c.js');
@@ -68,3 +69,4 @@ assert.strictEqual(
   path.posix.normalize('../.../../foobar/../../../bar/../../baz'),
   '../../../../baz'
 );
+assert.strictEqual(path.posix.normalize('foo/bar\\baz'), 'foo/bar\\baz');


### PR DESCRIPTION
Fixes a regression introduced in
https://github.com/nodejs/node/commit/4ae320f2b3c745402955019d6a57a22ee2b8d3bd
The posix version of normalize should not treat backslash as a path
separator.

Fixes: https://github.com/nodejs/node/issues/19519

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
