### PR TITLE
tools: make some changes to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 [vcbuild.bat]
 end_of_line = crlf
 
-[{lib,test}/**.js]
+[{lib,test,tools}/**.js]
 indent_style = space
 indent_size = 2
 
@@ -29,7 +29,7 @@ indent_size = 2
 indent_style = tab
 indent_size = 8
 
-[{deps,tools}/**]
+[{deps}/**]
 indent_style = ignore
 indent_size = ignore
 end_of_line = ignore

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 [vcbuild.bat]
 end_of_line = crlf
 
-[{lib,src,test}/**.js]
+[{lib,test}/**.js]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
1. The `src` directory does not contain any JavaScript source files, so there is no need to include the directory in the rule definition.
2. The `tools` directory contains JavaScript files which should be matched, most importantly `tools/eslint-rules` and `tools/doc`.

One side-effect of the second change is that the following rules now apply to some other files in the `tools` directory which were previously ignored:

```
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true
```

Will this cause problems for anyone?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
