### PR TITLE
test: removed unhelpful message from assert.strictEqual() calls

### DIFF
--- a/test/parallel/test-http-agent-error-on-idle.js
+++ b/test/parallel/test-http-agent-error-on-idle.js
@@ -27,8 +27,8 @@ server.listen(0, () => {
     res.on('end', common.mustCall(() => {
       process.nextTick(common.mustCall(() => {
         const freeSockets = agent.freeSockets[socketKey];
-        assert.strictEqual(freeSockets.length, 1,
-                           `expect a free socket on ${socketKey}`);
+        //expect a free socket on socketKey
+        assert.strictEqual(freeSockets.length, 1);
 
         //generate a random error on the free socket
         const freeSocket = freeSockets[0];
@@ -40,8 +40,8 @@ server.listen(0, () => {
   }));
 
   function done() {
-    assert.strictEqual(Object.keys(agent.freeSockets).length, 0,
-                       'expect the freeSockets pool to be empty');
+    //expect the freeSockets pool to be empty
+    assert.strictEqual(Object.keys(agent.freeSockets).length, 0);
 
     agent.destroy();
     server.close();


### PR DESCRIPTION
Converted the 'message' argument values from the last two free socket
assert.strictEqual() calls to code comments as they fail to provide the
necessary details and values specific to why the test is failing. The
default message returned from the strictEqual() call should provide
sufficient details for debugging errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
