### PR TITLE
test: remove optional third param from assert.strictEqual

### DIFF
--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -32,8 +32,8 @@ fs.mkdir(d, 0o666, common.mustCall(function(err) {
     assert.strictEqual(this, undefined);
     assert.ok(err, 'got no error');
     assert.ok(/^EEXIST/.test(err.message), 'got no EEXIST message');
-    assert.strictEqual(err.code, 'EEXIST', 'got no EEXIST code');
-    assert.strictEqual(err.path, d, 'got no proper path for EEXIST');
+    assert.strictEqual(err.code, 'EEXIST');
+    assert.strictEqual(err.path, d);
 
     fs.rmdir(d, assert.ifError);
   }));


### PR DESCRIPTION
Removing third argument in calls to assert.strictEqual() so that the
values of the first two arguments are shown instead as this is more
useful for debugging

Refs: https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
