### PR TITLE
tools: simplify tools/doc/preprocess.js

### DIFF
--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -10,7 +10,8 @@ const commentExpr = /^@\/\/.*$/gmi;
 
 function processIncludes(inputFile, input, cb) {
   const includes = input.match(includeExpr);
-  if (includes === null) return cb(null, input.replace(commentExpr, ''));
+  if (includes === null)
+    return cb(null, input.replace(commentExpr, ''));
 
   let errState = null;
   let incCount = includes.length;
@@ -30,7 +31,8 @@ function processIncludes(inputFile, input, cb) {
             `${inc}\n<!-- [end-include:${fname}] -->\n`;
       input = input.split(`${include}\n`).join(`${inc}\n`);
 
-      if (incCount === 0) return cb(null, input.replace(commentExpr, ''));
+      if (incCount === 0)
+        return cb(null, input.replace(commentExpr, ''));
     });
   });
 }

--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -1,58 +1,36 @@
 'use strict';
 
-module.exports = preprocess;
+module.exports = processIncludes;
 
 const path = require('path');
 const fs = require('fs');
 
-const includeExpr = /^@include\s+[\w-]+\.?[a-zA-Z]*$/gmi;
-const includeData = {};
-
-function preprocess(inputFile, input, cb) {
-  input = stripComments(input);
-  processIncludes(inputFile, input, cb);
-}
-
-function stripComments(input) {
-  return input.replace(/^@\/\/.*$/gmi, '');
-}
+const includeExpr = /^@include\s+([\w-]+)(?:\.md)?$/gmi;
+const commentExpr = /^@\/\/.*$/gmi;
 
 function processIncludes(inputFile, input, cb) {
   const includes = input.match(includeExpr);
-  if (includes === null) return cb(null, input);
+  if (includes === null) return cb(null, input.replace(commentExpr, ''));
+
   let errState = null;
   let incCount = includes.length;
 
   includes.forEach((include) => {
-    let fname = include.replace(/^@include\s+/, '');
-    if (!/\.md$/.test(fname)) fname = `${fname}.md`;
-
-    if (includeData.hasOwnProperty(fname)) {
-      input = input.split(include).join(includeData[fname]);
-      incCount--;
-      if (incCount === 0) {
-        return cb(null, input);
-      }
-    }
-
+    const fname = include.replace(includeExpr, '$1.md');
     const fullFname = path.resolve(path.dirname(inputFile), fname);
+
     fs.readFile(fullFname, 'utf8', function(er, inc) {
       if (errState) return;
       if (er) return cb(errState = er);
-      preprocess(inputFile, inc, function(er, inc) {
-        if (errState) return;
-        if (er) return cb(errState = er);
-        incCount--;
+      incCount--;
 
-        // Add comments to let the HTML generator know how the anchors for
-        // headings should look like.
-        includeData[fname] = `<!-- [start-include:${fname}] -->\n` +
-                             `${inc}\n<!-- [end-include:${fname}] -->\n`;
-        input = input.split(`${include}\n`).join(`${includeData[fname]}\n`);
-        if (incCount === 0) {
-          return cb(null, input);
-        }
-      });
+      // Add comments to let the HTML generator know
+      // how the anchors for headings should look like.
+      inc = `<!-- [start-include:${fname}] -->\n` +
+            `${inc}\n<!-- [end-include:${fname}] -->\n`;
+      input = input.split(`${include}\n`).join(`${inc}\n`);
+
+      if (incCount === 0) return cb(null, input.replace(commentExpr, ''));
     });
   });
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This PR seems to be a big refactoring, but it is rather simple and trims the script down almost by half, streamlining the logic significantly.

#### Investigated status quo in `preprocess.js`

`tools/doc/preprocess.js` seems to either contain artifacts from some very old doc system state or to be designed for a much more complicated doc system than the current one, just in case.

1. `preprocess.js` has two aims: strip `@//` comments in doc sources + replace `@include` directives with outer file content.
1. `preprocess.js` is designed to support repeated `@include` directives so it uses caching.
1. `preprocess.js` is designed to support nested `@include` directives so it calls its main exported function recursively.
1. `preprocess.js` is designed to support docs with various file extensions (`.md`, `.markdown`, etc).

#### Investigated status quo in doc building system and doc sources

1. Only included `doc/api/_toc.md` has [`@//` comments ](https://github.com/nodejs/node/blame/13861da9c01a652191220a7648b7dd814d61d613/doc/api/_toc.md#L1-L2).
1. Only [`doc/api/index.md`](https://raw.githubusercontent.com/nodejs/node/master/doc/api/index.md) and [`doc/api/all.md`](https://raw.githubusercontent.com/nodejs/node/master/doc/api/all.md) have `@include` directives. None of these cases has repeated or nested directives, so neither caching nor recursive processing is needed here.
1. Our docs have only `.md` extension.
1. Except for the main use in [`tools/doc/generate.js`](https://github.com/nodejs/node/blob/cef909797af1d716b802f04264e51cf7f26c1b51/tools/doc/generate.js#L60), ``preprocess.js`` is also used in [`tools/doc/html.js`](https://github.com/nodejs/node/blob/cef909797af1d716b802f04264e51cf7f26c1b51/tools/doc/html.js#L106) and [`test/doctool/test-doctool-html.js`](https://github.com/nodejs/node/blob/cef909797af1d716b802f04264e51cf7f26c1b51/test/doctool/test-doctool-html.js#L103). Neither of these cases means repeated or nested directives as well.
1. The only cause for recursive calls is comment stripping in main and included docs. This is a very simple operation needed only for one included doc, so it can be inlined (for both main and included docs to be on the safe side for future comment additions).

#### Simplification strategy

1. Remove caching.
1. Remove recursion.
1. Remove auxiliary functions and export the single remaining function.
1. Inline comment stripping.
1. Expect only `.md` file extension.

I've built the docs on Windows (using https://github.com/nodejs/node/issues/19330) before and after these changes and both doc sets are identical + `doctool` tests are OK.