### PR TITLE
doc: clarify child_process.exec promise rejection on non-zero exit

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -223,8 +223,9 @@ the existing process and uses a shell to execute the command.
 
 If this method is invoked as its [`util.promisify()`][]ed version, it returns
 a Promise for an object with `stdout` and `stderr` properties. In case of an
-error, a rejected promise is returned, with the same `error` object given in the
-callback, but with an additional two properties `stdout` and `stderr`.
+error (including any error resulting in an exit code other than 0), a rejected
+promise is returned, with the same `error` object given in the callback, but
+with an additional two properties `stdout` and `stderr`.
 
 ```js
 const util = require('util');

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -302,7 +302,8 @@ encoding, `Buffer` objects will be passed to the callback instead.
 
 If this method is invoked as its [`util.promisify()`][]ed version, it returns
 a Promise for an object with `stdout` and `stderr` properties. In case of an
-error, a rejected promise is returned, with the same `error` object given in the
+error (including any error resulting in an exit code other than 0), a rejected
+promise is returned, with the same `error` object given in the
 callback, but with an additional two properties `stdout` and `stderr`.
 
 ```js


### PR DESCRIPTION
Promisify section of child_process.exec doc changed to make clear
that non-zero exit codes will result in promise rejection.

fixes: https://github.com/nodejs/node/issues/19494

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
