### PR TITLE
doc: correct introduced_in metadata for buffer doc

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,6 +1,6 @@
 # Buffer
 
-<!--introduced_in=v0.10.0-->
+<!--introduced_in=v0.1.90-->
 <!--lint disable maximum-line-length-->
 
 > Stability: 2 - Stable


### PR DESCRIPTION
The buffer module was introduced in v0.1.90. Updated `introduced_in`
value in `buffer.md` to reflect this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
