### PR TITLE
src: name all builtin init functions Initialize

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -296,8 +296,8 @@ void Url(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(OneByteString(env->isolate(), url.c_str()));
 }
 
-void InitInspectorBindings(Local<Object> target, Local<Value> unused,
-                           Local<Context> context, void* priv) {
+void Initialize(Local<Object> target, Local<Value> unused,
+                Local<Context> context, void* priv) {
   Environment* env = Environment::GetCurrent(context);
   {
     auto obj = Object::New(env->isolate());
@@ -341,4 +341,4 @@ void InitInspectorBindings(Local<Object> target, Local<Value> unused,
 }  // namespace node
 
 NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector,
-                                  node::inspector::InitInspectorBindings);
+                                  node::inspector::Initialize);

--- a/src/node.cc
+++ b/src/node.cc
@@ -4664,7 +4664,7 @@ void RegisterBuiltinModules() {
 }  // namespace node
 
 #if !HAVE_INSPECTOR
-void InitEmptyBindings() {}
+void Initialize() {}
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector, InitEmptyBindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector, Initialize)
 #endif  // !HAVE_INSPECTOR

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -36,7 +36,7 @@ using v8::Value;
                            value, ReadOnly).FromJust();                       \
   } while (0)
 
-static void InitConfig(Local<Object> target,
+static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
@@ -138,4 +138,4 @@ static void InitConfig(Local<Object> target,
 
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(config, node::InitConfig)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(config, node::Initialize)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1143,9 +1143,9 @@ class ContextifyScript : public BaseObject {
 };
 
 
-void InitContextify(Local<Object> target,
-                    Local<Value> unused,
-                    Local<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);
@@ -1154,4 +1154,4 @@ void InitContextify(Local<Object> target,
 }  // namespace contextify
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(contextify, node::contextify::InitContextify)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(contextify, node::contextify::Initialize)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5719,7 +5719,7 @@ void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
 }
 #endif /* NODE_FIPS_MODE */
 
-void InitCrypto(Local<Object> target,
+void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
                 void* priv) {
@@ -5791,4 +5791,4 @@ void InitCrypto(Local<Object> target,
 }  // namespace crypto
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(crypto, node::crypto::InitCrypto)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(crypto, node::crypto::Initialize)

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1856,10 +1856,10 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void InitFs(Local<Object> target,
-            Local<Value> unused,
-            Local<Context> context,
-            void* priv) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "access", Access);
@@ -1975,4 +1975,4 @@ void InitFs(Local<Object> target,
 
 }  // end namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(fs, node::fs::InitFs)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(fs, node::fs::Initialize)

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -728,10 +728,10 @@ const struct http_parser_settings Parser::settings = {
 };
 
 
-void InitHttpParser(Local<Object> target,
-                    Local<Value> unused,
-                    Local<Context> context,
-                    void* priv) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -778,4 +778,4 @@ void InitHttpParser(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(http_parser, node::InitHttpParser)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(http_parser, node::Initialize)

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -852,10 +852,10 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(width);
 }
 
-void Init(Local<Object> target,
-          Local<Value> unused,
-          Local<Context> context,
-          void* priv) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "toUnicode", ToUnicode);
   env->SetMethod(target, "toASCII", ToASCII);
@@ -875,6 +875,6 @@ void Init(Local<Object> target,
 }  // namespace i18n
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(icu, node::i18n::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(icu, node::i18n::Initialize)
 
 #endif  // NODE_HAVE_I18N_SUPPORT

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -372,9 +372,9 @@ void Timerify(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Init(Local<Object> target,
-          Local<Value> unused,
-          Local<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   performance_state* state = env->performance_state();
@@ -443,4 +443,4 @@ void Init(Local<Object> target,
 }  // namespace performance
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(performance, node::performance::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(performance, node::performance::Initialize)

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -424,9 +424,9 @@ void DeserializerContext::ReadRawBytes(
   args.GetReturnValue().Set(offset);
 }
 
-void InitializeSerdesBindings(Local<Object> target,
-                              Local<Value> unused,
-                              Local<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> ser =
       env->NewFunctionTemplate(SerializerContext::New);
@@ -483,4 +483,4 @@ void InitializeSerdesBindings(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(serdes, node::InitializeSerdesBindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(serdes, node::Initialize)

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -132,10 +132,10 @@ static void CategoryGroupEnabled(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(*category_group_enabled > 0);
 }
 
-void InitializeTraceEvents(Local<Object> target,
-                           Local<Value> unused,
-                           Local<Context> context,
-                           void* priv) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "emit", Emit);
@@ -144,4 +144,4 @@ void InitializeTraceEvents(Local<Object> target,
 
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(trace_events, node::InitializeTraceEvents)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(trace_events, node::Initialize)

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2290,10 +2290,10 @@ static void SetURLConstructor(const FunctionCallbackInfo<Value>& args) {
   env->set_url_constructor_function(args[0].As<Function>());
 }
 
-static void Init(Local<Object> target,
-                 Local<Value> unused,
-                 Local<Context> context,
-                 void* priv) {
+static void Initialize(Local<Object> target,
+                       Local<Value> unused,
+                       Local<Context> context,
+                       void* priv) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "parse", Parse);
   env->SetMethod(target, "encodeAuth", EncodeAuthSet);
@@ -2313,4 +2313,4 @@ static void Init(Local<Object> target,
 }  // namespace url
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(url, node::url::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(url, node::url::Initialize)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -119,9 +119,9 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void InitializeV8Bindings(Local<Object> target,
-                          Local<Value> unused,
-                          Local<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "cachedDataVersionTag", CachedDataVersionTag);
@@ -201,4 +201,4 @@ void InitializeV8Bindings(Local<Object> target,
 
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(v8, node::InitializeV8Bindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(v8, node::Initialize)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -681,10 +681,10 @@ class ZCtx : public AsyncWrap {
 };
 
 
-void InitZlib(Local<Object> target,
-              Local<Value> unused,
-              Local<Context> context,
-              void* priv) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> z = env->NewFunctionTemplate(ZCtx::New);
 
@@ -709,4 +709,4 @@ void InitZlib(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(zlib, node::InitZlib)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(zlib, node::Initialize)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -50,9 +50,9 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void InitializeUV(Local<Object> target,
-                  Local<Value> unused,
-                  Local<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   target->Set(FIXED_ONE_BYTE_STRING(isolate, "errname"),
@@ -82,4 +82,4 @@ void InitializeUV(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(uv, node::InitializeUV)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(uv, node::Initialize)


### PR DESCRIPTION
This commit renames a few of the builtin modules init functions to
Initialize for consistency.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
