### PR TITLE
doc: remove confusing note about child process stdio

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -33,10 +33,6 @@ stdout in excess of that limit without the output being captured, the child
 process will block waiting for the pipe buffer to accept more data. This is
 identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }`
 option if the output will not be consumed.
-It is possible to stream data through these pipes in a non-blocking way. Note,
-however, that some programs use line-buffered I/O internally. While that does
-not affect Node.js, it can mean that data sent to the child process may not be
-immediately consumed.
 
 The [`child_process.spawn()`][] method spawns the child process asynchronously,
 without blocking the Node.js event loop. The [`child_process.spawnSync()`][]


### PR DESCRIPTION
It’s not obvious what the paragraph is supposed to say.
In particular, whether and what kind of buffering mechanism a process uses for its stdio streams does not affect that, in general, no guarantees can be made about when it consumes data that was sent to it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
