### PR TITLE
test: fix incorrect assumptions on the user uid and gid

### DIFF
--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -5,13 +5,15 @@ const spawnSync = require('child_process').spawnSync;
 const signals = process.binding('constants').os.signals;
 
 let invalidArgTypeError;
+let invalidArgTypeErrorCount = 62;
 
 if (common.isWindows) {
   invalidArgTypeError =
     common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 42);
 } else {
   invalidArgTypeError =
-    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 62);
+    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError },
+                        invalidArgTypeErrorCount);
 }
 
 const invalidRangeError =
@@ -76,6 +78,9 @@ if (!common.isWindows) {
       fail('uid', Infinity, invalidArgTypeError);
       fail('uid', 3.1, invalidArgTypeError);
       fail('uid', -3.1, invalidArgTypeError);
+    } else {
+      //Decrement invalidArgTypeErrorCount if validation isn't possible
+      invalidArgTypeErrorCount -= 10;
     }
   }
 
@@ -95,6 +100,9 @@ if (!common.isWindows) {
       fail('gid', Infinity, invalidArgTypeError);
       fail('gid', 3.1, invalidArgTypeError);
       fail('gid', -3.1, invalidArgTypeError);
+    } else {
+      //Decrement invalidArgTypeErrorCount if validation isn't possible
+      invalidArgTypeErrorCount -= 10;
     }
   }
 }


### PR DESCRIPTION
Add a invalidArgTypeErrorCount variable to adjust the number of expected
errors if the uid and gid options cannot be properly validated.

Fixes: https://github.com/nodejs/node/issues/19371

Has been tested as working on Ubuntu 14.04 LTS. Requires testing still in Windows with container/non-container environment still. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
