### PR TITLE
doc: add missing metadata for version properties

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1474,6 +1474,11 @@ console.log(`The parent process is pid ${process.ppid}`);
 <!-- YAML
 added: v3.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/19438
+    description: The `majorVersion`, `minorVersion`, `patchVersion`,
+                 `prereleaseTag`, `computedVersion` and `compareVersion`
+                 properties are now supported.
   - version: v4.2.0
     pr-url: https://github.com/nodejs/node/pull/3212
     description: The `lts` property is now supported.


### PR DESCRIPTION
https://github.com/nodejs/node/pull/19438 did not update the metadata within the documentation.

Side note: I am not sure whether the `computedVersion` property was exposed intentionally, and would gladly update the PR if we decide not to do so.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
