### PR TITLE
doc: add types for some `process` properties

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -489,6 +489,8 @@ $ bash -c 'exec -a customArgv0 ./node'
 added: v7.1.0
 -->
 
+* {Object}
+
 If the Node.js process was spawned with an IPC channel (see the
 [Child Process][] documentation), the `process.channel`
 property is a reference to the IPC channel. If no IPC channel exists, this
@@ -921,7 +923,7 @@ console.log(process.env.test);
 added: v0.7.7
 -->
 
-* {Object}
+* {Array}
 
 The `process.execArgv` property returns the set of Node.js-specific command-line
 options passed when the Node.js process was launched. These options do not
@@ -1250,6 +1252,8 @@ debugger, see [Signal Events][].
 added: v0.1.17
 -->
 
+* {Object}
+
 The `process.mainModule` property provides an alternative way of retrieving
 [`require.main`][]. The difference is that if the main module changes at
 runtime, [`require.main`][] may still refer to the original main module in
@@ -1478,6 +1482,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/3212
     description: The `lts` property is now supported.
 -->
+
+* {Object}
 
 The `process.release` property returns an Object containing metadata related to
 the current release, including URLs for the source tarball and headers-only


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Sync types:
* `process.channel` with [`subprocess.channel`](https://github.com/nodejs/node/blob/master/doc/api/child_process.md#subprocesschannel);
* `process.execArgv` with [`process.argv`](https://github.com/nodejs/node/blob/master/doc/api/process.md#processargv);
* `process.mainModule` with [`module`](https://github.com/nodejs/node/blob/master/doc/api/modules.md#module);
* `process.release` with [`process.versions`](https://github.com/nodejs/node/blob/master/doc/api/process.md#processversions).
