### PR TITLE
doc: add `require.main` to `require` properties

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -600,6 +600,43 @@ filename scales linearly with the number of registered extensions.
 In other words, adding extensions slows down the module loader and
 should be discouraged.
 
+#### require.main
+<!-- YAML
+added: v0.1.17
+-->
+
+* {Object}
+
+The `Module` object representing the entry script loaded when the Node.js
+process launched.
+See ["Accessing the main module"](#modules_accessing_the_main_module).
+
+In `entry.js` script:
+
+```js
+console.log(require.main);
+```
+
+```sh
+node entry.js
+```
+
+<!-- eslint-skip -->
+```js
+Module {
+  id: '.',
+  exports: {},
+  parent: null,
+  filename: '/absolute/path/to/entry.js',
+  loaded: false,
+  children: [],
+  paths:
+   [ '/absolute/path/to/node_modules',
+     '/absolute/path/node_modules',
+     '/absolute/node_modules',
+     '/node_modules' ] }
+```
+
 #### require.resolve(request[, options])
 <!-- YAML
 added: v0.3.0


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

`require.main` was documented [in a non-standard way](https://nodejs.org/api/modules.html#modules_accessing_the_main_module).

With this PR, the previous section is left as is to not break all the possible link references inside and outside Node.js docs.

A standard section is added to the `require` properties with a reference to the remaining description.

~~I cannot define when this property was added. I can only dig up to [this mention of a fix in the 0.3.8](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_ARCHIVE.md#20110204-version-038-unstable). Can anybody help with `added:` attribution?~~ (see https://github.com/nodejs/node/pull/19573#discussion_r176909075)