### PR TITLE
process: remove compareVersion and computedVersion (alternative to #19577)

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1507,17 +1507,6 @@ tarball.
 * `minorVersion` {number} The minor version of Node.js.
 * `patchVersion` {number} The patch version of Node.js.
 * `prereleaseTag` {string} The SemVer pre-release tag for Node.js.
-* `computedVersion` {number} A number representing the current version, created
-  using the following method:
-  `(majorVersion << 16) + (minorVersion << 8) + patchVersion`
-* `compareVersion` {function} Perform a SemVer comparison to the release
-  version.
-    * `major`
-    * `minor`
-    * `patch`
-    * Returns: {number} `-1` if the given version is lower than the release
-      version, `0` if the given version matches the process version, and `1`
-      if the given version is greater than the release version.
 
 <!-- eslint-skip -->
 ```js
@@ -1530,8 +1519,7 @@ tarball.
   majorVersion: 4,
   minorVersion: 4,
   patchVersion: 5,
-  prereleaseTag: '',
-  computedVersion: 263173,
+  prereleaseTag: ''
 }
 ```
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -38,7 +38,6 @@
     _process.setupConfig(NativeModule._source);
     _process.setupSignalHandlers();
     _process.setupUncaughtExceptionCapture(exceptionHandlerState);
-    _process.setupCompareVersion();
     NativeModule.require('internal/process/warning').setup();
     NativeModule.require('internal/process/next_tick').setup();
     NativeModule.require('internal/process/stdio').setup();

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -269,16 +269,6 @@ function setupUncaughtExceptionCapture(exceptionHandlerState) {
   };
 }
 
-function setupCompareVersion() {
-  const { computedVersion } = process.release;
-  process.release.compareVersion = (major, minor, patch) => {
-    const comp = (major << 16) + (minor << 8) + patch;
-    if (comp === computedVersion)
-      return 0;
-    return comp > computedVersion ? 1 : -1;
-  };
-}
-
 module.exports = {
   setup_performance,
   setup_cpuUsage,
@@ -289,6 +279,5 @@ module.exports = {
   setupSignalHandlers,
   setupChannel,
   setupRawDebug,
-  setupUncaughtExceptionCapture,
-  setupCompareVersion,
+  setupUncaughtExceptionCapture
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -3032,13 +3032,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(release, "prereleaseTag",
       OneByteString(env->isolate(), NODE_TAG));
 
-  READONLY_PROPERTY(release,
-                    "computedVersion",
-                    Integer::New(env->isolate(),
-                        (NODE_MAJOR_VERSION << 16) +
-                        (NODE_MINOR_VERSION << 8) +
-                        NODE_PATCH_VERSION));
-
 #if NODE_VERSION_IS_LTS
   READONLY_PROPERTY(release, "lts",
                     OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -18,3 +18,13 @@ if (versionParts[0] === '4' && versionParts[1] >= 2) {
 } else {
   assert.strictEqual(process.release.lts, undefined);
 }
+
+const {
+  majorVersion: major,
+  minorVersion: minor,
+  patchVersion: patch,
+  prereleaseTag: prerelease
+} = process.release;
+
+assert.strictEqual(process.versions.node,
+                   `${major}.${minor}.${patch}${prerelease}`);

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -18,18 +18,3 @@ if (versionParts[0] === '4' && versionParts[1] >= 2) {
 } else {
   assert.strictEqual(process.release.lts, undefined);
 }
-
-const {
-  majorVersion: major,
-  minorVersion: minor,
-  patchVersion: patch,
-  computedVersion,
-  compareVersion,
-} = process.release;
-
-assert.strictEqual(
-  (major << 16) + (minor << 8) + patch, computedVersion);
-
-assert.strictEqual(0, compareVersion(major, minor, patch));
-assert.strictEqual(1, compareVersion(major, minor, patch + 1));
-assert.strictEqual(-1, compareVersion(major - 1, minor, patch));


### PR DESCRIPTION
I apologize for voicing my opinion after https://github.com/nodejs/node/pull/19438 has already landed, I simply didn't see the PR before. Whether there is agreement that there should be a built-in way to compare the node version against a known version or not, both `compareVersion` and `computedVersion` are flawed in my opinion. The PR received very little attention and I would like to propose removing two of the added properties until a well-designed solution is found, mostly to avoid having to maintain them because they make their way into a release.

There are some problems with the added `compareVersion` function:

1. The signum of the result of `compareVersion` seems counter-intuitive to me. In most (if not all) frameworks, a comparator returns a negative result if the first argument (or `this`) is considered to be "before" the second argument, and a positive result if the first argument (or `this`) is considered to be "after" the second argument (see e.g. [java.lang.Comparable](https://docs.oracle.com/javase/7/docs/api/java/lang/Comparable.html#compareTo(T)) for a single-argument comparison). `compareVersion` contradicts this well-established norm. I would expect `compareVersion(10, 0, 0) >= 0` to return whether this release is v10 or newer, which follows the norm and is intuitive, but https://github.com/nodejs/node/pull/19438 implements the opposite.

2. The documentation claims that this is a semver comparison, but the semver specification has [specific rules](https://semver.org/#spec-item-11) for semver precedence, and this PR does not implement that behavior correctly, especially for prerelease tags. The documentation should either clearly state that this function does not conform to the semver specification or be adapted to do so.

3. Most users will likely expect an API that accepts a string instead of three distinct integer values.

On the other hand, `computedVersion` is something I don't like seeing exposed to users, and it seems like `compareVersion` was supposed to be a user-friendly alternative based on the discussion in https://github.com/nodejs/node/pull/19438. People will need to construct the required constants for comparison with `computedVersion`, and `process.release.computedVersion >= ((9 << 8) | 5) << 8 | 1` is not really pretty (and no, using the constant `591104` directly or storing the value in a named constant does not improve that all that much), so people will likely still use a proper semver implementation or manually compare `process.release.xxxVersion`. (`process.release.computedVersion` also ignores the prerelease tag.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

FYI @jasnell @BridgeAR @devsnek @Trott