### PR TITLE
Revert "process: add more version properties to release" (alternative to #19574)

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1509,21 +1509,6 @@ tarball.
   - `'Argon'` for the 4.x LTS line beginning with 4.2.0.
   - `'Boron'` for the 6.x LTS line beginning with 6.9.0.
   - `'Carbon'` for the 8.x LTS line beginning with 8.9.1.
-* `majorVersion` {number} The major version of Node.js.
-* `minorVersion` {number} The minor version of Node.js.
-* `patchVersion` {number} The patch version of Node.js.
-* `prereleaseTag` {string} The SemVer pre-release tag for Node.js.
-* `computedVersion` {number} A number representing the current version, created
-  using the following method:
-  `(majorVersion << 16) + (minorVersion << 8) + patchVersion`
-* `compareVersion` {function} Perform a SemVer comparison to the release
-  version.
-    * `major`
-    * `minor`
-    * `patch`
-    * Returns: {number} `-1` if the given version is lower than the release
-      version, `0` if the given version matches the process version, and `1`
-      if the given version is greater than the release version.
 
 <!-- eslint-skip -->
 ```js
@@ -1532,12 +1517,7 @@ tarball.
   lts: 'Argon',
   sourceUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5.tar.gz',
   headersUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5-headers.tar.gz',
-  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib',
-  majorVersion: 4,
-  minorVersion: 4,
-  patchVersion: 5,
-  prereleaseTag: '',
-  computedVersion: 263173,
+  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib'
 }
 ```
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -38,7 +38,6 @@
     _process.setupConfig(NativeModule._source);
     _process.setupSignalHandlers();
     _process.setupUncaughtExceptionCapture(exceptionHandlerState);
-    _process.setupCompareVersion();
     NativeModule.require('internal/process/warning').setup();
     NativeModule.require('internal/process/next_tick').setup();
     NativeModule.require('internal/process/stdio').setup();

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -269,16 +269,6 @@ function setupUncaughtExceptionCapture(exceptionHandlerState) {
   };
 }
 
-function setupCompareVersion() {
-  const { computedVersion } = process.release;
-  process.release.compareVersion = (major, minor, patch) => {
-    const comp = (major << 16) + (minor << 8) + patch;
-    if (comp === computedVersion)
-      return 0;
-    return comp > computedVersion ? 1 : -1;
-  };
-}
-
 module.exports = {
   setup_performance,
   setup_cpuUsage,
@@ -289,6 +279,5 @@ module.exports = {
   setupSignalHandlers,
   setupChannel,
   setupRawDebug,
-  setupUncaughtExceptionCapture,
-  setupCompareVersion,
+  setupUncaughtExceptionCapture
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -3022,23 +3022,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(release, "name",
                     OneByteString(env->isolate(), NODE_RELEASE));
 
-  READONLY_PROPERTY(release, "majorVersion",
-      Integer::New(env->isolate(), NODE_MAJOR_VERSION));
-  READONLY_PROPERTY(release, "minorVersion",
-      Integer::New(env->isolate(), NODE_MINOR_VERSION));
-  READONLY_PROPERTY(release, "patchVersion",
-      Integer::New(env->isolate(), NODE_PATCH_VERSION));
-
-  READONLY_PROPERTY(release, "prereleaseTag",
-      OneByteString(env->isolate(), NODE_TAG));
-
-  READONLY_PROPERTY(release,
-                    "computedVersion",
-                    Integer::New(env->isolate(),
-                        (NODE_MAJOR_VERSION << 16) +
-                        (NODE_MINOR_VERSION << 8) +
-                        NODE_PATCH_VERSION));
-
 #if NODE_VERSION_IS_LTS
   READONLY_PROPERTY(release, "lts",
                     OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -18,18 +18,3 @@ if (versionParts[0] === '4' && versionParts[1] >= 2) {
 } else {
   assert.strictEqual(process.release.lts, undefined);
 }
-
-const {
-  majorVersion: major,
-  minorVersion: minor,
-  patchVersion: patch,
-  computedVersion,
-  compareVersion,
-} = process.release;
-
-assert.strictEqual(
-  (major << 16) + (minor << 8) + patch, computedVersion);
-
-assert.strictEqual(0, compareVersion(major, minor, patch));
-assert.strictEqual(1, compareVersion(major, minor, patch + 1));
-assert.strictEqual(-1, compareVersion(major - 1, minor, patch));


### PR DESCRIPTION
This reverts commit 982e3bdb1f06bf9d9926c808d30864b32a8223f9. Alternative to https://github.com/nodejs/node/pull/19574 which only partially reverts said commit.

Refs: https://github.com/nodejs/node/pull/19438