### PR TITLE
test: amplify and optimize doctool/test-make-doc

### DIFF
--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -12,8 +12,13 @@ const fs = require('fs');
 const path = require('path');
 
 const apiPath = path.resolve(__dirname, '..', '..', 'out', 'doc', 'api');
-const docs = fs.readdirSync(apiPath);
-assert.ok(docs.includes('_toc.html'));
+const allDocs = fs.readdirSync(apiPath);
+assert.ok(allDocs.includes('_toc.html'));
+
+const filter = ['assets', '_toc.html', '.md'];
+const actualDocs = allDocs.filter(
+  (name) => !filter.some((str) => name.includes(str))
+);
 
 const toc = fs.readFileSync(path.resolve(apiPath, '_toc.html'), 'utf8');
 const re = /href="([^/]+\.html)"/;
@@ -21,23 +26,28 @@ const globalRe = new RegExp(re, 'g');
 const links = toc.match(globalRe);
 assert.notStrictEqual(links, null);
 
-// Test that all the relative links in the TOC of the documentation
-// work and all the generated documents are linked in TOC.
-const linkedHtmls = links.map((link) => link.match(re)[1]);
-for (const html of linkedHtmls) {
-  assert.ok(docs.includes(html), `${html} does not exist`);
+// Filter out duplicate links, leave just filenames, add expected JSON files.
+const linkedHtmls = [...new Set(links)].map((link) => link.match(re)[1]);
+const expectedJsons = linkedHtmls
+                       .map((name) => name.replace('.html', '.json'))
+                       .concat('_toc.json');
+const expectedDocs = linkedHtmls.concat(expectedJsons);
+
+// Test that all the relative links in the TOC match to the actual documents.
+for (const expectedDoc of expectedDocs) {
+  assert.ok(actualDocs.includes(expectedDoc), `${expectedDoc} does not exist`);
 }
 
-const excludes = ['.json', '.md', '_toc', 'assets'];
-const generatedHtmls = docs.filter(function(doc) {
-  for (const exclude of excludes) {
-    if (doc.includes(exclude)) {
-      return false;
-    }
-  }
-  return true;
-});
+// Test that all the actual documents match to the relative links in the TOC.
+for (const actualDoc of actualDocs) {
+  assert.ok(
+    expectedDocs.includes(actualDoc), `${actualDoc} does not not match TOC`);
+}
 
-for (const html of generatedHtmls) {
-  assert.ok(linkedHtmls.includes(html), `${html} is not linked in toc`);
+// Test that all the actual documents are not empty files.
+for (const actualDoc of actualDocs) {
+  assert.ok(
+    fs.statSync(path.join(apiPath, actualDoc)).size !== 0,
+    `${actualDoc} is empty`
+  );
 }

--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -38,14 +38,12 @@ for (const expectedDoc of expectedDocs) {
   assert.ok(actualDocs.includes(expectedDoc), `${expectedDoc} does not exist`);
 }
 
-// Test that all the actual documents match to the relative links in the TOC.
+// Test that all the actual documents match to the relative links in the TOC
+// and that they are not empty files.
 for (const actualDoc of actualDocs) {
   assert.ok(
     expectedDocs.includes(actualDoc), `${actualDoc} does not not match TOC`);
-}
 
-// Test that all the actual documents are not empty files.
-for (const actualDoc of actualDocs) {
   assert.ok(
     fs.statSync(path.join(apiPath, actualDoc)).size !== 0,
     `${actualDoc} is empty`


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Currently, the `doctool/test-make-doc.js` has 2 tiny performance nits and 2 logic oversights.

#### Performance nits

1. The list of doc files is filtered too late, after some usage with unneeded files burden.
2. The list of links in TOC is not filtered at all, while 48 links from 98 ones are duplicate.

#### Logic oversights.

1. JSON docs generation is not tested, while it is possible that JSON generation is aborted after all the HTML files are created.
2. `Makefile` generates docs by getting the `console.log()` output [from the `tools/doc/generate.js`](https://github.com/nodejs/node/blob/eeb57022e6bada13955a19b15232a9ee4fe9b465/tools/doc/generate.js#L69-L77) and [redirecting it to the doc files](https://github.com/nodejs/node/blob/eeb57022e6bada13955a19b15232a9ee4fe9b465/Makefile#L662-L664). If `tools/doc/generate.js` [throws](https://github.com/nodejs/node/blob/eeb57022e6bada13955a19b15232a9ee4fe9b465/tools/doc/generate.js#L68-L76), an empty doc file is still created. So we can have a situation when the last `.md` source has an error and all the needed files are nevertheless present, just one of them is empty. So we need to check if all the files are not empty.

#### Refactoring strategy

1. Filter out unneeded files as soon as possible.
2. Filter out duplicate links.
3. Include JSON files in generation tests.
4. Check that all the actual files are not empty.

The test is changed considerably, but it may be more strict, full and performant in this form.