### PR TITLE
tools: fix nits in tools/doc/common.js

### DIFF
--- a/tools/doc/common.js
+++ b/tools/doc/common.js
@@ -3,10 +3,8 @@
 const yaml = require('js-yaml');
 
 function isYAMLBlock(text) {
-  return !!text.match(/^<!-- YAML/);
+  return /^<!-- YAML/.test(text);
 }
-
-exports.isYAMLBlock = isYAMLBlock;
 
 function arrify(value) {
   return Array.isArray(value) ? value : [value];
@@ -32,11 +30,8 @@ function extractAndParseYAML(text) {
   }
 
   meta.changes = meta.changes || [];
-  for (const entry of meta.changes) {
-    entry.description = entry.description.replace(/^\^\s*/, '');
-  }
 
   return meta;
 }
 
-exports.extractAndParseYAML = extractAndParseYAML;
+module.exports = { isYAMLBlock, extractAndParseYAML };


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

1. Replace `.match()` with `.test()` in a boolean context.
2. Concentrate exports.
3. Remove obsolete "safety fuse" replacer (was meant to guard against backticks at the beginning of the lines, but it is not a common practice anymore and we has no cases for this pattern match now).  This change is approved by @addaleax (the deleted block was added [here](https://github.com/nodejs/node/commit/7cbb4b0e6e821ba851dbe038dd05794f2e69047b#diff-b2e2769ef68630a0addd814c2286f882)).