### PR TITLE
lib: ensure --check flag works with --require

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -75,6 +75,10 @@ Identical to `-e` but prints the result.
 added:
   - v5.0.0
   - v4.2.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/19600
+    description: The `--require` option is now supported when checking a file.
 -->
 
 Syntax check the script without executing.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -207,6 +207,12 @@
 
         const CJSModule = NativeModule.require('internal/modules/cjs/loader');
 
+        perf.markMilestone(NODE_PERFORMANCE_MILESTONE_MODULE_LOAD_END);
+        perf.markMilestone(
+          NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_START);
+        preloadModules();
+        perf.markMilestone(
+          NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
         // check if user passed `-c` or `--check` arguments to Node.
         if (process._syntax_check_only != null) {
           const fs = NativeModule.require('fs');
@@ -216,12 +222,6 @@
           checkScriptSyntax(source, filename);
           process.exit(0);
         }
-        perf.markMilestone(NODE_PERFORMANCE_MILESTONE_MODULE_LOAD_END);
-        perf.markMilestone(
-          NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_START);
-        preloadModules();
-        perf.markMilestone(
-          NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END);
         CJSModule.runMain();
       } else {
         perf.markMilestone(NODE_PERFORMANCE_MILESTONE_MODULE_LOAD_START);

--- a/test/fixtures/no-wrapper.js
+++ b/test/fixtures/no-wrapper.js
@@ -1,0 +1,1 @@
+require('module').wrapper = ['', ''];

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -140,3 +140,26 @@ syntaxArgs.forEach(function(args) {
     }));
   });
 });
+
+// should work with -r flags
+['-c', '--check'].forEach(function(checkFlag) {
+  ['-r', '--require'].forEach(function(requireFlag) {
+    const preloadFile = fixtures.path('no-wrapper.js');
+    const file = fixtures.path('syntax', 'illegal_if_not_wrapped.js');
+    const args = [requireFlag, preloadFile, checkFlag, file];
+    const cmd = [node, ...args].join(' ');
+    exec(cmd, common.mustCall((err, stdout, stderr) => {
+      assert.strictEqual(err instanceof Error, true);
+      assert.strictEqual(err.code, 1);
+
+      // no stdout should be produced
+      assert.strictEqual(stdout, '');
+
+      // stderr should have a syntax error message
+      assert(syntaxErrorRE.test(stderr), `${syntaxErrorRE} === ${stderr}`);
+
+      // stderr should include the filename
+      assert(stderr.startsWith(file), `${stderr} starts with ${file}`);
+    }));
+  });
+});


### PR DESCRIPTION
`--eval`, `--print`, and `--check`-with-piped-input work with `--require`.
However, `--check` with a file path does not. This PR fixes #18425.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
