### PR TITLE
zlib,stream: use “official” `util.types` typechecks

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -38,16 +38,15 @@ Stream.Stream = Stream;
 
 // Internal utilities
 try {
-  Stream._isUint8Array = require('internal/util/types').isUint8Array;
-} catch (e) {
-  // Throws for code outside of Node.js core.
-
-  try {
-    Stream._isUint8Array = process.binding('util').isUint8Array;
-  } catch (e) {
+  const types = require('util').types;
+  if (types && typeof types.isUint8Array === 'function') {
+    Stream._isUint8Array = types.isUint8Array;
+  } else {
     // This throws for Node < 4.2.0 because there's no util binding and
     // returns undefined for Node < 7.4.0.
+    Stream._isUint8Array = process.binding('util').isUint8Array;
   }
+} catch (e) {
 }
 
 if (!Stream._isUint8Array) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -28,9 +28,13 @@ const {
   ERR_ZLIB_INITIALIZATION_FAILED
 } = require('internal/errors').codes;
 const Transform = require('_stream_transform');
-const { _extend } = require('util');
-const { isAnyArrayBuffer } = process.binding('util');
-const { isArrayBufferView } = require('internal/util/types');
+const {
+  _extend,
+  types: {
+    isAnyArrayBuffer,
+    isArrayBufferView
+  }
+} = require('util');
 const binding = process.binding('zlib');
 const assert = require('assert').ok;
 const {


### PR DESCRIPTION
The old variants have been deprecated since b20af8088a4d5cccb19.

Refs: https://github.com/nodejs/node/pull/18415

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
