### PR TITLE
doc: rename HTTP2 to HTTP/2

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1,4 +1,4 @@
-# HTTP2
+# HTTP/2
 
 <!--introduced_in=v8.4.0-->
 
@@ -229,7 +229,7 @@ added: v8.4.0
 
 The `'stream'` event is emitted when a new `Http2Stream` is created. When
 invoked, the handler function will receive a reference to the `Http2Stream`
-object, a [HTTP2 Headers Object][], and numeric flags associated with the
+object, a [HTTP/2 Headers Object][], and numeric flags associated with the
 creation of the stream.
 
 ```js
@@ -381,7 +381,7 @@ Transmits a `GOAWAY` frame to the connected peer *without* shutting down the
 added: v8.4.0
 -->
 
-* Value: {HTTP2 Settings Object}
+* Value: {HTTP/2 Settings Object}
 
 A prototype-less object describing the current local settings of this
 `Http2Session`. The local settings are local to *this* `Http2Session` instance.
@@ -460,7 +460,7 @@ instance's underlying [`net.Socket`].
 added: v8.4.0
 -->
 
-* Value: {HTTP2 Settings Object}
+* Value: {HTTP/2 Settings Object}
 
 A prototype-less object describing the current remote settings of this
 `Http2Session`. The remote settings are set by the *connected* HTTP/2 peer.
@@ -530,7 +530,7 @@ An object describing the current status of this `Http2Session`.
 added: v8.4.0
 -->
 
-* `settings` {HTTP2 Settings Object}
+* `settings` {HTTP/2 Settings Object}
 
 Updates the current local settings for this `Http2Session` and sends a new
 `SETTINGS` frame to the connected HTTP/2 peer.
@@ -669,7 +669,7 @@ client.on('altsvc', (alt, origin, streamId) => {
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `endStream` {boolean} `true` if the `Http2Stream` *writable* side should
     be closed initially, such as when sending a `GET` request that should not
@@ -855,7 +855,7 @@ added: v8.4.0
 
 The `'trailers'` event is emitted when a block of headers associated with
 trailing header fields is received. The listener callback is passed the
-[HTTP2 Headers Object][] and flags associated with the headers.
+[HTTP/2 Headers Object][] and flags associated with the headers.
 
 ```js
 stream.on('trailers', (headers, flags) => {
@@ -952,7 +952,7 @@ calling `http2stream.close()`, or `http2stream.destroy()`. Will be
 added: v9.5.0
 -->
 
-* Value: {HTTP2 Headers Object}
+* Value: {HTTP/2 Headers Object}
 
 An object containing the outbound headers sent for this `Http2Stream`.
 
@@ -961,7 +961,7 @@ An object containing the outbound headers sent for this `Http2Stream`.
 added: v9.5.0
 -->
 
-* Value: {HTTP2 Headers Object[]}
+* Value: {HTTP/2 Headers Object[]}
 
 An array of objects containing the outbound informational (additional) headers
 sent for this `Http2Stream`.
@@ -971,7 +971,7 @@ sent for this `Http2Stream`.
 added: v9.5.0
 -->
 
-* Value: {HTTP2 Headers Object}
+* Value: {HTTP/2 Headers Object}
 
 An object containing the outbound trailers sent for this this `HttpStream`.
 
@@ -1053,7 +1053,7 @@ added: v8.4.0
 
 The `'headers'` event is emitted when an additional block of headers is received
 for a stream, such as when a block of `1xx` informational headers is received.
-The listener callback is passed the [HTTP2 Headers Object][] and flags
+The listener callback is passed the [HTTP/2 Headers Object][] and flags
 associated with the headers.
 
 ```js
@@ -1068,7 +1068,7 @@ added: v8.4.0
 -->
 
 The `'push'` event is emitted when response headers for a Server Push stream
-are received. The listener callback is passed the [HTTP2 Headers Object][] and
+are received. The listener callback is passed the [HTTP/2 Headers Object][] and
 flags associated with the headers.
 
 ```js
@@ -1085,7 +1085,7 @@ added: v8.4.0
 The `'response'` event is emitted when a response `HEADERS` frame has been
 received for this stream from the connected HTTP/2 server. The listener is
 invoked with two arguments: an Object containing the received
-[HTTP2 Headers Object][], and flags associated with the headers.
+[HTTP/2 Headers Object][], and flags associated with the headers.
 
 ```js
 const http2 = require('http2');
@@ -1113,7 +1113,7 @@ provide additional methods such as `http2stream.pushStream()` and
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 
 Sends an additional informational `HEADERS` frame to the connected HTTP/2 peer.
 
@@ -1143,7 +1143,7 @@ accepts push streams, `false` otherwise. Settings are the same for every
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     the created stream is made the sole direct dependency of the parent, with
@@ -1155,7 +1155,7 @@ added: v8.4.0
   initiated.
   * `err` {Error}
   * `pushStream` {ServerHttp2Stream} The returned pushStream object.
-  * `headers` {HTTP2 Headers Object} Headers object the pushStream was
+  * `headers` {HTTP/2 Headers Object} Headers object the pushStream was
   initiated with.
 
 Initiates a push stream. The callback is invoked with the new `Http2Stream`
@@ -1185,7 +1185,7 @@ a `weight` value to `http2stream.priority` with the `silent` option set to
 added: v8.4.0
 -->
 
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `endStream` {boolean} Set to `true` to indicate that the response will not
     include payload data.
@@ -1234,7 +1234,7 @@ changes:
 -->
 
 * `fd` {number} A readable file descriptor.
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}
   * `getTrailers` {Function} Callback function invoked to collect trailer
@@ -1329,7 +1329,7 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `headers` {HTTP2 Headers Object}
+* `headers` {HTTP/2 Headers Object}
 * `options` {Object}
   * `statCheck` {Function}
   * `onError` {Function} Callback function invoked in the case of an
@@ -1708,7 +1708,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `Http1IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage
     class to used for HTTP/1 fallback. Useful for extending the original
@@ -1817,7 +1817,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For
     servers, the identity options (`pfx` or `key`/`cert`) are usually required.
@@ -1913,7 +1913,7 @@ changes:
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
-  * `settings` {HTTP2 Settings Object} The initial settings to send to the
+  * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
   * `createConnection` {Function} An optional callback that receives the `URL`
     instance passed to `connect` and the `options` object, and returns any
@@ -1966,7 +1966,7 @@ a given number of milliseconds set using `http2server.setTimeout()`.
 added: v8.4.0
 -->
 
-* Returns: {HTTP2 Settings Object}
+* Returns: {HTTP/2 Settings Object}
 
 Returns an object containing the default settings for an `Http2Session`
 instance. This method returns a new object instance every time it is called
@@ -1977,7 +1977,7 @@ so instances returned may be safely modified for use.
 added: v8.4.0
 -->
 
-* `settings` {HTTP2 Settings Object}
+* `settings` {HTTP/2 Settings Object}
 * Returns: {Buffer}
 
 Returns a `Buffer` instance containing serialized representation of the given
@@ -1999,9 +1999,9 @@ added: v8.4.0
 -->
 
 * `buf` {Buffer|Uint8Array} The packed settings.
-* Returns: {HTTP2 Settings Object}
+* Returns: {HTTP/2 Settings Object}
 
-Returns a [HTTP2 Settings Object][] containing the deserialized settings from
+Returns a [HTTP/2 Settings Object][] containing the deserialized settings from
 the given `Buffer` as generated by `http2.getPackedSettings()`.
 
 ### Headers Object
@@ -2262,7 +2262,7 @@ In order to create a mixed [HTTPS][] and HTTP/2 server, refer to the
 [ALPN negotiation][] section.
 Upgrading from non-tls HTTP/1 servers is not supported.
 
-The HTTP2 compatibility API is composed of [`Http2ServerRequest`]() and
+The HTTP/2 compatibility API is composed of [`Http2ServerRequest`]() and
 [`Http2ServerResponse`](). They aim at API compatibility with HTTP/1, but
 they do not hide the differences between the protocols. As an example,
 the status message for HTTP codes is ignored.
@@ -2370,7 +2370,7 @@ Example:
 console.log(request.headers);
 ```
 
-See [HTTP2 Headers Object][].
+See [HTTP/2 Headers Object][].
 
 In HTTP/2, the request path, hostname, protocol, and method are represented as
 special headers prefixed with the `:` character (e.g. `':path'`). These special
@@ -3097,8 +3097,8 @@ following additional properties:
 [HTTP/1]: http.html
 [HTTP/2]: https://tools.ietf.org/html/rfc7540
 [HTTP/2 Unencrypted]: https://http2.github.io/faq/#does-http2-require-encryption
-[HTTP2 Headers Object]: #http2_headers_object
-[HTTP2 Settings Object]: #http2_settings_object
+[HTTP/2 Headers Object]: #http2_headers_object
+[HTTP/2 Settings Object]: #http2_settings_object
 [HTTPS]: https.html
 [Http2Session and Sockets]: #http2_http2session_and_sockets
 [Performance Observer]: perf_hooks.html

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -55,8 +55,8 @@ const typeMap = {
   'http.ServerResponse': 'http.html#http_class_http_serverresponse',
 
   'ClientHttp2Stream': 'http2.html#http2_class_clienthttp2stream',
-  'HTTP2 Headers Object': 'http2.html#http2_headers_object',
-  'HTTP2 Settings Object': 'http2.html#http2_settings_object',
+  'HTTP/2 Headers Object': 'http2.html#http2_headers_object',
+  'HTTP/2 Settings Object': 'http2.html#http2_settings_object',
   'http2.Http2ServerRequest': 'http2.html#http2_class_http2_http2serverrequest',
   'http2.Http2ServerResponse':
     'http2.html#http2_class_http2_http2serverresponse',


### PR DESCRIPTION
Previously, "HTTP/2" was strictly used to describe the protocol, and HTTP2 the module. This distinction is unnecessary in my opinion. Consistency between the two terms is enforced in this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
