### PR TITLE
test: adding tests for fs/promises.js fileHandle methods

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-append-file.js
+++ b/test/parallel/test-fs-promises-file-handle-append-file.js
@@ -12,39 +12,35 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateAppendBuffer({ filePath,
-                                      fileHandle,
-                                      bufferToAppend }) {
-  await fileHandle.appendFile(bufferToAppend);
-  const appendedFileData = fs.readFileSync(filePath);
-  assert.deepStrictEqual(appendedFileData, bufferToAppend);
-}
-
-async function validateAppendString({ filePath,
-                                      fileHandle,
-                                      stringToAppend,
-                                      bufferToAppend }) {
-  await fileHandle.appendFile(stringToAppend);
-  const stringAsBuffer = Buffer.from(stringToAppend, 'utf8');
-  const appendedFileData = fs.readFileSync(filePath);
-  const combinedBuffer = Buffer.concat([bufferToAppend, stringAsBuffer]);
-  assert.deepStrictEqual(appendedFileData, combinedBuffer);
-}
-
-async function executeTests() {
+async function validateAppendBuffer() {
   tmpdir.refresh();
   common.crashOnUnhandledRejection();
 
-  const filePath = path.resolve(tmpDir, 'tmp-append-file.txt');
-  const appendFileDetails = {
-    filePath,
-    fileHandle: await open(filePath, 'a'),
-    bufferToAppend: Buffer.from('a&Dp'.repeat(100), 'utf8'),
-    stringToAppend: 'x~yz'.repeat(100)
-  };
+  const filePath = path.resolve(tmpDir, 'tmp-append-file-buffer.txt');
+  const fileHandle = await open(filePath, 'a');
+  const buffer = Buffer.from('a&Dp'.repeat(100), 'utf8');
 
-  await validateAppendBuffer(appendFileDetails);
-  await validateAppendString(appendFileDetails);
+  await fileHandle.appendFile(buffer);
+  const appendedFileData = fs.readFileSync(filePath);
+  assert.deepStrictEqual(appendedFileData, buffer);
 }
 
-executeTests().then(common.mustCall());
+async function validateAppendString() {
+  //don't refresh the directory
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-append-file-buffer.txt');
+  const fileHandle = await open(filePath, 'a');
+  const buffer = Buffer.from('a&Dp'.repeat(100), 'utf8');
+  const string = 'x~yz'.repeat(100);
+
+  await fileHandle.appendFile(string);
+  const stringAsBuffer = Buffer.from(string, 'utf8');
+  const appendedFileData = fs.readFileSync(filePath);
+  const combinedBuffer = Buffer.concat([buffer, stringAsBuffer]);
+  assert.deepStrictEqual(appendedFileData, combinedBuffer);
+}
+
+validateAppendBuffer()
+  .then(validateAppendString)
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-append-file.js
+++ b/test/parallel/test-fs-promises-file-handle-append-file.js
@@ -26,7 +26,7 @@ async function validateAppendBuffer() {
 }
 
 async function validateAppendString() {
-  //don't refresh the directory
+  // don't refresh the directory
   common.crashOnUnhandledRejection();
 
   const filePath = path.resolve(tmpDir, 'tmp-append-file-buffer.txt');

--- a/test/parallel/test-fs-promises-file-handle-append-file.js
+++ b/test/parallel/test-fs-promises-file-handle-append-file.js
@@ -12,10 +12,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateAppendBuffer() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
+async function validateAppendBuffer() {
   const filePath = path.resolve(tmpDir, 'tmp-append-file-buffer.txt');
   const fileHandle = await open(filePath, 'a');
   const buffer = Buffer.from('a&Dp'.repeat(100), 'utf8');
@@ -26,19 +26,14 @@ async function validateAppendBuffer() {
 }
 
 async function validateAppendString() {
-  // don't refresh the directory
-  common.crashOnUnhandledRejection();
-
-  const filePath = path.resolve(tmpDir, 'tmp-append-file-buffer.txt');
+  const filePath = path.resolve(tmpDir, 'tmp-append-file-string.txt');
   const fileHandle = await open(filePath, 'a');
-  const buffer = Buffer.from('a&Dp'.repeat(100), 'utf8');
   const string = 'x~yz'.repeat(100);
 
   await fileHandle.appendFile(string);
   const stringAsBuffer = Buffer.from(string, 'utf8');
   const appendedFileData = fs.readFileSync(filePath);
-  const combinedBuffer = Buffer.concat([buffer, stringAsBuffer]);
-  assert.deepStrictEqual(appendedFileData, combinedBuffer);
+  assert.deepStrictEqual(appendedFileData, stringAsBuffer);
 }
 
 validateAppendBuffer()

--- a/test/parallel/test-fs-promises-file-handle-append-file.js
+++ b/test/parallel/test-fs-promises-file-handle-append-file.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.appendFile method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateAppendBuffer({ filePath,
+                                      fileHandle,
+                                      bufferToAppend }) {
+  await fileHandle.appendFile(bufferToAppend);
+  const appendedFileData = fs.readFileSync(filePath);
+  assert.deepStrictEqual(appendedFileData, bufferToAppend);
+}
+
+async function validateAppendString({ filePath,
+                                      fileHandle,
+                                      stringToAppend,
+                                      bufferToAppend }) {
+  await fileHandle.appendFile(stringToAppend);
+  const stringAsBuffer = Buffer.from(stringToAppend, 'utf8');
+  const appendedFileData = fs.readFileSync(filePath);
+  const combinedBuffer = Buffer.concat([bufferToAppend, stringAsBuffer]);
+  assert.deepStrictEqual(appendedFileData, combinedBuffer);
+}
+
+async function executeTests() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-append-file.txt');
+  const appendFileDetails = {
+    filePath,
+    fileHandle: await open(filePath, 'a'),
+    bufferToAppend: Buffer.from('a&Dp'.repeat(100), 'utf8'),
+    stringToAppend: 'x~yz'.repeat(100)
+  };
+
+  await validateAppendBuffer(appendFileDetails);
+  await validateAppendString(appendFileDetails);
+}
+
+executeTests().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.chmod method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateFilePermission({ filePath, fileHandle }) {
+  //file created with r/w, should not have execute
+  fs.access(filePath, fs.constants.X_OK, common.mustCall(async (err) => {
+    //err should an instance of Error
+    assert.deepStrictEqual(err instanceof Error, true);
+    //add execute permissions
+    await fileHandle.chmod(0o765);
+
+    fs.access(filePath, fs.constants.X_OK, common.mustCall((err) => {
+      //err should be undefined or null
+      assert.deepStrictEqual(!err, true);
+    }));
+  }));
+}
+
+async function executeTests() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-chmod.txt');
+  const chmodFileDetails = {
+    filePath,
+    fileHandle: await open(filePath, 'w+', 0o666)
+  };
+
+  await validateFilePermission(chmodFileDetails);
+}
+
+executeTests().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -17,14 +17,28 @@ async function validateFilePermission() {
   common.crashOnUnhandledRejection();
 
   const filePath = path.resolve(tmpDir, 'tmp-chmod.txt');
-  const fileHandle = await open(filePath, 'w+', 0o644);
-  // file created with r/w 644
+  const fileHandle = await open(filePath, 'w+', 0o444);
+  // file created with r--r--r-- 444
   const statsBeforeMod = fs.statSync(filePath);
-  assert.deepStrictEqual(statsBeforeMod.mode & 0o644, 0o644);
-  // change the permissions to 765
-  await fileHandle.chmod(0o765);
+  assert.deepStrictEqual(statsBeforeMod.mode & 0o444, 0o444);
+
+  let expectedAccess;
+  const newPermissions = 0o765;
+
+  if (common.isWindows) {
+    // chmod in Windows will only toggle read only/write access. the
+    // fs.Stats.mode in Windows is computed using read/write
+    // bits (not exec). read only at best returns 444; r/w 666.
+    // refer: /deps/uv/src/win/fs.cfs;
+    expectedAccess = 0o664;
+  } else {
+    expectedAccess = newPermissions;
+  }
+
+  //change the permissions to rwxr--r-x
+  await fileHandle.chmod(newPermissions);
   const statsAfterMod = fs.statSync(filePath);
-  assert.deepStrictEqual(statsAfterMod.mode & 0o765, 0o765);
+  assert.deepStrictEqual(statsAfterMod.mode & expectedAccess, expectedAccess);
 }
 
 validateFilePermission().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -18,10 +18,10 @@ async function validateFilePermission() {
 
   const filePath = path.resolve(tmpDir, 'tmp-chmod.txt');
   const fileHandle = await open(filePath, 'w+', 0o644);
-  //file created with r/w 644
+  // file created with r/w 644
   const statsBeforeMod = fs.statSync(filePath);
   assert.deepStrictEqual(statsBeforeMod.mode & 0o644, 0o644);
-  //change the permissions to 765
+  // change the permissions to 765
   await fileHandle.chmod(0o765);
   const statsAfterMod = fs.statSync(filePath);
   assert.deepStrictEqual(statsAfterMod.mode & 0o765, 0o765);

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -12,10 +12,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateFilePermission() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
+async function validateFilePermission() {
   const filePath = path.resolve(tmpDir, 'tmp-chmod.txt');
   const fileHandle = await open(filePath, 'w+', 0o444);
   // file created with r--r--r-- 444
@@ -35,7 +35,7 @@ async function validateFilePermission() {
     expectedAccess = newPermissions;
   }
 
-  //change the permissions to rwxr--r-x
+  // change the permissions to rwxr--r-x
   await fileHandle.chmod(newPermissions);
   const statsAfterMod = fs.statSync(filePath);
   assert.deepStrictEqual(statsAfterMod.mode & expectedAccess, expectedAccess);

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -12,10 +12,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateRead() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
+async function validateRead() {
   const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
   const fileHandle = await open(filePath, 'w+');
   const buffer = Buffer.from('Hello world', 'utf8');
@@ -29,8 +29,6 @@ async function validateRead() {
 }
 
 async function validateEmptyRead() {
-  common.crashOnUnhandledRejection();
-
   const filePath = path.resolve(tmpDir, 'tmp-read-empty-file.txt');
   const fileHandle = await open(filePath, 'w+');
   const buffer = Buffer.from('', 'utf8');

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -29,7 +29,6 @@ async function validateRead() {
 }
 
 async function validateEmptyRead() {
-  tmpdir.refresh();
   common.crashOnUnhandledRejection();
 
   const filePath = path.resolve(tmpDir, 'tmp-read-empty-file.txt');

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.read method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateRead() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
+  const fileHandle = await open(filePath, 'w+');
+  const buffer = Buffer.from('Hello world', 'utf8');
+
+  const fd = fs.openSync(filePath, 'w+');
+  fs.writeSync(fd, buffer, 0, buffer.length);
+  //use async read to get the buffer that was read into
+  const cb = common.mustCall(async (err, bytesRead, readBuffer) => {
+    assert.ifError(err);
+    fs.closeSync(fd);
+
+    const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
+    assert.deepStrictEqual(bytesRead,
+                           readAsyncHandle.bytesRead);
+    assert.deepStrictEqual(readBuffer.toString('utf8'),
+                           readAsyncHandle.buffer.toString('utf8'));
+  });
+  fs.read(fd, Buffer.alloc(11), 0, 11, 0, cb);
+}
+
+async function validateEmptyRead() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-read-empty-file.txt');
+  const fileHandle = await open(filePath, 'w+');
+  const buffer = Buffer.from('', 'utf8');
+
+  const fd = fs.openSync(filePath, 'w+');
+  fs.writeSync(fd, buffer, 0, buffer.length);
+  fs.closeSync(fd);
+  const bytesRead = fs.readFileSync(filePath, 'utf8');
+  const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
+  assert.deepStrictEqual(bytesRead.length, readAsyncHandle.bytesRead);
+}
+
+validateRead()
+  .then(validateEmptyRead)
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -22,18 +22,10 @@ async function validateRead() {
 
   const fd = fs.openSync(filePath, 'w+');
   fs.writeSync(fd, buffer, 0, buffer.length);
-  //use async read to get the buffer that was read into
-  const cb = common.mustCall(async (err, bytesRead, readBuffer) => {
-    assert.ifError(err);
-    fs.closeSync(fd);
-
-    const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
-    assert.deepStrictEqual(bytesRead,
-                           readAsyncHandle.bytesRead);
-    assert.deepStrictEqual(readBuffer.toString('utf8'),
-                           readAsyncHandle.buffer.toString('utf8'));
-  });
-  fs.read(fd, Buffer.alloc(11), 0, 11, 0, cb);
+  fs.closeSync(fd);
+  const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
+  assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
+  assert.deepStrictEqual(buffer, readAsyncHandle.buffer);
 }
 
 async function validateEmptyRead() {
@@ -47,9 +39,8 @@ async function validateEmptyRead() {
   const fd = fs.openSync(filePath, 'w+');
   fs.writeSync(fd, buffer, 0, buffer.length);
   fs.closeSync(fd);
-  const bytesRead = fs.readFileSync(filePath, 'utf8');
   const readAsyncHandle = await fileHandle.read(Buffer.alloc(11), 0, 11, 0);
-  assert.deepStrictEqual(bytesRead.length, readAsyncHandle.bytesRead);
+  assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
 }
 
 validateRead()

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -12,10 +12,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateReadFile() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
+async function validateReadFile() {
   const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
   const fileHandle = await open(filePath, 'w+');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.readFile method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateReadFile() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
+  const fileHandle = await open(filePath, 'w+');
+  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+
+  const fd = fs.openSync(filePath, 'w+');
+  fs.writeSync(fd, buffer, 0, buffer.length);
+  const readSyncData = fs.readFileSync(filePath);
+  fs.closeSync(fd);
+
+  const readAsyncData = await fileHandle.readFile();
+  assert.deepStrictEqual(readSyncData, readAsyncData);
+}
+
+validateReadFile()
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -22,11 +22,10 @@ async function validateReadFile() {
 
   const fd = fs.openSync(filePath, 'w+');
   fs.writeSync(fd, buffer, 0, buffer.length);
-  const readSyncData = fs.readFileSync(filePath);
   fs.closeSync(fd);
 
-  const readAsyncData = await fileHandle.readFile();
-  assert.deepStrictEqual(readSyncData, readAsyncData);
+  const readFileData = await fileHandle.readFile();
+  assert.deepStrictEqual(buffer, readFileData);
 }
 
 validateReadFile()

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -12,11 +12,11 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateWrite() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
-  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file.txt');
+async function validateWrite() {
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
 
@@ -26,10 +26,7 @@ async function validateWrite() {
 }
 
 async function validateEmptyWrite() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
-
-  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-empty-write.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
   const buffer = Buffer.from(''); // empty buffer
 

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.read method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateWrite() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+
+  const fd = fs.openSync(filePathForSync, 'w+');
+  fs.writeSync(fd, buffer, 0, buffer.length);
+  fs.closeSync(fd);
+
+  const bytesRead = fs.readFileSync(filePathForSync);
+  await fileHandle.write(buffer, 0, buffer.length);
+  const bytesReadHandle = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+}
+
+async function validateEmptyWrite() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  //empty buffer
+  const buffer = Buffer.from('');
+
+  const fd = fs.openSync(filePathForSync, 'w+');
+  fs.writeSync(fd, buffer, 0, buffer.length);
+  fs.closeSync(fd);
+
+  const bytesRead = fs.readFileSync(filePathForSync);
+  await fileHandle.write(buffer, 0, buffer.length);
+  const bytesReadHandle = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+}
+
+validateWrite()
+  .then(validateEmptyWrite)
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -16,39 +16,26 @@ async function validateWrite() {
   tmpdir.refresh();
   common.crashOnUnhandledRejection();
 
-  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
-  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
 
-  const fd = fs.openSync(filePathForSync, 'w+');
-  fs.writeSync(fd, buffer, 0, buffer.length);
-  fs.closeSync(fd);
-
-  const bytesRead = fs.readFileSync(filePathForSync);
   await fileHandle.write(buffer, 0, buffer.length);
-  const bytesReadHandle = fs.readFileSync(filePathForHandle);
-  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+  const readFileData = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(buffer, readFileData);
 }
 
 async function validateEmptyWrite() {
   tmpdir.refresh();
   common.crashOnUnhandledRejection();
 
-  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
-  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
-  //empty buffer
-  const buffer = Buffer.from('');
+  const buffer = Buffer.from(''); //empty buffer
 
-  const fd = fs.openSync(filePathForSync, 'w+');
-  fs.writeSync(fd, buffer, 0, buffer.length);
-  fs.closeSync(fd);
-
-  const bytesRead = fs.readFileSync(filePathForSync);
   await fileHandle.write(buffer, 0, buffer.length);
-  const bytesReadHandle = fs.readFileSync(filePathForHandle);
-  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+  const readFileData = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(buffer, readFileData);
 }
 
 validateWrite()

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -31,7 +31,7 @@ async function validateEmptyWrite() {
 
   const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
-  const buffer = Buffer.from(''); //empty buffer
+  const buffer = Buffer.from(''); // empty buffer
 
   await fileHandle.write(buffer, 0, buffer.length);
   const readFileData = fs.readFileSync(filePathForHandle);

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -12,10 +12,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
-async function validateWriteFile() {
-  tmpdir.refresh();
-  common.crashOnUnhandledRejection();
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
 
+async function validateWriteFile() {
   const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.readFile method.
+
+const fs = require('fs');
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+async function validateWriteFile() {
+  tmpdir.refresh();
+  common.crashOnUnhandledRejection();
+
+  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+
+  fs.writeFileSync(filePathForSync, buffer);
+  const bytesRead = fs.readFileSync(filePathForSync);
+
+  await fileHandle.writeFile(buffer);
+  const bytesReadHandle = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+}
+
+validateWriteFile()
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -16,17 +16,13 @@ async function validateWriteFile() {
   tmpdir.refresh();
   common.crashOnUnhandledRejection();
 
-  const filePathForSync = path.resolve(tmpDir, 'tmp-write-file1.txt');
   const filePathForHandle = path.resolve(tmpDir, 'tmp-write-file2.txt');
   const fileHandle = await open(filePathForHandle, 'w+');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
 
-  fs.writeFileSync(filePathForSync, buffer);
-  const bytesRead = fs.readFileSync(filePathForSync);
-
   await fileHandle.writeFile(buffer);
-  const bytesReadHandle = fs.readFileSync(filePathForHandle);
-  assert.deepStrictEqual(bytesRead, bytesReadHandle);
+  const readFileData = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(buffer, readFileData);
 }
 
 validateWriteFile()


### PR DESCRIPTION
Working to increase test code coverage for fs/promises.js.
Added tests for fileHandle.appendFile and fileHandle.chmod.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
