### PR TITLE
lib: move Pipe/TCPConnectWrap to obj destructuring

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -42,11 +42,17 @@ const {
 
 const { Buffer } = require('buffer');
 const TTYWrap = process.binding('tty_wrap');
-const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
-const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
-const { TCPConnectWrap } = process.binding('tcp_wrap');
-const { PipeConnectWrap } = process.binding('pipe_wrap');
 const { ShutdownWrap } = process.binding('stream_wrap');
+const {
+  TCP,
+  TCPConnectWrap,
+  constants: TCPConstants
+} = process.binding('tcp_wrap');
+const {
+  Pipe,
+  PipeConnectWrap,
+  constants: PipeConstants
+} = process.binding('pipe_wrap');
 const {
   newAsyncId,
   defaultTriggerAsyncIdScope,


### PR DESCRIPTION
This commit moves PipeConnectWrap and TCPConnectWrap into the object
destructuring assigments that already exist for pipe_wrap and tcp_wrap.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
