### PR TITLE
doc: remove use of "random port" regarding dgram send

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -319,7 +319,7 @@ the error is emitted as an `'error'` event on the `socket` object.
 Offset and length are optional but both *must* be set if either are used.
 They are supported only when the first argument is a `Buffer` or `Uint8Array`.
 
-Example of sending a UDP packet to a random port on `localhost`;
+Example of sending a UDP packet to a port on `localhost`;
 
 ```js
 const dgram = require('dgram');
@@ -330,8 +330,8 @@ client.send(message, 41234, 'localhost', (err) => {
 });
 ```
 
-Example of sending a UDP packet composed of multiple buffers to a random port
-on `127.0.0.1`;
+Example of sending a UDP packet composed of multiple buffers to a port on
+`127.0.0.1`;
 
 ```js
 const dgram = require('dgram');


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I removed the use of "random port" when referring to sending messages with dgram. Specifically in the examples the port isn't random, it is a hand-picked port which stays the same. Referring to it as a random port is confusing because in the listening methods the phrase "random port" has a special meaning, i.e. providing no port and letting the OS pick a random port.