### PR TITLE
test: refactor test-http-expect-continue

### DIFF
--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -20,70 +20,63 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-let outstanding_reqs = 0;
 const test_req_body = 'some stuff...\n';
 const test_res_body = 'other stuff!\n';
 let sent_continue = false;
 let got_continue = false;
 
-function handler(req, res) {
-  assert.strictEqual(sent_continue, true,
-                     'Full response sent before 100 Continue');
+const handler = common.mustCall((req, res) => {
+  assert.ok(sent_continue, 'Full response sent before 100 Continue');
   console.error('Server sending full response...');
   res.writeHead(200, {
     'Content-Type': 'text/plain',
     'ABCD': '1'
   });
   res.end(test_res_body);
-}
+});
 
-const server = http.createServer(handler);
-server.on('checkContinue', function(req, res) {
+const server = http.createServer();
+server.on('checkContinue', common.mustCall((req, res) => {
   console.error('Server got Expect: 100-continue...');
   res.writeContinue();
   sent_continue = true;
   setTimeout(function() {
     handler(req, res);
   }, 100);
-});
+}));
 server.listen(0);
 
 
-server.on('listening', function() {
+server.on('listening', common.mustCall(() => {
   const req = http.request({
-    port: this.address().port,
+    port: server.address().port,
     method: 'POST',
     path: '/world',
     headers: { 'Expect': '100-continue' }
   });
   console.error('Client sending request...');
-  outstanding_reqs++;
   let body = '';
-  req.on('continue', function() {
+  req.on('continue', common.mustCall(() => {
     console.error('Client got 100 Continue...');
     got_continue = true;
     req.end(test_req_body);
-  });
-  req.on('response', function(res) {
-    assert.strictEqual(got_continue, true,
-                       'Full response received before 100 Continue');
+  }));
+  req.on('response', common.mustCall((res) => {
+    assert.ok(got_continue, 'Full response received before 100 Continue');
     assert.strictEqual(200, res.statusCode,
                        `Final status code was ${res.statusCode}, not 200.`);
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });
-    res.on('end', function() {
+    res.on('end', common.mustCall(() => {
       console.error('Got full response.');
-      assert.strictEqual(body, test_res_body, 'Response body doesn\'t match.');
+      assert.strictEqual(body, test_res_body);
       assert.ok('abcd' in res.headers, 'Response headers missing.');
-      outstanding_reqs--;
-      if (outstanding_reqs === 0) {
-        server.close();
-        process.exit();
-      }
-    });
-  });
-});
+      server.close();
+      process.exit();
+    }));
+  }));
+}));


### PR DESCRIPTION
Use common.mustCall() where appropriate. Remove some logic that is not
required when common.mustCall() is used (incrementor/decrementor to make
sure everything is called the same number of times).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
