### PR TITLE
test: fix assert.throws error in test-http-parser

### DIFF
--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -97,9 +97,10 @@ function expectBody(expected) {
 
   parser.reinitialize(HTTPParser.REQUEST);
 
-  assert.throws(function() {
-    parser.execute(request, 0, request.length);
-  }, Error, 'hello world');
+  assert.throws(
+    () => { parser.execute(request, 0, request.length); },
+    { name: 'Error', message: 'hello world' }
+  );
 }
 
 


### PR DESCRIPTION
The third argument of `assert.throws()` is a message that is used by the
AssertionError, not the message to check in the thrown error. It appears
that there is an assert.throws() in test-http-parser that expects the
latter behavior. Rewrite the call to check the error message. Even if
this wasn't a mistake, this change results in a more robust check.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
