### PR TITLE
src: rename req_wrap with -async/-sync suffix

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -769,14 +769,14 @@ void Access(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NE(*path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // access(path, mode, req)
-    AsyncCall(env, req_wrap, args, "access", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // access(path, mode, req)
+    AsyncCall(env, req_wrap_async, args, "access", UTF8, AfterNoArgs,
               uv_fs_access, *path, mode);
   } else {  // access(path, mode, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[3], &req_wrap, "access", uv_fs_access, *path, mode);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "access", uv_fs_access, *path, mode);
   }
 }
 
@@ -790,14 +790,14 @@ void Close(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {  // close(fd, req)
-    AsyncCall(env, req_wrap, args, "close", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {  // close(fd, req)
+    AsyncCall(env, req_wrap_async, args, "close", UTF8, AfterNoArgs,
               uv_fs_close, fd);
   } else {  // close(fd, undefined, ctx)
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[2], &req_wrap, "close", uv_fs_close, fd);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[2], &req_wrap_sync, "close", uv_fs_close, fd);
   }
 }
 
@@ -898,17 +898,17 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NE(*path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {  // stat(path, req)
-    AsyncCall(env, req_wrap, args, "stat", UTF8, AfterStat,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {  // stat(path, req)
+    AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
               uv_fs_stat, *path);
   } else {  // stat(path, undefined, ctx)
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap;
-    int err = SyncCall(env, args[2], &req_wrap, "stat", uv_fs_stat, *path);
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[2], &req_wrap_sync, "stat", uv_fs_stat, *path);
     if (err == 0) {
       FillStatsArray(env->fs_stats_field_array(),
-                     static_cast<const uv_stat_t*>(req_wrap.req.ptr));
+                     static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     }
   }
 }
@@ -922,17 +922,18 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NE(*path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {  // lstat(path, req)
-    AsyncCall(env, req_wrap, args, "lstat", UTF8, AfterStat,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {  // lstat(path, req)
+    AsyncCall(env, req_wrap_async, args, "lstat", UTF8, AfterStat,
               uv_fs_lstat, *path);
   } else {  // lstat(path, undefined, ctx)
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap;
-    int err = SyncCall(env, args[2], &req_wrap, "lstat", uv_fs_lstat, *path);
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[2], &req_wrap_sync, "lstat", uv_fs_lstat,
+                       *path);
     if (err == 0) {
       FillStatsArray(env->fs_stats_field_array(),
-                     static_cast<const uv_stat_t*>(req_wrap.req.ptr));
+                     static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     }
   }
 }
@@ -946,17 +947,17 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {  // fstat(fd, req)
-    AsyncCall(env, req_wrap, args, "fstat", UTF8, AfterStat,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {  // fstat(fd, req)
+    AsyncCall(env, req_wrap_async, args, "fstat", UTF8, AfterStat,
               uv_fs_fstat, fd);
   } else {  // fstat(fd, undefined, ctx)
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap;
-    int err = SyncCall(env, args[2], &req_wrap, "fstat", uv_fs_fstat, fd);
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[2], &req_wrap_sync, "fstat", uv_fs_fstat, fd);
     if (err == 0) {
       FillStatsArray(env->fs_stats_field_array(),
-                     static_cast<const uv_stat_t*>(req_wrap.req.ptr));
+                     static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     }
   }
 }
@@ -975,14 +976,14 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   int flags = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // symlink(target, path, flags, req)
-    AsyncDestCall(env, req_wrap, args, "symlink", *path, path.length(), UTF8,
-                  AfterNoArgs, uv_fs_symlink, *target, *path, flags);
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // symlink(target, path, flags, req)
+    AsyncDestCall(env, req_wrap_async, args, "symlink", *path, path.length(),
+                  UTF8, AfterNoArgs, uv_fs_symlink, *target, *path, flags);
   } else {  // symlink(target, path, flags, undefinec, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req;
-    SyncCall(env, args[4], &req, "symlink",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "symlink",
              uv_fs_symlink, *target, *path, flags);
   }
 }
@@ -999,14 +1000,14 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   BufferValue dest(env->isolate(), args[1]);
   CHECK_NE(*dest, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // link(src, dest, req)
-    AsyncDestCall(env, req_wrap, args, "link", *dest, dest.length(), UTF8,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // link(src, dest, req)
+    AsyncDestCall(env, req_wrap_async, args, "link", *dest, dest.length(), UTF8,
                   AfterNoArgs, uv_fs_link, *src, *dest);
   } else {  // link(src, dest)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req;
-    SyncCall(env, args[3], &req, "link",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "link",
              uv_fs_link, *src, *dest);
   }
 }
@@ -1022,19 +1023,19 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // readlink(path, encoding, req)
-    AsyncCall(env, req_wrap, args, "readlink", encoding, AfterStringPtr,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // readlink(path, encoding, req)
+    AsyncCall(env, req_wrap_async, args, "readlink", encoding, AfterStringPtr,
               uv_fs_readlink, *path);
   } else {
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req;
-    int err = SyncCall(env, args[3], &req, "readlink",
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[3], &req_wrap_sync, "readlink",
                        uv_fs_readlink, *path);
     if (err < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
     }
-    const char* link_path = static_cast<const char*>(req.req.ptr);
+    const char* link_path = static_cast<const char*>(req_wrap_sync.req.ptr);
 
     Local<Value> error;
     MaybeLocal<Value> rc = StringBytes::Encode(env->isolate(),
@@ -1062,14 +1063,16 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   BufferValue new_path(env->isolate(), args[1]);
   CHECK_NE(*new_path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {
-    AsyncDestCall(env, req_wrap, args, "rename", *new_path, new_path.length(),
-                  UTF8, AfterNoArgs, uv_fs_rename, *old_path, *new_path);
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {
+    AsyncDestCall(env, req_wrap_async, args, "rename", *new_path,
+                  new_path.length(), UTF8, AfterNoArgs, uv_fs_rename,
+                  *old_path, *new_path);
   } else {
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req;
-    SyncCall(env, args[3], &req, "rename", uv_fs_rename, *old_path, *new_path);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "rename", uv_fs_rename,
+             *old_path, *new_path);
   }
 }
 
@@ -1085,14 +1088,15 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsNumber());
   const int64_t len = args[1].As<Integer>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {
-    AsyncCall(env, req_wrap, args, "ftruncate", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {
+    AsyncCall(env, req_wrap_async, args, "ftruncate", UTF8, AfterNoArgs,
               uv_fs_ftruncate, fd, len);
   } else {
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req;
-    SyncCall(env, args[3], &req, "ftruncate", uv_fs_ftruncate, fd, len);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "ftruncate", uv_fs_ftruncate, fd,
+             len);
   }
 }
 
@@ -1105,14 +1109,14 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {
-    AsyncCall(env, req_wrap, args, "fdatasync", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {
+    AsyncCall(env, req_wrap_async, args, "fdatasync", UTF8, AfterNoArgs,
               uv_fs_fdatasync, fd);
   } else {
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req;
-    SyncCall(env, args[2], &req, "fdatasync", uv_fs_fdatasync, fd);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[2], &req_wrap_sync, "fdatasync", uv_fs_fdatasync, fd);
   }
 }
 
@@ -1125,14 +1129,14 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   const int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {
-    AsyncCall(env, req_wrap, args, "fsync", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {
+    AsyncCall(env, req_wrap_async, args, "fsync", UTF8, AfterNoArgs,
               uv_fs_fsync, fd);
   } else {
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req;
-    SyncCall(env, args[2], &req, "fsync", uv_fs_fsync, fd);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[2], &req_wrap_sync, "fsync", uv_fs_fsync, fd);
   }
 }
 
@@ -1145,14 +1149,14 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NE(*path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);
-  if (req_wrap != nullptr) {
-    AsyncCall(env, req_wrap, args, "unlink", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
+  if (req_wrap_async != nullptr) {
+    AsyncCall(env, req_wrap_async, args, "unlink", UTF8, AfterNoArgs,
               uv_fs_unlink, *path);
   } else {
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req;
-    SyncCall(env, args[2], &req, "unlink", uv_fs_unlink, *path);
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[2], &req_wrap_sync, "unlink", uv_fs_unlink, *path);
   }
 }
 
@@ -1165,14 +1169,14 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NE(*path, nullptr);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[1]);  // rmdir(path, req)
-  if (req_wrap != nullptr) {
-    AsyncCall(env, req_wrap, args, "rmdir", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);  // rmdir(path, req)
+  if (req_wrap_async != nullptr) {
+    AsyncCall(env, req_wrap_async, args, "rmdir", UTF8, AfterNoArgs,
               uv_fs_rmdir, *path);
   } else {  // rmdir(path, undefined, ctx)
     CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[2], &req_wrap, "rmdir",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[2], &req_wrap_sync, "rmdir",
              uv_fs_rmdir, *path);
   }
 }
@@ -1189,14 +1193,14 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // mkdir(path, mode, req)
-    AsyncCall(env, req_wrap, args, "mkdir", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // mkdir(path, mode, req)
+    AsyncCall(env, req_wrap_async, args, "mkdir", UTF8, AfterNoArgs,
               uv_fs_mkdir, *path, mode);
   } else {  // mkdir(path, mode, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[3], &req_wrap, "mkdir",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "mkdir",
              uv_fs_mkdir, *path, mode);
   }
 }
@@ -1212,20 +1216,20 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // realpath(path, encoding, req)
-    AsyncCall(env, req_wrap, args, "realpath", encoding, AfterStringPtr,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // realpath(path, encoding, req)
+    AsyncCall(env, req_wrap_async, args, "realpath", encoding, AfterStringPtr,
               uv_fs_realpath, *path);
   } else {  // realpath(path, encoding, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    int err = SyncCall(env, args[3], &req_wrap, "realpath",
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[3], &req_wrap_sync, "realpath",
                        uv_fs_realpath, *path);
     if (err < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
     }
 
-    const char* link_path = static_cast<const char*>(req_wrap.req.ptr);
+    const char* link_path = static_cast<const char*>(req_wrap_sync.req.ptr);
 
     Local<Value> error;
     MaybeLocal<Value> rc = StringBytes::Encode(env->isolate(),
@@ -1253,20 +1257,20 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // readdir(path, encoding, req)
-    AsyncCall(env, req_wrap, args, "scandir", encoding, AfterScanDir,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // readdir(path, encoding, req)
+    AsyncCall(env, req_wrap_async, args, "scandir", encoding, AfterScanDir,
               uv_fs_scandir, *path, 0 /*flags*/);
   } else {  // readdir(path, encoding, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    int err = SyncCall(env, args[3], &req_wrap, "scandir",
+    FSReqWrapSync req_wrap_sync;
+    int err = SyncCall(env, args[3], &req_wrap_sync, "scandir",
                        uv_fs_scandir, *path, 0 /*flags*/);
     if (err < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
     }
 
-    CHECK_GE(req_wrap.req.result, 0);
+    CHECK_GE(req_wrap_sync.req.result, 0);
     int r;
     Local<Array> names = Array::New(env->isolate(), 0);
     Local<Function> fn = env->push_values_to_array_function();
@@ -1276,7 +1280,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     for (int i = 0; ; i++) {
       uv_dirent_t ent;
 
-      r = uv_fs_scandir_next(&(req_wrap.req), &ent);
+      r = uv_fs_scandir_next(&(req_wrap_sync.req), &ent);
       if (r == UV_EOF)
         break;
       if (r != 0) {
@@ -1337,14 +1341,14 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // open(path, flags, mode, req)
-    AsyncCall(env, req_wrap, args, "open", UTF8, AfterInteger,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // open(path, flags, mode, req)
+    AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterInteger,
               uv_fs_open, *path, flags, mode);
   } else {  // open(path, flags, mode, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    int result = SyncCall(env, args[4], &req_wrap, "open",
+    FSReqWrapSync req_wrap_sync;
+    int result = SyncCall(env, args[4], &req_wrap_sync, "open",
                           uv_fs_open, *path, flags, mode);
     args.GetReturnValue().Set(result);
   }
@@ -1365,14 +1369,14 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // openFileHandle(path, flags, mode, req)
-    AsyncCall(env, req_wrap, args, "open", UTF8, AfterOpenFileHandle,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // openFileHandle(path, flags, mode, req)
+    AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterOpenFileHandle,
               uv_fs_open, *path, flags, mode);
   } else {  // openFileHandle(path, flags, mode, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    int result = SyncCall(env, args[4], &req_wrap, "open",
+    FSReqWrapSync req_wrap_sync;
+    int result = SyncCall(env, args[4], &req_wrap_sync, "open",
                           uv_fs_open, *path, flags, mode);
     if (result < 0) {
       return;  // syscall failed, no need to continue, error info is in ctx
@@ -1398,15 +1402,15 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int flags = args[2].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // copyFile(src, dest, flags, req)
-    AsyncDestCall(env, req_wrap, args, "copyfile",
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // copyFile(src, dest, flags, req)
+    AsyncDestCall(env, req_wrap_async, args, "copyfile",
                   *dest, dest.length(), UTF8, AfterNoArgs,
                   uv_fs_copyfile, *src, *dest, flags);
   } else {  // copyFile(src, dest, flags, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[4], &req_wrap, "copyfile",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "copyfile",
              uv_fs_copyfile, *src, *dest, flags);
   }
 }
@@ -1450,14 +1454,14 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[5]);
-  if (req_wrap != nullptr) {  // write(fd, buffer, off, len, pos, req)
-    AsyncCall(env, req_wrap, args, "write", UTF8, AfterInteger,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[5]);
+  if (req_wrap_async != nullptr) {  // write(fd, buffer, off, len, pos, req)
+    AsyncCall(env, req_wrap_async, args, "write", UTF8, AfterInteger,
               uv_fs_write, fd, &uvbuf, 1, pos);
   } else {  // write(fd, buffer, off, len, pos, undefined, ctx)
     CHECK_EQ(argc, 7);
-    FSReqWrapSync req_wrap;
-    int bytesWritten = SyncCall(env, args[6], &req_wrap, "write",
+    FSReqWrapSync req_wrap_sync;
+    int bytesWritten = SyncCall(env, args[6], &req_wrap_sync, "write",
                                 uv_fs_write, fd, &uvbuf, 1, pos);
     args.GetReturnValue().Set(bytesWritten);
   }
@@ -1493,14 +1497,14 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
     iovs[i] = uv_buf_init(Buffer::Data(chunk), Buffer::Length(chunk));
   }
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // writeBuffers(fd, chunks, pos, req)
-    AsyncCall(env, req_wrap, args, "write", UTF8, AfterInteger,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // writeBuffers(fd, chunks, pos, req)
+    AsyncCall(env, req_wrap_async, args, "write", UTF8, AfterInteger,
               uv_fs_write, fd, *iovs, iovs.length(), pos);
   } else {  // writeBuffers(fd, chunks, pos, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    int bytesWritten = SyncCall(env, args[4], &req_wrap, "write",
+    FSReqWrapSync req_wrap_sync;
+    int bytesWritten = SyncCall(env, args[4], &req_wrap_sync, "write",
                                 uv_fs_write, fd, *iovs, iovs.length(), pos);
     args.GetReturnValue().Set(bytesWritten);
   }
@@ -1532,8 +1536,8 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   char* buf = nullptr;
   size_t len;
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[4]);
-  const bool is_async = req_wrap != nullptr;
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[4]);
+  const bool is_async = req_wrap_async != nullptr;
 
   // Avoid copying the string when it is externalized but only when:
   // 1. The target encoding is compatible with the string's encoding, and
@@ -1556,29 +1560,30 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (is_async) {  // write(fd, string, pos, enc, req)
-    CHECK_NE(req_wrap, nullptr);
+    CHECK_NE(req_wrap_async, nullptr);
     len = StringBytes::StorageSize(env->isolate(), value, enc);
     FSReqBase::FSReqBuffer& stack_buffer =
-        req_wrap->Init("write", len, enc);
+        req_wrap_async->Init("write", len, enc);
     // StorageSize may return too large a char, so correct the actual length
     // by the write size
     len = StringBytes::Write(env->isolate(), *stack_buffer, len, args[1], enc);
     stack_buffer.SetLengthAndZeroTerminate(len);
     uv_buf_t uvbuf = uv_buf_init(*stack_buffer, len);
-    int err = uv_fs_write(env->event_loop(), req_wrap->req(),
+    int err = uv_fs_write(env->event_loop(), req_wrap_async->req(),
                           fd, &uvbuf, 1, pos, AfterInteger);
-    req_wrap->Dispatched();
+    req_wrap_async->Dispatched();
     if (err < 0) {
-      uv_fs_t* uv_req = req_wrap->req();
+      uv_fs_t* uv_req = req_wrap_async->req();
       uv_req->result = err;
       uv_req->path = nullptr;
-      AfterInteger(uv_req);  // after may delete req_wrap if there is an error
+      AfterInteger(uv_req);  // after may delete req_wrap_async if there is
+                             // an error
     } else {
-      req_wrap->SetReturnValue(args);
+      req_wrap_async->SetReturnValue(args);
     }
   } else {  // write(fd, string, pos, enc, undefined, ctx)
     CHECK_EQ(argc, 6);
-    FSReqWrapSync req_wrap;
+    FSReqWrapSync req_wrap_sync;
     FSReqBase::FSReqBuffer stack_buffer;
     if (buf == nullptr) {
       len = StringBytes::StorageSize(env->isolate(), value, enc);
@@ -1591,7 +1596,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
       buf = *stack_buffer;
     }
     uv_buf_t uvbuf = uv_buf_init(buf, len);
-    int bytesWritten = SyncCall(env, args[5], &req_wrap, "write",
+    int bytesWritten = SyncCall(env, args[5], &req_wrap_sync, "write",
                                 uv_fs_write, fd, &uvbuf, 1, pos);
     args.GetReturnValue().Set(bytesWritten);
   }
@@ -1637,14 +1642,14 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(const_cast<char*>(buf), len);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[5]);
-  if (req_wrap != nullptr) {  // read(fd, buffer, offset, len, pos, req)
-    AsyncCall(env, req_wrap, args, "read", UTF8, AfterInteger,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[5]);
+  if (req_wrap_async != nullptr) {  // read(fd, buffer, offset, len, pos, req)
+    AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, &uvbuf, 1, pos);
   } else {  // read(fd, buffer, offset, len, pos, undefined, ctx)
     CHECK_EQ(argc, 7);
-    FSReqWrapSync req_wrap;
-    const int bytesRead = SyncCall(env, args[6], &req_wrap, "read",
+    FSReqWrapSync req_wrap_sync;
+    const int bytesRead = SyncCall(env, args[6], &req_wrap_sync, "read",
                                    uv_fs_read, fd, &uvbuf, 1, pos);
     args.GetReturnValue().Set(bytesRead);
   }
@@ -1666,14 +1671,14 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // chmod(path, mode, req)
-    AsyncCall(env, req_wrap, args, "chmod", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // chmod(path, mode, req)
+    AsyncCall(env, req_wrap_async, args, "chmod", UTF8, AfterNoArgs,
               uv_fs_chmod, *path, mode);
   } else {  // chmod(path, mode, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[3], &req_wrap, "chmod",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "chmod",
              uv_fs_chmod, *path, mode);
   }
 }
@@ -1694,14 +1699,14 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // fchmod(fd, mode, req)
-    AsyncCall(env, req_wrap, args, "fchmod", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // fchmod(fd, mode, req)
+    AsyncCall(env, req_wrap_async, args, "fchmod", UTF8, AfterNoArgs,
               uv_fs_fchmod, fd, mode);
   } else {  // fchmod(fd, mode, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[3], &req_wrap, "fchmod",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "fchmod",
              uv_fs_fchmod, fd, mode);
   }
 }
@@ -1725,14 +1730,14 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Uint32>()->Value());
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // chown(path, uid, gid, req)
-    AsyncCall(env, req_wrap, args, "chown", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // chown(path, uid, gid, req)
+    AsyncCall(env, req_wrap_async, args, "chown", UTF8, AfterNoArgs,
               uv_fs_chown, *path, uid, gid);
   } else {  // chown(path, uid, gid, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[4], &req_wrap, "chown",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "chown",
              uv_fs_chown, *path, uid, gid);
   }
 }
@@ -1756,14 +1761,14 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Uint32>()->Value());
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // fchown(fd, uid, gid, req)
-    AsyncCall(env, req_wrap, args, "fchown", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // fchown(fd, uid, gid, req)
+    AsyncCall(env, req_wrap_async, args, "fchown", UTF8, AfterNoArgs,
               uv_fs_fchown, fd, uid, gid);
   } else {  // fchown(fd, uid, gid, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[4], &req_wrap, "fchown",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "fchown",
              uv_fs_fchown, fd, uid, gid);
   }
 }
@@ -1784,14 +1789,14 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // utimes(path, atime, mtime, req)
-    AsyncCall(env, req_wrap, args, "utime", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // utimes(path, atime, mtime, req)
+    AsyncCall(env, req_wrap_async, args, "utime", UTF8, AfterNoArgs,
               uv_fs_utime, *path, atime, mtime);
   } else {  // utimes(path, atime, mtime, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[4], &req_wrap, "utime",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "utime",
              uv_fs_utime, *path, atime, mtime);
   }
 }
@@ -1811,14 +1816,14 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[3]);
-  if (req_wrap != nullptr) {  // futimes(fd, atime, mtime, req)
-    AsyncCall(env, req_wrap, args, "futime", UTF8, AfterNoArgs,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
+  if (req_wrap_async != nullptr) {  // futimes(fd, atime, mtime, req)
+    AsyncCall(env, req_wrap_async, args, "futime", UTF8, AfterNoArgs,
               uv_fs_futime, fd, atime, mtime);
   } else {  // futimes(fd, atime, mtime, undefined, ctx)
     CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[4], &req_wrap, "futime",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[4], &req_wrap_sync, "futime",
              uv_fs_futime, fd, atime, mtime);
   }
 }
@@ -1834,16 +1839,16 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
-  FSReqBase* req_wrap = GetReqWrap(env, args[2]);
-  if (req_wrap != nullptr) {  // mkdtemp(tmpl, encoding, req)
-    AsyncCall(env, req_wrap, args, "mkdtemp", encoding, AfterStringPath,
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
+  if (req_wrap_async != nullptr) {  // mkdtemp(tmpl, encoding, req)
+    AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
               uv_fs_mkdtemp, *tmpl);
   } else {  // mkdtemp(tmpl, encoding, undefined, ctx)
     CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap;
-    SyncCall(env, args[3], &req_wrap, "mkdtemp",
+    FSReqWrapSync req_wrap_sync;
+    SyncCall(env, args[3], &req_wrap_sync, "mkdtemp",
              uv_fs_mkdtemp, *tmpl);
-    const char* path = static_cast<const char*>(req_wrap.req.path);
+    const char* path = static_cast<const char*>(req_wrap_sync.req.path);
 
     Local<Value> error;
     MaybeLocal<Value> rc =


### PR DESCRIPTION
This commit renames the req_wrap variable to use an -async/-sync
suffix to avoid cases where the variables were being shadowed.

Refs: https://github.com/nodejs/node/pull/19614


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
