### PR TITLE
Test/improve deepstrict equal debug message

### DIFF
--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -91,11 +91,6 @@ server.listen(0, options.host, function() {
 
 process.on('exit', function() {
   console.error(`done=${requests_done} sent=${requests_sent}`);
-  assert.strictEqual(requests_done, requests_sent,
-                      `
-                        timeout on http request called too much.
-                        requests_done: ${requests_done},
-                        requests_sent: ${requests_sent}
-                      `
-                    );
+  // check that timeout on http request was not called too much
+  assert.strictEqual(requests_done, requests_sent);
 });

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -92,5 +92,10 @@ server.listen(0, options.host, function() {
 process.on('exit', function() {
   console.error(`done=${requests_done} sent=${requests_sent}`);
   assert.strictEqual(requests_done, requests_sent,
-                     'timeout on http request called too much');
+                      `
+                        timeout on http request called too much.
+                        requests_done: ${requests_done},
+                        requests_sent: ${requests_sent}
+                      `
+                    );
 });


### PR DESCRIPTION
This PR improves debugging output message from [assert.strictEqual()](https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message) function.

The function's 3rd param is a string, meaning  that the values of `requests_done` and `requests_sent` were not being included in the message. But those values are useful for debugging.

So I Changed the string to a template literal that will include those two values.

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
