### PR TITLE
test: use createReadStream instead of ReadStream

### DIFF
--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -35,7 +35,7 @@ const rangeFile = fixtures.path('x.txt');
   let paused = false;
   let bytesRead = 0;
 
-  const file = fs.ReadStream(fn);
+  const file = fs.createReadStream(fn);
   const fileSize = fs.statSync(fn).size;
 
   assert.strictEqual(file.bytesRead, 0);


### PR DESCRIPTION
This commit updates test-fs-read-stream to use fs.createReadStream
instead of using fs.ReadStream. All other places in this test use
the former.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
