### PR TITLE
doc: explain edge case when assigning port to url

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -331,13 +331,13 @@ string using `.toString()`.
 If that string is invalid, but it begins with a number, the leading number is
 assigned to `port`.
 Otherwise, or if the number lies outside the range denoted above,
-it is ignored. 
+it is ignored.
 
 Note that numbers which contain a decimal point,
 such as floating-point numbers or numbers in scientific notation,
 are not an exception to this rule.
 Leading numbers up to the decimal point will be set as the URL's port,
-assuming they are valid. 
+assuming they are valid.
 
 For example:
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -313,7 +313,7 @@ myURL.port = 1234.5678;
 console.log(myURL.port);
 // Prints 1234
 
-// Out-of-range numbers, which are not represented in scientific notation,
+// Out-of-range numbers which are not represented in scientific notation
 // will be ignored.
 myURL.port = 1e10; // 10000000000, will be range-checked as described below
 console.log(myURL.port);
@@ -328,7 +328,7 @@ the empty string (`''`).
 Upon assigning a value to the port, the value will first be converted to a
 string using `.toString()`.
 
-If that string is invalid, but it begins with a number, the leading number is
+If that string is invalid but it begins with a number, the leading number is
 assigned to `port`.
 Otherwise, or if the number lies outside the range denoted above,
 it is ignored.
@@ -337,9 +337,7 @@ Note that numbers which contain a decimal point,
 such as floating-point numbers or numbers in scientific notation,
 are not an exception to this rule.
 Leading numbers up to the decimal point will be set as the URL's port,
-assuming they are valid.
-
-For example:
+assuming they are valid:
 
 ```js
 myURL.port = 4.567e21;

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -313,19 +313,21 @@ myURL.port = 1234.5678;
 console.log(myURL.port);
 // Prints 1234
 
-// Out-of-range numbers are ignored
+// Numbers which are represented in scientific notation in a String,
+// or as very large / small numbers in a Number,
+// will be assigned the first digit of the coefficient,
+// assuming the number is normalized (for example, 0.9e30 => 9e29).
+
+myURL.port = 4.567e21;
+console.log(myURL.port);
+// Prints 4 (because the coefficient is 4.567)
+
+// Out-of-range numbers, which are not represented in scientific noation,
+// will be ignored.
 myURL.port = 1e10;
 console.log(myURL.port);
 // Prints 1234
 
-// Out-of-range numbers, which are converted to exponential 
-// notation via .toString(), will behave as strings with leading zeroes.
-// This means that the port will be assigned the integer part of the coefficient,
-// assuming the number is normalized (for example, 0.9e10 => 9e9).
-// See https://www.ecma-international.org/ecma-262/6.0/#sec-tostring-applied-to-the-number-type for more information
-myURL.port = 4.567e21;
-console.log(myURL.port);
-// Prints 4 (because the coefficient is 4.567)
 ```
 
 The port value may be set as either a number or as a String containing a number

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -317,6 +317,15 @@ console.log(myURL.port);
 myURL.port = 1e10;
 console.log(myURL.port);
 // Prints 1234
+
+// Out-of-range numbers, which are converted to exponential 
+// notation via .toString(), will behave as strings with leading zeroes.
+// This means that the port will be assigned the integer part of the coefficient,
+// assuming the number is normalized (for example, 0.9e10 => 9e9).
+// See https://www.ecma-international.org/ecma-262/6.0/#sec-tostring-applied-to-the-number-type for more information
+myURL.port = 4.567e21;
+console.log(myURL.port);
+// Prints 4 (because the coefficient is 4.567)
 ```
 
 The port value may be set as either a number or as a String containing a number

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -325,16 +325,19 @@ in the range `0` to `65535` (inclusive). Setting the value to the default port
 of the `URL` objects given `protocol` will result in the `port` value becoming
 the empty string (`''`).
 
-Upon assigning a value to the port, the value will first be converted to a string using `.toString()`.
+Upon assigning a value to the port, the value will first be converted to a
+string using `.toString()`.
 
-If that string is invalid, but it begins with a
-number, the leading number is assigned to `port`.  
-Otherwise, or if the number
-lies outside the range denoted above, it is ignored.  
+If that string is invalid, but it begins with a number, the leading number is
+assigned to `port`.
+Otherwise, or if the number lies outside the range denoted above,
+it is ignored. 
 
-Note that numbers which contain a decimal point,  
-such as floating-point numbers or numbers in scientific notation, are not an exception to this rule.  
-Leading numbers up to the decimal point will be set as the URL's port, assuming they are valid. 
+Note that numbers which contain a decimal point,
+such as floating-point numbers or numbers in scientific notation,
+are not an exception to this rule.
+Leading numbers up to the decimal point will be set as the URL's port,
+assuming they are valid. 
 
 For example:
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -315,7 +315,7 @@ console.log(myURL.port);
 
 // Out-of-range numbers, which are not represented in scientific noation,
 // will be ignored.
-myURL.port = 1e10; // 10000000000, will be range-checked
+myURL.port = 1e10; // 10000000000, will be range-checked as described below
 console.log(myURL.port);
 // Prints 1234
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -313,7 +313,7 @@ myURL.port = 1234.5678;
 console.log(myURL.port);
 // Prints 1234
 
-// Out-of-range numbers, which are not represented in scientific noation,
+// Out-of-range numbers, which are not represented in scientific notation,
 // will be ignored.
 myURL.port = 1e10; // 10000000000, will be range-checked as described below
 console.log(myURL.port);

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -313,18 +313,9 @@ myURL.port = 1234.5678;
 console.log(myURL.port);
 // Prints 1234
 
-// Numbers which are represented in scientific notation in a String,
-// or as very large / small numbers in a Number,
-// will be assigned the first digit of the coefficient,
-// assuming the number is normalized (for example, 0.9e30 => 9e29).
-
-myURL.port = 4.567e21;
-console.log(myURL.port);
-// Prints 4 (because the coefficient is 4.567)
-
 // Out-of-range numbers, which are not represented in scientific noation,
 // will be ignored.
-myURL.port = 1e10;
+myURL.port = 1e10; // 10000000000, will be range-checked
 console.log(myURL.port);
 // Prints 1234
 
@@ -335,9 +326,26 @@ in the range `0` to `65535` (inclusive). Setting the value to the default port
 of the `URL` objects given `protocol` will result in the `port` value becoming
 the empty string (`''`).
 
-If an invalid string is assigned to the `port` property, but it begins with a
-number, the leading number is assigned to `port`. Otherwise, or if the number
-lies outside the range denoted above, it is ignored.
+Upon assigning a value to the port, the value will first be converted to a string using `.toString()`.
+
+If that string is invalid, but it begins with a
+number, the leading number is assigned to `port`.  
+Otherwise, or if the number
+lies outside the range denoted above, it is ignored.  
+
+Note that numbers which contain a decimal point,  
+such as floating-point numbers or numbers in scientific notation, are not an exception to this rule.  
+Leading numbers up to the decimal point will be set as the url's port, assuming they are valid. 
+
+For example:
+
+```js
+myURL.port = 4.567e21;
+console.log(myURL.port);
+// Prints 4 (because it is the leading number in the string "4.567e21")
+
+```
+
 
 #### url.protocol
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -318,7 +318,6 @@ console.log(myURL.port);
 myURL.port = 1e10; // 10000000000, will be range-checked as described below
 console.log(myURL.port);
 // Prints 1234
-
 ```
 
 The port value may be set as either a number or as a String containing a number
@@ -335,17 +334,15 @@ lies outside the range denoted above, it is ignored.
 
 Note that numbers which contain a decimal point,  
 such as floating-point numbers or numbers in scientific notation, are not an exception to this rule.  
-Leading numbers up to the decimal point will be set as the url's port, assuming they are valid. 
+Leading numbers up to the decimal point will be set as the URL's port, assuming they are valid. 
 
 For example:
 
 ```js
 myURL.port = 4.567e21;
 console.log(myURL.port);
-// Prints 4 (because it is the leading number in the string "4.567e21")
-
+// Prints 4 (because it is the leading number in the string '4.567e21')
 ```
-
 
 #### url.protocol
 


### PR DESCRIPTION
numbers which are coerced to scientific notation via .toString(),
will behave unexpectedly when assigned to a url's port.

Fixes: https://github.com/nodejs/node/issues/19595

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
