### PR TITLE
doc: guard against md list parsing edge case

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2065,8 +2065,8 @@ properties.
 * `maxConcurrentStreams` {number} Specifies the maximum number of concurrent
   streams permitted on an `Http2Session`. There is no default value which
   implies, at least theoretically, 2<sup>31</sup>-1 streams may be open
-  concurrently at any given time in an `Http2Session`. The minimum value is
-  0. The maximum allowed value is 2<sup>31</sup>-1.
+  concurrently at any given time in an `Http2Session`. The minimum value
+  is 0. The maximum allowed value is 2<sup>31</sup>-1.
 * `maxHeaderListSize` {number} Specifies the maximum size (uncompressed octets)
   of header list that will be accepted. The minimum allowed value is 0. The
   maximum allowed value is 2<sup>32</sup>-1. **Default:** 65535.


### PR DESCRIPTION
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is funny (well, not so funny...) markdown list parsing edge case which erroneously adds a list and by a chance significantly perverts doc content in this situation (replace `0` by `1`).

[GitHub parses it correctly:](https://github.com/nodejs/node/blob/master/doc/api/http2.md#settings-object)

![gh](https://user-images.githubusercontent.com/10393198/38006632-92985b8c-324e-11e8-81ca-5dfae9b51df6.png)

[`marked` plays a nasty trick:](https://nodejs.org/download/nightly/v10.0.0-nightly201803278eca6b8d3d/docs/api/http2.html#http2_settings_object)

![marked](https://user-images.githubusercontent.com/10393198/38006671-bad17c5a-324e-11e8-9768-054bf2085abd.png)

Not sure if we can guard against this proactively.

BTW: detected by chance during [this investigation](https://github.com/markedjs/marked/issues/1179).