### PR TITLE
doc: shorten character encoding introduction

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -149,8 +149,8 @@ changes:
     description: Removed the deprecated `raw` and `raws` encodings.
 -->
 
-A character encoding may be specified when converting between a string and a
-`Buffer`.
+When string data is stored in or extracted out of a `Buffer` instance, a
+character encoding may be specified.
 
 ```js
 const buf = Buffer.from('hello world', 'ascii');
@@ -159,6 +159,11 @@ console.log(buf.toString('hex'));
 // Prints: 68656c6c6f20776f726c64
 console.log(buf.toString('base64'));
 // Prints: aGVsbG8gd29ybGQ=
+
+console.log(Buffer.from('fhqwhgads', 'ascii'));
+// Prints: <Buffer 66 68 71 77 68 67 61 64 73>
+console.log(Buffer.from('fhqwhgads', 'ucs2'));
+// Prints: <Buffer 66 00 68 00 71 00 77 00 68 00 67 00 61 00 64 00 73 00>
 ```
 
 The character encodings currently supported by Node.js include:

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -149,10 +149,8 @@ changes:
     description: Removed the deprecated `raw` and `raws` encodings.
 -->
 
-`Buffer` instances are commonly used to represent sequences of encoded characters
-such as UTF-8, UCS2, Base64, or even Hex-encoded data. It is possible to
-convert back and forth between `Buffer` instances and ordinary JavaScript strings
-by using an explicit character encoding.
+A character encoding may be specified when converting between a string and a
+`Buffer`.
 
 ```js
 const buf = Buffer.from('hello world', 'ascii');


### PR DESCRIPTION
Keep the introduction for Buffers and character encodings short and to
the point. The current introduction doesn't provide much in the way of
useful additional information, but it is a bit confusing in its wording.
("such as" seems like it ought to refer to "encoded characters" but it
actually refers to character encodings, which are not mentioned in the
sentence. It may be arguable as to whether "hex-encoded" is in fact a
character encoding, whether it should be stylized as "Hex-encoded" or
not, and whether it should be spelled out as "Hexadecimal-encoded". None
of that information is particularly useful to the end user at this point
in the text. Omitting it simplifies and improves the documentation.)

Additionally, the section is now wrapped to 80 characters.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
