### PR TITLE
assert: ensure .rejects() disallows sync throws

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -451,8 +451,11 @@ async function waitForActual(block) {
   if (typeof block !== 'function') {
     throw new ERR_INVALID_ARG_TYPE('block', 'Function', block);
   }
+
+  // Return a rejected promise if `block` throws synchronously.
+  const resultPromise = block();
   try {
-    await block();
+    await resultPromise;
   } catch (e) {
     return e;
   }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -13,7 +13,7 @@ common.crashOnUnhandledRejection();
 
 (async () => {
   await assert.rejects(
-    () => assert.fail(),
+    async () => assert.fail(),
     common.expectsError({
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
@@ -56,5 +56,18 @@ common.crashOnUnhandledRejection();
         return true;
       }
     );
+  }
+
+  {
+    const THROWN_ERROR = new Error();
+
+    await assert.rejects(() => {
+      throw THROWN_ERROR;
+    }).then(common.mustNotCall())
+      .catch(
+        common.mustCall((err) => {
+          assert.strictEqual(err, THROWN_ERROR);
+        })
+      );
   }
 })().then(common.mustCall());

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -9,58 +9,52 @@ const wait = promisify(setTimeout);
 // Test assert.rejects() and assert.doesNotReject() by checking their
 // expected output and by verifying that they do not work sync
 
-assert.rejects(
-  () => assert.fail(),
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'Failed'
-  })
-);
+common.crashOnUnhandledRejection();
 
-assert.doesNotReject(() => {});
-
-{
-  const promise = assert.rejects(async () => {
-    await wait(1);
-    assert.fail();
-  }, common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'Failed'
-  }));
-  assert.doesNotReject(() => promise);
-}
-
-{
-  const promise = assert.doesNotReject(async () => {
-    await wait(1);
-    throw new Error();
-  });
-  assert.rejects(() => promise,
-                 (err) => {
-                   assert(err instanceof assert.AssertionError,
-                          `${err.name} is not instance of AssertionError`);
-                   assert.strictEqual(err.code, 'ERR_ASSERTION');
-                   assert(/^Got unwanted rejection\.\n$/.test(err.message));
-                   assert.strictEqual(err.operator, 'doesNotReject');
-                   assert.ok(!err.stack.includes('at Function.doesNotReject'));
-                   return true;
-                 }
+(async () => {
+  await assert.rejects(
+    () => assert.fail(),
+    common.expectsError({
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'Failed'
+    })
   );
-}
 
-{
-  const promise = assert.rejects(() => {});
-  assert.rejects(() => promise,
-                 (err) => {
-                   assert(err instanceof assert.AssertionError,
-                          `${err.name} is not instance of AssertionError`);
-                   assert.strictEqual(err.code, 'ERR_ASSERTION');
-                   assert(/^Missing expected rejection\.$/.test(err.message));
-                   assert.strictEqual(err.operator, 'rejects');
-                   assert.ok(!err.stack.includes('at Function.rejects'));
-                   return true;
-                 }
-  );
-}
+  await assert.doesNotReject(() => {});
+
+  {
+    const promise = assert.doesNotReject(async () => {
+      await wait(1);
+      throw new Error();
+    });
+    await assert.rejects(
+      () => promise,
+      (err) => {
+        assert(err instanceof assert.AssertionError,
+               `${err.name} is not instance of AssertionError`);
+        assert.strictEqual(err.code, 'ERR_ASSERTION');
+        assert(/^Got unwanted rejection\.\n$/.test(err.message));
+        assert.strictEqual(err.operator, 'doesNotReject');
+        assert.ok(!err.stack.includes('at Function.doesNotReject'));
+        return true;
+      }
+    );
+  }
+
+  {
+    const promise = assert.rejects(() => {});
+    await assert.rejects(
+      () => promise,
+      (err) => {
+        assert(err instanceof assert.AssertionError,
+               `${err.name} is not instance of AssertionError`);
+        assert.strictEqual(err.code, 'ERR_ASSERTION');
+        assert(/^Missing expected rejection\.$/.test(err.message));
+        assert.strictEqual(err.operator, 'rejects');
+        assert.ok(!err.stack.includes('at Function.rejects'));
+        return true;
+      }
+    );
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This PR has two commits; the first commit fixes an issue with the `assert` tests, and the second commit fixes https://github.com/nodejs/node/issues/19646.

First commit:

```
test: ensure failed assertions cause build to fail

This updates the test in `test/parallel/test-assert-async.js` to add an
assertion that the Promises used in the test end up fulfilled.
Previously, if an assertion failure occurred, the Promises would have
rejected and a warning would have been logged, but the test would still
have exit code 0.
```

Second commit:

```
assert: ensure .rejects() disallows sync throws

This updates `assert.rejects()` to disallow any errors that are thrown
synchronously from the given function. Previously, throwing an error
would cause the same behavior as returning a rejected Promise.

Fixes: https://github.com/nodejs/node/issues/19646
```

Note that the second commit would be semver-major, but it modifies an API (introduced in https://github.com/nodejs/node/pull/18023) that has not been backported to a release branch yet. As a result, the second commit could be backported as long as it's applied at the same time as https://github.com/nodejs/node/pull/18023.