### PR TITLE
test: remove third argument from call to assert.strictEqual()

### DIFF
--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -62,11 +62,12 @@ server.listen(0, function() {
         break;
 
       default:
+        // Write to a torn down client should RESET or ABORT
         assert.strictEqual(er.code,
-                           'ECONNRESET',
-                           'Write to a torn down client should RESET or ABORT');
+                           'ECONNRESET');
         break;
     }
+
 
     assert.strictEqual(req.output.length, 0);
     assert.strictEqual(req.outputEncodings.length, 0);


### PR DESCRIPTION
Remove the message argument from call to assert.strictEqual so
that the AssertionError will report the value of er.code, and add
a comment with the message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
