### PR TITLE
test: removed default message from assert.strictEqual

### DIFF
--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -34,7 +34,7 @@ const server1ConnHandler = (socket) => {
       assert.fail('data event should not have happened yet');
     }
 
-    assert.strictEqual(data.toString(), msg, 'invalid data received');
+    assert.strictEqual(data.toString(), msg);
     socket.end();
     server1.close();
   });
@@ -46,12 +46,11 @@ const server1 = net.createServer({ pauseOnConnect: true }, server1ConnHandler);
 
 const server2ConnHandler = (socket) => {
   socket.on('data', function(data) {
-    assert.strictEqual(data.toString(), msg, 'invalid data received');
+    assert.strictEqual(data.toString(), msg);
     socket.end();
     server2.close();
 
-    assert.strictEqual(server1Sock.bytesRead, 0,
-                       'no data should have been read yet');
+    assert.strictEqual(server1Sock.bytesRead, 0);
     server1Sock.resume();
     stopped = false;
   });


### PR DESCRIPTION
assert.strictEqual default should include a better output message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
