### PR TITLE
inspector: report client-visible host and port

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -495,12 +495,12 @@ class HttpHandler : public ProtocolHandler {
         CancelHandshake();
         return;
       } else if (!event.upgrade) {
-        delegate()->OnHttpGet(event.path);
+        delegate()->OnHttpGet(event.host, event.path);
       } else if (event.ws_key.empty()) {
         CancelHandshake();
         return;
       } else {
-        delegate()->OnSocketUpgrade(event.path, event.ws_key);
+        delegate()->OnSocketUpgrade(event.host, event.path, event.ws_key);
       }
     }
   }

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -17,8 +17,10 @@ class InspectorSocket {
  public:
   class Delegate {
    public:
-    virtual void OnHttpGet(const std::string& path) = 0;
-    virtual void OnSocketUpgrade(const std::string& path,
+    virtual void OnHttpGet(const std::string& host,
+                           const std::string& path) = 0;
+    virtual void OnSocketUpgrade(const std::string& host,
+                                 const std::string& path,
                                  const std::string& accept_key) = 0;
     virtual void OnWsFrame(const std::vector<char>& frame) = 0;
     virtual ~Delegate() {}

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -67,7 +67,8 @@ class InspectorSocketServer {
 
   // Session connection lifecycle
   void Accept(int server_port, uv_stream_t* server_socket);
-  bool HandleGetRequest(int session_id, const std::string& path);
+  bool HandleGetRequest(int session_id, const std::string& host,
+                        const std::string& path);
   void SessionStarted(int session_id, const std::string& target_id,
                       const std::string& ws_id);
   void SessionTerminated(int session_id);
@@ -77,7 +78,8 @@ class InspectorSocketServer {
   SocketSession* Session(int session_id);
 
  private:
-  void SendListResponse(InspectorSocket* socket, SocketSession* session);
+  void SendListResponse(InspectorSocket* socket, const std::string& host,
+                        SocketSession* session);
   bool TargetExists(const std::string& id);
 
   enum class ServerState {kNew, kRunning, kStopping, kStopped};

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -112,11 +112,11 @@ class TestInspectorDelegate : public InspectorSocket::Delegate {
     delegate = nullptr;
   }
 
-  void OnHttpGet(const std::string& path) override {
+  void OnHttpGet(const std::string& host, const std::string& path) override {
     process(kInspectorHandshakeHttpGet, path);
   }
 
-  void OnSocketUpgrade(const std::string& path,
+  void OnSocketUpgrade(const std::string& host, const std::string& path,
                        const std::string& ws_key) override {
     ws_key_ = ws_key;
     process(kInspectorHandshakeUpgraded, path);

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -365,10 +365,11 @@ class NodeInstance {
     }
   }
 
-  httpGet(host, path) {
+  httpGet(host, path, hostHeaderValue) {
     console.log('[test]', `Testing ${path}`);
+    const headers = hostHeaderValue ? { 'Host': hostHeaderValue } : null;
     return this.portPromise.then((port) => new Promise((resolve, reject) => {
-      const req = http.get({ host, port, path }, (res) => {
+      const req = http.get({ host, port, path, headers }, (res) => {
         let response = '';
         res.setEncoding('utf8');
         res

--- a/test/parallel/test-inspector-reported-host.js
+++ b/test/parallel/test-inspector-reported-host.js
@@ -1,0 +1,22 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { NodeInstance } = require('../common/inspector-helper.js');
+
+common.crashOnUnhandledRejection();
+
+async function test() {
+  const madeUpHost = '111.111.111.111:11111';
+  const child = new NodeInstance(undefined, 'var a = 1');
+  const response = await child.httpGet(null, '/json', madeUpHost);
+  assert.ok(
+    response[0].webSocketDebuggerUrl.startsWith(`ws://${madeUpHost}`),
+    response[0].webSocketDebuggerUrl);
+  child.kill();
+}
+
+test();

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -11,8 +11,9 @@ function checkListResponse(response) {
   assert.strictEqual(1, response.length);
   assert.ok(response[0].devtoolsFrontendUrl);
   assert.ok(
-    /ws:\/\/127\.0\.0\.1:\d+\/[0-9A-Fa-f]{8}-/
-      .test(response[0].webSocketDebuggerUrl));
+    /ws:\/\/localhost:\d+\/[0-9A-Fa-f]{8}-/
+      .test(response[0].webSocketDebuggerUrl),
+    response[0].webSocketDebuggerUrl);
 }
 
 function checkVersion(response) {


### PR DESCRIPTION
Node instance may not know the real host and port user sees when
debug frontend connects through the SSH tunnel. This change fixes
'/json/list' response by using the value client provided in the host
header.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
