### PR TITLE
build: add support for IBM i platform

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -94,8 +94,17 @@
             'msvs_configuration_platform': 'x64',
           }],
           ['OS=="aix"', {
+            'variables': {'real_os_name': '<!(uname -s)',},
             'cflags': [ '-gxcoff' ],
             'ldflags': [ '-Wl,-bbigtoc' ],
+            'conditions': [
+              ['"<(real_os_name)"=="OS400"', {
+                'ldflags': [
+                  '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib',
+                  '-Wl,-brtl',
+                ],
+              }],
+            ],
           }],
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
@@ -345,6 +354,7 @@
             'ldflags!': [ '-pthread' ],
           }],
           [ 'OS=="aix"', {
+            'variables': {'real_os_name': '<!(uname -s)',},
             'conditions': [
               [ 'target_arch=="ppc"', {
                 'ldflags': [ '-Wl,-bmaxdata:0x60000000/dsa' ],
@@ -352,6 +362,12 @@
               [ 'target_arch=="ppc64"', {
                 'cflags': [ '-maix64' ],
                 'ldflags': [ '-maix64' ],
+              }],
+              ['"<(real_os_name)"=="OS400"', {
+                'ldflags': [
+                  '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib',
+                  '-Wl,-brtl',
+                ],
               }],
             ],
             'ldflags': [ '-Wl,-bbigtoc' ],

--- a/node.gyp
+++ b/node.gyp
@@ -967,6 +967,7 @@
 
   'conditions': [
     [ 'OS=="aix" and node_shared=="true"', {
+      'variables': {'real_os_name': '<!(uname -s)',},
       'targets': [
         {
           'target_name': 'node_aix_shared',
@@ -985,7 +986,14 @@
               'ldflags': [
                 '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread'
               ],
-            }]
+            }],
+            ['"<(real_os_name)"=="OS400"', {
+              'ldflags': [
+                '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib',
+                '-Wl,-bbigtoc',
+                '-Wl,-brtl',
+              ],
+            }],
           ],
           'includes': [
             'node.gypi'


### PR DESCRIPTION
This pull request proposes some minor changes to support builds on the IBM i platform. 

Let me offer some background that (I hope) will help you make sense of these small changes. 
- On IBM i, we enable a bulk of our open source technologies in an environment called the Portable Application Solution Environment (PASE).
- PASE is an AIX-derived runtime. As such, many (but not all) AIX-capable applications and tools can run under the belief that they are running AIX. 
- The build environment on IBM i is a little different from AIX in that runtime linking is needed for most open source technologies, and an explicit libpath helps avoid conflicts with software that can exist outside the PASE environment. 
- The GYP build system thinks it's running AIX, but we can check for IBM i by querying uname output for "OS400" (legacy name of ancestor OS).

We added support to libuv in a similar manner. For reference: https://github.com/libuv/libuv/blob/edf05b97f03472def2837ceb2d6bf61a0d0dc248/uv.gyp#L296

In future work, I'd like to add IBM i as a supported platform, and will contribute relevant documentation at that point. 

Thank you for consideration. 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
