### PR TITLE
test: make test-http-expect-continue more strict

### DIFF
--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -39,7 +39,7 @@ const handler = common.mustCall((req, res) => {
   res.end(test_res_body);
 });
 
-const server = http.createServer();
+const server = http.createServer(common.mustNotCall());
 server.on('checkContinue', common.mustCall((req, res) => {
   console.error('Server got Expect: 100-continue...');
   res.writeContinue();


### PR DESCRIPTION
In test-http-expect-continue, verify that the request listener is not
called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
