### PR TITLE
vm: remove MISSING_ARGS error code

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -123,10 +123,6 @@ function getContextOptions(options) {
 }
 
 function isContext(sandbox) {
-  if (arguments.length < 1) {
-    throw new ERR_MISSING_ARGS('sandbox');
-  }
-
   if (typeof sandbox !== 'object' && typeof sandbox !== 'function' ||
       sandbox === null) {
     throw new ERR_INVALID_ARG_TYPE('sandbox', 'object', sandbox);

--- a/test/parallel/test-vm-is-context.js
+++ b/test/parallel/test-vm-is-context.js
@@ -38,7 +38,7 @@ for (const valToTest of [
 common.expectsError(() => {
   vm.isContext();
 }, {
-  code: 'ERR_MISSING_ARGS',
+  code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError
 });
 


### PR DESCRIPTION
The documentation states:

> This is only used for strict compliance with the API specification
> (which in some cases may accept func(undefined) but not func()). In
> most native Node.js APIs, func(undefined) and func() are treated
> identically, and the ERR_INVALID_ARG_TYPE error code may be used
> instead.

Refs: https://github.com/nodejs/node/pull/19268#discussion_r173612193

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
