### PR TITLE
timers: enable timers to be used as primitives

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -92,12 +92,12 @@ Returns a reference to the `Timeout`.
 
 ### timeout[Symbol.toPrimitive]()
 
+* Returns: {integer}
+
 When coercing a `Timeout` to a primitive, a primitive will be generated that
 can be used with the appropriate function that can be used to clear the
 `Timeout`. This allows enhanced compatibility with browser `setTimeout`, and
 `setInterval` implementations.
-
-Returns a `number`.
 
 ## Scheduling Timers
 

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -90,6 +90,12 @@ of the Node.js application.
 
 Returns a reference to the `Timeout`.
 
+### timeout[Symbol.toPrimitive]()
+
+When coercing a `Timeout` to a primitive, a primitive will be generated that can be used with the appropriate function that can be used to clear the `Timeout`. This allows enhanced compatibility with browser `setTimeout`, and `setInterval` implementations.
+
+Returns a `number`.
+
 ## Scheduling Timers
 
 A timer in Node.js is an internal construct that calls a given function after

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -92,7 +92,10 @@ Returns a reference to the `Timeout`.
 
 ### timeout[Symbol.toPrimitive]()
 
-When coercing a `Timeout` to a primitive, a primitive will be generated that can be used with the appropriate function that can be used to clear the `Timeout`. This allows enhanced compatibility with browser `setTimeout`, and `setInterval` implementations.
+When coercing a `Timeout` to a primitive, a primitive will be generated that
+can be used with the appropriate function that can be used to clear the
+`Timeout`. This allows enhanced compatibility with browser `setTimeout`, and
+`setInterval` implementations.
 
 Returns a `number`.
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -539,7 +539,15 @@ function unrefdHandle(timer, now) {
 
 Timeout.prototype[Symbol.toPrimitive] = function() {
   const id = this[async_id_symbol];
-  KNOWN_TIMERS[id] = this;
+  if (id in KNOWN_TIMERS !== true) {
+    KNOWN_TIMERS[id] = this;
+    const $close = this.close;
+    this.close = function () {
+      delete KNOWN_TIMERS[this[async_id_symbol]];
+      this.close = $close;
+      this.close();
+    }
+  }
   return id;
 };
 
@@ -579,9 +587,6 @@ Timeout.prototype.ref = function() {
 
 Timeout.prototype.close = function() {
   this._onTimeout = null;
-  if (typeof this[async_id_symbol] === 'number') {
-    delete KNOWN_TIMERS[this[async_id_symbol]];
-  }
   if (this._handle) {
     if (destroyHooksExist() &&
         typeof this[async_id_symbol] === 'number' &&

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -504,7 +504,7 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   return timeout;
 };
 
-exports.clearInterval = function(timer) {
+const clearInterval = exports.clearInterval = function(timer) {
   if (typeof timer === 'number' || typeof timer === 'string') {
     if (timer in KNOWN_TIMERS) {
       clearInterval(KNOWN_TIMERS[timer]);

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -504,12 +504,11 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   return timeout;
 };
 
-const clearInterval = exports.clearInterval = function(timer) {
+exports.clearInterval = function(timer) {
   if (typeof timer === 'number' || typeof timer === 'string') {
     if (timer in KNOWN_TIMERS) {
       timer = KNOWN_TIMERS[timer];
-    }
-    else {
+    } else {
       return;
     }
   }
@@ -542,11 +541,11 @@ Timeout.prototype[Symbol.toPrimitive] = function() {
   if (id in KNOWN_TIMERS !== true) {
     KNOWN_TIMERS[id] = this;
     const $close = this.close;
-    this.close = function () {
+    this.close = function() {
       delete KNOWN_TIMERS[this[async_id_symbol]];
       this.close = $close;
       this.close();
-    }
+    };
   }
   return id;
 };

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -147,7 +147,6 @@ const unrefedLists = Object.create(null);
 
 const KNOWN_TIMERS = Object.create(null);
 
-
 // Schedule or re-schedule a timer.
 // The item must have been enroll()'d first.
 const active = exports.active = function(item) {
@@ -457,9 +456,10 @@ function rearm(timer, start = TimerWrap.now()) {
 const clearTimeout = exports.clearTimeout = function(timer) {
   if (typeof timer === 'number' || typeof timer === 'string') {
     if (timer in KNOWN_TIMERS) {
-      clearTimeout(KNOWN_TIMERS[timer]);
+      timer = KNOWN_TIMERS[timer];
+    } else {
+      return;
     }
-    return;
   }
   if (timer && timer._onTimeout) {
     timer._onTimeout = null;
@@ -507,9 +507,11 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
 const clearInterval = exports.clearInterval = function(timer) {
   if (typeof timer === 'number' || typeof timer === 'string') {
     if (timer in KNOWN_TIMERS) {
-      clearInterval(KNOWN_TIMERS[timer]);
+      timer = KNOWN_TIMERS[timer];
     }
-    return;
+    else {
+      return;
+    }
   }
   if (timer && timer._repeat) {
     timer._repeat = null;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -145,10 +145,13 @@ const kRefed = Symbol('refed');
 const refedLists = Object.create(null);
 const unrefedLists = Object.create(null);
 
+const KNOWN_TIMERS = Object.create(null);
+
 
 // Schedule or re-schedule a timer.
 // The item must have been enroll()'d first.
 const active = exports.active = function(item) {
+  KNOWN_TIMERS[item[async_id_symbol]] = item;
   insert(item, false);
 };
 
@@ -453,6 +456,12 @@ function rearm(timer, start = TimerWrap.now()) {
 
 
 const clearTimeout = exports.clearTimeout = function(timer) {
+  if (typeof timer === 'number' || typeof timer === 'string') {
+    if (timer in KNOWN_TIMERS) {
+      clearTimeout(KNOWN_TIMERS[timer]);
+    }
+    return;
+  }
   if (timer && timer._onTimeout) {
     timer._onTimeout = null;
     if (timer instanceof Timeout) {
@@ -497,6 +506,12 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
 };
 
 exports.clearInterval = function(timer) {
+  if (typeof timer === 'number' || typeof timer === 'string') {
+    if (timer in KNOWN_TIMERS) {
+      clearInterval(KNOWN_TIMERS[timer]);
+    }
+    return;
+  }
   if (timer && timer._repeat) {
     timer._repeat = null;
     clearTimeout(timer);
@@ -521,6 +536,9 @@ function unrefdHandle(timer, now) {
   return true;
 }
 
+Timeout.prototype[Symbol.toPrimitive] = function() {
+  return this[async_id_symbol];
+};
 
 Timeout.prototype.unref = function() {
   if (this._handle) {
@@ -558,6 +576,9 @@ Timeout.prototype.ref = function() {
 
 Timeout.prototype.close = function() {
   this._onTimeout = null;
+  if (typeof this[async_id_symbol] === 'number') {
+    delete KNOWN_TIMERS[this[async_id_symbol]];
+  }
   if (this._handle) {
     if (destroyHooksExist() &&
         typeof this[async_id_symbol] === 'number' &&

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -151,7 +151,6 @@ const KNOWN_TIMERS = Object.create(null);
 // Schedule or re-schedule a timer.
 // The item must have been enroll()'d first.
 const active = exports.active = function(item) {
-  KNOWN_TIMERS[item[async_id_symbol]] = item;
   insert(item, false);
 };
 
@@ -537,7 +536,9 @@ function unrefdHandle(timer, now) {
 }
 
 Timeout.prototype[Symbol.toPrimitive] = function() {
-  return this[async_id_symbol];
+  const id = this[async_id_symbol];
+  KNOWN_TIMERS[id] = this;
+  return id;
 };
 
 Timeout.prototype.unref = function() {

--- a/test/parallel/test-timers-toPrimitive.js
+++ b/test/parallel/test-timers-toPrimitive.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const timeout1 = setTimeout(common.mustNotCall(), 0);
+const timeout2 = setInterval(common.mustNotCall(), 0);
+
+assert.strictEqual(Number.isNaN(+timeout1), false);
+assert.strictEqual(Number.isNaN(+timeout2), false);
+
+assert.notStrictEqual(`${timeout1}`, Object.prototype.toString.call(timeout1));
+assert.notStrictEqual(`${timeout2}`, Object.prototype.toString.call(timeout2));
+
+assert.notStrictEqual(+timeout1, +timeout2);
+
+const o = {};
+o[timeout1] = timeout1;
+o[timeout2] = timeout2;
+const keys = Object.keys(o);
+assert.deepStrictEqual(keys, [`${timeout1}`, `${timeout2}`]);
+
+clearTimeout(keys[0]);
+clearInterval(keys[1]);


### PR DESCRIPTION
For web compatibility this allows timers to be stored as the key
of an Object property and be passed back to corresponding method to
clear the timer.

Note that this is using the `async_id_symbol` to get a numeric ID to correspond with timers.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
