### PR TITLE
doc: remove ES6/ECMAScript 2015 from buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -273,7 +273,7 @@ function:
 * [`Buffer.from(arrayBuffer[, byteOffset [, length]])`][`Buffer.from(arrayBuffer)`]
 * [`Buffer.from(string[, encoding])`][`Buffer.from(string)`]
 
-## Buffers and ES6 iteration
+## Buffers and iteration
 
 `Buffer` instances can be iterated over using `for..of` syntax:
 


### PR DESCRIPTION
As the introduction of ES6 features recedes further into the past, it is
less and less relevant (and more and more distracting) to cite it in
documentation text. Remove mention in buffer.md.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
