### PR TITLE
buffer: remove "new" from deprecation message

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -142,7 +142,7 @@ function alignPool() {
 var bufferWarn = true;
 const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'recommended for use due to security and usability ' +
-                      'concerns. Please use the new Buffer.alloc(), ' +
+                      'concerns. Please use the Buffer.alloc(), ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
 

--- a/test/parallel/test-buffer-pending-deprecation.js
+++ b/test/parallel/test-buffer-pending-deprecation.js
@@ -5,7 +5,7 @@ const common = require('../common');
 
 const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'recommended for use due to security and usability ' +
-                      'concerns. Please use the new Buffer.alloc(), ' +
+                      'concerns. Please use the Buffer.alloc(), ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
 


### PR DESCRIPTION
This change removes "new" as a description for `Buffer` construction
methods. They are arguably not "new" anymore and they certainly won't be
"new" anymore at some point.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
