### PR TITLE
doc: do not identify string as "JavaScript string"

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -464,8 +464,8 @@ changes:
 * `string` {string} String to encode.
 * `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
-Creates a new `Buffer` containing the given JavaScript string `string`. If
-provided, the `encoding` parameter identifies the character encoding of `string`.
+Creates a new `Buffer` containing `string`. If provided, the `encoding`
+parameter identifies the character encoding of `string`.
 
 ```js
 const buf1 = new Buffer('this is a tést');
@@ -850,8 +850,8 @@ added: v5.10.0
 * `string` {string} A string to encode.
 * `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
-Creates a new `Buffer` containing the given JavaScript string `string`. If
-provided, the `encoding` parameter identifies the character encoding of `string`.
+Creates a new `Buffer` containing `string`. If provided, the `encoding`
+parameter identifies the character encoding of `string`.
 
 ```js
 const buf1 = Buffer.from('this is a tést');


### PR DESCRIPTION
A parameter that is explicitly identified as a string does not need to
be further specified in the text as a "JavaScript string". Remove the
type altogether as it is indicated in the argument description.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
