### PR TITLE
doc: remove "if provided" for optional arguments

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -461,8 +461,8 @@ changes:
 * `string` {string} String to encode.
 * `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
-Creates a new `Buffer` containing `string`. If provided, the `encoding`
-parameter identifies the character encoding of `string`.
+Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+the character encoding of `string`.
 
 ```js
 const buf1 = new Buffer('this is a tést');
@@ -847,8 +847,8 @@ added: v5.10.0
 * `string` {string} A string to encode.
 * `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
-Creates a new `Buffer` containing `string`. If provided, the `encoding`
-parameter identifies the character encoding of `string`.
+Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+the character encoding of `string`.
 
 ```js
 const buf1 = Buffer.from('this is a tést');


### PR DESCRIPTION
Remove "if provided" when discussing arguments that are explicitly
indicated to be optional and have default values.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
