### PR TITLE
buffer: add {read|write}Big[U]Int64{BE|LE} methods

### DIFF
--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -2,6 +2,10 @@
 const common = require('../common.js');
 
 const types = [
+  'BigUInt64LE',
+  'BigUInt64BE',
+  'BigInt64LE',
+  'BigInt64BE',
   'UInt8',
   'UInt16LE',
   'UInt16BE',

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -2,6 +2,10 @@
 const common = require('../common.js');
 
 const types = [
+  'BigUInt64LE',
+  'BigUInt64BE',
+  'BigInt64LE',
+  'BigInt64BE',
   'UInt8',
   'UInt16LE',
   'UInt16BE',
@@ -32,11 +36,17 @@ const INT8 = 0x7f;
 const INT16 = 0x7fff;
 const INT32 = 0x7fffffff;
 const INT48 = 0x7fffffffffff;
+const INT64 = 0x7fffffffffffffffn;
 const UINT8 = 0xff;
 const UINT16 = 0xffff;
 const UINT32 = 0xffffffff;
+const UINT64 = 0xffffffffffffffffn;
 
 const mod = {
+  writeBigInt64BE: INT64,
+  writeBigInt64LE: INT64,
+  writeBigUInt64BE: UINT64,
+  writeBigUInt64LE: UINT64,
   writeInt8: INT8,
   writeInt16BE: INT16,
   writeInt16LE: INT16,
@@ -67,10 +77,21 @@ function main({ n, buf, type }) {
 
   if (!/\d/.test(fn))
     benchSpecialInt(buff, fn, n);
+  else if (/BigU?Int/.test(fn))
+    benchBigInt(buff, fn, BigInt(n));
   else if (/Int/.test(fn))
     benchInt(buff, fn, n);
   else
     benchFloat(buff, fn, n);
+}
+
+function benchBigInt(buff, fn, n) {
+  const m = mod[fn];
+  bench.start();
+  for (var i = 0n; i !== n; i++) {
+    buff[fn](i & m, 0);
+  }
+  bench.end(Number(n));
 }
 
 function benchInt(buff, fn, n) {

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2233,10 +2233,10 @@ endian).
 ```js
 const buf = Buffer.allocUnsafe(8);
 
-buf.writeBigUInt64LE(0xffffffffffffn, 0);
+buf.writeBigUInt64LE(0xdecafafecacefaden, 0);
 
 console.log(buf);
-// Prints: <Buffer ff ff ff ff ff ff 00 00>
+// Prints: <Buffer de fa ce ca fe fa ca de>
 ```
 
 ### buf.writeDoubleBE(value[, offset])

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1553,7 +1553,7 @@ added: REPLACEME
 -->
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
-  satisfy: `0 <= offset <= buf.length - 8`.
+  satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
 Reads a signed 64-bit integer from `buf` at the specified `offset` with
@@ -1569,7 +1569,7 @@ added: REPLACEME
 -->
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
-  satisfy: `0 <= offset <= buf.length - 8`.
+  satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
 Reads an unsigned 64-bit integer from `buf` at the specified `offset` with
@@ -2197,7 +2197,7 @@ added: REPLACEME
 
 * `value` {bigint} Number to be written to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write. Must
-  satisfy: `0 <= offset <= buf.length - 8`.
+  satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {integer} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2223,7 +2223,7 @@ added: REPLACEME
 
 * `value` {bigint} Number to be written to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write. Must
-  satisfy: `0 <= offset <= buf.length - 8`.
+  satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {integer} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` with specified endian

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2227,8 +2227,8 @@ added: REPLACEME
 * Returns: {integer} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` with specified endian
-format (`writeBigUInt64BE()` writes big endian, `writeBigUInt64LE()` writes little
-endian).
+format (`writeBigUInt64BE()` writes big endian, `writeBigUInt64LE()` writes
+little endian).
 
 ```js
 const buf = Buffer.allocUnsafe(8);

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1558,7 +1558,7 @@ added: REPLACEME
 
 Reads a signed 64-bit integer from `buf` at the specified `offset` with
 the specified endian format (`readBigInt64BE()` returns big endian,
-`readBigInt64LE()` return little endian).
+`readBigInt64LE()` returns little endian).
 
 Integers read from a `Buffer` are interpreted as two's complement signed values.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1546,6 +1546,46 @@ deprecated: v8.0.0
 
 The `buf.parent` property is a deprecated alias for `buf.buffer`.
 
+### buf.readBigInt64BE([offset])
+### buf.readBigInt64LE([offset])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `offset` {integer} Number of bytes to skip before starting to read. Must
+  satisfy: `0 <= offset <= buf.length - 8`.
+* Returns: {bigint}
+
+Reads a signed 64-bit integer from `buf` at the specified `offset` with
+the specified endian format (`readBigInt64BE()` returns big endian,
+`readBigInt64LE()` return little endian).
+
+Integers read from a `Buffer` are interpreted as two's complement signed values.
+
+### buf.readBigUInt64BE([offset])
+### buf.readBigUInt64LE([offset])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `offset` {integer} Number of bytes to skip before starting to read. Must
+  satisfy: `0 <= offset <= buf.length - 8`.
+* Returns: {bigint}
+
+Reads an unsigned 64-bit integer from `buf` at the specified `offset` with
+specified endian format (`readBigUInt64BE()` returns big endian,
+`readBigUInt64LE()` returns little endian).
+
+```js
+const buf = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+
+console.log(buf.readBigUInt64BE(0));
+// Prints: 4294967295n
+
+console.log(buf.readBigUInt64LE(0));
+// Prints: 18446744069414584320n
+```
+
 ### buf.readDoubleBE([offset])
 ### buf.readDoubleLE([offset])
 <!-- YAML
@@ -2147,6 +2187,56 @@ const len = buf.write('\u00bd + \u00bc = \u00be', 0);
 
 console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
 // Prints: 12 bytes: ½ + ¼ = ¾
+```
+
+### buf.writeBigInt64BE(value[, offset])
+### buf.writeBigInt64LE(value[, offset])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `value` {bigint} Number to be written to `buf`.
+* `offset` {integer} Number of bytes to skip before starting to write. Must
+  satisfy: `0 <= offset <= buf.length - 8`.
+* Returns: {integer} `offset` plus the number of bytes written.
+
+Writes `value` to `buf` at the specified `offset` with specified endian
+format (`writeBigInt64BE()` writes big endian, `writeBigInt64LE()` writes little
+endian).
+
+`value` is interpreted and written as a two's complement signed integer.
+
+```js
+const buf = Buffer.allocUnsafe(8);
+
+buf.writeBigInt64BE(0x0102030405060708n, 0);
+
+console.log(buf);
+// Prints: <Buffer 01 02 03 04 05 06 07 08>
+```
+
+### buf.writeBigUInt64BE(value[, offset])
+### buf.writeBigUInt64LE(value[, offset])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `value` {bigint} Number to be written to `buf`.
+* `offset` {integer} Number of bytes to skip before starting to write. Must
+  satisfy: `0 <= offset <= buf.length - 8`.
+* Returns: {integer} `offset` plus the number of bytes written.
+
+Writes `value` to `buf` at the specified `offset` with specified endian
+format (`writeBigUInt64BE()` writes big endian, `writeBigUInt64LE()` writes little
+endian).
+
+```js
+const buf = Buffer.allocUnsafe(8);
+
+buf.writeBigUInt64LE(0xffffffffffffn, 0);
+
+console.log(buf);
+// Prints: <Buffer ff ff ff ff ff ff 00 00>
 ```
 
 ### buf.writeDoubleBE(value[, offset])

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -547,21 +547,22 @@ function writeBigU_Int64LE(buf, value, offset, min, max) {
   // TODO: perform any conversions on value?
   checkInt(value, min, max, buf, offset, 7);
 
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset++] = Number(value & 0xffn);
+  let lo = Number(value & 0xffffffffn);
+  buf[offset++] = lo;
+  lo = lo >> 8;
+  buf[offset++] = lo;
+  lo = lo >> 8;
+  buf[offset++] = lo;
+  lo = lo >> 8;
+  buf[offset++] = lo;
+  let hi = Number(value >> 32n & 0xffffffffn);
+  buf[offset++] = hi;
+  hi = hi >> 8;
+  buf[offset++] = hi;
+  hi = hi >> 8;
+  buf[offset++] = hi;
+  hi = hi >> 8;
+  buf[offset++] = hi;
   return offset;
 }
 
@@ -573,21 +574,22 @@ function writeBigU_Int64BE(buf, value, offset, min, max) {
   // TODO: perform any conversions on value?
   checkInt(value, min, max, buf, offset, 7);
 
-  buf[offset + 7] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 6] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 5] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 4] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 3] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 2] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset + 1] = Number(value & 0xffn);
-  value = value >> 8n;
-  buf[offset] = Number(value & 0xffn);
+  let lo = Number(value & 0xffffffffn);
+  buf[offset + 7] = lo;
+  lo = lo >> 8;
+  buf[offset + 6] = lo;
+  lo = lo >> 8;
+  buf[offset + 5] = lo;
+  lo = lo >> 8;
+  buf[offset + 4] = lo;
+  let hi = Number(value >> 32n & 0xffffffffn);
+  buf[offset + 3] = hi;
+  hi = hi >> 8;
+  buf[offset + 2] = hi;
+  hi = hi >> 8;
+  buf[offset + 1] = hi;
+  hi = hi >> 8;
+  buf[offset] = hi;
   return offset + 8;
 }
 

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -63,7 +63,7 @@ function boundsError(value, length, type) {
 }
 
 // Read integers.
-function readBigUInt64LE(offset) {
+function readBigUInt64LE(offset = 0) {
   validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
@@ -83,7 +83,7 @@ function readBigUInt64LE(offset) {
   return BigInt(lo) + (BigInt(hi) << 32n);
 }
 
-function readBigUInt64BE(offset) {
+function readBigUInt64BE(offset = 0) {
   validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
@@ -103,7 +103,7 @@ function readBigUInt64BE(offset) {
   return (BigInt(hi) << 32n) + BigInt(lo);
 }
 
-function readBigInt64LE(offset) {
+function readBigInt64LE(offset = 0) {
   validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
@@ -121,7 +121,7 @@ function readBigInt64LE(offset) {
     this[++offset] * 2 ** 24);
 }
 
-function readBigInt64BE(offset) {
+function readBigInt64BE(offset = 0) {
   validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
@@ -571,7 +571,7 @@ function writeBigU_Int64LE(buf, value, offset, min, max) {
   return offset;
 }
 
-function writeBigUInt64LE(value, offset) {
+function writeBigUInt64LE(value, offset = 0) {
   return writeBigU_Int64LE(this, value, offset, 0n, 0xffffffffffffffffn);
 }
 
@@ -597,16 +597,16 @@ function writeBigU_Int64BE(buf, value, offset, min, max) {
   return offset + 8;
 }
 
-function writeBigUInt64BE(value, offset) {
+function writeBigUInt64BE(value, offset = 0) {
   return writeBigU_Int64BE(this, value, offset, 0n, 0xffffffffffffffffn);
 }
 
-function writeBigInt64LE(value, offset) {
+function writeBigInt64LE(value, offset = 0) {
   return writeBigU_Int64LE(
     this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
 }
 
-function writeBigInt64BE(value, offset) {
+function writeBigInt64BE(value, offset = 0) {
   return writeBigU_Int64BE(
     this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
 }

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -64,7 +64,7 @@ function boundsError(value, length, type) {
 
 // Read integers.
 function readBigUInt64LE(offset) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -84,7 +84,7 @@ function readBigUInt64LE(offset) {
 }
 
 function readBigUInt64BE(offset) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -104,7 +104,7 @@ function readBigUInt64BE(offset) {
 }
 
 function readBigInt64LE(offset) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -122,7 +122,7 @@ function readBigInt64LE(offset) {
 }
 
 function readBigInt64BE(offset) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -928,6 +928,7 @@ function writeFloatBackwards(val, offset = 0) {
 class FastBuffer extends Uint8Array {}
 
 function addBufferPrototypeMethods(proto) {
+  proto.readBigUInt64LE = readBigUInt64LE,
   proto.readBigUInt64BE = readBigUInt64BE,
   proto.readBigInt64LE = readBigInt64LE,
   proto.readBigInt64BE = readBigInt64BE,

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -70,14 +70,17 @@ function readBigUInt64LE(offset) {
   if (first === undefined || last === undefined)
     boundsError(offset, this.length - 8);
 
-  return BigInt(first +
+  const lo = first +
     this[++offset] * 2 ** 8 +
     this[++offset] * 2 ** 16 +
-    this[++offset] * 2 ** 24) +
-    (BigInt(this[++offset] +
+    this[++offset] * 2 ** 24;
+
+  const hi = this[++offset] +
     this[++offset] * 2 ** 8 +
     this[++offset] * 2 ** 16 +
-    last * 2 ** 24) << 32n);
+    last * 2 ** 24;
+
+  return BigInt(lo) + (BigInt(hi) << 32n);
 }
 
 function readBigUInt64BE(offset) {
@@ -87,14 +90,17 @@ function readBigUInt64BE(offset) {
   if (first === undefined || last === undefined)
     boundsError(offset, this.length - 8);
 
-  return (BigInt(first * 2 ** 24 +
+  const hi = first * 2 ** 24 +
     this[++offset] * 2 ** 16 +
     this[++offset] * 2 ** 8 +
-    this[++offset]) << 32n) +
-    BigInt(this[++offset] * 2 ** 24 +
+    this[++offset];
+
+  const lo = this[++offset] * 2 ** 24 +
     this[++offset] * 2 ** 16 +
     this[++offset] * 2 ** 8 +
-    last);
+    last;
+
+  return (BigInt(hi) << 32n) + BigInt(lo);
 }
 
 function readBigInt64LE(offset) {

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -550,7 +550,6 @@ function readDoubleForwards(offset = 0) {
 
 // Write integers.
 function writeBigU_Int64LE(buf, value, offset, min, max) {
-  // TODO: perform any conversions on value?
   checkInt(value, min, max, buf, offset, 7);
 
   let lo = Number(value & 0xffffffffn);
@@ -577,7 +576,6 @@ function writeBigUInt64LE(value, offset) {
 }
 
 function writeBigU_Int64BE(buf, value, offset, min, max) {
-  // TODO: perform any conversions on value?
   checkInt(value, min, max, buf, offset, 7);
 
   let lo = Number(value & 0xffffffffn);

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -596,11 +596,13 @@ function writeBigUInt64BE(value, offset) {
 }
 
 function writeBigInt64LE(value, offset) {
-  return writeBigU_Int64LE(this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
+  return writeBigU_Int64LE(
+    this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
 }
 
 function writeBigInt64BE(value, offset) {
-  return writeBigU_Int64BE(this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
+  return writeBigU_Int64BE(
+    this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
 }
 
 function writeUIntLE(value, offset, byteLength) {

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -63,6 +63,76 @@ function boundsError(value, length, type) {
 }
 
 // Read integers.
+function readBigUInt64LE(offset) {
+  checkNumberType(offset);
+  const first = this[offset];
+  const last = this[offset + 7];
+  if (first === undefined || last === undefined)
+    boundsError(offset, this.length - 8);
+
+  return BigInt(first +
+    this[++offset] * 2 ** 8 +
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 24) +
+    (BigInt(this[++offset] +
+    this[++offset] * 2 ** 8 +
+    this[++offset] * 2 ** 16 +
+    last * 2 ** 24) << 32n);
+}
+
+function readBigUInt64BE(offset) {
+  checkNumberType(offset);
+  const first = this[offset];
+  const last = this[offset + 7];
+  if (first === undefined || last === undefined)
+    boundsError(offset, this.length - 8);
+
+  return (BigInt(first * 2 ** 24 +
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 8 +
+    this[++offset]) << 32n) +
+    BigInt(this[++offset] * 2 ** 24 +
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 8 +
+    last);
+}
+
+function readBigInt64LE(offset) {
+  checkNumberType(offset);
+  const first = this[offset];
+  const last = this[offset + 7];
+  if (first === undefined || last === undefined)
+    boundsError(offset, this.length - 8);
+
+  const val = this[offset + 4] +
+    this[offset + 5] * 2 ** 8 +
+    this[offset + 6] * 2 ** 16 +
+    (last << 24); // Overflow
+  return (BigInt(val) << 32n) +
+    BigInt(first +
+    this[++offset] * 2 ** 8 +
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 24);
+}
+
+function readBigInt64BE(offset) {
+  checkNumberType(offset);
+  const first = this[offset];
+  const last = this[offset + 7];
+  if (first === undefined || last === undefined)
+    boundsError(offset, this.length - 8);
+
+  const val = (first << 24) + // Overflow
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 8 +
+    this[++offset];
+  return (BigInt(val) << 32n) +
+    BigInt(this[++offset] * 2 ** 24 +
+    this[++offset] * 2 ** 16 +
+    this[++offset] * 2 ** 8 +
+    last);
+}
+
 function readUIntLE(offset, byteLength) {
   if (offset === undefined)
     throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
@@ -473,6 +543,66 @@ function readDoubleForwards(offset = 0) {
 }
 
 // Write integers.
+function writeBigU_Int64LE(buf, value, offset, min, max) {
+  // TODO: perform any conversions on value?
+  checkInt(value, min, max, buf, offset, 7);
+
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset++] = Number(value & 0xffn);
+  return offset;
+}
+
+function writeBigUInt64LE(value, offset) {
+  return writeBigU_Int64LE(this, value, offset, 0n, 0xffffffffffffffffn);
+}
+
+function writeBigU_Int64BE(buf, value, offset, min, max) {
+  // TODO: perform any conversions on value?
+  checkInt(value, min, max, buf, offset, 7);
+
+  buf[offset + 7] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 6] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 5] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 4] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 3] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 2] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset + 1] = Number(value & 0xffn);
+  value = value >> 8n;
+  buf[offset] = Number(value & 0xffn);
+  return offset + 8;
+}
+
+function writeBigUInt64BE(value, offset) {
+  return writeBigU_Int64BE(this, value, offset, 0n, 0xffffffffffffffffn);
+}
+
+function writeBigInt64LE(value, offset) {
+  return writeBigU_Int64LE(this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
+}
+
+function writeBigInt64BE(value, offset) {
+  return writeBigU_Int64BE(this, value, offset, -0x8000000000000000n, 0x7fffffffffffffffn);
+}
+
 function writeUIntLE(value, offset, byteLength) {
   if (byteLength === 6)
     return writeU_Int48LE(this, value, offset, 0, 0xffffffffffff);
@@ -790,6 +920,14 @@ function writeFloatBackwards(val, offset = 0) {
 class FastBuffer extends Uint8Array {}
 
 function addBufferPrototypeMethods(proto) {
+  proto.readBigUInt64BE = readBigUInt64BE,
+  proto.readBigInt64LE = readBigInt64LE,
+  proto.readBigInt64BE = readBigInt64BE,
+  proto.writeBigUInt64LE = writeBigUInt64LE,
+  proto.writeBigUInt64BE = writeBigUInt64BE,
+  proto.writeBigInt64LE = writeBigInt64LE,
+  proto.writeBigInt64BE = writeBigInt64BE,
+
   proto.readUIntLE = readUIntLE;
   proto.readUInt32LE = readUInt32LE;
   proto.readUInt16LE = readUInt16LE;

--- a/test/parallel/test-buffer-bigint64.js
+++ b/test/parallel/test-buffer-bigint64.js
@@ -1,0 +1,51 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const buf = Buffer.allocUnsafe(8);
+
+['LE', 'BE'].forEach(function(endianness) {
+  // should allow simple BigInts to be written and read
+  let val = 123456789n;
+  buf['writeBigInt64' + endianness](val, 0);
+  let rtn = buf['readBigInt64' + endianness](0);
+  assert.strictEqual(val, rtn);
+
+  // should allow INT64_MAX to be written and read
+  val = 9223372036854775807n;
+  buf['writeBigInt64' + endianness](val, 0);
+  rtn = buf['readBigInt64' + endianness](0);
+  assert.strictEqual(val, rtn);
+
+  // should read and write a negative signed 64-bit integer
+  val = -123456789n;
+  buf['writeBigInt64' + endianness](val, 0);
+  assert.strictEqual(val, buf['readBigInt64' + endianness](0));
+
+  // should read and write an unsigned 64-bit integer
+  val = 123456789n;
+  buf['writeBigUInt64' + endianness](val, 0);
+  assert.strictEqual(val, buf['readBigUInt64' + endianness](0));
+
+  // should throw a RangeError upon INT64_MAX+1 being written
+  assert.throws(function() {
+    const val = 9223372036854775808n;
+    buf['writeBigInt64' + endianness](val, 0);
+  }, RangeError);
+
+  // should throw a RangeError upon UINT64_MAX+1 being written
+  assert.throws(function() {
+    const val = 18446744073709551616n;
+    buf['writeBigUInt64' + endianness](val, 0);
+  }, RangeError);
+
+  // should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf['writeBigInt64' + endianness]('bad', 0);
+  }, TypeError);
+
+  // should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf['writeBigUInt64' + endianness]('bad', 0);
+  }, TypeError);
+});

--- a/test/parallel/test-buffer-bigint64.js
+++ b/test/parallel/test-buffer-bigint64.js
@@ -5,46 +5,46 @@ const assert = require('assert');
 const buf = Buffer.allocUnsafe(8);
 
 ['LE', 'BE'].forEach(function(endianness) {
-  // should allow simple BigInts to be written and read
+  // Should allow simple BigInts to be written and read
   let val = 123456789n;
   buf['writeBigInt64' + endianness](val, 0);
   let rtn = buf['readBigInt64' + endianness](0);
   assert.strictEqual(val, rtn);
 
-  // should allow INT64_MAX to be written and read
+  // Should allow INT64_MAX to be written and read
   val = 0x7fffffffffffffffn;
   buf['writeBigInt64' + endianness](val, 0);
   rtn = buf['readBigInt64' + endianness](0);
   assert.strictEqual(val, rtn);
 
-  // should read and write a negative signed 64-bit integer
+  // Should read and write a negative signed 64-bit integer
   val = -123456789n;
   buf['writeBigInt64' + endianness](val, 0);
   assert.strictEqual(val, buf['readBigInt64' + endianness](0));
 
-  // should read and write an unsigned 64-bit integer
+  // Should read and write an unsigned 64-bit integer
   val = 123456789n;
   buf['writeBigUInt64' + endianness](val, 0);
   assert.strictEqual(val, buf['readBigUInt64' + endianness](0));
 
-  // should throw a RangeError upon INT64_MAX+1 being written
+  // Should throw a RangeError upon INT64_MAX+1 being written
   assert.throws(function() {
     const val = 0x8000000000000000n;
     buf['writeBigInt64' + endianness](val, 0);
   }, RangeError);
 
-  // should throw a RangeError upon UINT64_MAX+1 being written
+  // Should throw a RangeError upon UINT64_MAX+1 being written
   assert.throws(function() {
     const val = 0x10000000000000000n;
     buf['writeBigUInt64' + endianness](val, 0);
   }, RangeError);
 
-  // should throw a TypeError upon invalid input
+  // Should throw a TypeError upon invalid input
   assert.throws(function() {
     buf['writeBigInt64' + endianness]('bad', 0);
   }, TypeError);
 
-  // should throw a TypeError upon invalid input
+  // Should throw a TypeError upon invalid input
   assert.throws(function() {
     buf['writeBigUInt64' + endianness]('bad', 0);
   }, TypeError);

--- a/test/parallel/test-buffer-bigint64.js
+++ b/test/parallel/test-buffer-bigint64.js
@@ -12,7 +12,7 @@ const buf = Buffer.allocUnsafe(8);
   assert.strictEqual(val, rtn);
 
   // should allow INT64_MAX to be written and read
-  val = 9223372036854775807n;
+  val = 0x7fffffffffffffffn;
   buf['writeBigInt64' + endianness](val, 0);
   rtn = buf['readBigInt64' + endianness](0);
   assert.strictEqual(val, rtn);
@@ -29,13 +29,13 @@ const buf = Buffer.allocUnsafe(8);
 
   // should throw a RangeError upon INT64_MAX+1 being written
   assert.throws(function() {
-    const val = 9223372036854775808n;
+    const val = 0x8000000000000000n;
     buf['writeBigInt64' + endianness](val, 0);
   }, RangeError);
 
   // should throw a RangeError upon UINT64_MAX+1 being written
   assert.throws(function() {
-    const val = 18446744073709551616n;
+    const val = 0x10000000000000000n;
     buf['writeBigUInt64' + endianness](val, 0);
   }, RangeError);
 


### PR DESCRIPTION
This is a resurrection of #15152, this time with BigInts.

The functions `writeBigU_Int64LE` and `writeBigU_Int64BE` look so terrible because setting `Uint8Array` values to `BigInt` is disallowed by the spec. I submitted an issue about it in https://github.com/tc39/proposal-bigint/issues/137. Please 👍 it or whatever if you agree.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
