### PR TITLE
test: fix flaky test-cluster-send-handle-twice

### DIFF
--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -40,10 +40,10 @@ if (cluster.isMaster) {
     }));
   }
 } else {
-  const server = net.createServer(function(socket) {
+  const server = net.createServer(common.mustCall((socket) => {
     process.send('send-handle-1', socket);
     process.send('send-handle-2', socket);
-  });
+  }));
 
   server.listen(0, function() {
     const client = net.connect({
@@ -51,10 +51,9 @@ if (cluster.isMaster) {
       port: server.address().port
     });
     client.on('close', common.mustCall(() => { cluster.worker.disconnect(); }));
-    setTimeout(function() { client.end(); }, 50);
+    client.on('connect', () => { client.end(); });
   }).on('error', function(e) {
     console.error(e);
     assert.fail('server.listen failed');
-    cluster.worker.disconnect();
   });
 }


### PR DESCRIPTION
Use `common.mustCall()` to make sure connection callback runs exactly
once.

Use `connect` event instead of `setTimeout` to avoid test failing if
timer runs before client is connected.

Remove `cluster.worker.disconnect()` after `assert.fail()`. It is
unreachable code that is unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
