### PR TITLE
test: test process.setuid for bad argument types

### DIFF
--- a/test/parallel/test-process-setuid-setgid.js
+++ b/test/parallel/test-process-setuid-setgid.js
@@ -34,6 +34,10 @@ if (common.isWindows) {
 }
 
 assert.throws(() => {
+  process.setuid({});
+}, /^TypeError: setuid argument must be a number or a string$/);
+
+assert.throws(() => {
   process.setuid('fhqwhgadshgnsdhjsdbkhsdabkfabkveybvf');
 }, /^Error: setuid user id does not exist$/);
 


### PR DESCRIPTION
test process.setuid with an object as an argument. An equivalent test
exists for process.seteuid

Fixes: https://github.com/nodejs/node/issues/19591

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
