### PR TITLE
lib:  fixing isStackOverflowError to account for different JS engines

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -572,7 +572,8 @@ function dnsException(err, syscall, hostname) {
   return ex;
 }
 
-let MAX_STACK_MESSAGE;
+let MAX_STACK_ERROR_NAME;
+let MAX_STACK_ERROR_MESSAGE;
 /**
  * Returns true if `err` is a `RangeError` with an engine-specific message.
  * "Maximum call stack size exceeded" in V8.
@@ -581,16 +582,18 @@ let MAX_STACK_MESSAGE;
  * @returns {boolean}
  */
 function isStackOverflowError(err) {
-  if (MAX_STACK_MESSAGE === undefined) {
+  if (MAX_STACK_ERROR_MESSAGE === undefined) {
     try {
       function overflowStack() { overflowStack(); }
       overflowStack();
     } catch (err) {
-      MAX_STACK_MESSAGE = err.message;
+      MAX_STACK_ERROR_MESSAGE = err.message;
+      MAX_STACK_ERROR_NAME = err.name;
     }
   }
 
-  return err.name === 'RangeError' && err.message === MAX_STACK_MESSAGE;
+  return err.name === MAX_STACK_ERROR_NAME &&
+          err.message === MAX_STACK_ERROR_MESSAGE;
 }
 
 module.exports = exports = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -593,7 +593,7 @@ function isStackOverflowError(err) {
   }
 
   return err.name === MAX_STACK_ERROR_NAME &&
-          err.message === MAX_STACK_ERROR_MESSAGE;
+         err.message === MAX_STACK_ERROR_MESSAGE;
 }
 
 module.exports = exports = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -572,28 +572,29 @@ function dnsException(err, syscall, hostname) {
   return ex;
 }
 
-let MAX_STACK_ERROR_NAME;
-let MAX_STACK_ERROR_MESSAGE;
+let maxStack_ErrorName;
+let maxStack_ErrorMessage;
 /**
- * Returns true if `err` is a `RangeError` with an engine-specific message.
+ * Returns true if `err.name` and `err.message` are equal to engine-specific
+ * values indicating max call stack size has been exceeded.
  * "Maximum call stack size exceeded" in V8.
  *
  * @param {Error} err
  * @returns {boolean}
  */
 function isStackOverflowError(err) {
-  if (MAX_STACK_ERROR_MESSAGE === undefined) {
+  if (maxStack_ErrorMessage === undefined) {
     try {
       function overflowStack() { overflowStack(); }
       overflowStack();
     } catch (err) {
-      MAX_STACK_ERROR_MESSAGE = err.message;
-      MAX_STACK_ERROR_NAME = err.name;
+      maxStack_ErrorMessage = err.message;
+      maxStack_ErrorName = err.name;
     }
   }
 
-  return err.name === MAX_STACK_ERROR_NAME &&
-         err.message === MAX_STACK_ERROR_MESSAGE;
+  return err.name === maxStack_ErrorName &&
+         err.message === maxStack_ErrorMessage;
 }
 
 module.exports = exports = {


### PR DESCRIPTION
Assumption that stack overflow exception has name == "RangeError" is
v8-specific.  Updated logic to dynamically capture error name when
capturing error message.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
