### PR TITLE
test: removed third argument from assert.strictEqual()

### DIFF
--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -34,7 +34,8 @@ const server = http.Server(common.mustCall(function(req, res) {
   res.end();
 
   const r = res.write('This should raise an error.');
-  assert.strictEqual(r, true, 'write after end should return true');
+  // write after end should return true
+  assert.strictEqual(r, true);
 }));
 
 server.listen(0, function() {


### PR DESCRIPTION
If there is an AssertionError, the string literal is printed and not the
value of `r`. For debugging purposes, it is good to know if `r` is false
or null or something else.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
