### PR TITLE
doc: fix quotes mistypes in inline code blocks

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3427,7 +3427,7 @@ Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 
 The `fs/promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
-API is accessible via `require('fs/promises)`.
+API is accessible via `require('fs/promises')`.
 
 ### class: FileHandle
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -439,7 +439,7 @@ payload.
 session.ping(Buffer.from('abcdefgh'), (err, duration, payload) => {
   if (!err) {
     console.log(`Ping acknowledged in ${duration} milliseconds`);
-    console.log(`With payload '${payload.toString()}`);
+    console.log(`With payload '${payload.toString()}'`);
   }
 });
 ```

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -211,7 +211,7 @@ changes:
                  a process warning.
 -->
 
-The `'unhandledRejection`' event is emitted whenever a `Promise` is rejected and
+The `'unhandledRejection'` event is emitted whenever a `Promise` is rejected and
 no error handler is attached to the promise within a turn of the event loop.
 When programming with Promises, exceptions are encapsulated as "rejected
 promises". Rejections can be caught and handled using [`promise.catch()`][] and


### PR DESCRIPTION
This fixes trivial invalid quotes mistypes in inline code blocks, e.g. forgotten quotes or mixed order.

Whether this could be easily automatically checked in lint is a separate question: e.g. <code>&#96;'&#96;</code> is valid.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
