### PR TITLE
url: make urlToOptions() handle IPv6 literals

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1312,7 +1312,9 @@ function domainToUnicode(domain) {
 function urlToOptions(url) {
   var options = {
     protocol: url.protocol,
-    hostname: url.hostname,
+    hostname: url.hostname.startsWith('[') ?
+      url.hostname.slice(1, -1) :
+      url.hostname,
     hash: url.hash,
     search: url.search,
     pathname: url.pathname,

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -143,6 +143,9 @@ assert.strictEqual(url.searchParams, oldParams);
   assert.strictEqual(opts.pathname, '/aaa/zzz');
   assert.strictEqual(opts.search, '?l=24');
   assert.strictEqual(opts.hash, '#test');
+
+  const { hostname } = urlToOptions(new URL('http://[::1]:21'));
+  assert.strictEqual(hostname, '::1');
 }
 
 // Test special origins


### PR DESCRIPTION
Strip the enclosing square brackets from the parsed hostname.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
