### PR TITLE
test: check all properties in common.expectsError

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -691,7 +691,6 @@ exports.expectsError = function expectsError(fn, settings, exact) {
     fn = undefined;
   }
   function innerFn(error) {
-    assert.strictEqual(error.code, settings.code);
     if ('type' in settings) {
       const type = settings.type;
       if (type !== Error && !Error.isPrototypeOf(type)) {
@@ -714,18 +713,16 @@ exports.expectsError = function expectsError(fn, settings, exact) {
                `${error.message} does not match ${message}`);
       }
     }
-    if ('name' in settings) {
-      assert.strictEqual(error.name, settings.name);
-    }
-    if (error.constructor.name === 'AssertionError') {
-      ['generatedMessage', 'actual', 'expected', 'operator'].forEach((key) => {
-        if (key in settings) {
-          const actual = error[key];
-          const expected = settings[key];
-          assert.strictEqual(actual, expected,
-                             `${key}: expected ${expected}, not ${actual}`);
-        }
-      });
+
+    // Check all error properties.
+    const keys = Object.keys(settings);
+    for (const key of keys) {
+      if (key === 'message' || key === 'type')
+        continue;
+      const actual = error[key];
+      const expected = settings[key];
+      assert.strictEqual(actual, expected,
+                         `${key}: expected ${expected}, not ${actual}`);
     }
     return true;
   }


### PR DESCRIPTION
This makes sure all properties that are meant to be checked will
actually be tested for. Otherwise properties might be missed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
