### PR TITLE
assert: add `rawMessage` to error messages

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -51,6 +51,7 @@ and:
 * `code` {string} This is always set to the string `ERR_ASSERTION` to indicate
   that the error is actually an assertion error.
 * `operator` {string} Set to the passed in operator value.
+* `rawMessage` {string} Identical to the message, but without any colors.
 
 ```js
 const assert = require('assert');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -386,6 +386,7 @@ class AssertionError extends Error {
     this.actual = actual;
     this.expected = expected;
     this.operator = operator;
+    this.rawMessage = lazyInternalUtil().removeColors(this.message);
     Error.captureStackTrace(this, stackStartFn);
   }
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -386,8 +386,20 @@ class AssertionError extends Error {
     this.actual = actual;
     this.expected = expected;
     this.operator = operator;
-    this.rawMessage = lazyInternalUtil().removeColors(this.message);
     Error.captureStackTrace(this, stackStartFn);
+  }
+
+  get rawMessage() {
+    return lazyInternalUtil().removeColors(this.message);
+  }
+
+  set rawMessage(value) {
+    Object.defineProperty(this, 'rawMessage', {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true
+    });
   }
 }
 

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -12,7 +12,8 @@ assert.throws(
     message: 'Failed',
     operator: undefined,
     actual: undefined,
-    expected: undefined
+    expected: undefined,
+    rawMessage: 'Failed'
   }
 );
 
@@ -25,7 +26,8 @@ assert.throws(() => {
   message: 'custom message',
   operator: undefined,
   actual: undefined,
-  expected: undefined
+  expected: undefined,
+  rawMessage: 'custom message'
 });
 
 // One arg = Error

--- a/test/pseudo-tty/test-assert-colors.js
+++ b/test/pseudo-tty/test-assert-colors.js
@@ -1,6 +1,8 @@
 'use strict';
+// Flags: --expose-internals
 require('../common');
 const assert = require('assert').strict;
+const util = require('internal/util');
 
 try {
   // Activate colors even if the tty does not support colors.
@@ -15,4 +17,6 @@ try {
     '    2\n' +
     '  ]';
   assert.strictEqual(err.message, expected);
+  assert.strictEqual(err.rawMessage, util.removeColors(expected));
+  assert.notStrictEqual(err.message, err.rawMessage);
 }


### PR DESCRIPTION
The `rawMessage` provides the message with a guarantee not to include colors.

This was requested recently by @SimenB. I personally am not a fan of this. But I thought this way we can have a proper discussion about adding this property or not.

If a user sets the `util.inspect` 'colors' default options to true, assertion error messages are currently going to contain colors. The same applies to multiple errors coming from the assert `strict` mode.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
