### PR TITLE
fs: make ReadStream throw error on NaN

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2012,12 +2012,17 @@ function ReadStream(path, options) {
       throw new ERR_INVALID_ARG_TYPE('options.start', 'number', options.start);
     }
     if (!Number.isInteger(this.start)) {
-      throw new ERR_OUT_OF_RANGE('options.start', 'an integer', options.start);
+      throw new ERR_OUT_OF_RANGE('options.start', 'integer', options.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
-    } else if (!Number.isInteger(this.end)) {
-      throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
+    } else {
+      if (typeof this.end !== 'number') {
+        throw new ERR_INVALID_ARG_TYPE('options.end', 'number', this.end);
+      }
+      if (!(Number.isInteger(this.end) || this.end === Infinity)) {
+        throw new ERR_OUT_OF_RANGE('options.end', 'integer/infinity', this.end);
+      }
     }
 
     if (this.start > this.end) {
@@ -2032,8 +2037,8 @@ function ReadStream(path, options) {
     // TODO(addaleax): Make the above typecheck not depend on `start` instead.
     // (That is a semver-major change).
     this.end = Infinity;
-  } else if (!Number.isInteger(this.end)) {
-    throw new ERR_OUT_OF_RANGE('options.end', 'an integer', options.end);
+  } else if (!(Number.isInteger(this.end) || this.end === Infinity)) {
+    throw new ERR_OUT_OF_RANGE('options.end', 'integer/infinity', this.end);
   }
 
   if (typeof this.fd !== 'number')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2008,8 +2008,11 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
+    if (typeof this.start !== 'number') {
+      throw new ERR_INVALID_ARG_TYPE('options.start', 'number', options.start);
+    }
     if (!Number.isInteger(this.start)) {
-      throw new ERR_INVALID_ARG_TYPE('start', 'integer', this.start);
+      throw new ERR_OUT_OF_RANGE('options.start', 'an integer', options.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
@@ -2023,25 +2026,24 @@ function ReadStream(path, options) {
     }
 
     this.pos = this.start;
-  } else {
+  } else if (typeof this.end !== 'number') {
     // Backwards compatibility: Make sure `end` is a number regardless of
     // `start`.
     // TODO(addaleax): Make the above typecheck not depend on `start` instead.
     // (That is a semver-major change).
-    if (typeof this.end !== 'number')
-      this.end = Infinity;
-    else if (!Number.isInteger(this.end))
-      throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
-
-    if (typeof this.fd !== 'number')
-      this.open();
-
-    this.on('end', function() {
-      if (this.autoClose) {
-        this.destroy();
-      }
-    });
+    this.end = Infinity;
+  } else if (!Number.isInteger(this.end)) {
+    throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
   }
+
+  if (typeof this.fd !== 'number')
+    this.open();
+
+  this.on('end', function() {
+    if (this.autoClose) {
+      this.destroy();
+    }
+  });
 }
 
 fs.FileReadStream = fs.ReadStream; // support the legacy name

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2008,12 +2008,12 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number') {
+    if (typeof this.start !== 'number' || Number.isNaN(this.start)) {
       throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
-    } else if (typeof this.end !== 'number') {
+    } else if (typeof this.end !== 'number' || Number.isNaN(this.end)) {
       throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
     }
 
@@ -2028,7 +2028,7 @@ function ReadStream(path, options) {
   // Backwards compatibility: Make sure `end` is a number regardless of `start`.
   // TODO(addaleax): Make the above typecheck not depend on `start` instead.
   // (That is a semver-major change).
-  if (typeof this.end !== 'number')
+  if (typeof this.end !== 'number' || Number.isNaN(this.end))
     this.end = Infinity;
 
   if (typeof this.fd !== 'number')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2033,7 +2033,7 @@ function ReadStream(path, options) {
     // (That is a semver-major change).
     this.end = Infinity;
   } else if (!Number.isInteger(this.end)) {
-    throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
+    throw new ERR_OUT_OF_RANGE('options.end', 'an integer', options.end);
   }
 
   if (typeof this.fd !== 'number')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2008,12 +2008,12 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number' || !Number.isInteger(this.start)) {
+    if (!Number.isInteger(this.start)) {
       throw new ERR_INVALID_ARG_TYPE('start', 'integer', this.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
-    } else if (typeof this.end !== 'number' || !Number.isInteger(this.end)) {
+    } else if (!Number.isInteger(this.end)) {
       throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
     }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2023,24 +2023,25 @@ function ReadStream(path, options) {
     }
 
     this.pos = this.start;
+  } else {
+    // Backwards compatibility: Make sure `end` is a number regardless of
+    // `start`.
+    // TODO(addaleax): Make the above typecheck not depend on `start` instead.
+    // (That is a semver-major change).
+    if (typeof this.end !== 'number')
+      this.end = Infinity;
+    else if (!Number.isInteger(this.end))
+      throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
+
+    if (typeof this.fd !== 'number')
+      this.open();
+
+    this.on('end', function() {
+      if (this.autoClose) {
+        this.destroy();
+      }
+    });
   }
-
-  // Backwards compatibility: Make sure `end` is a number regardless of `start`.
-  // TODO(addaleax): Make the above typecheck not depend on `start` instead.
-  // (That is a semver-major change).
-  if (typeof this.end !== 'number')
-    this.end = Infinity;
-  else if (!Number.isInteger(this.end))
-    throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
-
-  if (typeof this.fd !== 'number')
-    this.open();
-
-  this.on('end', function() {
-    if (this.autoClose) {
-      this.destroy();
-    }
-  });
 }
 
 fs.FileReadStream = fs.ReadStream; // support the legacy name

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2008,13 +2008,13 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number' || Number.isNaN(this.start)) {
-      throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
+    if (typeof this.start !== 'number' || !Number.isInteger(this.start)) {
+      throw new ERR_INVALID_ARG_TYPE('start', 'integer', this.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
-    } else if (typeof this.end !== 'number' || Number.isNaN(this.end)) {
-      throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
+    } else if (typeof this.end !== 'number' || !Number.isInteger(this.end)) {
+      throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
     }
 
     if (this.start > this.end) {
@@ -2028,8 +2028,10 @@ function ReadStream(path, options) {
   // Backwards compatibility: Make sure `end` is a number regardless of `start`.
   // TODO(addaleax): Make the above typecheck not depend on `start` instead.
   // (That is a semver-major change).
-  if (typeof this.end !== 'number' || Number.isNaN(this.end))
+  if (typeof this.end !== 'number')
     this.end = Infinity;
+  else if (!Number.isInteger(this.end))
+    throw new ERR_INVALID_ARG_TYPE('end', 'integer', this.end);
 
   if (typeof this.fd !== 'number')
     this.open();

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -34,3 +34,11 @@ createReadStreamErr(example, false, 'ERR_INVALID_ARG_TYPE');
 createReadStreamErr(example, { start: NaN }, 'ERR_OUT_OF_RANGE');
 createReadStreamErr(example, { end: NaN }, 'ERR_OUT_OF_RANGE');
 createReadStreamErr(example, { start: NaN, end: NaN }, 'ERR_OUT_OF_RANGE');
+
+// Should also throw on non-integer Numbers and non-numbers
+createReadStreamErr(example, { start: 'a' }, 'ERR_INVALID_ARG_TYPE');
+createReadStreamErr(example, { start: 0.1 }, 'ERR_OUT_OF_RANGE');
+createReadStreamErr(example, { start: 0, end: 'a' }, 'ERR_INVALID_ARG_TYPE');
+createReadStreamErr(example, { start: 0, end: 0.1 }, 'ERR_OUT_OF_RANGE');
+createReadStreamErr(example, { start: 1, end: 0 }, 'ERR_OUT_OF_RANGE');
+createReadStreamErr(example, { end: 0.1 }, 'ERR_OUT_OF_RANGE');

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -22,8 +22,7 @@ const createReadStreamErr = (path, opt) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
-    }
-  );
+    });
 };
 
 createReadStreamErr(example, 123);

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -14,23 +14,23 @@ fs.createReadStream(example, null);
 fs.createReadStream(example, 'utf8');
 fs.createReadStream(example, { encoding: 'utf8' });
 
-const createReadStreamErr = (path, opt) => {
+const createReadStreamErr = (path, opt, errorCode) => {
   common.expectsError(
     () => {
       fs.createReadStream(path, opt);
     },
     {
-      code: 'ERR_INVALID_ARG_TYPE',
+      code: errorCode,
       type: TypeError
     });
 };
 
-createReadStreamErr(example, 123);
-createReadStreamErr(example, 0);
-createReadStreamErr(example, true);
-createReadStreamErr(example, false);
+createReadStreamErr(example, 123, 'ERR_INVALID_ARG_TYPE');
+createReadStreamErr(example, 0, 'ERR_INVALID_ARG_TYPE');
+createReadStreamErr(example, true, 'ERR_INVALID_ARG_TYPE');
+createReadStreamErr(example, false, 'ERR_INVALID_ARG_TYPE');
 
 // Should also throw on NaN (for https://github.com/nodejs/node/pull/19732)
-createReadStreamErr(example, { start: NaN });
-createReadStreamErr(example, { end: NaN });
-createReadStreamErr(example, { start: NaN, end: NaN });
+createReadStreamErr(example, { start: NaN }, 'ERR_OUT_OF_RANGE');
+createReadStreamErr(example, { end: NaN }, 'ERR_OUT_OF_RANGE');
+createReadStreamErr(example, { start: NaN, end: NaN }, 'ERR_OUT_OF_RANGE');

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,6 +1,10 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+
+// This test ensures that fs.createReadStream throws a TypeError when invalid
+// arguments are passed to it.
+
 const fs = require('fs');
 
 const example = fixtures.path('x.txt');
@@ -18,10 +22,16 @@ const createReadStreamErr = (path, opt) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
-    });
+    }
+  );
 };
 
 createReadStreamErr(example, 123);
 createReadStreamErr(example, 0);
 createReadStreamErr(example, true);
 createReadStreamErr(example, false);
+
+// Should also throw on NaN (for https://github.com/nodejs/node/pull/19732)
+createReadStreamErr(example, { start: NaN });
+createReadStreamErr(example, { end: NaN });
+createReadStreamErr(example, { start: NaN, end: NaN });


### PR DESCRIPTION
This test makes fs.ReadStream throw an error when either start or
end is NaN.

Fixes: https://github.com/nodejs/node/issues/19715

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @lpinca 
