### PR TITLE
net,http2: merge write error handling & property names

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1657,7 +1657,6 @@ class Http2Stream extends Duplex {
 
     const req = createWriteWrap(this[kHandle], afterDoStreamWrite);
     req.stream = this[kID];
-    req.callback = cb;
 
     writeGeneric(this, req, data, encoding, cb);
 
@@ -1690,7 +1689,6 @@ class Http2Stream extends Duplex {
 
     var req = createWriteWrap(this[kHandle], afterDoStreamWrite);
     req.stream = this[kID];
-    req.callback = cb;
 
     writevGeneric(this, req, data, cb);
 

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -61,15 +61,24 @@ function writevGeneric(self, req, data, cb) {
   // Retain chunks
   if (err === 0) req._chunks = chunks;
 
-  if (err)
-    return self.destroy(errnoException(err, 'write', req.error), cb);
+  afterWriteDispatched(self, req, err, cb);
 }
 
 function writeGeneric(self, req, data, encoding, cb) {
   var err = handleWriteReq(req, data, encoding);
 
-  if (err)
+  afterWriteDispatched(self, req, err, cb);
+}
+
+function afterWriteDispatched(self, req, err, cb) {
+  if (err !== 0)
     return self.destroy(errnoException(err, 'write', req.error), cb);
+
+  if (!req.async) {
+    cb();
+  } else {
+    req.callback = cb;
+  }
 }
 
 module.exports = {

--- a/lib/net.js
+++ b/lib/net.js
@@ -758,23 +758,13 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     return false;
   }
 
-  var ret;
   var req = createWriteWrap(this._handle, afterWrite);
   if (writev)
-    ret = writevGeneric(this, req, data, cb);
+    writevGeneric(this, req, data, cb);
   else
-    ret = writeGeneric(this, req, data, encoding, cb);
-
-  // Bail out if handle.write* returned an error
-  if (ret) return ret;
-
-  if (!req.async) {
-    cb();
-    return;
-  }
-
-  req.cb = cb;
-  this[kLastWriteQueueSize] = req.bytes;
+    writeGeneric(this, req, data, encoding, cb);
+  if (req.async)
+    this[kLastWriteQueueSize] = req.bytes;
 };
 
 
@@ -849,7 +839,7 @@ function afterWrite(status, handle, err) {
   if (status < 0) {
     var ex = errnoException(status, 'write', this.error);
     debug('write failure', ex);
-    self.destroy(ex, this.cb);
+    self.destroy(ex, this.callback);
     return;
   }
 
@@ -858,8 +848,8 @@ function afterWrite(status, handle, err) {
   if (self !== process.stderr && self !== process.stdout)
     debug('afterWrite call cb');
 
-  if (this.cb)
-    this.cb.call(undefined);
+  if (this.callback)
+    this.callback.call(undefined);
 }
 
 


### PR DESCRIPTION
Merge error handling for `net.Socket`s and `Http2Stream`s,
and align the callback property names as `callback`.

Refs: https://github.com/nodejs/node/issues/19060

(This has become possible after https://github.com/nodejs/node/pull/19551)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc fyi @aks- 