### PR TITLE
doc, tools: formalize, unify and codify default values

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -59,9 +59,9 @@
   * Use a capital letter after the "Note:" label.
   * Preferably, make the note a new paragraph for better visual distinction.
 * Function arguments or object properties should use the following format:
-  * <code>* \`name\` {type|type2} Optional description. \*\*Default:\*\* \`defaultValue\`</code>
-  * E.g. <code>* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`</code>
-  * The `type` should refer to a Node.js type or a [JavaScript type][]
+  * <code>* \`name\` {type|type2} Optional description. \*\*Default:\*\* \`defaultValue\`.</code>
+  * E.g. <code>* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.</code>
+  * The `type` should refer to a Node.js type or a [JavaScript type][].
 * Function returns should use the following format:
   * <code>* Returns: {type|type2} Optional description.</code>
   * E.g. <code>* Returns: {AsyncHook} A reference to `asyncHook`.</code>

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -503,7 +503,7 @@ changes:
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
-* `operator` {string} **Default:** '!='
+* `operator` {string} **Default:** `'!='`
 * `stackStartFunction` {Function} **Default:** `assert.fail`
 
 > Stability: 0 - Deprecated: Use `assert.fail([message])` or other assert

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -634,12 +634,11 @@ asyncResource.emitAfter();
 * `type` {string} The type of async event.
 * `options` {Object}
   * `triggerAsyncId` {number} The ID of the execution context that created this
-  async event.  **Default:** `executionAsyncId()`
+  async event.  **Default:** `executionAsyncId()`.
   * `requireManualDestroy` {boolean} Disables automatic `emitDestroy` when the
   object is garbage collected. This usually does not need to be set (even if
   `emitDestroy` is called manually), unless the resource's asyncId is retrieved
-  and the sensitive API's `emitDestroy` is called with it.
-  **Default:** `false`
+  and the sensitive API's `emitDestroy` is called with it. **Default:** `false`.
 
 Example usage:
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -345,9 +345,9 @@ changes:
 
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An [`ArrayBuffer`],
   [`SharedArrayBuffer`] or the `.buffer` property of a [`TypedArray`].
-* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`
+* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
 * `length` {integer} Number of bytes to expose.
-  **Default:** `arrayBuffer.length - byteOffset`
+  **Default:** `arrayBuffer.length - byteOffset`.
 
 This creates a view of the [`ArrayBuffer`] or [`SharedArrayBuffer`] without
 copying the underlying memory. For example, when passed a reference to the
@@ -459,7 +459,7 @@ changes:
 > Use [`Buffer.from(string[, encoding])`][`Buffer.from(string)`] instead.
 
 * `string` {string} String to encode.
-* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
+* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`.
 
 Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
 the character encoding of `string`.
@@ -496,9 +496,9 @@ changes:
 
 * `size` {integer} The desired length of the new `Buffer`.
 * `fill` {string|Buffer|integer} A value to pre-fill the new `Buffer` with.
-  **Default:** `0`
+  **Default:** `0`.
 * `encoding` {string} If `fill` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 
 Allocates a new `Buffer` of `size` bytes. If `fill` is `undefined`, the
 `Buffer` will be *zero-filled*.
@@ -654,7 +654,7 @@ changes:
 * `string` {string|Buffer|TypedArray|DataView|ArrayBuffer|SharedArrayBuffer} A
   value to calculate the length of.
 * `encoding` {string} If `string` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 * Returns: {integer} The number of bytes contained within `string`.
 
 Returns the actual byte length of a string. This is not the same as
@@ -774,9 +774,9 @@ added: v5.10.0
 
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An [`ArrayBuffer`],
   [`SharedArrayBuffer`], or the `.buffer` property of a [`TypedArray`].
-* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`
+* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
 * `length` {integer} Number of bytes to expose.
-  **Default:** `arrayBuffer.length - byteOffset`
+  **Default:** `arrayBuffer.length - byteOffset`.
 
 This creates a view of the [`ArrayBuffer`] without copying the underlying
 memory. For example, when passed a reference to the `.buffer` property of a
@@ -845,7 +845,7 @@ added: v5.10.0
 -->
 
 * `string` {string} A string to encode.
-* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
+* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`.
 
 Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
 the character encoding of `string`.
@@ -984,13 +984,13 @@ changes:
 
 * `target` {Buffer|Uint8Array} A `Buffer` or [`Uint8Array`] to compare to.
 * `targetStart` {integer} The offset within `target` at which to begin
-  comparison. **Default:** `0`
+  comparison. **Default:** `0`.
 * `targetEnd` {integer} The offset with `target` at which to end comparison
-  (not inclusive). **Default:** `target.length`
+  (not inclusive). **Default:** `target.length`.
 * `sourceStart` {integer} The offset within `buf` at which to begin comparison.
-  **Default:** `0`
+  **Default:** `0`.
 * `sourceEnd` {integer} The offset within `buf` at which to end comparison
-  (not inclusive). **Default:** [`buf.length`]
+  (not inclusive). **Default:** [`buf.length`].
 * Returns: {integer}
 
 Compares `buf` with `target` and returns a number indicating whether `buf`
@@ -1047,11 +1047,11 @@ added: v0.1.90
 
 * `target` {Buffer|Uint8Array} A `Buffer` or [`Uint8Array`] to copy into.
 * `targetStart` {integer} The offset within `target` at which to begin
-  copying to. **Default:** `0`
+  copying to. **Default:** `0`.
 * `sourceStart` {integer} The offset within `buf` at which to begin copying from.
-  **Default:** `0`
+  **Default:** `0`.
 * `sourceEnd` {integer} The offset within `buf` at which to stop copying (not
-  inclusive). **Default:** [`buf.length`]
+  inclusive). **Default:** [`buf.length`].
 * Returns: {integer} The number of bytes copied.
 
 Copies data from a region of `buf` to a region in `target` even if the `target`
@@ -1165,10 +1165,10 @@ changes:
 -->
 
 * `value` {string|Buffer|integer} The value to fill `buf` with.
-* `offset` {integer} Number of bytes to skip before starting to fill `buf`. **Default:** `0`
-* `end` {integer} Where to stop filling `buf` (not inclusive). **Default:** [`buf.length`]
+* `offset` {integer} Number of bytes to skip before starting to fill `buf`. **Default:** `0`.
+* `end` {integer} Where to stop filling `buf` (not inclusive). **Default:** [`buf.length`].
 * `encoding` {string} If `value` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 * Returns: {Buffer} A reference to `buf`.
 
 Fills `buf` with the specified `value`. If the `offset` and `end` are not given,
@@ -1216,9 +1216,9 @@ added: v5.3.0
 -->
 
 * `value` {string|Buffer|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. **Default:** `0`
+* `byteOffset` {integer} Where to begin searching in `buf`. **Default:** `0`.
 * `encoding` {string} If `value` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 * Returns: {boolean} `true` if `value` was found in `buf`, `false` otherwise.
 
 Equivalent to [`buf.indexOf() !== -1`][`buf.indexOf()`].
@@ -1256,9 +1256,9 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. **Default:** `0`
+* `byteOffset` {integer} Where to begin searching in `buf`. **Default:** `0`.
 * `encoding` {string} If `value` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 * Returns: {integer} The index of the first occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`.
 
@@ -1358,9 +1358,9 @@ changes:
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
 * `byteOffset` {integer} Where to begin searching in `buf`.
-  **Default:** [`buf.length`]` - 1`
+  **Default:** [`buf.length`]` - 1`.
 * `encoding` {string} If `value` is a string, this is its encoding.
-  **Default:** `'utf8'`
+  **Default:** `'utf8'`.
 * Returns: {integer} The index of the last occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`.
 
@@ -1792,9 +1792,9 @@ changes:
                  calculations with them.
 -->
 
-* `start` {integer} Where the new `Buffer` will start. **Default:** `0`
+* `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
 * `end` {integer} Where the new `Buffer` will end (not inclusive).
-  **Default:** [`buf.length`]
+  **Default:** [`buf.length`].
 * Returns: {Buffer}
 
 Returns a new `Buffer` that references the same memory as the original, but
@@ -1963,10 +1963,10 @@ console.log(copy);
 added: v0.1.90
 -->
 
-* `encoding` {string} The character encoding to decode to. **Default:** `'utf8'`
-* `start` {integer} The byte offset to start decoding at. **Default:** `0`
+* `encoding` {string} The character encoding to decode to. **Default:** `'utf8'`.
+* `start` {integer} The byte offset to start decoding at. **Default:** `0`.
 * `end` {integer} The byte offset to stop decoding at (not inclusive).
-  **Default:** [`buf.length`]
+  **Default:** [`buf.length`].
 * Returns: {string}
 
 Decodes `buf` to a string according to the specified character encoding in
@@ -2040,9 +2040,9 @@ added: v0.1.90
 -->
 
 * `string` {string} String to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write `string`. **Default:** `0`
-* `length` {integer} Number of bytes to write. **Default:** `buf.length - offset`
-* `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`
+* `offset` {integer} Number of bytes to skip before starting to write `string`. **Default:** `0`.
+* `length` {integer} Number of bytes to write. **Default:** `buf.length - offset`.
+* `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`.
 * Returns: {integer} Number of bytes written.
 
 Writes `string` to `buf` at `offset` according to the character encoding in `encoding`.
@@ -2369,7 +2369,7 @@ changes:
 * `value` {integer} Number to be written to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write. Must satisfy: `0 <= offset <= buf.length - byteLength`.
 * `byteLength` {integer} Number of bytes to write. Must satisfy: `0 < byteLength <= 6`.
-  **Default:** `false`
+  **Default:** `false`.
 * Returns: {integer} `offset` plus the number of bytes written.
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -139,15 +139,16 @@ changes:
 * `command` {string} The command to run, with space-separated arguments.
 * `options` {Object}
   * `cwd` {string} Current working directory of the child process.
-  * `env` {Object} Environment key-value pairs.
+    **Default:** `null`.
+  * `env` {Object} Environment key-value pairs. **Default:** `null`.
   * `encoding` {string} **Default:** `'utf8'`
-  * `shell` {string} Shell to execute the command with.
-    **Default:** `'/bin/sh'` on UNIX, `process.env.ComSpec` on Windows. See
-    [Shell Requirements][] and [Default Windows Shell][].
+  * `shell` {string} Shell to execute the command with. See
+    [Shell Requirements][] and [Default Windows Shell][]. **Default:**
+    `'/bin/sh'` on UNIX, `process.env.ComSpec` on Windows.
   * `timeout` {number} **Default:** `0`
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. **Default:** `200*1024`. If exceeded, the child process is terminated.
-    See caveat at [`maxBuffer` and Unicode][].
+    stderr. If exceeded, the child process is terminated. See caveat at
+    [`maxBuffer` and Unicode][]. **Default:** `200*1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -202,20 +203,6 @@ can be used to specify the character encoding used to decode the stdout and
 stderr output. If `encoding` is `'buffer'`, or an unrecognized character
 encoding, `Buffer` objects will be passed to the callback instead.
 
-The `options` argument may be passed as the second argument to customize how
-the process is spawned. The default options are:
-
-```js
-const defaults = {
-  encoding: 'utf8',
-  timeout: 0,
-  maxBuffer: 200 * 1024,
-  killSignal: 'SIGTERM',
-  cwd: null,
-  env: null
-};
-```
-
 If `timeout` is greater than `0`, the parent will send the signal
 identified by the `killSignal` property (the default is `'SIGTERM'`) if the
 child runs longer than `timeout` milliseconds.
@@ -258,8 +245,8 @@ changes:
   * `encoding` {string} **Default:** `'utf8'`
   * `timeout` {number} **Default:** `0`
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. **Default:** `200*1024` If exceeded, the child process is terminated.
-    See caveat at [`maxBuffer` and Unicode][].
+    stderr. If exceeded, the child process is terminated. See caveat at
+    [`maxBuffer` and Unicode][]. **Default:** `200*1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -341,11 +328,11 @@ changes:
   * `env` {Object} Environment key-value pairs.
   * `execPath` {string} Executable used to create the child process.
   * `execArgv` {Array} List of string arguments passed to the executable.
-    **Default:** `process.execArgv`
+    **Default:** `process.execArgv`.
   * `silent` {boolean} If `true`, stdin, stdout, and stderr of the child will be
     piped to the parent, otherwise they will be inherited from the parent, see
     the `'pipe'` and `'inherit'` options for [`child_process.spawn()`][]'s
-    [`stdio`][] for more details. **Default:** `false`
+    [`stdio`][] for more details. **Default:** `false`.
   * `stdio` {Array|string} See [`child_process.spawn()`][]'s [`stdio`][].
     When this option is provided, it overrides `silent`. If the array variant
     is used, it must contain exactly one item with value `'ipc'` or an error
@@ -701,22 +688,22 @@ changes:
 * `options` {Object}
   * `cwd` {string} Current working directory of the child process.
   * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
-    to the spawned process.
-    - supplying this value will override `stdio[0]`
-  * `stdio` {string|Array} Child's stdio configuration. **Default:** `'pipe'`
-    - `stderr` by default will be output to the parent process' stderr unless
-      `stdio` is specified
+    to the spawned process. Supplying this value will override `stdio[0]`.
+  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+    be output to the parent process' stderr unless `stdio` is specified.
+    **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs.
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
   * `timeout` {number} In milliseconds the maximum amount of time the process
-    is allowed to run. **Default:** `undefined`
+    is allowed to run. **Default:** `undefined`.
   * `killSignal` {string|integer} The signal value to be used when the spawned
-    process will be killed. **Default:** `'SIGTERM'`
+    process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. **Default:** `200*1024` If exceeded, the child process is terminated.
-    See caveat at [`maxBuffer` and Unicode][].
-  * `encoding` {string} The encoding used for all stdio inputs and outputs. **Default:** `'buffer'`
+    stderr. If exceeded, the child process is terminated. See caveat at
+    [`maxBuffer` and Unicode][]. **Default:** `200*1024`.
+  * `encoding` {string} The encoding used for all stdio inputs and outputs.
+    **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
@@ -759,26 +746,25 @@ changes:
 * `options` {Object}
   * `cwd` {string} Current working directory of the child process.
   * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
-    to the spawned process.
-    - supplying this value will override `stdio[0]`.
-  * `stdio` {string|Array} Child's stdio configuration. **Default:** `'pipe'`
-    - `stderr` by default will be output to the parent process' stderr unless
-      `stdio` is specified
+    to the spawned process. Supplying this value will override `stdio[0]`.
+  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+    be output to the parent process' stderr unless `stdio` is specified.
+    **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs.
-  * `shell` {string} Shell to execute the command with.
-    **Default:** `'/bin/sh'` on UNIX, `process.env.ComSpec` on Windows. See
-    [Shell Requirements][] and [Default Windows Shell][].
+  * `shell` {string} Shell to execute the command with. See
+    [Shell Requirements][] and [Default Windows Shell][]. **Default:**
+    `'/bin/sh'` on UNIX, `process.env.ComSpec` on Windows.
   * `uid` {number} Sets the user identity of the process. (See setuid(2)).
   * `gid` {number} Sets the group identity of the process. (See setgid(2)).
   * `timeout` {number} In milliseconds the maximum amount of time the process
-    is allowed to run. **Default:** `undefined`
+    is allowed to run. **Default:** `undefined`.
   * `killSignal` {string|integer} The signal value to be used when the spawned
-    process will be killed. **Default:** `'SIGTERM'`
+    process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. **Default:** `200*1024` If exceeded, the child process is terminated.
-    See caveat at [`maxBuffer` and Unicode][].
+    stderr. If exceeded, the child process is terminated. See caveat at
+    [`maxBuffer` and Unicode][]. **Default:** `200*1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
-    **Default:** `'buffer'`
+    **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
 * Returns: {Buffer|string} The stdout from the command.
@@ -821,21 +807,20 @@ changes:
 * `options` {Object}
   * `cwd` {string} Current working directory of the child process.
   * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
-    to the spawned process.
-    - supplying this value will override `stdio[0]`.
+    to the spawned process. Supplying this value will override `stdio[0]`.
   * `stdio` {string|Array} Child's stdio configuration.
   * `env` {Object} Environment key-value pairs.
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
   * `timeout` {number} In milliseconds the maximum amount of time the process
-    is allowed to run. **Default:** `undefined`
+    is allowed to run. **Default:** `undefined`.
   * `killSignal` {string|integer} The signal value to be used when the spawned
-    process will be killed. **Default:** `'SIGTERM'`
+    process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. **Default:** `200*1024` If exceeded, the child process is terminated.
-    See caveat at [`maxBuffer` and Unicode][].
+    stderr. If exceeded, the child process is terminated. See caveat at
+    [`maxBuffer` and Unicode][]. **Default:** `200*1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
-    **Default:** `'buffer'`
+    **Default:** `'buffer'`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell Requirements][] and
@@ -1106,7 +1091,12 @@ changes:
 
 * `message` {Object}
 * `sendHandle` {Handle}
-* `options` {Object}
+* `options` {Object} The `options` argument, if present, is an object used to
+  parameterize the sending of certain types of handles. `options` supports
+  the following properties:
+  * `keepOpen` - A Boolean value that can be used when passing instances of
+    `net.Socket`. When `true`, the socket is kept open in the sending process.
+    **Default:** `false`.
 * `callback` {Function}
 * Returns: {boolean}
 
@@ -1160,14 +1150,6 @@ for passing a TCP server or socket object to the child process. The child will
 receive the object as the second argument passed to the callback function
 registered on the [`process.on('message')`][] event. Any data that is received
 and buffered in the socket will not be sent to the child.
-
-The `options` argument, if present, is an object used to parameterize the
-sending of certain types of handles. `options` supports the following
-properties:
-
-  * `keepOpen` - A Boolean value that can be used when passing instances of
-    `net.Socket`. When `true`, the socket is kept open in the sending process.
-    Defaults to `false`.
 
 The optional `callback` is a function that is invoked after the message is
 sent but before the child may have received it.  The function is called with a

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -714,14 +714,14 @@ changes:
 
 * {Object}
   * `execArgv` {Array} List of string arguments passed to the Node.js
-    executable. **Default:** `process.execArgv`
-  * `exec` {string} File path to worker file. **Default:** `process.argv[1]`
+    executable. **Default:** `process.execArgv`.
+  * `exec` {string} File path to worker file. **Default:** `process.argv[1]`.
   * `args` {Array} String arguments passed to worker.
-    **Default:** `process.argv.slice(2)`
+    **Default:** `process.argv.slice(2)`.
   * `cwd` {string} Current working directory of the worker process. **Default:**
-    `undefined` (inherits from parent process)
+    `undefined` (inherits from parent process).
   * `silent` {boolean} Whether or not to send output to parent's stdio.
-    **Default:** `false`
+    **Default:** `false`.
   * `stdio` {Array} Configures the stdio of forked processes. Because the
     cluster module relies on IPC to function, this configuration must contain an
     `'ipc'` entry. When this option is provided, it overrides `silent`.
@@ -732,7 +732,7 @@ changes:
     number. By default each worker gets its own port, incremented from the
     master's `process.debugPort`.
   * `windowsHide` {boolean} Hide the forked processes console window that would
-    normally be created on Windows systems. **Default:** `false`
+    normally be created on Windows systems. **Default:** `false`.
 
 After calling `.setupMaster()` (or `.fork()`) this settings object will contain
 the settings, including the default values.

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -149,7 +149,7 @@ binary.
 added: v8.3.0
 -->
 
-* `label` {string} The display label for the counter. Defaults to `'default'`.
+* `label` {string} The display label for the counter. **Default:** `'default'`.
 
 Maintains an internal counter specific to `label` and outputs to `stdout` the
 number of times `console.count()` has been called with the given `label`.
@@ -182,7 +182,7 @@ undefined
 added: v8.3.0
 -->
 
-* `label` {string} The display label for the counter. Defaults to `'default'`.
+* `label` {string} The display label for the counter. **Default:** `'default'`.
 
 Resets the internal counter specific to `label`.
 
@@ -218,25 +218,17 @@ added: v0.1.101
 -->
 * `obj` {any}
 * `options` {Object}
-  * `showHidden` {boolean}
-  * `depth` {number}
-  * `colors` {boolean}
+  * `showHidden` {boolean} If `true` then the object's non-enumerable and symbol
+    properties will be shown too. **Default:** `false`.
+  * `depth` {number} Tells [`util.inspect()`][] how many times to recurse while
+    formatting the object. This is useful for inspecting large complicated
+    objects. To make it recurse indefinitely, pass `null`. **Default:** `2`.
+  * `colors` {boolean} If `true`, then the output will be styled with ANSI color
+     codes. Colors are customizable;
+     see [customizing `util.inspect()` colors][]. **Default:** `false`.
 
 Uses [`util.inspect()`][] on `obj` and prints the resulting string to `stdout`.
-This function bypasses any custom `inspect()` function defined on `obj`. An
-optional `options` object may be passed to alter certain aspects of the
-formatted string:
-
-- `showHidden` - if `true` then the object's non-enumerable and symbol
-properties will be shown too. Defaults to `false`.
-
-- `depth` - tells [`util.inspect()`][] how many times to recurse while
-formatting the object. This is useful for inspecting large complicated objects.
-Defaults to `2`. To make it recurse indefinitely, pass `null`.
-
-- `colors` - if `true`, then the output will be styled with ANSI color codes.
-Defaults to `false`. Colors are customizable; see
-[customizing `util.inspect()` colors][].
+This function bypasses any custom `inspect()` function defined on `obj`.
 
 ### console.dirxml(...data)
 <!-- YAML
@@ -377,7 +369,7 @@ console.table([{ a: 1, b: 'Y' }, { a: 'Z', b: 2 }], ['a']);
 <!-- YAML
 added: v0.1.104
 -->
-* `label` {string} Defaults to `'default'`.
+* `label` {string} **Default:** `'default'`
 
 Starts a timer that can be used to compute the duration of an operation. Timers
 are identified by a unique `label`. Use the same `label` when calling
@@ -393,7 +385,7 @@ changes:
     description: This method no longer supports multiple calls that don’t map
                  to individual `console.time()` calls; see below for details.
 -->
-* `label` {string} Defaults to `'default'`.
+* `label` {string} **Default:** `'default'`
 
 Stops a timer that was previously started by calling [`console.time()`][] and
 prints the result to `stdout`:
@@ -449,7 +441,7 @@ not display anything unless used in conjunction with the [inspector][]
 <!-- YAML
 added: v8.0.0
 -->
-* `label` {string} Defaults to `'default'`.
+* `label` {string} **Default:** `'default'`
 
 This method does not display anything unless used in the inspector. The
 `console.markTimeline()` method is the deprecated form of
@@ -506,7 +498,7 @@ This method does not display anything unless used in the inspector. The
 <!-- YAML
 added: v8.0.0
 -->
-* `label` {string} Defaults to `'default'`.
+* `label` {string} **Default:** `'default'`
 
 This method does not display anything unless used in the inspector. The
 `console.timeline()` method is the deprecated form of [`console.time()`][].
@@ -515,7 +507,7 @@ This method does not display anything unless used in the inspector. The
 <!-- YAML
 added: v8.0.0
 -->
-* `label` {string} Defaults to `'default'`.
+* `label` {string} **Default:** `'default'`
 
 This method does not display anything unless used in the inspector. The
 `console.timelineEnd()` method is the deprecated form of

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -270,7 +270,7 @@ been completed using the [`cipher.final()`][] method.
 <!-- YAML
 added: v0.7.1
 -->
-- `autoPadding` {boolean} Defaults to `true`.
+- `autoPadding` {boolean} **Default:** `true`
 - Returns the {Cipher} for method chaining.
 
 When using block encryption algorithms, the `Cipher` class will automatically
@@ -443,7 +443,7 @@ The `decipher.setAuthTag()` method must be called before
 <!-- YAML
 added: v0.7.1
 -->
-- `autoPadding` {boolean} Defaults to `true`.
+- `autoPadding` {boolean} **Default:** `true`
 - Returns the {Cipher} for method chaining.
 
 When data has been encrypted without standard block padding, calling
@@ -665,7 +665,7 @@ added: REPLACEME
 - `curve` {string}
 - `inputEncoding` {string}
 - `outputEncoding` {string}
-- `format` {string} Defaults to `uncompressed`.
+- `format` {string} **Default:** `uncompressed`
 
 Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the
 format specified by `format`. The `format` argument specifies point encoding
@@ -742,7 +742,7 @@ its recommended for developers to handle this exception accordingly.
 added: v0.11.14
 -->
 - `encoding` {string}
-- `format` {string} Defaults to `uncompressed`.
+- `format` {string} **Default:** `uncompressed`
 
 Generates private and public EC Diffie-Hellman key values, and returns
 the public key in the specified `format` and `encoding`. This key should be
@@ -771,7 +771,7 @@ a string is returned; otherwise a [`Buffer`][] is returned.
 added: v0.11.14
 -->
 - `encoding` {string}
-- `format` {string} Defaults to `uncompressed`.
+- `format` {string} **Default:** `uncompressed`
 
 Returns the EC Diffie-Hellman public key in the specified `encoding` and
 `format`.
@@ -1454,8 +1454,8 @@ changes:
 -->
 - `prime` {string | Buffer | TypedArray | DataView}
 - `primeEncoding` {string}
-- `generator` {number | string | Buffer | TypedArray | DataView} Defaults to
-  `2`.
+- `generator` {number | string | Buffer | TypedArray | DataView} **Default:**
+  `2`
 - `generatorEncoding` {string}
 
 Creates a `DiffieHellman` key exchange object using the supplied `prime` and an
@@ -1478,8 +1478,8 @@ otherwise a number, [`Buffer`][], `TypedArray`, or `DataView` is expected.
 added: v0.5.0
 -->
 - `primeLength` {number}
-- `generator` {number | string | Buffer | TypedArray | DataView} Defaults to
-  `2`.
+- `generator` {number | string | Buffer | TypedArray | DataView} **Default:**
+  `2`
 
 Creates a `DiffieHellman` key exchange object and generates a prime of
 `primeLength` bits using an optional specific numeric `generator`.
@@ -1957,8 +1957,8 @@ changes:
 -->
 
 * `buffer` {Buffer|TypedArray|DataView} Must be supplied.
-* `offset` {number} Defaults to `0`.
-* `size` {number} Defaults to `buffer.length - offset`.
+* `offset` {number} **Default:** `0`
+* `size` {number} **Default:** `buffer.length - offset`
 
 Synchronous version of [`crypto.randomFill()`][].
 
@@ -1999,8 +1999,8 @@ changes:
 -->
 
 * `buffer` {Buffer|TypedArray|DataView} Must be supplied.
-* `offset` {number} Defaults to `0`.
-* `size` {number} Defaults to `buffer.length - offset`.
+* `offset` {number} **Default:** `0`
+* `size` {number} **Default:** `buffer.length - offset`
 * `callback` {Function} `function(err, buf) {}`.
 
 This function is similar to [`crypto.randomBytes()`][] but requires the first
@@ -2064,7 +2064,7 @@ request.
 added: v0.11.11
 -->
 - `engine` {string}
-- `flags` {crypto.constants} Defaults to `crypto.constants.ENGINE_METHOD_ALL`.
+- `flags` {crypto.constants} **Default:** `crypto.constants.ENGINE_METHOD_ALL`
 
 Load and set the `engine` for some or all OpenSSL functions (selected by flags).
 

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -583,10 +583,10 @@ changes:
     Required.
   * `reuseAddr` {boolean} When `true` [`socket.bind()`][] will reuse the
     address, even if another process has already bound a socket on it.
-    Defaults to `false`.
+    **Default:** `false`.
   * `recvBufferSize` {number} - Sets the `SO_RCVBUF` socket value.
   * `sendBufferSize` {number} - Sets the `SO_SNDBUF` socket value.
-  * `lookup` {Function} Custom lookup function. Defaults to [`dns.lookup()`][].
+  * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
 * `callback` {Function} Attached as a listener for `'message'` events. Optional.
 * Returns: {dgram.Socket}
 

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -139,7 +139,7 @@ changes:
   - `hints` {number} One or more [supported `getaddrinfo` flags][]. Multiple
     flags may be passed by bitwise `OR`ing their values.
   - `all` {boolean} When `true`, the callback returns all resolved addresses in
-    an array. Otherwise, returns a single address. **Default:** `false`
+    an array. Otherwise, returns a single address. **Default:** `false`.
   - `verbatim` {boolean} When `true`, the callback receives IPv4 and IPv6
     addresses in the order the DNS resolver returned them.  When `false`,
     IPv4 addresses are placed before IPv6 addresses.
@@ -243,7 +243,7 @@ Promise for an object with `hostname` and `service` properties.
 added: v0.1.27
 -->
 - `hostname` {string} Hostname to resolve.
-- `rrtype` {string} Resource record type. **Default:** `'A'`
+- `rrtype` {string} Resource record type. **Default:** `'A'`.
 - `callback` {Function}
   - `err` {Error}
   - `records` {string[] | Object[] | Object}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1165,7 +1165,7 @@ added: v8.5.0
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `flags` {number} modifiers for copy operation. **Default:** `0`
+* `flags` {number} modifiers for copy operation. **Default:** `0`.
 * `callback` {Function}
 
 Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it
@@ -1208,7 +1208,7 @@ added: v8.5.0
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `flags` {number} modifiers for copy operation. **Default:** `0`
+* `flags` {number} modifiers for copy operation. **Default:** `0`.
 
 Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists. Returns `undefined`. Node.js makes no guarantees about the
@@ -1964,7 +1964,7 @@ changes:
   * `err` {Error}
 
 Asynchronously creates a directory. No arguments other than a possible exception
-are given to the completion callback. `mode` defaults to `0o777`.
+are given to the completion callback.
 
 See also: mkdir(2)
 
@@ -2093,7 +2093,7 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `flags` {string|number}
-* `mode` {integer} **Default:** `0o666`
+* `mode` {integer} **Default:** `0o666` (readable and writable)
 * `callback` {Function}
   * `err` {Error}
   * `fd` {integer}
@@ -2143,7 +2143,7 @@ The file is created if it does not exist.
 The file is created if it does not exist.
 
 `mode` sets the file mode (permission and sticky bits), but only if the file was
-created. It defaults to `0o666` (readable and writable).
+created.
 
 The callback gets two arguments `(err, fd)`.
 
@@ -2822,7 +2822,7 @@ changes:
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback. The `type` argument can be set to `'dir'`,
-`'file'`, or `'junction'` (default is `'file'`) and is only available on
+`'file'`, or `'junction'` and is only available on
 Windows (ignored on other platforms). Note that Windows junction points require
 the destination path to be absolute. When using `'junction'`, the `target`
 argument will automatically be normalized to absolute path.
@@ -3044,13 +3044,13 @@ changes:
 * `filename` {string|Buffer|URL}
 * `options` {string|Object}
   * `persistent` {boolean} Indicates whether the process should continue to run
-    as long as files are being watched. **Default:** `true`
+    as long as files are being watched. **Default:** `true`.
   * `recursive` {boolean} Indicates whether all subdirectories should be
     watched, or only the current directory. This applies when a directory is
     specified, and only on supported platforms (See [Caveats][]). **Default:**
-    `false`
+    `false`.
   * `encoding` {string} Specifies the character encoding to be used for the
-     filename passed to the listener. **Default:** `'utf8'`
+     filename passed to the listener. **Default:** `'utf8'`.
 * `listener` {Function|undefined} **Default:** `undefined`
   * `eventType` {string}
   * `filename` {string|Buffer}
@@ -3163,8 +3163,7 @@ The `options` argument may be omitted. If provided, it should be an object. The
 `options` object may contain a boolean named `persistent` that indicates
 whether the process should continue to run as long as files are being watched.
 The `options` object may specify an `interval` property indicating how often the
-target should be polled in milliseconds. The default is
-`{ persistent: true, interval: 5007 }`.
+target should be polled in milliseconds.
 
 The `listener` gets two arguments the current stat object and the previous
 stat object:
@@ -3337,8 +3336,7 @@ changes:
 Asynchronously writes data to a file, replacing the file if it already exists.
 `data` can be a string or a buffer.
 
-The `encoding` option is ignored if `data` is a buffer. It defaults
-to `'utf8'`.
+The `encoding` option is ignored if `data` is a buffer.
 
 Example:
 
@@ -3702,8 +3700,7 @@ Asynchronously writes data to a file, replacing the file if it already exists.
 `data` can be a string or a buffer. The `Promise` will be resolved with no
 arguments upon success.
 
-The `encoding` option is ignored if `data` is a buffer. It defaults
-to `'utf8'`.
+The `encoding` option is ignored if `data` is a buffer.
 
 If `options` is a string, then it specifies the encoding.
 
@@ -3806,7 +3803,7 @@ added: REPLACEME
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `flags` {number} modifiers for copy operation. **Default:** `0`
+* `flags` {number} modifiers for copy operation. **Default:** `0`.
 * Returns: {Promise}
 
 Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it
@@ -4062,7 +4059,7 @@ added: REPLACEME
 
 * `path` {string|Buffer|URL}
 * `flags` {string|number}
-* `mode` {integer} **Default:** `0o666`
+* `mode` {integer} **Default:** `0o666` (readable and writable)
 * Return: {Promise}
 
 Asynchronous file open that returns a `Promise` that, when resolved, yields a
@@ -4113,7 +4110,7 @@ The file is created if it does not exist.
 The file is created if it does not exist.
 
 `mode` sets the file mode (permission and sticky bits), but only if the file was
-created. It defaults to `0o666` (readable and writable).
+created.
 
 The exclusive flag `'x'` (`O_EXCL` flag in open(2)) ensures that `path` is newly
 created. On POSIX systems, `path` is considered to exist even if it is a symlink
@@ -4311,7 +4308,7 @@ Creates a symbolic link then resolves the `Promise` with no arguments upon
 success.
 
 The `type` argument is only used on Windows platforms and can be one of `'dir'`,
-`'file'`, or `'junction'` (default is `'file'`). Note that Windows junction
+`'file'`, or `'junction'`. Note that Windows junction
 points require the destination path to be absolute. When using `'junction'`,
 the `target` argument will automatically be normalized to absolute path.
 
@@ -4407,8 +4404,7 @@ Asynchronously writes data to a file, replacing the file if it already exists.
 `data` can be a string or a buffer. The `Promise` will be resolved with no
 arguments upon success.
 
-The `encoding` option is ignored if `data` is a buffer. It defaults
-to `'utf8'`.
+The `encoding` option is ignored if `data` is a buffer.
 
 If `options` is a string, then it specifies the encoding.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -116,16 +116,16 @@ added: v0.3.4
   Can have the following fields:
   * `keepAlive` {boolean} Keep sockets around even when there are no
     outstanding requests, so they can be used for future requests without
-    having to reestablish a TCP connection. Defaults to `false`
+    having to reestablish a TCP connection. **Default:** `false`.
   * `keepAliveMsecs` {number} When using the `keepAlive` option, specifies
     the [initial delay](net.html#net_socket_setkeepalive_enable_initialdelay)
     for TCP Keep-Alive packets. Ignored when the
-    `keepAlive` option is `false` or `undefined`. Defaults to `1000`.
+    `keepAlive` option is `false` or `undefined`. **Default:** `1000`.
   * `maxSockets` {number} Maximum number of sockets to allow per
-    host.  Defaults to `Infinity`.
+    host. **Default:** `Infinity`.
   * `maxFreeSockets` {number} Maximum number of sockets to leave open
     in a free state.  Only relevant if `keepAlive` is set to `true`.
-    Defaults to `256`.
+    **Default:** `256`.
 
 The default [`http.globalAgent`][] that is used by [`http.request()`][] has all
 of these values set to their respective defaults.
@@ -917,17 +917,16 @@ connections.
 added: v0.7.0
 -->
 
-* {number} Defaults to 2000.
+* {number} **Default:** `2000`
 
-Limits maximum incoming headers count, equal to 2000 by default. If set to 0 -
-no limit will be applied.
+Limits maximum incoming headers count. If set to 0 - no limit will be applied.
 
 ### server.setTimeout([msecs][, callback])
 <!-- YAML
 added: v0.9.12
 -->
 
-* `msecs` {number} Defaults to 120000 (2 minutes).
+* `msecs` {number} **Default:** `120000` (2 minutes)
 * `callback` {Function}
 
 Sets the timeout value for sockets, and emits a `'timeout'` event on
@@ -948,7 +947,7 @@ Returns `server`.
 added: v0.9.12
 -->
 
-* {number} Timeout in milliseconds. Defaults to 120000 (2 minutes).
+* {number} Timeout in milliseconds. **Default:** `120000` (2 minutes).
 
 The number of milliseconds of inactivity before a socket is presumed
 to have timed out.
@@ -963,7 +962,7 @@ value only affects new connections to the server, not any existing connections.
 added: v8.0.0
 -->
 
-* {number} Timeout in milliseconds. Defaults to 5000 (5 seconds).
+* {number} Timeout in milliseconds. **Default:** `5000` (5 seconds).
 
 The number of milliseconds of inactivity a server needs to wait for additional
 incoming data, after it has finished writing the last response, before a socket
@@ -1332,7 +1331,7 @@ added: v0.1.29
 -->
 
 * `chunk` {string|Buffer}
-* `encoding` {string}
+* `encoding` {string} **Default:** `'utf8'`
 * `callback` {Function}
 * Returns: {boolean}
 
@@ -1348,8 +1347,7 @@ _must not_ include a message body.
 
 `chunk` can be a string or a buffer. If `chunk` is a string,
 the second parameter specifies how to encode it into a byte stream.
-By default the `encoding` is `'utf8'`. `callback` will be called when this chunk
-of data is flushed.
+`callback` will be called when this chunk of data is flushed.
 
 This is the raw HTTP body and has nothing to do with higher-level multi-part
 body encodings that may be used.
@@ -1729,11 +1727,11 @@ changes:
 -->
 - `options` {Object}
   * `IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage class
-    to be used. Useful for extending the original `IncomingMessage`. Defaults
-    to: `IncomingMessage`
+    to be used. Useful for extending the original `IncomingMessage`.
+    **Default:** `IncomingMessage`.
   * `ServerResponse` {http.ServerResponse} Specifies the ServerResponse class to
-    be used. Useful for extending the original `ServerResponse`. Defaults to:
-    `ServerResponse`
+    be used. Useful for extending the original `ServerResponse`. **Default:**
+    `ServerResponse`.
 - `requestListener` {Function}
 
 * Returns: {http.Server}
@@ -1825,24 +1823,24 @@ changes:
 -->
 
 * `options` {Object | string | URL}
-  * `protocol` {string} Protocol to use. Defaults to `http:`.
+  * `protocol` {string} Protocol to use. **Default:** `http:`.
   * `host` {string} A domain name or IP address of the server to issue the
-    request to. Defaults to `localhost`.
+    request to. **Default:** `localhost`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` is preferred over `host`.
   * `family` {number} IP address family to use when resolving `host` and
     `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and
     v6 will be used.
-  * `port` {number} Port of remote server. Defaults to 80.
+  * `port` {number} Port of remote server. **Default:** `80`.
   * `localAddress` {string} Local interface to bind for network connections.
   * `socketPath` {string} Unix Domain Socket (use one of host:port or
     socketPath).
-  * `method` {string} A string specifying the HTTP request method. Defaults to
+  * `method` {string} A string specifying the HTTP request method. **Default:**
     `'GET'`.
-  * `path` {string} Request path. Defaults to `'/'`. Should include query
-    string if any. E.G. `'/index.html?page=12'`. An exception is thrown when
-    the request path contains illegal characters. Currently, only spaces are
-    rejected but that may change in the future.
+  * `path` {string} Request path. Should include query string if any.
+    E.G. `'/index.html?page=12'`. An exception is thrown when the request path
+    contains illegal characters. Currently, only spaces are rejected but that
+    may change in the future. **Default:** `'/'`.
   * `headers` {Object} An object containing request headers.
   * `auth` {string} Basic authentication i.e. `'user:password'` to compute an
     Authorization header.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -677,7 +677,7 @@ added: v8.4.0
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     the created stream is made the sole direct dependency of the parent, with
     all other existing dependents made a dependent of the newly created stream.
-    **Default:** `false`
+    **Default:** `false`.
   * `parent` {number} Specifies the numeric identifier of a stream the newly
     created stream is dependent on.
   * `weight` {number} Specifies the relative dependency of a stream in relation
@@ -879,7 +879,7 @@ added: v8.4.0
 -->
 
 * code {number} Unsigned 32-bit integer identifying the error code. **Default:**
-  `http2.constants.NGHTTP2_NO_ERROR` (`0x00`)
+  `http2.constants.NGHTTP2_NO_ERROR` (`0x00`).
 * `callback` {Function} An optional function registered to listen for the
   `'close'` event.
 
@@ -924,7 +924,7 @@ added: v8.4.0
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     this stream is made the sole direct dependency of the parent, with
     all other existing dependents made a dependent of this stream. **Default:**
-    `false`
+    `false`.
   * `parent` {number} Specifies the numeric identifier of a stream this stream
     is dependent on.
   * `weight` {number} Specifies the relative dependency of a stream in relation
@@ -1148,7 +1148,7 @@ added: v8.4.0
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     the created stream is made the sole direct dependency of the parent, with
     all other existing dependents made a dependent of the newly created stream.
-    **Default:** `false`
+    **Default:** `false`.
   * `parent` {number} Specifies the numeric identifier of a stream the newly
     created stream is dependent on.
 * `callback` {Function} Callback that is called once the push stream has been
@@ -1665,20 +1665,20 @@ changes:
 
 * `options` {Object}
   * `maxDeflateDynamicTableSize` {number} Sets the maximum dynamic table size
-    for deflating header fields. **Default:** `4Kib`
+    for deflating header fields. **Default:** `4Kib`.
   * `maxSessionMemory`{number} Sets the maximum memory that the `Http2Session`
     is permitted to use. The value is expressed in terms of number of megabytes,
-    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`. **Default:**
-    `10`. This is a credit based limit, existing `Http2Stream`s may cause this
+    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`.
+    This is a credit based limit, existing `Http2Stream`s may cause this
     limit to be exceeded, but new `Http2Stream` instances will be rejected
     while this limit is exceeded. The current number of `Http2Stream` sessions,
     the current memory use of the header compression tables, current data
     queued to be sent, and unacknowledged PING and SETTINGS frames are all
-    counted towards the current limit.
+    counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    **Default:** `128`. The minimum value is `4`.
+    The minimum value is `4`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
-    unacknowledged pings. The default is `10`.
+    unacknowledged pings. **Default:** `10`.
   * `maxSendHeaderBlockLength` {number} Sets the maximum allowed size for a
     serialized, compressed block of headers. Attempts to send headers that
     exceed this limit will result in a `'frameError'` event being emitted
@@ -1704,7 +1704,7 @@ changes:
   * `peerMaxConcurrentStreams` {number} Sets the maximum number of concurrent
     streams for the remote peer as if a SETTINGS frame had been received. Will
     be overridden if the remote peer sets its own value for
-    `maxConcurrentStreams`. **Default:** `100`
+    `maxConcurrentStreams`. **Default:** `100`.
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
@@ -1712,18 +1712,18 @@ changes:
     remote peer upon connection.
   * `Http1IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage
     class to used for HTTP/1 fallback. Useful for extending the original
-    `http.IncomingMessage`. **Default:** `http.IncomingMessage`
+    `http.IncomingMessage`. **Default:** `http.IncomingMessage`.
   * `Http1ServerResponse` {http.ServerResponse} Specifies the ServerResponse
     class to used for HTTP/1 fallback. Useful for extending the original
-    `http.ServerResponse`. **Default:** `http.ServerResponse`
+    `http.ServerResponse`. **Default:** `http.ServerResponse`.
   * `Http2ServerRequest` {http2.Http2ServerRequest} Specifies the
     Http2ServerRequest class to use.
     Useful for extending the original `Http2ServerRequest`.
-    **Default:** `Http2ServerRequest`
+    **Default:** `Http2ServerRequest`.
   * `Http2ServerResponse` {http2.Http2ServerResponse} Specifies the
     Http2ServerResponse class to use.
     Useful for extending the original `Http2ServerResponse`.
-    **Default:** `Http2ServerResponse`
+    **Default:** `Http2ServerResponse`.
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 
@@ -1771,23 +1771,24 @@ changes:
 
 * `options` {Object}
   * `allowHTTP1` {boolean} Incoming client connections that do not support
-    HTTP/2 will be downgraded to HTTP/1.x when set to `true`. **Default:**
-    `false`. See the [`'unknownProtocol'`][] event. See [ALPN negotiation][].
+    HTTP/2 will be downgraded to HTTP/1.x when set to `true`.
+    See the [`'unknownProtocol'`][] event. See [ALPN negotiation][].
+    **Default:** `false`.
   * `maxDeflateDynamicTableSize` {number} Sets the maximum dynamic table size
-    for deflating header fields. **Default:** `4Kib`
+    for deflating header fields. **Default:** `4Kib`.
   * `maxSessionMemory`{number} Sets the maximum memory that the `Http2Session`
     is permitted to use. The value is expressed in terms of number of megabytes,
-    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`. **Default:**
-    `10`. This is a credit based limit, existing `Http2Stream`s may cause this
+    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`. This is a
+    credit based limit, existing `Http2Stream`s may cause this
     limit to be exceeded, but new `Http2Stream` instances will be rejected
     while this limit is exceeded. The current number of `Http2Stream` sessions,
     the current memory use of the header compression tables, current data
     queued to be sent, and unacknowledged PING and SETTINGS frames are all
-    counted towards the current limit.
+    counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    **Default:** `128`. The minimum value is `4`.
+    The minimum value is `4`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
-    unacknowledged pings. The default is `10`.
+    unacknowledged pings. **Default:** `10`.
   * `maxSendHeaderBlockLength` {number} Sets the maximum allowed size for a
     serialized, compressed block of headers. Attempts to send headers that
     exceed this limit will result in a `'frameError'` event being emitted
@@ -1813,7 +1814,7 @@ changes:
   * `peerMaxConcurrentStreams` {number} Sets the maximum number of concurrent
     streams for the remote peer as if a SETTINGS frame had been received. Will
     be overridden if the remote peer sets its own value for
-    `maxConcurrentStreams`. **Default:** `100`
+    `maxConcurrentStreams`. **Default:** `100`.
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
@@ -1866,20 +1867,20 @@ changes:
 * `authority` {string|URL}
 * `options` {Object}
   * `maxDeflateDynamicTableSize` {number} Sets the maximum dynamic table size
-    for deflating header fields. **Default:** `4Kib`
+    for deflating header fields. **Default:** `4Kib`.
   * `maxSessionMemory`{number} Sets the maximum memory that the `Http2Session`
     is permitted to use. The value is expressed in terms of number of megabytes,
-    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`. **Default:**
-    `10`. This is a credit based limit, existing `Http2Stream`s may cause this
+    e.g. `1` equal 1 megabyte. The minimum value allowed is `1`.
+    This is a credit based limit, existing `Http2Stream`s may cause this
     limit to be exceeded, but new `Http2Stream` instances will be rejected
     while this limit is exceeded. The current number of `Http2Stream` sessions,
     the current memory use of the header compression tables, current data
     queued to be sent, and unacknowledged PING and SETTINGS frames are all
-    counted towards the current limit.
+    counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    **Default:** `128`. The minimum value is `1`.
+    The minimum value is `1`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
-    unacknowledged pings. The default is `10`.
+    unacknowledged pings. **Default:** `10`.
   * `maxReservedRemoteStreams` {number} Sets the maximum number of reserved push
     streams the client will accept at any given time. Once the current number of
     currently reserved push streams exceeds reaches this limit, new push streams
@@ -1909,7 +1910,7 @@ changes:
   * `peerMaxConcurrentStreams` {number} Sets the maximum number of concurrent
     streams for the remote peer as if a SETTINGS frame had been received. Will
     be overridden if the remote peer sets its own value for
-    `maxConcurrentStreams`. **Default:** `100`
+    `maxConcurrentStreams`. **Default:** `100`.
   * `selectPadding` {Function} When `options.paddingStrategy` is equal to
     `http2.constants.PADDING_STRATEGY_CALLBACK`, provides the callback function
     used to determine the padding. See [Using options.selectPadding][].
@@ -2052,16 +2053,16 @@ These objects are ordinary JavaScript objects containing the following
 properties.
 
 * `headerTableSize` {number} Specifies the maximum number of bytes used for
-  header compression. **Default:** `4,096 octets`. The minimum allowed
-  value is 0. The maximum allowed value is 2<sup>32</sup>-1.
+  header compression. The minimum allowed value is 0. The maximum allowed value
+  is 2<sup>32</sup>-1. **Default:** `4,096 octets`.
 * `enablePush` {boolean} Specifies `true` if HTTP/2 Push Streams are to be
   permitted on the `Http2Session` instances.
 * `initialWindowSize` {number} Specifies the *senders* initial window size
-  for stream-level flow control. **Default:** `65,535 bytes`. The minimum
-  allowed value is 0. The maximum allowed value is 2<sup>32</sup>-1.
+  for stream-level flow control. The minimum allowed value is 0. The maximum
+  allowed value is 2<sup>32</sup>-1. **Default:** `65,535 bytes`.
 * `maxFrameSize` {number} Specifies the size of the largest frame payload.
-  **Default:** `16,384 bytes`. The minimum allowed value is 16,384. The maximum
-  allowed value is 2<sup>24</sup>-1.
+  The minimum allowed value is 16,384. The maximum allowed value
+  is 2<sup>24</sup>-1. **Default:** `16,384 bytes`.
 * `maxConcurrentStreams` {number} Specifies the maximum number of concurrent
   streams permitted on an `Http2Session`. There is no default value which
   implies, at least theoretically, 2<sup>31</sup>-1 streams may be open
@@ -2069,7 +2070,7 @@ properties.
   is 0. The maximum allowed value is 2<sup>31</sup>-1.
 * `maxHeaderListSize` {number} Specifies the maximum size (uncompressed octets)
   of header list that will be accepted. The minimum allowed value is 0. The
-  maximum allowed value is 2<sup>32</sup>-1. **Default:** 65535.
+  maximum allowed value is 2<sup>32</sup>-1. **Default:** `65535`.
 
 All additional properties on the settings object are ignored.
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -40,7 +40,7 @@ This method is identical to [`server.listen()`][] from [`net.Server`][].
 <!-- YAML
 added: v0.11.2
 -->
-- `msecs` {number} Defaults to 120000 (2 minutes).
+- `msecs` {number} **Default:** `120000` (2 minutes)
 - `callback` {Function}
 
 See [`http.Server#setTimeout()`][].
@@ -49,7 +49,7 @@ See [`http.Server#setTimeout()`][].
 <!-- YAML
 added: v0.11.2
 -->
-- {number} Defaults to 120000 (2 minutes).
+- {number} **Default:** `120000` (2 minutes)
 
 See [`http.Server#timeout`][].
 
@@ -57,7 +57,7 @@ See [`http.Server#timeout`][].
 <!-- YAML
 added: v8.0.0
 -->
-- {number} Defaults to 5000 (5 seconds).
+- {number} **Default:** `5000` (5 seconds)
 
 See [`http.Server#keepAliveTimeout`][].
 
@@ -160,9 +160,9 @@ changes:
 -->
 - `options` {Object | string | URL} Accepts all `options` from
   [`http.request()`][], with some differences in default values:
-  - `protocol` Defaults to `https:`
-  - `port` Defaults to `443`.
-  - `agent` Defaults to `https.globalAgent`.
+  - `protocol` **Default:** `https:`
+  - `port` **Default:** `443`
+  - `agent` **Default:** `https.globalAgent`
 - `callback` {Function}
 
 

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -14,12 +14,12 @@ const inspector = require('inspector');
 
 ## inspector.open([port[, host[, wait]]])
 
-* port {number} Port to listen on for inspector connections. Optional,
-  defaults to what was specified on the CLI.
-* host {string} Host to listen on for inspector connections. Optional,
-  defaults to what was specified on the CLI.
-* wait {boolean} Block until a client has connected. Optional, defaults
-  to false.
+* `port` {number} Port to listen on for inspector connections. Optional.
+  **Default:** what was specified on the CLI.
+* `host` {string} Host to listen on for inspector connections. Optional.
+  **Default:** what was specified on the CLI.
+* `wait` {boolean} Block until a client has connected. Optional.
+  **Default:** `false`.
 
 Activate inspector on host and port. Equivalent to `node
 --inspect=[[host:]port]`, but can be done programmatically after node has

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -383,11 +383,11 @@ Creates a new socket object.
     the given file descriptor, otherwise a new socket will be created.
   * `allowHalfOpen` {boolean} Indicates whether half-opened TCP connections
     are allowed. See [`net.createServer()`][] and the [`'end'`][] event
-    for details. **Default:** `false`
+    for details. **Default:** `false`.
   * `readable` {boolean} Allow reads on the socket when an `fd` is passed,
-    otherwise ignored. **Default:** `false`
+    otherwise ignored. **Default:** `false`.
   * `writable` {boolean} Allow writes on the socket when an `fd` is passed,
-    otherwise ignored. **Default:** `false`
+    otherwise ignored. **Default:** `false`.
 * Returns: {net.Socket}
 
 The newly created socket can be either a TCP socket or a streaming [IPC][]
@@ -578,12 +578,13 @@ this only when implementing a custom Socket.
 For TCP connections, available `options` are:
 
 * `port` {number} Required. Port the socket should connect to.
-* `host` {string} Host the socket should connect to. **Default:** `'localhost'`
+* `host` {string} Host the socket should connect to. **Default:** `'localhost'`.
 * `localAddress` {string} Local address the socket should connect from.
 * `localPort` {number} Local port the socket should connect from.
-* `family` {number}: Version of IP stack, can be either 4 or 6. **Default:** `4`
+* `family` {number}: Version of IP stack, can be either `4` or `6`.
+  **Default:** `4`.
 * `hints` {number} Optional [`dns.lookup()` hints][].
-* `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][]
+* `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
 
 For [IPC][] connections, available `options` are:
 
@@ -752,28 +753,29 @@ Set the encoding for the socket as a [Readable Stream][]. See
 added: v0.1.92
 -->
 
+* `enable` {boolean} **Default:** `false`
+* `initialDelay` {number} **Default:** `0`
 * Returns: {net.Socket} The socket itself.
 
 Enable/disable keep-alive functionality, and optionally set the initial
 delay before the first keepalive probe is sent on an idle socket.
-`enable` defaults to `false`.
 
 Set `initialDelay` (in milliseconds) to set the delay between the last
 data packet received and the first keepalive probe. Setting 0 for
 initialDelay will leave the value unchanged from the default
-(or previous) setting. Defaults to `0`.
+(or previous) setting.
 
 ### socket.setNoDelay([noDelay])
 <!-- YAML
 added: v0.1.90
 -->
 
+* `noDelay` {boolean} **Default:** `true`
 * Returns: {net.Socket} The socket itself.
 
 Disables the Nagle algorithm. By default TCP connections use the Nagle
 algorithm, they buffer data before sending it off. Setting `true` for
 `noDelay` will immediately fire off data each time `socket.write()` is called.
-`noDelay` defaults to `true`.
 
 ### socket.setTimeout(timeout[, callback])
 <!-- YAML
@@ -964,7 +966,7 @@ added: v0.1.90
   [`socket.connect(port[, host][, connectListener])`][`socket.connect(port, host)`].
 * `host` {string} Host the socket should connect to. Will be passed to
   [`socket.connect(port[, host][, connectListener])`][`socket.connect(port, host)`].
-   **Default:** `'localhost'`
+   **Default:** `'localhost'`.
 * `connectListener` {Function} Common parameter of the
   [`net.createConnection()`][] functions, an "once" listener for the
   `'connect'` event on the initiating socket. Will be passed to
@@ -987,9 +989,9 @@ Creates a new TCP or [IPC][] server.
 
 * `options` {Object}
   * `allowHalfOpen` {boolean} Indicates whether half-opened TCP
-    connections are allowed. **Default:** `false`
+    connections are allowed. **Default:** `false`.
   * `pauseOnConnect` {boolean} Indicates whether the socket should be
-    paused on incoming connections. **Default:** `false`
+    paused on incoming connections. **Default:** `false`.
 * `connectionListener` {Function} Automatically set as a listener for the
   [`'connection'`][] event.
 * Returns: {net.Server}

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -398,7 +398,7 @@ added: v6.0.0
 * `options` {Object}
   * `encoding` {string} Character encoding used to interpret resulting strings.
     If `encoding` is set to `'buffer'`, the `username`, `shell`, and `homedir`
-    values will be `Buffer` instances. **Default:** `'utf8'`
+    values will be `Buffer` instances. **Default:** `'utf8'`.
 * Returns: {Object}
 
 The `os.userInfo()` method returns information about the currently effective

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -531,7 +531,7 @@ added: v8.5.0
   * `buffered` {boolean} If true, the notification callback will be
     called using `setImmediate()` and multiple `PerformanceEntry` instance
     notifications will be buffered internally. If `false`, notifications will
-    be immediate and synchronous. Defaults to `false`.
+    be immediate and synchronous. **Default:** `false`.
 
 Subscribes the `PerformanceObserver` instance to notifications of new
 `PerformanceEntry` instances identified by `options.entryTypes`.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -661,7 +661,7 @@ changes:
 
 * `module` {Object}
 * `filename` {string}
-* `flags` {os.constants.dlopen} Defaults to `os.constants.dlopen.RTLD_LAZY`.
+* `flags` {os.constants.dlopen} **Default:** `os.constants.dlopen.RTLD_LAZY`
 
 The `process.dlopen()` method allows to dynamically load shared
 objects. It is primarily used by `require()` to load
@@ -700,11 +700,11 @@ added: v8.0.0
 * `warning` {string|Error} The warning to emit.
 * `options` {Object}
   * `type` {string} When `warning` is a String, `type` is the name to use
-    for the *type* of warning being emitted. Default: `Warning`.
+    for the *type* of warning being emitted. **Default:** `Warning`.
   * `code` {string} A unique identifier for the warning instance being emitted.
   * `ctor` {Function} When `warning` is a String, `ctor` is an optional
-    function used to limit the generated stack trace. Default
-    `process.emitWarning`
+    function used to limit the generated stack trace. **Default:**
+    `process.emitWarning`.
   * `detail` {string} Additional text to include with the error.
 
 The `process.emitWarning()` method can be used to emit custom or application
@@ -745,11 +745,11 @@ added: v6.0.0
 
 * `warning` {string|Error} The warning to emit.
 * `type` {string} When `warning` is a String, `type` is the name to use
-  for the *type* of warning being emitted. Default: `Warning`.
+  for the *type* of warning being emitted. **Default:** `Warning`.
 * `code` {string} A unique identifier for the warning instance being emitted.
 * `ctor` {Function} When `warning` is a String, `ctor` is an optional
-  function used to limit the generated stack trace. Default
-  `process.emitWarning`
+  function used to limit the generated stack trace. **Default:**
+  `process.emitWarning`.
 
 The `process.emitWarning()` method can be used to emit custom or application
 specific process warnings. These can be listened for by adding a handler to the
@@ -971,7 +971,7 @@ that started the Node.js process.
 added: v0.1.13
 -->
 
-* `code` {integer} The exit code. Defaults to `0`.
+* `code` {integer} The exit code. **Default:** `0`.
 
 The `process.exit()` method instructs Node.js to terminate the process
 synchronously with an exit status of `code`. If `code` is omitted, exit uses
@@ -1214,7 +1214,7 @@ added: v0.0.6
 
 * `pid` {number} A process ID
 * `signal` {string|number} The signal to send, either as a string or number.
-  Defaults to `'SIGTERM'`.
+  **Default:** `'SIGTERM'`.
 
 The `process.kill()` method sends the `signal` to the process identified by
 `pid`.

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -46,15 +46,15 @@ changes:
 
 * `str` {string} The URL query string to parse
 * `sep` {string} The substring used to delimit key and value pairs in the
-  query string. Defaults to `'&'`.
+  query string. **Default:** `'&'`.
 * `eq` {string}. The substring used to delimit keys and values in the
-  query string. Defaults to `'='`.
+  query string. **Default:** `'='`.
 * `options` {Object}
   * `decodeURIComponent` {Function} The function to use when decoding
-    percent-encoded characters in the query string. Defaults to
+    percent-encoded characters in the query string. **Default:**
     `querystring.unescape()`.
   * `maxKeys` {number} Specifies the maximum number of keys to parse.
-    Defaults to `1000`. Specify `0` to remove key counting limitations.
+    Specify `0` to remove key counting limitations. **Default:** `1000`.
 
 The `querystring.parse()` method parses a URL query string (`str`) into a
 collection of key and value pairs.
@@ -93,12 +93,12 @@ added: v0.1.25
 
 * `obj` {Object} The object to serialize into a URL query string
 * `sep` {string} The substring used to delimit key and value pairs in the
-  query string. Defaults to `'&'`.
+  query string. **Default:** `'&'`.
 * `eq` {string}. The substring used to delimit keys and values in the
-  query string. Defaults to `'='`.
+  query string. **Default:** `'='`.
 * `options`
   * `encodeURIComponent` {Function} The function to use when converting
-    URL-unsafe characters to percent-encoding in the query string. Defaults to
+    URL-unsafe characters to percent-encoding in the query string. **Default:**
     `querystring.escape()`.
 
 The `querystring.stringify()` method produces a URL query string from a

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -357,22 +357,22 @@ changes:
   * `completer` {Function} An optional function used for Tab autocompletion.
   * `terminal` {boolean} `true` if the `input` and `output` streams should be
     treated like a TTY, and have ANSI/VT100 escape codes written to it.
-    Defaults to checking `isTTY` on the `output` stream upon instantiation.
+    **Default:** checking `isTTY` on the `output` stream upon instantiation.
   * `historySize` {number} Maximum number of history lines retained. To disable
     the history set this value to `0`. This option makes sense only if
     `terminal` is set to `true` by the user or by an internal `output` check,
     otherwise the history caching mechanism is not initialized at all.
-    **Default:** `30`
-  * `prompt` {string} The prompt string to use. **Default:** `'> '`
+    **Default:** `30`.
+  * `prompt` {string} The prompt string to use. **Default:** `'> '`.
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. `crlfDelay` will be coerced to a number no less than
     `100`. It can be set to `Infinity`, in which case `\r` followed by `\n`
     will always be considered a single newline (which may be reasonable for
-    [reading files][] with `\r\n` line delimiter). **Default:** `100`
+    [reading files][] with `\r\n` line delimiter). **Default:** `100`.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
-    from the list. **Default:** `false`
+    from the list. **Default:** `false`.
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -430,33 +430,33 @@ changes:
 -->
 
 * `options` {Object|string}
-  * `prompt` {string} The input prompt to display. Defaults to `> `
+  * `prompt` {string} The input prompt to display. **Default:** `> `.
     (with a trailing space).
   * `input` {stream.Readable} The Readable stream from which REPL input will be
-    read. Defaults to `process.stdin`.
+    read. **Default:** `process.stdin`.
   * `output` {stream.Writable} The Writable stream to which REPL output will be
-    written. Defaults to `process.stdout`.
+    written. **Default:** `process.stdout`.
   * `terminal` {boolean} If `true`, specifies that the `output` should be
     treated as a TTY terminal, and have ANSI/VT100 escape codes written to it.
-    Defaults to checking the value of the `isTTY` property on the `output`
+    **Default:** checking the value of the `isTTY` property on the `output`
     stream upon instantiation.
   * `eval` {Function} The function to be used when evaluating each given line
-    of input. Defaults to an async wrapper for the JavaScript `eval()`
+    of input. **Default:** an async wrapper for the JavaScript `eval()`
     function.  An `eval` function can error with `repl.Recoverable` to indicate
     the input was incomplete and prompt for additional lines.
   * `useColors` {boolean} If `true`, specifies that the default `writer`
     function should include ANSI color styling to REPL output. If a custom
-    `writer` function is provided then this has no effect. Defaults to the
+    `writer` function is provided then this has no effect. **Default:** the
      REPL instances `terminal` value.
   * `useGlobal` {boolean} If `true`, specifies that the default evaluation
      function will use the JavaScript `global` as the context as opposed to
      creating a new separate context for the REPL instance. The node CLI REPL
-     sets this value to `true`. Defaults to `false`.
+     sets this value to `true`. **Default:** `false`.
   * `ignoreUndefined` {boolean} If `true`, specifies that the default writer
      will not output the return value of a command if it evaluates to
-     `undefined`. Defaults to `false`.
+     `undefined`. **Default:** `false`.
   * `writer` {Function} The function to invoke to format the output of each
-     command before writing to `output`. Defaults to [`util.inspect()`][].
+     command before writing to `output`. **Default:** [`util.inspect()`][].
   * `completer` {Function} An optional function used for custom Tab auto
      completion. See [`readline.InterfaceCompleter`][] for an example.
   * `replMode` {symbol} A flag that specifies whether the default evaluator
@@ -467,7 +467,7 @@ changes:
       equivalent to prefacing every repl statement with `'use strict'`.
   * `breakEvalOnSigint` - Stop evaluating the current piece of code when
     `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
-    with a custom `eval` function. Defaults to `false`.
+    with a custom `eval` function. **Default:** `false`.
 
 The `repl.start()` method creates and starts a `repl.REPLServer` instance.
 
@@ -510,10 +510,11 @@ environment variables:
    will be saved to the specified file rather than `.node_repl_history` in the
    user's home directory. Setting this value to `""` will disable persistent
    REPL history. Whitespace will be trimmed from the value.
- - `NODE_REPL_HISTORY_SIZE` - Defaults to `1000`. Controls how many lines of
-   history will be persisted if history is available. Must be a positive number.
- - `NODE_REPL_MODE` - May be either `sloppy` or `strict`. Defaults
-   to `sloppy`, which will allow non-strict mode code to be run.
+ - `NODE_REPL_HISTORY_SIZE` - Controls how many lines of history will be
+   persisted if history is available. Must be a positive number.
+   **Default:** `1000`.
+ - `NODE_REPL_MODE` - May be either `sloppy` or `strict`. **Default:** `sloppy`,
+   which will allow non-strict mode code to be run.
 
 ### Persistent History
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -873,7 +873,7 @@ added: v0.9.4
 
 * `destination` {stream.Writable} The destination for writing data
 * `options` {Object} Pipe options
-  * `end` {boolean} End the writer when the reader ends. Defaults to `true`.
+  * `end` {boolean} End the writer when the reader ends. **Default:** `true`.
 * Returns: {stream.Writable} making it possible to set up chains of piped
   streams
 
@@ -1405,18 +1405,18 @@ changes:
 
 * `options` {Object}
   * `highWaterMark` {number} Buffer level when
-    [`stream.write()`][stream-write] starts returning `false`. Defaults to
+    [`stream.write()`][stream-write] starts returning `false`. **Default:**
     `16384` (16kb), or `16` for `objectMode` streams.
   * `decodeStrings` {boolean} Whether or not to decode strings into
     Buffers before passing them to [`stream._write()`][stream-_write].
-    Defaults to `true`
+    **Default:** `true`.
   * `objectMode` {boolean} Whether or not the
     [`stream.write(anyObj)`][stream-write] is a valid operation. When set,
     it becomes possible to write JavaScript values other than string,
     `Buffer` or `Uint8Array` if supported by the stream implementation.
-    Defaults to `false`
+    **Default:** `false`.
   * `emitClose` {boolean} Whether or not the stream should emit `close`
-    after it has been destroyed. Defaults to `true`
+    after it has been destroyed. **Default:** `true`.
   * `write` {Function} Implementation for the
     [`stream._write()`][stream-_write] method.
   * `writev` {Function} Implementation for the
@@ -1666,12 +1666,12 @@ constructor and implement the `readable._read()` method.
 * `options` {Object}
   * `highWaterMark` {number} The maximum [number of bytes][hwm-gotcha] to store
     in the internal buffer before ceasing to read from the underlying resource.
-    Defaults to `16384` (16kb), or `16` for `objectMode` streams
+    **Default:** `16384` (16kb), or `16` for `objectMode` streams.
   * `encoding` {string} If specified, then buffers will be decoded to
-    strings using the specified encoding. Defaults to `null`
+    strings using the specified encoding. **Default:** `null`.
   * `objectMode` {boolean} Whether this stream should behave
     as a stream of objects. Meaning that [`stream.read(n)`][stream-read] returns
-    a single value instead of a Buffer of size n. Defaults to `false`
+    a single value instead of a Buffer of size n. **Default:** `false`.
   * `read` {Function} Implementation for the [`stream._read()`][stream-_read]
     method.
   * `destroy` {Function} Implementation for the
@@ -1923,15 +1923,13 @@ changes:
 
 * `options` {Object} Passed to both Writable and Readable
   constructors. Also has the following fields:
-  * `allowHalfOpen` {boolean} Defaults to `true`. If set to `false`, then
-    the stream will automatically end the writable side when the
-    readable side ends.
-  * `readableObjectMode` {boolean} Defaults to `false`. Sets `objectMode`
-    for readable side of the stream. Has no effect if `objectMode`
-    is `true`.
-  * `writableObjectMode` {boolean} Defaults to `false`. Sets `objectMode`
-    for writable side of the stream. Has no effect if `objectMode`
-    is `true`.
+  * `allowHalfOpen` {boolean} If set to `false`, then the stream will
+    automatically end the writable side when the readable side ends.
+    **Default:** `true`.
+  * `readableObjectMode` {boolean} Sets `objectMode` for readable side of the
+    stream. Has no effect if `objectMode` is `true`. **Default:** `false`.
+  * `writableObjectMode` {boolean} Sets `objectMode` for writable side of the
+    stream. Has no effect if `objectMode` is `true`. **Default:** `false`.
   * `readableHighWaterMark` {number} Sets `highWaterMark` for the readable side
     of the stream. Has no effect if `highWaterMark` is provided.
   * `writableHighWaterMark` {number} Sets `highWaterMark` for the writable side

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -48,7 +48,7 @@ added: v0.1.99
 -->
 
 * `encoding` {string} The character encoding the `StringDecoder` will use.
-  Defaults to `'utf8'`.
+  **Default:** `'utf8'`.
 
 Creates a new `StringDecoder` instance.
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -129,9 +129,9 @@ An `'error'` event is emitted on the [`tls.TLSSocket`][] instance when this
 threshold is exceeded. The limits are configurable:
 
 * `tls.CLIENT_RENEG_LIMIT` {number} Specifies the number of renegotiation
-  requests. Defaults to `3`.
+  requests. **Default:** `3`.
 * `tls.CLIENT_RENEG_WINDOW` {number} Specifies the time renegotiation window
-  in seconds. Defaults to `600` (10 minutes).
+  in seconds. **Default:** `600` (10 minutes).
 
 The default renegotiation limits should not be modified without a full
 understanding of the implications and risks.
@@ -453,7 +453,7 @@ changes:
 * `options` {Object}
   * `isServer`: The SSL/TLS protocol is asymmetrical, TLSSockets must know if
     they are to behave as a server or a client. If `true` the TLS socket will be
-    instantiated as a server.  Defaults to `false`.
+    instantiated as a server. **Default:** `false`.
   * `server` {net.Server} An optional [`net.Server`][] instance.
   * `requestCert`: Whether to authenticate the remote peer by requesting a
      certificate. Clients always request a server certificate. Servers
@@ -737,7 +737,7 @@ added: v0.11.8
 * `options` {Object}
   * `rejectUnauthorized` {boolean} If not `false`, the server certificate is
     verified against the list of supplied CAs. An `'error'` event is emitted if
-    verification fails; `err.code` contains the OpenSSL error code. Defaults to
+    verification fails; `err.code` contains the OpenSSL error code. **Default:**
     `true`.
   * `requestCert`
 * `callback` {Function} A function that will be called when the renegotiation
@@ -758,8 +758,8 @@ When running as the server, the socket will be destroyed with an error after
 added: v0.11.11
 -->
 
-* `size` {number} The maximum TLS fragment size. Defaults to `16384`. The
-  maximum value is `16384`.
+* `size` {number} The maximum TLS fragment size. The maximum value is `16384`.
+  **Default:** `16384`.
 
 The `tlsSocket.setMaxSendFragment()` method sets the maximum TLS fragment size.
 Returns `true` if setting the limit succeeded; `false` otherwise.
@@ -842,7 +842,8 @@ changes:
 -->
 
 * `options` {Object}
-  * `host` {string} Host the client should connect to, defaults to 'localhost'.
+  * `host` {string} Host the client should connect to. **Default:**
+    `'localhost'`.
   * `port` {number} Port the client should connect to.
   * `path` {string} Creates unix socket connection to path. If this option is
     specified, `host` and `port` are ignored.
@@ -857,7 +858,7 @@ changes:
     called.
   * `rejectUnauthorized` {boolean} If not `false`, the server certificate is
     verified against the list of supplied CAs. An `'error'` event is emitted if
-    verification fails; `err.code` contains the OpenSSL error code. Defaults to
+    verification fails; `err.code` contains the OpenSSL error code. **Default:**
     `true`.
   * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
@@ -877,12 +878,13 @@ changes:
   * `minDHSize` {number} Minimum size of the DH parameter in bits to accept a
     TLS connection. When a server offers a DH parameter with a size less
     than `minDHSize`, the TLS connection is destroyed and an error is thrown.
-    Defaults to `1024`.
+    **Default:** `1024`.
   * `secureContext`: Optional TLS context object created with
     [`tls.createSecureContext()`][]. If a `secureContext` is _not_ provided, one
     will be created by passing the entire `options` object to
     `tls.createSecureContext()`.
-  * `lookup`: {Function} Custom lookup function. Defaults to [`dns.lookup()`][].
+  * `lookup`: {Function} Custom lookup function. **Default:**
+    [`dns.lookup()`][].
   * ...: Optional [`tls.createSecureContext()`][] options that are used if the
     `secureContext` option is missing, otherwise they are ignored.
 * `callback` {Function}
@@ -1049,10 +1051,10 @@ changes:
   * `ecdhCurve` {string} A string describing a named curve or a colon separated
     list of curve NIDs or names, for example `P-521:P-384:P-256`, to use for
     ECDH key agreement, or `false` to disable ECDH. Set to `auto` to select the
-    curve automatically. Defaults to [`tls.DEFAULT_ECDH_CURVE`]. Use
-    [`crypto.getCurves()`][] to obtain a list of available curve names. On
-    recent releases, `openssl ecparam -list_curves` will also display the name
-    and description of each available elliptic curve.
+    curve automatically. Use [`crypto.getCurves()`][] to obtain a list of
+    available curve names. On recent releases, `openssl ecparam -list_curves`
+    will also display the name and description of each available elliptic curve.
+    **Default:** [`tls.DEFAULT_ECDH_CURVE`].
   * `clientCertEngine` {string} Optional name of an OpenSSL engine which can
     provide the client certificate.
   * `crl` {string|string[]|Buffer|Buffer[]} Optional PEM formatted
@@ -1067,10 +1069,10 @@ changes:
     which is not usually necessary. This should be used carefully if at all!
     Value is a numeric bitmask of the `SSL_OP_*` options from
     [OpenSSL Options][].
-  * `secureProtocol` {string} Optional SSL method to use, default is
-    `"SSLv23_method"`. The possible values are listed as [SSL_METHODS][], use
-    the function names as strings. For example, `"SSLv3_method"` to force SSL
-    version 3.
+  * `secureProtocol` {string} Optional SSL method to use. The possible values
+    are listed as [SSL_METHODS][], use the function names as strings.
+    For example, `'SSLv3_method'` to force SSL version 3. **Default:**
+    `'SSLv23_method'`.
   * `sessionIdContext` {string} Optional opaque identifier used by servers to
     ensure session state is not shared between applications. Unused by clients.
 
@@ -1110,15 +1112,15 @@ changes:
   * `clientCertEngine` {string} Optional name of an OpenSSL engine which can
     provide the client certificate.
   * `handshakeTimeout` {number} Abort the connection if the SSL/TLS handshake
-    does not finish in the specified number of milliseconds. Defaults to
-    `120000` (120 seconds). A `'tlsClientError'` is emitted on the `tls.Server`
-    object whenever a handshake times out.
+    does not finish in the specified number of milliseconds.
+    A `'tlsClientError'` is emitted on the `tls.Server` object whenever
+    a handshake times out. **Default:** `120000` (120 seconds).
   * `requestCert` {boolean} If `true` the server will request a certificate from
-    clients that connect and attempt to verify that certificate. Defaults to
+    clients that connect and attempt to verify that certificate. **Default:**
     `false`.
   * `rejectUnauthorized` {boolean} If not `false` the server will reject any
     connection which is not authorized with the list of supplied CAs. This
-    option only has an effect if `requestCert` is `true`. Defaults to `true`.
+    option only has an effect if `requestCert` is `true`. **Default:** `true`.
   * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing the supported ALPN protocols. `Buffer`s should have
@@ -1302,7 +1304,7 @@ changes:
   * `secureContext`: An optional TLS context object from
      [`tls.createSecureContext()`][]
   * `isServer`: If `true` the TLS socket will be instantiated in server-mode.
-    Defaults to `false`.
+    **Default:** `false`.
   * `server` {net.Server} An optional [`net.Server`][] instance
   * `requestCert`: Optional, see [`tls.createServer()`][]
   * `rejectUnauthorized`: Optional, see [`tls.createServer()`][]

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -127,7 +127,7 @@ added: v9.9.0
 -->
 
 * `env` {Object} A object containing the environment variables to check.
-  Defaults to `process.env`.
+  **Default:** `process.env`.
 * Returns: {number}
 
 Returns:

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -793,14 +793,14 @@ added: v7.6.0
 * `URL` {URL} A [WHATWG URL][] object
 * `options` {Object}
   * `auth` {boolean} `true` if the serialized URL string should include the
-    username and password, `false` otherwise. Defaults to `true`.
+    username and password, `false` otherwise. **Default:** `true`.
   * `fragment` {boolean} `true` if the serialized URL string should include the
-    fragment, `false` otherwise. Defaults to `true`.
+    fragment, `false` otherwise. **Default:** `true`.
   * `search` {boolean} `true` if the serialized URL string should include the
-    search query, `false` otherwise. Defaults to `true`.
+    search query, `false` otherwise. **Default:** `true`.
   * `unicode` {boolean} `true` if Unicode characters appearing in the host
     component of the URL string should be encoded directly as opposed to being
-    Punycode encoded. Defaults to `false`.
+    Punycode encoded. **Default:** `false`.
 
 Returns a customizable serialization of a URL String representation of a
 [WHATWG URL][] object.
@@ -1032,12 +1032,12 @@ changes:
 * `parseQueryString` {boolean} If `true`, the `query` property will always
   be set to an object returned by the [`querystring`][] module's `parse()`
   method. If `false`, the `query` property on the returned URL object will be an
-  unparsed, undecoded string. Defaults to `false`.
+  unparsed, undecoded string. **Default:** `false`.
 * `slashesDenoteHost` {boolean} If `true`, the first token after the literal
   string `//` and preceding the next `/` will be interpreted as the `host`.
   For instance, given `//foo/bar`, the result would be
   `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
-  Defaults to `false`.
+  **Default:** `false`.
 
 The `url.parse()` method takes a URL string, parses it, and returns a URL
 object.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -373,37 +373,37 @@ changes:
 * `options` {Object}
   * `showHidden` {boolean} If `true`, the `object`'s non-enumerable symbols and
     properties will be included in the formatted result as well as [`WeakMap`][]
-    and [`WeakSet`][] entries. Defaults to `false`.
+    and [`WeakSet`][] entries. **Default:** `false`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
-    codes. Defaults to `false`. Colors are customizable, see
-    [Customizing `util.inspect` colors][].
+    codes. Colors are customizable, see [Customizing `util.inspect` colors][].
+    **Default:** `false`.
   * `customInspect` {boolean} If `false`, then custom `inspect(depth, opts)`
-    functions will not be called. Defaults to `true`.
+    functions will not be called. **Default:** `true`.
   * `showProxy` {boolean} If `true`, then objects and functions that are
     `Proxy` objects will be introspected to show their `target` and `handler`
-    objects. Defaults to `false`.
+    objects. **Default:** `false`.
     <!--
     TODO(BridgeAR): Deprecate `maxArrayLength` and replace it with
                     `maxEntries`.
     -->
   * `maxArrayLength` {number} Specifies the maximum number of `Array`,
     [`TypedArray`][], [`WeakMap`][] and [`WeakSet`][] elements to include when
-    formatting. Defaults to `100`. Set to `null` or `Infinity` to show all
-    elements. Set to `0` or negative to show no elements.
+    formatting. Set to `null` or `Infinity` to show all elements. Set to `0` or
+    negative to show no elements. **Default:** `100`.
   * `breakLength` {number} The length at which an object's keys are split
     across multiple lines. Set to `Infinity` to format an object as a single
-    line. Defaults to 60 for legacy compatibility.
+    line. **Default:** `60` for legacy compatibility.
   * `compact` {boolean} Setting this to `false` changes the default indentation
     to use a line break for each object key instead of lining up multiple
     properties in one line. It will also break text that is above the
     `breakLength` size into smaller and better readable chunks and indents
     objects the same as arrays. Note that no text will be reduced below 16
     characters, no matter the `breakLength` size. For more information, see the
-    example below. Defaults to `true`.
+    example below. **Default:** `true`.
   * `depth` {number} Specifies the number visible nested Objects in an `object`.
     This is useful to minimize the inspection output for large complicated
-    objects. To make it recurse indefinitely pass `null` or `Infinity`. Defaults
-    to `Infinity`.
+    objects. To make it recurse indefinitely pass `null` or `Infinity`.
+    **Default:** `Infinity`.
 * Returns: {string} The representation of passed object
 
 The `util.inspect()` method returns a string representation of `object` that is
@@ -842,15 +842,15 @@ is not supported.
 ### new TextDecoder([encoding[, options]])
 
 * `encoding` {string} Identifies the `encoding` that this `TextDecoder` instance
-  supports. Defaults to `'utf-8'`.
+  supports. **Default:** `'utf-8'`.
 * `options` {Object}
-  * `fatal` {boolean} `true` if decoding failures are fatal. Defaults to
-    `false`. This option is only supported when ICU is enabled (see
-    [Internationalization][]).
+  * `fatal` {boolean} `true` if decoding failures are fatal. This option is only
+    supported when ICU is enabled (see [Internationalization][]). **Default:**
+    `false`.
   * `ignoreBOM` {boolean} When `true`, the `TextDecoder` will include the byte
      order mark in the decoded result. When `false`, the byte order mark will
      be removed from the output. This option is only used when `encoding` is
-     `'utf-8'`, `'utf-16be'` or `'utf-16le'`. Defaults to `false`.
+     `'utf-8'`, `'utf-16be'` or `'utf-16le'`. **Default:** `false`.
 
 Creates an new `TextDecoder` instance. The `encoding` may specify one of the
 supported encodings or an alias.
@@ -861,7 +861,7 @@ supported encodings or an alias.
   Typed Array instance containing the encoded data.
 * `options` {Object}
   * `stream` {boolean} `true` if additional chunks of data are expected.
-    Defaults to `false`.
+    **Default:** `false`.
 * Returns: {string}
 
 Decodes the `input` and returns a string. If `options.stream` is `true`, any
@@ -906,7 +906,7 @@ const uint8array = encoder.encode('this is some data');
 
 ### textEncoder.encode([input])
 
-* `input` {string} The text to encode. Defaults to an empty string.
+* `input` {string} The text to encode. **Default:** an empty string.
 * Returns: {Uint8Array}
 
 UTF-8 encodes the `input` string and returns a `Uint8Array` containing the

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -285,12 +285,10 @@ by subclasses.
 
 #### serializer.\_setTreatArrayBufferViewsAsHostObjects(flag)
 
-* `flag` {boolean}
+* `flag` {boolean} **Default:** `false`
 
 Indicate whether to treat `TypedArray` and `DataView` objects as
 host objects, i.e. pass them to [`serializer._writeHostObject()`][].
-
-The default is not to treat those objects as host objects.
 
 ### class: v8.Deserializer
 <!--

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -159,7 +159,7 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
 
 * `code` {string} JavaScript Module code to parse
 * `options`
-  * `url` {string} URL used in module resolution and stack traces. **Default**:
+  * `url` {string} URL used in module resolution and stack traces. **Default:**
     `'vm:module(i)'` where `i` is a context-specific ascending index.
   * `context` {Object} The [contextified][] object as returned by the
     `vm.createContext()` method, to compile and evaluate this Module in.
@@ -542,11 +542,9 @@ changes:
   * `contextCodeGeneration` {Object}
     * `strings` {boolean} If set to false any calls to `eval` or function
       constructors (`Function`, `GeneratorFunction`, etc) will throw an
-      `EvalError`.
-      **Default**: `true`.
+      `EvalError`. **Default:** `true`.
     * `wasm` {boolean} If set to false any attempt to compile a WebAssembly
-      module will throw a `WebAssembly.CompileError`.
-      **Default**: `true`.
+      module will throw a `WebAssembly.CompileError`. **Default:** `true`.
 
 First contextifies the given `sandbox`, runs the compiled code contained by
 the `vm.Script` object within the created sandbox, and returns the result.
@@ -637,11 +635,9 @@ changes:
   * `codeGeneration` {Object}
     * `strings` {boolean} If set to false any calls to `eval` or function
       constructors (`Function`, `GeneratorFunction`, etc) will throw an
-      `EvalError`.
-      **Default**: `true`.
+      `EvalError`. **Default:** `true`.
     * `wasm` {boolean} If set to false any attempt to compile a WebAssembly
-      module will throw a `WebAssembly.CompileError`.
-      **Default**: `true`.
+      module will throw a `WebAssembly.CompileError`. **Default:** `true`.
 
 If given a `sandbox` object, the `vm.createContext()` method will [prepare
 that sandbox][contextified] so that it can be used in calls to

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -303,9 +303,9 @@ Each class takes an `options` object.  All options are optional.
 Note that some options are only relevant when compressing, and are
 ignored by the decompression classes.
 
-* `flush` {integer} (default: `zlib.constants.Z_NO_FLUSH`)
-* `finishFlush` {integer} (default: `zlib.constants.Z_FINISH`)
-* `chunkSize` {integer} (default: 16\*1024)
+* `flush` {integer} **Default:** `zlib.constants.Z_NO_FLUSH`
+* `finishFlush` {integer} **Default:** `zlib.constants.Z_FINISH`
+* `chunkSize` {integer} **Default:** `16 * 1024`
 * `windowBits` {integer}
 * `level` {integer} (compression only)
 * `memLevel` {integer} (compression only)
@@ -420,7 +420,7 @@ Close the underlying handle.
 added: v0.5.8
 -->
 
-`kind` defaults to `zlib.constants.Z_FULL_FLUSH`.
+* `kind` **Default:** `zlib.constants.Z_FULL_FLUSH`
 
 Flush pending data. Don't call this frivolously, premature flushes negatively
 impact the effectiveness of the compression algorithm.

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -399,10 +399,10 @@ function parseListItem(item) {
   }
 
   text = text.trim();
-  const defaultExpr = /\(default\s*[:=]?\s*['"`]?([^, '"`]*)['"`]?\)/i;
+  const defaultExpr = /\s*\*\*Default:\*\*\s*([^]+)$/i;
   const def = text.match(defaultExpr);
   if (def) {
-    item.default = def[1];
+    item.default = def[1].replace(/\.$/, '');
     text = text.replace(defaultExpr, '');
   }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Status Quo

1. The format of default values is defined in [STYLE_GUIDE.md](https://github.com/nodejs/node/blame/8ed0f3409a31abae87bf6aae394b8901c5e6ecab/doc/STYLE_GUIDE.md#L61-L63). But the current state of sources is not unified: many default values are stated in informal ways or with tiny deviations.

2. `tools/doc/json.js` has [an obsolete RegExp](https://github.com/nodejs/node/blob/303354b4f7214388783037333dc82d64179b77cd/tools/doc/json.js#L402) to detect the default values in parameter lists. Because of this, only one `default` field is added to JSON docs, and even this is detected wrongly: [this source](https://github.com/nodejs/node/blame/a29089d7c866955616c0e363843017e9b9b2a736/doc/api/http.md#L1851) produces this item:

```diff
{
  "textRaw": "`undefined` (default): use [`http.globalAgent`][] for this host and port. ",
  "name": "undefined",
- "default": "",
- "desc": ": use [`http.globalAgent`][] for this host and port."
}
```
insstead of:
```diff
{
  "textRaw": "`undefined` (default): use [`http.globalAgent`][] for this host and port. ",
  "name": "undefined",
+ "desc": "(default): use [`http.globalAgent`][] for this host and port."
}
```

#### Fixing strategy

1. The first commit formalizes and unifies doc sources: informal definitions are replaced by formal ones, deviating nits in the formal definitions are unified (definitions are moved to the end, backticks and periods are added, duplicate info is removed etc.)

2. The second commit codifies default values format: periods are added to STYLE_GUIDE.md and RegExp in `tools/doc/json.js` is replaced by the actual one.

#### Results

* Doc sources are unified and often fixed.
* ~340 default values are moved from description blobs to default value fields in JSON docs.
* The mentioned false-positive case is fixed.

JSON example of old and new state in diff:
```diff
{
  "textRaw": "`code` {integer} The exit code. **Default:** `0`. ",
  "name": "code",
  "type": "integer",
- "desc": "The exit code. **Default:** `0`.",
  "optional": true
}

{
  "textRaw": "`code` {integer} The exit code. **Default:** `0`. ",
  "name": "code",
+ "default": "`0`",
  "type": "integer",
+ "desc": "The exit code.",
  "optional": true
}
```