### PR TITLE
buffer: use v8::TypedArray::kMaxLength as buffer::kMaxLength

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -31,8 +31,7 @@ extern bool zero_fill_all_buffers;
 
 namespace Buffer {
 
-static const unsigned int kMaxLength =
-    sizeof(int32_t) == sizeof(intptr_t) ? 0x3fffffff : 0x7fffffff;
+static const unsigned int kMaxLength = v8::TypedArray::kMaxLength;
 
 typedef void (*FreeCallback)(char* data, void* hint);
 


### PR DESCRIPTION
This was added in v8 6.2 by https://github.com/v8/v8/commit/19fee8b24b2f1580a92910635e0ca02cbdf615af, looks like a safe replacement for our own buffer::kMaxLength

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
