### PR TITLE
buffer: shorten deprecation warning

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -140,11 +140,9 @@ function alignPool() {
 }
 
 var bufferWarn = true;
-const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
-                      'recommended for use due to security and usability ' +
-                      'concerns. Please use the Buffer.alloc(), ' +
-                      'Buffer.allocUnsafe(), or Buffer.from() construction ' +
-                      'methods instead.';
+const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
+                      'issues. Please use the Buffer.alloc(), ' +
+                      'Buffer.allocUnsafe(), or Buffer.from() methods instead.';
 
 function showFlaggedDeprecation() {
   if (bufferWarn) {

--- a/test/parallel/test-buffer-pending-deprecation.js
+++ b/test/parallel/test-buffer-pending-deprecation.js
@@ -3,11 +3,9 @@
 
 const common = require('../common');
 
-const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
-                      'recommended for use due to security and usability ' +
-                      'concerns. Please use the Buffer.alloc(), ' +
-                      'Buffer.allocUnsafe(), or Buffer.from() construction ' +
-                      'methods instead.';
+const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
+                      'issues. Please use the Buffer.alloc(), ' +
+                      'Buffer.allocUnsafe(), or Buffer.from() methods instead.';
 
 common.expectWarning('DeprecationWarning', bufferWarning, 'DEP0005');
 


### PR DESCRIPTION
Remove "construction" from the deprecation warning for Buffer
constructor.

Ref: https://github.com/nodejs/node/pull/19687#pullrequestreview-108329609

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
