### PR TITLE
[v9.x backport] crypto: add ECDH.convertKey to convert public keys

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -665,7 +665,7 @@ added: REPLACEME
 - `curve` {string}
 - `inputEncoding` {string}
 - `outputEncoding` {string}
-- `format` {string} Defaults to `uncompressed`.
+- `format` {string} **Default:** `uncompressed`
 
 Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the
 format specified by `format`. The `format` argument specifies point encoding

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -656,6 +656,54 @@ assert.strictEqual(aliceSecret.toString('hex'), bobSecret.toString('hex'));
 // OK
 ```
 
+### ECDH.convertKey(key, curve[, inputEncoding[, outputEncoding[, format]]])
+<!-- YAML
+added: REPLACEME
+-->
+
+- `key` {string | Buffer | TypedArray | DataView}
+- `curve` {string}
+- `inputEncoding` {string}
+- `outputEncoding` {string}
+- `format` {string} Defaults to `uncompressed`.
+
+Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the
+format specified by `format`. The `format` argument specifies point encoding
+and can be `'compressed'`, `'uncompressed'` or `'hybrid'`. The supplied key is
+interpreted using the specified `inputEncoding`, and the returned key is encoded
+using the specified `outputEncoding`. Encodings can be `'latin1'`, `'hex'`,
+or `'base64'`.
+
+Use [`crypto.getCurves()`][] to obtain a list of available curve names.
+On recent OpenSSL releases, `openssl ecparam -list_curves` will also display
+the name and description of each available elliptic curve.
+
+If `format` is not specified the point will be returned in `'uncompressed'`
+format.
+
+If the `inputEncoding` is not provided, `key` is expected to be a [`Buffer`][],
+`TypedArray`, or `DataView`.
+
+Example (uncompressing a key):
+
+```js
+const { ECDH } = require('crypto');
+
+const ecdh = ECDH('secp256k1');
+ecdh.generateKeys();
+
+const compressedKey = ecdh.getPublicKey('hex', 'compressed');
+
+const uncompressedKey = ECDH.convertKey(compressedKey,
+                                        'secp256k1',
+                                        'hex',
+                                        'hex',
+                                        'uncompressed');
+
+// the converted key and the uncompressed public key should be the same
+console.log(uncompressedKey === ecdh.getPublicKey('hex'));
+```
+
 ### ecdh.computeSecret(otherPublicKey[, inputEncoding][, outputEncoding])
 <!-- YAML
 added: v0.11.14

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -10,7 +10,8 @@ const {
 const {
   DiffieHellman: _DiffieHellman,
   DiffieHellmanGroup: _DiffieHellmanGroup,
-  ECDH: _ECDH
+  ECDH: _ECDH,
+  ECDHConvertKey: _ECDHConvertKey
 } = process.binding('crypto');
 const {
   POINT_CONVERSION_COMPRESSED,
@@ -79,11 +80,9 @@ DiffieHellmanGroup.prototype.generateKeys =
     dhGenerateKeys;
 
 function dhGenerateKeys(encoding) {
-  var keys = this._handle.generateKeys();
+  const keys = this._handle.generateKeys();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    keys = keys.toString(encoding);
-  return keys;
+  return encode(keys, encoding);
 }
 
 
@@ -95,10 +94,8 @@ function dhComputeSecret(key, inEnc, outEnc) {
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;
-  var ret = this._handle.computeSecret(toBuf(key, inEnc));
-  if (outEnc && outEnc !== 'buffer')
-    ret = ret.toString(outEnc);
-  return ret;
+  const ret = this._handle.computeSecret(toBuf(key, inEnc));
+  return encode(ret, outEnc);
 }
 
 
@@ -107,11 +104,9 @@ DiffieHellmanGroup.prototype.getPrime =
     dhGetPrime;
 
 function dhGetPrime(encoding) {
-  var prime = this._handle.getPrime();
+  const prime = this._handle.getPrime();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    prime = prime.toString(encoding);
-  return prime;
+  return encode(prime, encoding);
 }
 
 
@@ -120,11 +115,9 @@ DiffieHellmanGroup.prototype.getGenerator =
     dhGetGenerator;
 
 function dhGetGenerator(encoding) {
-  var generator = this._handle.getGenerator();
+  const generator = this._handle.getGenerator();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    generator = generator.toString(encoding);
-  return generator;
+  return encode(generator, encoding);
 }
 
 
@@ -133,11 +126,9 @@ DiffieHellmanGroup.prototype.getPublicKey =
     dhGetPublicKey;
 
 function dhGetPublicKey(encoding) {
-  var key = this._handle.getPublicKey();
+  const key = this._handle.getPublicKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
+  return encode(key, encoding);
 }
 
 
@@ -146,11 +137,9 @@ DiffieHellmanGroup.prototype.getPrivateKey =
     dhGetPrivateKey;
 
 function dhGetPrivateKey(encoding) {
-  var key = this._handle.getPrivateKey();
+  const key = this._handle.getPrivateKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
+  return encode(key, encoding);
 }
 
 
@@ -190,7 +179,41 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 };
 
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
-  var f;
+  const f = getFormat(format);
+  const key = this._handle.getPublicKey(f);
+  encoding = encoding || getDefaultEncoding();
+  return encode(key, encoding);
+};
+
+ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
+  if (typeof key !== 'string' && !isArrayBufferView(key)) {
+    throw new errors.TypeError(
+      'ERR_INVALID_ARG_TYPE',
+      'key',
+      ['string', 'Buffer', 'TypedArray', 'DataView']
+    );
+  }
+
+  if (typeof curve !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
+  }
+
+  const encoding = getDefaultEncoding();
+  inEnc = inEnc || encoding;
+  outEnc = outEnc || encoding;
+  const f = getFormat(format);
+  const convertedKey = _ECDHConvertKey(toBuf(key, inEnc), curve, f);
+  return encode(convertedKey, outEnc);
+};
+
+function encode(buffer, encoding) {
+  if (encoding && encoding !== 'buffer')
+    buffer = buffer.toString(encoding);
+  return buffer;
+}
+
+function getFormat(format) {
+  let f;
   if (format) {
     if (format === 'compressed')
       f = POINT_CONVERSION_COMPRESSED;
@@ -204,12 +227,8 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   } else {
     f = POINT_CONVERSION_UNCOMPRESSED;
   }
-  var key = this._handle.getPublicKey(f);
-  encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
-  return key;
-};
+  return f;
+}
 
 module.exports = {
   DiffieHellman,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -709,6 +709,10 @@ class ECDH : public BaseObject {
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
+  static EC_POINT* BufferToPoint(Environment* env,
+                                 const EC_GROUP* group,
+                                 char* data,
+                                 size_t len);
 
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, EC_KEY* key)
@@ -726,8 +730,6 @@ class ECDH : public BaseObject {
   static void SetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  EC_POINT* BufferToPoint(char* data, size_t len);
 
   bool IsKeyPairValid();
   bool IsKeyValidForCurve(const BIGNUM* private_key);

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -1,0 +1,101 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+
+const { ECDH, getCurves } = require('crypto');
+
+// A valid private key for the secp256k1 curve.
+const cafebabeKey = 'cafebabe'.repeat(8);
+// Associated compressed and uncompressed public keys (points).
+const cafebabePubPtComp =
+    '03672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3';
+const cafebabePubPtUnComp =
+    '04672a31bfc59d3f04548ec9b7daeeba2f61814e8ccc40448045007f5479f693a3' +
+    '2e02c7f93d13dc2732b760ca377a5897b9dd41a1c1b29dc0442fdce6d0a04d1d';
+
+// Invalid test: key argument is undefined.
+common.expectsError(
+  () => ECDH.convertKey(),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+  });
+
+// Invalid test: curve argument is undefined.
+common.expectsError(
+  () => ECDH.convertKey(cafebabePubPtComp),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+  });
+
+// Invalid test: curve argument is invalid.
+common.expectsError(
+  () => ECDH.convertKey(cafebabePubPtComp, 'badcurve'),
+  {
+    type: TypeError,
+    message: 'Invalid ECDH curve name'
+  });
+
+if (getCurves().includes('secp256k1')) {
+  // Invalid test: format argument is undefined.
+  common.expectsError(
+    () => ECDH.convertKey(cafebabePubPtComp, 'secp256k1', 'hex', 'hex', 10),
+    {
+      code: 'ERR_CRYPTO_ECDH_INVALID_FORMAT',
+      type: TypeError,
+      message: 'Invalid ECDH format: 10'
+    });
+
+  // Point formats.
+  let uncompressed = ECDH.convertKey(cafebabePubPtComp,
+                                     'secp256k1',
+                                     'hex',
+                                     'buffer',
+                                     'uncompressed');
+  let compressed = ECDH.convertKey(cafebabePubPtComp,
+                                   'secp256k1',
+                                   'hex',
+                                   'buffer',
+                                   'compressed');
+  let hybrid = ECDH.convertKey(cafebabePubPtComp,
+                               'secp256k1',
+                               'hex',
+                               'buffer',
+                               'hybrid');
+  assert.strictEqual(uncompressed[0], 4);
+  let firstByte = compressed[0];
+  assert(firstByte === 2 || firstByte === 3);
+  firstByte = hybrid[0];
+  assert(firstByte === 6 || firstByte === 7);
+
+  // Format conversion from hex to hex
+  uncompressed = ECDH.convertKey(cafebabePubPtComp,
+                                 'secp256k1',
+                                 'hex',
+                                 'hex',
+                                 'uncompressed');
+  compressed = ECDH.convertKey(cafebabePubPtComp,
+                               'secp256k1',
+                               'hex',
+                               'hex',
+                               'compressed');
+  hybrid = ECDH.convertKey(cafebabePubPtComp,
+                           'secp256k1',
+                           'hex',
+                           'hex',
+                           'hybrid');
+  assert.strictEqual(uncompressed, cafebabePubPtUnComp);
+  assert.strictEqual(compressed, cafebabePubPtComp);
+
+  // Compare to getPublicKey.
+  const ecdh1 = ECDH('secp256k1');
+  ecdh1.generateKeys();
+  ecdh1.setPrivateKey(cafebabeKey, 'hex');
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'uncompressed'), uncompressed);
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'compressed'), compressed);
+  assert.strictEqual(ecdh1.getPublicKey('hex', 'hybrid'), hybrid);
+}


### PR DESCRIPTION
ECDH.convertKey is used to convert public keys between different
formats.

PR-URL: https://github.com/nodejs/node/pull/19080
Fixes: https://github.com/nodejs/node/issues/18977
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: James M Snell <jasnell@gmail.com>

/cc @tniessen 