### PR TITLE
build: make lint-ci work properly on Linux make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1133,7 +1133,8 @@ lint-js-ci:
 jslint-ci: lint-js-ci
 	@echo "Please use lint-js-ci instead of jslint-ci"
 
-LINT_CPP_ADDON_DOC_FILES = $(wildcard test/addons/??_*/*.cc test/addons/??_*/*.h)
+LINT_CPP_ADDON_DOC_FILES_GLOB = test/addons/??_*/*.cc test/addons/??_*/*.h
+LINT_CPP_ADDON_DOC_FILES = $(wildcard $(LINT_CPP_ADDON_DOC_FILES_GLOB))
 LINT_CPP_EXCLUDE ?=
 LINT_CPP_EXCLUDE += src/node_root_certs.h
 LINT_CPP_EXCLUDE += $(LINT_CPP_ADDON_DOC_FILES)
@@ -1176,7 +1177,7 @@ tools/.cpplintstamp: $(LINT_CPP_FILES)
 
 lint-addon-docs: test/addons/.docbuildstamp
 	@echo "Running C++ linter on addon docs..."
-	@$(PYTHON) tools/cpplint.py --filter=$(ADDON_DOC_LINT_FLAGS) $(LINT_CPP_ADDON_DOC_FILES)
+	@$(PYTHON) tools/cpplint.py --filter=$(ADDON_DOC_LINT_FLAGS) $(LINT_CPP_ADDON_DOC_FILES_GLOB)
 
 cpplint: lint-cpp
 	@echo "Please use lint-cpp instead of cpplint"


### PR DESCRIPTION
I want to ditch the FreeBSD 10 machines from running node-test-lint and just get the jenkins-workspace machines to do it. Unfortunately it doesn't work because it seems we're using a quirk of `gmake` that ships with FreeBSD 10.

`$(wildcard test/addons/??_*/*.cc test/addons/??_*/*.h)` is executed when `Makefile` is loaded, and before the body of `lint-addon-docs` is executed. So in a pristine clone it expands to nothing, since those files are created by `test/addons/.docbuildstamp` which is a direct dependency of `lint-addon-docs` (it'd probably be OK if that was done before the call to `$(MAKE) lint-addon-docs` but then `make lint-addon-docs` as a stand-alone wouldn't work).

/cc @bnoordhuis who last tried to touch this stuff when attempting a refactor in d9b59def72c718aaad3e which was subsequently reverted
/cc @joyeecheung who introduced part of this functionality in #16377 and may have more of a clue than me about why this only seems to work on the FreeBSD 10 `linter` hosts
