### PR TITLE
buffer: use a default offset

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -7,7 +7,6 @@ const {
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { setupBufferJS } = binding;
-const { endianness } = require('os');
 
 // Remove from the binding so that function is only available as exported here.
 // (That is, for internal use only.)
@@ -20,7 +19,10 @@ const float64Array = new Float64Array(1);
 const uInt8Float64Array = new Uint8Array(float64Array.buffer);
 
 // Check endianness.
-const bigEndian = endianness === 'BE';
+float32Array[0] = -1; // 0xBF800000
+// Either it is [0, 0, 128, 191] or [191, 128, 0, 0]. It is not possible to
+// check this with `os.endianness()` because that is determined at compile time.
+const bigEndian = uInt8Float32Array[3] === 0;
 
 function checkBounds(buf, offset, byteLength) {
   checkNumberType(offset);

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -57,8 +57,6 @@ function boundsError(value, length, type) {
 
 // Read integers.
 function readUIntLE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readUInt48LE(this, offset);
   if (byteLength === 5)
@@ -69,7 +67,7 @@ function readUIntLE(offset, byteLength) {
     return this.readUInt32LE(offset);
   if (byteLength === 2)
     return this.readUInt16LE(offset);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return this.readUInt8(offset);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -146,8 +144,6 @@ function readUInt8(offset = 0) {
 }
 
 function readUIntBE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readUInt48BE(this, offset);
   if (byteLength === 5)
@@ -158,7 +154,7 @@ function readUIntBE(offset, byteLength) {
     return this.readUInt32BE(offset);
   if (byteLength === 2)
     return this.readUInt16BE(offset);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return this.readUInt8(offset);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -226,8 +222,6 @@ function readUInt16BE(offset = 0) {
 }
 
 function readIntLE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readInt48LE(this, offset);
   if (byteLength === 5)
@@ -238,7 +232,7 @@ function readIntLE(offset, byteLength) {
     return this.readInt32LE(offset);
   if (byteLength === 2)
     return this.readInt16LE(offset);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return this.readInt8(offset);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -318,8 +312,6 @@ function readInt8(offset = 0) {
 }
 
 function readIntBE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readInt48BE(this, offset);
   if (byteLength === 5)
@@ -330,7 +322,7 @@ function readIntBE(offset, byteLength) {
     return this.readInt32BE(offset);
   if (byteLength === 2)
     return this.readInt16BE(offset);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return this.readInt8(offset);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -466,7 +458,7 @@ function readDoubleForwards(offset = 0) {
 }
 
 // Write integers.
-function writeUIntLE(value, offset, byteLength) {
+function writeUIntLE(value, offset = 0, byteLength) {
   if (byteLength === 6)
     return writeU_Int48LE(this, value, offset, 0, 0xffffffffffff);
   if (byteLength === 5)
@@ -477,7 +469,7 @@ function writeUIntLE(value, offset, byteLength) {
     return writeU_Int32LE(this, value, offset, 0, 0xffffffff);
   if (byteLength === 2)
     return writeU_Int16LE(this, value, offset, 0, 0xffff);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return writeU_Int8(this, value, offset, 0, 0xff);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -577,7 +569,7 @@ function writeUInt8(value, offset = 0) {
   return writeU_Int8(this, value, offset, 0, 0xff);
 }
 
-function writeUIntBE(value, offset, byteLength) {
+function writeUIntBE(value, offset = 0, byteLength) {
   if (byteLength === 6)
     return writeU_Int48BE(this, value, offset, 0, 0xffffffffffffff);
   if (byteLength === 5)
@@ -588,7 +580,7 @@ function writeUIntBE(value, offset, byteLength) {
     return writeU_Int32BE(this, value, offset, 0, 0xffffffff);
   if (byteLength === 2)
     return writeU_Int16BE(this, value, offset, 0, 0xffff);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return writeU_Int8(this, value, offset, 0, 0xff);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -669,7 +661,7 @@ function writeUInt16BE(value, offset = 0) {
   return writeU_Int16BE(this, value, offset, 0, 0xffffffff);
 }
 
-function writeIntLE(value, offset, byteLength) {
+function writeIntLE(value, offset = 0, byteLength) {
   if (byteLength === 6)
     return writeU_Int48LE(this, value, offset, -0x800000000000, 0x7fffffffffff);
   if (byteLength === 5)
@@ -680,7 +672,7 @@ function writeIntLE(value, offset, byteLength) {
     return writeU_Int32LE(this, value, offset, -0x80000000, 0x7fffffff);
   if (byteLength === 2)
     return writeU_Int16LE(this, value, offset, -0x8000, 0x7fff);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return writeU_Int8(this, value, offset, -0x80, 0x7f);
 
   boundsError(byteLength, 6, 'byteLength');
@@ -698,7 +690,7 @@ function writeInt8(value, offset = 0) {
   return writeU_Int8(this, value, offset, -0x80, 0x7f);
 }
 
-function writeIntBE(value, offset, byteLength) {
+function writeIntBE(value, offset = 0, byteLength) {
   if (byteLength === 6)
     return writeU_Int48BE(this, value, offset, -0x800000000000, 0x7fffffffffff);
   if (byteLength === 5)
@@ -709,7 +701,7 @@ function writeIntBE(value, offset, byteLength) {
     return writeU_Int32BE(this, value, offset, -0x80000000, 0x7fffffff);
   if (byteLength === 2)
     return writeU_Int16BE(this, value, offset, -0x8000, 0x7fff);
-  if (byteLength === 1)
+  if (byteLength === 1 || byteLength === undefined)
     return writeU_Int8(this, value, offset, -0x80, 0x7f);
 
   boundsError(byteLength, 6, 'byteLength');

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -7,6 +7,7 @@ const {
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { setupBufferJS } = binding;
+const { endianness } = require('os');
 
 // Remove from the binding so that function is only available as exported here.
 // (That is, for internal use only.)
@@ -19,8 +20,7 @@ const float64Array = new Float64Array(1);
 const uInt8Float64Array = new Uint8Array(float64Array.buffer);
 
 // Check endianness.
-float32Array[0] = -1;
-const bigEndian = uInt8Float32Array[3] === 0;
+const bigEndian = endianness === 'BE';
 
 function checkBounds(buf, offset, byteLength) {
   checkNumberType(offset);
@@ -57,6 +57,8 @@ function boundsError(value, length, type) {
 
 // Read integers.
 function readUIntLE(offset, byteLength) {
+  if (offset === undefined)
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readUInt48LE(this, offset);
   if (byteLength === 5)
@@ -73,7 +75,7 @@ function readUIntLE(offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function readUInt48LE(buf, offset) {
+function readUInt48LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 5];
@@ -87,7 +89,7 @@ function readUInt48LE(buf, offset) {
     (buf[++offset] + last * 2 ** 8) * 2 ** 32;
 }
 
-function readUInt40LE(buf, offset) {
+function readUInt40LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 4];
@@ -101,7 +103,7 @@ function readUInt40LE(buf, offset) {
     last * 2 ** 32;
 }
 
-function readUInt32LE(offset) {
+function readUInt32LE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -114,7 +116,7 @@ function readUInt32LE(offset) {
     last * 2 ** 24;
 }
 
-function readUInt24LE(buf, offset) {
+function readUInt24LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 2];
@@ -124,7 +126,7 @@ function readUInt24LE(buf, offset) {
   return first + buf[++offset] * 2 ** 8 + last * 2 ** 16;
 }
 
-function readUInt16LE(offset) {
+function readUInt16LE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 1];
@@ -134,7 +136,7 @@ function readUInt16LE(offset) {
   return first + last * 2 ** 8;
 }
 
-function readUInt8(offset) {
+function readUInt8(offset = 0) {
   checkNumberType(offset);
   const val = this[offset];
   if (val === undefined)
@@ -144,6 +146,8 @@ function readUInt8(offset) {
 }
 
 function readUIntBE(offset, byteLength) {
+  if (offset === undefined)
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readUInt48BE(this, offset);
   if (byteLength === 5)
@@ -160,7 +164,7 @@ function readUIntBE(offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function readUInt48BE(buf, offset) {
+function readUInt48BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 5];
@@ -174,7 +178,7 @@ function readUInt48BE(buf, offset) {
     last;
 }
 
-function readUInt40BE(buf, offset) {
+function readUInt40BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 4];
@@ -188,7 +192,7 @@ function readUInt40BE(buf, offset) {
     last;
 }
 
-function readUInt32BE(offset) {
+function readUInt32BE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -201,7 +205,7 @@ function readUInt32BE(offset) {
     last;
 }
 
-function readUInt24BE(buf, offset) {
+function readUInt24BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 2];
@@ -211,7 +215,7 @@ function readUInt24BE(buf, offset) {
   return first * 2 ** 16 + buf[++offset] * 2 ** 8 + last;
 }
 
-function readUInt16BE(offset) {
+function readUInt16BE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 1];
@@ -222,6 +226,8 @@ function readUInt16BE(offset) {
 }
 
 function readIntLE(offset, byteLength) {
+  if (offset === undefined)
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readInt48LE(this, offset);
   if (byteLength === 5)
@@ -238,7 +244,7 @@ function readIntLE(offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function readInt48LE(buf, offset) {
+function readInt48LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 5];
@@ -253,7 +259,7 @@ function readInt48LE(buf, offset) {
     buf[++offset] * 2 ** 24;
 }
 
-function readInt40LE(buf, offset) {
+function readInt40LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 4];
@@ -267,7 +273,7 @@ function readInt40LE(buf, offset) {
     buf[++offset] * 2 ** 24;
 }
 
-function readInt32LE(offset) {
+function readInt32LE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -280,7 +286,7 @@ function readInt32LE(offset) {
     (last << 24); // Overflow
 }
 
-function readInt24LE(buf, offset) {
+function readInt24LE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 2];
@@ -291,7 +297,7 @@ function readInt24LE(buf, offset) {
   return val | (val & 2 ** 23) * 0x1fe;
 }
 
-function readInt16LE(offset) {
+function readInt16LE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 1];
@@ -302,7 +308,7 @@ function readInt16LE(offset) {
   return val | (val & 2 ** 15) * 0x1fffe;
 }
 
-function readInt8(offset) {
+function readInt8(offset = 0) {
   checkNumberType(offset);
   const val = this[offset];
   if (val === undefined)
@@ -312,6 +318,8 @@ function readInt8(offset) {
 }
 
 function readIntBE(offset, byteLength) {
+  if (offset === undefined)
+    throw new ERR_INVALID_ARG_TYPE('offset', 'number', undefined);
   if (byteLength === 6)
     return readInt48BE(this, offset);
   if (byteLength === 5)
@@ -328,7 +336,7 @@ function readIntBE(offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function readInt48BE(buf, offset) {
+function readInt48BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 5];
@@ -343,7 +351,7 @@ function readInt48BE(buf, offset) {
     last;
 }
 
-function readInt40BE(buf, offset) {
+function readInt40BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 4];
@@ -357,7 +365,7 @@ function readInt40BE(buf, offset) {
     last;
 }
 
-function readInt32BE(offset) {
+function readInt32BE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -370,7 +378,7 @@ function readInt32BE(offset) {
     last;
 }
 
-function readInt24BE(buf, offset) {
+function readInt24BE(buf, offset = 0) {
   checkNumberType(offset);
   const first = buf[offset];
   const last = buf[offset + 2];
@@ -381,7 +389,7 @@ function readInt24BE(buf, offset) {
   return val | (val & 2 ** 23) * 0x1fe;
 }
 
-function readInt16BE(offset) {
+function readInt16BE(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 1];
@@ -393,7 +401,7 @@ function readInt16BE(offset) {
 }
 
 // Read floats
-function readFloatBackwards(offset) {
+function readFloatBackwards(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -407,7 +415,7 @@ function readFloatBackwards(offset) {
   return float32Array[0];
 }
 
-function readFloatForwards(offset) {
+function readFloatForwards(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 3];
@@ -421,7 +429,7 @@ function readFloatForwards(offset) {
   return float32Array[0];
 }
 
-function readDoubleBackwards(offset) {
+function readDoubleBackwards(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 7];
@@ -439,7 +447,7 @@ function readDoubleBackwards(offset) {
   return float64Array[0];
 }
 
-function readDoubleForwards(offset) {
+function readDoubleForwards(offset = 0) {
   checkNumberType(offset);
   const first = this[offset];
   const last = this[offset + 7];
@@ -522,7 +530,7 @@ function writeU_Int32LE(buf, value, offset, min, max) {
   return offset;
 }
 
-function writeUInt32LE(value, offset) {
+function writeUInt32LE(value, offset = 0) {
   return writeU_Int32LE(this, value, offset, 0, 0xffffffff);
 }
 
@@ -547,7 +555,7 @@ function writeU_Int16LE(buf, value, offset, min, max) {
   return offset;
 }
 
-function writeUInt16LE(value, offset) {
+function writeUInt16LE(value, offset = 0) {
   return writeU_Int16LE(this, value, offset, 0, 0xffff);
 }
 
@@ -565,7 +573,7 @@ function writeU_Int8(buf, value, offset, min, max) {
   return offset + 1;
 }
 
-function writeUInt8(value, offset) {
+function writeUInt8(value, offset = 0) {
   return writeU_Int8(this, value, offset, 0, 0xff);
 }
 
@@ -632,7 +640,7 @@ function writeU_Int32BE(buf, value, offset, min, max) {
   return offset + 4;
 }
 
-function writeUInt32BE(value, offset) {
+function writeUInt32BE(value, offset = 0) {
   return writeU_Int32BE(this, value, offset, 0, 0xffffffff);
 }
 
@@ -657,7 +665,7 @@ function writeU_Int16BE(buf, value, offset, min, max) {
   return offset;
 }
 
-function writeUInt16BE(value, offset) {
+function writeUInt16BE(value, offset = 0) {
   return writeU_Int16BE(this, value, offset, 0, 0xffffffff);
 }
 
@@ -678,15 +686,15 @@ function writeIntLE(value, offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function writeInt32LE(value, offset) {
+function writeInt32LE(value, offset = 0) {
   return writeU_Int32LE(this, value, offset, -0x80000000, 0x7fffffff);
 }
 
-function writeInt16LE(value, offset) {
+function writeInt16LE(value, offset = 0) {
   return writeU_Int16LE(this, value, offset, -0x8000, 0x7fff);
 }
 
-function writeInt8(value, offset) {
+function writeInt8(value, offset = 0) {
   return writeU_Int8(this, value, offset, -0x80, 0x7f);
 }
 
@@ -707,16 +715,16 @@ function writeIntBE(value, offset, byteLength) {
   boundsError(byteLength, 6, 'byteLength');
 }
 
-function writeInt32BE(value, offset) {
+function writeInt32BE(value, offset = 0) {
   return writeU_Int32BE(this, value, offset, -0x80000000, 0x7fffffff);
 }
 
-function writeInt16BE(value, offset) {
+function writeInt16BE(value, offset = 0) {
   return writeU_Int16BE(this, value, offset, -0x8000, 0x7fff);
 }
 
 // Write floats.
-function writeDoubleForwards(val, offset) {
+function writeDoubleForwards(val, offset = 0) {
   val = +val;
   checkBounds(this, offset, 7);
 
@@ -732,7 +740,7 @@ function writeDoubleForwards(val, offset) {
   return offset;
 }
 
-function writeDoubleBackwards(val, offset) {
+function writeDoubleBackwards(val, offset = 0) {
   val = +val;
   checkBounds(this, offset, 7);
 
@@ -748,7 +756,7 @@ function writeDoubleBackwards(val, offset) {
   return offset;
 }
 
-function writeFloatForwards(val, offset) {
+function writeFloatForwards(val, offset = 0) {
   val = +val;
   checkBounds(this, offset, 3);
 
@@ -760,7 +768,7 @@ function writeFloatForwards(val, offset) {
   return offset;
 }
 
-function writeFloatBackwards(val, offset) {
+function writeFloatBackwards(val, offset = 0) {
   val = +val;
   checkBounds(this, offset, 3);
 

--- a/test/parallel/test-buffer-readdouble.js
+++ b/test/parallel/test-buffer-readdouble.js
@@ -99,7 +99,12 @@ assert.strictEqual(buffer.readDoubleBE(0), 3.04814e-319);
 assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
 
 ['readDoubleLE', 'readDoubleBE'].forEach((fn) => {
-  ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+
+  // Verify that default offset works fine.
+  buffer[fn](undefined);
+  buffer[fn]();
+
+  ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
     assert.throws(
       () => buffer[fn](off),
       { code: 'ERR_INVALID_ARG_TYPE' }

--- a/test/parallel/test-buffer-readfloat.js
+++ b/test/parallel/test-buffer-readfloat.js
@@ -62,7 +62,12 @@ assert.strictEqual(buffer.readFloatBE(0), 4.627507918739843e-41);
 assert.strictEqual(buffer.readFloatLE(0), -Infinity);
 
 ['readFloatLE', 'readFloatBE'].forEach((fn) => {
-  ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+
+  // Verify that default offset works fine.
+  buffer[fn](undefined);
+  buffer[fn]();
+
+  ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
     assert.throws(
       () => buffer[fn](off),
       { code: 'ERR_INVALID_ARG_TYPE' }

--- a/test/parallel/test-buffer-readint.js
+++ b/test/parallel/test-buffer-readint.js
@@ -134,7 +134,13 @@ const assert = require('assert');
 
   // Check byteLength.
   ['readIntBE', 'readIntLE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((len) => {
+
+    // Verify that default offset & byteLength works fine.
+    buffer[fn](undefined, undefined);
+    buffer[fn](undefined);
+    buffer[fn]();
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((len) => {
       assert.throws(
         () => buffer[fn](0, len),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -165,7 +171,7 @@ const assert = require('assert');
   // Test 1 to 6 bytes.
   for (let i = 1; i < 6; i++) {
     ['readIntBE', 'readIntLE'].forEach((fn) => {
-      ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+      ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
         assert.throws(
           () => buffer[fn](o, i),
           {

--- a/test/parallel/test-buffer-readint.js
+++ b/test/parallel/test-buffer-readint.js
@@ -8,7 +8,12 @@ const assert = require('assert');
   const buffer = Buffer.alloc(4);
 
   ['Int8', 'Int16BE', 'Int16LE', 'Int32BE', 'Int32LE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+
+    // Verify that default offset works fine.
+    buffer[`read${fn}`](undefined);
+    buffer[`read${fn}`]();
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
       assert.throws(
         () => buffer[`read${fn}`](o),
         {

--- a/test/parallel/test-buffer-writedouble.js
+++ b/test/parallel/test-buffer-writedouble.js
@@ -80,6 +80,11 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
   const small = Buffer.allocUnsafe(1);
 
   ['writeDoubleLE', 'writeDoubleBE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
     assert.throws(
       () => small[fn](11.11, 0),
       {
@@ -88,7 +93,7 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
         message: 'Attempt to write outside buffer bounds'
       });
 
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
       assert.throws(
         () => small[fn](23, off),
         { code: 'ERR_INVALID_ARG_TYPE' });

--- a/test/parallel/test-buffer-writefloat.js
+++ b/test/parallel/test-buffer-writefloat.js
@@ -61,6 +61,11 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
   const small = Buffer.allocUnsafe(1);
 
   ['writeFloatLE', 'writeFloatBE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
     assert.throws(
       () => small[fn](11.11, 0),
       {
@@ -69,7 +74,7 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
         message: 'Attempt to write outside buffer bounds'
       });
 
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
       assert.throws(
         () => small[fn](23, off),
         { code: 'ERR_INVALID_ARG_TYPE' }

--- a/test/parallel/test-buffer-writeint.js
+++ b/test/parallel/test-buffer-writeint.js
@@ -168,7 +168,13 @@ const errorOutOfBounds = common.expectsError({
 
   // Check byteLength.
   ['writeIntBE', 'writeIntLE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((bl) => {
+
+    // Verify that default offset & byteLength works fine.
+    data[fn](undefined, undefined);
+    data[fn](undefined);
+    data[fn]();
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((bl) => {
       assert.throws(
         () => data[fn](23, 0, bl),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -214,7 +220,7 @@ const errorOutOfBounds = common.expectsError({
         });
       });
 
-      ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+      ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
         assert.throws(
           () => data[fn](min, o, i),
           {

--- a/test/parallel/test-buffer-writeint.js
+++ b/test/parallel/test-buffer-writeint.js
@@ -31,7 +31,11 @@ const errorOutOfBounds = common.expectsError({
     buffer.writeInt8(-0x80 - 1, 0);
   }, errorOutOfBounds);
 
-  ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+  // Verify that default offset works fine.
+  buffer.writeInt8(23, undefined);
+  buffer.writeInt8(23);
+
+  ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
     assert.throws(
       () => buffer.writeInt8(23, off),
       { code: 'ERR_INVALID_ARG_TYPE' });
@@ -70,6 +74,11 @@ const errorOutOfBounds = common.expectsError({
   assert.ok(buffer.equals(new Uint8Array([ 0xff, 0x7f, 0x00, 0x80 ])));
 
   ['writeInt16BE', 'writeInt16LE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
     assert.throws(() => {
       buffer[fn](0x7fff + 1, 0);
     }, errorOutOfBounds);
@@ -77,7 +86,7 @@ const errorOutOfBounds = common.expectsError({
       buffer[fn](-0x8000 - 1, 0);
     }, errorOutOfBounds);
 
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
       assert.throws(
         () => buffer[fn](23, off),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -127,6 +136,11 @@ const errorOutOfBounds = common.expectsError({
   ])));
 
   ['writeInt32BE', 'writeInt32LE'].forEach((fn) => {
+
+    // Verify that default offset works fine.
+    buffer[fn](23, undefined);
+    buffer[fn](23);
+
     assert.throws(() => {
       buffer[fn](0x7fffffff + 1, 0);
     }, errorOutOfBounds);
@@ -134,7 +148,7 @@ const errorOutOfBounds = common.expectsError({
       buffer[fn](-0x80000000 - 1, 0);
     }, errorOutOfBounds);
 
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((off) => {
+    ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
       assert.throws(
         () => buffer[fn](23, off),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -154,9 +168,9 @@ const errorOutOfBounds = common.expectsError({
 
   // Check byteLength.
   ['writeIntBE', 'writeIntLE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((bl) => {
       assert.throws(
-        () => data[fn](23, 0, o),
+        () => data[fn](23, 0, bl),
         { code: 'ERR_INVALID_ARG_TYPE' });
     });
 

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -14,7 +14,12 @@ const assert = require('assert');
 { // OOB
   const data = Buffer.alloc(8);
   ['UInt8', 'UInt16BE', 'UInt16LE', 'UInt32BE', 'UInt32LE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+
+    // Verify that default offset works fine.
+    data[`write${fn}`](23, undefined);
+    data[`write${fn}`](23);
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
       assert.throws(
         () => data[`write${fn}`](23, o),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -112,9 +117,9 @@ const assert = require('assert');
 
   // Check byteLength.
   ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((bl) => {
       assert.throws(
-        () => data[fn](23, 0, o),
+        () => data[fn](23, 0, bl),
         { code: 'ERR_INVALID_ARG_TYPE' });
     });
 

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -117,7 +117,13 @@ const assert = require('assert');
 
   // Check byteLength.
   ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
-    ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((bl) => {
+
+    // Verify that default offset & byteLength works fine.
+    data[fn](undefined, undefined);
+    data[fn](undefined);
+    data[fn]();
+
+    ['', '0', null, {}, [], () => {}, true, false].forEach((bl) => {
       assert.throws(
         () => data[fn](23, 0, bl),
         { code: 'ERR_INVALID_ARG_TYPE' });
@@ -158,7 +164,7 @@ const assert = require('assert');
                  `It must be >= 0 and <= ${val - 1}. Received ${val}`
       });
 
-      ['', '0', null, undefined, {}, [], () => {}, true, false].forEach((o) => {
+      ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
         assert.throws(
           () => data[fn](23, o, i),
           {


### PR DESCRIPTION
If none is provided, use zero as a default offset for all read/write operations on the buffer.

This reverts some former changes to make sure the default offset for buffer read / write functions is set to zero. This was possible before due to the implicit type coercion.

I only added support for the functions that do not require a `byteLength` because writing e.g., `buffer.readIntBe(undefined, 4)` is very likely a bug in the users code and not expected to be zero.

<s>At the same time I added a documentation-only deprecation for the default offset.</s> There were six modules with > 10dm that used this notation and three of those merged my fix already. 

Refs: #18395

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
