### PR TITLE
doc: fix about `decodeStrings` property of `stream.Writable`

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1502,7 +1502,7 @@ data at once, the `writable._writev()` method should be implemented.
 
 If the `decodeStrings` property is explicitly set to `false` in the constructor
 options, then `chunk` will remain the same object that is passed to `.write()`,
-and may be a string rather than a Buffer. This is to support implementations
+and may be a string rather than a `Buffer`. This is to support implementations
 that have an optimized handling for certain string data encodings. In that case,
 the `encoding` argument will indicate the character encoding of the string.
 Otherwise, the `encoding` argument can be safely ignored.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1504,7 +1504,7 @@ If the `decodeStrings` property is set in the constructor options, then
 `chunk` may be a string rather than a Buffer, and `encoding` will
 indicate the character encoding of the string. This is to support
 implementations that have an optimized handling for certain string
-data encodings. If the `decodeStrings` property is explicitly set to `false`,
+data encodings. Unless the `decodeStrings` property is explicitly set to `false`,
 the `encoding` argument can be safely ignored, and `chunk` will remain the same
 object that is passed to `.write()`.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1502,9 +1502,10 @@ data at once, the `writable._writev()` method should be implemented.
 
 If the `decodeStrings` property is explicitly set to `false` in the constructor
 options, then `chunk` will remain the same object that is passed to `.write()`,
-and may be a string rather than a Buffer. In that case, the `encoding` argument
-will indicate the character encoding of the string. Otherwise, the `encoding`
-argument can be safely ignored.
+and may be a string rather than a Buffer. This is to support implementations
+that have an optimized handling for certain string data encodings. In that case,
+the `encoding` argument will indicate the character encoding of the string.
+Otherwise, the `encoding` argument can be safely ignored.
 
 The `writable._write()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1500,13 +1500,11 @@ buffered. When the `callback` is invoked, the stream might emit a [`'drain'`][]
 event. If a stream implementation is capable of processing multiple chunks of
 data at once, the `writable._writev()` method should be implemented.
 
-If the `decodeStrings` property is set in the constructor options, then
-`chunk` may be a string rather than a Buffer, and `encoding` will
-indicate the character encoding of the string. This is to support
-implementations that have an optimized handling for certain string
-data encodings. Unless the `decodeStrings` property is explicitly set to `false`,
-the `encoding` argument can be safely ignored, and `chunk` will remain the same
-object that is passed to `.write()`.
+If the `decodeStrings` property is explicitly set to `false` in the constructor
+options, then `chunk` will remain the same object that is passed to `.write()`,
+and may be a string rather than a Buffer. In that case, the `encoding` argument
+will indicate the character encoding of the string. Otherwise, the `encoding`
+argument can be safely ignored.
 
 The `writable._write()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by


### PR DESCRIPTION
This fixes negation ommitted at 80ea0c5a64fe673011e8b1025de23a0ea7f3f7f8.

Corresponding sentence at 5292a1358f834d4788ab10dbe83bf5ea2d35a54d (before 80ea0c5a64fe673011e8b1025de23a0ea7f3f7f8):
> If you do not explicitly set the `decodeStrings` option to `false`, then you can safely ignore the `encoding` argument, and assume that `chunk` will always be a Buffer.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
