### PR TITLE
dns: consistently add hostname

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -229,7 +229,7 @@ function resolver(bindingName) {
     req.oncomplete = onresolve;
     req.ttl = !!(options && options.ttl);
     var err = this._handle[bindingName](req, name);
-    if (err) throw dnsException(err, bindingName);
+    if (err) throw dnsException(err, bindingName, name);
     return req;
   }
   Object.defineProperty(query, 'name', { value: bindingName });

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -556,20 +556,20 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
  * @returns {Error}
  */
 function dnsException(code, syscall, hostname) {
-  let message;
-  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
-  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-  if (code === UV_EAI_MEMORY ||
-      code === UV_EAI_NODATA ||
-      code === UV_EAI_NONAME) {
-    code = 'ENOTFOUND'; // Fabricated error name.
+  // If `code` is of type number, it is a libuv error number, else it is a
+  // c-ares error code.
+  if (typeof code === 'number') {
+    // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
+    // the true error to the user. ENOTFOUND is not even a proper POSIX error!
+    if (code === UV_EAI_MEMORY ||
+        code === UV_EAI_NODATA ||
+        code === UV_EAI_NONAME) {
+      code = 'ENOTFOUND'; // Fabricated error name.
+    } else {
+      code = lazyInternalUtil().getSystemErrorName(code);
+    }
   }
-  if (typeof code === 'string') { // c-ares error code.
-    message = `${syscall} ${code}${hostname ? ` ${hostname}` : ''}`;
-  } else {  // libuv error number
-    code = lazyInternalUtil().getSystemErrorName(code);
-    message = `${syscall} ${code}`;
-  }
+  const message = `${syscall} ${code}${hostname ? ` ${hostname}` : ''}`;
   // eslint-disable-next-line no-restricted-syntax
   const ex = new Error(message);
   // TODO(joyeecheung): errno is supposed to be a number / err, like in


### PR DESCRIPTION
Right now the hostname could in some cases be missed, depending on
the libuv error number. This makes sure there the hostname is always
added, if available.

This currently relies on https://github.com/nodejs/node/pull/19719 and I am
going to rebase the PR as soon as that lands.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
