### PR TITLE
test: resolve process.setegid error for nobody on ubuntu

### DIFF
--- a/test/parallel/test-process-geteuid-getegid.js
+++ b/test/parallel/test-process-geteuid-getegid.js
@@ -38,7 +38,15 @@ if (process.getuid() !== 0) {
 
 // If we are running as super user...
 const oldgid = process.getegid();
-process.setegid('nobody');
+try {
+  process.setegid('nobody');
+} catch (err) {
+  if (err.message !== 'setegid group id does not exist') {
+    throw err;
+  } else {
+    process.setegid('nogroup');
+  }
+}
 const newgid = process.getegid();
 assert.notStrictEqual(newgid, oldgid);
 


### PR DESCRIPTION
When the tests are run as root in Ubuntu, process.setegid is called with
'nobody' as an argument. This throws an error in Ubuntu. This is because
in Ubuntu the equivalent of 'nobody' group is named as 'nogroup'.

This commit sets egid to 'nobody' first and if it throws a `group id
does not exist` error, it attempts to set egid to 'nogroup'. If it still
causes an error, the error is thrown.

Refs: https://github.com/nodejs/node/issues/19594

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
