### PR TITLE
test: fix multiple expectedWarnings bug

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -631,7 +631,7 @@ function expectWarning(name, expected) {
     // Remove a warning message after it is seen so that we guarantee that we
     // get each message only once.
     map.delete(expected);
-  }, map.size);
+  }, expected.length);
 }
 
 function expectWarningByName(name, expected, code) {


### PR DESCRIPTION
Commit 8fb4ea9f75 ("test: add deprecation code to expectWarning") did
not take into account that the same warning could be expected multiple
times. This bug was discovered in
https://github.com/nodejs/node/pull/18138 and this commit adds a fix for
this issue.

Refs: https://github.com/nodejs/node/pull/18138


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
