### PR TITLE
test: set clientOpts.port property

### DIFF
--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -14,22 +14,6 @@ function loadPEM(n) {
 }
 
 const testCases = [
-  { // Test 0: for the check of a cert not in the whitelist.
-    // agent7-cert.pem is issued by the fake CNNIC root CA so that its
-    // hash is not listed in the whitelist.
-    // fake-cnnic-root-cert has the same subject name as the original
-    // rootCA.
-    serverOpts: {
-      key: loadPEM('agent7-key'),
-      cert: loadPEM('agent7-cert')
-    },
-    clientOpts: {
-      port: undefined,
-      rejectUnauthorized: true,
-      ca: [loadPEM('fake-cnnic-root-cert')]
-    },
-    errorCode: 'CERT_HAS_EXPIRED'
-  },
   // Test 1: for the fix of node#2061
   // agent6-cert.pem is signed by intermediate cert of ca3.
   // The server has a cert chain of agent6->ca3->ca1(root) but

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -28,7 +28,7 @@ const testCases = [
       rejectUnauthorized: true,
       ca: [loadPEM('fake-cnnic-root-cert')]
     },
-    errorCode: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+    errorCode: 'CERT_HAS_EXPIRED'
   },
   // Test 1: for the fix of node#2061
   // agent6-cert.pem is signed by intermediate cert of ca3.
@@ -58,7 +58,7 @@ function runTest(tindex) {
   const server = tls.createServer(tcase.serverOpts, (s) => {
     s.resume();
   }).listen(0, common.mustCall(function() {
-    tcase.clientOpts = this.address().port;
+    tcase.clientOpts.port = this.address().port;
     const client = tls.connect(tcase.clientOpts);
     client.on('error', common.mustCall((e) => {
       assert.strictEqual(e.code, tcase.errorCode);


### PR DESCRIPTION
Currently this test will overwrite the clientOpts object with the port,
instead of setting the port property on the clientOpts object which
looks like the original intent.

Doing this the test fails reporting that the fake-cnnic-root-cert has
expired. This is indeed true:
```console
$ openssl x509 -in test/fixtures/keys/fake-cnnic-root-cert.pem \
-text -noout
Certificate:
        ...
        Validity
            Not Before: Jun  9 17:15:16 2015 GMT
            Not After : Mar 29 17:15:16 2018 GMT
```
This commit sets the errorCode to `CERT_HAS_EXPIRED`. I tried updating the
certificate using test/fixtures/keys/Makefile but then no error is
thrown and I'm currently looking into this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
