### PR TITLE
[v9.x]  deps: cherry-pick a803fad from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -5244,6 +5244,7 @@ Local<v8::Context> v8::Object::CreationContext() {
 
 
 int v8::Object::GetIdentityHash() {
+  i::DisallowHeapAllocation no_gc;
   auto isolate = Utils::OpenHandle(this)->GetIsolate();
   i::HandleScope scope(isolate);
   auto self = Utils::OpenHandle(this);

--- a/deps/v8/src/code-stub-assembler.cc
+++ b/deps/v8/src/code-stub-assembler.cc
@@ -1187,8 +1187,8 @@ TNode<Int32T> CodeStubAssembler::LoadHashForJSObject(
   {
     Node* length_and_hash_int32 = LoadAndUntagToWord32ObjectField(
         properties_or_hash, PropertyArray::kLengthAndHashOffset);
-    var_hash.Bind(Word32And(length_and_hash_int32,
-                            Int32Constant(PropertyArray::kHashMask)));
+    var_hash.Bind(
+        DecodeWord32<PropertyArray::HashField>(length_and_hash_int32));
     Goto(&done);
   }
 
@@ -2508,7 +2508,8 @@ void CodeStubAssembler::InitializePropertyArrayLength(Node* property_array,
   CSA_ASSERT(
       this,
       IntPtrOrSmiLessThanOrEqual(
-          length, IntPtrOrSmiConstant(PropertyArray::kMaxLength, mode), mode));
+          length, IntPtrOrSmiConstant(PropertyArray::LengthField::kMax, mode),
+          mode));
   StoreObjectFieldNoWriteBarrier(
       property_array, PropertyArray::kLengthAndHashOffset,
       ParameterToTagged(length, mode), MachineRepresentation::kTaggedSigned);

--- a/deps/v8/src/compiler/js-native-context-specialization.cc
+++ b/deps/v8/src/compiler/js-native-context-specialization.cc
@@ -2255,14 +2255,18 @@ Node* JSNativeContextSpecialization::BuildExtendPropertiesBackingStore(
         jsgraph()->SmiConstant(PropertyArray::kNoHashSentinel));
     hash = graph()->NewNode(common()->TypeGuard(Type::SignedSmall()), hash,
                             control);
+    hash =
+        graph()->NewNode(simplified()->NumberShiftLeft(), hash,
+                         jsgraph()->Constant(PropertyArray::HashField::kShift));
   } else {
     hash = effect = graph()->NewNode(
         simplified()->LoadField(AccessBuilder::ForPropertyArrayLengthAndHash()),
         properties, effect, control);
     effect = graph()->NewNode(
         common()->BeginRegion(RegionObservability::kNotObservable), effect);
-    hash = graph()->NewNode(simplified()->NumberBitwiseAnd(), hash,
-                            jsgraph()->Constant(JSReceiver::kHashMask));
+    hash =
+        graph()->NewNode(simplified()->NumberBitwiseAnd(), hash,
+                         jsgraph()->Constant(PropertyArray::HashField::kMask));
   }
 
   Node* new_length_and_hash = graph()->NewNode(

--- a/deps/v8/src/objects-inl.h
+++ b/deps/v8/src/objects-inl.h
@@ -2679,33 +2679,31 @@ SYNCHRONIZED_SMI_ACCESSORS(FixedArrayBase, length, kLengthOffset)
 int PropertyArray::length() const {
   Object* value_obj = READ_FIELD(this, kLengthAndHashOffset);
   int value = Smi::ToInt(value_obj);
-  return value & kLengthMask;
+  return LengthField::decode(value);
 }
 
 void PropertyArray::initialize_length(int len) {
   SLOW_DCHECK(len >= 0);
-  SLOW_DCHECK(len < kMaxLength);
+  SLOW_DCHECK(len < LengthField::kMax);
   WRITE_FIELD(this, kLengthAndHashOffset, Smi::FromInt(len));
 }
 
 int PropertyArray::synchronized_length() const {
   Object* value_obj = ACQUIRE_READ_FIELD(this, kLengthAndHashOffset);
   int value = Smi::ToInt(value_obj);
-  return value & kLengthMask;
+  return LengthField::decode(value);
 }
 
 int PropertyArray::Hash() const {
   Object* value_obj = READ_FIELD(this, kLengthAndHashOffset);
   int value = Smi::ToInt(value_obj);
-  int hash = value & kHashMask;
-  return hash;
+  return HashField::decode(value);
 }
 
-void PropertyArray::SetHash(int masked_hash) {
-  DCHECK_EQ(masked_hash & JSReceiver::kHashMask, masked_hash);
+void PropertyArray::SetHash(int hash) {
   Object* value_obj = READ_FIELD(this, kLengthAndHashOffset);
   int value = Smi::ToInt(value_obj);
-  value = (value & kLengthMask) | masked_hash;
+  value = HashField::update(value, hash);
   WRITE_FIELD(this, kLengthAndHashOffset, Smi::FromInt(value));
 }
 

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -2301,6 +2301,7 @@ namespace {
 // objects.  This avoids a double lookup in the cases where we know we will
 // add the hash to the JSObject if it does not already exist.
 Object* GetSimpleHash(Object* object) {
+  DisallowHeapAllocation no_gc;
   // The object is either a Smi, a HeapNumber, a name, an odd-ball, a real JS
   // object, or a Harmony proxy.
   if (object->IsSmi()) {
@@ -2333,10 +2334,10 @@ Object* GetSimpleHash(Object* object) {
 }  // namespace
 
 Object* Object::GetHash() {
+  DisallowHeapAllocation no_gc;
   Object* hash = GetSimpleHash(this);
   if (hash->IsSmi()) return hash;
 
-  DisallowHeapAllocation no_gc;
   DCHECK(IsJSReceiver());
   JSReceiver* receiver = JSReceiver::cast(this);
   Isolate* isolate = receiver->GetIsolate();
@@ -2345,10 +2346,12 @@ Object* Object::GetHash() {
 
 // static
 Smi* Object::GetOrCreateHash(Isolate* isolate, Object* key) {
+  DisallowHeapAllocation no_gc;
   return key->GetOrCreateHash(isolate);
 }
 
 Smi* Object::GetOrCreateHash(Isolate* isolate) {
+  DisallowHeapAllocation no_gc;
   Object* hash = GetSimpleHash(this);
   if (hash->IsSmi()) return Smi::cast(hash);
 
@@ -6286,6 +6289,7 @@ Object* SetHashAndUpdateProperties(HeapObject* properties, int masked_hash) {
 }
 
 int GetIdentityHashHelper(Isolate* isolate, JSReceiver* object) {
+  DisallowHeapAllocation no_gc;
   Object* properties = object->raw_properties_or_hash();
   if (properties->IsSmi()) {
     return Smi::ToInt(properties);
@@ -6312,6 +6316,7 @@ int GetIdentityHashHelper(Isolate* isolate, JSReceiver* object) {
 }  // namespace
 
 void JSReceiver::SetIdentityHash(int masked_hash) {
+  DisallowHeapAllocation no_gc;
   DCHECK_NE(PropertyArray::kNoHashSentinel, masked_hash);
   DCHECK_EQ(masked_hash & JSReceiver::kHashMask, masked_hash);
 
@@ -6322,6 +6327,7 @@ void JSReceiver::SetIdentityHash(int masked_hash) {
 }
 
 void JSReceiver::SetProperties(HeapObject* properties) {
+  DisallowHeapAllocation no_gc;
   Isolate* isolate = properties->GetIsolate();
   int hash = GetIdentityHashHelper(isolate, this);
   Object* new_properties = properties;
@@ -6337,6 +6343,7 @@ void JSReceiver::SetProperties(HeapObject* properties) {
 
 template <typename ProxyType>
 Smi* GetOrCreateIdentityHashHelper(Isolate* isolate, ProxyType* proxy) {
+  DisallowHeapAllocation no_gc;
   Object* maybe_hash = proxy->hash();
   if (maybe_hash->IsSmi()) return Smi::cast(maybe_hash);
 
@@ -6346,6 +6353,7 @@ Smi* GetOrCreateIdentityHashHelper(Isolate* isolate, ProxyType* proxy) {
 }
 
 Object* JSObject::GetIdentityHash(Isolate* isolate) {
+  DisallowHeapAllocation no_gc;
   if (IsJSGlobalProxy()) {
     return JSGlobalProxy::cast(this)->hash();
   }
@@ -6359,6 +6367,7 @@ Object* JSObject::GetIdentityHash(Isolate* isolate) {
 }
 
 Smi* JSObject::GetOrCreateIdentityHash(Isolate* isolate) {
+  DisallowHeapAllocation no_gc;
   if (IsJSGlobalProxy()) {
     return GetOrCreateIdentityHashHelper(isolate, JSGlobalProxy::cast(this));
   }

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -6368,13 +6368,8 @@ Smi* JSObject::GetOrCreateIdentityHash(Isolate* isolate) {
     return Smi::cast(hash_obj);
   }
 
-  int masked_hash;
-  // TODO(gsathya): Remove the loop and pass kHashMask directly to
-  // GenerateIdentityHash.
-  do {
-    int hash = isolate->GenerateIdentityHash(Smi::kMaxValue);
-    masked_hash = hash & JSReceiver::kHashMask;
-  } while (masked_hash == PropertyArray::kNoHashSentinel);
+  int masked_hash = isolate->GenerateIdentityHash(JSReceiver::kHashMask);
+  DCHECK_NE(PropertyArray::kNoHashSentinel, masked_hash);
 
   SetIdentityHash(masked_hash);
   return Smi::FromInt(masked_hash);

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -1954,8 +1954,13 @@ class PropertyArray : public HeapObject {
   typedef BodyDescriptor BodyDescriptorWeak;
 
   static const int kLengthMask = 0x3ff;
+#if V8_TARGET_ARCH_64_BIT
   static const int kHashMask = 0x7ffffc00;
   STATIC_ASSERT(kLengthMask + kHashMask == 0x7fffffff);
+#else
+  static const int kHashMask = 0x3ffffc00;
+  STATIC_ASSERT(kLengthMask + kHashMask == 0x3fffffff);
+#endif
 
   static const int kMaxLength = kLengthMask;
   STATIC_ASSERT(kMaxLength > kMaxNumberOfDescriptors);

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -1953,17 +1953,10 @@ class PropertyArray : public HeapObject {
   // No weak fields.
   typedef BodyDescriptor BodyDescriptorWeak;
 
-  static const int kLengthMask = 0x3ff;
-#if V8_TARGET_ARCH_64_BIT
-  static const int kHashMask = 0x7ffffc00;
-  STATIC_ASSERT(kLengthMask + kHashMask == 0x7fffffff);
-#else
-  static const int kHashMask = 0x3ffffc00;
-  STATIC_ASSERT(kLengthMask + kHashMask == 0x3fffffff);
-#endif
-
-  static const int kMaxLength = kLengthMask;
-  STATIC_ASSERT(kMaxLength > kMaxNumberOfDescriptors);
+  static const int kLengthFieldSize = 10;
+  class LengthField : public BitField<int, 0, kLengthFieldSize> {};
+  class HashField : public BitField<int, kLengthFieldSize,
+                                    kSmiValueSize - kLengthFieldSize - 1> {};
 
   static const int kNoHashSentinel = 0;
 
@@ -2190,7 +2183,7 @@ class JSReceiver: public HeapObject {
   MUST_USE_RESULT static MaybeHandle<FixedArray> GetOwnEntries(
       Handle<JSReceiver> object, PropertyFilter filter);
 
-  static const int kHashMask = PropertyArray::kHashMask;
+  static const int kHashMask = PropertyArray::HashField::kMask;
 
   // Layout description.
   static const int kPropertiesOrHashOffset = HeapObject::kHeaderSize;

--- a/deps/v8/src/objects/dictionary.h
+++ b/deps/v8/src/objects/dictionary.h
@@ -138,14 +138,16 @@ class BaseNameDictionary : public Dictionary<Derived, Shape> {
     return Smi::ToInt(this->get(kNextEnumerationIndexIndex));
   }
 
-  void SetHash(int masked_hash) {
-    DCHECK_EQ(masked_hash & JSReceiver::kHashMask, masked_hash);
-    this->set(kObjectHashIndex, Smi::FromInt(masked_hash));
+  void SetHash(int hash) {
+    DCHECK(PropertyArray::HashField::is_valid(hash));
+    this->set(kObjectHashIndex, Smi::FromInt(hash));
   }
 
   int Hash() const {
     Object* hash_obj = this->get(kObjectHashIndex);
-    return Smi::ToInt(hash_obj);
+    int hash = Smi::ToInt(hash_obj);
+    DCHECK(PropertyArray::HashField::is_valid(hash));
+    return hash;
   }
 
   // Creates a new dictionary.

--- a/deps/v8/test/cctest/test-weakmaps.cc
+++ b/deps/v8/test/cctest/test-weakmaps.cc
@@ -191,7 +191,7 @@ TEST(Regress2060a) {
       Handle<JSObject> object = factory->NewJSObject(function, TENURED);
       CHECK(!heap->InNewSpace(*object));
       CHECK(!first_page->Contains(object->address()));
-      int32_t hash = object->GetOrCreateHash(isolate)->value();
+      int32_t hash = key->GetOrCreateHash(isolate)->value();
       JSWeakCollection::Set(weakmap, key, object, hash);
     }
   }


### PR DESCRIPTION
This also includes two other commits to avoid cherry-pick conflicts.

Fixes: https://github.com/nodejs/node/issues/19769

Commits in v8/v8:
https://github.com/v8/v8/commit/a4bddba0b0dac116d987eea28479dba14663cda0
https://github.com/v8/v8/commit/7abdadca0e3e5a780647b8ade0c586c2e7583f9c
https://github.com/v8/v8/commit/a803fad068211ab6c445f485130dc52cbeadfd52

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
