### PR TITLE
fs: make ReadStream throw TypeError on NaN

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2008,12 +2008,12 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number') {
+    if (typeof this.start !== 'number' || Number.isNaN(this.start)) {
       throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
     }
     if (this.end === undefined) {
       this.end = Infinity;
-    } else if (typeof this.end !== 'number') {
+    } else if (typeof this.end !== 'number' || Number.isNaN(this.end)) {
       throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
     }
 
@@ -2030,6 +2030,8 @@ function ReadStream(path, options) {
   // (That is a semver-major change).
   if (typeof this.end !== 'number')
     this.end = Infinity;
+  else if (Number.isNaN(this.end))
+    throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
 
   if (typeof this.fd !== 'number')
     this.open();

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -3,6 +3,9 @@ const common = require('../common');
 const fixtures = require('../common/fixtures');
 const fs = require('fs');
 
+// This test ensures that appropriate TypeError is thrown by createReadStream
+// when an argument with invalid type is passed
+
 const example = fixtures.path('x.txt');
 // Should not throw.
 fs.createReadStream(example, undefined);
@@ -25,3 +28,8 @@ createReadStreamErr(example, 123);
 createReadStreamErr(example, 0);
 createReadStreamErr(example, true);
 createReadStreamErr(example, false);
+
+// createReadSteam _should_ throw on NaN
+createReadStreamErr(example, { start: NaN });
+createReadStreamErr(example, { end: NaN });
+createReadStreamErr(example, { start: NaN, end: NaN });


### PR DESCRIPTION
Make ReadStream (and thus createReadStream) throw a TypeError signalling
towards an invalid argument type when either options.start or
options.end (or obviously, both) are set to NaN.
Also add regression tests for the same.

Fixes: https://github.com/nodejs/node/issues/19715

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @lpinca @BridgeAR @addaleax @anliting