### PR TITLE
doc: update "Breaking changes" link

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -166,7 +166,7 @@ contain an explanation about the reason of the breaking change, which
 situation would trigger the breaking change and what is the exact change.
 
 Breaking changes will be listed in the wiki with the aim to make upgrading
-easier.  Please have a look at [Breaking Changes](https://github.com/nodejs/node/wiki/Breaking-changes-between-v4-LTS-and-v6-LTS)
+easier.  Please have a look at [Breaking Changes](https://github.com/nodejs/node/wiki#apibreaking-changes)
 for the level of detail that's suitable.
 
 Sample complete commit message:


### PR DESCRIPTION
This code change updates "Breaking changes" link from "v0.4 to v0.6" to
generic "API/Breaking Changes" wiki

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
