### PR TITLE
test: add test for tmpdir.refresh() failures on Pi

### DIFF
--- a/test/parallel/test-common-tmpdir-refresh-twice.js
+++ b/test/parallel/test-common-tmpdir-refresh-twice.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// On CI, running `tmpdir.refresh()` twice fails on the Raspberry Pi devices if
+// the tmpdir is not empty for the second call.
+//
+// This may have something to do with the fact that the tmp directory is NFS
+// mounted on those devices.
+
+require('../common');
+const tmpdir = require('../common/tmpdir');
+
+const fs = require('fs');
+const path = require('path');
+
+tmpdir.refresh();
+fs.closeSync(fs.openSync(path.join(tmpdir.path, 'fhqwhgads'), 'w'));
+tmpdir.refresh(); // This should not throw.


### PR DESCRIPTION
Raspberry PI devices in CI fail if `tmpdir.refresh()` is called twice
and the tmpdir is not empty on the second call. This probably has
something to do with the tmpdir being NFS mounted. This is a
work-in-progress and this commit message should be updated once this is
fixed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
