### PR TITLE
doc: remove link to "breaking changes" wiki

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -165,10 +165,6 @@ use `Refs:`.
 contain an explanation about the reason of the breaking change, which
 situation would trigger the breaking change and what is the exact change.
 
-Breaking changes will be listed in the wiki with the aim to make upgrading
-easier.  Please have a look at [Breaking Changes](https://github.com/nodejs/node/wiki/Breaking-changes-between-v4-LTS-and-v6-LTS)
-for the level of detail that's suitable.
-
 Sample complete commit message:
 
 ```txt


### PR DESCRIPTION
Breaking changes wiki is not updated, so removing the paragraph as per comments by:
* @Trott in https://github.com/nodejs/node/pull/19781#pullrequestreview-109105136
* @lpinca in https://github.com/nodejs/node/pull/19781#issuecomment-378525454

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
