### PR TITLE
errors: fix typo in internal/errors.js

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -846,7 +846,7 @@ E('ERR_MODULE_RESOLUTION_LEGACY',
 E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times', Error);
 E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function', TypeError);
 E('ERR_NAPI_INVALID_DATAVIEW_ARGS',
-  'byte_offset + byte_length should be less than or eqaul to the size in ' +
+  'byte_offset + byte_length should be less than or equal to the size in ' +
     'bytes of the array passed in',
   RangeError);
 E('ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT',


### PR DESCRIPTION
corrects "eqaul" to "equal" in the description
for the ERR_NAPI_INVALID_DATAVIEW_ARGS error message

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

