### PR TITLE
errors: change ERR_HTTP2_HEADER_SINGLE_VALUE to instance of TypeError

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -706,9 +706,8 @@ E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
   'Cannot specify additional headers after response initiated', Error);
 E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.', Error);
 
-// This should probably be a `TypeError`.
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
-  'Header field "%s" must have only a single value', Error);
+  'Header field "%s" must only have a single value', TypeError);
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
   'Informational status codes cannot be used', RangeError);
 

--- a/test/parallel/test-http2-multi-content-length.js
+++ b/test/parallel/test-http2-multi-content-length.js
@@ -31,8 +31,8 @@ server.listen(0, common.mustCall(() => {
       });
     }, {
       code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
-      type: Error,
-      message: 'Header field "content-length" must have only a single value'
+      type: TypeError,
+      message: 'Header field "content-length" must only have a single value'
     }
   );
 

--- a/test/parallel/test-http2-single-headers.js
+++ b/test/parallel/test-http2-single-headers.js
@@ -31,8 +31,8 @@ server.listen(0, common.mustCall(() => {
       () => client.request({ [i]: 'abc', [i.toUpperCase()]: 'xyz' }),
       {
         code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
-        type: Error,
-        message: `Header field "${i}" must have only a single value`
+        type: TypeError,
+        message: `Header field "${i}" must only have a single value`
       }
     );
 
@@ -40,8 +40,8 @@ server.listen(0, common.mustCall(() => {
       () => client.request({ [i]: ['abc', 'xyz'] }),
       {
         code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
-        type: Error,
-        message: `Header field "${i}" must have only a single value`
+        type: TypeError,
+        message: `Header field "${i}" must only have a single value`
       }
     );
   });

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -177,8 +177,8 @@ const {
 
   common.expectsError({
     code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
-    type: Error,
-    message: 'Header field ":status" must have only a single value'
+    type: TypeError,
+    message: 'Header field ":status" must only have a single value'
   })(mapToHeaders(headers));
 }
 
@@ -223,7 +223,7 @@ const {
   HTTP2_HEADER_USER_AGENT,
   HTTP2_HEADER_X_CONTENT_TYPE_OPTIONS
 ].forEach((name) => {
-  const msg = `Header field "${name}" must have only a single value`;
+  const msg = `Header field "${name}" must only have a single value`;
   common.expectsError({
     code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
     message: msg


### PR DESCRIPTION
changes the base instance for ERR_HTTP2_HEADER_SINGLE_VALUE
from Error to TypeError as a more accurate representation
of the error. Additionally corrects the grammar of the error
message.

Arguably the error type could also be `RangeError`, but only in cases 
where a header key in an object is assigned an array with more than one
element, instead of a string. However, this inconsistency could be confusing
and unnecessarily complex/convoluted.  It could also be (possibly weakly) argued 
that a "type" in JS is defined by object shape, so an object that's an instance of `Array`,
with one key (`0`) is the expected type. 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
