### PR TITLE
errors: alter ERR_HTTP2_INVALID_CONNECTION_HEADERS

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -712,9 +712,8 @@ E('ERR_HTTP2_HEADER_SINGLE_VALUE',
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
   'Informational status codes cannot be used', RangeError);
 
-// This should probably be a `TypeError`.
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-  'HTTP/1 Connection specific headers are forbidden: "%s"', Error);
+  'HTTP/1 Connection specific headers are forbidden: "%s"', TypeError);
 E('ERR_HTTP2_INVALID_HEADER_VALUE',
   'Invalid value "%s" for header "%s"', TypeError);
 E('ERR_HTTP2_INVALID_INFO_STATUS',


### PR DESCRIPTION
changes the base instance for ERR_HTTP2_INVALID_CONNECTION_HEADERS
from Error to TypeError as a more accurate representation
of the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
