### PR TITLE
errors: alter ERR_HTTP2_INVALID_PSEUDOHEADER

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -721,10 +721,8 @@ E('ERR_HTTP2_INVALID_INFO_STATUS',
   'Invalid informational status code: %s', RangeError);
 E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
   'Packed settings length must be a multiple of six', RangeError);
-
-// This should probably be a `TypeError`.
 E('ERR_HTTP2_INVALID_PSEUDOHEADER',
-  '"%s" is an invalid pseudoheader or is used incorrectly', Error);
+  '"%s" is an invalid pseudoheader or is used incorrectly', TypeError);
 E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed', Error);
 E('ERR_HTTP2_INVALID_SETTING_VALUE',
   'Invalid value for setting "%s": %s', TypeError, RangeError);

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -36,7 +36,7 @@ function onStream(stream, headers, flags) {
     () => stream.additionalHeaders({ ':method': 'POST' }),
     {
       code: 'ERR_HTTP2_INVALID_PSEUDOHEADER',
-      type: Error,
+      type: TypeError,
       message: '":method" is an invalid pseudoheader or is used incorrectly'
     }
   );

--- a/test/parallel/test-http2-util-assert-valid-pseudoheader.js
+++ b/test/parallel/test-http2-util-assert-valid-pseudoheader.js
@@ -17,7 +17,7 @@ function isNotError(val) {
 function isError(val) {
   common.expectsError({
     code: 'ERR_HTTP2_INVALID_PSEUDOHEADER',
-    type: Error,
+    type: TypeError,
     message: '":foo" is an invalid pseudoheader or is used incorrectly'
   })(val);
 }


### PR DESCRIPTION
changes the base instance for ERR_HTTP2_INVALID_PSEUDOHEADER
from Error to TypeError as a more accurate representation
of the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
