### PR TITLE
crypto,doc: update language regarding key stretching

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1365,6 +1365,13 @@ The `key` is the raw key used by the `algorithm` and `iv` is an
 [Buffers][`Buffer`], `TypedArray`, or `DataView`s. If the cipher does not need
 an initialization vector, `iv` may be `null`.
 
+Initialization vectors should be unpredictable and unique; ideally, they will be
+cryptographically random. They do not have to be secret: IVs are typically just
+added to ciphertext messages unencrypted. It may sound contradictory that
+something has to be unpredictable and unique, but does not have to be secret;
+it is important to remember that an attacker must not be able to predict ahead
+of time what a given IV will be.
+
 ### crypto.createCredentials(details)
 <!-- YAML
 added: v0.1.92
@@ -1436,6 +1443,13 @@ The `key` is the raw key used by the `algorithm` and `iv` is an
 [initialization vector][]. Both arguments must be `'utf8'` encoded strings,
 [Buffers][`Buffer`], `TypedArray`, or `DataView`s. If the cipher does not need
 an initialization vector, `iv` may be `null`.
+
+Initialization vectors should be unpredictable and unique; ideally, they will be
+cryptographically random. They do not have to be secret: IVs are typically just
+added to ciphertext messages unencrypted. It may sound contradictory that
+something has to be unpredictable and unique, but does not have to be secret;
+it is important to remember that an attacker must not be able to predict ahead
+of time what a given IV will be.
 
 ### crypto.createDiffieHellman(prime[, primeEncoding][, generator][, generatorEncoding])
 <!-- YAML


### PR DESCRIPTION
Update the docs to provide clearer instructions regarding the exact scope
of the use (and re-use) of an IV, stating the instructions explicitly with
greater clarity.

Fixes: https://github.com/nodejs/node/issues/19748

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @bnoordhuis @tniessen 