### PR TITLE
Increase test coverage for fs/promises.js

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -106,25 +106,25 @@ function verifyStatObject(stat) {
 
     await chmod(dest, 0o666);
     await fchmod(handle, 0o666);
-    handle.chmod(0o666);
+    await handle.chmod(0o666);
 
     // `mode` can't be > 0o777
     assert.rejects(
-      () => chmod(handle, (0o777 + 1)),
+      async () => chmod(handle, (0o777 + 1)),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]'
       }
     );
     assert.rejects(
-      () => fchmod(handle, (0o777 + 1)),
+      async () => fchmod(handle, (0o777 + 1)),
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError [ERR_OUT_OF_RANGE]'
       }
     );
     assert.rejects(
-      () => handle.chmod(handle, (0o777 + 1)),
+      async () => handle.chmod(handle, (0o777 + 1)),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]'


### PR DESCRIPTION
I was looking at [test coverage](https://coverage.nodejs.org/coverage-fdb35d89605de642/root/fs/promises.js.html) for the new things in `fs/promises.js` and wanted to add some more.  This adds test cases using `FileHandle` objects vs. only using paths or fds.

Due to https://github.com/nodejs/node/issues/19057, I'm unable to run coverage locally on macOS; apologies for not including updated coverage info.