### PR TITLE
trace_events: add support for line-delimited JSON output

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -235,6 +235,15 @@ added: v7.7.0
 A comma separated list of categories that should be traced when trace event
 tracing is enabled using `--trace-events-enabled`.
 
+### `--trace-event-format`
+<!-- YAML
+added: REPLACEME
+-->
+
+Specifies the trace events output format. Must be one of either: `'json'`
+(the default V8 Trace Events format) or `'ldjson'` (newline-delimited JSON).
+Defaults to `'json'`.
+
 ### `--trace-event-file-pattern`
 <!-- YAML
 added: v9.8.0

--- a/doc/node.1
+++ b/doc/node.1
@@ -156,6 +156,9 @@ Enable the collection of trace event tracing information.
 A comma-separated list of categories that should be traced when trace event tracing is enabled using
 .Fl -trace-events-enabled .
 .
+.It Fl --trace-event-format Ar format
+Specifies the trace event output format. The value must be one of: \fBjson\fR (The V8 Trace Events format) or \fBldson\fR (newline-delimited JSON).
+.
 .It Fl -trace-event-file-pattern Ar pattern
 Template string specifying the filepath for the trace event data, it
 supports \fB${rotation}\fR and \fB${pid}\fR.

--- a/node.gyp
+++ b/node.gyp
@@ -346,6 +346,7 @@
         'src/tcp_wrap.cc',
         'src/timer_wrap.cc',
         'src/tracing/agent.cc',
+        'src/tracing/node_ldjson_trace_writer.cc',
         'src/tracing/node_trace_buffer.cc',
         'src/tracing/node_trace_writer.cc',
         'src/tracing/trace_event.cc',

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -13,12 +13,13 @@ namespace tracing {
 using v8::platform::tracing::TraceConfig;
 using std::string;
 
-Agent::Agent(const std::string& log_file_pattern) {
+Agent::Agent(const std::string& log_file_pattern,
+             enum trace_format format) {
   int err = uv_loop_init(&tracing_loop_);
   CHECK_EQ(err, 0);
 
   NodeTraceWriter* trace_writer = new NodeTraceWriter(
-      log_file_pattern, &tracing_loop_);
+      log_file_pattern, &tracing_loop_, format);
   TraceBuffer* trace_buffer = new NodeTraceBuffer(
       NodeTraceBuffer::kBufferChunks, trace_writer, &tracing_loop_);
   tracing_controller_ = new TracingController();

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -4,6 +4,7 @@
 #include "libplatform/v8-tracing.h"
 #include "uv.h"
 #include "v8.h"
+#include "node_trace_writer.h"
 
 namespace node {
 namespace tracing {
@@ -19,7 +20,8 @@ class TracingController : public v8::platform::tracing::TracingController {
 
 class Agent {
  public:
-  explicit Agent(const std::string& log_file_pattern);
+  explicit Agent(const std::string& log_file_pattern,
+                 enum trace_format format = TRACE_FORMAT_JSON);
   void Start(const std::string& enabled_categories);
   void Stop();
 

--- a/src/tracing/node_ldjson_trace_writer.cc
+++ b/src/tracing/node_ldjson_trace_writer.cc
@@ -1,0 +1,171 @@
+// Code adapted from the V8 JSONTraceWriter ...
+// Original license header:
+//   Copyright 2016 the V8 project authors. All rights reserved.
+//   Use of this source code is governed by a BSD-style license that can be
+//   found in the LICENSE file.
+
+// note(jasnell): This will need to be kept in sync with the JSONTraceWriter
+// in v8::platform::tracing
+
+#include "tracing/node_ldjson_trace_writer.h"
+#include "util.h"
+#include <cmath>
+#include <sstream>
+#include <string.h>
+
+namespace node {
+namespace tracing {
+
+using v8::ConvertableToTraceFormat;
+using v8::platform::tracing::TracingController;
+
+// Writes the given string to a stream, taking care to escape characters
+// when necessary.
+static void WriteJSONStringToStream(const char* str, std::ostream& stream) {
+  size_t len = strlen(str);
+  stream << "\"";
+  for (size_t i = 0; i < len; ++i) {
+    // All of the permitted escape sequences in JSON strings, as per
+    // https://mathiasbynens.be/notes/javascript-escapes
+    switch (str[i]) {
+      case '\b':
+        stream << "\\b";
+        break;
+      case '\f':
+        stream << "\\f";
+        break;
+      case '\n':
+        stream << "\\n";
+        break;
+      case '\r':
+        stream << "\\r";
+        break;
+      case '\t':
+        stream << "\\t";
+        break;
+      case '\"':
+        stream << "\\\"";
+        break;
+      case '\\':
+        stream << "\\\\";
+        break;
+      // Note that because we use double quotes for JSON strings,
+      // we don't need to escape single quotes.
+      default:
+        stream << str[i];
+        break;
+    }
+  }
+  stream << "\"";
+}
+
+void LDJSONTraceWriter::AppendArgValue(uint8_t type,
+                                       TraceObject::ArgValue value) {
+  switch (type) {
+    case TRACE_VALUE_TYPE_BOOL:
+      stream_ << (value.as_bool ? "true" : "false");
+      break;
+    case TRACE_VALUE_TYPE_UINT:
+      stream_ << value.as_uint;
+      break;
+    case TRACE_VALUE_TYPE_INT:
+      stream_ << value.as_int;
+      break;
+    case TRACE_VALUE_TYPE_DOUBLE: {
+      std::string real;
+      double val = value.as_double;
+      if (std::isfinite(val)) {
+        std::ostringstream convert_stream;
+        convert_stream << val;
+        real = convert_stream.str();
+        // Ensure that the number has a .0 if there's no decimal or 'e'.  This
+        // makes sure that when we read the JSON back, it's interpreted as a
+        // real rather than an int.
+        if (real.find('.') == std::string::npos &&
+            real.find('e') == std::string::npos &&
+            real.find('E') == std::string::npos) {
+          real += ".0";
+        }
+      } else if (std::isnan(val)) {
+        // The JSON spec doesn't allow NaN and Infinity (since these are
+        // objects in EcmaScript).  Use strings instead.
+        real = "\"NaN\"";
+      } else if (val < 0) {
+        real = "\"-Infinity\"";
+      } else {
+        real = "\"Infinity\"";
+      }
+      stream_ << real;
+      break;
+    }
+    case TRACE_VALUE_TYPE_POINTER:
+      // JSON only supports double and int numbers.
+      // So as not to lose bits from a 64-bit pointer, output as a hex string.
+      stream_ << "\"" << value.as_pointer << "\"";
+      break;
+    case TRACE_VALUE_TYPE_STRING:
+    case TRACE_VALUE_TYPE_COPY_STRING:
+      if (value.as_string == nullptr) {
+        stream_ << "\"nullptr\"";
+      } else {
+        WriteJSONStringToStream(value.as_string, stream_);
+      }
+      break;
+    default:
+      UNREACHABLE();
+      break;
+  }
+}
+
+void LDJSONTraceWriter::AppendArgValue(ConvertableToTraceFormat* value) {
+  std::string arg_stringified;
+  value->AppendAsTraceFormat(&arg_stringified);
+  stream_ << arg_stringified;
+}
+
+LDJSONTraceWriter::LDJSONTraceWriter(std::ostream& stream) : stream_(stream) {}
+
+LDJSONTraceWriter::~LDJSONTraceWriter() {}
+
+void LDJSONTraceWriter::AppendTraceEvent(TraceObject* trace_event) {
+  stream_ << "{\"pid\":" << trace_event->pid()
+          << ",\"tid\":" << trace_event->tid()
+          << ",\"ts\":" << trace_event->ts()
+          << ",\"tts\":" << trace_event->tts() << ",\"ph\":\""
+          << trace_event->phase() << "\",\"cat\":\""
+          << TracingController::GetCategoryGroupName(
+                 trace_event->category_enabled_flag())
+          << "\",\"name\":\"" << trace_event->name()
+          << "\",\"dur\":" << trace_event->duration()
+          << ",\"tdur\":" << trace_event->cpu_duration();
+  if (trace_event->flags() & TRACE_EVENT_FLAG_HAS_ID) {
+    if (trace_event->scope() != nullptr) {
+      stream_ << ",\"scope\":\"" << trace_event->scope() << "\"";
+    }
+    // So as not to lose bits from a 64-bit integer, output as a hex string.
+    stream_ << ",\"id\":\"0x" << std::hex << trace_event->id() << "\""
+            << std::dec;
+  }
+  stream_ << ",\"args\":{";
+  const char** arg_names = trace_event->arg_names();
+  const uint8_t* arg_types = trace_event->arg_types();
+  TraceObject::ArgValue* arg_values = trace_event->arg_values();
+  std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables =
+      trace_event->arg_convertables();
+  for (int i = 0; i < trace_event->num_args(); ++i) {
+    if (i > 0) stream_ << ",";
+    stream_ << "\"" << arg_names[i] << "\":";
+    if (arg_types[i] == TRACE_VALUE_TYPE_CONVERTABLE) {
+      AppendArgValue(arg_convertables[i].get());
+    } else {
+      AppendArgValue(arg_types[i], arg_values[i]);
+    }
+  }
+  stream_ << "}}\n";
+  // TODO(fmeawad): Add support for Flow Events.
+}
+
+void LDJSONTraceWriter::Flush() {}
+
+}  // namespace tracing
+}  // namespace node

--- a/src/tracing/node_ldjson_trace_writer.h
+++ b/src/tracing/node_ldjson_trace_writer.h
@@ -1,0 +1,41 @@
+// Code adapted from the V8 JSONTraceWriter ...
+// Original license header:
+//   Copyright 2016 the V8 project authors. All rights reserved.
+//   Use of this source code is governed by a BSD-style license that can be
+//   found in the LICENSE file.
+
+#ifndef SRC_TRACING_NODE_LDJSON_TRACE_WRITER_H_
+#define SRC_TRACING_NODE_LDJSON_TRACE_WRITER_H_
+
+#include "libplatform/v8-tracing.h"
+#include "tracing/trace_event_common.h"
+#include <sstream>
+
+namespace node {
+namespace tracing {
+
+using v8::platform::tracing::TraceObject;
+using v8::platform::tracing::TraceWriter;
+
+class LDJSONTraceWriter : public TraceWriter {
+ public:
+  explicit LDJSONTraceWriter(std::ostream& stream);
+  ~LDJSONTraceWriter();
+  void AppendTraceEvent(TraceObject* trace_event) override;
+  void Flush() override;
+
+  static TraceWriter* Create(std::ostream& stream) {
+    return new LDJSONTraceWriter(stream);
+  }
+
+ private:
+  void AppendArgValue(uint8_t type, TraceObject::ArgValue value);
+  void AppendArgValue(v8::ConvertableToTraceFormat*);
+
+  std::ostream& stream_;
+};
+
+}  // namespace tracing
+}  // namespace node
+
+#endif  // SRC_TRACING_NODE_LDJSON_TRACE_WRITER_H_

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -14,10 +14,16 @@ namespace tracing {
 using v8::platform::tracing::TraceObject;
 using v8::platform::tracing::TraceWriter;
 
+enum trace_format {
+  TRACE_FORMAT_JSON,
+  TRACE_FORMAT_LDJSON
+};
+
 class NodeTraceWriter : public TraceWriter {
  public:
   explicit NodeTraceWriter(const std::string& log_file_pattern,
-                           uv_loop_t* tracing_loop);
+                           uv_loop_t* tracing_loop,
+                           enum trace_format format = TRACE_FORMAT_JSON);
   ~NodeTraceWriter();
 
   void AppendTraceEvent(TraceObject* trace_event) override;
@@ -64,6 +70,7 @@ class NodeTraceWriter : public TraceWriter {
   int total_traces_ = 0;
   int file_num_ = 0;
   const std::string& log_file_pattern_;
+  enum trace_format format_;
   std::ostringstream stream_;
   TraceWriter* json_trace_writer_ = nullptr;
   bool exited_ = false;

--- a/test/parallel/test-trace-events-ldjson.js
+++ b/test/parallel/test-trace-events-ldjson.js
@@ -1,0 +1,62 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+
+const CODE =
+  'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
+const FILE_NAME = 'node_trace.1.log';
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
+
+const proc = cp.spawn(process.execPath,
+                      [ '--trace-event-format', 'ldjson',
+                        '--trace-events-enabled', '-e', CODE ]);
+
+proc.once('exit', common.mustCall(() => {
+  assert(common.fileExists(FILE_NAME));
+  fs.readFile(FILE_NAME, common.mustCall((err, data) => {
+    const traces =
+      data.toString().split('\n')
+                     .slice(0, -1)
+                     .map(JSON.parse);
+
+    assert(traces.length > 0);
+    // V8 trace events should be generated.
+    assert(traces.some((trace) => {
+      if (trace.pid !== proc.pid)
+        return false;
+      if (trace.cat !== 'v8')
+        return false;
+      if (trace.name !== 'V8.ScriptCompiler')
+        return false;
+      return true;
+    }));
+
+    // C++ async_hooks trace events should be generated.
+    assert(traces.some((trace) => {
+      if (trace.pid !== proc.pid)
+        return false;
+      if (trace.cat !== 'node,node.async_hooks')
+        return false;
+      if (trace.name !== 'TIMERWRAP')
+        return false;
+      return true;
+    }));
+
+
+    // JavaScript async_hooks trace events should be generated.
+    assert(traces.some((trace) => {
+      if (trace.pid !== proc.pid)
+        return false;
+      if (trace.cat !== 'node,node.async_hooks')
+        return false;
+      if (trace.name !== 'Timeout')
+        return false;
+      return true;
+    }));
+  }));
+}));


### PR DESCRIPTION
Adds a new `--trace-event-format` command line option that may be
used to specify V8 Trace Event JSON output or a line-delimited
JSON variant.

By default, the V8 Trace Events format uses a root object with a
single `trace_events: []` property. While there are some hackish
ways to process that format in a fully streaming model, newline
delimited JSON is a better general approach. However, as newline
delimited JSON is not yet supported by the V8 trace events viewer,
it cannot be the default.

This PR adds the option of using either...

```
node --trace-event-format ldjson --trace-events-enabled
node --trace-event-format json --trace-events-enabled
```

This also gives us the option of potentially adding other formats
later on down the line.

/cc @ofrobots @AndreasMadsen @mcollina @nodejs/diagnostics 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
