### PR TITLE
constants: freeze the constants object

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,3 +32,4 @@ Object.assign(exports,
               constants.os.signals,
               constants.fs,
               constants.crypto);
+Object.freeze(exports);

--- a/test/parallel/test-constants.js
+++ b/test/parallel/test-constants.js
@@ -24,3 +24,5 @@ assert.ok(binding.crypto);
     }
   });
 });
+
+assert.ok(Object.isFrozen(constants));


### PR DESCRIPTION
Constants ought to be constant. The primary goal of this commit is to
make constants exposed in require('constants') immutable, as they were
prior to node@7.0.0, and as the constants exposed on fs.constants,
crypto.constants, etc. are.

Since this is implemented by using Object.freeze, it also has the side
effect of making the entire exports of require('constants') immutable,
so no new constants can be defined on the object in userland.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
