### PR TITLE
stream: always emit error before close

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -30,18 +30,25 @@ function destroy(err, cb) {
   }
 
   this._destroy(err || null, (err) => {
-    process.nextTick(emitCloseNT, this);
     if (!cb && err) {
-      process.nextTick(emitErrorNT, this, err);
+      process.nextTick(emitErrorAndCloseNT, this, err);
       if (this._writableState) {
         this._writableState.errorEmitted = true;
       }
     } else if (cb) {
+      process.nextTick(emitCloseNT, this);
       cb(err);
+    } else {
+      process.nextTick(emitCloseNT, this);
     }
   });
 
   return this;
+}
+
+function emitErrorAndCloseNT(self, err) {
+  emitErrorNT(self, err);
+  emitCloseNT(self);
 }
 
 function emitCloseNT(self) {

--- a/test/parallel/test-http2-stream-destroy-event-order.js
+++ b/test/parallel/test-http2-stream-destroy-event-order.js
@@ -9,8 +9,8 @@ let client;
 let req;
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
-  stream.on('close', common.mustCall(() => {
-    stream.on('error', common.mustCall(() => {
+  stream.on('error', common.mustCall(() => {
+    stream.on('close', common.mustCall(() => {
       server.close();
     }));
   }));
@@ -21,8 +21,8 @@ server.listen(0, common.mustCall(() => {
   client = http2.connect(`http://localhost:${server.address().port}`);
   req = client.request();
   req.resume();
-  req.on('close', common.mustCall(() => {
-    req.on('error', common.mustCall(() => {
+  req.on('error', common.mustCall(() => {
+    req.on('close', common.mustCall(() => {
       client.close();
     }));
   }));

--- a/test/parallel/test-stream-destroy-event-order.js
+++ b/test/parallel/test-stream-destroy-event-order.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+const rs = new Readable({
+  read() {}
+});
+
+let closed = false;
+let errored = false;
+
+rs.on('close', common.mustCall(() => {
+  closed = true;
+  assert(errored);
+}));
+
+rs.on('error', common.mustCall((err) => {
+  errored = true;
+  assert(!closed);
+}));
+
+rs.destroy(new Error('kaboom'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Extracted from #19828. Fixes an issue from my error-handling pr, #18438 where a stream emits `close` before `error` on destroy. It should be `error` before `close`.