### PR TITLE
http2: invoke connect callback immediately if session was connected 

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -320,6 +320,17 @@ added: v9.4.0
 Will be `true` if this `Http2Session` instance has been closed, otherwise
 `false`.
 
+#### http2session.connecting
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Will be `true` if this `Http2Session` instance is still connecting, will be set
+to `false` before emitting `connect` event and/or calling the `http2.connect`
+callback.
+
 #### http2session.destroy([error,][code])
 <!-- YAML
 added: v8.4.0

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -774,7 +774,7 @@ function setupHandle(socket, type, options) {
   // core will check for session.destroyed before progressing, this
   // ensures that those at l`east get cleared out.
   if (this.destroyed) {
-    this.emit('connect', this, socket);
+    process.nextTick(emit, this, 'connect', this, socket);
     return;
   }
   debug(`Http2Session ${sessionName(type)}: setting up session handle`);
@@ -816,7 +816,7 @@ function setupHandle(socket, type, options) {
     options.settings : {};
 
   this.settings(settings);
-  this.emit('connect', this, socket);
+  process.nextTick(emit, this, 'connect', this, socket);
 }
 
 // Emits a close event followed by an error event if err is truthy. Used


### PR DESCRIPTION
Resolves https://github.com/nodejs/node/issues/19839

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
