### PR TITLE
src: remove unused util.h from tls_wrap.h

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -29,6 +29,7 @@
 #include "node_counters.h"
 #include "node_internals.h"
 #include "stream_base-inl.h"
+#include "util-inl.h"
 
 namespace node {
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -30,7 +30,6 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "stream_wrap.h"
-#include "util.h"
 #include "v8.h"
 
 #include <openssl/ssl.h>


### PR DESCRIPTION
This commit removes util.h from tls_wrap.h and adds util-inl.h to
tls_wrap.cc which does use it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
