### PR TITLE
http2: add failing writes with destroy test

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1176,7 +1176,7 @@ class Http2Session extends EventEmitter {
     // Otherwise, destroy immediately.
     if (!socket.destroyed) {
       if (!error) {
-        setImmediate(socket.end.bind(socket));
+        setImmediate(socket.destroy.bind(socket));
       } else {
         socket.destroy(error);
       }

--- a/test/parallel/test-http2-many-writes-and-destroy.js
+++ b/test/parallel/test-http2-many-writes-and-destroy.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+{
+  const server = http2.createServer((req, res) => {
+    req.pipe(res);
+  });
+
+  server.listen(0, () => {
+    const url = `http://localhost:${server.address().port}`;
+    const client = http2.connect(url);
+    const req = client.request({ ':method': 'POST' });
+
+    for (let i = 0; i < 4000; i++) {
+      req.write(Buffer.alloc(6));
+    }
+
+    req.on('close', common.mustCall(() => {
+      console.log('(req onclose)');
+      server.close();
+      client.close();
+    }));
+
+    req.once('data', common.mustCall(() => req.destroy()));
+  });
+}

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -21,6 +21,10 @@ const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   const dest = stream.pipe(fs.createWriteStream(fn));
 
+  // we might get an ECONNRESET here
+  // or not
+  stream.on('error', () => {});
+
   dest.on('finish', () => {
     assert.strictEqual(fs.readFileSync(loc).length,
                        fs.readFileSync(fn).length);
@@ -33,6 +37,11 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
 
   const req = client.request({ ':method': 'POST' });
+
+  // we might get an ECONNRESET here
+  // or not
+  req.on('error', () => {});
+
   req.on('response', common.mustCall());
   req.resume();
 

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -21,10 +21,6 @@ const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   const dest = stream.pipe(fs.createWriteStream(fn));
 
-  // we might get an ECONNRESET here
-  // or not
-  stream.on('error', () => {});
-
   dest.on('finish', () => {
     assert.strictEqual(fs.readFileSync(loc).length,
                        fs.readFileSync(fn).length);
@@ -37,10 +33,6 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
 
   const req = client.request({ ':method': 'POST' });
-
-  // we might get an ECONNRESET here
-  // or not
-  req.on('error', () => {});
 
   req.on('response', common.mustCall());
   req.resume();

--- a/test/parallel/test-http2-server-close-callback.js
+++ b/test/parallel/test-http2-server-close-callback.js
@@ -10,17 +10,15 @@ const server = http2.createServer();
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
-
-  // depending on network events, this might or might not be emitted
-  client.on('error', () => {});
-
-  client.on('connect', common.mustCall(() => {
-    server.close(common.mustCall());
-  }));
+  client.on('error', (err) => {
+    if (err.code !== 'ECONNRESET')
+      throw err;
+  });
 }));
 
 server.on('session', common.mustCall((s) => {
   setImmediate(() => {
+    server.close(common.mustCall());
     s.destroy();
   });
 }));

--- a/test/parallel/test-http2-server-close-callback.js
+++ b/test/parallel/test-http2-server-close-callback.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  // depending on network events, this might or might not be emitted
+  client.on('error', () => {});
+
+  client.on('connect', common.mustCall(() => {
+    server.close(common.mustCall());
+  }));
+}));
+
+server.on('session', common.mustCall((s) => {
+  setImmediate(() => {
+    s.destroy();
+  });
+}));

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -44,10 +44,16 @@ server.on('stream', common.mustCall((stream) => {
 
 server.listen(0, common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`);
-  client.on('error', () => {});
+  client.on('error', (err) => {
+    if (err.code !== 'ECONNRESET')
+      throw err;
+  });
   const req = client.request();
   req.resume();
   req.on('end', common.mustCall());
-  req.on('close', common.mustCall(() => server.close()));
-  req.on('error', () => {});
+  req.on('close', common.mustCall(() => server.close(common.mustCall())));
+  req.on('error', (err) => {
+    if (err.code !== 'ECONNRESET')
+      throw err;
+  });
 }));

--- a/test/parallel/test-http2-session-unref.js
+++ b/test/parallel/test-http2-session-unref.js
@@ -34,8 +34,11 @@ server.listen(0, common.mustCall(() => {
   // unref destroyed client
   {
     const client = http2.connect(`http://localhost:${port}`);
-    client.destroy();
-    client.unref();
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
   }
 
   // unref destroyed client
@@ -43,8 +46,11 @@ server.listen(0, common.mustCall(() => {
     const client = http2.connect(`http://localhost:${port}`, {
       createConnection: common.mustCall(() => clientSide)
     });
-    client.destroy();
-    client.unref();
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
   }
 }));
 server.emit('connection', serverSide);

--- a/test/sequential/test-http2-max-session-memory.js
+++ b/test/sequential/test-http2-max-session-memory.js
@@ -13,10 +13,10 @@ const largeBuffer = Buffer.alloc(1e6);
 const server = http2.createServer({ maxSessionMemory: 1 });
 
 server.on('stream', common.mustCall((stream) => {
-  stream.on('error', common.expectsError({
-    code: 'ECONNRESET',
-    type: Error
-  }));
+  stream.on('error', (err) => {
+    if (err.code !== 'ECONNRESET')
+      throw err;
+  });
   stream.respond();
   stream.end(largeBuffer);
 }));

--- a/test/sequential/test-http2-max-session-memory.js
+++ b/test/sequential/test-http2-max-session-memory.js
@@ -13,6 +13,10 @@ const largeBuffer = Buffer.alloc(1e6);
 const server = http2.createServer({ maxSessionMemory: 1 });
 
 server.on('stream', common.mustCall((stream) => {
+  stream.on('error', common.expectsError({
+    code: 'ECONNRESET',
+    type: Error
+  }));
   stream.respond();
   stream.end(largeBuffer);
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Simplified the failing http2 test from #19828 into this test case. Basically when doing *lots* of writes and then destroying the request, the process will hang instead of exiting normally.

Fixes https://github.com/nodejs/node/issues/20630