### PR TITLE
tools: include exit code in test failures

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -254,11 +254,12 @@ class DotsProgressIndicator(SimpleProgressIndicator):
 
 class TapProgressIndicator(SimpleProgressIndicator):
 
-  def _printDiagnostic(self, traceback, severity):
-    logger.info('  severity: %s', severity)
+  def _printDiagnostic(self):
+    logger.info('  severity: %s', self.severity)
+    self.exitcode and logger.info('  exitcode: %s', self.exitcode)
     logger.info('  stack: |-')
 
-    for l in traceback.splitlines():
+    for l in self.traceback.splitlines():
       logger.info('    ' + l)
 
   def Starting(self):
@@ -273,6 +274,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
     self._done += 1
     self.traceback = ''
     self.severity = 'ok'
+    self.exitcode = ''
 
     # Print test name as (for example) "parallel/test-assert".  Tests that are
     # scraped from the addons documentation are all named test.js, making it
@@ -284,7 +286,8 @@ class TapProgressIndicator(SimpleProgressIndicator):
     if output.UnexpectedOutput():
       status_line = 'not ok %i %s' % (self._done, command)
       self.severity = 'fail'
-      self.traceback = "exit code: " + output.output.exit_code + "\n" + output.output.stdout + output.output.stderr
+      self.exitcode = output.output.exit_code
+      self.traceback = output.output.stdout + output.output.stderr
 
       if FLAKY in output.test.outcomes and self.flaky_tests_mode == DONTCARE:
         status_line = status_line + ' # TODO : Fix flaky test'
@@ -330,7 +333,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
     if self.severity is not 'ok' or self.traceback is not '':
       if output.HasTimedOut():
         self.traceback = 'timeout'
-      self._printDiagnostic(self.traceback, self.severity)
+      self._printDiagnostic()
     logger.info('  ...')
 
   def Done(self):

--- a/tools/test.py
+++ b/tools/test.py
@@ -284,7 +284,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
     if output.UnexpectedOutput():
       status_line = 'not ok %i %s' % (self._done, command)
       self.severity = 'fail'
-      self.traceback = output.output.stdout + output.output.stderr
+      self.traceback = "exit code: " + output.output.exit_code + "\n" + output.output.stdout + output.output.stderr
 
       if FLAKY in output.test.outcomes and self.flaky_tests_mode == DONTCARE:
         status_line = status_line + ' # TODO : Fix flaky test'


### PR DESCRIPTION
Include the exit code in test failures. This will give us more
information during the currently-puzzling failures that provide no
information in CI such as:

```
03:10:10 not ok 563 parallel/test-fs-truncate
03:10:10   ---
03:10:10   duration_ms: 1.119
03:10:10   severity: fail
03:10:10   stack: |-
03:10:10   ...
```

@BridgeAR @addaleax @nodejs/build @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
