### PR TITLE
test: fix flaky http-client-timeout-agent

### DIFF
--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -46,11 +46,10 @@ const server = http.createServer(function(req, res) {
 
 server.listen(0, options.host, function() {
   options.port = this.address().port;
-  let req;
 
   for (requests_sent = 0; requests_sent < 30; requests_sent += 1) {
     options.path = `/${requests_sent}`;
-    req = http.request(options);
+    const req = http.request(options);
     req.id = requests_sent;
     req.on('response', function(res) {
       res.on('data', function(data) {
@@ -59,6 +58,7 @@ server.listen(0, options.host, function() {
       res.on('end', function(data) {
         console.log(`res#${this.req.id} end`);
         requests_done += 1;
+        req.destroy();
       });
     });
     req.on('close', function() {


### PR DESCRIPTION
Close the connection immediately after receiving the `end` event to
avoid that the `timeout` event is fired before the connection closes
gracefully.

Fixes: https://github.com/nodejs/node/issues/19804

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
