### PR TITLE
assert: lazy load acorn

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -33,7 +33,6 @@ const {
   }
 } = require('internal/errors');
 const { openSync, closeSync, readSync } = require('fs');
-const { parseExpressionAt } = require('internal/deps/acorn/dist/acorn');
 const { inspect } = require('util');
 const { EOL } = require('os');
 const { NativeModule } = require('internal/bootstrap/loaders');
@@ -173,6 +172,8 @@ function getErrMessage(call) {
     fd = openSync(filename, 'r', 0o666);
     const buffers = getBuffer(fd, line);
     const code = Buffer.concat(buffers).toString('utf8');
+    // Lazy load acorn.
+    const { parseExpressionAt } = require('internal/deps/acorn/dist/acorn');
     const nodes = parseExpressionAt(code, column);
     // Node type should be "CallExpression" and some times
     // "SequenceExpression".


### PR DESCRIPTION
This makes sure acorn is only loaded in case it is necessary. This prevents acorn always being loaded on startup.

I decided to use the modules cache instead of special handling this. The loading
is only done rarely.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
