### PR TITLE
src: rename ERR_STRING_TOO_LARGE to ERR_STRING_TOO_LONG

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1474,8 +1474,8 @@ additional details.
 A stream method was called that cannot complete because the stream was
 destroyed using `stream.destroy()`.
 
-<a id="ERR_STRING_TOO_LARGE"></a>
-### ERR_STRING_TOO_LARGE
+<a id="ERR_STRING_TOO_LONG"></a>
+### ERR_STRING_TOO_LONG
 
 An attempt has been made to create a string larger than the maximum allowed
 size.

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -18,7 +18,7 @@ namespace node {
 
 #define ERRORS_WITH_CODE(V)                                                  \
   V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                     \
-  V(ERR_STRING_TOO_LARGE, Error)                                             \
+  V(ERR_STRING_TOO_LONG, Error)                                             \
   V(ERR_BUFFER_TOO_LARGE, Error)
 
 #define V(code, type)                                                         \
@@ -58,12 +58,12 @@ inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate *isolate) {
   return ERR_BUFFER_TOO_LARGE(isolate, message);
 }
 
-inline v8::Local<v8::Value> ERR_STRING_TOO_LARGE(v8::Isolate *isolate) {
+inline v8::Local<v8::Value> ERR_STRING_TOO_LONG(v8::Isolate *isolate) {
   char message[128];
   snprintf(message, sizeof(message),
-      "Cannot create a string larger than 0x%x bytes",
+      "Cannot create a string longer than 0x%x characters",
       v8::String::kMaxLength);
-  return ERR_STRING_TOO_LARGE(isolate, message);
+  return ERR_STRING_TOO_LONG(isolate, message);
 }
 
 }  // namespace node

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -113,7 +113,7 @@ class ExternString: public ResourceType {
 
     if (str.IsEmpty()) {
       delete h_str;
-      *error = node::ERR_STRING_TOO_LARGE(isolate);
+      *error = node::ERR_STRING_TOO_LONG(isolate);
       return MaybeLocal<Value>();
     }
 
@@ -170,7 +170,7 @@ MaybeLocal<Value> ExternOneByteString::NewSimpleFromCopy(Isolate* isolate,
                              v8::NewStringType::kNormal,
                              length);
   if (str.IsEmpty()) {
-    *error = node::ERR_STRING_TOO_LARGE(isolate);
+    *error = node::ERR_STRING_TOO_LONG(isolate);
     return MaybeLocal<Value>();
   }
   return str.ToLocalChecked();
@@ -188,7 +188,7 @@ MaybeLocal<Value> ExternTwoByteString::NewSimpleFromCopy(Isolate* isolate,
                              v8::NewStringType::kNormal,
                              length);
   if (str.IsEmpty()) {
-    *error = node::ERR_STRING_TOO_LARGE(isolate);
+    *error = node::ERR_STRING_TOO_LONG(isolate);
     return MaybeLocal<Value>();
   }
   return str.ToLocalChecked();
@@ -657,7 +657,7 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
                                 v8::NewStringType::kNormal,
                                 buflen);
       if (val.IsEmpty()) {
-        *error = node::ERR_STRING_TOO_LARGE(isolate);
+        *error = node::ERR_STRING_TOO_LONG(isolate);
         return MaybeLocal<Value>();
       }
       return val.ToLocalChecked();

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -28,7 +28,8 @@ const stringLengthHex = kStringMaxLength.toString(16);
 common.expectsError(function() {
   buf.toString('ascii');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -28,7 +28,8 @@ const stringLengthHex = kStringMaxLength.toString(16);
 common.expectsError(function() {
   buf.toString('base64');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -29,8 +29,9 @@ const stringLengthHex = kStringMaxLength.toString(16);
 common.expectsError(function() {
   buf.toString('latin1');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });
 

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -28,7 +28,8 @@ const stringLengthHex = kStringMaxLength.toString(16);
 common.expectsError(function() {
   buf.toString('hex');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -32,8 +32,9 @@ assert.throws(function() {
 }, function(e) {
   if (e.message !== 'Array buffer allocation failed') {
     common.expectsError({
-      message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-      code: 'ERR_STRING_TOO_LARGE',
+      message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+               'characters',
+      code: 'ERR_STRING_TOO_LONG',
       type: Error
     })(e);
     return true;
@@ -45,7 +46,8 @@ assert.throws(function() {
 common.expectsError(function() {
   buf.toString('utf8');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -29,7 +29,8 @@ const stringLengthHex = kStringMaxLength.toString(16);
 common.expectsError(function() {
   buf.toString('utf16le');
 }, {
-  message: `Cannot create a string larger than 0x${stringLengthHex} bytes`,
-  code: 'ERR_STRING_TOO_LARGE',
+  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
+           'characters',
+  code: 'ERR_STRING_TOO_LONG',
   type: Error
 });

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -35,9 +35,9 @@ stream.on('finish', common.mustCall(function() {
     if (err.message !== 'Array buffer allocation failed') {
       const stringLengthHex = kStringMaxLength.toString(16);
       common.expectsError({
-        message: 'Cannot create a string larger than ' +
-                 `0x${stringLengthHex} bytes`,
-        code: 'ERR_STRING_TOO_LARGE',
+        message: 'Cannot create a string longer than ' +
+                 `0x${stringLengthHex} characters`,
+        code: 'ERR_STRING_TOO_LONG',
         type: Error
       })(err);
     }


### PR DESCRIPTION
The old error name and message were trying to be consistent with
ERR_BUFFER_TOO_LARGE but they were not really accurate.
The kStringMaxLength was measured in number of characters,
not number of bytes. The name ERR_STRING_TOO_LARGE also
seems a bit awkward. This patch tries to correct them before
they get released to users.

Refs: https://github.com/nodejs/node/pull/19739
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
