### PR TITLE
assert: fix error message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -465,7 +465,9 @@ async function waitForActual(block) {
 function expectsError(stackStartFn, actual, error, message) {
   if (typeof error === 'string') {
     if (arguments.length === 4) {
-      throw new ERR_INVALID_ARG_TYPE('error', ['Function', 'RegExp'], error);
+      throw new ERR_INVALID_ARG_TYPE('error',
+                                     ['Object', 'Error', 'Function', 'RegExp'],
+                                     error);
     }
     message = error;
     error = null;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -741,8 +741,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "error" argument must be one of type Function or RegExp. ' +
-             'Received type string'
+    message: 'The "error" argument must be one of type Object, Error, ' +
+             'Function, or RegExp. Received type string'
   }
 );
 


### PR DESCRIPTION
`assert.throws` also accepts objects and errors as input. This fixes
the error message accodingly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
