### PR TITLE
 assert: detect faulty throws usage 

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -586,6 +586,14 @@ found [here][online].
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
+<a id="ERR_AMBIGUOUS_ARGUMENT"></a>
+### ERR_AMBIGUOUS_ARGUMENT
+
+This is triggered by the `assert` module in case e.g.,
+`assert.throws(fn, message)` is used in a way that the message is the thrown
+error message. This is ambiguous because the message is not verifying the error
+message and will only be thrown in case no error is thrown.
+
 <a id="ERR_ARG_NOT_ITERABLE"></a>
 ### ERR_ARG_NOT_ITERABLE
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -471,7 +471,7 @@ function expectsError(stackStartFn, actual, error, message) {
                                      ['Object', 'Error', 'Function', 'RegExp'],
                                      error);
     }
-    if (typeof actual === 'object') {
+    if (typeof actual === 'object' && actual !== null) {
       if (actual.message === error) {
         throw new ERR_AMBIGUOUS_ARGUMENT(
           'error/message',

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,6 +29,7 @@ const {
   AssertionError,
   errorCache,
   codes: {
+    ERR_AMBIGUOUS_ARGUMENT,
     ERR_INVALID_ARG_TYPE
   }
 } = require('internal/errors');
@@ -469,6 +470,19 @@ function expectsError(stackStartFn, actual, error, message) {
       throw new ERR_INVALID_ARG_TYPE('error',
                                      ['Object', 'Error', 'Function', 'RegExp'],
                                      error);
+    }
+    if (typeof actual === 'object') {
+      if (actual.message === error) {
+        throw new ERR_AMBIGUOUS_ARGUMENT(
+          'error/message',
+          `The error message "${actual.message}" is identical to the message.`
+        );
+      }
+    } else if (actual === error) {
+      throw new ERR_AMBIGUOUS_ARGUMENT(
+        'error/message',
+        `The error "${actual}" is identical to the message.`
+      );
     }
     message = error;
     error = null;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -640,6 +640,7 @@ module.exports = exports = {
 //
 // Note: Node.js specific errors must begin with the prefix ERR_
 
+E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
 E('ERR_ASSERTION', '%s', Error);
 E('ERR_ASYNC_CALLBACK', '%s must be a function', TypeError);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -833,13 +833,38 @@ common.expectsError(
 
   // eslint-disable-next-line no-throw-literal
   assert.throws(() => { throw undefined; }, /undefined/);
-  common.expectsError(
+  assert.throws(
     // eslint-disable-next-line no-throw-literal
     () => a.doesNotThrow(() => { throw undefined; }),
     {
-      type: assert.AssertionError,
+      name: 'AssertionError [ERR_ASSERTION]',
       code: 'ERR_ASSERTION',
       message: 'Got unwanted exception.\nundefined'
     }
   );
 }
+
+assert.throws(
+  () => a.throws(
+    // eslint-disable-next-line no-throw-literal
+    () => { throw 'foo'; },
+    'foo'
+  ),
+  {
+    code: 'ERR_AMBIGUOUS_ARGUMENT',
+    message: 'The "error/message" argument is ambiguous. ' +
+             'The error "foo" is identical to the message.'
+  }
+);
+
+assert.throws(
+  () => a.throws(
+    () => { throw new TypeError('foo'); },
+    'foo'
+  ),
+  {
+    code: 'ERR_AMBIGUOUS_ARGUMENT',
+    message: 'The "error/message" argument is ambiguous. ' +
+             'The error message "foo" is identical to the message.'
+  }
+);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -868,3 +868,7 @@ assert.throws(
              'The error message "foo" is identical to the message.'
   }
 );
+
+// Should not throw.
+// eslint-disable-next-line no-restricted-syntax, no-throw-literal
+assert.throws(() => { throw null; }, 'foo');


### PR DESCRIPTION
This is a attempt in fixing the ambiguous behavior of the `assert.throws` message. It is the best way to detect it out of my perspective. This ambiguity is the only real problem with the current API. It would of course be nicer if this would have always tested for the error message but changing that is not possible because quite some code will rely on the current behavior.

<s>The PR currently relies on #19865 to prevent conflicts after landing that PR. I am going to remove that commit as soon as that lands.</s> Done.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
