### PR TITLE
doc: add comma and colon in message with --inspector doc url

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -14,7 +14,7 @@ prompt will be displayed indicating successful launch of the debugger:
 ```txt
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/80e7a814-7cd3-49fb-921a-2e02228cd5ba
-< For help see https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/inspector
 < Debugger attached.
 Break on start in myscript.js:1
 > 1 (function (exports, require, module, __filename, __dirname) { global.x = 5;
@@ -45,7 +45,7 @@ Once the debugger is run, a breakpoint will occur at line 3:
 ```txt
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/80e7a814-7cd3-49fb-921a-2e02228cd5ba
-< For help see https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/inspector
 < Debugger attached.
 Break on start in myscript.js:1
 > 1 (function (exports, require, module, __filename, __dirname) { global.x = 5;
@@ -127,7 +127,7 @@ is not loaded yet:
 ```txt
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/4e3db158-9791-4274-8909-914f7facf3bd
-< For help see https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/inspector
 < Debugger attached.
 Break on start in main.js:1
 > 1 (function (exports, require, module, __filename, __dirname) { const mod = require('./mod.js');

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -104,7 +104,7 @@ void PrintDebuggerReadyMessage(const std::string& host,
     fprintf(out, "Debugger listening on %s\n",
             FormatWsAddress(host, port, id, true).c_str());
   }
-  fprintf(out, "For help see %s\n",
+  fprintf(out, "For help, see: %s\n",
           "https://nodejs.org/en/docs/inspector");
   fflush(out);
 }


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

When i follow link https://nodejs.org/en/docs/inspector i get 404 error. Replaced on https://nodejs.org/en/docs/guides/debugging-getting-started/ with inspect flag documentation