### PR TITLE
stream: use instanceof when checking chunk type

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -291,7 +291,7 @@ function addChunk(stream, state, chunk, addToFront) {
 
 function chunkInvalid(state, chunk) {
   var er;
-  if (!Stream._isUint8Array(chunk) &&
+  if (!(chunk instanceof Uint8Array) &&
       typeof chunk !== 'string' &&
       chunk !== undefined &&
       !state.objectMode) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -269,7 +269,7 @@ function validChunk(stream, state, chunk, cb) {
 Writable.prototype.write = function(chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
-  var isBuf = !state.objectMode && Stream._isUint8Array(chunk);
+  var isBuf = !state.objectMode && chunk instanceof Uint8Array;
 
   if (isBuf && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
     chunk = Stream._uint8ArrayToBuffer(chunk);


### PR DESCRIPTION
Use the `instanceof` operator instead of `Stream._isUint8Array()` when
checking if a chunk is a `Uint8Array` as this is faster.

```js
'use strict';

const assert = require('assert');
const Benchmark = require('benchmark');
const { _isUint8Array } = require('stream');

const suite = new Benchmark.Suite();
const buf = Buffer.alloc(0);
var ret;

suite.add('instanceof', function () {
  ret = buf instanceof Uint8Array;
  assert(ret);
});
suite.add('_isUint8Array', function () {
  ret = _isUint8Array(buf);
  assert(ret);
});
suite.on('cycle', function (event) {
  console.log(event.target.toString());
});
suite.on('complete', function () {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
});

suite.run({ async: true });
```

Node.js 9.11.1:

```
$ node index.js 
instanceof x 151,468,107 ops/sec ±0.31% (90 runs sampled)
_isUint8Array x 66,015,037 ops/sec ±0.28% (89 runs sampled)
Fastest is instanceof
```

Node.js master:

```
$ ../node/node index.js 
instanceof x 217,093,783 ops/sec ±0.14% (94 runs sampled)
_isUint8Array x 179,445,229 ops/sec ±0.22% (93 runs sampled)
Fastest is instanceof
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)