### PR TITLE
test: verify multiple init via well-known symbol

### DIFF
--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -1,6 +1,13 @@
 'use strict';
 const common = require('../../common');
 const assert = require('assert');
-const binding = require(`./build/${common.buildType}/binding`);
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
 assert.strictEqual(binding.hello(), 'world');
 console.log('binding.hello() =', binding.hello());
+
+// Test multiple loading of the same module.
+delete require.cache[bindingPath];
+const rebinding = require(bindingPath);
+assert.strictEqual(rebinding.hello(), 'world');
+assert.notStrictEqual(binding.hello, rebinding.hello);


### PR DESCRIPTION
Re-`require()` the addon after clearing its cache to ensure that it is
re-initialized via the well-known symbol.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
