### PR TITLE
doc, src: sort cli cmd options and env vars

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -24,95 +24,63 @@ _For more info about `node debug`, please see the [debugger][] documentation._
 
 ## Options
 
-### `-v`, `--version`
+### `-`
 <!-- YAML
-added: v0.1.3
+added: v8.0.0
 -->
 
-Print node's version.
+Alias for stdin, analogous to the use of - in other command line utilities,
+meaning that the script will be read from stdin, and the rest of the options
+are passed to that script.
 
 
-### `-h`, `--help`
+### `--`
 <!-- YAML
-added: v0.1.3
+added: v6.11.0
 -->
 
-Print node command line options.
-The output of this option is less detailed than this document.
+Indicate the end of node options. Pass the rest of the arguments to the script.
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
 
 
-### `-e`, `--eval "script"`
+### `--abort-on-uncaught-exception`
 <!-- YAML
-added: v0.5.2
-changes:
-  - version: v5.11.0
-    pr-url: https://github.com/nodejs/node/pull/5348
-    description: Built-in libraries are now available as predefined variables.
+added: v0.10
 -->
 
-Evaluate the following argument as JavaScript. The modules which are
-predefined in the REPL can also be used in `script`.
+Aborting instead of exiting causes a core file to be generated for post-mortem
+analysis using a debugger (such as `lldb`, `gdb`, and `mdb`).
 
-On Windows, using `cmd.exe` a single quote will not work correctly because it
-only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
-and `"` are usable.
+If this flag is passed, the behavior can still be set to not abort through
+[`process.setUncaughtExceptionCaptureCallback()`][] (and through usage of the
+`domain` module that uses it).
 
 
-### `-p`, `--print "script"`
+### `--enable-fips`
 <!-- YAML
-added: v0.6.4
-changes:
-  - version: v5.11.0
-    pr-url: https://github.com/nodejs/node/pull/5348
-    description: Built-in libraries are now available as predefined variables.
+added: v6.0.0
 -->
 
-Identical to `-e` but prints the result.
+Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
+`./configure --openssl-fips`)
 
 
-### `-c`, `--check`
+### `--force-fips`
 <!-- YAML
-added:
-  - v5.0.0
-  - v4.2.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/19600
-    description: The `--require` option is now supported when checking a file.
+added: v6.0.0
 -->
 
-Syntax check the script without executing.
+Force FIPS-compliant crypto on startup. (Cannot be disabled from script code.)
+(Same requirements as `--enable-fips`)
 
 
-### `-i`, `--interactive`
+### `--icu-data-dir=file`
 <!-- YAML
-added: v0.7.7
+added: v0.11.15
 -->
 
-Opens the REPL even if stdin does not appear to be a terminal.
-
-
-### `-r`, `--require module`
-<!-- YAML
-added: v1.6.0
--->
-
-Preload the specified module at startup.
-
-Follows `require()`'s module resolution
-rules. `module` may be either a path to a file, or a node module name.
-
-
-### `--inspect[=[host:]port]`
-<!-- YAML
-added: v6.3.0
--->
-
-Activate inspector on host:port. Default is 127.0.0.1:9229.
-
-V8 inspector integration allows tools such as Chrome DevTools and IDEs to debug
-and profile Node.js instances. The tools attach to Node.js instances via a
-tcp port and communicate using the [Chrome Debugging Protocol][].
+Specify ICU data load path. (overrides `NODE_ICU_DATA`)
 
 
 ### `--inspect-brk[=[host:]port]`
@@ -135,6 +103,18 @@ Useful when activating the inspector by sending the `SIGUSR1` signal.
 Default host is 127.0.0.1.
 
 
+### `--inspect[=[host:]port]`
+<!-- YAML
+added: v6.3.0
+-->
+
+Activate inspector on host:port. Default is 127.0.0.1:9229.
+
+V8 inspector integration allows tools such as Chrome DevTools and IDEs to debug
+and profile Node.js instances. The tools attach to Node.js instances via a
+tcp port and communicate using the [Chrome Debugging Protocol][].
+
+
 ### `--no-deprecation`
 <!-- YAML
 added: v0.8.0
@@ -143,20 +123,32 @@ added: v0.8.0
 Silence deprecation warnings.
 
 
-### `--trace-deprecation`
+### `--no-force-async-hooks-checks`
 <!-- YAML
-added: v0.8.0
+added: v9.0.0
 -->
 
-Print stack traces for deprecations.
+Disables runtime checks for `async_hooks`. These will still be enabled
+dynamically when `async_hooks` is enabled.
 
 
-### `--throw-deprecation`
+### `--no-warnings`
 <!-- YAML
-added: v0.11.14
+added: v6.0.0
 -->
 
-Throw errors for deprecations.
+Silence all process warnings (including deprecations).
+
+
+### `--openssl-config=file`
+<!-- YAML
+added: v6.9.0
+-->
+
+Load an OpenSSL configuration file on startup. Among other uses, this can be
+used to enable FIPS-compliant crypto if Node.js is built with
+`./configure --openssl-fips`.
+
 
 ### `--pending-deprecation`
 <!-- YAML
@@ -171,89 +163,6 @@ unless either the `--pending-deprecation` command line flag, or the
 `NODE_PENDING_DEPRECATION=1` environment variable, is set. Pending deprecations
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
-
-### `--no-warnings`
-<!-- YAML
-added: v6.0.0
--->
-
-Silence all process warnings (including deprecations).
-
-### `--abort-on-uncaught-exception`
-<!-- YAML
-added: v0.10
--->
-
-Aborting instead of exiting causes a core file to be generated for post-mortem
-analysis using a debugger (such as `lldb`, `gdb`, and `mdb`).
-
-If this flag is passed, the behavior can still be set to not abort through
-[`process.setUncaughtExceptionCaptureCallback()`][] (and through usage of the
-`domain` module that uses it).
-
-### `--trace-warnings`
-<!-- YAML
-added: v6.0.0
--->
-
-Print stack traces for process warnings (including deprecations).
-
-### `--redirect-warnings=file`
-<!-- YAML
-added: v8.0.0
--->
-
-Write process warnings to the given file instead of printing to stderr. The
-file will be created if it does not exist, and will be appended to if it does.
-If an error occurs while attempting to write the warning to the file, the
-warning will be written to stderr instead.
-
-### `--trace-sync-io`
-<!-- YAML
-added: v2.1.0
--->
-
-Prints a stack trace whenever synchronous I/O is detected after the first turn
-of the event loop.
-
-### `--no-force-async-hooks-checks`
-<!-- YAML
-added: v9.0.0
--->
-
-Disables runtime checks for `async_hooks`. These will still be enabled
-dynamically when `async_hooks` is enabled.
-
-### `--trace-events-enabled`
-<!-- YAML
-added: v7.7.0
--->
-
-Enables the collection of trace event tracing information.
-
-### `--trace-event-categories`
-<!-- YAML
-added: v7.7.0
--->
-
-A comma separated list of categories that should be traced when trace event
-tracing is enabled using `--trace-events-enabled`.
-
-### `--trace-event-file-pattern`
-<!-- YAML
-added: v9.8.0
--->
-
-Template string specifying the filepath for the trace event data, it
-supports `${rotation}` and `${pid}`.
-
-### `--zero-fill-buffers`
-<!-- YAML
-added: v6.0.0
--->
-
-Automatically zero-fills all newly allocated [Buffer][] and [SlowBuffer][]
-instances.
 
 
 ### `--preserve-symlinks`
@@ -296,13 +205,6 @@ are linked from more than one location in the dependency tree (Node.js would
 see those as two separate modules and would attempt to load the module multiple
 times, causing an exception to be thrown).
 
-### `--track-heap-objects`
-<!-- YAML
-added: v2.4.0
--->
-
-Track heap object allocations for heap snapshots.
-
 
 ### `--prof-process`
 <!-- YAML
@@ -312,17 +214,24 @@ added: v5.2.0
 Process V8 profiler output generated using the V8 option `--prof`.
 
 
-### `--v8-options`
+### `--redirect-warnings=file`
 <!-- YAML
-added: v0.1.3
+added: v8.0.0
 -->
 
-Print V8 command line options.
+Write process warnings to the given file instead of printing to stderr. The
+file will be created if it does not exist, and will be appended to if it does.
+If an error occurs while attempting to write the warning to the file, the
+warning will be written to stderr instead.
 
-V8 options allow words to be separated by both dashes (`-`) or
-underscores (`_`).
 
-For example, `--stack-trace-limit` is equivalent to `--stack_trace_limit`.
+### `--throw-deprecation`
+<!-- YAML
+added: v0.11.14
+-->
+
+Throw errors for deprecations.
+
 
 ### `--tls-cipher-list=list`
 <!-- YAML
@@ -333,32 +242,64 @@ Specify an alternative default TLS cipher list. (Requires Node.js to be built
 with crypto support. (Default))
 
 
-### `--enable-fips`
+### `--trace-deprecation`
+<!-- YAML
+added: v0.8.0
+-->
+
+Print stack traces for deprecations.
+
+
+### `--trace-event-categories`
+<!-- YAML
+added: v7.7.0
+-->
+
+A comma separated list of categories that should be traced when trace event
+tracing is enabled using `--trace-events-enabled`.
+
+
+### `--trace-event-file-pattern`
+<!-- YAML
+added: v9.8.0
+-->
+
+Template string specifying the filepath for the trace event data, it
+supports `${rotation}` and `${pid}`.
+
+
+### `--trace-events-enabled`
+<!-- YAML
+added: v7.7.0
+-->
+
+Enables the collection of trace event tracing information.
+
+
+### `--trace-sync-io`
+<!-- YAML
+added: v2.1.0
+-->
+
+Prints a stack trace whenever synchronous I/O is detected after the first turn
+of the event loop.
+
+
+### `--trace-warnings`
 <!-- YAML
 added: v6.0.0
 -->
 
-Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
-`./configure --openssl-fips`)
+Print stack traces for process warnings (including deprecations).
 
 
-### `--force-fips`
+### `--track-heap-objects`
 <!-- YAML
-added: v6.0.0
+added: v2.4.0
 -->
 
-Force FIPS-compliant crypto on startup. (Cannot be disabled from script code.)
-(Same requirements as `--enable-fips`)
+Track heap object allocations for heap snapshots.
 
-
-### `--openssl-config=file`
-<!-- YAML
-added: v6.9.0
--->
-
-Load an OpenSSL configuration file on startup. Among other uses, this can be
-used to enable FIPS-compliant crypto if Node.js is built with
-`./configure --openssl-fips`.
 
 ### `--use-openssl-ca`, `--use-bundled-ca`
 <!-- YAML
@@ -379,32 +320,106 @@ that is fixed at release time. It is identical on all supported platforms.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
-### `--icu-data-dir=file`
+
+### `--v8-options`
 <!-- YAML
-added: v0.11.15
+added: v0.1.3
 -->
 
-Specify ICU data load path. (overrides `NODE_ICU_DATA`)
+Print V8 command line options.
+
+V8 options allow words to be separated by both dashes (`-`) or
+underscores (`_`).
+
+For example, `--stack-trace-limit` is equivalent to `--stack_trace_limit`.
 
 
-### `-`
+### `--zero-fill-buffers`
 <!-- YAML
-added: v8.0.0
+added: v6.0.0
 -->
 
-Alias for stdin, analogous to the use of - in other command line utilities,
-meaning that the script will be read from stdin, and the rest of the options
-are passed to that script.
+Automatically zero-fills all newly allocated [Buffer][] and [SlowBuffer][]
+instances.
 
 
-### `--`
+### `-c`, `--check`
 <!-- YAML
-added: v6.11.0
+added:
+  - v5.0.0
+  - v4.2.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/19600
+    description: The `--require` option is now supported when checking a file.
 -->
 
-Indicate the end of node options. Pass the rest of the arguments to the script.
-If no script filename or eval/print script is supplied prior to this, then
-the next argument will be used as a script filename.
+Syntax check the script without executing.
+
+
+### `-e`, `--eval "script"`
+<!-- YAML
+added: v0.5.2
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Built-in libraries are now available as predefined variables.
+-->
+
+Evaluate the following argument as JavaScript. The modules which are
+predefined in the REPL can also be used in `script`.
+
+On Windows, using `cmd.exe` a single quote will not work correctly because it
+only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
+and `"` are usable.
+
+
+### `-h`, `--help`
+<!-- YAML
+added: v0.1.3
+-->
+
+Print node command line options.
+The output of this option is less detailed than this document.
+
+
+### `-i`, `--interactive`
+<!-- YAML
+added: v0.7.7
+-->
+
+Opens the REPL even if stdin does not appear to be a terminal.
+
+
+### `-p`, `--print "script"`
+<!-- YAML
+added: v0.6.4
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Built-in libraries are now available as predefined variables.
+-->
+
+Identical to `-e` but prints the result.
+
+
+### `-r`, `--require module`
+<!-- YAML
+added: v1.6.0
+-->
+
+Preload the specified module at startup.
+
+Follows `require()`'s module resolution
+rules. `module` may be either a path to a file, or a node module name.
+
+
+### `-v`, `--version`
+<!-- YAML
+added: v0.1.3
+-->
+
+Print node's version.
 
 ## Environment Variables
 
@@ -416,22 +431,27 @@ added: v0.1.32
 `','`-separated list of core modules that should print debug information.
 
 
-### `NODE_PATH=path[:…]`
-<!-- YAML
-added: v0.1.32
--->
-
-`':'`-separated list of directories prefixed to the module search path.
-
-On Windows, this is a `';'`-separated list instead.
-
-
 ### `NODE_DISABLE_COLORS=1`
 <!-- YAML
 added: v0.3.0
 -->
 
 When set to `1` colors will not be used in the REPL.
+
+
+### `NODE_EXTRA_CA_CERTS=file`
+<!-- YAML
+added: v7.3.0
+-->
+
+When set, the well known "root" CAs (like VeriSign) will be extended with the
+extra certificates in `file`. The file should consist of one or more trusted
+certificates in PEM format. A message will be emitted (once) with
+[`process.emitWarning()`][emit_warning] if the file is missing or
+malformed, but any errors are otherwise ignored.
+
+Note that neither the well known nor extra certificates are used when the `ca`
+options property is explicitly specified for a TLS or HTTPS client or server.
 
 
 ### `NODE_ICU_DATA=file`
@@ -442,12 +462,14 @@ added: v0.11.15
 Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small-icu support.
 
+
 ### `NODE_NO_WARNINGS=1`
 <!-- YAML
 added: v6.11.0
 -->
 
 When set to `1`, process warnings are silenced.
+
 
 ### `NODE_OPTIONS=options...`
 <!-- YAML
@@ -492,6 +514,17 @@ V8 options that are allowed are:
 - `--perf-prof`
 - `--stack-trace-limit`
 
+
+### `NODE_PATH=path[:…]`
+<!-- YAML
+added: v0.1.32
+-->
+
+`':'`-separated list of directories prefixed to the module search path.
+
+On Windows, this is a `';'`-separated list instead.
+
+
 ### `NODE_PENDING_DEPRECATION=1`
 <!-- YAML
 added: v8.0.0
@@ -506,6 +539,7 @@ unless either the `--pending-deprecation` command line flag, or the
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
+
 ### `NODE_PRESERVE_SYMLINKS=1`
 <!-- YAML
 added: v7.1.0
@@ -513,6 +547,19 @@ added: v7.1.0
 
 When set to `1`, instructs the module loader to preserve symbolic links when
 resolving and caching modules.
+
+
+### `NODE_REDIRECT_WARNINGS=file`
+<!-- YAML
+added: v8.0.0
+-->
+
+When set, process warnings will be emitted to the given file instead of
+printing to stderr. The file will be created if it does not exist, and will be
+appended to if it does. If an error occurs while attempting to write the
+warning to the file, the warning will be written to stderr instead. This is
+equivalent to using the `--redirect-warnings=file` command-line flag.
+
 
 ### `NODE_REPL_HISTORY=file`
 <!-- YAML
@@ -523,20 +570,6 @@ Path to the file used to store the persistent REPL history. The default path is
 `~/.node_repl_history`, which is overridden by this variable. Setting the value
 to an empty string (`''` or `' '`) disables persistent REPL history.
 
-
-### `NODE_EXTRA_CA_CERTS=file`
-<!-- YAML
-added: v7.3.0
--->
-
-When set, the well known "root" CAs (like VeriSign) will be extended with the
-extra certificates in `file`. The file should consist of one or more trusted
-certificates in PEM format. A message will be emitted (once) with
-[`process.emitWarning()`][emit_warning] if the file is missing or
-malformed, but any errors are otherwise ignored.
-
-Note that neither the well known nor extra certificates are used when the `ca`
-options property is explicitly specified for a TLS or HTTPS client or server.
 
 ### `OPENSSL_CONF=file`
 <!-- YAML
@@ -550,6 +583,7 @@ used to enable FIPS-compliant crypto if Node.js is built with `./configure
 If the [`--openssl-config`][] command line option is used, the environment
 variable is ignored.
 
+
 ### `SSL_CERT_DIR=dir`
 <!-- YAML
 added: v7.7.0
@@ -561,6 +595,7 @@ containing trusted certificates.
 Be aware that unless the child environment is explicitly set, this environment
 variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
+
 
 ### `SSL_CERT_FILE=file`
 <!-- YAML
@@ -574,16 +609,6 @@ Be aware that unless the child environment is explicitly set, this environment
 variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
 
-### `NODE_REDIRECT_WARNINGS=file`
-<!-- YAML
-added: v8.0.0
--->
-
-When set, process warnings will be emitted to the given file instead of
-printing to stderr. The file will be created if it does not exist, and will be
-appended to if it does. If an error occurs while attempting to write the
-warning to the file, the warning will be written to stderr instead. This is
-equivalent to using the `--redirect-warnings=file` command-line flag.
 
 ### `UV_THREADPOOL_SIZE=size`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -331,17 +331,18 @@ Track heap object allocations for heap snapshots.
 added: v6.11.0
 -->
 
-Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by
-current Node.js version. The default store is selectable at build-time.
+Use bundled Mozilla CA store as supplied by current Node.js version
+or use OpenSSL's default CA store. The default store is selectable
+at build-time.
+
+The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store
+that is fixed at release time. It is identical on all supported platforms.
 
 Using OpenSSL store allows for external modifications of the store. For most
 Linux and BSD distributions, this store is maintained by the distribution
 maintainers and system administrators. OpenSSL CA store location is dependent on
 configuration of the OpenSSL library but this can be altered at runtime using
 environment variables.
-
-The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store
-that is fixed at release time. It is identical on all supported platforms.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -66,6 +66,22 @@ Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
 `./configure --openssl-fips`)
 
 
+### `--experimental-modules`
+<!-- YAML
+added: v8.5.0
+-->
+
+Enable experimental ES module support and caching modules.
+
+
+### `--experimental-vm-modules`
+<!-- YAML
+added: v9.6.0
+-->
+
+Enable experimental ES Module support in the `vm` module.
+
+
 ### `--force-fips`
 <!-- YAML
 added: v6.0.0
@@ -113,6 +129,15 @@ Activate inspector on host:port. Default is 127.0.0.1:9229.
 V8 inspector integration allows tools such as Chrome DevTools and IDEs to debug
 and profile Node.js instances. The tools attach to Node.js instances via a
 tcp port and communicate using the [Chrome Debugging Protocol][].
+
+
+### `--napi-modules`
+<!-- YAML
+added: v7.10.0
+-->
+
+Enable loading native modules compiled with the ABI-stable Node.js API (N-API)
+(experimental).
 
 
 ### `--no-deprecation`
@@ -301,7 +326,7 @@ added: v2.4.0
 Track heap object allocations for heap snapshots.
 
 
-### `--use-openssl-ca`, `--use-bundled-ca`
+### `--use-bundled-ca`, `--use-openssl-ca`
 <!-- YAML
 added: v6.11.0
 -->
@@ -332,6 +357,20 @@ V8 options allow words to be separated by both dashes (`-`) or
 underscores (`_`).
 
 For example, `--stack-trace-limit` is equivalent to `--stack_trace_limit`.
+
+
+### `--v8-pool-size=num`
+<!-- YAML
+added: v5.10.0
+-->
+
+Set V8's thread pool size which will be used to allocate background jobs.
+
+If set to `0` then V8 will choose an appropriate size of the thread pool based
+on the number of online processors.
+
+If the value provided is larger than V8's maximum, then the largest value
+will be chosen.
 
 
 ### `--zero-fill-buffers`

--- a/doc/node.1
+++ b/doc/node.1
@@ -61,46 +61,41 @@ without arguments to start a REPL.
 .
 .Sh OPTIONS
 .Bl -tag -width 6n
-.It Fl v , Fl -version
-Print node's version.
+.It Sy \-
+Alias for stdin, analogous to the use of - in other command-line utilities.
+The executed script is read from stdin, and remaining arguments are passed to the script.
 .
-.It Fl h , Fl -help
-Print node command line options.
-The output of this option is less detailed than this document.
-.
-.It Fl e , Fl -eval Ar string
-Evaluate
-.Ar string
-as JavaScript.
-.
-.It Fl p , Fl -print Ar string
-Identical to
-.Fl e ,
-but prints the result.
-.
-.It Fl c , Fl -check
-Check the script's syntax without executing it.
-Exits with an error code if script is invalid.
-.
-.It Fl i , Fl -interactive
-Open the REPL even if stdin does not appear to be a terminal.
-.
-.It Fl r , Fl -require Ar module
-Preload the specified
-.Ar module
-at startup.
-Follows `require()`'s module resolution rules.
-.Ar module
-may be either a path to a file, or a node module name.
-.
-.It Fl -inspect Ns = Ns Ar [host:]port
-Activate inspector on
-.Ar host:port .
-Default is
-.Sy 127.0.0.1:9229 .
+.It Fl \-
+Indicate the end of node options.
+Pass the rest of the arguments to the script.
 .Pp
-V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
-It uses the Chrome Debugging Protocol.
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
+.
+.It Fl -abort-on-uncaught-exception
+Aborting instead of exiting causes a core file to be generated for analysis.
+.
+.It Fl -enable-fips
+Enable FIPS-compliant crypto at startup.
+Requires Node.js to be built with
+.Sy ./configure --openssl-fips .
+.
+.It Fl \-experimental-modules
+Enable experimental ES module support and caching modules.
+.
+.It Fl \-experimental-vm-modules
+Enable experimental ES module support in VM module.
+.
+.It Fl -force-fips
+Force FIPS-compliant crypto on startup
+(Cannot be disabled from script code).
+Same requirements as
+.Fl -enable-fips .
+.
+.It Fl -icu-data-dir Ns = Ns Ar file
+Specify ICU data load path.
+Overrides
+.Ev NODE_ICU_DATA .
 .
 .It Fl -inspect-brk Ns = Ns Ar [host:]port
 Activate inspector on
@@ -112,45 +107,58 @@ Set the
 .Ar host:port
 to be used when the inspector is activated.
 .
-.It Fl -no-deprecation
-Silence deprecation warnings.
-.
-.It Fl -trace-deprecation
-Print stack traces for deprecations.
-.
-.It Fl -throw-deprecation
-Throw errors for deprecations.
-.
-.It Fl -pending-deprecation
-Emit pending deprecation warnings.
-.
-.It Fl -no-warnings
-Silence all process warnings (including deprecations).
+.It Fl -inspect Ns = Ns Ar [host:]port
+Activate inspector on
+.Ar host:port .
+Default is
+.Sy 127.0.0.1:9229 .
+.Pp
+V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
+It uses the Chrome Debugging Protocol.
 .
 .It Fl -napi-modules
 Enable loading native modules compiled with the ABI-stable Node.js API (N-API)
 (experimental).
 .
-.It Fl -abort-on-uncaught-exception
-Aborting instead of exiting causes a core file to be generated for analysis.
+.It Fl -no-deprecation
+Silence deprecation warnings.
 .
-.It Fl -trace-warnings
-Print stack traces for process warnings (including deprecations).
+.It Fl -no-force-async-hooks-checks
+Disable runtime checks for `async_hooks`.
+These will still be enabled dynamically when `async_hooks` is enabled.
+.
+.It Fl -no-warnings
+Silence all process warnings (including deprecations).
+.
+.It Fl -openssl-config Ns = Ns Ar file
+Load an OpenSSL configuration file on startup.
+Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is built with
+.Sy ./configure --openssl-fips .
+.
+.It Fl -pending-deprecation
+Emit pending deprecation warnings.
+.
+.It Fl -preserve-symlinks
+Instructs the module loader to preserve symbolic links when resolving and caching modules.
+.
+.It Fl -prof-process
+Process V8 profiler output generated using the V8 option
+.Fl -prof .
 .
 .It Fl -redirect-warnings Ns = Ns Ar file
 Write process warnings to the given
 .Ar file
 instead of printing to stderr.
 .
-.It Fl -trace-sync-io
-Print a stack trace whenever synchronous I/O is detected after the first turn of the event loop.
+.It Fl -throw-deprecation
+Throw errors for deprecations.
 .
-.It Fl -no-force-async-hooks-checks
-Disable runtime checks for `async_hooks`.
-These will still be enabled dynamically when `async_hooks` is enabled.
+.It Fl -tls-cipher-list Ns = Ns Ar list
+Specify an alternative default TLS cipher list.
+Requires Node.js to be built with crypto support. (Default)
 .
-.It Fl -trace-events-enabled
-Enable the collection of trace event tracing information.
+.It Fl -trace-deprecation
+Print stack traces for deprecations.
 .
 .It Fl -trace-event-categories Ar categories
 A comma-separated list of categories that should be traced when trace event tracing is enabled using
@@ -160,18 +168,33 @@ A comma-separated list of categories that should be traced when trace event trac
 Template string specifying the filepath for the trace event data, it
 supports \fB${rotation}\fR and \fB${pid}\fR.
 .
-.It Fl -zero-fill-buffers
-Automatically zero-fills all newly allocated Buffer and SlowBuffer instances.
+.It Fl -trace-events-enabled
+Enable the collection of trace event tracing information.
 .
-.It Fl -preserve-symlinks
-Instructs the module loader to preserve symbolic links when resolving and caching modules.
+.It Fl -trace-sync-io
+Print a stack trace whenever synchronous I/O is detected after the first turn of the event loop.
+.
+.It Fl -trace-warnings
+Print stack traces for process warnings (including deprecations).
 .
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.
 .
-.It Fl -prof-process
-Process V8 profiler output generated using the V8 option
-.Fl -prof .
+.It Fl -use-bundled\-ca, Fl -use-openssl-ca
+Use bundled Mozilla CA store as supplied by current Node.js version or use OpenSSL's default CA store.
+The default store is selectable at build-time.
+.Pp
+The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store that is fixed at release time.
+It is identical on all supported platforms.
+.Pp
+Using OpenSSL store allows for external modifications of the store.
+For most Linux and BSD distributions, this store is maintained by the distribution maintainers and system administrators.
+OpenSSL CA store location is dependent on configuration of the OpenSSL library but this can be altered at runtime using environment variables.
+.Pp
+See
+.Ev SSL_CERT_DIR
+and
+.Ev SSL_CERT_FILE .
 .
 .It Fl -v8-options
 Print V8 command-line options.
@@ -188,63 +211,40 @@ Set V8's thread pool size which will be used to allocate background jobs.
 If set to 0 then V8 will choose an appropriate size of the thread pool based on the number of online processors.
 If the value provided is larger than V8's maximum, then the largest value will be chosen.
 .
-.It Fl -tls-cipher-list Ns = Ns Ar list
-Specify an alternative default TLS cipher list.
-Requires Node.js to be built with crypto support. (Default)
+.It Fl -zero-fill-buffers
+Automatically zero-fills all newly allocated Buffer and SlowBuffer instances.
 .
-.It Fl -enable-fips
-Enable FIPS-compliant crypto at startup.
-Requires Node.js to be built with
-.Sy ./configure --openssl-fips .
+.It Fl c , Fl -check
+Check the script's syntax without executing it.
+Exits with an error code if script is invalid.
 .
-.It Fl -force-fips
-Force FIPS-compliant crypto on startup
-(Cannot be disabled from script code).
-Same requirements as
-.Fl -enable-fips .
+.It Fl e , Fl -eval Ar string
+Evaluate
+.Ar string
+as JavaScript.
 .
-.It Fl -openssl-config Ns = Ns Ar file
-Load an OpenSSL configuration file on startup.
-Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is built with
-.Sy ./configure --openssl-fips .
+.It Fl h , Fl -help
+Print node command line options.
+The output of this option is less detailed than this document.
 .
-.It Fl -use-openssl-ca , Fl -use-bundled\-ca
-Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by current Node.js version.
-The default store is selectable at build-time.
-.Pp
-Using OpenSSL store allows for external modifications of the store.
-For most Linux and BSD distributions, this store is maintained by the distribution maintainers and system administrators.
-OpenSSL CA store location is dependent on configuration of the OpenSSL library but this can be altered at runtime using environment variables.
-.Pp
-The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store that is fixed at release time.
-It is identical on all supported platforms.
-.Pp
-See
-.Ev SSL_CERT_DIR
-and
-.Ev SSL_CERT_FILE .
+.It Fl i , Fl -interactive
+Open the REPL even if stdin does not appear to be a terminal.
 .
-.It Fl -icu-data-dir Ns = Ns Ar file
-Specify ICU data load path.
-Overrides
-.Ev NODE_ICU_DATA .
+.It Fl p , Fl -print Ar string
+Identical to
+.Fl e ,
+but prints the result.
 .
-.It Fl \-experimental-modules
-Enable experimental ES module support and caching modules.
+.It Fl r , Fl -require Ar module
+Preload the specified
+.Ar module
+at startup.
+Follows `require()`'s module resolution rules.
+.Ar module
+may be either a path to a file, or a node module name.
 .
-.It Fl \-experimental-vm-modules
-Enable experimental ES module support in VM module.
-.
-.It Sy \-
-Alias for stdin, analogous to the use of - in other command-line utilities.
-The executed script is read from stdin, and remaining arguments are passed to the script.
-.
-.It Fl \-
-Indicate the end of node options.
-Pass the rest of the arguments to the script.
-.Pp
-If no script filename or eval/print script is supplied prior to this, then
-the next argument will be used as a script filename.
+.It Fl v , Fl -version
+Print node's version.
 .El
 .
 .\" =====================================================================
@@ -298,6 +298,13 @@ When set to
 .Ar 1 ,
 emit pending deprecation warnings.
 .
+.It Ev NODE_REDIRECT_WARNINGS Ar file
+Write process warnings to the given
+.Ar file
+instead of printing to stderr.
+Equivalent to passing
+.Fl -redirect-warnings Ar file
+on command-line.
 .It Ev NODE_REPL_HISTORY Ar file
 Path to the
 .Ar file
@@ -325,14 +332,6 @@ is enabled, this overrides and sets OpenSSL's directory containing trusted certi
 If
 .Fl -use-openssl-ca
 is enabled, this overrides and sets OpenSSL's file containing trusted certificates.
-.
-.It Ev NODE_REDIRECT_WARNINGS Ar file
-Write process warnings to the given
-.Ar file
-instead of printing to stderr.
-Equivalent to passing
-.Fl -redirect-warnings Ar file
-on command-line.
 .El
 .
 .\"=====================================================================

--- a/src/node.cc
+++ b/src/node.cc
@@ -3445,62 +3445,79 @@ static void PrintHelp() {
          "       node inspect script.js [arguments]\n"
          "\n"
          "Options:\n"
-         "  -v, --version              print Node.js version\n"
-         "  -e, --eval script          evaluate script\n"
-         "  -p, --print                evaluate script and print result\n"
-         "  -c, --check                syntax check script without executing\n"
-         "  -i, --interactive          always enter the REPL even if stdin\n"
-         "                             does not appear to be a terminal\n"
-         "  -r, --require              module to preload (option can be "
-         "repeated)\n"
-         "  -                          script read from stdin (default; "
-         "interactive mode if a tty)\n"
+         "  -                          script read from stdin (default; \n"
+         "                             interactive mode if a tty)\n"
+         "  --                         indicate the end of node options\n"
+         "  --abort-on-uncaught-exception\n"
+         "                             aborting instead of exiting causes a\n"
+         "                             core file to be generated for analysis\n"
+#if HAVE_OPENSSL && NODE_FIPS_MODE
+         "  --enable-fips              enable FIPS crypto at startup\n"
+#endif  // NODE_FIPS_MODE && NODE_FIPS_MODE
+#if defined(NODE_HAVE_I18N_SUPPORT)
+         "  --experimental-modules     experimental ES Module support\n"
+         "                             and caching modules\n"
+         "  --experimental-vm-modules  experimental ES Module support\n"
+         "                             in vm module\n"
+#endif  // defined(NODE_HAVE_I18N_SUPPORT)
+#if HAVE_OPENSSL && NODE_FIPS_MODE
+         "  --force-fips               force FIPS crypto (cannot be disabled)\n"
+#endif  // HAVE_OPENSSL && NODE_FIPS_MODE
+#if defined(NODE_HAVE_I18N_SUPPORT)
+         "  --icu-data-dir=dir         set ICU data load path to dir\n"
+         "                             (overrides NODE_ICU_DATA)\n"
+#if !defined(NODE_HAVE_SMALL_ICU)
+         "                             note: linked-in ICU data is present\n"
+#endif
+#endif  // defined(NODE_HAVE_I18N_SUPPORT)
 #if HAVE_INSPECTOR
-         "  --inspect[=[host:]port]    activate inspector on host:port\n"
-         "                             (default: 127.0.0.1:9229)\n"
          "  --inspect-brk[=[host:]port]\n"
          "                             activate inspector on host:port\n"
          "                             and break at start of user script\n"
          "  --inspect-port=[host:]port\n"
          "                             set host:port for inspector\n"
-#endif
-         "  --no-deprecation           silence deprecation warnings\n"
-         "  --trace-deprecation        show stack traces on deprecations\n"
-         "  --throw-deprecation        throw an exception on deprecations\n"
-         "  --pending-deprecation      emit pending deprecation warnings\n"
-         "  --no-warnings              silence all process warnings\n"
+         "  --inspect[=[host:]port]    activate inspector on host:port\n"
+         "                             (default: 127.0.0.1:9229)\n"
+#endif  // HAVE_INSPECTOR
          "  --napi-modules             load N-API modules (no-op - option\n"
          "                             kept for compatibility)\n"
-         "  --abort-on-uncaught-exception\n"
-         "                             aborting instead of exiting causes a\n"
-         "                             core file to be generated for analysis\n"
-         "  --trace-warnings           show stack traces on process warnings\n"
+         "  --no-deprecation           silence deprecation warnings\n"
+         "  --no-force-async-hooks-checks\n"
+         "                             disable checks for async_hooks\n"
+         "  --no-warnings              silence all process warnings\n"
+#if HAVE_OPENSSL
+         "  --openssl-config=file      load OpenSSL configuration from the\n"
+         "                             specified file (overrides\n"
+         "                             OPENSSL_CONF)\n"
+#endif  // HAVE_OPENSSL
+         "  --pending-deprecation      emit pending deprecation warnings\n"
+#if defined(NODE_HAVE_I18N_SUPPORT)
+         "  --preserve-symlinks        preserve symbolic links when resolving\n"
+#endif
+         "  --prof-process             process v8 profiler output generated\n"
+         "                             using --prof\n"
          "  --redirect-warnings=file\n"
          "                             write warnings to file instead of\n"
          "                             stderr\n"
-         "  --trace-sync-io            show stack trace when use of sync IO\n"
-         "                             is detected after the first tick\n"
-         "  --no-force-async-hooks-checks\n"
-         "                             disable checks for async_hooks\n"
-         "  --trace-events-enabled     track trace events\n"
+         "  --throw-deprecation        throw an exception on deprecations\n"
+#if HAVE_OPENSSL
+         "  --tls-cipher-list=val      use an alternative default TLS cipher "
+         "list\n"
+#endif  // HAVE_OPENSSL
+         "  --trace-deprecation        show stack traces on deprecations\n"
          "  --trace-event-categories   comma separated list of trace event\n"
          "                             categories to record\n"
          "  --trace-event-file-pattern Template string specifying the\n"
          "                             filepath for the trace-events data, it\n"
          "                             supports ${rotation} and ${pid}\n"
          "                             log-rotation id. %%2$u is the pid.\n"
+         "  --trace-events-enabled     track trace events\n"
+         "  --trace-sync-io            show stack trace when use of sync IO\n"
+         "                             is detected after the first tick\n"
+         "  --trace-warnings           show stack traces on process warnings\n"
          "  --track-heap-objects       track heap object allocations for heap "
          "snapshots\n"
-         "  --prof-process             process v8 profiler output generated\n"
-         "                             using --prof\n"
-         "  --zero-fill-buffers        automatically zero-fill all newly "
-         "allocated\n"
-         "                             Buffer and SlowBuffer instances\n"
-         "  --v8-options               print v8 command line options\n"
-         "  --v8-pool-size=num         set v8's thread pool size\n"
 #if HAVE_OPENSSL
-         "  --tls-cipher-list=val      use an alternative default TLS cipher "
-         "list\n"
          "  --use-bundled-ca           use bundled CA store"
 #if !defined(NODE_OPENSSL_CERT_STORE)
          " (default)"
@@ -3510,27 +3527,23 @@ static void PrintHelp() {
 #if defined(NODE_OPENSSL_CERT_STORE)
          " (default)"
 #endif
+#endif  // HAVE_OPENSSL
          "\n"
-#if NODE_FIPS_MODE
-         "  --enable-fips              enable FIPS crypto at startup\n"
-         "  --force-fips               force FIPS crypto (cannot be disabled)\n"
-#endif  /* NODE_FIPS_MODE */
-         "  --openssl-config=file      load OpenSSL configuration from the\n"
-         "                             specified file (overrides\n"
-         "                             OPENSSL_CONF)\n"
-#endif /* HAVE_OPENSSL */
-#if defined(NODE_HAVE_I18N_SUPPORT)
-         "  --icu-data-dir=dir         set ICU data load path to dir\n"
-         "                             (overrides NODE_ICU_DATA)\n"
-#if !defined(NODE_HAVE_SMALL_ICU)
-         "                             note: linked-in ICU data is present\n"
-#endif
-         "  --preserve-symlinks        preserve symbolic links when resolving\n"
-         "  --experimental-modules     experimental ES Module support\n"
-         "                             and caching modules\n"
-         "  --experimental-vm-modules  experimental ES Module support\n"
-         "                             in vm module\n"
-#endif
+         "  --v8-options               print v8 command line options\n"
+         "  --v8-pool-size=num         set v8's thread pool size\n"
+         "  --zero-fill-buffers        automatically zero-fill all newly "
+         "allocated\n"
+         "                             Buffer and SlowBuffer instances\n"
+         "  -c, --check                syntax check script without executing\n"
+         "  -e, --eval script          evaluate script\n"
+         "  -h, --help                 print node command line options\n"
+         "  -i, --interactive          always enter the REPL even if stdin\n"
+         "                             does not appear to be a terminal\n"
+         "  -p, --print                evaluate script and print result\n"
+         "  -r, --require              module to preload (option can be "
+         "repeated)\n"
+         "  -v, --version              print Node.js version\n"
+
          "\n"
          "Environment variables:\n"
          "NODE_DEBUG                   ','-separated list of core modules\n"
@@ -3543,12 +3556,12 @@ static void PrintHelp() {
 #if !defined(NODE_HAVE_SMALL_ICU)
          "                             (will extend linked-in data)\n"
 #endif
-#endif
+#endif  // defined(NODE_HAVE_I18N_SUPPORT)
          "NODE_NO_WARNINGS             set to 1 to silence process warnings\n"
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
          "NODE_OPTIONS                 set CLI options in the environment\n"
          "                             via a space-separated list\n"
-#endif
+#endif  // !defined(NODE_WITHOUT_NODE_OPTIONS)
 #ifdef _WIN32
          "NODE_PATH                    ';'-separated list of directories\n"
 #else
@@ -3557,10 +3570,14 @@ static void PrintHelp() {
          "                             prefixed to the module search path\n"
          "NODE_PENDING_DEPRECATION     set to 1 to emit pending deprecation\n"
          "                             warnings\n"
-         "NODE_REPL_HISTORY            path to the persistent REPL history\n"
-         "                             file\n"
+#if defined(NODE_HAVE_I18N_SUPPORT)
+         "NODE_PRESERVE_SYMLINKS       set to 1 to preserve symbolic links\n"
+         "                             when resolving and caching modules\n"
+#endif
          "NODE_REDIRECT_WARNINGS       write warnings to path instead of\n"
          "                             stderr\n"
+         "NODE_REPL_HISTORY            path to the persistent REPL history\n"
+         "                             file\n"
          "OPENSSL_CONF                 load OpenSSL configuration from file\n"
          "\n"
          "Documentation can be found at https://nodejs.org/\n");
@@ -3597,43 +3614,44 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
 
   static const char* whitelist[] = {
     // Node options, sorted in `node --help` order for ease of comparison.
-    "--require", "-r",
+    "--enable-fips",
+    "--experimental-modules",
+    "--experimental-vm-modules",
+    "--expose-http2",   // keep as a non-op through v9.x
+    "--force-fips",
+    "--icu-data-dir",
     "--inspect",
     "--inspect-brk",
     "--inspect-port",
-    "--no-deprecation",
-    "--trace-deprecation",
-    "--throw-deprecation",
-    "--pending-deprecation",
-    "--no-warnings",
-    "--napi-modules",
-    "--expose-http2",   // keep as a non-op through v9.x
-    "--experimental-modules",
-    "--experimental-vm-modules",
     "--loader",
-    "--trace-warnings",
-    "--redirect-warnings",
-    "--trace-sync-io",
+    "--napi-modules",
+    "--no-deprecation",
     "--no-force-async-hooks-checks",
-    "--trace-events-enabled",
+    "--no-warnings",
+    "--openssl-config",
+    "--pending-deprecation",
+    "--redirect-warnings",
+    "--require",
+    "--throw-deprecation",
+    "--tls-cipher-list",
+    "--trace-deprecation",
     "--trace-event-categories",
     "--trace-event-file-pattern",
+    "--trace-events-enabled",
+    "--trace-sync-io",
+    "--trace-warnings",
     "--track-heap-objects",
-    "--zero-fill-buffers",
-    "--v8-pool-size",
-    "--tls-cipher-list",
     "--use-bundled-ca",
     "--use-openssl-ca",
-    "--enable-fips",
-    "--force-fips",
-    "--openssl-config",
-    "--icu-data-dir",
+    "--v8-pool-size",
+    "--zero-fill-buffers",
+    "-r",
 
     // V8 options (define with '_', which allows '-' or '_')
-    "--perf_prof",
-    "--perf_basic_prof",
     "--abort_on_uncaught_exception",
     "--max_old_space_size",
+    "--perf_basic_prof",
+    "--perf_prof",
     "--stack_trace_limit",
   };
 

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests assert that the node.cc PrintHelp() function
+// returns the proper set of cli options when invoked
+
+const assert = require('assert');
+const { exec } = require('child_process');
+let stdOut;
+
+
+function startPrintHelpTest() {
+  exec(`${process.execPath} --help`, common.mustCall((err, stdout, stderr) => {
+    assert.ifError(err);
+    stdOut = stdout;
+    validateNodePrintHelp();
+  }));
+}
+
+function validateNodePrintHelp() {
+  const config = process.config;
+  const HAVE_OPENSSL = common.hasCrypto;
+  const NODE_FIPS_MODE = common.hasFipsCrypto;
+  const NODE_HAVE_I18N_SUPPORT = common.hasIntl;
+  const HAVE_INSPECTOR = config.variables.v8_enable_inspector === 1;
+
+  const cliHelpOptions = [
+    { compileConstant: HAVE_OPENSSL,
+      flags: [ '--openssl-config=file', '--tls-cipher-list=val',
+               '--use-bundled-ca', '--use-openssl-ca' ] },
+    { compileConstant: NODE_FIPS_MODE,
+      flags: [ '--enable-fips', '--force-fips' ] },
+    { compileConstant: NODE_HAVE_I18N_SUPPORT,
+      flags: [ '--experimental-modules', '--experimental-vm-modules',
+               '--icu-data-dir=dir', '--preserve-symlinks',
+               'NODE_ICU_DATA', 'NODE_PRESERVE_SYMLINKS' ] },
+    { compileConstant: HAVE_INSPECTOR,
+      flags: [ '--inspect-brk[=[host:]port]', '--inspect-port=[host:]port',
+               '--inspect[=[host:]port]' ] },
+  ];
+
+  cliHelpOptions.forEach(testForSubstring);
+}
+
+function testForSubstring(options) {
+  if (options.compileConstant) {
+    options.flags.forEach((flag) => {
+      assert.strictEqual(stdOut.indexOf(flag) !== -1, true);
+    });
+  } else {
+    options.flags.forEach((flag) => {
+      assert.strictEqual(stdOut.indexOf(flag), -1);
+    });
+  }
+}
+
+startPrintHelpTest();


### PR DESCRIPTION
Alphabetizing the command line options and environment
variables in doc/api/cli.md for consistency and readability.

Refs: https://github.com/nodejs/node/issues/19814

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
