### PR TITLE
doc, tools: make type parsing more strict

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1096,8 +1096,10 @@ has ended but before the JavaScript VM is terminated and Node.js shuts down.
 
 #### void AtExit(callback, args)
 
-* `callback` {void (\*)(void\*)} A pointer to the function to call at exit.
-* `args` {void\*} A pointer to pass to the callback at exit.
+* `callback` <span class="type">&lt;void (\*)(void\*)&gt;</span>
+  A pointer to the function to call at exit.
+* `args` <span class="type">&lt;void\*&gt;</span>
+  A pointer to pass to the callback at exit.
 
 Registers exit hooks that run after the event loop has ended but before the VM
 is killed.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -886,12 +886,13 @@ should start using the `async_context` variant of `MakeCallback` or
 `CallbackScope`, or the high-level `AsyncResource` class.
 
 <a id="DEP0098"></a>
-### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs
+### DEP0098: AsyncHooks Embedder AsyncResource.emitBefore and AsyncResource.emitAfter APIs
 
 Type: Runtime
 
-The embedded API provided by AsyncHooks exposes emit{Before,After} methods
-which are very easy to use incorrectly which can lead to unrecoverable errors.
+The embedded API provided by AsyncHooks exposes `.emitBefore()` and
+`.emitAfter()` methods which are very easy to use incorrectly which can lead
+to unrecoverable errors.
 
 Use [`asyncResource.runInAsyncScope()`][] API instead which provides a much
 safer, and more convenient, alternative. See

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2521,7 +2521,7 @@ authentication details.
 added: v8.4.0
 -->
 
-* {http2.Http2Stream}
+* {Http2Stream}
 
 The [`Http2Stream`][] object backing the request.
 
@@ -2937,7 +2937,7 @@ an empty string.
 added: v8.4.0
 -->
 
-* {http2.Http2Stream}
+* {Http2Stream}
 
 The [`Http2Stream`][] object backing the response.
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -89,8 +89,8 @@ the child process.
 
 The listener callback is invoked with the following arguments:
 * `message` {Object} a parsed JSON object or primitive value.
-* `sendHandle` {Handle object} a [`net.Socket`][] or [`net.Server`][] object, or
-  undefined.
+* `sendHandle` {net.Server|net.Socket} a [`net.Server`][] or [`net.Socket`][]
+  object, or undefined.
 
 The message goes through serialization and parsing. The resulting message might
 not be the same as what is originally sent.
@@ -1531,7 +1531,7 @@ added: v0.5.9
 -->
 
 * `message` {Object}
-* `sendHandle` {Handle object}
+* `sendHandle` {net.Server|net.Socket}
 * `options` {Object}
 * `callback` {Function}
 * Returns: {boolean}

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -144,8 +144,8 @@ function toLink(typeInput) {
           `<a href="${typeUrl}" class="type">&lt;${typeTextFull}&gt;</a>`);
       } else {
         throw new Error(
-          `Unrecognized type: '${typeTextFull
-          }'. Please, edit the type or update the 'tools/doc/type-parser.js'.`
+          `Unrecognized type: '${typeTextFull}'.\n` +
+          "Please, edit the type or update the 'tools/doc/type-parser.js'."
         );
       }
     } else {

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -2,15 +2,15 @@
 
 const jsDocPrefix = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/';
 
-const jsPrimitiveUrl = `${jsDocPrefix}Data_structures`;
+const jsDataStructuresUrl = `${jsDocPrefix}Data_structures`;
 const jsPrimitives = {
-  'boolean': 'Boolean',
-  'integer': 'Number', // Not a primitive, used for clarification.
-  'null': 'Null',
-  'number': 'Number',
-  'string': 'String',
-  'symbol': 'Symbol',
-  'undefined': 'Undefined'
+  boolean: 'Boolean',
+  integer: 'Number', // Not a primitive, used for clarification.
+  null: 'Null',
+  number: 'Number',
+  string: 'String',
+  symbol: 'Symbol',
+  undefined: 'Undefined'
 };
 
 const jsGlobalObjectsUrl = `${jsDocPrefix}Reference/Global_Objects/`;
@@ -25,12 +25,14 @@ const jsGlobalTypes = [
 ];
 
 const customTypesMap = {
+  'any': `${jsDataStructuresUrl}#Data_types`,
+
+  'this': `${jsDocPrefix}Reference/Operators/this`,
+
   'Iterable':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterable_protocol`,
   'Iterator':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterator_protocol`,
-
-  'this': `${jsDocPrefix}Reference/Operators/this`,
 
   'AsyncHook': 'async_hooks.html#async_hooks_async_hooks_createhook_callbacks',
 
@@ -63,12 +65,14 @@ const customTypesMap = {
   'http.Server': 'http.html#http_class_http_server',
   'http.ServerResponse': 'http.html#http_class_http_serverresponse',
 
+  'ClientHttp2Session': 'http2.html#http2_class_clienthttp2session',
   'ClientHttp2Stream': 'http2.html#http2_class_clienthttp2stream',
   'HTTP/2 Headers Object': 'http2.html#http2_headers_object',
   'HTTP/2 Settings Object': 'http2.html#http2_settings_object',
   'http2.Http2ServerRequest': 'http2.html#http2_class_http2_http2serverrequest',
   'http2.Http2ServerResponse':
     'http2.html#http2_class_http2_http2serverresponse',
+  'Http2SecureServer': 'http2.html#http2_class_http2secureserver',
   'Http2Server': 'http2.html#http2_class_http2server',
   'Http2Session': 'http2.html#http2_class_http2session',
   'Http2Stream': 'http2.html#http2_class_http2stream',
@@ -83,6 +87,8 @@ const customTypesMap = {
   'os.constants.dlopen': 'os.html#os_dlopen_constants',
 
   'PerformanceEntry': 'perf_hooks.html#perf_hooks_class_performanceentry',
+  'PerformanceNodeTiming':
+    'perf_hooks.html#perf_hooks_class_performancenodetiming_extends_performanceentry', // eslint-disable-line max-len
   'PerformanceObserver':
     'perf_hooks.html#perf_hooks_class_performanceobserver_callback',
   'PerformanceObserverEntryList':
@@ -123,10 +129,10 @@ function toLink(typeInput) {
       const typeTextFull = typeText;
       typeText = typeText.replace(arrayPart, '');
 
-      const primitive = jsPrimitives[typeText.toLowerCase()];
+      const primitive = jsPrimitives[typeText];
 
       if (primitive !== undefined) {
-        typeUrl = `${jsPrimitiveUrl}#${primitive}_type`;
+        typeUrl = `${jsDataStructuresUrl}#${primitive}_type`;
       } else if (jsGlobalTypes.includes(typeText)) {
         typeUrl = `${jsGlobalObjectsUrl}${typeText}`;
       } else if (customTypesMap[typeText]) {
@@ -137,7 +143,10 @@ function toLink(typeInput) {
         typeLinks.push(
           `<a href="${typeUrl}" class="type">&lt;${typeTextFull}&gt;</a>`);
       } else {
-        typeLinks.push(`<span class="type">&lt;${typeTextFull}&gt;</span>`);
+        throw new Error(
+          `Unrecognized type: '${typeTextFull
+          }'. Please, edit the type or update the 'tools/doc/type-parser.js'.`
+        );
       }
     } else {
       throw new Error(`Empty type slot: ${typeInput}`);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

We do many small correction PRs for doc types format. This change makes type parsing more strict to avoid these post-corrections. Wrong or undefined types would throw on doc build stage.

Main code changes:

* Make type check case-sensitive (no more uppercased primitives, lowercased global objects etc).
* Make `any` type linkable (to [this section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types)).
* Throw on any unrecognized type.

New parsing mode had detected some issues which have been fixed.

* Fix miscased unlinkable types like `{object}` [here](https://nodejs.org/download/nightly/v10.0.0-nightly2018040777b52fd58f/docs/api/crypto.html#crypto_cipher_setaad_buffer_options).
* Add missing type definitions for unlinkable types like `{Cipher}` [here](https://nodejs.org/download/nightly/v10.0.0-nightly2018040777b52fd58f/docs/api/crypto.html#crypto_cipher_setaad_buffer_options).
* Fix undefined type synonyms in docs.
* Replace non-JavaScript types with verbatim HTML fragments to be consistent in CSS style: [only one place here](https://nodejs.org/download/nightly/v10.0.0-nightly2018040777b52fd58f/docs/api/addons.html#addons_void_atexit_callback_args).
* Change type false-positive format [here](https://nodejs.org/download/nightly/v10.0.0-nightly2018040777b52fd58f/docs/api/deprecations.html#deprecations_dep0098_asynchooks_embedder_asyncresource_emit_span_class_type_lt_before_after_gt_span_apis) — notice the bizarre heading rendering and #hash URL part.

Also, some style nits in `tools/doc/type-parser.js` were fixed.