### PR TITLE
assert: provide info about actual error

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -507,7 +507,8 @@ function expectsNoError(stackStartFn, actual, error, message) {
       actual,
       expected: error,
       operator: stackStartFn.name,
-      message: `Got unwanted ${fnType}${details}\n${actual && actual.message}`,
+      message: `Got unwanted ${fnType}${details}\n` +
+               `Actual message: ${actual && actual.message}`,
       stackStartFn
     });
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -508,7 +508,7 @@ function expectsNoError(stackStartFn, actual, error, message) {
       expected: error,
       operator: stackStartFn.name,
       message: `Got unwanted ${fnType}${details}\n` +
-               `Actual message: ${actual && actual.message}`,
+               `Actual message: "${actual && actual.message}"`,
       stackStartFn
     });
   }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -34,7 +34,8 @@ common.crashOnUnhandledRejection();
         assert(err instanceof assert.AssertionError,
                `${err.name} is not instance of AssertionError`);
         assert.strictEqual(err.code, 'ERR_ASSERTION');
-        assert(/^Got unwanted rejection\.\n$/.test(err.message));
+        assert.strictEqual(err.message,
+                           'Got unwanted rejection.\nActual message: ""');
         assert.strictEqual(err.operator, 'doesNotReject');
         assert.ok(!err.stack.includes('at Function.doesNotReject'));
         return true;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -826,11 +826,11 @@ common.expectsError(
 
   // eslint-disable-next-line no-throw-literal
   assert.throws(() => { throw undefined; }, /undefined/);
-  common.expectsError(
+  assert.throws(
     // eslint-disable-next-line no-throw-literal
     () => a.doesNotThrow(() => { throw undefined; }),
     {
-      type: assert.AssertionError,
+      name: 'AssertionError [ERR_ASSERTION]',
       code: 'ERR_ASSERTION',
       message: 'Got unwanted exception.\nActual message: undefined'
     }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -131,7 +131,7 @@ assert.throws(
     code: 'ERR_ASSERTION',
     operator: 'doesNotThrow',
     message: 'Got unwanted exception: user message\n' +
-             'Actual message: [object Object]'
+             'Actual message: "[object Object]"'
   }
 );
 
@@ -139,7 +139,7 @@ assert.throws(
   () => a.doesNotThrow(() => thrower(Error)),
   {
     code: 'ERR_ASSERTION',
-    message: 'Got unwanted exception.\nActual message: [object Object]'
+    message: 'Got unwanted exception.\nActual message: "[object Object]"'
   }
 );
 
@@ -832,7 +832,7 @@ common.expectsError(
     {
       name: 'AssertionError [ERR_ASSERTION]',
       code: 'ERR_ASSERTION',
-      message: 'Got unwanted exception.\nActual message: undefined'
+      message: 'Got unwanted exception.\nActual message: "undefined"'
     }
   );
 }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -124,29 +124,22 @@ assert.throws(() => thrower(TypeError));
   assert.ok(threw, 'a.doesNotThrow is not catching type matching errors');
 }
 
-common.expectsError(
+assert.throws(
   () => a.doesNotThrow(() => thrower(Error), 'user message'),
   {
-    type: a.AssertionError,
+    name: 'AssertionError [ERR_ASSERTION]',
     code: 'ERR_ASSERTION',
     operator: 'doesNotThrow',
-    message: 'Got unwanted exception: user message\n[object Object]'
+    message: 'Got unwanted exception: user message\n' +
+             'Actual message: [object Object]'
   }
 );
 
-common.expectsError(
-  () => a.doesNotThrow(() => thrower(Error), 'user message'),
-  {
-    code: 'ERR_ASSERTION',
-    message: /Got unwanted exception: user message\n\[object Object\]/
-  }
-);
-
-common.expectsError(
+assert.throws(
   () => a.doesNotThrow(() => thrower(Error)),
   {
     code: 'ERR_ASSERTION',
-    message: /Got unwanted exception\.\n\[object Object\]/
+    message: 'Got unwanted exception.\nActual message: [object Object]'
   }
 );
 
@@ -839,7 +832,7 @@ common.expectsError(
     {
       type: assert.AssertionError,
       code: 'ERR_ASSERTION',
-      message: 'Got unwanted exception.\nundefined'
+      message: 'Got unwanted exception.\nActual message: undefined'
     }
   );
 }


### PR DESCRIPTION
In case a error is caught in `assert.doesNotThrow` or
`assert.doesNotReject` it will now also indicate what the real
error message was.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
