### PR TITLE
test: verify inspector help url works

### DIFF
--- a/test/internet/test-inspector-help-page.js
+++ b/test/internet/test-inspector-help-page.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const https = require('https');
+const { spawnSync } = require('child_process');
+const child = spawnSync(process.execPath, ['--inspect', '-e', '""']);
+const stderr = child.stderr.toString();
+const helpUrl = stderr.match(/For help, see: (.+)/)[1];
+
+function check(url, cb) {
+  https.get(url, common.mustCall((res) => {
+    assert(res.statusCode >= 200 && res.statusCode < 400);
+
+    if (res.statusCode >= 300)
+      return check(res.headers.location, cb);
+
+    let result = '';
+
+    res.setEncoding('utf8');
+    res.on('data', (data) => {
+      result += data;
+    });
+
+    res.on('end', common.mustCall(() => {
+      assert(/>Debugging Guide</.test(result));
+      cb();
+    }));
+  })).on('error', common.mustNotCall);
+}
+
+check(helpUrl, common.mustCall());


### PR DESCRIPTION
This commit adds basic functionality testing of the help URL printed when the inspector starts.

Refs: https://github.com/nodejs/node/pull/19871

~~Note that this test will fail until https://github.com/nodejs/node/pull/19871 or https://github.com/nodejs/build/pull/1219 land. If you want to see it working until then, just add ` + '/'` to the end of `helpUrl`.~~

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
