### PR TITLE
doc: add missing quotes in default string values

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -678,7 +678,7 @@ added: REPLACEME
 - `curve` {string}
 - `inputEncoding` {string}
 - `outputEncoding` {string}
-- `format` {string} **Default:** `uncompressed`
+- `format` {string} **Default:** `'uncompressed'`
 - Returns: {Buffer | string}
 
 Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the
@@ -757,7 +757,7 @@ its recommended for developers to handle this exception accordingly.
 added: v0.11.14
 -->
 - `encoding` {string}
-- `format` {string} **Default:** `uncompressed`
+- `format` {string} **Default:** `'uncompressed'`
 - Returns: {Buffer | string}
 
 Generates private and public EC Diffie-Hellman key values, and returns
@@ -786,7 +786,7 @@ added: v0.11.14
 added: v0.11.14
 -->
 - `encoding` {string}
-- `format` {string} **Default:** `uncompressed`
+- `format` {string} **Default:** `'uncompressed'`
 - Returns: {Buffer | string} The EC Diffie-Hellman public key in the specified
   `encoding` and `format`.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1823,9 +1823,9 @@ changes:
 -->
 
 * `options` {Object | string | URL}
-  * `protocol` {string} Protocol to use. **Default:** `http:`.
+  * `protocol` {string} Protocol to use. **Default:** `'http:'`.
   * `host` {string} A domain name or IP address of the server to issue the
-    request to. **Default:** `localhost`.
+    request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` is preferred over `host`.
   * `family` {number} IP address family to use when resolving `host` and

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -160,7 +160,7 @@ changes:
 -->
 - `options` {Object | string | URL} Accepts all `options` from
   [`http.request()`][], with some differences in default values:
-  - `protocol` **Default:** `https:`
+  - `protocol` **Default:** `'https:'`
   - `port` **Default:** `443`
   - `agent` **Default:** `https.globalAgent`
 - `callback` {Function}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -700,7 +700,7 @@ added: v8.0.0
 * `warning` {string|Error} The warning to emit.
 * `options` {Object}
   * `type` {string} When `warning` is a String, `type` is the name to use
-    for the *type* of warning being emitted. **Default:** `Warning`.
+    for the *type* of warning being emitted. **Default:** `'Warning'`.
   * `code` {string} A unique identifier for the warning instance being emitted.
   * `ctor` {Function} When `warning` is a String, `ctor` is an optional
     function used to limit the generated stack trace. **Default:**
@@ -745,7 +745,7 @@ added: v6.0.0
 
 * `warning` {string|Error} The warning to emit.
 * `type` {string} When `warning` is a String, `type` is the name to use
-  for the *type* of warning being emitted. **Default:** `Warning`.
+  for the *type* of warning being emitted. **Default:** `'Warning'`.
 * `code` {string} A unique identifier for the warning instance being emitted.
 * `ctor` {Function} When `warning` is a String, `ctor` is an optional
   function used to limit the generated stack trace. **Default:**

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -430,7 +430,7 @@ changes:
 -->
 
 * `options` {Object|string}
-  * `prompt` {string} The input prompt to display. **Default:** `> `.
+  * `prompt` {string} The input prompt to display. **Default:** `'> '`
     (with a trailing space).
   * `input` {stream.Readable} The Readable stream from which REPL input will be
     read. **Default:** `process.stdin`.
@@ -513,8 +513,8 @@ environment variables:
  - `NODE_REPL_HISTORY_SIZE` - Controls how many lines of history will be
    persisted if history is available. Must be a positive number.
    **Default:** `1000`.
- - `NODE_REPL_MODE` - May be either `sloppy` or `strict`. **Default:** `sloppy`,
-   which will allow non-strict mode code to be run.
+ - `NODE_REPL_MODE` - May be either `'sloppy'` or `'strict'`. **Default:**
+   `'sloppy'`, which will allow non-strict mode code to be run.
 
 ### Persistent History
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
