### PR TITLE
fs: improve argument handling for ReadStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1348,7 +1348,7 @@ start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 The `encoding` can be any one of those accepted by [`Buffer`][].
 
 If `start` or `end` are not integers, then they are rounded to the closest
-integer using `Math.round`.
+integer using `Math.round()`.
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1291,7 +1291,7 @@ fs.copyFileSync('source.txt', 'destination.txt', COPYFILE_EXCL);
 <!-- YAML
 added: v0.1.31
 changes:
-  - version: v10.0.0
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/19898
     description: Impose new restrictions on `start` and `end`, throwing
                  more appropriate errors in cases when we cannot reasonably

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1330,9 +1330,6 @@ start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 `fs.createReadStream()` reads sequentially from the current file position.
 The `encoding` can be any one of those accepted by [`Buffer`][].
 
-If `start` or `end` are not integers, then they are rounded to the closest
-integer using `Math.round()`.
-
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be
 emitted. Note that `fd` should be blocking; non-blocking `fd`s should be passed

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1291,6 +1291,11 @@ fs.copyFileSync('source.txt', 'destination.txt', COPYFILE_EXCL);
 <!-- YAML
 added: v0.1.31
 changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19898
+    description: Impose new restrictions on `start` and `end`, throwing
+                 more appropriate errors in cases when we cannot reasonably
+                 handle the input values.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using
@@ -1325,19 +1330,6 @@ start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 `fs.createReadStream()` reads sequentially from the current file position.
 The `encoding` can be any one of those accepted by [`Buffer`][].
 
-The following rules apply to the `start` and `end` values:
-
-- If `end` is omitted or set to undefined, then it will be coerced to `Infinity`.
-- The type of both `start` and `end` needs to be `number`. If not, then the
-function would throw a `TypeError` with the code `ERR_INVALID_ARG_TYPE`.
-- Both `start` and `end` should be valid values (i.e. they should neither be
-negative nor `NaN`, and `start` should not be greater than `end`). If they are,
-the function would throw a `RangeError` with the code `ERR_OUT_OF_RANGE`.
-- Both `start` and `end` should be integer values. If they are not, then they
-are rounded to the closest integer using `Math.round`.
-- If none of the above rules apply, then the function works without any quirks
-as expected.
-
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be
 emitted. Note that `fd` should be blocking; non-blocking `fd`s should be passed
@@ -1359,6 +1351,19 @@ fs.createReadStream('sample.txt', { start: 90, end: 99 });
 ```
 
 If `options` is a string, then it specifies the encoding.
+
+The following rules apply to the `start` and `end` values:
+
+- If `end` is omitted or set to undefined, then it will be coerced to `Infinity`.
+- The type of both `start` and `end` needs to be `number`. If not, then the
+function would throw a `TypeError` with the code `ERR_INVALID_ARG_TYPE`.
+- Both `start` and `end` should be valid values (i.e. they should neither be
+negative nor `NaN`, and `start` should not be greater than `end`). If they are,
+the function would throw a `RangeError` with the code `ERR_OUT_OF_RANGE`.
+- Both `start` and `end` should be integer values. If they are not, then they
+are rounded to the closest integer using `Math.round`.
+- If none of the above rules apply, then the function works without any quirks
+as expected.
 
 ## fs.createWriteStream(path[, options])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1324,11 +1324,31 @@ Be aware that, unlike the default value set for `highWaterMark` on a
 readable stream (16 kb), the stream returned by this method has a
 default value of 64 kb for the same parameter.
 
+<<<<<<< HEAD
+=======
+`options` is an object or string with the following defaults:
+
+```js
+const defaults = {
+  end: Infinity,
+  flags: 'r',
+  encoding: null,
+  fd: null,
+  mode: 0o666,
+  autoClose: true,
+  highWaterMark: 64 * 1024
+};
+```
+
+>>>>>>> Minimize comments and documentation
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file. Both `start` and `end` are inclusive and
 start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 `fs.createReadStream()` reads sequentially from the current file position.
 The `encoding` can be any one of those accepted by [`Buffer`][].
+
+If `start` or `end` are not integers, then they are rounded to the closest
+integer using `Math.round`.
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be
@@ -1351,19 +1371,6 @@ fs.createReadStream('sample.txt', { start: 90, end: 99 });
 ```
 
 If `options` is a string, then it specifies the encoding.
-
-The following rules apply to the `start` and `end` values:
-
-- If `end` is omitted or set to undefined, then it will be coerced to `Infinity`.
-- The type of both `start` and `end` needs to be `number`. If not, then the
-function would throw a `TypeError` with the code `ERR_INVALID_ARG_TYPE`.
-- Both `start` and `end` should be valid values (i.e. they should neither be
-negative nor `NaN`, and `start` should not be greater than `end`). If they are,
-the function would throw a `RangeError` with the code `ERR_OUT_OF_RANGE`.
-- Both `start` and `end` should be integer values. If they are not, then they
-are rounded to the closest integer using `Math.round`.
-- If none of the above rules apply, then the function works without any quirks
-as expected.
 
 ## fs.createWriteStream(path[, options])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1324,23 +1324,6 @@ Be aware that, unlike the default value set for `highWaterMark` on a
 readable stream (16 kb), the stream returned by this method has a
 default value of 64 kb for the same parameter.
 
-<<<<<<< HEAD
-=======
-`options` is an object or string with the following defaults:
-
-```js
-const defaults = {
-  end: Infinity,
-  flags: 'r',
-  encoding: null,
-  fd: null,
-  mode: 0o666,
-  autoClose: true,
-  highWaterMark: 64 * 1024
-};
-```
-
->>>>>>> Minimize comments and documentation
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file. Both `start` and `end` are inclusive and
 start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1325,6 +1325,19 @@ start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 `fs.createReadStream()` reads sequentially from the current file position.
 The `encoding` can be any one of those accepted by [`Buffer`][].
 
+The following rules apply to the `start` and `end` values:
+
+- If `end` is omitted or set to undefined, then it will be coerced to `Infinity`.
+- The type of both `start` and `end` needs to be `number`. If not, then the
+function would throw a `TypeError` with the code `ERR_INVALID_ARG_TYPE`.
+- Both `start` and `end` should be valid values (i.e. they should neither be
+negative nor `NaN`, and `start` should not be greater than `end`). If they are,
+the function would throw a `RangeError` with the code `ERR_OUT_OF_RANGE`.
+- Both `start` and `end` should be integer values. If they are not, then they
+are rounded to the closest integer using `Math.round`.
+- If none of the above rules apply, then the function works without any quirks
+as expected.
+
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `'open'` event will be
 emitted. Note that `fd` should be blocking; non-blocking `fd`s should be passed

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2013,9 +2013,7 @@ function ReadStream(path, options) {
   this.bytesRead = 0;
   this.closed = false;
 
-  // Case 0: If either start or end is undefined, set them to defaults
-  // (0, Infinity) respectively.
-  this.start = this.start === undefined ? 0 : this.start;
+  // Case 0: If end is undefined, set it to default (Infinity)
   this.end = this.end === undefined ? Infinity : this.end;
 
   // Case 1: If the type of either start or end is not number, throw

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2013,53 +2013,71 @@ function ReadStream(path, options) {
   this.bytesRead = 0;
   this.closed = false;
 
-  // Case 0: If end is undefined, set it to default (Infinity)
-  this.end = this.end === undefined ? Infinity : this.end;
+  if (this.start !== undefined) {
+    // Case 1: If the type of start is not 'number', throw ERR_INVALID_ARG_TYPE
+    // (TypeError).
+    if (typeof this.start !== 'number') {
+      throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
+    }
 
-  // Case 1: If the type of either start or end is not number, throw
-  // ERR_INVALID_ARG_TYPE (TypeError).
-  if (typeof this.start !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
-  }
-  if (typeof this.end !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
-  }
+    // Case 2: If start is NaN, throw ERR_OUT_OF_RANGE (RangeError).
+    if (Number.isNaN(this.start)) {
+      throw new ERR_OUT_OF_RANGE('start', 'not NaN', this.start);
+    }
 
-  // Case 2: If either start or end is NaN, throw ERR_OUT_OF_RANGE (RangeError).
-  if (Number.isNaN(this.start)) {
-    throw new ERR_OUT_OF_RANGE('start', 'not NaN', this.start);
-  }
-  if (Number.isNaN(this.end)) {
-    throw new ERR_OUT_OF_RANGE('end', 'not NaN', this.end);
-  }
+    // Case 3: If start is negative, throw ERR_OUT_OF_RANGE (RangeError).
+    if (this.start < 0) {
+      throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
+    }
 
-  // Case 3: If either start or end is negative, throw ERR_OUT_OF_RANGE
-  // (RangeError).
-  if (this.start < 0) {
-    throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
-  }
-  if (this.end < 0) {
-    throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
-  }
+    // Case 4: If start is fractional, round them to the nearest whole number.
+    // (Not integer as negatives not allowed)
+    if (!Number.isInteger(this.start)) {
+      this.start = Math.round(this.start);
+    }
+    if (!Number.isInteger(this.end)) {
+      this.end = Math.round(this.end);
+    }
 
-  // Case 4: If either start or end is fractional, round them to the nearest
-  // whole number. (Not integer as negatives not allowed)
-  if (!Number.isInteger(this.start)) {
-    this.start = Math.round(this.start);
-  }
-  if (!Number.isInteger(this.end)) {
-    this.end = Math.round(this.end);
-  }
+    // Case 5: If start is a whole number, work perfectly.
 
-  // Case 5: If start and end are both whole numbers, work perfectly.
+    // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
+    if (this.start > this.end) {
+      const errVal = `{start: ${this.start}, end: ${this.end}}`;
+      throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
+    }
 
-  // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
-  if (this.start > this.end) {
-    const errVal = `{start: ${this.start}, end: ${this.end}}`;
-    throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
+    this.pos = this.start;
   }
 
-  this.pos = this.start;
+  // Case 0: If end is undefined, set end to Infinity.
+  if (this.end === undefined) {
+    this.end = Infinity;
+  } else {
+    // Case 1: If the type of end is not 'number', throw ERR_INVALID_ARG_TYPE
+    // (TypeError).
+    if (typeof this.end !== 'number') {
+      throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
+    }
+
+    // Case 2: If end is NaN, throw ERR_OUT_OF_RANGE (RangeError).
+    if (Number.isNaN(this.end)) {
+      throw new ERR_OUT_OF_RANGE('end', 'not NaN', this.end);
+    }
+
+    // Case 3: If end is negative, throw ERR_OUT_OF_RANGE (RangeError).
+    if (this.end < 0) {
+      throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
+    }
+
+    // Case 4: If end is fractional, round them to the nearest whole number.
+    // (Not integer as negatives not allowed)
+    if (!Number.isInteger(this.end)) {
+      this.end = Math.round(this.end);
+    }
+
+    // Case 5: If end is a whole number, work perfectly.
+  }
 
   if (typeof this.fd !== 'number')
     this.open();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2027,7 +2027,7 @@ function ReadStream(path, options) {
     }
 
     if (!Number.isInteger(this.start)) {
-      this.start = Math.round(this.start);
+      throw new ERR_OUT_OF_RANGE('start', 'integer', this.start);
     }
 
     this.pos = this.start;
@@ -2049,7 +2049,7 @@ function ReadStream(path, options) {
     }
 
     if (!Number.isInteger(this.end)) {
-      this.end = Math.round(this.end);
+      throw new ERR_OUT_OF_RANGE('start', 'integer', this.end);
     }
 
     if (this.start !== undefined && this.start > this.end) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2013,31 +2013,55 @@ function ReadStream(path, options) {
   this.bytesRead = 0;
   this.closed = false;
 
-  if (this.start !== undefined) {
-    if (typeof this.start !== 'number' || Number.isNaN(this.start)) {
-      throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
-    }
-    if (this.end === undefined) {
-      this.end = Infinity;
-    } else if (typeof this.end !== 'number' || Number.isNaN(this.end)) {
-      throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
-    }
+  // Case 0: If either start or end is undefined, set them to defaults
+  // (0, Infinity) respectively.
+  this.start = this.start === undefined ? 0 : this.start;
+  this.end = this.end === undefined ? Infinity : this.end;
 
-    if (this.start > this.end) {
-      const errVal = `{start: ${this.start}, end: ${this.end}}`;
-      throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
-    }
-
-    this.pos = this.start;
+  // Case 1: If the type of either start or end is not number, throw
+  // ERR_INVALID_ARG_TYPE (TypeError).
+  if (typeof this.start !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
+  }
+  if (typeof this.end !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
   }
 
-  // Backwards compatibility: Make sure `end` is a number regardless of `start`.
-  // TODO(addaleax): Make the above typecheck not depend on `start` instead.
-  // (That is a semver-major change).
-  if (typeof this.end !== 'number')
-    this.end = Infinity;
-  else if (Number.isNaN(this.end))
-    throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
+  // Case 2: If either start or end is NaN, throw ERR_OUT_OF_RANGE (RangeError).
+  if (Number.isNaN(this.start)) {
+    throw new ERR_OUT_OF_RANGE('start', 'not NaN', this.start);
+  }
+  if (Number.isNaN(this.end)) {
+    throw new ERR_OUT_OF_RANGE('end', 'not NaN', this.end);
+  }
+
+  // Case 3: If either start or end is negative, throw ERR_OUT_OF_RANGE
+  // (RangeError).
+  if (this.start < 0) {
+    throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
+  }
+  if (this.end < 0) {
+    throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
+  }
+
+  // Case 4: If either start or end is fractional, round them to the nearest
+  // whole number. (Not integer as negatives not allowed)
+  if (!Number.isInteger(this.start)) {
+    this.start = Math.round(this.start);
+  }
+  if (!Number.isInteger(this.end)) {
+    this.end = Math.round(this.end);
+  }
+
+  // Case 5: If start and end are both whole numbers, work perfectly.
+
+  // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
+  if (this.start > this.end) {
+    const errVal = `{start: ${this.start}, end: ${this.end}}`;
+    throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
+  }
+
+  this.pos = this.start;
 
   if (typeof this.fd !== 'number')
     this.open();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2013,9 +2013,6 @@ function ReadStream(path, options) {
   this.bytesRead = 0;
   this.closed = false;
 
-  // Case 0: If end is undefined, set end to Infinity.
-  this.end = this.end === undefined ? Infinity : this.end;
-
   if (this.start !== undefined) {
     // Case 1: If the type of start is not 'number', throw ERR_INVALID_ARG_TYPE
     // (TypeError).
@@ -2041,16 +2038,13 @@ function ReadStream(path, options) {
 
     // Case 5: If start is a whole number, work perfectly.
 
-    // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
-    if (this.start > this.end) {
-      const errVal = `{start: ${this.start}, end: ${this.end}}`;
-      throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
-    }
-
     this.pos = this.start;
   }
 
-  if (this.end !== undefined) {
+  // Case 0: If end is undefined, set end to Infinity.
+  if (this.end === undefined) {
+    this.end = Infinity;
+  } else {
     // Case 1: If the type of end is not 'number', throw ERR_INVALID_ARG_TYPE
     // (TypeError).
     if (typeof this.end !== 'number') {
@@ -2074,6 +2068,12 @@ function ReadStream(path, options) {
     }
 
     // Case 5: If end is a whole number, work perfectly.
+
+    // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
+    if (this.start !== undefined && this.start > this.end) {
+      const errVal = `{start: ${this.start}, end: ${this.end}}`;
+      throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
+    }
   }
 
   if (typeof this.fd !== 'number')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2013,6 +2013,9 @@ function ReadStream(path, options) {
   this.bytesRead = 0;
   this.closed = false;
 
+  // Case 0: If end is undefined, set end to Infinity.
+  this.end = this.end === undefined ? Infinity : this.end;
+
   if (this.start !== undefined) {
     // Case 1: If the type of start is not 'number', throw ERR_INVALID_ARG_TYPE
     // (TypeError).
@@ -2047,10 +2050,7 @@ function ReadStream(path, options) {
     this.pos = this.start;
   }
 
-  // Case 0: If end is undefined, set end to Infinity.
-  if (this.end === undefined) {
-    this.end = Infinity;
-  } else {
+  if (this.end !== undefined) {
     // Case 1: If the type of end is not 'number', throw ERR_INVALID_ARG_TYPE
     // (TypeError).
     if (typeof this.end !== 'number') {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2035,9 +2035,6 @@ function ReadStream(path, options) {
     if (!Number.isInteger(this.start)) {
       this.start = Math.round(this.start);
     }
-    if (!Number.isInteger(this.end)) {
-      this.end = Math.round(this.end);
-    }
 
     // Case 5: If start is a whole number, work perfectly.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2014,62 +2014,44 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    // Case 1: If the type of start is not 'number', throw ERR_INVALID_ARG_TYPE
-    // (TypeError).
     if (typeof this.start !== 'number') {
       throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
     }
 
-    // Case 2: If start is NaN, throw ERR_OUT_OF_RANGE (RangeError).
     if (Number.isNaN(this.start)) {
       throw new ERR_OUT_OF_RANGE('start', 'not NaN', this.start);
     }
 
-    // Case 3: If start is negative, throw ERR_OUT_OF_RANGE (RangeError).
     if (this.start < 0) {
       throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
     }
 
-    // Case 4: If start is fractional, round them to the nearest whole number.
-    // (Not integer as negatives not allowed)
     if (!Number.isInteger(this.start)) {
       this.start = Math.round(this.start);
     }
 
-    // Case 5: If start is a whole number, work perfectly.
-
     this.pos = this.start;
   }
 
-  // Case 0: If end is undefined, set end to Infinity.
   if (this.end === undefined) {
     this.end = Infinity;
   } else {
-    // Case 1: If the type of end is not 'number', throw ERR_INVALID_ARG_TYPE
-    // (TypeError).
     if (typeof this.end !== 'number') {
       throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
     }
 
-    // Case 2: If end is NaN, throw ERR_OUT_OF_RANGE (RangeError).
     if (Number.isNaN(this.end)) {
       throw new ERR_OUT_OF_RANGE('end', 'not NaN', this.end);
     }
 
-    // Case 3: If end is negative, throw ERR_OUT_OF_RANGE (RangeError).
     if (this.end < 0) {
       throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
     }
 
-    // Case 4: If end is fractional, round them to the nearest whole number.
-    // (Not integer as negatives not allowed)
     if (!Number.isInteger(this.end)) {
       this.end = Math.round(this.end);
     }
 
-    // Case 5: If end is a whole number, work perfectly.
-
-    // Case 6: If start is greater than end, throw ERR_OUT_OF_RANGE (RangeError)
     if (this.start !== undefined && this.start > this.end) {
       const errVal = `{start: ${this.start}, end: ${this.end}}`;
       throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2019,10 +2019,10 @@ function ReadStream(path, options) {
         throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
       if (!Number.isInteger(this.start))
         throw new ERR_OUT_OF_RANGE('start', 'an integer', this.start);
-      throw new ERR_OUT_OF_RANGE('start', '=> 0 and <= 2 ** 53 - 1', this.start);
+      throw new ERR_OUT_OF_RANGE('start', '>= 0 and <= 2 ** 53 - 1', this.start);
     }
     if (this.start < 0) {
-      throw new ERR_OUT_OF_RANGE('start', '=> 0 and <= 2 ** 53 - 1', this.start);
+      throw new ERR_OUT_OF_RANGE('start', '>= 0 and <= 2 ** 53 - 1', this.start);
     }
 
     this.pos = this.start;
@@ -2044,8 +2044,7 @@ function ReadStream(path, options) {
     }
 
     if (this.start !== undefined && this.start > this.end) {
-      const errVal = `{start: ${this.start}, end: ${this.end}}`;
-      throw new ERR_OUT_OF_RANGE('start', `<= "end" (here: ${this.end})`, errVal);
+      throw new ERR_OUT_OF_RANGE('start', `<= "end" (here: ${this.end})`, this.start);
     }
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2014,20 +2014,15 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (typeof this.start !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
-    }
-
-    if (Number.isNaN(this.start)) {
-      throw new ERR_OUT_OF_RANGE('start', 'not NaN', this.start);
-    }
-
-    if (this.start < 0) {
-      throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
-    }
-
     if (!Number.isSafeInteger(this.start)) {
-      throw new ERR_OUT_OF_RANGE('start', 'safe integer', this.start);
+      if (typeof this.start !== 'number')
+        throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
+      if (!Number.isInteger(this.start))
+        throw new ERR_OUT_OF_RANGE('start', 'an integer', this.start);
+      throw new ERR_OUT_OF_RANGE('start', '=> 0 and <= 2 ** 53 - 1', this.start);
+    }
+    if (this.start < 0) {
+      throw new ERR_OUT_OF_RANGE('start', '=> 0 and <= 2 ** 53 - 1', this.start);
     }
 
     this.pos = this.start;
@@ -2036,25 +2031,21 @@ function ReadStream(path, options) {
   if (this.end === undefined) {
     this.end = Infinity;
   } else if (this.end !== Infinity) {
-    if (typeof this.end !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
-    }
-
-    if (Number.isNaN(this.end)) {
-      throw new ERR_OUT_OF_RANGE('end', 'not NaN', this.end);
+    if (!Number.isSafeInteger(this.end)) {
+      if (typeof this.end !== 'number')
+        throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
+      if (!Number.isInteger(this.end))
+        throw new ERR_OUT_OF_RANGE('end', 'an integer', this.end);
+      throw new ERR_OUT_OF_RANGE('end', '>= 0 and <= 2 ** 53 - 1', this.end);
     }
 
     if (this.end < 0) {
-      throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
-    }
-
-    if (!Number.isSafeInteger(this.end)) {
-      throw new ERR_OUT_OF_RANGE('end', 'safe integer', this.end);
+      throw new ERR_OUT_OF_RANGE('end', '>= 0 and <= 2 ** 53 - 1', this.end);
     }
 
     if (this.start !== undefined && this.start > this.end) {
       const errVal = `{start: ${this.start}, end: ${this.end}}`;
-      throw new ERR_OUT_OF_RANGE('start', '<= "end"', errVal);
+      throw new ERR_OUT_OF_RANGE('start', `<= "end" (here: ${this.end})`, errVal);
     }
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2049,7 +2049,7 @@ function ReadStream(path, options) {
     }
 
     if (!Number.isInteger(this.end)) {
-      throw new ERR_OUT_OF_RANGE('start', 'integer', this.end);
+      throw new ERR_OUT_OF_RANGE('end', 'integer', this.end);
     }
 
     if (this.start !== undefined && this.start > this.end) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2026,7 +2026,7 @@ function ReadStream(path, options) {
       throw new ERR_OUT_OF_RANGE('start', 'positive', this.start);
     }
 
-    if (!Number.isInteger(this.start)) {
+    if (!Number.isSafeInteger(this.start)) {
       throw new ERR_OUT_OF_RANGE('start', 'integer', this.start);
     }
 
@@ -2048,7 +2048,7 @@ function ReadStream(path, options) {
       throw new ERR_OUT_OF_RANGE('end', 'positive', this.end);
     }
 
-    if (!Number.isInteger(this.end)) {
+    if (!Number.isSafeInteger(this.end)) {
       throw new ERR_OUT_OF_RANGE('end', 'integer', this.end);
     }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2027,7 +2027,7 @@ function ReadStream(path, options) {
     }
 
     if (!Number.isSafeInteger(this.start)) {
-      throw new ERR_OUT_OF_RANGE('start', 'integer', this.start);
+      throw new ERR_OUT_OF_RANGE('start', 'safe integer', this.start);
     }
 
     this.pos = this.start;
@@ -2049,7 +2049,7 @@ function ReadStream(path, options) {
     }
 
     if (!Number.isSafeInteger(this.end)) {
-      throw new ERR_OUT_OF_RANGE('end', 'integer', this.end);
+      throw new ERR_OUT_OF_RANGE('end', 'safe integer', this.end);
     }
 
     if (this.start !== undefined && this.start > this.end) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2033,7 +2033,7 @@ function ReadStream(path, options) {
     this.pos = this.start;
   }
 
-  if (this.end === undefined) {
+  if (this.end === undefined || this.end === Infinity) {
     this.end = Infinity;
   } else {
     if (typeof this.end !== 'number') {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2019,10 +2019,18 @@ function ReadStream(path, options) {
         throw new ERR_INVALID_ARG_TYPE('start', 'number', this.start);
       if (!Number.isInteger(this.start))
         throw new ERR_OUT_OF_RANGE('start', 'an integer', this.start);
-      throw new ERR_OUT_OF_RANGE('start', '>= 0 and <= 2 ** 53 - 1', this.start);
+      throw new ERR_OUT_OF_RANGE(
+        'start',
+        '>= 0 and <= 2 ** 53 - 1',
+        this.start
+      );
     }
     if (this.start < 0) {
-      throw new ERR_OUT_OF_RANGE('start', '>= 0 and <= 2 ** 53 - 1', this.start);
+      throw new ERR_OUT_OF_RANGE(
+        'start',
+        '>= 0 and <= 2 ** 53 - 1',
+        this.start
+      );
     }
 
     this.pos = this.start;
@@ -2044,7 +2052,11 @@ function ReadStream(path, options) {
     }
 
     if (this.start !== undefined && this.start > this.end) {
-      throw new ERR_OUT_OF_RANGE('start', `<= "end" (here: ${this.end})`, this.start);
+      throw new ERR_OUT_OF_RANGE(
+        'start',
+        `<= "end" (here: ${this.end})`,
+        this.start
+      );
     }
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2033,9 +2033,9 @@ function ReadStream(path, options) {
     this.pos = this.start;
   }
 
-  if (this.end === undefined || this.end === Infinity) {
+  if (this.end === undefined) {
     this.end = Infinity;
-  } else {
+  } else if (this.end !== Infinity) {
     if (typeof this.end !== 'number') {
       throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
     }

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -110,8 +110,8 @@ const rangeFile = fixtures.path('x.txt');
 
 {
   const message =
-    'The value of "start" is out of range. It must be <= "end". ' +
-    'Received {start: 10, end: 2}';
+    'The value of "start" is out of range. It must be <= "end" (here: 2).' +
+    ' Received 10';
 
   common.expectsError(
     () => {

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -13,23 +13,54 @@ fs.createReadStream(example, null);
 fs.createReadStream(example, 'utf8');
 fs.createReadStream(example, { encoding: 'utf8' });
 
-const createReadStreamErr = (path, opt) => {
-  common.expectsError(
-    () => {
-      fs.createReadStream(path, opt);
-    },
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    });
+const createReadStreamErr = (path, opt, error) => {
+  common.expectsError(() => {
+    fs.createReadStream(path, opt);
+  }, error);
 };
 
-createReadStreamErr(example, 123);
-createReadStreamErr(example, 0);
-createReadStreamErr(example, true);
-createReadStreamErr(example, false);
+const typeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError
+};
 
-// createReadSteam _should_ throw on NaN
-createReadStreamErr(example, { start: NaN });
-createReadStreamErr(example, { end: NaN });
-createReadStreamErr(example, { start: NaN, end: NaN });
+const rangeError = {
+  code: 'ERR_OUT_OF_RANGE',
+  type: RangeError
+};
+
+createReadStreamErr(example, 123, typeError);
+createReadStreamErr(example, 0, typeError);
+createReadStreamErr(example, true, typeError);
+createReadStreamErr(example, false, typeError);
+
+// Case 0: Should not throw if either start or end is undefined
+fs.createReadStream(example, {});
+fs.createReadStream(example, { start: 0 });
+fs.createReadStream(example, { end: Infinity });
+
+// Case 1: Should throw TypeError if either start or end is not of type 'number'
+createReadStreamErr(example, { start: 'invalid' }, typeError);
+createReadStreamErr(example, { end: 'invalid' }, typeError);
+createReadStreamErr(example, { start: 'invalid', end: 'invalid' }, typeError);
+
+// Case 2: Should throw RangeError if either start or end is NaN
+createReadStreamErr(example, { start: NaN }, rangeError);
+createReadStreamErr(example, { end: NaN }, rangeError);
+createReadStreamErr(example, { start: NaN, end: NaN }, rangeError);
+
+// Case 3: Should throw RangeError if either start or end is negative
+createReadStreamErr(example, { start: -1 }, rangeError);
+createReadStreamErr(example, { end: -1 }, rangeError);
+createReadStreamErr(example, { start: -1, end: -1 }, rangeError);
+
+// Case 4: Should not throw if either start or end is fractional
+fs.createReadStream(example, { start: 0.1 });
+fs.createReadStream(example, { end: 0.1 });
+fs.createReadStream(example, { start: 0.1, end: 0.1 });
+
+// Case 5: Should not throw if both start and end are whole numbers
+fs.createReadStream(example, { start: 1, end: 5 });
+
+// Case 6: Should throw RangeError if start is greater than end
+createReadStreamErr(example, { start: 5, end: 1 }, rangeError);

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -54,10 +54,10 @@ createReadStreamErr(example, { start: -1 }, rangeError);
 createReadStreamErr(example, { end: -1 }, rangeError);
 createReadStreamErr(example, { start: -1, end: -1 }, rangeError);
 
-// Case 4: Should not throw if either start or end is fractional
-fs.createReadStream(example, { start: 0.1 });
-fs.createReadStream(example, { end: 0.1 });
-fs.createReadStream(example, { start: 0.1, end: 0.1 });
+// Case 4: Should throw RangeError if either start or end is fractional
+createReadStreamErr(example, { start: 0.1 }, rangeError);
+createReadStreamErr(example, { end: 0.1 }, rangeError);
+createReadStreamErr(example, { start: 0.1, end: 0.1 }, rangeError);
 
 // Case 5: Should not throw if both start and end are whole numbers
 fs.createReadStream(example, { start: 1, end: 5 });

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -29,35 +29,36 @@ const rangeError = {
   type: RangeError
 };
 
-createReadStreamErr(example, 123, typeError);
-createReadStreamErr(example, 0, typeError);
-createReadStreamErr(example, true, typeError);
-createReadStreamErr(example, false, typeError);
+[123, 0, true, false].forEach((opts) =>
+  createReadStreamErr(example, opts, typeError)
+);
 
 // Case 0: Should not throw if either start or end is undefined
-fs.createReadStream(example, {});
-fs.createReadStream(example, { start: 0 });
-fs.createReadStream(example, { end: Infinity });
+[{}, { start: 0 }, { end: Infinity }].forEach((opts) =>
+  fs.createReadStream(example, opts)
+);
 
 // Case 1: Should throw TypeError if either start or end is not of type 'number'
-createReadStreamErr(example, { start: 'invalid' }, typeError);
-createReadStreamErr(example, { end: 'invalid' }, typeError);
-createReadStreamErr(example, { start: 'invalid', end: 'invalid' }, typeError);
+[
+  { start: 'invalid' },
+  { end: 'invalid' },
+  { start: 'invalid', end: 'invalid' }
+].forEach((opts) => createReadStreamErr(example, opts, typeError));
 
 // Case 2: Should throw RangeError if either start or end is NaN
-createReadStreamErr(example, { start: NaN }, rangeError);
-createReadStreamErr(example, { end: NaN }, rangeError);
-createReadStreamErr(example, { start: NaN, end: NaN }, rangeError);
+[{ start: NaN }, { end: NaN }, { start: NaN, end: NaN }].forEach((opts) =>
+  createReadStreamErr(example, opts, rangeError)
+);
 
 // Case 3: Should throw RangeError if either start or end is negative
-createReadStreamErr(example, { start: -1 }, rangeError);
-createReadStreamErr(example, { end: -1 }, rangeError);
-createReadStreamErr(example, { start: -1, end: -1 }, rangeError);
+[{ start: -1 }, { end: -1 }, { start: -1, end: -1 }].forEach((opts) =>
+  createReadStreamErr(example, opts, rangeError)
+);
 
 // Case 4: Should throw RangeError if either start or end is fractional
-createReadStreamErr(example, { start: 0.1 }, rangeError);
-createReadStreamErr(example, { end: 0.1 }, rangeError);
-createReadStreamErr(example, { start: 0.1, end: 0.1 }, rangeError);
+[{ start: 0.1 }, { end: 0.1 }, { start: 0.1, end: 0.1 }].forEach((opts) =>
+  createReadStreamErr(example, opts, rangeError)
+);
 
 // Case 5: Should not throw if both start and end are whole numbers
 fs.createReadStream(example, { start: 1, end: 5 });

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -148,8 +148,8 @@ common.expectsError(
   },
   {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "start" is out of range. It must be <= "end". ' +
-             'Received {start: 10, end: 2}',
+    message: 'The value of "start" is out of range. It must be <= "end"' +
+             ' (here: 2). Received 10',
     type: RangeError
   });
 


### PR DESCRIPTION
Improve handling of erratic arguments in fs.ReadStream

Refs: https://github.com/nodejs/node/pull/19732

For the uninitiated, a summary of what I'm planning to change:

| Type | Current Behavior | Proposed Behavior |
|---|---|---|
| `undefined` | (0, `Infinity`) | (0, `Infinity`) |
| Anything other than `Number`   | `ERR_INVALID_ARG_TYPE` | `ERR_INVALID_ARG_TYPE` |
| `NaN` | `ERR_INVALID_ARG_TYPE` | `ERR_OUT_OF_RANGE` |
| Negative `Number`s | ✘ | `ERR_OUT_OF_RANGE` |
| Fractional `Number`s | ✘ | `Math.round` |
| Integers | Work Perfectly | Still work perfectly |
| Invalid Arguments | `ERR_OUT_OF_RANGE` | `ERR_OUT_OF_RANGE` |

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @addaleax @anliting @nodejs/fs 