### PR TITLE
doc: clarify url doc

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -93,14 +93,14 @@ return `true`.
 
 #### Constructor: new URL(input[, base])
 
-* `input` {string} The input URL to parse
+* `input` {string} The absolute or relative input URL to parse. If `input`
+  is relative, then `base` is required. If `input` is absolute, the `base`
+  is ignored.
 * `base` {string|URL} The base URL to resolve against if the `input` is not
   absolute.
 
 Creates a new `URL` object by parsing the `input` relative to the `base`. If
 `base` is passed as a string, it will be parsed equivalent to `new URL(base)`.
-
-The `base` is ignored if the `input` is an absolute URL.
 
 ```js
 const myURL = new URL('/foo', 'https://example.org/');
@@ -126,6 +126,26 @@ const myURL = new URL('https://你好你好');
 
 This feature is only available if the `node` executable was compiled with
 [ICU][] enabled. If not, the domain names are passed through unchanged.
+
+In cases where it is not known in advance if `input` is an absolute URL
+and a `base` is provided, it is advised to validate that the `origin` of
+the `URL` object is what is expected.
+
+```js
+const { URL } = require('url');
+var myURL = new URL('http://anotherExample.org/', 'https://example.org/');
+// http://anotherexample.org/
+myURL = new URL('https://anotherExample.org/', 'https://example.org/');
+// https://anotherexample.org/
+myURL = new URL('foo://anotherExample.org/', 'https://example.org/');
+// foo://anotherExample.org/
+myURL = new URL('http:anotherExample.org/', 'https://example.org/');
+// http://anotherexample.org/
+myURL = new URL('https:anotherExample.org/', 'https://example.org/');
+// https://example.org/anotherExample.org/
+myURL = new URL('foo:anotherExample.org/', 'https://example.org/');
+// foo:anotherExample.org/
+```
 
 #### url.hash
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -133,16 +133,22 @@ the `URL` object is what is expected.
 
 ```js
 const { URL } = require('url');
-var myURL = new URL('http://anotherExample.org/', 'https://example.org/');
+
+let myURL = new URL('http://anotherExample.org/', 'https://example.org/');
 // http://anotherexample.org/
+
 myURL = new URL('https://anotherExample.org/', 'https://example.org/');
 // https://anotherexample.org/
+
 myURL = new URL('foo://anotherExample.org/', 'https://example.org/');
 // foo://anotherExample.org/
+
 myURL = new URL('http:anotherExample.org/', 'https://example.org/');
 // http://anotherexample.org/
+
 myURL = new URL('https:anotherExample.org/', 'https://example.org/');
 // https://example.org/anotherExample.org/
+
 myURL = new URL('foo:anotherExample.org/', 'https://example.org/');
 // foo:anotherExample.org/
 ```

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -100,6 +100,8 @@ return `true`.
 Creates a new `URL` object by parsing the `input` relative to the `base`. If
 `base` is passed as a string, it will be parsed equivalent to `new URL(base)`.
 
+The `base` is ignored if the `input` is an absolute URL.
+
 ```js
 const myURL = new URL('/foo', 'https://example.org/');
 // https://example.org/foo


### PR DESCRIPTION
Indicate that `base` is ignored if `input` is absolute.


##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
