### PR TITLE
fs: add 'close' event to FSWatcher

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -329,6 +329,13 @@ added: v0.5.8
 
 Emitted when an error occurs while watching the file.
 
+### Event: 'close'
+<!-- YAML
+added: REPLACEME
+-->
+
+Emitted when the watcher stops watching for changes.
+
 ### watcher.close()
 <!-- YAML
 added: v0.5.8

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1387,7 +1387,12 @@ FSWatcher.prototype.close = function() {
     return;
   }
   this._handle.close();
+  process.nextTick(emitCloseNT, this);
 };
+
+function emitCloseNT(self) {
+  self.emit('close');
+}
 
 fs.watch = function(filename, options, listener) {
   if (typeof options === 'function') {

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -54,6 +54,7 @@ for (const testCase of cases) {
     }
     assert.fail(err);
   });
+  watcher.on('close', common.mustCall());
   watcher.on('change', common.mustCall(function(eventType, argFilename) {
     if (interval) {
       clearInterval(interval);


### PR DESCRIPTION
Should `process.nextTick` wrap this? Are tests necessary here?

- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
