### PR TITLE
test: move require('http2') after crypto check

### DIFF
--- a/test/parallel/test-http2-client-write-empty-string.js
+++ b/test/parallel/test-http2-client-write-empty-string.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const assert = require('assert');
-const http2 = require('http2');
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const http2 = require('http2');
 
 for (const chunkSequence of [
   [ '' ],


### PR DESCRIPTION
This test currently fails when configured --without-ssl:
```
Error [ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto support
```

This commit moves the require of http2 to come after the crypto check to
avoid the error.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
