### PR TITLE
doc: prevent a false-positive linkification

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -281,7 +281,7 @@ Compression strategy.
 * `zlib.constants.Z_FIXED`
 * `zlib.constants.Z_DEFAULT_STRATEGY`
 
-## Class Options
+## Class: Options
 <!-- YAML
 added: v0.11.1
 changes:
@@ -473,14 +473,14 @@ Provides an object enumerating Zlib-related constants.
 added: v0.5.8
 -->
 
-Creates and returns a new [Deflate][] object with the given [options][].
+Creates and returns a new [Deflate][] object with the given [`options`][].
 
 ## zlib.createDeflateRaw([options])
 <!-- YAML
 added: v0.5.8
 -->
 
-Creates and returns a new [DeflateRaw][] object with the given [options][].
+Creates and returns a new [DeflateRaw][] object with the given [`options`][].
 
 An upgrade of zlib from 1.2.8 to 1.2.11 changed behavior when windowBits
 is set to 8 for raw deflate streams. zlib would automatically set windowBits
@@ -494,35 +494,35 @@ that effectively uses an 8-bit window only.
 added: v0.5.8
 -->
 
-Creates and returns a new [Gunzip][] object with the given [options][].
+Creates and returns a new [Gunzip][] object with the given [`options`][].
 
 ## zlib.createGzip([options])
 <!-- YAML
 added: v0.5.8
 -->
 
-Creates and returns a new [Gzip][] object with the given [options][].
+Creates and returns a new [Gzip][] object with the given [`options`][].
 
 ## zlib.createInflate([options])
 <!-- YAML
 added: v0.5.8
 -->
 
-Creates and returns a new [Inflate][] object with the given [options][].
+Creates and returns a new [Inflate][] object with the given [`options`][].
 
 ## zlib.createInflateRaw([options])
 <!-- YAML
 added: v0.5.8
 -->
 
-Creates and returns a new [InflateRaw][] object with the given [options][].
+Creates and returns a new [InflateRaw][] object with the given [`options`][].
 
 ## zlib.createUnzip([options])
 <!-- YAML
 added: v0.5.8
 -->
 
-Creates and returns a new [Unzip][] object with the given [options][].
+Creates and returns a new [Unzip][] object with the given [`options`][].
 
 ## Convenience Methods
 
@@ -771,6 +771,7 @@ Decompress a chunk of data with [Unzip][].
 [`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
 [`DataView`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
 [`TypedArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+[`options`]: #zlib_class_options
 [DeflateRaw]: #zlib_class_zlib_deflateraw
 [Deflate]: #zlib_class_zlib_deflate
 [Gunzip]: #zlib_class_zlib_gunzip
@@ -778,7 +779,6 @@ Decompress a chunk of data with [Unzip][].
 [InflateRaw]: #zlib_class_zlib_inflateraw
 [Inflate]: #zlib_class_zlib_inflate
 [Memory Usage Tuning]: #zlib_memory_usage_tuning
-[options]: #zlib_class_options
 [Unzip]: #zlib_class_zlib_unzip
 [`UV_THREADPOOL_SIZE`]: cli.html#cli_uv_threadpool_size_size
 [`zlib.bytesWritten`]: #zlib_zlib_byteswritten


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is an example of tricky doc issues we may have.

When we create too common bottom references, there are two dangers:

1. Inside the module document, there can be false-positive linkification in function signatures and maybe other places. The linkification in signature deletes `[]` square brackets and optional parameters become mandatory. See examples: [`zlib.createDeflate([options])`](https://nodejs.org/api/zlib.html#zlib_zlib_createdeflate_options), [`zlib.createDeflateRaw([options])`](https://nodejs.org/api/zlib.html#zlib_zlib_createdeflateraw_options) and so on.

2. When these references are merged into the `all.html`, the `[]` square brackets deletion is complicated with confusing wrong links. See examples (beware that `all.html` is a big file): [`new Agent([options])`](https://nodejs.org/api/all.html#http_new_agent_options), [`new net.Socket([options])`](https://nodejs.org/api/all.html#net_new_net_socket_options), [`os.userInfo([options])`](https://nodejs.org/api/all.html#os_os_userinfo_options), [`repl.start([options])`](https://nodejs.org/api/all.html#repl_repl_start_options) etc. which currenty refer to `zlib` `option` class that is wrong.