### PR TITLE
assert: fix actual & expected input

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -471,7 +471,7 @@ function expectsError(stackStartFn, actual, error, message) {
                                      error);
     }
     message = error;
-    error = null;
+    error = undefined;
   }
 
   if (actual === NO_EXCEPTION_SENTINEL) {
@@ -482,7 +482,7 @@ function expectsError(stackStartFn, actual, error, message) {
     details += message ? `: ${message}` : '.';
     const fnType = stackStartFn === rejects ? 'rejection' : 'exception';
     innerFail({
-      actual,
+      actual: undefined,
       expected: error,
       operator: stackStartFn.name,
       message: `Missing expected ${fnType}${details}`,
@@ -500,7 +500,7 @@ function expectsNoError(stackStartFn, actual, error, message) {
 
   if (typeof error === 'string') {
     message = error;
-    error = null;
+    error = undefined;
   }
 
   if (!error || expectedException(actual, error)) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -199,32 +199,40 @@ a.throws(() => thrower(TypeError), (err) => {
   const noop = () => {};
   assert.throws(
     () => { a.throws((noop)); },
-    common.expectsError({
+    {
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception\.$/,
-      operator: 'throws'
-    }));
+      message: 'Missing expected exception.',
+      operator: 'throws',
+      actual: undefined,
+      expected: undefined
+    });
 
   assert.throws(
     () => { a.throws(noop, TypeError); },
-    common.expectsError({
+    {
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception \(TypeError\)\.$/
-    }));
+      message: 'Missing expected exception (TypeError).',
+      actual: undefined,
+      expected: TypeError
+    });
 
   assert.throws(
     () => { a.throws(noop, 'fhqwhgads'); },
-    common.expectsError({
+    {
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception: fhqwhgads$/
-    }));
+      message: 'Missing expected exception: fhqwhgads',
+      actual: undefined,
+      expected: undefined
+    });
 
   assert.throws(
     () => { a.throws(noop, TypeError, 'fhqwhgads'); },
-    common.expectsError({
+    {
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception \(TypeError\): fhqwhgads$/
-    }));
+      message: 'Missing expected exception (TypeError): fhqwhgads',
+      actual: undefined,
+      expected: TypeError
+    });
 
   let threw = false;
   try {


### PR DESCRIPTION
This makes sure the actual and expected values on the error thrown
by `assert.throws` etc. are always as they should be.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
