### PR TITLE
tools: stricter no-undef eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,7 +185,7 @@ module.exports = {
     'no-this-before-super': 'error',
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'error',
-    'no-undef': 'error',
+    'no-undef': ['error', { typeof: true }],
     'no-undef-init': 'error',
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -350,7 +350,7 @@ function validateLen(len) {
   let err;
 
   if (!isInt32(len)) {
-    if (typeof value !== 'number') {
+    if (typeof len !== 'number') {
       err = new ERR_INVALID_ARG_TYPE('len', 'number', len);
     } else {
       // TODO(BridgeAR): Improve this error message.


### PR DESCRIPTION
By default eslint does not validate variables that are placed in a
typeof check. This caused a error that is fixed in this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
