### PR TITLE
fs: choose right callback function in fs.access

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -173,17 +173,17 @@ Object.defineProperties(fs, {
 });
 
 fs.access = function(path, mode, callback) {
-  if (typeof mode === 'function') {
-    callback = mode;
+  path = getPathFromURL(path);
+  validatePath(path);
+  var req = new FSReqWrap();
+  req.oncomplete = makeCallback(callback || mode);
+
+  if (callback !== undefined) {
+    mode = mode | 0;
+  } else {
     mode = fs.F_OK;
   }
 
-  path = getPathFromURL(path);
-  validatePath(path);
-
-  mode = mode | 0;
-  var req = new FSReqWrap();
-  req.oncomplete = makeCallback(callback);
   binding.access(pathModule.toNamespacedPath(path), mode, req);
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -178,7 +178,7 @@ fs.access = function(path, mode, callback) {
   var req = new FSReqWrap();
   req.oncomplete = makeCallback(callback || mode);
 
-  if (callback !== undefined) {
+  if (mode !== null && mode !== undefined && typeof mode !== 'function') {
     mode = mode | 0;
   } else {
     mode = fs.F_OK;

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -112,6 +112,24 @@ common.expectsError(
     type: TypeError
   });
 
+common.expectsError(
+  () => {
+    fs.access(__filename);
+  },
+  {
+    code: 'ERR_INVALID_CALLBACK',
+    type: TypeError
+  });
+
+common.expectsError(
+  () => {
+    fs.access(__filename, () => {}, {});
+  },
+  {
+    code: 'ERR_INVALID_CALLBACK',
+    type: TypeError
+  });
+
 // Regular access should not throw.
 fs.accessSync(__filename);
 const mode = fs.F_OK | fs.R_OK | fs.W_OK;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.


Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
in `fs.access`, I think we should use the third paramter as callback function if `arguments.length > 2`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
