### PR TITLE
build: check without_ssl in warn openssl_no_asm

### DIFF
--- a/configure
+++ b/configure
@@ -1083,7 +1083,8 @@ def configure_openssl(o):
   ('llvm_version' in variables and variables['llvm_version'] >= '3.3') or \
   ('nasm_version' in variables and variables['nasm_version'] >= '2.10')
 
-  if not openssl110_asm_supported and variables['openssl_no_asm'] == 0:
+  if not options.without_ssl and not openssl110_asm_supported and \
+	  variables['openssl_no_asm'] == 0:
     warn('''openssl_no_asm is enabled due to missed or old assembler.
             Please refer BUILDING.md''')
     variables['openssl_no_asm'] = 1


### PR DESCRIPTION
Currently when configuring `--without-ssl`  the following warning is
displayed:
```console
WARNING: openssl_no_asm is enabled due to missed or old assembler.
            Please refer BUILDING.md
```
This commit adds a check of options.without_ssl to avoid this warning
when --without-ssl is used.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
