### PR TITLE
timers: fix subsequent enroll calls not working

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -353,13 +353,14 @@ exports.unenroll = util.deprecate(unenroll,
 // This function does not start the timer, see `active()`.
 // Using existing objects as timers slightly reduces object overhead.
 function enroll(item, msecs) {
-  item._idleTimeout = validateTimerDuration(msecs);
+  msecs = validateTimerDuration(msecs);
 
   // if this item was already in a list somewhere
   // then we should unenroll it from that
   if (item._idleNext) unenroll(item);
 
   L.init(item);
+  item._idleTimeout = msecs;
 }
 
 exports.enroll = util.deprecate(enroll,

--- a/test/parallel/test-timers-enroll-second-time.js
+++ b/test/parallel/test-timers-enroll-second-time.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const timers = require('timers');
+
+let didCall = false;
+const enrollObj = {
+  _onTimeout: common.mustCall(() => assert(didCall)),
+};
+
+timers.enroll(enrollObj, 1);
+timers.enroll(enrollObj, 10);
+timers.active(enrollObj);
+setTimeout(common.mustCall(() => { didCall = true; }), 1);

--- a/test/parallel/test-timers-enroll-second-time.js
+++ b/test/parallel/test-timers-enroll-second-time.js
@@ -5,12 +5,12 @@ const common = require('../common');
 const assert = require('assert');
 const timers = require('timers');
 
-let didCall = false;
 const enrollObj = {
-  _onTimeout: common.mustCall(() => assert(didCall)),
+  _onTimeout: common.mustCall(),
 };
 
 timers.enroll(enrollObj, 1);
+assert.strictEqual(enrollObj._idleTimeout, 1);
 timers.enroll(enrollObj, 10);
+assert.strictEqual(enrollObj._idleTimeout, 10);
 timers.active(enrollObj);
-setTimeout(common.mustCall(() => { didCall = true; }), 1);


### PR DESCRIPTION
This PR resolves one recently introduced bug and one long-standing incompatibility with browser behaviour:

1. A bug was introduced in a recent `semver-major` PR which makes it impossible to `enroll` an already `enrolled` object. This resolves the issue by keeping the validation function at the top but moving the assignment of the potentially modified `msecs` below.

2. ~~Node.js currently doesn't match browser behaviour when it comes to intervals that throw during their execution. In all browsers, the interval continues running but in Node.js it will never be rescheduled after a throw nor will the destroy async hook for that interval fire.~~

Edit: The second change has been backed out now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)