### PR TITLE
crypto: move Decipher.finaltol to End-of-Life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -958,11 +958,11 @@ property to a string before assigning it to `process.env`.
 <a id="DEP0105"></a>
 ### DEP0105: decipher.finaltol
 
-Type: Runtime
+Type: End-of-Life
 
-`decipher.finaltol()` has never been documented and is currently an alias for
-[`decipher.final()`][]. In the future, this API will likely be removed, and it
-is recommended to use [`decipher.final()`][] instead.
+`decipher.finaltol()` has never been documented and was an alias for
+[`decipher.final()`][]. This API has been removed, and it is recommended to use
+[`decipher.final()`][] instead.
 
 <a id="DEP0106"></a>
 ### DEP0106: crypto.createCipher and crypto.createDecipher

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -31,7 +31,7 @@ const LazyTransform = require('internal/streams/lazy_transform');
 const { StringDecoder } = require('string_decoder');
 
 const { inherits } = require('util');
-const { deprecate, normalizeEncoding } = require('internal/util');
+const { normalizeEncoding } = require('internal/util');
 
 function rsaPublic(method, defaultPadding) {
   return function(options, buffer) {
@@ -240,10 +240,6 @@ Cipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;
 Cipheriv.prototype.setAAD = Cipher.prototype.setAAD;
 
 
-const finaltol = deprecate(Cipher.prototype.final,
-                           'crypto.Decipher.finaltol is deprecated. Use ' +
-                           'crypto.Decipher.final instead.', 'DEP0105');
-
 function Decipher(cipher, password, options) {
   if (!(this instanceof Decipher))
     return new Decipher(cipher, password, options);
@@ -275,7 +271,6 @@ Decipher.prototype._transform = Cipher.prototype._transform;
 Decipher.prototype._flush = Cipher.prototype._flush;
 Decipher.prototype.update = Cipher.prototype.update;
 Decipher.prototype.final = Cipher.prototype.final;
-Decipher.prototype.finaltol = finaltol;
 Decipher.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 Decipher.prototype.getAuthTag = Cipher.prototype.getAuthTag;
 Decipher.prototype.setAuthTag = Cipher.prototype.setAuthTag;
@@ -322,7 +317,6 @@ Decipheriv.prototype._transform = Cipher.prototype._transform;
 Decipheriv.prototype._flush = Cipher.prototype._flush;
 Decipheriv.prototype.update = Cipher.prototype.update;
 Decipheriv.prototype.final = Cipher.prototype.final;
-Decipheriv.prototype.finaltol = finaltol;
 Decipheriv.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
 Decipheriv.prototype.getAuthTag = Cipher.prototype.getAuthTag;
 Decipheriv.prototype.setAuthTag = Cipher.prototype.setAuthTag;

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -11,9 +11,7 @@ common.expectWarning('DeprecationWarning', [
   ['crypto.Credentials is deprecated. Use tls.SecureContext instead.',
    'DEP0011'],
   ['crypto.createCredentials is deprecated. Use tls.createSecureContext ' +
-  'instead.', 'DEP0010'],
-  ['crypto.Decipher.finaltol is deprecated. Use crypto.Decipher.final instead.',
-   'DEP0105']
+  'instead.', 'DEP0010']
 ]);
 
 // Accessing the deprecated function is enough to trigger the warning event.
@@ -22,15 +20,3 @@ common.expectWarning('DeprecationWarning', [
 // mapped to the correct non-deprecated function.
 assert.strictEqual(crypto.Credentials, tls.SecureContext);
 assert.strictEqual(crypto.createCredentials, tls.createSecureContext);
-
-{
-  const cipher = crypto.createCipheriv('aes-128-cbc', '0000000000000000',
-                                       '0000000000000000');
-  const ciphertext = cipher.update('Node.js', 'utf8', 'hex') +
-                     cipher.final('hex');
-  const decipher = crypto.createDecipheriv('aes-128-cbc', '0000000000000000',
-                                           '0000000000000000');
-  const plaintext = decipher.update(ciphertext, 'hex', 'utf8') +
-                    decipher.finaltol('utf8');
-  assert.strictEqual(plaintext, 'Node.js');
-}

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -29,39 +29,34 @@ const crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
-function aes256(decipherFinal) {
-  const iv = Buffer.from('00000000000000000000000000000000', 'hex');
-  const key = Buffer.from('0123456789abcdef0123456789abcdef' +
-                          '0123456789abcdef0123456789abcdef', 'hex');
+const iv = Buffer.from('00000000000000000000000000000000', 'hex');
+const key = Buffer.from('0123456789abcdef0123456789abcdef' +
+                        '0123456789abcdef0123456789abcdef', 'hex');
 
-  function encrypt(val, pad) {
-    const c = crypto.createCipheriv('aes256', key, iv);
-    c.setAutoPadding(pad);
-    return c.update(val, 'utf8', 'latin1') + c.final('latin1');
-  }
-
-  function decrypt(val, pad) {
-    const c = crypto.createDecipheriv('aes256', key, iv);
-    c.setAutoPadding(pad);
-    return c.update(val, 'latin1', 'utf8') + c[decipherFinal]('utf8');
-  }
-
-  // echo 0123456789abcdef0123456789abcdef \
-  // | openssl enc -e -aes256 -nopad -K <key> -iv <iv> \
-  // | openssl enc -d -aes256 -nopad -K <key> -iv <iv>
-  let plaintext = '0123456789abcdef0123456789abcdef'; // multiple of block size
-  let encrypted = encrypt(plaintext, false);
-  let decrypted = decrypt(encrypted, false);
-  assert.strictEqual(decrypted, plaintext);
-
-  // echo 0123456789abcdef0123456789abcde \
-  // | openssl enc -e -aes256 -K <key> -iv <iv> \
-  // | openssl enc -d -aes256 -K <key> -iv <iv>
-  plaintext = '0123456789abcdef0123456789abcde'; // not a multiple
-  encrypted = encrypt(plaintext, true);
-  decrypted = decrypt(encrypted, true);
-  assert.strictEqual(decrypted, plaintext);
+function encrypt(val, pad) {
+  const c = crypto.createCipheriv('aes256', key, iv);
+  c.setAutoPadding(pad);
+  return c.update(val, 'utf8', 'latin1') + c.final('latin1');
 }
 
-aes256('final');
-aes256('finaltol');
+function decrypt(val, pad) {
+  const c = crypto.createDecipheriv('aes256', key, iv);
+  c.setAutoPadding(pad);
+  return c.update(val, 'latin1', 'utf8') + c.final('utf8');
+}
+
+// echo 0123456789abcdef0123456789abcdef \
+// | openssl enc -e -aes256 -nopad -K <key> -iv <iv> \
+// | openssl enc -d -aes256 -nopad -K <key> -iv <iv>
+let plaintext = '0123456789abcdef0123456789abcdef'; // multiple of block size
+let encrypted = encrypt(plaintext, false);
+let decrypted = decrypt(encrypted, false);
+assert.strictEqual(decrypted, plaintext);
+
+// echo 0123456789abcdef0123456789abcde \
+// | openssl enc -e -aes256 -K <key> -iv <iv> \
+// | openssl enc -d -aes256 -K <key> -iv <iv>
+plaintext = '0123456789abcdef0123456789abcde'; // not a multiple
+encrypted = encrypt(plaintext, true);
+decrypted = decrypt(encrypted, true);
+assert.strictEqual(decrypted, plaintext);


### PR DESCRIPTION
`Decipher.finaltol` was deprecated in https://github.com/nodejs/node/pull/19353 and should be removed in node 11.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
