### PR TITLE
doc: remove superfluous word from crypto doc

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -233,9 +233,8 @@ added: v0.1.94
 -->
 - `outputEncoding` {string}
 - Returns: {Buffer | string} Any remaining enciphered contents.
-  If `outputEncoding` parameter is one of `'latin1'`, `'base64'` or `'hex'`,
-  a string is returned. If an `outputEncoding` is not provided, a [`Buffer`][]
-  is returned.
+  If `outputEncoding` is one of `'latin1'`, `'base64'` or `'hex'`, a string is
+  returned. If an `outputEncoding` is not provided, a [`Buffer`][] is returned.
 
 Once the `cipher.final()` method has been called, the `Cipher` object can no
 longer be used to encrypt data. Attempts to call `cipher.final()` more than


### PR DESCRIPTION
It should probably have been "If *the* `outputEncoding` parameter is...", but "If `outputEncoding` is..." works as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
