### PR TITLE
timers: fix clearInterval to work with timers from setTimeout

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -52,8 +52,8 @@ Returns a reference to the `Immediate`.
 ## Class: Timeout
 
 This object is created internally and is returned from [`setTimeout()`][] and
-[`setInterval()`][]. It can be passed to [`clearTimeout()`][] or
-[`clearInterval()`][] (respectively) in order to cancel the scheduled actions.
+[`setInterval()`][]. It can be passed to either [`clearTimeout()`][] or
+[`clearInterval()`][] in order to cancel the scheduled actions.
 
 By default, when a timer is scheduled using either [`setTimeout()`][] or
 [`setInterval()`][], the Node.js event loop will continue running as long as the

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -496,13 +496,12 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   return timeout;
 };
 
-exports.clearInterval = function(timer) {
-  if (timer && timer._repeat) {
-    timer._repeat = null;
-    clearTimeout(timer);
-  }
+exports.clearInterval = function clearInterval(timer) {
+  // clearTimeout and clearInterval can be used to clear timers created from
+  // both setTimeout and setInterval, as specified by HTML Living Standard:
+  // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval
+  clearTimeout(timer);
 };
-
 
 function unrefdHandle(timer, now) {
   try {

--- a/test/parallel/test-timers-clear-timeout-interval-equivalent.js
+++ b/test/parallel/test-timers-clear-timeout-interval-equivalent.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+
+// This test makes sure that timers created with setTimeout can be disarmed by
+// clearInterval and that timers created with setInterval can be disarmed by
+// clearTimeout.
+//
+// This behavior is documented in the HTML Living Standard:
+//
+// * Refs: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval
+
+// Disarm interval with clearTimeout.
+const interval = setInterval(common.mustNotCall(), 1);
+clearTimeout(interval);
+
+// Disarm timeout with clearInterval.
+const timeout = setTimeout(common.mustNotCall(), 1);
+clearInterval(timeout);


### PR DESCRIPTION
According to HTML Living Standard, "either method [clearInterval or
clearTimeout] can be used to clear timers created by setTimeout() or
setInterval()."[1].

The current implementation of `clearTimeout` is already able to destroy a
timer created by `setInterval`, but not the other way around.

Refs: https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval

##### Checklist

- [x] `make -j4 jstest` (UNIX)
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
- [x] documentation is changed or added


#### Affected core subsystem(s)

`timers`.