### PR TITLE
http2: fix ping duration calculation

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2616,8 +2616,8 @@ void Http2Session::Http2Ping::Send(uint8_t* payload) {
 }
 
 void Http2Session::Http2Ping::Done(bool ack, const uint8_t* payload) {
-  session_->statistics_.ping_rtt = (uv_hrtime() - startTime_);
-  double duration = (session_->statistics_.ping_rtt - startTime_) / 1e6;
+  session_->statistics_.ping_rtt = uv_hrtime() - startTime_;
+  double duration = session_->statistics_.ping_rtt / 1e6;
 
   Local<Value> buf = Undefined(env()->isolate());
   if (payload != nullptr) {


### PR DESCRIPTION
`startTime_` was being subtracted twice.

/cc @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
