### PR TITLE
errors: alter ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -750,10 +750,8 @@ E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
   'Responses with %s status must not have a payload', Error);
 E('ERR_HTTP2_PING_CANCEL', 'HTTP2 ping cancelled', Error);
 E('ERR_HTTP2_PING_LENGTH', 'HTTP2 ping payload must be 8 bytes', RangeError);
-
-// This should probably be a `TypeError`.
 E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
-  'Cannot set HTTP/2 pseudo-headers', Error);
+  'Cannot set HTTP/2 pseudo-headers', TypeError);
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams', Error);
 E('ERR_HTTP2_SEND_FILE', 'Directories cannot be sent', Error);
 E('ERR_HTTP2_SEND_FILE_NOSEEK',

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -63,7 +63,7 @@ server.listen(0, common.mustCall(function() {
       () => response.setHeader(header, 'foobar'),
       {
         code: 'ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
-        type: Error,
+        type: TypeError,
         message: 'Cannot set HTTP/2 pseudo-headers'
       })
     );


### PR DESCRIPTION
changes the base instance for ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED
from Error to TypeError as a more accurate representation
of the error. 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
