### PR TITLE
http2: refactor how trailers are done

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1017,6 +1017,19 @@ When setting the priority for an HTTP/2 stream, the stream may be marked as
 a dependency for a parent stream. This error code is used when an attempt is
 made to mark a stream and dependent of itself.
 
+<a id="ERR_HTTP2_TRAILERS_ALREADY_SENT"></a>
+### ERR_HTTP2_TRAILERS_ALREADY_SENT
+
+Trailing headers have already been sent on the `Http2Stream`.
+
+<a id="ERR_HTTP2_TRAILERS_NOT_READY"></a>
+### ERR_HTTP2_TRAILERS_NOT_READY
+
+The `http2stream.sendTrailers()` method cannot be called until after the
+`'wantTrailers'` event is emitted on an `Http2Stream` object. The
+`'wantTrailers'` event will only be emitted if the `waitForTrailers` option
+is set for the `Http2Stream`.
+
 <a id="ERR_HTTP2_UNSUPPORTED_PROTOCOL"></a>
 ### ERR_HTTP2_UNSUPPORTED_PROTOCOL
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -842,6 +842,11 @@ E('ERR_HTTP2_STREAM_CANCEL', 'The pending stream has been canceled', Error);
 E('ERR_HTTP2_STREAM_ERROR', 'Stream closed with error code %s', Error);
 E('ERR_HTTP2_STREAM_SELF_DEPENDENCY',
   'A stream cannot depend on itself', Error);
+E('ERR_HTTP2_TRAILERS_ALREADY_SENT',
+  'Trailing headers have already been sent', Error);
+E('ERR_HTTP2_TRAILERS_NOT_READY',
+  'Trailing headers cannot be sent until after the wantTrailers event is ' +
+  'emitted', Error);
 E('ERR_HTTP2_UNSUPPORTED_PROTOCOL', 'protocol "%s" is unsupported.', Error);
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot %s headers after they are sent to the client', Error);

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -358,6 +358,10 @@ class Http2ServerRequest extends Readable {
   }
 }
 
+function onStreamTrailersReady() {
+  this[kStream].sendTrailers(this[kTrailers]);
+}
+
 class Http2ServerResponse extends Stream {
   constructor(stream, options) {
     super(options);
@@ -377,6 +381,7 @@ class Http2ServerResponse extends Stream {
     stream.on('drain', onStreamDrain);
     stream.on('aborted', onStreamAbortedResponse);
     stream.on('close', this[kFinish].bind(this));
+    stream.on('wantTrailers', onStreamTrailersReady.bind(this));
   }
 
   // User land modules such as finalhandler just check truthiness of this
@@ -648,7 +653,7 @@ class Http2ServerResponse extends Stream {
     headers[HTTP2_HEADER_STATUS] = state.statusCode;
     const options = {
       endStream: state.ending,
-      getTrailers: (trailers) => Object.assign(trailers, this[kTrailers])
+      waitForTrailers: true,
     };
     this[kStream].respond(headers, options);
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -49,6 +49,8 @@ const {
     ERR_HTTP2_STREAM_CANCEL,
     ERR_HTTP2_STREAM_ERROR,
     ERR_HTTP2_STREAM_SELF_DEPENDENCY,
+    ERR_HTTP2_TRAILERS_ALREADY_SENT,
+    ERR_HTTP2_TRAILERS_NOT_READY,
     ERR_HTTP2_UNSUPPORTED_PROTOCOL,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_CALLBACK,
@@ -295,25 +297,18 @@ function tryClose(fd) {
   fs.close(fd, (err) => assert.ifError(err));
 }
 
-// Called to determine if there are trailers to be sent at the end of a
-// Stream. The 'getTrailers' callback is invoked and passed a holder object.
-// The trailers to return are set on that object by the handler. Once the
-// event handler returns, those are sent off for processing. Note that this
-// is a necessarily synchronous operation. We need to know immediately if
-// there are trailing headers to send.
+// Called when the Http2Stream has finished sending data and is ready for
+// trailers to be sent. This will only be called if the { hasOptions: true }
+// option is set.
 function onStreamTrailers() {
   const stream = this[kOwner];
+  stream[kState].trailersReady = true;
   if (stream.destroyed)
-    return [];
-  const trailers = Object.create(null);
-  stream[kState].getTrailers.call(stream, trailers);
-  const headersList = mapToHeaders(trailers, assertValidPseudoHeaderTrailer);
-  if (!Array.isArray(headersList)) {
-    stream.destroy(headersList);
-    return [];
+    return;
+  if (!stream.emit('wantTrailers')) {
+    // There are no listeners, send empty trailing HEADERS frame and close.
+    stream.sendTrailers({});
   }
-  stream[kSentTrailers] = trailers;
-  return headersList;
 }
 
 // Submit an RST-STREAM frame to be sent to the remote peer.
@@ -527,10 +522,8 @@ function requestOnConnect(headers, options) {
   if (options.endStream)
     streamOptions |= STREAM_OPTION_EMPTY_PAYLOAD;
 
-  if (typeof options.getTrailers === 'function') {
+  if (options.waitForTrailers)
     streamOptions |= STREAM_OPTION_GET_TRAILERS;
-    this[kState].getTrailers = options.getTrailers;
-  }
 
   // ret will be either the reserved stream ID (if positive)
   // or an error code (if negative)
@@ -1408,11 +1401,6 @@ class ClientHttp2Session extends Http2Session {
       throw new ERR_INVALID_OPT_VALUE('endStream', options.endStream);
     }
 
-    if (options.getTrailers !== undefined &&
-      typeof options.getTrailers !== 'function') {
-      throw new ERR_INVALID_OPT_VALUE('getTrailers', options.getTrailers);
-    }
-
     const headersList = mapToHeaders(headers);
     if (!Array.isArray(headersList))
       throw headersList;
@@ -1504,7 +1492,8 @@ class Http2Stream extends Duplex {
     this[kState] = {
       flags: STREAM_FLAGS_PENDING,
       rstCode: NGHTTP2_NO_ERROR,
-      writeQueueSize: 0
+      writeQueueSize: 0,
+      trailersReady: false
     };
 
     this.on('resume', streamOnResume);
@@ -1743,6 +1732,33 @@ class Http2Stream extends Duplex {
       return;
     }
     priorityFn();
+  }
+
+  sendTrailers(headers) {
+    if (this.destroyed || this.closed)
+      throw new ERR_HTTP2_INVALID_STREAM();
+    if (this[kSentTrailers])
+      throw new ERR_HTTP2_TRAILERS_ALREADY_SENT();
+    if (!this[kState].trailersReady)
+      throw new ERR_HTTP2_TRAILERS_NOT_READY();
+
+    assertIsObject(headers, 'headers');
+    headers = Object.assign(Object.create(null), headers);
+
+    const session = this[kSession];
+    debug(`Http2Stream ${this[kID]} [Http2Session ` +
+    `${sessionName(session[kType])}]: sending trailers`);
+
+    this[kUpdateTimer]();
+
+    const headersList = mapToHeaders(headers, assertValidPseudoHeaderTrailer);
+    if (!Array.isArray(headersList))
+      throw headersList;
+    this[kSentTrailers] = headers;
+
+    const ret = this[kHandle].trailers(headersList);
+    if (ret < 0)
+      this.destroy(new NghttpError(ret));
   }
 
   get closed() {
@@ -2208,13 +2224,8 @@ class ServerHttp2Stream extends Http2Stream {
     if (options.endStream)
       streamOptions |= STREAM_OPTION_EMPTY_PAYLOAD;
 
-    if (options.getTrailers !== undefined) {
-      if (typeof options.getTrailers !== 'function') {
-        throw new ERR_INVALID_OPT_VALUE('getTrailers', options.getTrailers);
-      }
+    if (options.waitForTrailers)
       streamOptions |= STREAM_OPTION_GET_TRAILERS;
-      state.getTrailers = options.getTrailers;
-    }
 
     headers = processHeaders(headers);
     const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
@@ -2274,13 +2285,8 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     let streamOptions = 0;
-    if (options.getTrailers !== undefined) {
-      if (typeof options.getTrailers !== 'function') {
-        throw new ERR_INVALID_OPT_VALUE('getTrailers', options.getTrailers);
-      }
+    if (options.waitForTrailers)
       streamOptions |= STREAM_OPTION_GET_TRAILERS;
-      this[kState].getTrailers = options.getTrailers;
-    }
 
     if (typeof fd !== 'number')
       throw new ERR_INVALID_ARG_TYPE('fd', 'number', fd);
@@ -2340,13 +2346,8 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     let streamOptions = 0;
-    if (options.getTrailers !== undefined) {
-      if (typeof options.getTrailers !== 'function') {
-        throw new ERR_INVALID_OPT_VALUE('getTrailers', options.getTrailers);
-      }
+    if (options.waitForTrailers)
       streamOptions |= STREAM_OPTION_GET_TRAILERS;
-      this[kState].getTrailers = options.getTrailers;
-    }
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -10,7 +10,6 @@ const http2 = require('http2');
 
 const optionsToTest = {
   endStream: 'boolean',
-  getTrailers: 'function',
   weight: 'number',
   parent: 'number',
   exclusive: 'boolean',

--- a/test/parallel/test-http2-compat-serverrequest-trailers.js
+++ b/test/parallel/test-http2-compat-serverrequest-trailers.js
@@ -50,15 +50,18 @@ server.listen(0, common.mustCall(function() {
       ':scheme': 'http',
       ':authority': `localhost:${port}`
     };
-    const request = client.request(headers, {
-      getTrailers(trailers) {
-        trailers['x-fOo'] = 'xOxOxOx';
-        trailers['x-foO'] = 'OxOxOxO';
-        trailers['X-fOo'] = 'xOxOxOx';
-        trailers['X-foO'] = 'OxOxOxO';
-        trailers['x-foo-test'] = 'test, test';
-      }
+    const request = client.request(headers, { waitForTrailers: true });
+
+    request.on('wantTrailers', () => {
+      request.sendTrailers({
+        'x-fOo': 'xOxOxOx',
+        'x-foO': 'OxOxOxO',
+        'X-fOo': 'xOxOxOx',
+        'X-foO': 'OxOxOxO',
+        'x-foo-test': 'test, test'
+      });
     });
+
     request.resume();
     request.on('end', common.mustCall(function() {
       server.close();

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -28,6 +28,15 @@ const server = h2.createServer((request, response) => {
     }
   );
 
+  response.stream.on('close', () => {
+    response.createPushResponse({
+      ':path': '/pushed',
+      ':method': 'GET'
+    }, common.mustCall((error) => {
+      assert.strictEqual(error.code, 'ERR_HTTP2_INVALID_STREAM');
+    }));
+  });
+
   response.createPushResponse({
     ':path': '/pushed',
     ':method': 'GET'
@@ -36,16 +45,6 @@ const server = h2.createServer((request, response) => {
     assert.strictEqual(push.stream.id % 2, 0);
     push.end(pushExpect);
     response.end();
-
-    // wait for a tick, so the stream is actually closed
-    setImmediate(function() {
-      response.createPushResponse({
-        ':path': '/pushed',
-        ':method': 'GET'
-      }, common.mustCall((error) => {
-        assert.strictEqual(error.code, 'ERR_HTTP2_INVALID_STREAM');
-      }));
-    });
   }));
 });
 

--- a/test/parallel/test-http2-misused-pseudoheaders.js
+++ b/test/parallel/test-http2-misused-pseudoheaders.js
@@ -20,15 +20,16 @@ server.on('stream', common.mustCall((stream) => {
                         });
   });
 
-  stream.respond({}, {
-    getTrailers: common.mustCall((trailers) => {
-      trailers[':status'] = 'bar';
-    })
-  });
+  stream.respond({}, { waitForTrailers: true });
 
-  stream.on('error', common.expectsError({
-    code: 'ERR_HTTP2_INVALID_PSEUDOHEADER'
-  }));
+  stream.on('wantTrailers', () => {
+    common.expectsError(() => {
+      stream.sendTrailers({ ':status': 'bar' });
+    }, {
+      code: 'ERR_HTTP2_INVALID_PSEUDOHEADER'
+    });
+    stream.close();
+  });
 
   stream.end('hello world');
 }));
@@ -37,12 +38,6 @@ server.on('stream', common.mustCall((stream) => {
 server.listen(0, common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
-
-  req.on('error', common.expectsError({
-    code: 'ERR_HTTP2_STREAM_ERROR',
-    type: Error,
-    message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
-  }));
 
   req.on('response', common.mustCall());
   req.resume();

--- a/test/parallel/test-http2-no-wanttrailers-listener.js
+++ b/test/parallel/test-http2-no-wanttrailers-listener.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+// we use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.respond(undefined, { waitForTrailers: true });
+  // There is no wantTrailers handler so this should close naturally
+  // without hanging. If the test completes without timing out, then
+  // it passes.
+  stream.end('ok');
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const client = h2.connect(`http://localhost:${this.address().port}`);
+  const req = client.request();
+  req.resume();
+  req.on('trailers', common.mustCall((headers) => {
+    assert.strictEqual(Object.keys(headers).length, 0);
+  }));
+  req.on('close', common.mustCall(() => {
+    server.close();
+    client.close();
+  }));
+}));

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -7,48 +7,13 @@ if (!common.hasCrypto)
 const http2 = require('http2');
 const { Http2Stream } = process.binding('http2');
 
-const types = {
-  boolean: true,
-  function: () => {},
-  number: 1,
-  object: {},
-  array: [],
-  null: null,
-  symbol: Symbol('test')
-};
-
 const server = http2.createServer();
 
 Http2Stream.prototype.respond = () => 1;
 server.on('stream', common.mustCall((stream) => {
 
-  // Check for all possible TypeError triggers on options.getTrailers
-  Object.entries(types).forEach(([type, value]) => {
-    if (type === 'function') {
-      return;
-    }
-
-    common.expectsError(
-      () => stream.respond({
-        'content-type': 'text/plain'
-      }, {
-        ['getTrailers']: value
-      }),
-      {
-        type: TypeError,
-        code: 'ERR_INVALID_OPT_VALUE',
-        message: `The value "${String(value)}" is invalid ` +
-                  'for option "getTrailers"'
-      }
-    );
-  });
-
   // Send headers
-  stream.respond({
-    'content-type': 'text/plain'
-  }, {
-    ['getTrailers']: () => common.mustCall()
-  });
+  stream.respond({ 'content-type': 'text/plain' });
 
   // Should throw if headers already sent
   common.expectsError(

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -9,8 +9,7 @@ const http2 = require('http2');
 const optionsWithTypeError = {
   offset: 'number',
   length: 'number',
-  statCheck: 'function',
-  getTrailers: 'function'
+  statCheck: 'function'
 };
 
 const types = {

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -10,8 +10,7 @@ const fs = require('fs');
 const optionsWithTypeError = {
   offset: 'number',
   length: 'number',
-  statCheck: 'function',
-  getTrailers: 'function'
+  statCheck: 'function'
 };
 
 const types = {

--- a/test/parallel/test-http2-sent-headers.js
+++ b/test/parallel/test-http2-sent-headers.js
@@ -12,10 +12,9 @@ server.on('stream', common.mustCall((stream) => {
   stream.additionalHeaders({ ':status': 102 });
   assert.strictEqual(stream.sentInfoHeaders[0][':status'], 102);
 
-  stream.respond({ abc: 'xyz' }, {
-    getTrailers(headers) {
-      headers.xyz = 'abc';
-    }
+  stream.respond({ abc: 'xyz' }, { waitForTrailers: true });
+  stream.on('wantTrailers', () => {
+    stream.sendTrailers({ xyz: 'abc' });
   });
   assert.strictEqual(stream.sentHeaders.abc, 'xyz');
   assert.strictEqual(stream.sentHeaders[':status'], 200);


### PR DESCRIPTION
Rather than an option, introduce a method and an event...

```js
server.on('stream', (stream) => {
  stream.respond(undefined, { hasTrailers: true });
  stream.on('trailers-ready', () => {
    stream.trailers({ abc: 'xyz'});
  });
  stream.end('hello world');
});
```

The `'trailers-ready'` event is necessary because of
`respondWithFile` and `respondWithFD`... neither of
which cause the `Http2Stream` to emit the normal stream
related events (by design).

If using the Stream API, however, we can also do:

```js
server.on('stream', (stream) => {
  stream.respond(undefined, { hasTrailers: true });
  stream.on('finish', () => {
    stream.trailers({ abc: 'xyz' });
  });
  stream.end('hello world');
```

This is a breaking change in the API such that the prior
`options.getTrailers` is no longer supported at all.
Ordinarily this would be semver-major and require a
deprecation but the http2 stuff is still experimental.

/cc @mcollina @addaleax @sebdeckers @apapirovski @trivikr @nodejs/http2

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
