### PR TITLE
errors: alter ERR_INVALID_CURSOR_POS

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -874,10 +874,8 @@ E('ERR_INVALID_BUFFER_SIZE',
   'Buffer size must be a multiple of %s', RangeError);
 E('ERR_INVALID_CALLBACK', 'Callback must be a function', TypeError);
 E('ERR_INVALID_CHAR', invalidChar, TypeError);
-
-// This should probably be a `TypeError`.
 E('ERR_INVALID_CURSOR_POS',
-  'Cannot set cursor row without setting its column', Error);
+  'Cannot set cursor row without setting its column', TypeError);
 E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name', TypeError);
 E('ERR_INVALID_FD',
   '"fd" must be a positive integer: %s', RangeError);

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -77,7 +77,7 @@ writable.data = '';
 common.expectsError(
   () => readline.cursorTo(writable, 'a', 1),
   {
-    type: Error,
+    type: TypeError,
     code: 'ERR_INVALID_CURSOR_POS',
     message: 'Cannot set cursor row without setting its column'
   });


### PR DESCRIPTION
changes the base instance for ERR_INVALID_CURSOR_POS
from Error to TypeError as a more accurate representation
of the error. 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
