### PR TITLE
errors: alter ERR_INVALID_DOMAIN_NAME

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -804,9 +804,7 @@ E('ERR_INVALID_CHAR', invalidChar, TypeError);
 // This should probably be a `TypeError`.
 E('ERR_INVALID_CURSOR_POS',
   'Cannot set cursor row without setting its column', Error);
-
-// This should probably be a `TypeError`.
-E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name', Error);
+E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name', TypeError);
 E('ERR_INVALID_FD',
   '"fd" must be a positive integer: %s', RangeError);
 E('ERR_INVALID_FD_TYPE', 'Unsupported fd type: %s', TypeError);

--- a/test/parallel/test-http-invalid-urls.js
+++ b/test/parallel/test-http-invalid-urls.js
@@ -19,7 +19,10 @@ function test(host) {
         `${module}.${fn} should not connect to ${host}`
       );
       const throws = () => { modules[module][fn](host, doNotCall); };
-      common.expectsError(throws, { code: 'ERR_INVALID_DOMAIN_NAME' });
+      common.expectsError(throws, {
+        type: TypeError,
+        code: 'ERR_INVALID_DOMAIN_NAME'
+      });
     });
   });
 }


### PR DESCRIPTION
changes the base instance for ERR_INVALID_DOMAIN_NAME
from Error to TypeError as a more accurate representation
of the error. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
