### PR TITLE
test: fix warning in dlopen-ping-pong/binding.cc

### DIFF
--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -23,7 +23,7 @@ typedef const char* (*ping)(void);
 static ping ping_func;
 
 void LoadLibrary(const FunctionCallbackInfo<Value>& args) {
-  const String::Utf8Value filename(args[0]);
+  const String::Utf8Value filename(args.GetIsolate(), args[0]);
   void* handle = dlopen(*filename, RTLD_LAZY);
   assert(handle != nullptr);
   ping_func = reinterpret_cast<ping>(dlsym(handle, "dlopen_ping"));


### PR DESCRIPTION
Currently, the following compiler warning is issued:
```console
../binding.cc:26:27:
warning: 'Utf8Value' is deprecated [-Wdeprecated-declarations]
  const String::Utf8Value filename(args[0]);
                          ^
```
This commit updates the code to use the Isolate version.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
