### PR TITLE
net: honor default values in Socket constructor

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -131,8 +131,11 @@ const handleConversion = {
     },
 
     got: function(message, handle, emit) {
-      var socket = new net.Socket({ handle: handle });
-      socket.readable = socket.writable = true;
+      var socket = new net.Socket({
+        handle: handle,
+        readable: true,
+        writable: true
+      });
 
       // if the socket was created by net.Server we will track the socket
       if (message.key) {

--- a/lib/internal/wrap_js_stream.js
+++ b/lib/internal/wrap_js_stream.js
@@ -72,6 +72,8 @@ class JSStreamWrap extends Socket {
     this.stream = stream;
     this[kCurrentWriteRequest] = null;
     this[kCurrentShutdownRequest] = null;
+    this.readable = stream.readable;
+    this.writable = stream.writable;
 
     // Start reading.
     this.read(0);

--- a/lib/net.js
+++ b/lib/net.js
@@ -244,6 +244,8 @@ function Socket(options) {
   else
     options = util._extend({}, options);
 
+  options.readable = options.readable || false;
+  options.writable = options.writable || false;
   const allowHalfOpen = options.allowHalfOpen;
 
   // Prevent the "no-half-open enforcer" from being inherited from `Duplex`.
@@ -283,9 +285,6 @@ function Socket(options) {
         value: 0, writable: true
       });
     }
-  } else {
-    // these will be set once there is a connection
-    this.readable = this.writable = false;
   }
 
   // shut down the socket when we're finished with it.
@@ -1537,10 +1536,10 @@ function onconnection(err, clientHandle) {
   var socket = new Socket({
     handle: clientHandle,
     allowHalfOpen: self.allowHalfOpen,
-    pauseOnCreate: self.pauseOnConnect
+    pauseOnCreate: self.pauseOnConnect,
+    readable: true,
+    writable: true
   });
-  socket.readable = socket.writable = true;
-
 
   self._connections++;
   socket.server = self;

--- a/test/parallel/test-net-socket-constructor.js
+++ b/test/parallel/test-net-socket-constructor.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+function test(sock, readable, writable) {
+  let socket;
+  if (sock instanceof net.Socket) {
+    socket = sock;
+  } else {
+    socket = new net.Socket(sock);
+    socket.unref();
+  }
+
+  assert.strictEqual(socket.readable, readable);
+  assert.strictEqual(socket.writable, writable);
+}
+
+test(undefined, false, false);
+
+const server = net.createServer(common.mustCall((socket) => {
+  test(socket, true, true);
+  test({ handle: socket._handle }, false, false);
+  test({ handle: socket._handle, readable: true, writable: true }, true, true);
+  if (socket._handle.fd >= 0) {
+    test(socket._handle.fd, false, false);
+    test({ fd: socket._handle.fd }, false, false);
+    test({ fd: socket._handle.fd, readable: true, writable: true }, true, true);
+  }
+
+  server.close();
+}));
+
+server.listen(common.mustCall(() => {
+  const { port } = server.address();
+  const socket = net.connect(port, common.mustCall(() => {
+    test(socket, true, true);
+    socket.end();
+  }));
+
+  test(socket, false, true);
+}));


### PR DESCRIPTION
Specifically `readable` and `writable` that default to `false`.

Fixes: https://github.com/libuv/libuv/issues/1794

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
