### PR TITLE
src: add HandleScope to fix error

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -50,6 +50,7 @@ inline AsyncWrap::AsyncScope::AsyncScope(AsyncWrap* wrap)
   Environment* env = wrap->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kBefore] == 0)
     return;
+  v8::HandleScope handle_scope(env->isolate());
   EmitBefore(env, wrap->get_async_id());
 }
 
@@ -57,6 +58,7 @@ inline AsyncWrap::AsyncScope::~AsyncScope() {
   Environment* env = wrap_->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kAfter] == 0)
     return;
+  v8::HandleScope handle_scope(env->isolate());
   EmitAfter(env, wrap_->get_async_id());
 }
 


### PR DESCRIPTION
Add `HandleError`s to the AsyncScope constructor and destructor in
async_wrap-inl.h to fix "FATAL ERROR" incurring observed while running
test-http2-respond-with-file using the --trace-events-enabled flag.

Fixes: https://github.com/nodejs/node/issues/19921

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @addaleax @jasnell 