### PR TITLE
errors: alter ERR_INVALID_IP_ADDRESS

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -316,7 +316,7 @@ function setServers(servers) {
       return newSet.push([ipVersion, s, parseInt(p)]);
     }
 
-    throw new ERR_INVALID_IP_ADDRESS.Error(serv);
+    throw new ERR_INVALID_IP_ADDRESS(serv);
   });
 
   const errorNumber = this._handle.setServers(newSet);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -815,8 +815,7 @@ E('ERR_INVALID_FILE_URL_HOST',
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
-// The `Error` should probably be a `TypeError`.
-E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError, Error);
+E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
   TypeError,

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -70,12 +70,12 @@ dns.setServers(goog);
 assert.deepStrictEqual(dns.getServers(), goog);
 common.expectsError(() => dns.setServers(['foobar']), {
   code: 'ERR_INVALID_IP_ADDRESS',
-  type: Error,
+  type: TypeError,
   message: 'Invalid IP address: foobar'
 });
 common.expectsError(() => dns.setServers(['127.0.0.1:va']), {
   code: 'ERR_INVALID_IP_ADDRESS',
-  type: Error,
+  type: TypeError,
   message: 'Invalid IP address: 127.0.0.1:va'
 });
 assert.deepStrictEqual(dns.getServers(), goog);


### PR DESCRIPTION
changes the base instance for ERR_INVALID_IP_ADDRESS
from Error to TypeError as a more accurate representation
of the error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
