### PR TITLE
[reland] deps: cherry-pick b767cde1e7 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.2',
+    'v8_embedder_string': '-node.3',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/runtime/runtime-intl.cc
+++ b/deps/v8/src/runtime/runtime-intl.cc
@@ -627,8 +627,7 @@ RUNTIME_FUNCTION(Runtime_PluralRulesSelect) {
   icu::UnicodeString result = plural_rules->select(rounded);
   return *isolate->factory()
               ->NewStringFromTwoByte(Vector<const uint16_t>(
-                  reinterpret_cast<const uint16_t*>(
-                      icu::toUCharPtr(result.getBuffer())),
+                  reinterpret_cast<const uint16_t*>(result.getBuffer()),
                   result.length()))
               .ToHandleChecked();
 }


### PR DESCRIPTION
This is a cherry pick of https://github.com/nodejs/node/pull/19710 that we missed to re-apply in the V8 6.6 update

/cc @nodejs/v8-update 