### PR TITLE
http: relax requirements on upgrade listener

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -471,8 +471,9 @@ added: v0.1.94
 * `head` {Buffer}
 
 Emitted each time a server responds to a request with an upgrade. If this
-event is not being listened for, clients receiving an upgrade header will have
-their connections closed.
+event is not being listened for and the response status code is 101 Switching
+Protocols, clients receiving an upgrade header will have their connections
+closed.
 
 A client server pair demonstrating how to listen for the `'upgrade'` event.
 
@@ -873,6 +874,11 @@ per connection (in the case of HTTP Keep-Alive connections).
 ### Event: 'upgrade'
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Not listening to this event no longer causes the socket
+                 to be destroyed if a client sends an Upgrade header.
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in
@@ -880,9 +886,8 @@ added: v0.1.94
 * `socket` {net.Socket} Network socket between the server and client
 * `head` {Buffer} The first packet of the upgraded stream (may be empty)
 
-Emitted each time a client requests an HTTP upgrade. If this event is not
-listened for, then clients requesting an upgrade will have their connections
-closed.
+Emitted each time a client requests an HTTP upgrade. Listening to this event
+is optional and clients cannot insist on a protocol change.
 
 After this event is emitted, the request's socket will not have a `'data'`
 event listener, meaning it will need to be bound in order to handle data

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -426,7 +426,7 @@ function socketOnData(d) {
     req.socket._hadError = true;
     req.emit('error', ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
-    // Upgrade or CONNECT
+    // Upgrade (if status code 101) or CONNECT
     var bytesParsed = ret;
     var res = parser.incoming;
     req.res = res;
@@ -453,7 +453,7 @@ function socketOnData(d) {
       req.emit(eventName, res, socket, bodyHead);
       req.emit('close');
     } else {
-      // Got Upgrade header or CONNECT method, but have no handler.
+      // Requested Upgrade or used CONNECT method, but have no handler.
       socket.destroy();
     }
   } else if (parser.incoming && parser.incoming.complete &&
@@ -491,6 +491,9 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
     return 0;  // No special treatment.
   }
   req.res = res;
+
+  if (res.upgrade)
+    return 2;
 
   // Responses to CONNECT request is handled as Upgrade.
   const method = req.method;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -492,6 +492,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   }
   req.res = res;
 
+  // Skip body and treat as Upgrade.
   if (res.upgrade)
     return 2;
 

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -83,6 +83,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   parser.incoming.httpVersionMinor = versionMinor;
   parser.incoming.httpVersion = `${versionMajor}.${versionMinor}`;
   parser.incoming.url = url;
+  parser.incoming.upgrade = upgrade;
 
   var n = headers.length;
 
@@ -100,19 +101,6 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
     parser.incoming.statusCode = statusCode;
     parser.incoming.statusMessage = statusMessage;
   }
-
-  if (upgrade && parser.outgoing !== null && !parser.outgoing.upgrading) {
-    // The client made non-upgrade request, and server is just advertising
-    // supported protocols.
-    //
-    // See RFC7230 Section 6.7
-    upgrade = false;
-  }
-
-  parser.incoming.upgrade = upgrade;
-
-  if (upgrade)
-    return 2;  // Skip body and treat as Upgrade.
 
   return parser.onIncoming(parser.incoming, shouldKeepAlive);
 }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -98,7 +98,6 @@ function OutgoingMessage() {
   this.writable = true;
 
   this._last = false;
-  this.upgrading = false;
   this.chunkedEncoding = false;
   this.shouldKeepAlive = true;
   this.useChunkedEncodingByDefault = true;
@@ -304,7 +303,6 @@ function _storeHeader(firstLine, headers) {
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
   var state = {
     connection: false,
-    connUpgrade: false,
     contLen: false,
     te: false,
     date: false,
@@ -365,10 +363,6 @@ function _storeHeader(firstLine, headers) {
       storeHeader(this, state, field, value, true);
     }
   }
-
-  // Are we upgrading the connection?
-  if (state.connUpgrade && state.upgrade)
-    this.upgrading = true;
 
   // Date header
   if (this.sendDate && !state.date) {
@@ -460,8 +454,6 @@ function matchConnValue(self, state, value) {
   while (m) {
     if (m[0].length === 5)
       sawClose = true;
-    else
-      state.connUpgrade = true;
     m = RE_CONN_VALUES.exec(value);
   }
   if (sawClose)

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -530,14 +530,14 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     parser = null;
 
     var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-    if (server.listenerCount(eventName) > 0) {
+    if (eventName === 'upgrade' || server.listenerCount(eventName) > 0) {
       debug('SERVER have listener for %s', eventName);
       var bodyHead = d.slice(bytesParsed, d.length);
 
       socket.readableFlowing = null;
       server.emit(eventName, req, socket, bodyHead);
     } else {
-      // Got upgrade header or CONNECT method, but have no handler.
+      // Got CONNECT method, but have no handler.
       socket.destroy();
     }
   }
@@ -591,6 +591,13 @@ function resOnFinish(req, res, socket, state, server) {
 // to the user.
 function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
+
+  if (req.upgrade) {
+    req.upgrade = req.method === 'CONNECT' ||
+                  server.listenerCount('upgrade') > 0;
+    if (req.upgrade)
+      return 2;
+  }
 
   state.incoming.push(req);
 

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -121,8 +121,6 @@ function test_upgrade_with_listener() {
 /*-----------------------------------------------
   connection: Upgrade, no listener
 -----------------------------------------------*/
-let test_upgrade_no_listener_ended = false;
-
 function test_upgrade_no_listener() {
   const conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
@@ -135,8 +133,9 @@ function test_upgrade_no_listener() {
              '\r\n');
   });
 
-  conn.on('end', function() {
-    test_upgrade_no_listener_ended = true;
+  conn.once('data', (data) => {
+    assert.strictEqual('string', typeof data);
+    assert.strictEqual('HTTP/1.1 200', data.substr(0, 12));
     conn.end();
   });
 
@@ -182,5 +181,4 @@ server.listen(0, function() {
 process.on('exit', function() {
   assert.strictEqual(3, requests_recv);
   assert.strictEqual(3, requests_sent);
-  assert.ok(test_upgrade_no_listener_ended);
 });

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -134,8 +134,8 @@ function test_upgrade_no_listener() {
   });
 
   conn.once('data', (data) => {
-    assert.strictEqual('string', typeof data);
-    assert.strictEqual('HTTP/1.1 200', data.substr(0, 12));
+    assert.strictEqual(typeof data, 'string');
+    assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 200');
     conn.end();
   });
 


### PR DESCRIPTION
The http spec does not say anything about Upgrade headers making
protocol switch mandatory but Node.js implements them as if they
are. Relax the requirements to only destroy the socket if no
upgrade listener exists on the client when status code is 101.

Refs: https://tools.ietf.org/html/rfc7230#section-6.7
Fixes: https://github.com/nodejs/node/issues/11552

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
