### PR TITLE
errors: alter and test ERR_INVALID_REPL_EVAL_CONFIG

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -828,10 +828,8 @@ E('ERR_INVALID_PERFORMANCE_MARK',
 
 // This should probably be a `TypeError`.
 E('ERR_INVALID_PROTOCOL', 'Protocol "%s" not supported. Expected "%s"', Error);
-
-// This should probably be a `TypeError`.
 E('ERR_INVALID_REPL_EVAL_CONFIG',
-  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', Error);
+  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', TypeError);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support Buffer, Uint8Array or string input: %s',
   TypeError);

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -89,7 +89,19 @@ assert.strictEqual(r2.rli.input, r2.inputStream);
 assert.strictEqual(r2.rli.output, r2.outputStream);
 assert.strictEqual(r2.rli.terminal, false);
 
-// Verify that defaults are used when no arguments are provided
+// 3, breakEvalOnSigint and eval supplied together should cause a throw
+const r3 = () => repl.start({
+  breakEvalOnSigint: true,
+  eval: true
+});
+
+common.expectsError(r3, {
+  code: 'ERR_INVALID_REPL_EVAL_CONFIG',
+  type: TypeError,
+  message: 'Cannot specify both "breakEvalOnSigint" and "eval" for REPL'
+});
+
+// 4, Verify that defaults are used when no arguments are provided
 const r4 = repl.start();
 
 assert.strictEqual(r4._prompt, '> ');


### PR DESCRIPTION
changes the base instance for ERR_INVALID_REPL_EVAL_CONFIG
from Error to TypeError as a more accurate representation
of the error and adds a unit test for the repl options that
trigger this error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
