### PR TITLE
http2: add missing error handlers

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -215,6 +215,8 @@ function emit(self, ...args) {
   self.emit(...args);
 }
 
+const noop = () => {};
+
 // Called when a new block of headers has been received for a given
 // stream. The stream may or may not be new. If the stream is new,
 // create the associated Http2Stream instance and emit the 'stream'
@@ -868,7 +870,9 @@ class Http2Session extends EventEmitter {
 
     if (!socket._handle || !socket._handle._externalStream) {
       socket = new StreamWrap(socket);
-      socket.on('error', () => {});
+      socket.on('error', (err) => {
+        this.emit('error', err);
+      });
     }
 
     // No validation is performed on the input parameters because this
@@ -2519,6 +2523,8 @@ function connectionListener(socket) {
     // Let event handler deal with the socket
     debug(`Unknown protocol from ${socket.remoteAddress}:${socket.remotePort}`);
     if (!this.emit('unknownProtocol', socket)) {
+      socket.on('error', noop);
+
       // We don't know what to do, so let's just tell the other side what's
       // going on in a format that they *might* understand.
       socket.end('HTTP/1.0 403 Forbidden\r\n' +
@@ -2527,8 +2533,6 @@ function connectionListener(socket) {
                  'If this is a HTTP request: The server was not ' +
                  'configured with the `allowHTTP1` option or a ' +
                  'listener for the `unknownProtocol` event.\n');
-
-      socket.on('error', () => {});
     }
     return;
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -868,6 +868,7 @@ class Http2Session extends EventEmitter {
 
     if (!socket._handle || !socket._handle._externalStream) {
       socket = new StreamWrap(socket);
+      socket.on('error', () => {});
     }
 
     // No validation is performed on the input parameters because this
@@ -2526,6 +2527,8 @@ function connectionListener(socket) {
                  'If this is a HTTP request: The server was not ' +
                  'configured with the `allowHTTP1` option or a ' +
                  'listener for the `unknownProtocol` event.\n');
+
+      socket.on('error', () => {});
     }
     return;
   }


### PR DESCRIPTION
Attach simple error handlers in http2/core.js on sockets where they
seem to be missing to avoid the process from crashing.

Fixes: https://github.com/nodejs/node/issues/19978

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @mafintosh @nodejs/http2 