### PR TITLE
src: limit foreground tasks draining loop

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -937,6 +937,7 @@
         'test/cctest/test_base64.cc',
         'test/cctest/test_node_postmortem_metadata.cc',
         'test/cctest/test_environment.cc',
+        'test/cctest/test_platform.cc',
         'test/cctest/test_util.cc',
         'test/cctest/test_url.cc'
       ],

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -316,7 +316,7 @@ class NodeInspectorClient : public V8InspectorClient {
     terminated_ = false;
     running_nested_loop_ = true;
     while (!terminated_ && channel_->waitForFrontendMessage()) {
-      platform_->FlushForegroundTasks(env_->isolate());
+      while (platform_->FlushForegroundTasks(env_->isolate())) {}
     }
     terminated_ = false;
     running_nested_loop_ = false;

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -260,8 +260,8 @@ void NodePlatform::CallDelayedOnForegroundThread(Isolate* isolate,
     std::unique_ptr<Task>(task), delay_in_seconds);
 }
 
-void NodePlatform::FlushForegroundTasks(v8::Isolate* isolate) {
-  ForIsolate(isolate)->FlushForegroundTasksInternal();
+bool NodePlatform::FlushForegroundTasks(v8::Isolate* isolate) {
+  return ForIsolate(isolate)->FlushForegroundTasksInternal();
 }
 
 void NodePlatform::CancelPendingDelayedTasks(v8::Isolate* isolate) {

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -67,7 +67,8 @@ class PerIsolatePlatformData :
   int unref();
 
   // Returns true iff work was dispatched or executed.
-  // New tasks that are posted during flushing of the queue are not run.
+  // New tasks that are posted during flushing of the queue are postponed until
+  // the next flushing.
   bool FlushForegroundTasksInternal();
   void CancelPendingDelayedTasks();
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -26,6 +26,7 @@ class TaskQueue {
   void Push(std::unique_ptr<T> task);
   std::unique_ptr<T> Pop();
   std::unique_ptr<T> BlockingPop();
+  std::queue<std::unique_ptr<T>> PopAll();
   void NotifyOfCompletion();
   void BlockingDrain();
   void Stop();
@@ -66,6 +67,7 @@ class PerIsolatePlatformData :
   int unref();
 
   // Returns true iff work was dispatched or executed.
+  // New tasks that are posted during flushing of the queue are not run.
   bool FlushForegroundTasksInternal();
   void CancelPendingDelayedTasks();
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -66,7 +66,7 @@ class PerIsolatePlatformData :
   void ref();
   int unref();
 
-  // Returns true iff work was dispatched or executed. New tasks that are
+  // Returns true if work was dispatched or executed. New tasks that are
   // posted during flushing of the queue are postponed until the next
   // flushing.
   bool FlushForegroundTasksInternal();
@@ -133,7 +133,7 @@ class NodePlatform : public MultiIsolatePlatform {
   double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
 
-  // Returns true iff work was dispatched or executed. New tasks that are
+  // Returns true if work was dispatched or executed. New tasks that are
   // posted during flushing of the queue are postponed until the next
   // flushing.
   bool FlushForegroundTasks(v8::Isolate* isolate);

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -66,9 +66,9 @@ class PerIsolatePlatformData :
   void ref();
   int unref();
 
-  // Returns true iff work was dispatched or executed.
-  // New tasks that are posted during flushing of the queue are postponed until
-  // the next flushing.
+  // Returns true iff work was dispatched or executed. New tasks that are
+  // posted during flushing of the queue are postponed until the next
+  // flushing.
   bool FlushForegroundTasksInternal();
   void CancelPendingDelayedTasks();
 
@@ -133,7 +133,10 @@ class NodePlatform : public MultiIsolatePlatform {
   double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
 
-  void FlushForegroundTasks(v8::Isolate* isolate);
+  // Returns true iff work was dispatched or executed. New tasks that are
+  // posted during flushing of the queue are postponed until the next
+  // flushing.
+  bool FlushForegroundTasks(v8::Isolate* isolate);
 
   void RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) override;
   void UnregisterIsolate(IsolateData* isolate_data) override;

--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -45,10 +45,11 @@ TEST_F(PlatformTest, SkipNewTasksInFlushForegroundTasks) {
   int run_count = 0;
   platform->CallOnForegroundThread(
       isolate_, new RepostingTask(2, &run_count, isolate_, platform.get()));
-  platform->FlushForegroundTasks(isolate_);
+  EXPECT_TRUE(platform->FlushForegroundTasks(isolate_));
   EXPECT_EQ(1, run_count);
-  platform->FlushForegroundTasks(isolate_);
+  EXPECT_TRUE(platform->FlushForegroundTasks(isolate_));
   EXPECT_EQ(2, run_count);
-  platform->FlushForegroundTasks(isolate_);
+  EXPECT_TRUE(platform->FlushForegroundTasks(isolate_));
   EXPECT_EQ(3, run_count);
+  EXPECT_FALSE(platform->FlushForegroundTasks(isolate_));
 }

--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -1,0 +1,54 @@
+#include "node_internals.h"
+#include "libplatform/libplatform.h"
+
+#include <string>
+#include "gtest/gtest.h"
+#include "node_test_fixture.h"
+
+// This task increments the given run counter and reposts itself until the
+// repost counter reaches zero.
+class RepostingTask : public v8::Task {
+ public:
+  explicit RepostingTask(int repost_count,
+                         int* run_count,
+                         v8::Isolate* isolate,
+                         node::NodePlatform* platform)
+      : repost_count_(repost_count),
+        run_count_(run_count),
+        isolate_(isolate),
+        platform_(platform) {}
+
+  // v8::Task implementation
+  void Run() final {
+    ++*run_count_;
+    if (repost_count_ > 0) {
+      --repost_count_;
+      platform_->CallOnForegroundThread(isolate_,
+          new RepostingTask(repost_count_, run_count_, isolate_, platform_));
+    }
+  }
+
+ private:
+  int repost_count_;
+  int* run_count_;
+  v8::Isolate* isolate_;
+  node::NodePlatform* platform_;
+};
+
+class PlatformTest : public EnvironmentTestFixture {};
+
+TEST_F(PlatformTest, SkipNewTasksInFlushForegroundTasks) {
+  v8::Isolate::Scope isolate_scope(isolate_);
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env {handle_scope, argv};
+  int run_count = 0;
+  platform->CallOnForegroundThread(
+      isolate_, new RepostingTask(3, &run_count, isolate_, platform.get()));
+  platform->FlushForegroundTasks(isolate_);
+  EXPECT_EQ(1, run_count);
+  platform->FlushForegroundTasks(isolate_);
+  EXPECT_EQ(2, run_count);
+  platform->FlushForegroundTasks(isolate_);
+  EXPECT_EQ(3, run_count);
+}

--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -44,7 +44,7 @@ TEST_F(PlatformTest, SkipNewTasksInFlushForegroundTasks) {
   Env env {handle_scope, argv};
   int run_count = 0;
   platform->CallOnForegroundThread(
-      isolate_, new RepostingTask(3, &run_count, isolate_, platform.get()));
+      isolate_, new RepostingTask(2, &run_count, isolate_, platform.get()));
   platform->FlushForegroundTasks(isolate_);
   EXPECT_EQ(1, run_count);
   platform->FlushForegroundTasks(isolate_);


### PR DESCRIPTION
Foreground tasks that repost themselves can force the draining loop
to run indefinitely long without giving other tasks chance to run.

This limits the foreground task draining loop to run only the tasks
that were in the tasks queue at the beginning of the loop.

Fixes: https://github.com/nodejs/node/issues/19937

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
