### PR TITLE
errors: alter and test ERR_TLS_REQUIRED_SERVER_NAME

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1665,12 +1665,6 @@ An attempt to renegotiate the TLS session failed.
 
 An attempt was made to renegotiate TLS on a socket instance with TLS disabled.
 
-<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
-### ERR_TLS_REQUIRED_SERVER_NAME
-
-While using TLS, the `server.addContext()` method was called without providing
-a hostname in the first parameter.
-
 <a id="ERR_TLS_SESSION_ATTACK"></a>
 ### ERR_TLS_SESSION_ATTACK
 
@@ -2029,6 +2023,15 @@ removed: v10.0.0
 -->
 
 Used when a TLS renegotiation request has failed in a non-specific way.
+
+<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
+### ERR_TLS_REQUIRED_SERVER_NAME
+<!-- YAML
+removed: REPLACEME
+-->
+
+While using TLS, the `server.addContext()` method was called without providing
+a hostname in the first parameter.
 
 <a id="ERR_UNKNOWN_BUILTIN_MODULE"></a>
 ### ERR_UNKNOWN_BUILTIN_MODULE

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -347,18 +347,18 @@ called:
 * `tlsSocket` {tls.TLSSocket} The `tls.TLSSocket` instance from which the
   error originated.
 
-### server.addContext(hostname, context)
+### server.addContext(servername, context)
 <!-- YAML
 added: v0.5.3
 -->
 
-* `hostname` {string} A SNI hostname or wildcard (e.g. `'*'`)
+* `servername` {string} A SNI hostname or wildcard (e.g. `'*'`)
 * `context` {Object} An object containing any of the possible properties
   from the [`tls.createSecureContext()`][] `options` arguments (e.g. `key`,
   `cert`, `ca`, etc).
 
 The `server.addContext()` method adds a secure context that will be used if
-the client request's SNI name matches the supplied `hostname` (or wildcard).
+the client request's SNI name matches the supplied `severname` (or wildcard).
 
 ### server.address()
 <!-- YAML

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -39,13 +39,13 @@ const { owner_symbol } = require('internal/async_hooks').symbols;
 const { SecureContext: NativeSecureContext } = internalBinding('crypto');
 const {
   ERR_INVALID_ARG_TYPE,
+  ERR_MISSING_ARGS,
   ERR_MULTIPLE_CALLBACK,
   ERR_SOCKET_CLOSED,
   ERR_TLS_DH_PARAM_SIZE,
   ERR_TLS_HANDSHAKE_TIMEOUT,
   ERR_TLS_RENEGOTIATE,
   ERR_TLS_RENEGOTIATION_DISABLED,
-  ERR_TLS_REQUIRED_SERVER_NAME,
   ERR_TLS_SESSION_ATTACK,
   ERR_TLS_SNI_FROM_SERVER
 } = require('internal/errors').codes;
@@ -1051,7 +1051,7 @@ Server.prototype.setOptions = util.deprecate(function(options) {
 // SNI Contexts High-Level API
 Server.prototype.addContext = function(servername, context) {
   if (!servername) {
-    throw new ERR_TLS_REQUIRED_SERVER_NAME();
+    throw new ERR_MISSING_ARGS('servername');
   }
 
   var re = new RegExp('^' +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -864,10 +864,8 @@ E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout', Error);
 E('ERR_TLS_RENEGOTIATE', 'Attempt to renegotiate TLS session failed', Error);
 E('ERR_TLS_RENEGOTIATION_DISABLED',
   'TLS session renegotiation disabled for this socket', Error);
-
-// This should probably be a `TypeError`.
 E('ERR_TLS_REQUIRED_SERVER_NAME',
-  '"servername" is required parameter for Server.addContext', Error);
+  '"servername" is a required parameter', TypeError);
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected', Error);
 E('ERR_TLS_SNI_FROM_SERVER',
   'Cannot issue SNI from a TLS server-side socket', Error);

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -87,8 +87,8 @@ const clientResults = [];
 // check for throwing case where servername is not supplied
 common.expectsError(tls.createServer(serverOptions, () => {}).addContext, {
   type: TypeError,
-  code: 'ERR_TLS_REQUIRED_SERVER_NAME',
-  message: '"servername" is a required parameter'
+  code: 'ERR_MISSING_ARGS',
+  message: 'The "servername" argument must be specified'
 });
 
 const server = tls.createServer(serverOptions, function(c) {

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -84,6 +84,13 @@ const clientsOptions = [{
 const serverResults = [];
 const clientResults = [];
 
+// check for throwing case where servername is not supplied
+common.expectsError(tls.createServer(serverOptions, () => {}).addContext, {
+  type: TypeError,
+  code: 'ERR_TLS_REQUIRED_SERVER_NAME',
+  message: '"servername" is a required parameter'
+});
+
 const server = tls.createServer(serverOptions, function(c) {
   serverResults.push(c.servername);
 });


### PR DESCRIPTION
changes the base instance for ERR_TLS_REQUIRED_SERVER_NAME
from Error to TypeError as a more accurate representation
of the error and adds a unit test for missing servername
input that triggers this error in Server.prototype.addContext

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
