### PR TITLE
timers: call destroy on interval error

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -292,7 +292,7 @@ function tryOnTimeout(timer, start) {
     if (timerAsyncId !== null) {
       if (!threw)
         emitAfter(timerAsyncId);
-      if (!timer._repeat && destroyHooksExist() &&
+      if ((threw || !timer._repeat) && destroyHooksExist() &&
           !timer._destroyed) {
         emitDestroy(timerAsyncId);
         timer._destroyed = true;

--- a/test/async-hooks/test-timers.setInterval.js
+++ b/test/async-hooks/test-timers.setInterval.js
@@ -9,7 +9,6 @@ const TIMEOUT = common.platformTimeout(100);
 const hooks = initHooks();
 hooks.enable();
 
-// install first timeout
 setInterval(common.mustCall(ontimeout), TIMEOUT);
 const as = hooks.activitiesOfTypes('Timeout');
 assert.strictEqual(as.length, 1);
@@ -25,8 +24,8 @@ function ontimeout() {
   throw new Error('setInterval Error');
 }
 
-process.on('uncaughtException', common.mustCall((err) => {
-  assert(err.message, 'setInterval Error');
+process.once('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'setInterval Error');
 }));
 
 process.on('exit', () => {

--- a/test/async-hooks/test-timers.setInterval.js
+++ b/test/async-hooks/test-timers.setInterval.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const initHooks = require('./init-hooks');
+const { checkInvocations } = require('./hook-checks');
+const TIMEOUT = common.platformTimeout(100);
+
+const hooks = initHooks();
+hooks.enable();
+
+// install first timeout
+setInterval(common.mustCall(ontimeout), TIMEOUT);
+const as = hooks.activitiesOfTypes('Timeout');
+assert.strictEqual(as.length, 1);
+const t1 = as[0];
+assert.strictEqual(t1.type, 'Timeout');
+assert.strictEqual(typeof t1.uid, 'number');
+assert.strictEqual(typeof t1.triggerAsyncId, 'number');
+checkInvocations(t1, { init: 1 }, 't1: when timer installed');
+
+function ontimeout() {
+  checkInvocations(t1, { init: 1, before: 1 }, 't1: when first timer fired');
+
+  throw new Error('setInterval Error');
+}
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert(err.message, 'setInterval Error');
+}));
+
+process.on('exit', () => {
+  hooks.disable();
+  hooks.sanityCheck('Timeout');
+
+  checkInvocations(t1, { init: 1, before: 1, after: 1, destroy: 1 },
+                   't1: when process exits');
+});


### PR DESCRIPTION
When an interval callback throws an error, the destroy hook is never called due to a faulty if condition.

This change can be backported unlike the semver-major one in the next PR which would bring us in line with the browsers (and the spec).

CI: https://ci.nodejs.org/job/node-test-pull-request/14244/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
