### PR TITLE
timers: reschedule interval even if it threw

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -285,15 +285,18 @@ function tryOnTimeout(timer, start) {
   var threw = true;
   if (timerAsyncId !== null)
     emitBefore(timerAsyncId, timer[trigger_async_id_symbol]);
+  if (start === undefined && timer._repeat)
+    start = TimerWrap.now();
   try {
-    ontimeout(timer, start);
+    ontimeout(timer);
     threw = false;
   } finally {
     if (timerAsyncId !== null) {
       if (!threw)
         emitAfter(timerAsyncId);
-      if ((threw || !timer._repeat) && destroyHooksExist() &&
-          !timer._destroyed) {
+      if (timer._repeat) {
+        rearm(timer, start);
+      } else if (destroyHooksExist() && !timer._destroyed) {
         emitDestroy(timerAsyncId);
         timer._destroyed = true;
       }
@@ -417,18 +420,14 @@ setTimeout[internalUtil.promisify.custom] = function(after, value) {
 exports.setTimeout = setTimeout;
 
 
-function ontimeout(timer, start) {
+function ontimeout(timer) {
   const args = timer._timerArgs;
   if (typeof timer._onTimeout !== 'function')
     return promiseResolve(timer._onTimeout, args[0]);
-  if (start === undefined && timer._repeat)
-    start = TimerWrap.now();
   if (!args)
     timer._onTimeout();
   else
     Reflect.apply(timer._onTimeout, timer, args);
-  if (timer._repeat)
-    rearm(timer, start);
 }
 
 function rearm(timer, start = TimerWrap.now()) {

--- a/test/parallel/test-timers-interval-throw.js
+++ b/test/parallel/test-timers-interval-throw.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// To match browser behaviour, interval should continue
+// being rescheduled even if it throws.
+
+let count = 2;
+const interval = setInterval(() => { throw new Error('IntervalError'); }, 1);
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'IntervalError');
+  if (--count === 0) {
+    clearInterval(interval);
+  }
+}, 2));


### PR DESCRIPTION
Node.js currently doesn't match browser behaviour when it comes to intervals that throw during their execution. In all browsers, the interval continues running but in Node.js it will never be rescheduled after a throw nor will the destroy async hook for that interval fire.

This is a semver-major change and IMO bringing us in line with the browsers is a good idea. If someone is handling `uncaughtException` or using domains then they should know what they're doing as far as concerns about leaking memory as a result of this.

IMO this is a pretty well documented behaviour of `setInterval`, at least as far as the JS ecosystem outside of Node.js is concerned.

I'm fine with getting this in v11 instead of v10 and going from there, if that's preferable.

CI: https://ci.nodejs.org/job/node-test-pull-request/14245/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
