### PR TITLE
doc: remove _writableState reference

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1652,8 +1652,7 @@ const { StringDecoder } = require('string_decoder');
 class StringWritable extends Writable {
   constructor(options) {
     super(options);
-    const state = this._writableState;
-    this._decoder = new StringDecoder(state.defaultEncoding);
+    this._decoder = new StringDecoder(options && options.defaultEncoding);
     this.data = '';
   }
   _write(chunk, encoding, callback) {


### PR DESCRIPTION
The doc currently includes one last reference to `_writableState` which can easily be removed.

Fixes: https://github.com/nodejs/node/issues/6799

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
