### PR TITLE
test: fix http-agent-destroyed-socket cb not firing

### DIFF
--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -44,7 +44,6 @@ const server = http.createServer(common.mustCall((req, res) => {
     // assert request2 is queued in the agent
     const key = agent.getName(requestOptions);
     assert.strictEqual(agent.requests[key].length, 1);
-    request1.socket.on('close', common.mustCall());
     response.resume();
     response.on('end', common.mustCall(() => {
       request1.socket.destroy();


### PR DESCRIPTION
A whole part of the test-http-agent-destroyed-socket test was not running as the semantics of http events changed slightly and were no longer triggering the expected event. Instead listen to the same event on the socket to verify that the code being tested is still working as expected.

Fixes: https://github.com/nodejs/node/issues/8613

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
