### PR TITLE
util: fix inspect performance bug

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -445,6 +445,11 @@ function formatValue(ctx, value, recurseTimes, ln) {
     }
   }
 
+  // Using an array here is actually better for the average case than using
+  // a Set. `seen` will only check for the depth and will never grow too large.
+  if (ctx.seen.indexOf(value) !== -1)
+    return ctx.stylize('[Circular]', 'special');
+
   let keys;
   let symbols = Object.getOwnPropertySymbols(value);
 
@@ -624,11 +629,6 @@ function formatValue(ctx, value, recurseTimes, ln) {
       }
     }
   }
-
-  // Using an array here is actually better for the average case than using
-  // a Set. `seen` will only check for the depth and will never grow too large.
-  if (ctx.seen.indexOf(value) !== -1)
-    return ctx.stylize('[Circular]', 'special');
 
   if (recurseTimes != null) {
     if (recurseTimes < 0)


### PR DESCRIPTION
In case an object contained a circular reference `Object.keys` was
called even though it was not necessary at all. This caused a
significant overhead for objects that contained a lot of such entries.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
