### PR TITLE
deps: cherry-pick 39d546a from upstream v8

### DIFF
--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -70,6 +70,7 @@ Felix Geisendörfer <haimuiba@gmail.com>
 Filipe David Manana <fdmanana@gmail.com>
 Franziska Hinkelmann <franziska.hinkelmann@gmail.com>
 Geoffrey Garside <ggarside@gmail.com>
+Gus Caplan <me@gus.host>
 Gwang Yoon Hwang <ryumiel@company100.net>
 Henrique Ferreiro <henrique.ferreiro@gmail.com>
 Hirofumi Mako <mkhrfm@gmail.com>

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2354,6 +2354,11 @@ class V8_EXPORT Value : public Data {
 
   bool IsWebAssemblyCompiledModule() const;
 
+  /**
+   * Returns true if the value is a Module Namespace Object.
+   */
+  bool IsModuleNamespaceObject() const;
+
   V8_WARN_UNUSED_RESULT MaybeLocal<Boolean> ToBoolean(
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT MaybeLocal<Number> ToNumber(

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -3584,6 +3584,10 @@ bool Value::IsSetIterator() const {
 
 bool Value::IsPromise() const { return Utils::OpenHandle(this)->IsJSPromise(); }
 
+bool Value::IsModuleNamespaceObject() const {
+  return Utils::OpenHandle(this)->IsJSModuleNamespace();
+}
+
 MaybeLocal<String> Value::ToString(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
   if (obj->IsString()) return ToApiHandle<String>(obj);

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -34,6 +34,7 @@ namespace {
   V(SharedArrayBuffer)                                                        \
   V(Proxy)                                                                    \
   V(WebAssemblyCompiledModule)                                                \
+  V(ModuleNamespaceObject)                                                    \
 
 
 #define V(type) \

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,4 +1,4 @@
-// Flags: --harmony-bigint
+// Flags: --harmony-bigint --experimental-vm-modules
 /* global SharedArrayBuffer */
 'use strict';
 const common = require('../common');
@@ -126,3 +126,11 @@ for (const [ value, _method ] of [
     assert.deepStrictEqual(yup, expected[testedFunc]);
   }
 }
+
+(async () => {
+  const m = new vm.Module('');
+  await m.link(() => 0);
+  m.instantiate();
+  await m.evaluate();
+  assert.ok(types.isModuleNamespaceObject(m.namespace));
+})();


### PR DESCRIPTION
Two commits here:

1. `[api] introduce v8::Value::IsModuleNamespaceObject` (https://github.com/v8/v8/commit/39d546a24022b62b00aedf7b556ac6c9e2306aab)
2. `util: introduce isModuleNamespaceObject` (ff9eba9e4dfd99f5d5d3f4963e3703a3128cc6f0)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
