### PR TITLE
Revert 17907: util: change inspect depth default

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -364,9 +364,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/19259
     description: The `WeakMap` and `WeakSet` entries can now be inspected
                  as well.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17907
-    description: The `depth` default changed to `Infinity`.
   - version: v9.9.0
     pr-url: https://github.com/nodejs/node/pull/17576
     description: The `compact` option is supported now.
@@ -390,6 +387,9 @@ changes:
   * `showHidden` {boolean} If `true`, the `object`'s non-enumerable symbols and
     properties will be included in the formatted result as well as [`WeakMap`][]
     and [`WeakSet`][] entries. **Default:** `false`.
+  * `depth` {number} Specifies the number of times to recurse while formatting
+    the `object`. This is useful for inspecting large complicated objects.
+    To make it recurse indefinitely pass `null`. **Default:** `2`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.
@@ -416,10 +416,7 @@ changes:
     objects the same as arrays. Note that no text will be reduced below 16
     characters, no matter the `breakLength` size. For more information, see the
     example below. **Default:** `true`.
-  * `depth` {number} Specifies the number of visible nested `Object`s in an
-    `object`. This is useful to minimize the inspection output for large
-    complicated objects. To make it recurse indefinitely pass `null` or
-    `Infinity`. **Default:** `Infinity`.
+
 * Returns: {string} The representation of passed object
 
 The `util.inspect()` method returns a string representation of `object` that is
@@ -445,23 +442,12 @@ util.inspect(new Bar()); // 'Bar {}'
 util.inspect(baz);       // '[foo] {}'
 ```
 
-The following example limits the inspected output of the `paths` property:
+The following example inspects all properties of the `util` object:
 
 ```js
 const util = require('util');
 
-console.log(util.inspect(module, { depth: 0 }));
-// Instead of showing all entries in `paths` `[Array]` is used to limit the
-// output for readability:
-
-// Module {
-//   id: '<repl>',
-//   exports: {},
-//   parent: undefined,
-//   filename: null,
-//   loaded: false,
-//   children: [],
-//   paths: [Array] }
+console.log(util.inspect(util, { showHidden: true, depth: null }));
 ```
 
 Values may supply their own custom `inspect(depth, opts)` functions, when
@@ -481,7 +467,7 @@ const o = {
     'foo']], 4],
   b: new Map([['za', 1], ['zb', 'test']])
 };
-console.log(util.inspect(o, { compact: true, breakLength: 80 }));
+console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
 
 // This will print
 
@@ -495,7 +481,7 @@ console.log(util.inspect(o, { compact: true, breakLength: 80 }));
 //   b: Map { 'za' => 1, 'zb' => 'test' } }
 
 // Setting `compact` to false changes the output to be more reader friendly.
-console.log(util.inspect(o, { compact: false, breakLength: 80 }));
+console.log(util.inspect(o, { compact: false, depth: 5, breakLength: 80 }));
 
 // {
 //   a: [

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -183,9 +183,6 @@ property take precedence over `--trace-deprecation` and
 <!-- YAML
 added: v0.5.3
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17907
-    description: The `%o` specifiers `depth` option is now set to `Infinity`.
   - version: v8.4.0
     pr-url: https://github.com/nodejs/node/pull/14558
     description: The `%o` and `%O` specifiers are supported now.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -115,9 +115,8 @@ function hasOwnProperty(obj, prop) {
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options = Object.assign({},
-                               util.inspect.defaultOptions,
-                               { showProxy: true, depth: 2 });
+writer.options =
+    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
 
 exports._builtinLibs = builtinLibs;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -217,7 +217,8 @@ function formatWithOptions(inspectOptions, f) {
           {
             const opts = Object.assign({}, inspectOptions, {
               showHidden: true,
-              showProxy: true
+              showProxy: true,
+              depth: 4
             });
             tempStr = inspect(arguments[a++], opts);
             break;

--- a/lib/util.js
+++ b/lib/util.js
@@ -80,7 +80,7 @@ const {
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: null,
+  depth: 2,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -3,7 +3,6 @@
 require('../common');
 const assert = require('assert');
 const BufferList = require('internal/streams/buffer_list');
-const util = require('util');
 
 // Test empty buffer list.
 const emptyList = new BufferList();
@@ -31,10 +30,3 @@ assert.strictEqual(list.join(','), 'foo');
 const shifted = list.shift();
 assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());
-
-const tmp = util.inspect.defaultOptions.colors;
-util.inspect.defaultOptions = { colors: true };
-assert.strictEqual(
-  util.inspect(list),
-  'BufferList { length: \u001b[33m0\u001b[39m }');
-util.inspect.defaultOptions = { colors: tmp };

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -48,17 +48,13 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ],' +
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], {} ],' +
                   ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
-                  ', Proxy [ Proxy [ {}, {} ], {} ] ] ]';
-const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
-                    'Proxy [ {}, {} ] ],\n' +
-                  '    Proxy [ Proxy [ {}, {} ], ' +
-                    'Proxy [ Proxy [ {}, {} ], {} ] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
-                    'Proxy [ {}, {} ] ],\n' +
-                  '    Proxy [ Proxy [ {}, {} ], ' +
-                    'Proxy [ Proxy [ {}, {} ], {} ] ] ] ]';
+                  ', Proxy [ Proxy [Array], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], Proxy [Array]' +
+                  ' ],\n    Proxy [ Proxy [Array], Proxy [Array] ] ],\n' +
+                  '  Proxy [ Proxy [ Proxy [Array], Proxy [Array] ],\n' +
+                  '    Proxy [ Proxy [Array], Proxy [Array] ] ] ]';
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: true, depth: null }),
   expected1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -68,7 +68,7 @@ assert.strictEqual(util.inspect({ a: 1, b: 2 }), '{ a: 1, b: 2 }');
 assert.strictEqual(util.inspect({ 'a': {} }), '{ a: {} }');
 assert.strictEqual(util.inspect({ 'a': { 'b': 2 } }), '{ a: { b: 2 } }');
 assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }),
-                   '{ a: { b: { c: { d: 2 } } } }');
+                   '{ a: { b: { c: [Object] } } }');
 assert.strictEqual(
   util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }, false, null),
   '{ a: { b: { c: { d: 2 } } } }');
@@ -106,7 +106,7 @@ assert.strictEqual(util.inspect((new JSStream())._externalStream),
   assert.strictEqual(util.inspect({ a: regexp }, false, 0), '{ a: /regexp/ }');
 }
 
-assert(!/Object/.test(
+assert(/Object/.test(
   util.inspect({ a: { a: { a: { a: {} } } } }, undefined, undefined, true)
 ));
 assert(!/Object/.test(
@@ -1011,15 +1011,15 @@ if (typeof Symbol !== 'undefined') {
 // Empty and circular before depth.
 {
   const arr = [[[[]]]];
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [] ] ] ]');
   arr[0][0][0][0] = [];
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Array] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Array] ] ] ]');
   arr[0][0][0] = {};
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ {} ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ {} ] ] ]');
   arr[0][0][0] = { a: 2 };
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Object] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
   arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Circular] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
 }
 
 // Corner cases.
@@ -1116,10 +1116,10 @@ if (typeof Symbol !== 'undefined') {
   assert(!/1 more item/.test(util.inspect(arr)));
   util.inspect.defaultOptions.maxArrayLength = oldOptions.maxArrayLength;
   assert(/1 more item/.test(util.inspect(arr)));
-  util.inspect.defaultOptions.depth = 2;
-  assert(/Object/.test(util.inspect(obj)));
-  util.inspect.defaultOptions.depth = oldOptions.depth;
+  util.inspect.defaultOptions.depth = null;
   assert(!/Object/.test(util.inspect(obj)));
+  util.inspect.defaultOptions.depth = oldOptions.depth;
+  assert(/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)
@@ -1131,7 +1131,7 @@ if (typeof Symbol !== 'undefined') {
   assert(/Object/.test(util.inspect(obj)));
   util.inspect.defaultOptions = oldOptions;
   assert(/1 more item/.test(util.inspect(arr)));
-  assert(!/Object/.test(util.inspect(obj)));
+  assert(/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1404,3 +1404,15 @@ util.inspect(process);
   const args = (function() { return arguments; })('a');
   assert.strictEqual(util.inspect(args), "[Arguments] { '0': 'a' }");
 }
+
+{
+  // Test that a long linked list can be inspected without throwing an error.
+  const list = {};
+  let head = list;
+  // The real cutoff value is closer to 1400 stack frames as of May 2018,
+  // but let's be generous here – even a linked listed of length 100k should be
+  // inspectable in some way.
+  for (let i = 0; i < 100000; i++)
+    head = head.next = {};
+  util.inspect(list);
+}


### PR DESCRIPTION
* Revert "util: change util.inspect depth default"
    
    This reverts commit b994b8eff6018433a56bb10dbc473cefa0dd9370.
    
    This caused regressions in ecosystem code. While the change originally
    was semver-major and could be postponed until after Node.js 10,
    I think reverting it is a good choice at this point.
    
    Also, I personally do not think defaulting to a shallow inspect
    is a bad thing at all – quite the opposite: It makes `util.inspect()`
    give an overview of an object, rather than providing a full
    display of its contents. Changing the `depth` default to infinity
    fundamentally changed the role that `util.inspect()` plays,
    and makes output much more verbose and thus at times unusable
    for `console.log()`-style debugging.
    
    Fixes: https://github.com/nodejs/node/issues/19405
    Refs: https://github.com/nodejs/node/pull/17907

* Revert "util: change %o depth default"
    
    This reverts commit 8f153092d86b0605af8a2ef294dc310fefa83e30.

(https://github.com/nodejs/node/pull/19994 also has a `Fixes:` tag for https://github.com/nodejs/node/issues/19405, but it’s independent from this PR and is not uncontroversial)

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
