### PR TITLE
doc: add missing type=misc top comments

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1,6 +1,7 @@
 # C++ Addons
 
 <!--introduced_in=v0.10.0-->
+<!-- type=misc -->
 
 Node.js Addons are dynamically-linked shared objects, written in C++, that
 can be loaded into Node.js using the [`require()`][require] function, and used

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1,6 +1,7 @@
 # Deprecated APIs
 
 <!--introduced_in=v7.7.0-->
+<!-- type=misc -->
 
 Node.js may deprecate APIs when either: (a) use of the API is considered to be
 unsafe, (b) an improved alternative API has been made available, or (c)

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1,6 +1,7 @@
 # ECMAScript Modules
 
 <!--introduced_in=v8.5.0-->
+<!-- type=misc -->
 
 > Stability: 1 - Experimental
 

--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -1,6 +1,7 @@
 # Internationalization Support
 
 <!--introduced_in=v8.2.0-->
+<!-- type=misc -->
 
 Node.js has many features that make it easier to write internationalized
 programs. Some of them are:

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1,6 +1,7 @@
 # N-API
 
 <!--introduced_in=v7.10.0-->
+<!-- type=misc -->
 
 > Stability: 2 - Stable
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

If I get this right, we have two types of docs: concerning `require`-able modules and other docs.

Other docs usually have top level `<!-- type=misc -->` comments, so that the top JSON container for them [would be `miscs`](https://nodejs.org/download/nightly/v10.0.0-nightly201804132a6ab9b37b/docs/api/synopsis.json) (compare [a `require`-able module doc](https://nodejs.org/download/nightly/v10.0.0-nightly201804132a6ab9b37b/docs/api/string_decoder.json)). These docs adhere this rule:

- cli.md
- debugger.md
- documentation.md
- errors.md
- globals.md
- synopsis.md

These ones seem to lack these comments:

+ addons.md
+ deprecations.md
+ esm.md
+ intl.md
+ n-api.md

`addons`, `esm`, and `n-api` docs concern importable modules, but they are mostly tutorials, not module API docs. I may be wrong in these cases, so correct me if so.

As for `tracing.md`, it [will become a `require`-able module doc soon](https://github.com/nodejs/node/pull/19803), so the mentioned comment is not needed there now.