### PR TITLE
src: make process.env.TZ setter clear tz cache

### DIFF
--- a/test/parallel/test-process-env-tz.js
+++ b/test/parallel/test-process-env-tz.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.isMainThread)
+  common.skip('process.env.TZ is not intercepted in Workers');
+
+if (common.isWindows)  // Using a different TZ format.
+  common.skip('todo: test on Windows');
+
+const date = new Date('2018-04-14T12:34:56.789Z');
+
+process.env.TZ = 'Europe/Amsterdam';
+
+if (date.toString().includes('(Europe)'))
+  common.skip('not using bundled ICU');  // Shared library or --with-intl=none.
+
+if ('Sat Apr 14 2018 12:34:56 GMT+0000 (GMT)' === date.toString())
+  common.skip('missing tzdata');  // Alpine buildbots lack Europe/Amsterdam.
+
+if (date.toString().includes('(Central European Time)') ||
+    date.toString().includes('(CET)')) {
+  // The AIX and SmartOS buildbots report 2018 CEST as CET
+  // because apparently for them that's still the deep future.
+  common.skip('tzdata too old');
+}
+
+assert.strictEqual(
+  date.toString().replace('Central European Summer Time', 'CEST'),
+  'Sat Apr 14 2018 14:34:56 GMT+0200 (CEST)');
+
+process.env.TZ = 'Europe/London';
+assert.strictEqual(
+  date.toString().replace('British Summer Time', 'BST'),
+  'Sat Apr 14 2018 13:34:56 GMT+0100 (BST)');
+
+process.env.TZ = 'Etc/UTC';
+assert.strictEqual(
+  date.toString().replace('Coordinated Universal Time', 'UTC'),
+  'Sat Apr 14 2018 12:34:56 GMT+0000 (UTC)');
+
+// Just check that deleting the environment variable doesn't crash the process.
+// We can't really check the result of date.toString() because we don't know
+// the default time zone.
+delete process.env.TZ;
+date.toString();


### PR DESCRIPTION
Since the presence of the libc and V8 timezone caches seem to be
a perennial source of confusion to users ("why doesn't it work?!"),
let's try to support that pattern by intercepting assignments to
the `TZ` environment variable and reset the caches as a side effect.

Fixes: https://github.com/nodejs/node/issues/19974
~~CI: https://ci.nodejs.org/job/node-test-pull-request/14278/~~ - I expect the results will be... interesting.
~~CI: https://ci.nodejs.org/job/node-test-pull-request/14280/~~ - with tweaks
~~CI: https://ci.nodejs.org/job/node-test-pull-request/14287/~~ -  one more tweak
~~CI: https://ci.nodejs.org/job/node-test-pull-request/23223/~~
~~CI: https://ci.nodejs.org/job/node-test-pull-request/23228/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/23249/