### PR TITLE
doc: unify section structures

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -340,12 +340,16 @@ The high resolution millisecond timestamp at which the V8 platform was
 initialized.
 
 
-## Class: PerformanceObserver(callback)
+## Class: PerformanceObserver
+
+### new PerformanceObserver(callback)
 <!-- YAML
 added: v8.5.0
 -->
 
-* `callback` {Function} A `PerformanceObserverCallback` callback function.
+* `callback` {Function}
+  * `list` {PerformanceObserverEntryList}
+  * `observer` {PerformanceObserver}
 
 `PerformanceObserver` objects provide notifications when new
 `PerformanceEntry` instances have been added to the Performance Timeline.
@@ -364,68 +368,15 @@ obs.observe({ entryTypes: ['mark'], buffered: true });
 
 performance.mark('test');
 ```
-
 Because `PerformanceObserver` instances introduce their own additional
 performance overhead, instances should not be left subscribed to notifications
 indefinitely. Users should disconnect observers as soon as they are no
 longer needed.
 
-### Callback: PerformanceObserverCallback(list, observer)
-<!-- YAML
-added: v8.5.0
--->
-
-* `list` {PerformanceObserverEntryList}
-* `observer` {PerformanceObserver}
-
-The `PerformanceObserverCallback` is invoked when a `PerformanceObserver` is
+The `callback` is invoked when a `PerformanceObserver` is
 notified about new `PerformanceEntry` instances. The callback receives a
 `PerformanceObserverEntryList` instance and a reference to the
 `PerformanceObserver`.
-
-### Class: PerformanceObserverEntryList
-<!-- YAML
-added: v8.5.0
--->
-
-The `PerformanceObserverEntryList` class is used to provide access to the
-`PerformanceEntry` instances passed to a `PerformanceObserver`.
-
-#### performanceObserverEntryList.getEntries()
-<!-- YAML
-added: v8.5.0
--->
-
-* Returns: {PerformanceEntry[]}
-
-Returns a list of `PerformanceEntry` objects in chronological order
-with respect to `performanceEntry.startTime`.
-
-#### performanceObserverEntryList.getEntriesByName(name[, type])
-<!-- YAML
-added: v8.5.0
--->
-
-* `name` {string}
-* `type` {string}
-* Returns: {PerformanceEntry[]}
-
-Returns a list of `PerformanceEntry` objects in chronological order
-with respect to `performanceEntry.startTime` whose `performanceEntry.name` is
-equal to `name`, and optionally, whose `performanceEntry.entryType` is equal to
-`type`.
-
-#### performanceObserverEntryList.getEntriesByType(type)
-<!-- YAML
-added: v8.5.0
--->
-
-* `type` {string}
-* Returns: {PerformanceEntry[]}
-
-Returns a list of `PerformanceEntry` objects in chronological order
-with respect to `performanceEntry.startTime` whose `performanceEntry.entryType`
-is equal to `type`.
 
 ### performanceObserver.disconnect()
 <!-- YAML
@@ -481,6 +432,51 @@ obs.observe({ entryTypes: ['mark'], buffered: true });
 for (let n = 0; n < 3; n++)
   performance.mark(`test${n}`);
 ```
+
+## Class: PerformanceObserverEntryList
+<!-- YAML
+added: v8.5.0
+-->
+
+The `PerformanceObserverEntryList` class is used to provide access to the
+`PerformanceEntry` instances passed to a `PerformanceObserver`.
+
+### performanceObserverEntryList.getEntries()
+<!-- YAML
+added: v8.5.0
+-->
+
+* Returns: {PerformanceEntry[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order
+with respect to `performanceEntry.startTime`.
+
+### performanceObserverEntryList.getEntriesByName(name[, type])
+<!-- YAML
+added: v8.5.0
+-->
+
+* `name` {string}
+* `type` {string}
+* Returns: {PerformanceEntry[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order
+with respect to `performanceEntry.startTime` whose `performanceEntry.name` is
+equal to `name`, and optionally, whose `performanceEntry.entryType` is equal to
+`type`.
+
+### performanceObserverEntryList.getEntriesByType(type)
+<!-- YAML
+added: v8.5.0
+-->
+
+* `type` {string}
+* Returns: {PerformanceEntry[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order
+with respect to `performanceEntry.startTime` whose `performanceEntry.entryType`
+is equal to `type`.
+
 
 ## Examples
 

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -42,7 +42,9 @@ decoder.write(Buffer.from([0x82]));
 console.log(decoder.end(Buffer.from([0xAC])));
 ```
 
-## Class: new StringDecoder([encoding])
+## Class: StringDecoder
+
+### new StringDecoder([encoding])
 <!-- YAML
 added: v0.1.99
 -->

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -92,7 +92,7 @@ const customTypesMap = {
   'PerformanceNodeTiming':
     'perf_hooks.html#perf_hooks_class_performancenodetiming_extends_performanceentry', // eslint-disable-line max-len
   'PerformanceObserver':
-    'perf_hooks.html#perf_hooks_class_performanceobserver_callback',
+    'perf_hooks.html#perf_hooks_class_performanceobserver',
   'PerformanceObserverEntryList':
     'perf_hooks.html#perf_hooks_class_performanceobserverentrylist',
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

We had two docs with slight deviations from the common section structure concerning:

* class <-> constructor hierarchy;
* method's callback signature and description.

There are 'before' and 'after' states:

1. `string_decoder.md`

```
String Decoder
  Class: new StringDecoder([encoding])
    stringDecoder.end([buffer])
    stringDecoder.write(buffer)
```
```
String Decoder
  Class: StringDecoder
    new StringDecoder([encoding])
    stringDecoder.end([buffer])
    stringDecoder.write(buffer)
```

2. `perf_hooks.md`

```
Class: PerformanceObserver(callback)
  Callback: PerformanceObserverCallback(list, observer)
  Class: PerformanceObserverEntryList
    performanceObserverEntryList.getEntries()
    performanceObserverEntryList.getEntriesByName(name[, type])
    performanceObserverEntryList.getEntriesByType(type)
  performanceObserver.disconnect()
  performanceObserver.observe(options)
Examples
```
```
Class: PerformanceObserver
  new PerformanceObserver(callback)
  performanceObserver.disconnect()
  performanceObserver.observe(options)
Class: PerformanceObserverEntryList
  performanceObserverEntryList.getEntries()
  performanceObserverEntryList.getEntriesByName(name[, type])
  performanceObserverEntryList.getEntriesByType(type)
Examples
```
with `Callback: PerformanceObserverCallback(list, observer)` incorporated in the parent section as we usually do for all the callbacks.

These changes also help `tools/doc/json.js` to parse and JSON-ize the docs more properly.
