### PR TITLE
http: fix undefined error in parser event

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -62,7 +62,8 @@ function parserOnHeaders(headers, url) {
 function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
                                  url, statusCode, statusMessage, upgrade,
                                  shouldKeepAlive) {
-  var parser = this;
+  const parser = this;
+  const { socket } = parser;
 
   if (!headers) {
     headers = parser._headers;
@@ -75,10 +76,11 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   }
 
   // Parser is also used by http client
-  var ParserIncomingMessage = parser.socket && parser.socket.server ?
-    parser.socket.server[kIncomingMessage] : IncomingMessage;
+  const ParserIncomingMessage = (socket && socket.server &&
+                                 socket.server[kIncomingMessage]) ||
+                                 IncomingMessage;
 
-  parser.incoming = new ParserIncomingMessage(parser.socket);
+  parser.incoming = new ParserIncomingMessage(socket);
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
   parser.incoming.httpVersion = `${versionMajor}.${versionMinor}`;


### PR DESCRIPTION
The current check for `socket.server[kIncomingMessage]` does not account for the possibility of a `socket.server` that doesn't have that property defined. Fix it.

No test as this isn't officially supported behaviour but the fix is simple so we might as well do it to not break the ecosystem.

(Would be nice to get this in v10.x if possible.)

Fixes: https://github.com/nodejs/node/issues/19231

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
