### PR TITLE
tools: fix broken link in icu notes

### DIFF
--- a/tools/icu/README.md
+++ b/tools/icu/README.md
@@ -1,6 +1,6 @@
 # Notes about the `tools/icu` subdirectory
 
-This directory contains tools, data, and information about the [http://icu-project.org](ICU)
+This directory contains tools, data, and information about the [ICU](http://icu-project.org)
 (International Components for Unicode) integration. ICU is used to provide
 internationalization functionality.
 


### PR DESCRIPTION
The link to ICU was broken in ./tools/icu/README.md, this PR fixes the link so that clicking on it takes the user to the ICU homepage.

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
