### PR TITLE
doc: added explicitly that the close event does not take arguments

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -128,8 +128,8 @@ solely on the API of the `Http2Session`.
 added: v8.4.0
 -->
 
-The `'close'` event is emitted once the `Http2Session` has been destroyed. It
-does not expect any arguments.
+The `'close'` event is emitted once the `Http2Session` has been destroyed. Its
+listener does not expect any arguments.
 
 #### Event: 'connect'
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -128,7 +128,8 @@ solely on the API of the `Http2Session`.
 added: v8.4.0
 -->
 
-The `'close'` event is emitted once the `Http2Session` has been destroyed.
+The `'close'` event is emitted once the `Http2Session` has been destroyed. It
+does not expect any arguments.
 
 #### Event: 'connect'
 <!-- YAML


### PR DESCRIPTION
Explicitly added in the docs that the close event does not expect
any arguments when invoked.

Fixes: https://github.com/nodejs/node/issues/20018

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
