### PR TITLE
benchmark: add bench for zlib gzip + gunzip cycle

### DIFF
--- a/benchmark/zlib/pipe.js
+++ b/benchmark/zlib/pipe.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common.js');
+const fs = require('fs');
+const zlib = require('zlib');
+
+const bench = common.createBenchmark(main, {
+  inputLen: [1024],
+  duration: [5],
+  type: ['string', 'buffer']
+});
+
+function main({ inputLen, duration, type }) {
+  const buffer = Buffer.alloc(inputLen, fs.readFileSync(__filename));
+  const chunk = type === 'buffer' ? buffer : buffer.toString('utf8');
+
+  const input = zlib.createGzip();
+  const output = zlib.createGunzip();
+
+  let readFromOutput = 0;
+  input.pipe(output);
+  if (type === 'string')
+    output.setEncoding('utf8');
+  output.on('data', (chunk) => readFromOutput += chunk.length);
+
+  function write() {
+    input.write(chunk, write);
+  }
+
+  bench.start();
+  write();
+
+  setTimeout(() => {
+    // Give result in GBit/s, like the net benchmarks do
+    bench.end(readFromOutput * 8 / (1024 ** 3));
+
+    // Cut off writing the easy way.
+    input.write = () => {};
+  }, duration * 1000);
+}

--- a/test/parallel/test-benchmark-zlib.js
+++ b/test/parallel/test-benchmark-zlib.js
@@ -9,5 +9,7 @@ runBenchmark('zlib',
                'method=deflate',
                'n=1',
                'options=true',
-               'type=Deflate'
+               'type=Deflate',
+               'inputLen=1024',
+               'duration=0.1'
              ]);

--- a/test/parallel/test-benchmark-zlib.js
+++ b/test/parallel/test-benchmark-zlib.js
@@ -11,5 +11,5 @@ runBenchmark('zlib',
                'options=true',
                'type=Deflate',
                'inputLen=1024',
-               'duration=0.1'
+               'duration=1'
              ]);

--- a/test/parallel/test-benchmark-zlib.js
+++ b/test/parallel/test-benchmark-zlib.js
@@ -11,5 +11,8 @@ runBenchmark('zlib',
                'options=true',
                'type=Deflate',
                'inputLen=1024',
-               'duration=1'
-             ]);
+               'duration=0.001'
+             ],
+             {
+               'NODEJS_BENCHMARK_ZERO_ALLOWED': 1
+             });


### PR DESCRIPTION
Originally wrote this for some work that is going to take a while
longer before it’s ready to be PR’ed, so it seems fine to start
with this on its own.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
