### PR TITLE
lib: fix coverage reporting

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -390,17 +390,16 @@ function isInsideNodeModules() {
     // Use `runInNewContext()` to get something tamper-proof and
     // side-effect-free. Since this is currently only used for a deprecated API,
     // the perf implications should be okay.
-    getStructuredStack = runInNewContext('(' + function() {
+    getStructuredStack = runInNewContext(`function() {
       Error.prepareStackTrace = function(err, trace) {
         err.stack = trace;
       };
       Error.stackTraceLimit = Infinity;
 
       return function structuredStack() {
-        // eslint-disable-next-line no-restricted-syntax
         return new Error().stack;
       };
-    } + ')()', {}, { filename: 'structured-stack' });
+    })()`, {}, { filename: 'structured-stack' });
   }
 
   const stack = getStructuredStack();


### PR DESCRIPTION
Taking the source code of a function and running it in another
context does not play well with coverage instrumentation.
For now, do the simple thing and just write the source code as
a string literal.

Fixes: https://github.com/nodejs/node/issues/19912
Refs: https://github.com/nodejs/node/pull/19524

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
