### PR TITLE
crypto: allow to restrict valid GCM tag length

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1457,6 +1457,10 @@ to create the `Decipher` object.
 <!-- YAML
 added: v0.1.94
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/???
+    description: The `authTagLength` option can now be used to restrict accepted
+                 GCM authentication tag lengths.
   - version: v9.9.0
     pr-url: https://github.com/nodejs/node/pull/18644
     description: The `iv` parameter may now be `null` for ciphers which do not
@@ -1474,7 +1478,9 @@ and initialization vector (`iv`).
 The `options` argument controls stream behavior and is optional except when a
 cipher in CCM mode is used (e.g. `'aes-128-ccm'`). In that case, the
 `authTagLength` option is required and specifies the length of the
-authentication tag in bytes, see [CCM mode][].
+authentication tag in bytes, see [CCM mode][]. In GCM mode, the `authTagLength`
+option is not required but can be used to restrict accepted authentication tags
+to those with the specified length.
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
 recent OpenSSL releases, `openssl list-cipher-algorithms` will display the

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -359,6 +359,7 @@ class CipherBase : public BaseObject {
     kErrorMessageSize,
     kErrorState
   };
+  static const unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
 
   void Init(const char* cipher_type,
             const char* key_buf,
@@ -398,7 +399,7 @@ class CipherBase : public BaseObject {
         ctx_(nullptr),
         kind_(kind),
         auth_tag_set_(false),
-        auth_tag_len_(-1),
+        auth_tag_len_(kNoAuthTagLength),
         pending_auth_failed_(false) {
     MakeWeak<CipherBase>(this);
   }
@@ -407,7 +408,7 @@ class CipherBase : public BaseObject {
   EVP_CIPHER_CTX* ctx_;
   const CipherKind kind_;
   bool auth_tag_set_;
-  int auth_tag_len_;
+  unsigned int auth_tag_len_;
   char auth_tag_[EVP_GCM_TLS_TAG_LEN];
   bool pending_auth_failed_;
   int max_message_size_;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -398,7 +398,7 @@ class CipherBase : public BaseObject {
         ctx_(nullptr),
         kind_(kind),
         auth_tag_set_(false),
-        auth_tag_len_(0),
+        auth_tag_len_(-1),
         pending_auth_failed_(false) {
     MakeWeak<CipherBase>(this);
   }
@@ -407,7 +407,7 @@ class CipherBase : public BaseObject {
   EVP_CIPHER_CTX* ctx_;
   const CipherKind kind_;
   bool auth_tag_set_;
-  unsigned int auth_tag_len_;
+  int auth_tag_len_;
   char auth_tag_[EVP_GCM_TLS_TAG_LEN];
   bool pending_auth_failed_;
   int max_message_size_;


### PR DESCRIPTION
This change allows users to restrict accepted GCM authentication tag lengths to a single value as proposed in https://github.com/nodejs/node/issues/17523#issuecomment-359395838. This relies on the API changes introduced in https://github.com/nodejs/node/pull/18138.

Fixes: https://github.com/nodejs/node/issues/17523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
