### PR TITLE
src: move v8::HandleScope call to Emit

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -50,7 +50,6 @@ inline AsyncWrap::AsyncScope::AsyncScope(AsyncWrap* wrap)
   Environment* env = wrap->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kBefore] == 0)
     return;
-  v8::HandleScope handle_scope(env->isolate());
   EmitBefore(env, wrap->get_async_id());
 }
 
@@ -58,7 +57,6 @@ inline AsyncWrap::AsyncScope::~AsyncScope() {
   Environment* env = wrap_->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kAfter] == 0)
     return;
-  v8::HandleScope handle_scope(env->isolate());
   EmitAfter(env, wrap_->get_async_id());
 }
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -169,6 +169,7 @@ void Emit(Environment* env, double async_id, AsyncHooks::Fields type,
   if (async_hooks->fields()[type] == 0)
     return;
 
+  v8::HandleScope handle_scope(env->isolate());
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   FatalTryCatch try_catch(env);
   USE(fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value));


### PR DESCRIPTION
Move v8::HandleScope call to Emit removing it from previous locations
where it was added to avoid crashing (constructor and destructor of
AsyncWrap) for a more general and fool-proof solution.

Ref: https://github.com/nodejs/node/pull/19972#issuecomment-381353894

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @addaleax @hashseed