### PR TITLE
doc: unify more headings

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -75,7 +75,7 @@ function destroy(asyncId) { }
 function promiseResolve(asyncId) { }
 ```
 
-#### `async_hooks.createHook(callbacks)`
+#### async_hooks.createHook(callbacks)
 
 <!-- YAML
 added: v8.1.0
@@ -168,7 +168,7 @@ provided by AsyncHooks itself. The logging should then be skipped when
 it was the logging itself that caused AsyncHooks callback to call. By
 doing this the otherwise infinite recursion is broken.
 
-#### `asyncHook.enable()`
+#### asyncHook.enable()
 
 * Returns: {AsyncHook} A reference to `asyncHook`.
 
@@ -184,7 +184,7 @@ const async_hooks = require('async_hooks');
 const hook = async_hooks.createHook(callbacks).enable();
 ```
 
-#### `asyncHook.disable()`
+#### asyncHook.disable()
 
 * Returns: {AsyncHook} A reference to `asyncHook`.
 
@@ -200,7 +200,7 @@ Key events in the lifetime of asynchronous events have been categorized into
 four areas: instantiation, before/after the callback is called, and when the
 instance is destroyed.
 
-##### `init(asyncId, type, triggerAsyncId, resource)`
+##### init(asyncId, type, triggerAsyncId, resource)
 
 * `asyncId` {number} A unique ID for the async resource.
 * `type` {string} The type of the async resource.
@@ -250,7 +250,7 @@ It is possible to have type name collisions. Embedders are encouraged to use
 unique prefixes, such as the npm package name, to prevent collisions when
 listening to the hooks.
 
-###### `triggerId`
+###### `triggerAsyncId`
 
 `triggerAsyncId` is the `asyncId` of the resource that caused (or "triggered")
 the new resource to initialize and that caused `init` to call. This is different
@@ -396,7 +396,7 @@ The graph only shows *when* a resource was created, not *why*, so to track
 the *why* use `triggerAsyncId`.
 
 
-##### `before(asyncId)`
+##### before(asyncId)
 
 * `asyncId` {number}
 
@@ -414,7 +414,7 @@ callback multiple times, while other operations like `fs.open()` will call
 it only once.
 
 
-##### `after(asyncId)`
+##### after(asyncId)
 
 * `asyncId` {number}
 
@@ -425,7 +425,7 @@ will run *after* the `'uncaughtException'` event is emitted or a `domain`'s
 handler runs.
 
 
-##### `destroy(asyncId)`
+##### destroy(asyncId)
 
 * `asyncId` {number}
 
@@ -437,7 +437,7 @@ made to the `resource` object passed to `init` it is possible that `destroy`
 will never be called, causing a memory leak in the application. If the resource
 does not depend on garbage collection, then this will not be an issue.
 
-##### `promiseResolve(asyncId)`
+##### promiseResolve(asyncId)
 
 * `asyncId` {number}
 
@@ -464,7 +464,7 @@ init for PROMISE with id 6, trigger id: 5  # the Promise returned by then()
   after 6
 ```
 
-#### `async_hooks.executionAsyncId()`
+#### async_hooks.executionAsyncId()
 
 <!-- YAML
 added: v8.1.0
@@ -506,7 +506,7 @@ const server = net.createServer(function onConnection(conn) {
 Note that promise contexts may not get precise executionAsyncIds by default.
 See the section on [promise execution tracking][].
 
-#### `async_hooks.triggerAsyncId()`
+#### async_hooks.triggerAsyncId()
 
 * Returns: {number} The ID of the resource responsible for calling the callback
   that is currently being executed.
@@ -583,7 +583,7 @@ Library developers that handle their own asynchronous resources performing tasks
 like I/O, connection pooling, or managing callback queues may use the
 `AsyncWrap` JavaScript API so that all the appropriate callbacks are called.
 
-### `class AsyncResource()`
+### Class: AsyncResource
 
 The class `AsyncResource` is designed to be extended by the embedder's async
 resources. Using this, users can easily trigger the lifetime events of their
@@ -629,7 +629,7 @@ asyncResource.emitBefore();
 asyncResource.emitAfter();
 ```
 
-#### `AsyncResource(type[, options])`
+#### new AsyncResource(type[, options])
 
 * `type` {string} The type of async event.
 * `options` {Object}
@@ -662,7 +662,7 @@ class DBQuery extends AsyncResource {
 }
 ```
 
-#### `asyncResource.runInAsyncScope(fn[, thisArg, ...args])`
+#### asyncResource.runInAsyncScope(fn[, thisArg, ...args])
 <!-- YAML
 added: v9.6.0
 -->
@@ -677,7 +677,7 @@ of the async resource. This will establish the context, trigger the AsyncHooks
 before callbacks, call the function, trigger the AsyncHooks after callbacks, and
 then restore the original execution context.
 
-#### `asyncResource.emitBefore()`
+#### asyncResource.emitBefore()
 <!-- YAML
 deprecated: v9.6.0
 -->
@@ -693,7 +693,7 @@ will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
 considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
 alternative.
 
-#### `asyncResource.emitAfter()`
+#### asyncResource.emitAfter()
 <!-- YAML
 deprecated: v9.6.0
 -->
@@ -712,18 +712,18 @@ will abort. For this reason, the `emitBefore` and `emitAfter` APIs are
 considered deprecated. Please use `runInAsyncScope`, as it provides a much safer
 alternative.
 
-#### `asyncResource.emitDestroy()`
+#### asyncResource.emitDestroy()
 
 Call all `destroy` hooks. This should only ever be called once. An error will
 be thrown if it is called more than once. This **must** be manually called. If
 the resource is left to be collected by the GC then the `destroy` hooks will
 never be called.
 
-#### `asyncResource.asyncId()`
+#### asyncResource.asyncId()
 
 * Returns: {number} The unique `asyncId` assigned to the resource.
 
-#### `asyncResource.triggerAsyncId()`
+#### asyncResource.triggerAsyncId()
 
 * Returns: {number} The same `triggerAsyncId` that is passed to the
 `AsyncResource` constructor.

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -56,7 +56,7 @@ dns.resolve4('archive.org', (err, addresses) => {
 There are subtle consequences in choosing one over the other, please consult
 the [Implementation considerations section][] for more information.
 
-## Class dns.Resolver
+## Class: dns.Resolver
 <!-- YAML
 added: v8.3.0
 -->

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -37,11 +37,14 @@ Only the CLI argument for the main entry point to the program can be an entry
 point into an ESM graph. Dynamic import can also be used to create entry points
 into ESM graphs at runtime.
 
-#### `import.meta`
+#### import.meta
+
+* {Object}
 
 The `import.meta` metaproperty is an `Object` that contains the following
 property:
-* `url` {string} The absolute `file:` URL of the module
+
+* `url` {string} The absolute `file:` URL of the module.
 
 ### Unsupported
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

* Unify punctuation.
* Unify case.
* Unify format nits (add `new` for a constructor, remove `()` from a class name).
* Unify backticks. We usually do not wrap headings in backticks if these headings contain only API properties or function signatures. In such cases, backticks break uniformity, reduce font size in TOC and headings and baffle doctools.

Also in passing:

* Fix a typo.
* Add a type.