### PR TITLE
http,stream: remove usage of _readableState

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -560,7 +560,7 @@ function resOnFinish(req, res, socket, state, server) {
   // if the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the
   // bytes will be pulled off the wire.
-  if (!req._readableState.resumeScheduled)
+  if (req.readableFlowing === null)
     req._dump();
 
   res.detachSocket(socket);


### PR DESCRIPTION
Remove the usage of the restricted _readableState property and use the
readableFlowing property instead.

Refs: https://github.com/nodejs/node/issues/445

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This *should* work but doesn't. According to the original code:

```js
  // if the user never called req.read(), and didn't pipe() or
  // .resume() or .on('data'), then we call req._dump() so that the
  // bytes will be pulled off the wire.
  if (!req._readableState.resumeScheduled)
    req._dump();
```

Technically, it should be called whenever the stream isn't accessed.

According to the docs of `Readable` at https://nodejs.org/api/stream.html#stream_readable_streams:

1. `req` must be a `Readable` stream.
2. `readable.readableFlowing = null` when the above condition is true (Ref: https://nodejs.org/api/stream.html#stream_three_states)

Therefore, substituting the above condition by `if (req.readableFlowing === null)` *must* work.

But it doesn't.

@mcollina @mafintosh @nodejs/streams any idea why?