### PR TITLE
src: use v8:: namepace consistently in node_file

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -108,13 +108,13 @@ FileHandle::FileHandle(Environment* env, int fd, Local<Object> obj)
                               attr).FromJust();
 }
 
-void FileHandle::New(const v8::FunctionCallbackInfo<v8::Value>& args) {
+void FileHandle::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args.IsConstructCall());
   CHECK(args[0]->IsInt32());
 
   FileHandle* handle =
-      new FileHandle(env, args[0].As<v8::Int32>()->Value(), args.This());
+      new FileHandle(env, args[0].As<Int32>()->Value(), args.This());
   if (args[1]->IsNumber())
     handle->read_offset_ = args[1]->IntegerValue(env->context()).FromJust();
   if (args[2]->IsNumber())
@@ -671,7 +671,7 @@ inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value) {
   if (value->IsObject()) {
     return Unwrap<FSReqBase>(value.As<Object>());
   } else if (value->StrictEquals(env->fs_use_promises_symbol())) {
-    return new FSReqPromise<double, v8::Float64Array>(env);
+    return new FSReqPromise<double, Float64Array>(env);
   }
   return nullptr;
 }


### PR DESCRIPTION
Currently node_file.cc has a number of using declarations but in a few
places still uses the qualified names. This commit changes this for
consistency.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
