### PR TITLE
Revert "process: add version constants and compare" #19587

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1482,9 +1482,6 @@ changes:
   - version: v4.2.0
     pr-url: https://github.com/nodejs/node/pull/3212
     description: The `lts` property is now supported.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/19587
-    description: Add SemVer properties.
 -->
 
 * {Object}
@@ -1513,10 +1510,6 @@ tarball.
   - `'Argon'` for the 4.x LTS line beginning with 4.2.0.
   - `'Boron'` for the 6.x LTS line beginning with 6.9.0.
   - `'Carbon'` for the 8.x LTS line beginning with 8.9.1.
-* `majorVersion` {number} The major version of this release.
-* `minorVersion` {number} The minor version of this release.
-* `patchVersion` {number} The patch version of this release.
-* `prereleaseTag` {string} The SemVer pre-release tag for Node.js.
 
 <!-- eslint-skip -->
 ```js
@@ -1525,34 +1518,13 @@ tarball.
   lts: 'Argon',
   sourceUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5.tar.gz',
   headersUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5-headers.tar.gz',
-  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib',
-  majorVersion: 4,
-  minorVersion: 4,
-  patchVersion: 5,
-  prereleaseTag: '',
-  compareVersion: [Function: compareVersion]
+  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib'
 }
 ```
 
-
 In custom builds from non-release versions of the source tree, only the
-`name` property and SemVer properties may be present. The additional properties
-should not be relied upon to exist.
-
-## process.release.compareVersion(major, minor, patch[, tag])
-<!-- YAML
-added: REPLACEME
--->
-
-Perform a SemVer comparison to the release version.
-
-* `major` {number} The major version to compare.
-* `minor` {number} The minor version to compare.
-* `patch` {number} The patch version to compare.
-* `tag` {string} The pre-release tag to compare.
-* Returns: {number} `1` if the given version is lower than the current release
-  version, `0` if the given version matches the process version, and `-1`
-  if the given version is greater than the release version.
+`name` property may be present. The additional properties should not be
+relied upon to exist.
 
 ## process.send(message[, sendHandle[, options]][, callback])
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -35,7 +35,6 @@
     setupGlobalVariables();
 
     const _process = NativeModule.require('internal/process');
-    _process.setupCompareVersion();
     _process.setupConfig(NativeModule._source);
     _process.setupSignalHandlers();
     _process.setupUncaughtExceptionCapture(exceptionHandlerState);

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -283,47 +283,6 @@ function setupUncaughtExceptionCapture(exceptionHandlerState) {
   };
 }
 
-function setupCompareVersion() {
-  const {
-    majorVersion,
-    minorVersion,
-    patchVersion,
-    prereleaseTag,
-  } = process.release;
-
-  process.release.compareVersion = (major, minor, patch, tag) => {
-    if (typeof major !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('major', 'number', major);
-    if (typeof minor !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('minor', 'number', minor);
-    if (typeof patch !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('patch', 'number', patch);
-    if (tag !== undefined && typeof tag !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('tag', 'string', tag);
-
-    if (major > majorVersion)
-      return -1;
-    if (major < majorVersion)
-      return 1;
-
-    if (minor > minorVersion)
-      return -1;
-    if (minor < minorVersion)
-      return 1;
-
-    if (patch > patchVersion)
-      return -1;
-    if (patch < patchVersion)
-      return 1;
-    if (prereleaseTag)
-      return prereleaseTag === tag ? 0 : 1;
-    if (tag)
-      return -1;
-
-    return 0;
-  };
-}
-
 module.exports = {
   setup_performance,
   setup_cpuUsage,
@@ -334,6 +293,5 @@ module.exports = {
   setupSignalHandlers,
   setupChannel,
   setupRawDebug,
-  setupUncaughtExceptionCapture,
-  setupCompareVersion,
+  setupUncaughtExceptionCapture
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -3015,17 +3015,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(release, "name",
                     OneByteString(env->isolate(), NODE_RELEASE));
 
-  READONLY_PROPERTY(release, "majorVersion",
-      Integer::New(env->isolate(), NODE_MAJOR_VERSION));
-  READONLY_PROPERTY(release, "minorVersion",
-      Integer::New(env->isolate(), NODE_MINOR_VERSION));
-  READONLY_PROPERTY(release, "patchVersion",
-      Integer::New(env->isolate(), NODE_PATCH_VERSION));
-  std::string node_tag(NODE_TAG);
-  READONLY_PROPERTY(release, "prereleaseTag",
-      OneByteString(env->isolate(), node_tag.size() > 0 ?
-          node_tag.substr(1).c_str() : ""));
-
 #if NODE_VERSION_IS_LTS
   READONLY_PROPERTY(release, "lts",
                     OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const versionParts = process.versions.node.split('.');
@@ -17,41 +17,4 @@ if (versionParts[0] === '4' && versionParts[1] >= 2) {
   assert.strictEqual(process.release.lts, 'Carbon');
 } else {
   assert.strictEqual(process.release.lts, undefined);
-}
-
-const {
-  majorVersion: major,
-  minorVersion: minor,
-  patchVersion: patch,
-  prereleaseTag: tag,
-  compareVersion,
-} = process.release;
-
-assert.strictEqual(compareVersion(major, minor, patch, tag), 0);
-
-assert.strictEqual(compareVersion(major + 1, minor, patch, tag), -1);
-assert.strictEqual(compareVersion(major - 1, minor, patch, tag), 1);
-
-assert.strictEqual(compareVersion(major, minor + 1, patch, tag), -1);
-assert.strictEqual(compareVersion(major, minor - 1, patch, tag), 1);
-
-assert.strictEqual(compareVersion(major, minor, patch + 1, tag), -1);
-assert.strictEqual(compareVersion(major, minor, patch - 1, tag), 1);
-
-if (tag)
-  assert.strictEqual(compareVersion(major, minor, patch), 1);
-else
-  assert.strictEqual(compareVersion(major, minor, patch, 'notrealtag'), -1);
-
-for (const args of [
-  ['', 0, 0, ''],
-  [0, '', 0, ''],
-  [0, 0, '', ''],
-  [0, 0, 0, 0],
-]) {
-  common.expectsError(() => {
-    compareVersion(...args);
-  }, {
-    code: 'ERR_INVALID_ARG_TYPE',
-  });
 }


### PR DESCRIPTION
This reverts commit 91e0f8db118b125e805a77ce31dc21af57ee7abf, PR #19587

This is not a good API addition and should not make it in to Node 10. Here's some reasons:

* It's unnecessary feature bloat
* Major version can be fetched by a single-line of JavaScript, there is no good case for the other `xVersion` properties and this is just more for us to maintain
* It turns `process.release` into a complex object with a method, rather than a simple object that contains simple classes (JSONifiable)
* It forces us maintain the complex semver rules, these rules are already encapsulated in [node-semver](https://github.com/npm/node-semver) which has been battle tested and gone through so many revisions to get the rules just right, now we need to duplicate all of that and maintain that compatibility. Users should just install node-semver and use it if they need to do anything complex with the Node version.

Aside from being unnecessary feature bloat (my main objection), that last point is critical to consider. Here's how this is already a broken feature, let's take a 10.0.0-rc.2 (not available yet but it will be soon)

```
$ ./node -v
v10.0.0-rc.2
$ ./node -p 'process.release.compareVersion(9,0,0)'
1
$ ./node -p 'process.release.compareVersion(11,0,0)'
-1
$ ./node -p 'process.release.compareVersion(10,0,0,"foo")'
1
$ ./node -p 'process.release.compareVersion(10,0,0,"rc.1")'
1
$ ./node -p 'process.release.compareVersion(10,0,0)'
1 # WRONG
$ ./node -p 'process.release.compareVersion(10,0,0,"rc.9")'
1 # WRONG
$ ./node -p 'process.release.compareVersion(10,0,0,"zzz")'
1 # WRONG
```

Yes we could fix these, but that's not the point, the fact that these even need fixing shows what a mess we're wading in to here. Review [semver.org](https://semver.org/) and look particularly at the pre-release rules. This is not a simple specification and it's taken a long time for node-semver to get it just right. We should leave this kind of thing to userland. If we include a proper semver parser and comparator then we'll next be getting calls to expose that from core .. this is how our stdlib bloats and it's not how Node was supposed to work.

/cc @devsnek @BridgeAR @tniessen @cjihrig @jasnell @apapirovski 