### PR TITLE
src: remove req_wrap-inl.h from stream_base.h

### DIFF
--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "env.h"
-#include "req_wrap.h"
+#include "req_wrap-inl.h"
 #include "async_wrap.h"
 #include "v8.h"
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -4,8 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "env.h"
-#include "async_wrap.h"
-#include "req_wrap-inl.h"
+#include "async_wrap-inl.h"
 #include "node.h"
 #include "util.h"
 


### PR DESCRIPTION
This commit removes the inclusion of req_wrap-inl.h in stream_base.h
as ReqWrap is not used. This removal required stream_base.h to include
async_wrap-inl.h so there is an implementation of BaseObject::object.

The above change also affected connect_wrap, which needs to include
req_wrap-inl.h to get an implementation of ReqWrap::Dispatched.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
