### PR TITLE
test: remove message from strictEqual assertions

### DIFF
--- a/test/parallel/test-http-response-readable.js
+++ b/test/parallel/test-http-response-readable.js
@@ -31,10 +31,9 @@ const testServer = new http.Server(function(req, res) {
 
 testServer.listen(0, function() {
   http.get({ port: this.address().port }, function(res) {
-    assert.strictEqual(res.readable, true, 'res.readable initially true');
+    assert.strictEqual(res.readable, true);
     res.on('end', function() {
-      assert.strictEqual(res.readable, false,
-                         'res.readable set to false after end');
+      assert.strictEqual(res.readable, false);
       testServer.close();
     });
     res.resume();


### PR DESCRIPTION
If values are not equals in strictEqual assertions, an AssertionError is
thrown with a message property set equals to the value of the message
parameter. If we pass a message, this message will be printed instead of
the default message, which contains the value that is causing the error.
Hence removed the value passed as the message in strictEqual assertions
of test/parallel/test-http-response-readable.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
