### PR TITLE
tools: improve heading type detection in json.js

### DIFF
--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -558,11 +558,11 @@ function cloneValue(src) {
 // To reduse escape slashes in RegExp string components.
 const r = String.raw;
 
-const eventPrefix = r`^Event:\s+`;
-const classPrefix = r`^[Cc]lass:\s+`;
-const ctorPrefix = r`^(?:[Cc]onstructor:\s+)?new\s+`;
-const classMethodPrefix = r`^Class Method:\s+`;
-const maybeClassPropertyPrefix = r`(?:Class Property:\s+)?`;
+const eventPrefix = '^Event: +';
+const classPrefix = '^[Cc]lass: +';
+const ctorPrefix = '^(?:[Cc]onstructor: +)?new +';
+const classMethodPrefix = '^Class Method: +';
+const maybeClassPropertyPrefix = '(?:Class Property: +)?';
 
 const maybeQuote = '[\'"]?';
 const notQuotes = '[^\'"]+';
@@ -581,7 +581,7 @@ const callWithParams = r`\([^)]*\)`;
 
 const noCallOrProp = '(?![.[(])';
 
-const maybeExtends = r`(?:\s+extends\s+${maybeAncestors}${classId})?`;
+const maybeExtends = `(?: +extends +${maybeAncestors}${classId})?`;
 
 const headingExpressions = [
   { type: 'event', re: RegExp(


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

It appears that heading type detection in `tools/doc/json.js` is not accurate because some RegExps are too narrow and some are too wide. Maybe some mean an older source state.

This is an incomplete list of examples of false-positive and false-negative results:

* Not detected as constructor signatures (with `Constructor: ` prefix or class parent object):
```js
new assert.AssertionError(options)
new crypto.Certificate()
Constructor: new inspector.Session()
new net.Server([options][, connectionListener])
new net.Socket([options])
Constructor: new stream.Writable([options])
new stream.Readable([options])
new stream.Duplex(options)
new stream.Transform([options])
new tls.TLSSocket(socket[, options])
Constructor: new URL(input[, base])
Constructor: new URLSearchParams()
Constructor: new URLSearchParams(string)
Constructor: new URLSearchParams(obj)
Constructor: new URLSearchParams(iterable)
Constructor: new vm.Module(code[, options])
new vm.Script(code, options)
```

* Not detected as methods signatures (with more than one ancestor):
```js
fs.realpath.native(path[, options], callback)
fs.realpathSync.native(path[, options])
require.resolve.paths(request)
punycode.ucs2.decode(string)
punycode.ucs2.encode(codePoints)
util.types.isAnyArrayBuffer(value)
util.types.isArgumentsObject(value)
util.types.isArrayBuffer(value)
```

* Wrongly detected as method signatures:
```js
DEP0022: os.tmpDir()
DEP0023: os.getNetworkInterfaces()
DEP0026: util.print()
DEP0079: Custom inspection function on Objects via .inspect()
```

* Not detected as properties (with more than one ancestor):
```js
buffer.constants.MAX_LENGTH
buffer.constants.MAX_STRING_LENGTH
util.inspect.custom
util.inspect.defaultOptions
util.promisify.custom
```

* Wrongly detected as properties:
```js
No `require.extensions`
No `require.cache`
Node.js Crypto Constants
Node.js Error Codes
Native Abstractions for Node.js
V8 Inspector Integration for Node.js
DEP0011: crypto.Credentials
DEP0012: Domain.dispose
```

I've tried to make RegExp more accurate, but they became more and more complicated, so I've decided to build them from smaller string components so that the final RegExps were more self-explanatory.
