### PR TITLE
http request fixes

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -328,26 +328,33 @@ function socketCloseListener() {
 
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
-  var parser = socket.parser;
-  if (req.res && req.res.readable) {
+  const parser = socket.parser;
+  const res = req.res;
+  if (res) {
     // Socket closed before we emitted 'end' below.
-    if (!req.res.complete) {
-      req.res.aborted = true;
-      req.res.emit('aborted');
+    if (!res.complete) {
+      res.aborted = true;
+      res.emit('aborted');
     }
-    var res = req.res;
-    res.on('end', function() {
+    req.emit('close');
+    if (res.readable) {
+      res.on('end', function() {
+        this.emit('close');
+      });
+      res.push(null);
+    } else {
       res.emit('close');
-    });
-    res.push(null);
-  } else if (!req.res && !req.socket._hadError) {
-    // This socket error fired before we started to
-    // receive a response. The error needs to
-    // fire on the request.
-    req.socket._hadError = true;
-    req.emit('error', createHangUpError());
+    }
+  } else {
+    if (!req.socket._hadError) {
+      // This socket error fired before we started to
+      // receive a response. The error needs to
+      // fire on the request.
+      req.socket._hadError = true;
+      req.emit('error', createHangUpError());
+    }
+    req.emit('close');
   }
-  req.emit('close');
 
   // Too bad.  That output wasn't getting written.
   // This is pretty terrible that it doesn't raise an error.

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -23,29 +23,50 @@
 const common = require('../common');
 const http = require('http');
 
-const server = http.createServer(common.mustCall(function(req, res) {
-  res.writeHead(200);
-  res.write('a');
+{
+  const server = http.createServer(
+    common.mustCall((req, res) => {
+      res.writeHead(200);
+      res.write('a');
+    })
+  );
+  server.listen(
+    0,
+    common.mustCall(() => {
+      http.get(
+        { port: server.address().port },
+        common.mustCall((res) => {
+          res.on('data', common.mustCall(() => {
+            res.destroy();
+          }));
+          res.on('close', common.mustCall(() => {
+            server.close();
+          }));
+        })
+      );
+    })
+  );
+}
 
-  req.on('close', common.mustCall(function() {
-    console.error('request aborted');
-  }));
-  res.on('close', common.mustCall(function() {
-    console.error('response aborted');
-  }));
-}));
-server.listen(0);
-
-server.on('listening', function() {
-  console.error('make req');
-  http.get({
-    port: this.address().port
-  }, function(res) {
-    console.error('got res');
-    res.on('data', function(data) {
-      console.error('destroy res');
-      res.destroy();
-      server.close();
-    });
-  });
-});
+{
+  const server = http.createServer(
+    common.mustCall((req, res) => {
+      res.writeHead(200);
+      res.end('a');
+    })
+  );
+  server.listen(
+    0,
+    common.mustCall(() => {
+      http.get(
+        { port: server.address().port },
+        common.mustCall((res) => {
+          res.on('close', common.mustCall(() => {
+            server.close();
+          }));
+          res.resume();
+        })
+      );
+    })
+  );
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20102
Fixes: https://github.com/nodejs/node/issues/20101
Fixes: https://github.com/nodejs/node/issues/17352

- Response should always emit close.
- Response should always emit aborted if aborted.
- Response should always emit close after request has emitted close, never before.

Checklist

 - [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
 - [x] tests and/or benchmarks are included
 - [x] commit message follows commit guidelines