### PR TITLE
http: ignore socket errors after req.abort

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -537,7 +537,8 @@ added: v0.3.8
 -->
 
 Marks the request as aborting. Calling this will cause remaining data
-in the response to be dropped and the socket to be destroyed.
+in the response to be dropped and the socket to be destroyed. After
+calling this method no further errors will be emitted.
 
 ### request.aborted
 <!-- YAML
@@ -2138,8 +2139,6 @@ will be emitted in the following order:
 * `'socket'`
 * (`req.abort()` called here)
 * `'abort'`
-* `'error'` with an error with message `'Error: socket hang up'` and code
-  `'ECONNRESET'`
 * `'close'`
 
 If `req.abort()` is called after the response is received, the following events

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -373,7 +373,9 @@ function socketCloseListener() {
       // receive a response. The error needs to
       // fire on the request.
       req.socket._hadError = true;
-      req.emit('error', connResetException('socket hang up'));
+      if (!req.aborted) {
+        req.emit('error', connResetException('socket hang up'));
+      }
     }
     req.emit('close');
   }
@@ -399,7 +401,9 @@ function socketErrorListener(err) {
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;
-    req.emit('error', err);
+    if (!req.aborted) {
+      req.emit('error', err);
+    }
   }
 
   // Handle any pending data
@@ -433,7 +437,9 @@ function socketOnEnd() {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
     req.socket._hadError = true;
-    req.emit('error', connResetException('socket hang up'));
+    if (!req.aborted) {
+      req.emit('error', connResetException('socket hang up'));
+    }
   }
   if (parser) {
     parser.finish();
@@ -455,7 +461,9 @@ function socketOnData(d) {
     freeParser(parser, req, socket);
     socket.destroy();
     req.socket._hadError = true;
-    req.emit('error', ret);
+    if (!req.aborted) {
+      req.emit('error', ret);
+    }
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade (if status code 101) or CONNECT
     var bytesParsed = ret;

--- a/test/parallel/test-http-client-aborted.js
+++ b/test/parallel/test-http-client-aborted.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('aborted', common.mustCall(function() {
+    assert.strictEqual(this.aborted, true);
+    server.close();
+  }));
+  assert.strictEqual(req.aborted, false);
+  res.write('hello');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    port: server.address().port,
+    headers: { connection: 'keep-alive' }
+  }, common.mustCall((res) => {
+    req.abort();
+  }));
+}));

--- a/test/parallel/test-http-client-no-error-after-aborted.js
+++ b/test/parallel/test-http-client-no-error-after-aborted.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.write('hello');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    port: server.address().port
+  }, common.mustCall((res) => {
+    req.on('error', common.mustNotCall());
+    req.abort();
+    req.socket.destroy(new Error());
+    req.on('close', common.mustCall(() => {
+      server.close();
+    }));
+  }));
+}));

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -23,8 +23,7 @@ server.listen(0, common.localhostIPv4, common.mustCall(() => {
     }));
   }));
   req.on('timeout', common.mustCall(() => req.abort()));
-  req.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'socket hang up');
+  req.on('abort', common.mustCall(() => {
     server.close();
   }));
 }));

--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -34,7 +34,7 @@ const server = createServer(common.mustCall((req, res) => {
     }));
   }).listen(0, () => {
     external = get(`http://127.0.0.1:${server.address().port}`);
-    external.on('error', common.mustCall(() => {
+    external.on('abort', common.mustCall(() => {
       server.close();
       internal.close();
     }));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20107

After calling`abort` we might still receive socket errors. Most users will remove the `error` listener after calling `abort`. I would propose that errors after abort be ignored.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)