### PR TITLE
doc: fix suspicious heading emphasis in n-api.md

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3475,7 +3475,7 @@ is sufficient and appropriate. Use of the `napi_make_callback` function
 may be required when implementing custom async behavior that does not use
 `napi_create_async_work`.
 
-### *napi_open_callback_scope*
+### napi_open_callback_scope
 <!-- YAML
 added: v9.6.0
 -->
@@ -3500,7 +3500,7 @@ the stack the [`napi_open_callback_scope`][] and
 [`napi_close_callback_scope`][] functions can be used to open/close
 the required scope.
 
-### *napi_close_callback_scope*
+### napi_close_callback_scope
 <!-- YAML
 added: v9.6.0
 -->


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I do not know C++ and N-API domain, so I am not sure what these cases are: some accidental artifacts, intentional markdown emphasis for just these two headings or some not escaped C++ syntax. But rather than creating an issue to ask, I've decided to make a PR so that we can close it if these are not typos.

To check the rendering: [napi_open_callback_scope](https://nodejs.org/download/nightly/v10.0.0-nightly201804120aab8ff602/docs/api/n-api.html#n_api_napi_open_callback_scope), [napi_close_callback_scope](https://nodejs.org/download/nightly/v10.0.0-nightly201804120aab8ff602/docs/api/n-api.html#n_api_napi_close_callback_scope).

cc @nodejs/n-api 

