### PR TITLE
doc: prevent one more false-positive linkification

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -379,7 +379,7 @@ will be chosen.
 added: v6.0.0
 -->
 
-Automatically zero-fills all newly allocated [Buffer][] and [SlowBuffer][]
+Automatically zero-fills all newly allocated [`Buffer`][] and [`SlowBuffer`][]
 instances.
 
 
@@ -675,11 +675,11 @@ greater than `4` (its current default value). For more information, see the
 [libuv threadpool documentation][].
 
 [`--openssl-config`]: #cli_openssl_config_file
-[Buffer]: buffer.html#buffer_buffer
+[`Buffer`]: buffer.html#buffer_class_buffer
+[`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer
 [REPL]: repl.html
-[SlowBuffer]: buffer.html#buffer_class_slowbuffer
 [debugger]: debugger.html
 [emit_warning]: process.html#process_process_emitwarning_warning_type_code_ctor
 [libuv threadpool documentation]: http://docs.libuv.org/en/latest/threadpool.html
-[`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is the same tricky case as described in https://github.com/nodejs/node/pull/19913, I've somehow missed it then.

Too common link reference in `cli.md` corrupts heading from `string_decoder.md` in assembled `all.html` (markdown references seem to be case-insensitive).

Compare: [`stringDecoder.end([buffer])`](https://nodejs.org/download/nightly/v10.0.0-nightly201804120aab8ff602/docs/api/string_decoder.html#string_decoder_stringdecoder_end_buffer) in `string_decoder.html` and [`stringDecoder.end(buffer)`](https://nodejs.org/download/nightly/v10.0.0-nightly201804120aab8ff602/docs/api/all.html#string_decoder_stringdecoder_end_buffer) in `all.html` with `buffer` parameter made mandatory and linkified.

I've checked all the headings in `all.html` for any additional child HTML elements except expected (`code` and `span` with `#` TOC links) and found only this anomaly plus nits addressed in https://github.com/nodejs/node/pull/20086. So, for now, there are no more similar issues.

However, I do not know how we can prevent this false linkification and parameter corruption in the future. I can think of these options at least:

* Escape all the `[]` in headings and demand this from now on by a rule. This may be a huge churn PR and a hard rule to follow unless added in doc linting.
* Make a doc linting rule to compare all the link references in all docs with parameters in all headings in all docs and warn about collisions. I do not know if this is implementable and performance-safe.
* Forbid `tools/doc/html.js` from adding any links to headings except for `#` TOC links.

cc @nodejs/documentation to consider this.

Also in passing:

* Fix sort nit in bottom references.
* Make the `Buffer` link refer to `Buffer` class instead of the top module heading.