### PR TITLE
http: fix _dump regression

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -38,6 +38,8 @@ function readStop(socket) {
 function IncomingMessage(socket) {
   Stream.Readable.call(this);
 
+  this._readableState.readingMore = true;
+
   this.socket = socket;
   this.connection = socket;
 
@@ -63,6 +65,7 @@ function IncomingMessage(socket) {
   this.statusMessage = null;
   this.client = socket;
 
+  this._consuming = false;
   // flag for when we decide that this message cannot possibly be
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
@@ -79,6 +82,11 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 
 
 IncomingMessage.prototype._read = function _read(n) {
+  if (!this._consuming) {
+    this._readableState.readingMore = false;
+    this._consuming = true;
+  }
+
   // We actually do almost nothing here, because the parserOnBody
   // function fills up our internal buffer directly.  However, we
   // do need to unpause the underlying socket so that it flows.

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -560,7 +560,7 @@ function resOnFinish(req, res, socket, state, server) {
   // if the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the
   // bytes will be pulled off the wire.
-  if (!req._readableState.resumeScheduled)
+  if (!req._consuming && !req._readableState.resumeScheduled)
     req._dump();
 
   res.detachSocket(socket);

--- a/test/parallel/test-http-pause-no-dump.js
+++ b/test/parallel/test-http-pause-no-dump.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.once('data', common.mustCall(() => {
+    req.pause();
+    res.writeHead(200);
+    res.end();
+    res.on('finish', common.mustCall(() => {
+      assert(!req._dumped);
+    }));
+  }));
+}));
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const req = http.request({
+    port: this.address().port,
+    method: 'POST',
+    path: '/'
+  }, common.mustCall(function(res) {
+    assert.strictEqual(res.statusCode, 200);
+    res.resume();
+    res.on('end', common.mustCall(() => {
+      server.close();
+    }));
+  }));
+
+  req.end(Buffer.allocUnsafe(1024));
+}));


### PR DESCRIPTION
A recent set of changes removed `_consuming` tracking from server incoming messages which ensures that `IncomingMessage#_dump` only runs if the user has never attempted to read the incoming data. Fix by reintroducing `_consuming` which tracks whether `IncomingMessage#_read` was ever successfully called.

Long-term it would be nice if it was possible to reply with status code 413 to a request with a long payload (without actually handling all of that payload) and not have the http client throw `write EPIPE` error while not receiving any of that response.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
