### PR TITLE
doc: fix inconsistency in documentation for building

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -176,10 +176,10 @@ If you are running tests prior to submitting a Pull Request, the recommended
 command is:
 
 ```console
-$ make test
+$ make -j4 test
 ```
 
-`make test` does a full check on the codebase, including running linters and
+`make -j4 test` does a full check on the codebase, including running linters and
 documentation tests.
 
 Optionally, continue below.


### PR DESCRIPTION
Specifically, fix the inconsistency where the documentation
suggests running "$ make test" instead of "$ make -j4 test".
The "-j4" flag uses multiple processes, making the command
faster.

Fixes: https://github.com/nodejs/node/issues/19919

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
