### PR TITLE
doc: update trace_event doc in tracing.md

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -13,15 +13,17 @@ a list of comma-separated category names.
 
 The available categories are:
 
-* `node`
-* `node.async_hooks` - Enables capture of detailed async_hooks trace data.
+* `node` - An empty placeholder.
+* `node.async_hooks` - Enables capture of detailed [async_hooks] trace data.
+  The [async_hooks] events have a unique `asyncId` and a special triggerId
+  `triggerAsyncId` property.
 * `node.bootstrap` - Enables capture of Node.js bootstrap milestones.
 * `node.perf` - Enables capture of [Performance API] measurements.
   * `node.perf.usertiming` - Enables capture of only Performance API User Timing
     measures and marks.
   * `node.perf.timerify` - Enables capture of only Performance API timerify
     measurements.
-* `v8`
+* `v8` - The [V8] events are GC, compiling, and execution related.
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
@@ -193,3 +195,5 @@ console.log(trace_events.getEnabledCategories());
 ```
 
 [Performance API]: perf_hooks.html
+[V8]: v8.html
+[async_hooks]: async_hooks.html


### PR DESCRIPTION
Change title from `tracing` to `trace_event` in the documentation content. Update the description of `node `, `node.async_hooks` and `v8` category to contain information highlighted in #16315.

Fixes: #16315

##### Checklist
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

P.S.: After reading #16315, the the [async_hooks](https://github.com/nodejs/node/blob/master/doc/api/async_hooks.md) and [v8](https://github.com/nodejs/node/blob/master/doc/api/v8.md) documentations in details, I'm hoping to give this "_good first issue_" issue an attempt.

Thanks for your time to review in advance. Hoping the PR looks okay. Happy to update according to any review feedback. ✌️ 