### PR TITLE
test: fix flaky http-server-keep-alive-timeout

### DIFF
--- a/test/parallel/test-http-server-keep-alive-timeout.js
+++ b/test/parallel/test-http-server-keep-alive-timeout.js
@@ -18,15 +18,29 @@ function run() {
   if (fn) fn(run);
 }
 
-test(function serverEndKeepAliveTimeoutWithPipeline(cb) {
+function done(server, socket, cb) {
+  socket.destroy();
+  server.close();
+  cb();
+}
+
+function server_test(with_pipeline, cb) {
+  let got_all = false;
+  let timedout = false;
   const server = http.createServer(common.mustCall((req, res) => {
-    res.end();
+    if (with_pipeline)
+      res.end();
+    if (req.url === '/3') {
+      got_all = true;
+      if (timedout)
+        done(server, req.socket, cb);
+    }
   }, 3));
   server.setTimeout(500, common.mustCall((socket) => {
     // End this test and call `run()` for the next test (if any).
-    socket.destroy();
-    server.close();
-    cb();
+    timedout = true;
+    if (got_all)
+      done(server, socket, cb);
   }));
   server.keepAliveTimeout = 50;
   server.listen(0, common.mustCall(() => {
@@ -40,26 +54,12 @@ test(function serverEndKeepAliveTimeoutWithPipeline(cb) {
       c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
     });
   }));
+}
+
+test(function serverEndKeepAliveTimeoutWithPipeline(cb) {
+  server_test(true, cb);
 });
 
 test(function serverNoEndKeepAliveTimeoutWithPipeline(cb) {
-  const server = http.createServer(common.mustCall(3));
-  server.setTimeout(500, common.mustCall((socket) => {
-    // End this test and call `run()` for the next test (if any).
-    socket.destroy();
-    server.close();
-    cb();
-  }));
-  server.keepAliveTimeout = 50;
-  server.listen(0, common.mustCall(() => {
-    const options = {
-      port: server.address().port,
-      allowHalfOpen: true
-    };
-    const c = net.connect(options, () => {
-      c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-      c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-      c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-    });
-  }));
+  server_test(false, cb);
 });

--- a/test/parallel/test-http-server-keep-alive-timeout.js
+++ b/test/parallel/test-http-server-keep-alive-timeout.js
@@ -20,11 +20,10 @@ function run() {
 
 function done(server, socket, cb) {
   socket.destroy();
-  server.close();
-  cb();
+  server.close(cb);
 }
 
-function server_test(with_pipeline, cb) {
+function serverTest(with_pipeline, cb) {
   let got_all = false;
   let timedout = false;
   const server = http.createServer(common.mustCall((req, res) => {
@@ -36,7 +35,7 @@ function server_test(with_pipeline, cb) {
         done(server, req.socket, cb);
     }
   }, 3));
-  server.setTimeout(500, common.mustCall((socket) => {
+  server.setTimeout(500, common.mustCallAtLeast((socket) => {
     // End this test and call `run()` for the next test (if any).
     timedout = true;
     if (got_all)
@@ -57,9 +56,9 @@ function server_test(with_pipeline, cb) {
 }
 
 test(function serverEndKeepAliveTimeoutWithPipeline(cb) {
-  server_test(true, cb);
+  serverTest(true, cb);
 });
 
 test(function serverNoEndKeepAliveTimeoutWithPipeline(cb) {
-  server_test(false, cb);
+  serverTest(false, cb);
 });


### PR DESCRIPTION
Make sure the connection is not closed until the 3 requests and the
`timeout` event are received.
Some code refactoring to avoid duplicated code.

Fixes: https://github.com/nodejs/node/issues/20013

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
