### PR TITLE
http: added aborted property to request

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1483,7 +1483,7 @@ following additional events, methods, and properties.
 added: v0.3.8
 -->
 
-Emitted when the request has been aborted and the network socket has closed.
+Emitted when the request has been aborted.
 
 ### Event: 'close'
 <!-- YAML
@@ -1492,6 +1492,16 @@ added: v0.4.2
 
 Indicates that the underlying connection was closed.
 Just like `'end'`, this event occurs only once per response.
+
+### message.aborted
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+The `message.aborted` property will be `true` if the request has
+been aborted.
 
 ### message.destroy([error])
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2414,6 +2414,16 @@ added: v8.4.0
 Indicates that the underlying [`Http2Stream`][] was closed.
 Just like `'end'`, this event occurs only once per response.
 
+#### request.aborted
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+The `request.aborted` property will be `true` if the request has
+been aborted.
+
 #### request.destroy([error])
 <!-- YAML
 added: v8.4.0

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -279,6 +279,7 @@ ClientRequest.prototype.abort = function abort() {
   if (!this.aborted) {
     process.nextTick(emitAbortNT.bind(this));
   }
+
   // Mark as aborting so we can avoid sending queued request data
   // This is used as a truthy flag elsewhere. The use of Date.now is for
   // debugging purposes only.
@@ -330,7 +331,10 @@ function socketCloseListener() {
   var parser = socket.parser;
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.
-    if (!req.res.complete) req.res.emit('aborted');
+    if (!req.res.complete) {
+      req.res.aborted = true;
+      req.res.emit('aborted');
+    }
     var res = req.res;
     res.on('end', function() {
       res.emit('close');

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -52,6 +52,8 @@ function IncomingMessage(socket) {
 
   this.readable = true;
 
+  this.aborted = false;
+
   this.upgrade = null;
 
   // request (server) only

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -444,6 +444,7 @@ function socketOnClose(socket, state) {
 function abortIncoming(incoming) {
   while (incoming.length) {
     var req = incoming.shift();
+    req.aborted = true;
     req.emit('aborted');
     req.emit('close');
   }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -31,6 +31,7 @@ const kTrailers = Symbol('trailers');
 const kRawTrailers = Symbol('rawTrailers');
 const kProxySocket = Symbol('proxySocket');
 const kSetHeader = Symbol('setHeader');
+const kAborted = Symbol('aborted');
 
 const {
   HTTP2_HEADER_AUTHORITY,
@@ -137,6 +138,7 @@ function onStreamDrain() {
 function onStreamAbortedRequest() {
   const request = this[kRequest];
   if (request !== undefined && request[kState].closed === false) {
+    request[kAborted] = true;
     request.emit('aborted');
   }
 }
@@ -233,6 +235,7 @@ class Http2ServerRequest extends Readable {
     this[kTrailers] = {};
     this[kRawTrailers] = [];
     this[kStream] = stream;
+    this[kAborted] = false;
     stream[kProxySocket] = null;
     stream[kRequest] = this;
 
@@ -246,6 +249,10 @@ class Http2ServerRequest extends Readable {
     stream.on('close', this[kFinish].bind(this));
     this.on('pause', onRequestPause);
     this.on('resume', onRequestResume);
+  }
+
+  get aborted() {
+    return this[kAborted];
   }
 
   get complete() {

--- a/test/parallel/test-http-aborted.js
+++ b/test/parallel/test-http-aborted.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('aborted', common.mustCall(function() {
+    assert.strictEqual(this.aborted, true);
+    server.close();
+  }));
+  assert.strictEqual(req.aborted, false);
+  res.write('hello');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    port: server.address().port,
+    headers: { connection: 'keep-alive' }
+  }, common.mustCall((res) => {
+    res.on('aborted', common.mustCall(() => {
+      assert.strictEqual(res.aborted, true);
+    }));
+    req.abort();
+  }));
+}));

--- a/test/parallel/test-http2-compat-aborted.js
+++ b/test/parallel/test-http2-compat-aborted.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+const assert = require('assert');
+
+
+const server = h2.createServer(common.mustCall(function(req, res) {
+  req.on('aborted', common.mustCall(function() {
+    assert.strictEqual(this.aborted, true);
+  }));
+  assert.strictEqual(req.aborted, false);
+  res.write('hello');
+  server.close();
+}));
+
+server.listen(0, common.mustCall(function() {
+  const url = `http://localhost:${server.address().port}`;
+  const client = h2.connect(url, common.mustCall(() => {
+    const request = client.request();
+    request.on('data', common.mustCall((chunk) => {
+      client.destroy();
+    }));
+  }));
+}));


### PR DESCRIPTION
Added an `aborted` property to the request object. Currently, it is not possible to query whether a `close` event was emitted due to client side socket close without also listening to `aborted`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)