### PR TITLE
lib: remove duplicate require calls in tls.js

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -34,6 +34,8 @@ const { Buffer } = require('buffer');
 const EventEmitter = require('events');
 const DuplexPair = require('internal/streams/duplexpair');
 const { canonicalizeIP } = process.binding('cares_wrap');
+const _tls_common = require('_tls_common');
+const _tls_wrap = require('_tls_wrap');
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
 // every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more
@@ -265,12 +267,12 @@ exports.parseCertString = internalUtil.deprecate(
   'Please use querystring.parse() instead.',
   'DEP0076');
 
-exports.createSecureContext = require('_tls_common').createSecureContext;
-exports.SecureContext = require('_tls_common').SecureContext;
-exports.TLSSocket = require('_tls_wrap').TLSSocket;
-exports.Server = require('_tls_wrap').Server;
-exports.createServer = require('_tls_wrap').createServer;
-exports.connect = require('_tls_wrap').connect;
+exports.createSecureContext = _tls_common.createSecureContext;
+exports.SecureContext = _tls_common.SecureContext;
+exports.TLSSocket = _tls_wrap.TLSSocket;
+exports.Server = _tls_wrap.Server;
+exports.createServer = _tls_wrap.createServer;
+exports.connect = _tls_wrap.connect;
 
 exports.createSecurePair = internalUtil.deprecate(
   function createSecurePair(...args) {


### PR DESCRIPTION
This commit removes the duplicate require calls of the `_tls_common` and
`_tls_wrap` modules. The motivation for this being that even though the
modules are cached the additional calls are unnecessary.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
