### PR TITLE
deps: bump V8 embedder string

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.3',
+    'v8_embedder_string': '-node.4',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,


### PR DESCRIPTION
This was missed in a previous PR

Refs: https://github.com/nodejs/node/pull/20016

would like this to fast track to not block other V8 prs