### PR TITLE
src: remove `MarkIndependent()` calls

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -70,7 +70,6 @@ inline void BaseObject::MakeWeak(Type* ptr) {
   v8::Local<v8::Object> handle = object();
   CHECK_GT(handle->InternalFieldCount(), 0);
   Wrap(handle, ptr);
-  persistent_handle_.MarkIndependent();
   persistent_handle_.SetWeak<Type>(ptr, WeakCallback<Type>,
                                    v8::WeakCallbackType::kParameter);
 }

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -387,7 +387,6 @@ class Reference : private Finalizer {
     if (initial_refcount == 0) {
       _persistent.SetWeak(
           this, FinalizeCallback, v8::WeakCallbackType::kParameter);
-      _persistent.MarkIndependent();
     }
   }
 
@@ -431,7 +430,6 @@ class Reference : private Finalizer {
     if (--_refcount == 0) {
       _persistent.SetWeak(
           this, FinalizeCallback, v8::WeakCallbackType::kParameter);
-      _persistent.MarkIndependent();
     }
 
     return _refcount;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -140,7 +140,6 @@ CallbackInfo::CallbackInfo(Isolate* isolate,
 
   persistent_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
   persistent_.SetWrapperClassId(BUFFER_ID);
-  persistent_.MarkIndependent();
   isolate->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
 }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -104,7 +104,6 @@ ContextifyContext::ContextifyContext(
   if (context_.IsEmpty())
     return;
   context_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
-  context_.MarkIndependent();
 }
 
 

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -83,7 +83,6 @@ class ObjectWrap {
 
   inline void MakeWeak(void) {
     persistent().SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
-    persistent().MarkIndependent();
   }
 
   /* Ref() marks the object as being attached to an event loop.


### PR DESCRIPTION
The method has been deprecated in upstream V8, with messaging
indicating that it is the default for handles to be independent
now anyway.

Refs: https://github.com/v8/v8/commit/71ad48fb8f214e80518ba0419796e4c571351255

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
