### PR TITLE
src: remove redundant calls to v8::HandleScope

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -50,7 +50,6 @@ inline AsyncWrap::AsyncScope::AsyncScope(AsyncWrap* wrap)
   Environment* env = wrap->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kBefore] == 0)
     return;
-  v8::HandleScope handle_scope(env->isolate());
   EmitBefore(env, wrap->get_async_id());
 }
 
@@ -58,7 +57,6 @@ inline AsyncWrap::AsyncScope::~AsyncScope() {
   Environment* env = wrap_->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kAfter] == 0)
     return;
-  v8::HandleScope handle_scope(env->isolate());
   EmitAfter(env, wrap_->get_async_id());
 }
 


### PR DESCRIPTION
### Blocked for https://github.com/nodejs/node/pull/20045

Remove redundant calls to v8::HandleScope in the contructor and
destructor for the AsyncScope class

Refs: https://github.com/nodejs/node/pull/19972#issuecomment-381353894
Refs: https://github.com/nodejs/node/pull/20045

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @hashseed @addaleax @nodejs/v8 