### PR TITLE
doc: update links and names for DevTools Protocol

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -128,7 +128,7 @@ Activate inspector on host:port. Default is 127.0.0.1:9229.
 
 V8 inspector integration allows tools such as Chrome DevTools and IDEs to debug
 and profile Node.js instances. The tools attach to Node.js instances via a
-tcp port and communicate using the [Chrome Debugging Protocol][].
+tcp port and communicate using the [Chrome DevTools Protocol][].
 
 
 ### `--napi-modules`
@@ -678,7 +678,7 @@ greater than `4` (its current default value). For more information, see the
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
-[Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer
+[Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [debugger]: debugger.html
 [emit_warning]: process.html#process_process_emitwarning_warning_type_code_ctor

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -174,7 +174,7 @@ breakpoint)
 
 V8 Inspector integration allows attaching Chrome DevTools to Node.js
 instances for debugging and profiling. It uses the
-[Chrome Debugging Protocol][].
+[Chrome DevTools Protocol][].
 
 V8 Inspector can be enabled by passing the `--inspect` flag when starting a
 Node.js application. It is also possible to supply a custom port with that flag,
@@ -194,5 +194,5 @@ To start debugging, open the following URL in Chrome:
 at the end of the URL is generated on the fly, it varies in different
 debugging sessions.)
 
-[Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer/
+[Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [V8 Inspector]: #debugger_v8_inspector_integration_for_node_js

--- a/doc/node.1
+++ b/doc/node.1
@@ -114,7 +114,7 @@ Default is
 .Sy 127.0.0.1:9229 .
 .Pp
 V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js instances for debugging and profiling.
-It uses the Chrome Debugging Protocol.
+It uses the Chrome DevTools Protocol.
 .
 .It Fl -napi-modules
 Enable loading native modules compiled with the ABI-stable Node.js API (N-API)


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

The old URL is now redirected to this URL.