### PR TITLE
src: kickstart addon by calling its constructor

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -545,6 +545,16 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
   /* NOLINTNEXTLINE (readability/null_usage) */                       \
   NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
 
+#define NODE_MODULE_FALLBACK_X(modname)                               \
+  extern "C" {                                                        \
+    void node_kickstart_module() {                                    \
+      _register_ ## modname();                                        \
+    }                                                                 \
+  }
+
+#define NODE_MODULE_FALLBACK(modname)                                 \
+  NODE_MODULE_FALLBACK_X(modname)
+
 /*
  * For backward compatibility in add-on modules.
  */

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -93,6 +93,16 @@ typedef struct {
 #define NAPI_MODULE(modname, regfunc) \
   NAPI_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
 
+#define NAPI_MODULE_FALLBACK_X(modname)                               \
+  EXTERN_C_START                                                      \
+    void node_kickstart_module() {                                    \
+      _register_ ## modname();                                        \
+    }                                                                 \
+  EXTERN_C_END
+
+#define NAPI_MODULE_FALLBACK(modname)                                 \
+  NAPI_MODULE_FALLBACK_X(modname)
+
 #define NAPI_AUTO_LENGTH SIZE_MAX
 
 EXTERN_C_START

--- a/test/addons-napi/addon-fallback/binding.c
+++ b/test/addons-napi/addon-fallback/binding.c
@@ -1,0 +1,14 @@
+#include "node_api.h"
+#include "../common.h"
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_value result, answer;
+
+  NAPI_CALL(env, napi_create_object(env, &result));
+  NAPI_CALL(env, napi_create_int64(env, 42, &answer));
+  NAPI_CALL(env, napi_set_named_property(env, result, "answer", answer));
+  return result;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
+NAPI_MODULE_FALLBACK(NODE_GYP_MODULE_NAME)

--- a/test/addons-napi/addon-fallback/binding.gyp
+++ b/test/addons-napi/addon-fallback/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.c' ]
+    }
+  ]
+}

--- a/test/addons-napi/addon-fallback/test.js
+++ b/test/addons-napi/addon-fallback/test.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
+assert.strictEqual(binding.answer, 42);
+
+// Test multiple loading of the same module.
+delete require.cache[bindingPath];
+const rebinding = require(bindingPath);
+assert.strictEqual(rebinding.answer, 42);
+assert.notStrictEqual(binding, rebinding);

--- a/test/addons/addon-fallback/binding.cc
+++ b/test/addons/addon-fallback/binding.cc
@@ -1,0 +1,33 @@
+#include "node.h"
+
+void Init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Value> module,
+          v8::Local<v8::Context> context) {
+  const char *error = nullptr;
+
+  v8::Isolate *isolate = context->GetIsolate();
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  v8::Local<v8::String> prop_name;
+  auto answer = v8::Number::New(isolate, 42.0).As<v8::Value>();
+
+  prop_name = v8::String::NewFromUtf8(isolate, "answer",
+      v8::NewStringType::kNormal).ToLocalChecked();
+  if (result->Set(context, prop_name, answer).FromJust()) {
+    prop_name = v8::String::NewFromUtf8(isolate, "exports",
+        v8::NewStringType::kNormal).ToLocalChecked();
+    if (module.As<v8::Object>()->Set(context, prop_name, result).FromJust()) {
+      return;
+    } else {
+      error = "Failed to set exports";
+    }
+  } else {
+    error = "Failed to set property";
+  }
+
+  isolate->ThrowException(
+      v8::String::NewFromUtf8(isolate, error,
+          v8::NewStringType::kNormal).ToLocalChecked());
+}
+
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Init)
+NODE_MODULE_FALLBACK(NODE_GYP_MODULE_NAME)

--- a/test/addons/addon-fallback/binding.gyp
+++ b/test/addons/addon-fallback/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/addon-fallback/test.js
+++ b/test/addons/addon-fallback/test.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
+assert.strictEqual(binding.answer, 42);
+
+// Test multiple loading of the same module.
+delete require.cache[bindingPath];
+const rebinding = require(bindingPath);
+assert.strictEqual(rebinding.answer, 42);
+assert.notStrictEqual(binding, rebinding);


### PR DESCRIPTION
If the addon does not self-register and a well-known Init symbol cannot
be found, look for a version-agnostic symbol which calls the library
constructor and call it if found.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
