### PR TITLE
test: check that modules backed by read-only files can load (win32)

### DIFF
--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const fixtures = require('../common/fixtures');
+
+if (process.platform == 'win32') {
+    // Create readOnlyMod.js and set to read only
+    const readOnlyMod = fixtures.path('readOnlyMod');
+    const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
+    const readOnlyModFullPath = readOnlyMod + ".js";
+    fs.writeFileSync(readOnlyModFullPath, "module.exports = 42;");
+
+    // Removed any inherited ACEs, and any explicitly granted ACEs for the current user
+    cp.execSync(`icacls.exe "${readOnlyModFullPath}" /inheritance:r /remove "%USERNAME%"`);
+    // Grant the current user read & execute only
+    cp.execSync(`icacls.exe "${readOnlyModFullPath}" /grant "%USERNAME%":RX`);
+
+    let except = null;
+    try {
+        // Attempt to load the module. Will fail if write access is required
+        const mymod = require(readOnlyModRelative);
+    } catch(err) {
+        except = err;
+    }
+
+    // Remove the expliclty granted rights, and reenable inheritance
+    cp.execSync(`icacls.exe "${readOnlyModFullPath}" /remove "%USERNAME%" /inheritance:e`);
+
+    // Delete the file
+    fs.unlinkSync(readOnlyModFullPath);
+
+    if (except) throw except;
+}
+// TODO: Similar checks on *nix-like systems (e.g. using chmod or the like)

--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -1,11 +1,13 @@
-const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
 if (process.platform == 'win32') {
     // Create readOnlyMod.js and set to read only
-    const readOnlyMod = path.join(os.tmpdir(), 'readOnlyMod');
+    const readOnlyMod = path.join(tmpdir.path, 'readOnlyMod');
     const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
     const readOnlyModFullPath = readOnlyMod + ".js";
     fs.writeFileSync(readOnlyModFullPath, "module.exports = 42;");

--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -1,12 +1,11 @@
+const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 
-const fixtures = require('../common/fixtures');
-
 if (process.platform == 'win32') {
     // Create readOnlyMod.js and set to read only
-    const readOnlyMod = fixtures.path('readOnlyMod');
+    const readOnlyMod = path.join(os.tmpdir(), 'readOnlyMod');
     const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
     const readOnlyModFullPath = readOnlyMod + ".js";
     fs.writeFileSync(readOnlyModFullPath, "module.exports = 42;");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is the test-case for the issue at https://github.com/nodejs/node/issues/20112 . This fails with the issue present, and passes with the fix applied. 

Note: Even before any changes, `vcbuild test` gave a ton of failures for me, so not sure if that is my machine or something more fundamental. This test behaves as expected though.

CC @vsemozhetbyt, @cjihrig, @richardlau 