### PR TITLE
tests/parallel: removes string literals from test-domain-timer.js

### DIFF
--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -27,8 +27,7 @@ const assert = require('assert');
 const timeoutd = domain.create();
 
 timeoutd.on('error', common.mustCall(function(e) {
-  assert.strictEqual(e.message, 'Timeout UNREFd',
-                     'Domain should catch timer error');
+  assert.strictEqual(e.message, 'Timeout UNREFd');
   clearTimeout(timeout);
 }, 2));
 
@@ -47,8 +46,7 @@ t.unref();
 const immediated = domain.create();
 
 immediated.on('error', common.mustCall(function(e) {
-  assert.strictEqual(e.message, 'Immediate Error',
-                     'Domain should catch immediate error');
+  assert.strictEqual(e.message, 'Immediate Error');
 }));
 
 immediated.run(function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


This PR is related to the issue given by **nodetodo**. cc @Trott 