### PR TITLE
http: _http_common.js (and associated) cleanup

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -606,7 +606,6 @@ function tickOnSocket(req, socket) {
   req.connection = socket;
   parser.reinitialize(HTTPParser.RESPONSE);
   parser.socket = socket;
-  parser.incoming = null;
   parser.outgoing = req;
   req.parser = parser;
 
@@ -619,9 +618,6 @@ function tickOnSocket(req, socket) {
   // Propagate headers limit from request object to parser
   if (typeof req.maxHeadersCount === 'number') {
     parser.maxHeaderPairs = req.maxHeadersCount << 1;
-  } else {
-    // Set default value because parser may be reused from FreeList
-    parser.maxHeaderPairs = 2000;
   }
 
   parser.onIncoming = parserOnIncomingClient;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -65,12 +65,12 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   const parser = this;
   const { socket } = parser;
 
-  if (!headers) {
+  if (headers === undefined) {
     headers = parser._headers;
     parser._headers = [];
   }
 
-  if (!url) {
+  if (url === undefined) {
     url = parser._url;
     parser._url = '';
   }
@@ -80,12 +80,12 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
                                  socket.server[kIncomingMessage]) ||
                                  IncomingMessage;
 
-  parser.incoming = new ParserIncomingMessage(socket);
-  parser.incoming.httpVersionMajor = versionMajor;
-  parser.incoming.httpVersionMinor = versionMinor;
-  parser.incoming.httpVersion = `${versionMajor}.${versionMinor}`;
-  parser.incoming.url = url;
-  parser.incoming.upgrade = upgrade;
+  const incoming = parser.incoming = new ParserIncomingMessage(socket);
+  incoming.httpVersionMajor = versionMajor;
+  incoming.httpVersionMinor = versionMinor;
+  incoming.httpVersion = `${versionMajor}.${versionMinor}`;
+  incoming.url = url;
+  incoming.upgrade = upgrade;
 
   var n = headers.length;
 
@@ -93,51 +93,48 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   if (parser.maxHeaderPairs > 0)
     n = Math.min(n, parser.maxHeaderPairs);
 
-  parser.incoming._addHeaderLines(headers, n);
+  incoming._addHeaderLines(headers, n);
 
   if (typeof method === 'number') {
     // server only
-    parser.incoming.method = methods[method];
+    incoming.method = methods[method];
   } else {
     // client only
-    parser.incoming.statusCode = statusCode;
-    parser.incoming.statusMessage = statusMessage;
+    incoming.statusCode = statusCode;
+    incoming.statusMessage = statusMessage;
   }
 
-  return parser.onIncoming(parser.incoming, shouldKeepAlive);
+  return parser.onIncoming(incoming, shouldKeepAlive);
 }
 
 // XXX This is a mess.
 // TODO: http.Parser should be a Writable emits request/response events.
 function parserOnBody(b, start, len) {
-  var parser = this;
-  var stream = parser.incoming;
+  const stream = this.incoming;
 
   // if the stream has already been removed, then drop it.
-  if (!stream)
+  if (stream === null)
     return;
-
-  var socket = stream.socket;
 
   // pretend this was the result of a stream._read call.
   if (len > 0 && !stream._dumped) {
     var slice = b.slice(start, start + len);
     var ret = stream.push(slice);
     if (!ret)
-      readStop(socket);
+      readStop(this.socket);
   }
 }
 
 function parserOnMessageComplete() {
-  var parser = this;
-  var stream = parser.incoming;
+  const parser = this;
+  const stream = parser.incoming;
 
-  if (stream) {
+  if (stream !== null) {
     stream.complete = true;
     // Emit any trailing headers.
-    var headers = parser._headers;
-    if (headers) {
-      parser.incoming._addHeaderLines(headers, headers.length);
+    const headers = parser._headers;
+    if (headers.length) {
+      stream._addHeaderLines(headers, headers.length);
       parser._headers = [];
       parser._url = '';
     }
@@ -151,8 +148,8 @@ function parserOnMessageComplete() {
 }
 
 
-var parsers = new FreeList('parsers', 1000, function() {
-  var parser = new HTTPParser(HTTPParser.REQUEST);
+const parsers = new FreeList('parsers', 1000, function() {
+  const parser = new HTTPParser(HTTPParser.REQUEST);
 
   parser._headers = [];
   parser._url = '';

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -41,6 +41,8 @@ const kOnBody = HTTPParser.kOnBody | 0;
 const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 const kOnExecute = HTTPParser.kOnExecute | 0;
 
+const MAX_HEADER_PAIRS = 2000;
+
 // Only called in the slow case where slow means
 // that the request headers were either fragmented
 // across multiple TCP packets or too large to be
@@ -159,6 +161,9 @@ const parsers = new FreeList('parsers', 1000, function() {
   parser.incoming = null;
   parser.outgoing = null;
 
+  parser.maxHeaderPairs = MAX_HEADER_PAIRS;
+
+  parser.onIncoming = null;
   parser[kOnHeaders] = parserOnHeaders;
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;
@@ -180,6 +185,8 @@ function closeParserInstance(parser) { parser.close(); }
 function freeParser(parser, req, socket) {
   if (parser) {
     parser._headers = [];
+    parser._url = '';
+    parser.maxHeaderPairs = MAX_HEADER_PAIRS;
     parser.onIncoming = null;
     if (parser._consumed)
       parser.unconsume();

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -191,8 +191,6 @@ function freeParser(parser, req, socket) {
     if (parser._consumed)
       parser.unconsume();
     parser._consumed = false;
-    if (parser.socket)
-      parser.socket.parser = null;
     parser.socket = null;
     parser.incoming = null;
     parser.outgoing = null;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -159,11 +159,6 @@ const parsers = new FreeList('parsers', 1000, function() {
   parser.incoming = null;
   parser.outgoing = null;
 
-  // Only called in the slow case where slow means
-  // that the request headers were either fragmented
-  // across multiple TCP packets or too large to be
-  // processed in a single run. This method is also
-  // called to process trailing HTTP headers.
   parser[kOnHeaders] = parserOnHeaders;
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -522,7 +522,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     socket.removeListener('error', socketOnError);
     unconsume(parser, socket);
     parser.finish();
-    freeParser(parser, req, null);
+    freeParser(parser, req, socket);
     parser = null;
 
     var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -342,14 +342,10 @@ function connectionListenerInternal(server, socket) {
   parser.reinitialize(HTTPParser.REQUEST);
   parser.socket = socket;
   socket.parser = parser;
-  parser.incoming = null;
 
   // Propagate headers limit from server instance to parser
   if (typeof server.maxHeadersCount === 'number') {
     parser.maxHeaderPairs = server.maxHeadersCount << 1;
-  } else {
-    // Set default value because parser may be reused from FreeList
-    parser.maxHeaderPairs = 2000;
   }
 
   var state = {


### PR DESCRIPTION
There are 4 smaller commits here:

1. Remove constant deep property access by storing a reference,
use more const, make some conditionals stricter.

2. A comment explaining kOnHeaders function of the parser was duplicated
in two places but the second instance was more confusing than helpful.

3. Cleanup constructor and freeParser to manage all existing parser
properties, not just some.

4. freeParser already unsets parser property of socket if socket is passed
in specifically. There's no need to do this twice.

This is a part of an upcoming deep dive into cleaning up some internals of the `http` module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
