### PR TITLE
http: simplify various RegExp and related checks

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -52,8 +52,6 @@ const { utcDate } = internalHttp;
 
 const kIsCorked = Symbol('isCorked');
 
-var RE_FIELDS =
-  /^(?:Connection|Transfer-Encoding|Content-Length|Date|Expect|Trailer|Upgrade)$/i;
 var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
 var RE_TE_CHUNKED = common.chunkExpression;
 
@@ -449,28 +447,27 @@ function matchConnValue(self, state, value) {
 }
 
 function matchHeader(self, state, field, value) {
-  var m = RE_FIELDS.exec(field);
-  if (!m)
+  if (field.length < 4 || field.length > 17)
     return;
-  var len = m[0].length;
-  if (len === 10) {
-    state.connection = true;
-    matchConnValue(self, state, value);
-  } else if (len === 17) {
-    state.te = true;
-    if (RE_TE_CHUNKED.test(value)) self.chunkedEncoding = true;
-  } else if (len === 14) {
-    state.contLen = true;
-  } else if (len === 4) {
-    state.date = true;
-  } else if (len === 6) {
-    state.expect = true;
-  } else if (len === 7) {
-    var ch = m[0].charCodeAt(0);
-    if (ch === 85 || ch === 117)
-      state.upgrade = true;
-    else
-      state.trailer = true;
+  field = field.toLowerCase();
+  switch (field) {
+    case 'connection':
+      state.connection = true;
+      matchConnValue(self, state, value);
+      break;
+    case 'transfer-encoding':
+      state.te = true;
+      if (RE_TE_CHUNKED.test(value)) self.chunkedEncoding = true;
+      break;
+    case 'content-length':
+      state.contLen = true;
+      break;
+    case 'date':
+    case 'expect':
+    case 'trailer':
+    case 'upgrade':
+      state[field] = true;
+      break;
   }
 }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -58,24 +58,10 @@ var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
 var RE_TE_CHUNKED = common.chunkExpression;
 
 // isCookieField performs a case-insensitive comparison of a provided string
-// against the word "cookie." This method (at least as of V8 5.4) is faster than
-// the equivalent case-insensitive regexp, even if isCookieField does not get
-// inlined.
+// against the word "cookie." As of V8 6.6 this is faster than handrolling or
+// using a case-insensitive RegExp.
 function isCookieField(s) {
-  if (s.length !== 6) return false;
-  var ch = s.charCodeAt(0);
-  if (ch !== 99 && ch !== 67) return false;
-  ch = s.charCodeAt(1);
-  if (ch !== 111 && ch !== 79) return false;
-  ch = s.charCodeAt(2);
-  if (ch !== 111 && ch !== 79) return false;
-  ch = s.charCodeAt(3);
-  if (ch !== 107 && ch !== 75) return false;
-  ch = s.charCodeAt(4);
-  if (ch !== 105 && ch !== 73) return false;
-  ch = s.charCodeAt(5);
-  if (ch !== 101 && ch !== 69) return false;
-  return true;
+  return s.length === 6 && s.toLowerCase() === 'cookie';
 }
 
 function noopPendingOutput(amount) {}

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -52,7 +52,7 @@ const { utcDate } = internalHttp;
 
 const kIsCorked = Symbol('isCorked');
 
-var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
+var RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 var RE_TE_CHUNKED = common.chunkExpression;
 
 // isCookieField performs a case-insensitive comparison of a provided string
@@ -432,20 +432,6 @@ function storeHeader(self, state, key, value, validate) {
   matchHeader(self, state, key, value);
 }
 
-function matchConnValue(self, state, value) {
-  var sawClose = false;
-  var m = RE_CONN_VALUES.exec(value);
-  while (m) {
-    if (m[0].length === 5)
-      sawClose = true;
-    m = RE_CONN_VALUES.exec(value);
-  }
-  if (sawClose)
-    self._last = true;
-  else
-    self.shouldKeepAlive = true;
-}
-
 function matchHeader(self, state, field, value) {
   if (field.length < 4 || field.length > 17)
     return;
@@ -453,7 +439,10 @@ function matchHeader(self, state, field, value) {
   switch (field) {
     case 'connection':
       state.connection = true;
-      matchConnValue(self, state, value);
+      if (RE_CONN_CLOSE.test(value))
+        self._last = true;
+      else
+        self.shouldKeepAlive = true;
       break;
     case 'transfer-encoding':
       state.te = true;


### PR DESCRIPTION
This PR simplifies a number of header related checks in `_http_outgoing.js`:

1. http: simplify `isCookieField`
Handrolling and checking char by char is no longer faster than just using toLowerCase and strict comparison.
2. http: use switch in matchHeader
Using a switch improves clarity of the code but also performance for all but a few edge cases which remain on par with the old code.
3. http: simplify `connection: close` search

I've confirmed there is no performance regression from these tests by creating small micro benchmarks with old and new versions of these functions. All the changes should actually improve performance. That said, that wasn't the main point of this PR — readability was.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
