### PR TITLE
loader: fix importing cjs with url parts such as query

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ lib/internal/v8.js
 lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*
-test/es-module/test-esm-dynamic-import.js
 test/fixtures
 test/message/esm_display_syntax_error.mjs
 tools/icu

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -52,9 +52,10 @@ const extensionFormatMap = {
 };
 
 function resolve(specifier, parentURL) {
-  if (NativeModule.nonInternalExists(specifier)) {
+  const [maybeBuiltinSpecifier] = specifier.split(/\?|#/);
+  if (NativeModule.nonInternalExists(maybeBuiltinSpecifier)) {
     return {
-      url: specifier,
+      url: maybeBuiltinSpecifier,
       format: 'builtin'
     };
   }
@@ -90,6 +91,11 @@ function resolve(specifier, parentURL) {
       format = 'cjs';
     else
       throw new ERR_UNKNOWN_FILE_EXTENSION(url.pathname);
+  }
+
+  if (format === 'cjs') {
+    url.search = '';
+    url.hash = '';
   }
 
   return { url: `${url}`, format };


### PR DESCRIPTION
Module.prototype.load doesn't have query/fragment/etc so it is unable to properly reach back into the loader cache and importing any cjs modules with these parts of a url resulted in getting a namespace with default being undefined. also the cjs loader sometimes would completely overwrite entries in the module map which like breaks all sorts of things so that's fixed too.

props to @bdistin for trying out esm with his codebase and finding this, i wish more people would :(

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

p.s. `import 'fs?q=1'` is broken but i don't know a good way to fix it (my current thought is `specifier.split(/[?#]/)[0]` but that seems nasty)
