### PR TITLE
test: fix test-child-process-send-returns-boolean

### DIFF
--- a/test/fixtures/child-process-persistent.js
+++ b/test/fixtures/child-process-persistent.js
@@ -1,1 +1,1 @@
-setInterval(function() {}, 500);
+setInterval(function() {}, 9999);

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -17,9 +17,9 @@ const subScript = fixtures.path('child-process-persistent.js');
   // Test `send` return value on `fork` that opens and IPC by default.
   const n = fork(subScript);
   // `subprocess.send` should always return `true` for the first send.
-  const rv = n.send({ h: 'w' }, (err) => { if (err) assert.fail(err); });
+  const rv = n.send({ h: 'w' }, assert.ifError);
   assert.strictEqual(rv, true);
-  n.kill();
+  n.kill('SIGKILL');
 }
 
 {


### PR DESCRIPTION
test-child-process-send-returns-boolean was unreliable in CI and
locally.

* use 'SIGKILL' for more reliable process termination
* replace callback with assert.ifError()
* increase interval in fixture from 500ms to 9999ms. It's only purpose
  is to keep the process from exiting.

Fixes: https://github.com/nodejs/node/issues/20135

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
