### PR TITLE
test: add test for loading read-only modules

### DIFF
--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+if (common.isWindows) {
+  // Create readOnlyMod.js and set to read only
+  const readOnlyMod = path.join(tmpdir.path, 'readOnlyMod');
+  const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
+  const readOnlyModFullPath = readOnlyMod + '.js';
+
+  fs.writeFileSync(readOnlyModFullPath, 'module.exports = 42;');
+  // Removed any inherited ACEs, and any explicitly granted ACEs for the
+  // current user
+  cp.execSync('icacls.exe "' + readOnlyModFullPath +
+    '" /inheritance:r /remove "%USERNAME%"');
+
+  // Grant the current user read & execute only
+  cp.execSync('icacls.exe "' + readOnlyModFullPath +
+    '" /grant "%USERNAME%":RX');
+
+  let except = null;
+  try {
+    // Attempt to load the module. Will fail if write access is required
+    require(readOnlyModRelative);
+  } catch (err) {
+    except = err;
+  }
+
+  // Remove the expliclty granted rights, and reenable inheritance
+  cp.execSync('icacls.exe "' + readOnlyModFullPath +
+    '" /remove "%USERNAME%" /inheritance:e');
+  // Delete the test module (note: tmpdir should get cleaned anyway)
+  fs.unlinkSync(readOnlyModFullPath);
+
+  assert.ifError(except);
+} else {
+  // TODO: Similar checks on *nix-like systems (e.g using chmod or the like)
+  common.skip('test only runs on Windows');
+}

--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const common = require('../common');
+
+if (!common.isWindows) {
+  // TODO: Similar checks on *nix-like systems (e.g using chmod or the like)
+  common.skip('test only runs on Windows');
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
@@ -9,38 +15,34 @@ const cp = require('child_process');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-if (common.isWindows) {
-  // Create readOnlyMod.js and set to read only
-  const readOnlyMod = path.join(tmpdir.path, 'readOnlyMod');
-  const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
-  const readOnlyModFullPath = readOnlyMod + '.js';
+// Create readOnlyMod.js and set to read only
+const readOnlyMod = path.join(tmpdir.path, 'readOnlyMod');
+const readOnlyModRelative = path.relative(__dirname, readOnlyMod);
+const readOnlyModFullPath = `${readOnlyMod}.js`;
 
-  fs.writeFileSync(readOnlyModFullPath, 'module.exports = 42;');
-  // Removed any inherited ACEs, and any explicitly granted ACEs for the
-  // current user
-  cp.execSync('icacls.exe "' + readOnlyModFullPath +
-    '" /inheritance:r /remove "%USERNAME%"');
+fs.writeFileSync(readOnlyModFullPath, 'module.exports = 42;');
 
-  // Grant the current user read & execute only
-  cp.execSync('icacls.exe "' + readOnlyModFullPath +
-    '" /grant "%USERNAME%":RX');
+// Removed any inherited ACEs, and any explicitly granted ACEs for the
+// current user
+cp.execSync(
+  `icacls.exe "${readOnlyModFullPath}" /inheritance:r /remove "%USERNAME%"`);
 
-  let except = null;
-  try {
-    // Attempt to load the module. Will fail if write access is required
-    require(readOnlyModRelative);
-  } catch (err) {
-    except = err;
-  }
+// Grant the current user read & execute only
+cp.execSync(`icacls.exe "${readOnlyModFullPath}" /grant "%USERNAME%":RX`);
 
-  // Remove the expliclty granted rights, and reenable inheritance
-  cp.execSync('icacls.exe "' + readOnlyModFullPath +
-    '" /remove "%USERNAME%" /inheritance:e');
-  // Delete the test module (note: tmpdir should get cleaned anyway)
-  fs.unlinkSync(readOnlyModFullPath);
-
-  assert.ifError(except);
-} else {
-  // TODO: Similar checks on *nix-like systems (e.g using chmod or the like)
-  common.skip('test only runs on Windows');
+let except = null;
+try {
+  // Attempt to load the module. Will fail if write access is required
+  require(readOnlyModRelative);
+} catch (err) {
+  except = err;
 }
+
+// Remove the expliclty granted rights, and reenable inheritance
+cp.execSync(
+  `icacls.exe "${readOnlyModFullPath}" /remove "%USERNAME%" /inheritance:e`);
+
+// Delete the test module (note: tmpdir should get cleaned anyway)
+fs.unlinkSync(readOnlyModFullPath);
+
+assert.ifError(except);


### PR DESCRIPTION
Adds a test-case to cover loading modules the user does not have permission
to write to.

Covers issue logged in #20112

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CC @Trott @cjihrig @richardlau 