### PR TITLE
lib: remove unnecessary assignment of exports

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -687,7 +687,7 @@ function isStackOverflowError(err) {
          err.message === maxStack_ErrorMessage;
 }
 
-module.exports = exports = {
+module.exports = {
   dnsException,
   errnoException,
   exceptionWithHostPort,

--- a/lib/os.js
+++ b/lib/os.js
@@ -159,7 +159,7 @@ function networkInterfaces() {
   }, {});
 }
 
-module.exports = exports = {
+module.exports = {
   arch,
   cpus,
   endianness,

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -213,7 +213,7 @@ function deserialize(buffer) {
   return der.readValue();
 }
 
-module.exports = exports = {
+module.exports = {
   cachedDataVersionTag,
   getHeapStatistics,
   getHeapSpaceStatistics,


### PR DESCRIPTION
This commit removes the assignment of `exports` since it is not used
in these files and there is no harm re-assigning `module.exports`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
