### PR TITLE
lib: remove unused binding const

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -34,8 +34,7 @@ const { SSL_OP_CIPHER_SERVER_PREFERENCE } = process.binding('constants').crypto;
 // Lazily loaded
 var crypto = null;
 
-const binding = process.binding('crypto');
-const NativeSecureContext = binding.SecureContext;
+const NativeSecureContext = process.binding('crypto').SecureContext;
 
 function SecureContext(secureProtocol, secureOptions, context) {
   if (!(this instanceof SecureContext)) {


### PR DESCRIPTION
This commit removes the binding const as it is only used in one place
which is in the following line.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
