### PR TITLE
src: CancelTerminateExecution before throwing errors

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -279,7 +279,9 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
     result = module->Evaluate(context);
   }
 
+  // Convert the termination exception into a regular exception.
   if (timed_out || received_signal) {
+    env->isolate()->CancelTerminateExecution();
     // It is possible that execution was terminated by another timeout in
     // which this timeout is nested, so check whether one of the watchdogs
     // from this invocation is responsible for termination.
@@ -288,7 +290,6 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
     } else if (received_signal) {
       env->ThrowError("Script execution interrupted.");
     }
-    env->isolate()->CancelTerminateExecution();
   }
 
   if (try_catch.HasCaught()) {

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -852,7 +852,9 @@ class ContextifyScript : public BaseObject {
       result = script->Run(env->context());
     }
 
+    // Convert the termination exception into a regular exception.
     if (timed_out || received_signal) {
+      env->isolate()->CancelTerminateExecution();
       // It is possible that execution was terminated by another timeout in
       // which this timeout is nested, so check whether one of the watchdogs
       // from this invocation is responsible for termination.
@@ -861,7 +863,6 @@ class ContextifyScript : public BaseObject {
       } else if (received_signal) {
         env->ThrowError("Script execution interrupted.");
       }
-      env->isolate()->CancelTerminateExecution();
     }
 
     if (try_catch.HasCaught()) {


### PR DESCRIPTION
Terminating the execution of a script would create a pending
exception, therefore we should cancel the termination
*before* throwing a new exception, otherwise the attempt to
create a custom error may fail.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
