### PR TITLE
Use the correct user-space marker for SystemTap node_gc_stop probe

### DIFF
--- a/src/node.stp
+++ b/src/node.stp
@@ -125,7 +125,7 @@ probe node_gc_start = process("node").mark("gc__start")
     flags);
 }
 
-probe node_gc_stop = process("node").mark("gc__stop")
+probe node_gc_stop = process("node").mark("gc__done")
 {
   scavenge = 1 << 0;
   compact = 1 << 1;


### PR DESCRIPTION
The process("node").mark("gc__stop") is actually
process("node").mark("gc__done").  Use the proper name so that a
developer can use SystemTap to determine the duration of garbage
collection.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
