### PR TITLE
doc: update required compiler level for AIX

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -84,6 +84,9 @@ Depending on host platform, the selection of toolchains may vary.
 * GCC 4.9.4 or newer
 * Clang 3.4.2 or newer
 
+#### AIX
+* GCC 6.3 or newer
+
 #### Windows
 
 * Visual Studio 2017 or the Build Tools thereof


### PR DESCRIPTION
Compilers were updated for 10.X as per
discussion in: https://github.com/nodejs/build/issues/925

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
