### PR TITLE
console: fix class inheritance regression

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -62,21 +62,20 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     return new Console(...arguments);
   }
 
-  let stdout, stderr, ignoreErrors, colorMode;
-  if (options && typeof options.write !== 'function') {
-    ({
-      stdout,
-      stderr = stdout,
-      ignoreErrors = true,
-      colorMode = 'auto'
-    } = options);
-  } else {
-    return new Console({
+  if (!options || typeof options.write === 'function') {
+    options = {
       stdout: options,
       stderr: arguments[1],
       ignoreErrors: arguments[2]
-    });
+    };
   }
+
+  const {
+    stdout,
+    stderr = stdout,
+    ignoreErrors = true,
+    colorMode = 'auto'
+  } = options;
 
   if (!stdout || typeof stdout.write !== 'function') {
     throw new ERR_CONSOLE_WRITABLE_STREAM('stdout');

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -89,6 +89,13 @@ out.write = common.mustCall((d) => {
 // Console() detects if it is called without `new` keyword.
 Console(out, err);
 
+// Extending Console works.
+class MyConsole extends Console {
+  hello() {}
+}
+const myConsole = new MyConsole(process.stdout);
+assert.strictEqual(typeof myConsole.hello, 'function');
+
 // Instance that does not ignore the stream errors.
 const c2 = new Console(out, err, false);
 


### PR DESCRIPTION
Due to a return statement combined with new inside the function, extending Console class does not work when passing in just the stdout arg. This PR fixes it and needs to land for 10.0.0.

Fixes: https://github.com/nodejs/node/issues/20157

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
