### PR TITLE
n-api: initialize a module via a special symbol

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -982,6 +982,32 @@ napi_value Init(napi_env env, napi_value exports) {
 }
 ```
 
+If you expect that your module will be loaded multiple times during the lifetime
+of the Node.js process, you can use the `NAPI_MODULE_INIT` macro to initialize
+your module:
+
+```C
+NAPI_MODULE_INIT() {
+  napi_value answer;
+  napi_status result;
+
+  status = napi_create_int64(env, 42, &answer);
+  if (status != napi_ok) return NULL;
+
+  status = napi_set_named_property(env, exports, "answer", answer);
+  if (status != napi_ok) return NULL;
+
+  return exports;
+}
+```
+
+This macro includes `NAPI_MODULE`, and declares an `Init` function with a
+special name and with visibility beyond the addon. This will allow Node.js to
+initialize the module even if it is loaded multiple times.
+
+The variables `env` and `exports` will be available inside the function body
+following the macro invocation.
+
 For more details on setting properties on objects, see the section on
 [Working with JavaScript Properties][].
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -860,16 +860,23 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
                              v8::Local<v8::Value> module,
                              v8::Local<v8::Context> context,
                              void* priv) {
-  napi_module* mod = static_cast<napi_module*>(priv);
+  napi_module_register_by_symbol(exports, module, context,
+      static_cast<napi_module*>(priv)->nm_register_func);
+}
 
+}  // end of anonymous namespace
+
+void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
+                                    v8::Local<v8::Value> module,
+                                    v8::Local<v8::Context> context,
+                                    napi_addon_register_func init) {
   // Create a new napi_env for this module or reference one if a pre-existing
   // one is found.
   napi_env env = v8impl::GetEnv(context);
 
   napi_value _exports;
   NAPI_CALL_INTO_MODULE_THROW(env,
-      _exports = mod->nm_register_func(env,
-          v8impl::JsValueFromV8LocalValue(exports)));
+      _exports = init(env, v8impl::JsValueFromV8LocalValue(exports)));
 
   // If register function returned a non-null exports object different from
   // the exports object we passed it, set that as the "exports" property of
@@ -880,8 +887,6 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
     napi_set_named_property(env, _module, "exports", _exports);
   }
 }
-
-}  // end of anonymous namespace
 
 // Registers a NAPI module.
 void napi_module_register(napi_module* mod) {

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -90,8 +90,27 @@ typedef struct {
     }                                                                 \
   EXTERN_C_END
 
-#define NAPI_MODULE(modname, regfunc) \
+#define NAPI_MODULE(modname, regfunc)                                 \
   NAPI_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
+
+#define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
+
+#define NAPI_MODULE_INITIALIZER_X(base, version)                      \
+    NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
+#define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
+
+#define NAPI_MODULE_INITIALIZER                                       \
+  NAPI_MODULE_INITIALIZER_X(NAPI_MODULE_INITIALIZER_BASE,             \
+      NAPI_MODULE_VERSION)
+
+#define NAPI_MODULE_INIT()                                            \
+  EXTERN_C_START                                                      \
+  NAPI_MODULE_EXPORT napi_value                                       \
+  NAPI_MODULE_INITIALIZER(napi_env env, napi_value exports);          \
+  EXTERN_C_END                                                        \
+  NAPI_MODULE(NODE_GYP_MODULE_NAME, NAPI_MODULE_INITIALIZER)          \
+  napi_value NAPI_MODULE_INITIALIZER(napi_env env,                    \
+                                     napi_value exports)
 
 #define NAPI_AUTO_LENGTH SIZE_MAX
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -33,6 +33,7 @@
 #include "tracing/trace_event.h"
 #include "node_perf_common.h"
 #include "node_debug_options.h"
+#include "node_api.h"
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -833,6 +834,10 @@ static inline const char *errno_string(int errorno) {
 
 }  // namespace node
 
+void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
+                                    v8::Local<v8::Value> module,
+                                    v8::Local<v8::Context> context,
+                                    napi_addon_register_func init);
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 

--- a/test/addons-napi/1_hello_world/binding.c
+++ b/test/addons-napi/1_hello_world/binding.c
@@ -10,10 +10,8 @@ napi_value Method(napi_env env, napi_callback_info info) {
   return world;
 }
 
-napi_value Init(napi_env env, napi_value exports) {
+NAPI_MODULE_INIT() {
   napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("hello", Method);
   NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
   return exports;
 }
-
-NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/1_hello_world/test.js
+++ b/test/addons-napi/1_hello_world/test.js
@@ -1,6 +1,13 @@
 'use strict';
 const common = require('../../common');
 const assert = require('assert');
-const addon = require(`./build/${common.buildType}/binding`);
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
+assert.strictEqual(binding.hello(), 'world');
+console.log('binding.hello() =', binding.hello());
 
-assert.strictEqual(addon.hello(), 'world');
+// Test multiple loading of the same module.
+delete require.cache[bindingPath];
+const rebinding = require(bindingPath);
+assert.strictEqual(rebinding.hello(), 'world');
+assert.notStrictEqual(binding.hello, rebinding.hello);


### PR DESCRIPTION
Much like regular modules, N-API modules can also benefit from having
a special symbol which they can expose.

Fixes: https://github.com/nodejs/node/issues/19845

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
