### PR TITLE
buffer: fix deprecation warning emit

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -332,21 +332,8 @@ function spliceOne(list, index) {
 const kNodeModulesRE = /^(.*)[\\/]node_modules[\\/]/;
 
 let getStructuredStack;
-let mainPrefix;
 
 function isInsideNodeModules() {
-  // Match the prefix of the main file, if it is inside a `node_modules` folder,
-  // up to and including the innermost `/node_modules/` bit, so that
-  // we can later ignore files which are at the same node_modules level.
-  // For example, having the main script at `/c/node_modules/d/d.js`
-  // would match all code coming from `/c/node_modules/`.
-  if (mainPrefix === undefined) {
-    const match = process.mainModule &&
-                  process.mainModule.filename &&
-                  process.mainModule.filename.match(kNodeModulesRE);
-    mainPrefix = match ? match[0] : '';
-  }
-
   if (getStructuredStack === undefined) {
     // Lazy-load to avoid a circular dependency.
     const { runInNewContext } = require('vm');
@@ -375,8 +362,7 @@ function isInsideNodeModules() {
     // it's likely from Node.js core.
     if (!/^\/|\\/.test(filename))
       continue;
-    const match = filename.match(kNodeModulesRE);
-    return !!match && match[0] !== mainPrefix;
+    return kNodeModulesRE.test(filename);
   }
 
   return false;  // This should be unreachable.

--- a/test/parallel/test-buffer-constructor-node-modules-paths.js
+++ b/test/parallel/test-buffer-constructor-node-modules-paths.js
@@ -20,16 +20,18 @@ function test(main, callSite, expected) {
     assert.strictEqual(stderr.trim(), '');
 }
 
-test('/a/node_modules/b.js', '/a/node_modules/x.js', true);
+test('/a/node_modules/b.js', '/a/node_modules/x.js', false);
 test('/a/node_modules/b.js', '/a/node_modules/foo/node_modules/x.js', false);
 test('/a/node_modules/foo/node_modules/b.js', '/a/node_modules/x.js', false);
 test('/node_modules/foo/b.js', '/node_modules/foo/node_modules/x.js', false);
 test('/a.js', '/b.js', true);
 test('/a.js', '/node_modules/b.js', false);
-test('c:\\a\\node_modules\\b.js', 'c:\\a\\node_modules\\x.js', true);
+test('/node_modules/a.js.js', '/b.js', true);
+test('c:\\a\\node_modules\\b.js', 'c:\\a\\node_modules\\x.js', false);
 test('c:\\a\\node_modules\\b.js',
      'c:\\a\\node_modules\\foo\\node_modules\\x.js', false);
 test('c:\\node_modules\\foo\\b.js',
      'c:\\node_modules\\foo\\node_modules\\x.js', false);
 test('c:\\a.js', 'c:\\b.js', true);
 test('c:\\a.js', 'c:\\node_modules\\b.js', false);
+test('c:\\node_modules\\a.js', 'c:\\b.js', true);


### PR DESCRIPTION
Due to npm using workers on Windows which inititate processes for code within node_modules, the current way of testing is a little too strict to catch all occurrences.

I understand that the previous implementation was there for a reason but as far as I can tell it's also likely to get a lot of other false positives than just the `npm install` issue — such as running code in `node_modules/.bin/`.

Fixes: https://github.com/nodejs/node/issues/20160

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
