### PR TITLE
test: remove message from strictEqual assertions

### DIFF
--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -48,8 +48,7 @@ server.on('listening', common.mustCall(() => {
 
   req.on('response', common.mustCall((headers) => {
     assert(Array.isArray(headers['set-cookie']));
-    assert.deepStrictEqual(headers['set-cookie'], setCookie,
-                           'set-cookie header does not match');
+    assert.deepStrictEqual(headers['set-cookie'], setCookie);
   }));
 
   req.on('end', common.mustCall(() => {


### PR DESCRIPTION
When an AssertionError happens, the value of headers['set-cookie']
is not reported. That information is useful for debugging.
Hence removed the value passed as the message in deepStrictEqual assertions
of test/parallel/test-http2-cookies.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This first contribution is based on a suggestion from cc @Trott 
