### PR TITLE
src: create per-isolate strings after platform setup

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -28,44 +28,46 @@ IsolateData::IsolateData(Isolate* isolate,
                          uv_loop_t* event_loop,
                          MultiIsolatePlatform* platform,
                          uint32_t* zero_fill_field) :
-
-// Create string and private symbol properties as internalized one byte strings.
-//
-// Internalized because it makes property lookups a little faster and because
-// the string is created in the old space straight away.  It's going to end up
-// in the old space sooner or later anyway but now it doesn't go through
-// v8::Eternal's new space handling first.
-//
-// One byte because our strings are ASCII and we can safely skip V8's UTF-8
-// decoding step.  It's a one-time cost, but why pay it when you don't have to?
-#define V(PropertyName, StringValue)                                          \
-    PropertyName ## _(                                                        \
-        isolate,                                                              \
-        Private::New(                                                         \
-            isolate,                                                          \
-            String::NewFromOneByte(                                           \
-                isolate,                                                      \
-                reinterpret_cast<const uint8_t*>(StringValue),                \
-                v8::NewStringType::kInternalized,                             \
-                sizeof(StringValue) - 1).ToLocalChecked())),
-  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
-#undef V
-#define V(PropertyName, StringValue)                                          \
-    PropertyName ## _(                                                        \
-        isolate,                                                              \
-        String::NewFromOneByte(                                               \
-            isolate,                                                          \
-            reinterpret_cast<const uint8_t*>(StringValue),                    \
-            v8::NewStringType::kInternalized,                                 \
-            sizeof(StringValue) - 1).ToLocalChecked()),
-    PER_ISOLATE_STRING_PROPERTIES(V)
-#undef V
     isolate_(isolate),
     event_loop_(event_loop),
     zero_fill_field_(zero_fill_field),
     platform_(platform) {
   if (platform_ != nullptr)
     platform_->RegisterIsolate(this, event_loop);
+
+  // Create string and private symbol properties as internalized one byte
+  // strings after the platform is properly initialized.
+  //
+  // Internalized because it makes property lookups a little faster and
+  // because the string is created in the old space straight away.  It's going
+  // to end up in the old space sooner or later anyway but now it doesn't go
+  // through v8::Eternal's new space handling first.
+  //
+  // One byte because our strings are ASCII and we can safely skip V8's UTF-8
+  // decoding step.
+
+#define V(PropertyName, StringValue)                                        \
+    PropertyName ## _.Set(                                                  \
+        isolate,                                                            \
+        Private::New(                                                       \
+            isolate,                                                        \
+            String::NewFromOneByte(                                         \
+                isolate,                                                    \
+                reinterpret_cast<const uint8_t*>(StringValue),              \
+                v8::NewStringType::kInternalized,                           \
+                sizeof(StringValue) - 1).ToLocalChecked()));
+  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
+#undef V
+#define V(PropertyName, StringValue)                                        \
+    PropertyName ## _.Set(                                                  \
+        isolate,                                                            \
+        String::NewFromOneByte(                                             \
+            isolate,                                                        \
+            reinterpret_cast<const uint8_t*>(StringValue),                  \
+            v8::NewStringType::kInternalized,                               \
+            sizeof(StringValue) - 1).ToLocalChecked());
+  PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
 }
 
 IsolateData::~IsolateData() {


### PR DESCRIPTION
Allocation of strings may cause a garbage collection that uses
the platform to post tasks.

Fixes: https://github.com/nodejs/node/issues/20171

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
