### PR TITLE
doc: fix a typo in console documentation

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -425,7 +425,7 @@ added: v0.1.104
 * `message` {any}
 * `...args` {any}
 
-Prints to `stderr` the string `'Trace :'`, followed by the [`util.format()`][]
+Prints to `stderr` the string `'Trace: '`, followed by the [`util.format()`][]
 formatted message and stack trace to the current position in the code.
 
 ```js


### PR DESCRIPTION
`console.trace()` function prints 'Trace: ', not 'Trace :'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
