### PR TITLE
src: cover extra load-via-special-symbol scenario

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2290,6 +2290,13 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
 
   // -1 is used for N-API modules
   if ((mp->nm_version != -1) && (mp->nm_version != NODE_MODULE_VERSION)) {
+    // Even if the module did self-register, it may have done so with the wrong
+    // version. We must only give up after having checked to see if it has an
+    // appropriate initializer callback.
+    if (auto callback = GetInitializerCallback(&dlib)) {
+      callback(exports, module, context);
+      return;
+    }
     char errmsg[1024];
     snprintf(errmsg,
              sizeof(errmsg),

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -15,3 +15,20 @@ extern "C" NODE_MODULE_EXPORT void INITIALIZER(v8::Local<v8::Object> exports,
                                                v8::Local<v8::Context> context) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
+
+static void FakeInit(v8::Local<v8::Object> exports,
+                     v8::Local<v8::Value> module,
+                     v8::Local<v8::Context> context) {
+  auto isolate = context->GetIsolate();
+  auto exception = v8::Exception::Error(v8::String::NewFromUtf8(isolate,
+      "FakeInit should never run!", v8::NewStringType::kNormal)
+          .ToLocalChecked());
+  isolate->ThrowException(exception);
+}
+
+// Define a Node.js module, but with the wrong version. Node.js should still be
+// able to load this module, multiple times even, because it exposes the
+// specially named initializer above.
+#undef NODE_MODULE_VERSION
+#define NODE_MODULE_VERSION 3
+NODE_MODULE(NODE_GYP_MODULE_NAME, FakeInit)


### PR DESCRIPTION
We need to look for a special symbol even if the module self-registers
when the module self-registers with the wrong version.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Re https://github.com/nodejs/node/pull/20161