### PR TITLE
test: add strictEqual method to assert

### DIFF
--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -21,7 +21,7 @@ function onStream(stream, headers) {
   const socket = stream.session[kSocket];
 
   assert(stream.session.encrypted);
-  assert(stream.session.alpnProtocol, 'h2');
+  assert.strictEqual(stream.session.alpnProtocol, 'h2');
   const originSet = stream.session.originSet;
   assert(Array.isArray(originSet));
   assert.strictEqual(originSet[0],


### PR DESCRIPTION
Adds strictEqual method to assert on stream.session.alpnProtocol
to verify expected value 'h2'. This changes 'h2' from an assertion
error message to the value expected from stream.session.alpnProtocol.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
