### PR TITLE
doc,http2: add parameters for Http2Session:connect event

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -136,6 +136,9 @@ listener does not expect any arguments.
 added: v8.4.0
 -->
 
+* `session` {Http2Session}
+* `socket` {net.Socket}
+
 The `'connect'` event is emitted once the `Http2Session` has been successfully
 connected to the remote peer and communication may begin.
 


### PR DESCRIPTION
Add parameters for the callback for the Http2Session:connect event
inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mcollina @nodejs/http2 