### PR TITLE
test: improve http res write and end dont take array

### DIFF
--- a/test/parallel/test-http-res-write-end-dont-take-array.js
+++ b/test/parallel/test-http-res-write-end-dont-take-array.js
@@ -35,15 +35,26 @@ server.once('request', common.mustCall((req, res) => {
   // write should accept buffer
   res.write(Buffer.from('asdf'));
 
+  const expectedError = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  };
+
   // write should not accept an Array
-  assert.throws(function() {
-    res.write(['array']);
-  }, TypeError, 'first argument must be a string or Buffer');
+  assert.throws(
+    () => {
+      res.write(['array']);
+    },
+    expectedError
+  );
 
   // end should not accept an Array
-  assert.throws(function() {
-    res.end(['moo']);
-  }, TypeError, 'first argument must be a string or Buffer');
+  assert.throws(
+    () => {
+      res.end(['moo']);
+    },
+    expectedError
+  );
 
   // end should accept string
   res.end('string');


### PR DESCRIPTION
Checking if the error thrown in res.write and res.end is ERR_INVALID_ARG_TYPE if arg is array.
