### PR TITLE
tools: delete redundant .eslintignore rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,7 +8,6 @@ test/message/esm_display_syntax_error.mjs
 tools/node_modules
 tools/icu
 tools/remark-*
-node_modules
 benchmark/tmp
 doc/**/*.js
 !.eslintrc.js


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Top-level `node_modules` folders are ignored by default.

Refs: https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories
