### PR TITLE
tools: delete redundant .eslintignore rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ test/addons/??_*
 test/es-module/test-esm-dynamic-import.js
 test/fixtures
 test/message/esm_display_syntax_error.mjs
-tools/node_modules
 tools/icu
 tools/remark-*
 node_modules


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

The `node_modules` rule below is treated as a glob pattern, so it includes the `tools/node_modules` folder.

Refs: https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories
Refs: https://git-scm.com/docs/gitignore#_pattern_format