### PR TITLE
test: increase speed of test-benchmark-http

### DIFF
--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -18,12 +18,14 @@ runBenchmark('http',
                'chunkedEnc=true',
                'chunks=0',
                'dur=0.1',
+               'input=',
                'key=""',
                'len=1',
                'method=write',
                'n=1',
                'res=normal',
-               'type=asc'
+               'type=asc',
+               'value=X-Powered-By'
              ],
              {
                NODEJS_BENCHMARK_ZERO_ALLOWED: 1,


### PR DESCRIPTION
More benchmark options have been added but not specified in the
benchmark test to reduce runtime of that test. This adds those options,
reducing run time by about 40% on my machine locally.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
