### PR TITLE
doc,http2: add parameters for Http2Session:error event

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -149,6 +149,8 @@ User code will typically not listen for this event directly.
 added: v8.4.0
 -->
 
+* `error` {Error}
+
 The `'error'` event is emitted when an error occurs during the processing of
 an `Http2Session`.
 


### PR DESCRIPTION
Add parameters for the callback for the Http2Session:error event
inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mcollina @nodejs/http2 @vsemozhetbyt 
