### PR TITLE
meta: document commit msg exception for long URLs

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -151,7 +151,7 @@ A good commit message should describe what changed and why.
 
 
 2. Keep the second line blank.
-3. Wrap all other lines at 72 columns.
+3. Wrap all other lines at 72 columns (except for long URLs).
 
 4. If your patch fixes an open issue, you can add a reference to it at the end
 of the log. Use the `Fixes:` prefix and the full issue URL. For other references


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: https://github.com/nodejs/node/issues/17116
Refs: https://github.com/nodejs/core-validate-commit/issues/24