### PR TITLE
doc: fix incorrect net listen signature

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -192,7 +192,7 @@ Possible signatures:
 * [`server.listen(options[, callback])`][`server.listen(options)`]
 * [`server.listen(path[, backlog][, callback])`][`server.listen(path)`]
   for [IPC][] servers
-* [`server.listen([[[port[, hostname[, backlog]]][, callback])`][`server.listen(port, host)`]
+* [`server.listen([[[port[, host[, backlog]]][, callback])`][`server.listen(port, host)`]
   for TCP servers
 
 This function is asynchronous. When the server starts listening, the
@@ -264,7 +264,7 @@ added: v0.11.14
 * Returns: {net.Server}
 
 If `port` is specified, it behaves the same as
-[`server.listen([[[port[, hostname[, backlog]]][, callback])`][`server.listen(port, host)`].
+[`server.listen([[[port[, host[, backlog]]][, callback])`][`server.listen(port, host)`].
 Otherwise, if `path` is specified, it behaves the same as
 [`server.listen(path[, backlog][, callback])`][`server.listen(path)`].
 If none of them is specified, an error will be thrown.
@@ -296,7 +296,7 @@ added: v0.1.90
 
 Start a [IPC][] server listening for connections on the given `path`.
 
-#### server.listen([port][, host][, backlog][, callback])
+#### server.listen([[[port[, host[, backlog]]][, callback])
 <!-- YAML
 added: v0.1.90
 -->

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -192,7 +192,7 @@ Possible signatures:
 * [`server.listen(options[, callback])`][`server.listen(options)`]
 * [`server.listen(path[, backlog][, callback])`][`server.listen(path)`]
   for [IPC][] servers
-* [`server.listen([[[port[, host[, backlog]]][, callback])`][`server.listen(port, host)`]
+* [`server.listen([port[, host[, backlog]]][, callback])`][`server.listen(port, host)`]
   for TCP servers
 
 This function is asynchronous. When the server starts listening, the
@@ -264,7 +264,7 @@ added: v0.11.14
 * Returns: {net.Server}
 
 If `port` is specified, it behaves the same as
-[`server.listen([[[port[, host[, backlog]]][, callback])`][`server.listen(port, host)`].
+[`server.listen([port[, host[, backlog]]][, callback])`][`server.listen(port, host)`].
 Otherwise, if `path` is specified, it behaves the same as
 [`server.listen(path[, backlog][, callback])`][`server.listen(path)`].
 If none of them is specified, an error will be thrown.
@@ -296,7 +296,7 @@ added: v0.1.90
 
 Start a [IPC][] server listening for connections on the given `path`.
 
-#### server.listen([[[port[, host[, backlog]]][, callback])
+#### server.listen([port[, host[, backlog]]][, callback])
 <!-- YAML
 added: v0.1.90
 -->


### PR DESCRIPTION
Corrects the param name from hostname to host to be consistent everywhere and also corrects the actual heading signature rather than just the instances linking to it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
