### PR TITLE
test: fix flaky child-process-exec-kill-throws

### DIFF
--- a/test/parallel/test-child-process-exec-kill-throws.js
+++ b/test/parallel/test-child-process-exec-kill-throws.js
@@ -19,7 +19,8 @@ if (process.argv[2] === 'child') {
   };
 
   const cmd = `"${process.execPath}" "${__filename}" child`;
-  const options = { maxBuffer: 0 };
+  const options = { maxBuffer: 0, killSignal: 'SIGKILL' };
+
   const child = cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
     // Verify that if ChildProcess#kill() throws, the error is reported.
     assert.strictEqual(err.message, 'mock error', err);


### PR DESCRIPTION
Kill the child process with `SIGKILL` to make sure the child process
does not remain alive.

Fixes: https://github.com/nodejs/node/issues/20139

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
