### PR TITLE
src: prefer false instead of bool zero

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5170,7 +5170,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 
 
 bool VerifySpkac(const char* data, unsigned int len) {
-  bool i = false;
+  bool verify_result = false;
   EVP_PKEY* pkey = nullptr;
   NETSCAPE_SPKI* spki = nullptr;
 
@@ -5182,7 +5182,7 @@ bool VerifySpkac(const char* data, unsigned int len) {
   if (pkey == nullptr)
     goto exit;
 
-  i = NETSCAPE_SPKI_verify(spki, pkey) > 0;
+  verify_result = NETSCAPE_SPKI_verify(spki, pkey) > 0;
 
  exit:
   if (pkey != nullptr)
@@ -5191,23 +5191,23 @@ bool VerifySpkac(const char* data, unsigned int len) {
   if (spki != nullptr)
     NETSCAPE_SPKI_free(spki);
 
-  return i;
+  return verify_result;
 }
 
 
 void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
-  bool i = false;
+  bool verify_result = false;
 
   size_t length = Buffer::Length(args[0]);
   if (length == 0)
-    return args.GetReturnValue().Set(i);
+    return args.GetReturnValue().Set(verify_result);
 
   char* data = Buffer::Data(args[0]);
   CHECK_NE(data, nullptr);
 
-  i = VerifySpkac(data, length);
+  verify_result = VerifySpkac(data, length);
 
-  args.GetReturnValue().Set(i);
+  args.GetReturnValue().Set(verify_result);
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5170,7 +5170,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 
 
 bool VerifySpkac(const char* data, unsigned int len) {
-  bool i = 0;
+  bool i = false;
   EVP_PKEY* pkey = nullptr;
   NETSCAPE_SPKI* spki = nullptr;
 


### PR DESCRIPTION
This commit updates node_crypto.cc VerifySpkac function to use false
instead of 0 for its return bool value i.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
