### PR TITLE
test: added coverage for fs/promises API

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -35,6 +35,18 @@ async function validateEmptyWrite() {
   assert.deepStrictEqual(buffer, readFileData);
 }
 
-validateWrite()
-  .then(validateEmptyWrite)
-  .then(common.mustCall());
+async function validateNonUint8ArrayWrite() {
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-data-write.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  const buffer = Buffer.from('Hello world', 'utf8').toString('base64');
+
+  await fileHandle.write(buffer, 0, buffer.length);
+  const readFileData = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(Buffer.from(buffer, 'utf8'), readFileData);
+}
+
+Promise.all([
+  validateWrite(),
+  validateEmptyWrite(),
+  validateNonUint8ArrayWrite()
+]).then(common.mustCall());


### PR DESCRIPTION
Added coverage for block inside `promises#write` where the `buffer` fails `isUint8Array` check

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
