### PR TITLE
fs: support BigInt in fs.*stat and fs.watchFile

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -415,6 +415,8 @@ A `fs.Stats` object provides information about a file.
 
 Objects returned from [`fs.stat()`][], [`fs.lstat()`][] and [`fs.fstat()`][] and
 their synchronous counterparts are of this type.
+If `bigint` in the `options` passed to those methods is true, the numeric values
+will be `bigint` instead of `number`.
 
 ```console
 Stats {
@@ -432,6 +434,30 @@ Stats {
   mtimeMs: 1318289051000.1,
   ctimeMs: 1318289051000.1,
   birthtimeMs: 1318289051000.1,
+  atime: Mon, 10 Oct 2011 23:24:11 GMT,
+  mtime: Mon, 10 Oct 2011 23:24:11 GMT,
+  ctime: Mon, 10 Oct 2011 23:24:11 GMT,
+  birthtime: Mon, 10 Oct 2011 23:24:11 GMT }
+```
+
+`bigint` version:
+
+```console
+Stats {
+  dev: 2114n,
+  ino: 48064969n,
+  mode: 33188n,
+  nlink: 1n,
+  uid: 85n,
+  gid: 100n,
+  rdev: 0n,
+  size: 527n,
+  blksize: 4096n,
+  blocks: 8n,
+  atimeMs: 1318289051000n,
+  mtimeMs: 1318289051000n,
+  ctimeMs: 1318289051000n,
+  birthtimeMs: 1318289051000n,
   atime: Mon, 10 Oct 2011 23:24:11 GMT,
   mtime: Mon, 10 Oct 2011 23:24:11 GMT,
   ctime: Mon, 10 Oct 2011 23:24:11 GMT,
@@ -506,61 +532,61 @@ This method is only valid when using [`fs.lstat()`][].
 
 ### stats.dev
 
-* {number}
+* {number|bigint}
 
 The numeric identifier of the device containing the file.
 
 ### stats.ino
 
-* {number}
+* {number|bigint}
 
 The file system specific "Inode" number for the file.
 
 ### stats.mode
 
-* {number}
+* {number|bigint}
 
 A bit-field describing the file type and mode.
 
 ### stats.nlink
 
-* {number}
+* {number|bigint}
 
 The number of hard-links that exist for the file.
 
 ### stats.uid
 
-* {number}
+* {number|bigint}
 
 The numeric user identifier of the user that owns the file (POSIX).
 
 ### stats.gid
 
-* {number}
+* {number|bigint}
 
 The numeric group identifier of the group that owns the file (POSIX).
 
 ### stats.rdev
 
-* {number}
+* {number|bigint}
 
 A numeric device identifier if the file is considered "special".
 
 ### stats.size
 
-* {number}
+* {number|bigint}
 
 The size of the file in bytes.
 
 ### stats.blksize
 
-* {number}
+* {number|bigint}
 
 The file system block size for i/o operations.
 
 ### stats.blocks
 
-* {number}
+* {number|bigint}
 
 The number of blocks allocated for this file.
 
@@ -569,7 +595,7 @@ The number of blocks allocated for this file.
 added: v8.1.0
 -->
 
-* {number}
+* {number|bigint}
 
 The timestamp indicating the last time this file was accessed expressed in
 milliseconds since the POSIX Epoch.
@@ -579,7 +605,7 @@ milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number}
+* {number|bigint}
 
 The timestamp indicating the last time this file was modified expressed in
 milliseconds since the POSIX Epoch.
@@ -589,7 +615,7 @@ milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number}
+* {number|bigint}
 
 The timestamp indicating the last time the file status was changed expressed
 in milliseconds since the POSIX Epoch.
@@ -599,7 +625,7 @@ in milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number}
+* {number|bigint}
 
 The timestamp indicating the creation time of this file expressed in
 milliseconds since the POSIX Epoch.
@@ -1648,7 +1674,7 @@ added: v0.1.96
 
 Synchronous fdatasync(2). Returns `undefined`.
 
-## fs.fstat(fd, callback)
+## fs.fstat(fd[, options], callback)
 <!-- YAML
 added: v0.1.95
 changes:
@@ -1660,9 +1686,16 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/7897
     description: The `callback` parameter is no longer optional. Not passing
                  it will emit a deprecation warning with id DEP0013.
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `fd` {integer}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -1671,12 +1704,20 @@ Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is an [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][],
 except that the file to be stat-ed is specified by the file descriptor `fd`.
 
-## fs.fstatSync(fd)
+## fs.fstatSync(fd[, options])
 <!-- YAML
 added: v0.1.95
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `fd` {integer}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous fstat(2).
@@ -1942,7 +1983,7 @@ changes:
 
 Synchronous link(2). Returns `undefined`.
 
-## fs.lstat(path, callback)
+## fs.lstat(path[, options], callback)
 <!-- YAML
 added: v0.1.30
 changes:
@@ -1958,9 +1999,16 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/7897
     description: The `callback` parameter is no longer optional. Not passing
                  it will emit a deprecation warning with id DEP0013.
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -1970,7 +2018,7 @@ Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
 except that if `path` is a symbolic link, then the link itself is stat-ed,
 not the file that it refers to.
 
-## fs.lstatSync(path)
+## fs.lstatSync(path[, options])
 <!-- YAML
 added: v0.1.30
 changes:
@@ -1978,9 +2026,16 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using `file:`
                  protocol. Support is currently still *experimental*.
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous lstat(2).
@@ -2698,7 +2753,7 @@ Synchronous rmdir(2). Returns `undefined`.
 Using `fs.rmdirSync()` on a file (not a directory) results in an `ENOENT` error
 on Windows and an `ENOTDIR` error on POSIX.
 
-## fs.stat(path, callback)
+## fs.stat(path[, options], callback)
 <!-- YAML
 added: v0.0.2
 changes:
@@ -2714,9 +2769,16 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/7897
     description: The `callback` parameter is no longer optional. Not passing
                  it will emit a deprecation warning with id DEP0013.
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -2734,7 +2796,7 @@ error raised if the file is not available.
 To check if a file exists without manipulating it afterwards, [`fs.access()`]
 is recommended.
 
-## fs.statSync(path)
+## fs.statSync(path[, options])
 <!-- YAML
 added: v0.1.21
 changes:
@@ -2742,9 +2804,16 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using `file:`
                  protocol. Support is currently still *experimental*.
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous stat(2).
@@ -3521,10 +3590,18 @@ returned.
 
 The `FileHandle` has to support reading.
 
-#### filehandle.stat()
+#### filehandle.stat([options])
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {Promise}
 
 Retrieves the [`fs.Stats`][] for the file.
@@ -3849,12 +3926,20 @@ added: v10.0.0
 
 Asynchronous link(2). The `Promise` is resolved with no arguments upon success.
 
-### fsPromises.lstat(path)
+### fsPromises.lstat(path[, options])
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {Promise}
 
 Asynchronous lstat(2). The `Promise` is resolved with the [`fs.Stats`][] object
@@ -4035,12 +4120,20 @@ Using `fsPromises.rmdir()` on a file (not a directory) results in the
 `Promise` being rejected with an `ENOENT` error on Windows and an `ENOTDIR`
 error on POSIX.
 
-### fsPromises.stat(path)
+### fsPromises.stat(path[, options])
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Accepts an additional `options` object to specify whether
+                 the numeric values returned should be bigint.
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
 * Returns: {Promise}
 
 The `Promise` is resolved with the [`fs.Stats`][] object for the given `path`.
@@ -4496,9 +4589,9 @@ the file contents.
 [`fs.chown()`]: #fs_fs_chown_path_uid_gid_callback
 [`fs.copyFile()`]: #fs_fs_copyfile_src_dest_flags_callback
 [`fs.exists()`]: fs.html#fs_fs_exists_path_callback
-[`fs.fstat()`]: #fs_fs_fstat_fd_callback
+[`fs.fstat()`]: #fs_fs_fstat_fd_options_callback
 [`fs.futimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
-[`fs.lstat()`]: #fs_fs_lstat_path_callback
+[`fs.lstat()`]: #fs_fs_lstat_path_options_callback
 [`fs.mkdir()`]: #fs_fs_mkdir_path_mode_callback
 [`fs.mkdtemp()`]: #fs_fs_mkdtemp_prefix_options_callback
 [`fs.open()`]: #fs_fs_open_path_flags_mode_callback
@@ -4507,7 +4600,7 @@ the file contents.
 [`fs.readFileSync()`]: #fs_fs_readfilesync_path_options
 [`fs.realpath()`]: #fs_fs_realpath_path_options_callback
 [`fs.rmdir()`]: #fs_fs_rmdir_path_callback
-[`fs.stat()`]: #fs_fs_stat_path_callback
+[`fs.stat()`]: #fs_fs_stat_path_options_callback
 [`fs.utimes()`]: #fs_fs_utimes_path_atime_mtime_callback
 [`fs.watch()`]: #fs_fs_watch_filename_options_listener
 [`fs.write()`]: #fs_fs_write_fd_buffer_offset_length_position_callback

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -248,7 +248,7 @@ function readFileAfterOpen(err, fd) {
   const req = new FSReqWrap();
   req.oncomplete = readFileAfterStat;
   req.context = context;
-  binding.fstat(fd, req);
+  binding.fstat(fd, false, req);
 }
 
 function readFileAfterStat(err, stats) {
@@ -307,7 +307,7 @@ function readFile(path, options, callback) {
 
 function tryStatSync(fd, isUserFd) {
   const ctx = {};
-  const stats = binding.fstat(fd, undefined, ctx);
+  const stats = binding.fstat(fd, false, undefined, ctx);
   if (ctx.errno !== undefined && !isUserFd) {
     fs.closeSync(fd);
     throw errors.uvException(ctx);
@@ -760,55 +760,67 @@ function readdirSync(path, options) {
   return result;
 }
 
-function fstat(fd, callback) {
+function fstat(fd, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   validateUint32(fd, 'fd');
-  const req = new FSReqWrap();
+  const req = new FSReqWrap(options.bigint);
   req.oncomplete = makeStatsCallback(callback);
-  binding.fstat(fd, req);
+  binding.fstat(fd, options.bigint, req);
 }
 
-function lstat(path, callback) {
+function lstat(path, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   callback = makeStatsCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap();
+  const req = new FSReqWrap(options.bigint);
   req.oncomplete = callback;
-  binding.lstat(pathModule.toNamespacedPath(path), req);
+  binding.lstat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function stat(path, callback) {
+function stat(path, options, callback) {
+  if (arguments.length < 3) {
+    callback = options;
+    options = {};
+  }
   callback = makeStatsCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap();
+  const req = new FSReqWrap(options.bigint);
   req.oncomplete = callback;
-  binding.stat(pathModule.toNamespacedPath(path), req);
+  binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function fstatSync(fd) {
+function fstatSync(fd, options = {}) {
   validateUint32(fd, 'fd');
   const ctx = { fd };
-  const stats = binding.fstat(fd, undefined, ctx);
+  const stats = binding.fstat(fd, options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 
-function lstatSync(path) {
+function lstatSync(path, options = {}) {
   path = getPathFromURL(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
-                              undefined, ctx);
+                              options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 
-function statSync(path) {
+function statSync(path, options = {}) {
   path = getPathFromURL(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
-                             undefined, ctx);
+                             options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
@@ -1264,7 +1276,7 @@ function watchFile(filename, options, listener) {
   if (stat === undefined) {
     if (!watchers)
       watchers = require('internal/fs/watchers');
-    stat = new watchers.StatWatcher();
+    stat = new watchers.StatWatcher(options.bigint);
     stat.start(filename, options.persistent, options.interval);
     statWatchers.set(filename, stat);
   }
@@ -1379,7 +1391,7 @@ function realpathSync(p, options) {
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
     const ctx = { path: base };
-    binding.lstat(pathModule.toNamespacedPath(base), undefined, ctx);
+    binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
     handleErrorFromBinding(ctx);
     knownHard[base] = true;
   }
@@ -1421,7 +1433,7 @@ function realpathSync(p, options) {
 
       const baseLong = pathModule.toNamespacedPath(base);
       const ctx = { path: base };
-      const stats = binding.lstat(baseLong, undefined, ctx);
+      const stats = binding.lstat(baseLong, false, undefined, ctx);
       handleErrorFromBinding(ctx);
 
       if (!isFileType(stats, S_IFLNK)) {
@@ -1444,7 +1456,7 @@ function realpathSync(p, options) {
       }
       if (linkTarget === null) {
         const ctx = { path: base };
-        binding.stat(baseLong, undefined, ctx);
+        binding.stat(baseLong, false, undefined, ctx);
         handleErrorFromBinding(ctx);
         linkTarget = binding.readlink(baseLong, undefined, undefined, ctx);
         handleErrorFromBinding(ctx);
@@ -1465,7 +1477,7 @@ function realpathSync(p, options) {
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
       const ctx = { path: base };
-      binding.lstat(pathModule.toNamespacedPath(base), undefined, ctx);
+      binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
       handleErrorFromBinding(ctx);
       knownHard[base] = true;
     }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -82,8 +82,8 @@ class FileHandle {
     return readFile(this, options);
   }
 
-  stat() {
-    return fstat(this);
+  stat(options) {
+    return fstat(this, options);
   }
 
   truncate(len = 0) {
@@ -107,7 +107,6 @@ class FileHandle {
   }
 }
 
-
 function validateFileHandle(handle) {
   if (!(handle instanceof FileHandle))
     throw new ERR_INVALID_ARG_TYPE('filehandle', 'FileHandle', handle);
@@ -128,7 +127,7 @@ async function writeFileHandle(filehandle, data, options) {
 }
 
 async function readFileHandle(filehandle, options) {
-  const statFields = await binding.fstat(filehandle.fd, kUsePromises);
+  const statFields = await binding.fstat(filehandle.fd, false, kUsePromises);
 
   let size;
   if ((statFields[1/* mode */] & S_IFMT) === S_IFREG) {
@@ -319,25 +318,25 @@ async function symlink(target, path, type_) {
                          kUsePromises);
 }
 
-async function fstat(handle) {
+async function fstat(handle, options = { bigint: false }) {
   validateFileHandle(handle);
-  const result = await binding.fstat(handle.fd, kUsePromises);
+  const result = await binding.fstat(handle.fd, options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 
-async function lstat(path) {
+async function lstat(path, options = { bigint: false }) {
   path = getPathFromURL(path);
   validatePath(path);
   const result = await binding.lstat(pathModule.toNamespacedPath(path),
-                                     kUsePromises);
+                                     options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 
-async function stat(path) {
+async function stat(path, options = { bigint: false }) {
   path = getPathFromURL(path);
   validatePath(path);
   const result = await binding.stat(pathModule.toNamespacedPath(path),
-                                    kUsePromises);
+                                    options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -114,7 +114,7 @@ function preprocessSymlinkDestination(path, type, linkPath) {
 }
 
 function dateFromNumeric(num) {
-  return new Date(num + 0.5);
+  return new Date(Number(num) + 0.5);
 }
 
 // Constructor for file stats.
@@ -155,7 +155,11 @@ function Stats(
 }
 
 Stats.prototype._checkModeProperty = function(property) {
-  return ((this.mode & S_IFMT) === property);
+  if (typeof this.mode === 'bigint') {  // eslint-disable-line valid-typeof
+    // eslint-disable-next-line no-undef
+    return (this.mode & BigInt(S_IFMT)) === BigInt(property);
+  }
+  return (this.mode & S_IFMT) === property;
 };
 
 Stats.prototype.isDirectory = function() {

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -155,6 +155,10 @@ function Stats(
 }
 
 Stats.prototype._checkModeProperty = function(property) {
+  if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
+    property === S_IFSOCK)) {
+    return false;  // Some types are not available on Windows
+  }
   if (typeof this.mode === 'bigint') {  // eslint-disable-line valid-typeof
     // eslint-disable-next-line no-undef
     return (this.mode & BigInt(S_IFMT)) === BigInt(property);
@@ -193,9 +197,9 @@ Stats.prototype.isSocket = function() {
 function getStatsFromBinding(stats, offset = 0) {
   return new Stats(stats[0 + offset], stats[1 + offset], stats[2 + offset],
                    stats[3 + offset], stats[4 + offset], stats[5 + offset],
-                   stats[6 + offset] < 0 ? undefined : stats[6 + offset],
+                   isWindows ? undefined : stats[6 + offset],  // blksize
                    stats[7 + offset], stats[8 + offset],
-                   stats[9 + offset] < 0 ? undefined : stats[9 + offset],
+                   isWindows ? undefined : stats[9 + offset],  // blocks
                    stats[10 + offset], stats[11 + offset],
                    stats[12 + offset], stats[13 + offset]);
 }

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -21,10 +21,10 @@ function emitStop(self) {
   self.emit('stop');
 }
 
-function StatWatcher() {
+function StatWatcher(bigint) {
   EventEmitter.call(this);
 
-  this._handle = new _StatWatcher();
+  this._handle = new _StatWatcher(bigint);
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -542,6 +542,11 @@ Environment::fs_stats_field_array() {
   return &fs_stats_field_array_;
 }
 
+inline AliasedBuffer<uint64_t, v8::BigUint64Array>*
+Environment::fs_stats_field_bigint_array() {
+  return &fs_stats_field_bigint_array_;
+}
+
 inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
 Environment::file_handle_read_wrap_freelist() {
   return file_handle_read_wrap_freelist_;

--- a/src/env.cc
+++ b/src/env.cc
@@ -101,6 +101,7 @@ Environment::Environment(IsolateData* isolate_data,
 #endif
       http_parser_buffer_(nullptr),
       fs_stats_field_array_(isolate_, kFsStatsFieldsLength * 2),
+      fs_stats_field_bigint_array_(isolate_, kFsStatsFieldsLength * 2),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());

--- a/src/env.h
+++ b/src/env.h
@@ -668,6 +668,8 @@ class Environment {
   void set_debug_categories(const std::string& cats, bool enabled);
 
   inline AliasedBuffer<double, v8::Float64Array>* fs_stats_field_array();
+  inline AliasedBuffer<uint64_t, v8::BigUint64Array>*
+      fs_stats_field_bigint_array();
 
   // stat fields contains twice the number of entries because `fs.StatWatcher`
   // needs room to store data for *two* `fs.Stats` instances.
@@ -869,6 +871,7 @@ class Environment {
   bool debug_enabled_[static_cast<int>(DebugCategory::CATEGORY_COUNT)] = {0};
 
   AliasedBuffer<double, v8::Float64Array> fs_stats_field_array_;
+  AliasedBuffer<uint64_t, v8::BigUint64Array> fs_stats_field_bigint_array_;
 
   std::vector<std::unique_ptr<fs::FileHandleReadWrap>>
       file_handle_read_wrap_freelist_;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -49,6 +49,7 @@ namespace node {
 namespace fs {
 
 using v8::Array;
+using v8::BigUint64Array;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Float64Array;
@@ -413,7 +414,7 @@ void FSReqWrap::Reject(Local<Value> reject) {
 }
 
 void FSReqWrap::ResolveStat(const uv_stat_t* stat) {
-  Resolve(node::FillGlobalStatsArray(env(), stat));
+  Resolve(node::FillGlobalStatsArray(env(), stat, use_bigint()));
 }
 
 void FSReqWrap::Resolve(Local<Value> value) {
@@ -433,7 +434,7 @@ void FSReqWrap::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
 void NewFSReqWrap(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  new FSReqWrap(env, args.This());
+  new FSReqWrap(env, args.This(), args[0]->IsTrue());
 }
 
 FSReqAfterScope::FSReqAfterScope(FSReqBase* wrap, uv_fs_t* req)
@@ -670,11 +671,16 @@ inline int SyncCall(Environment* env, Local<Value> ctx, FSReqWrapSync* req_wrap,
   return err;
 }
 
-inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value) {
+inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value,
+                             bool use_bigint = false) {
   if (value->IsObject()) {
     return Unwrap<FSReqBase>(value.As<Object>());
   } else if (value->StrictEquals(env->fs_use_promises_symbol())) {
-    return new FSReqPromise<double, Float64Array>(env);
+    if (use_bigint) {
+      return new FSReqPromise<uint64_t, BigUint64Array>(env, use_bigint);
+    } else {
+      return new FSReqPromise<double, Float64Array>(env, use_bigint);
+    }
   }
   return nullptr;
 }
@@ -825,22 +831,23 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
-  if (req_wrap_async != nullptr) {  // stat(path, req)
+  bool use_bigint = args[1]->IsTrue();
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  if (req_wrap_async != nullptr) {  // stat(path, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
               uv_fs_stat, *path);
-  } else {  // stat(path, undefined, ctx)
-    CHECK_EQ(argc, 3);
+  } else {  // stat(path, use_bigint, undefined, ctx)
+    CHECK_EQ(argc, 4);
     FSReqWrapSync req_wrap_sync;
     FS_SYNC_TRACE_BEGIN(stat);
-    int err = SyncCall(env, args[2], &req_wrap_sync, "stat", uv_fs_stat, *path);
+    int err = SyncCall(env, args[3], &req_wrap_sync, "stat", uv_fs_stat, *path);
     FS_SYNC_TRACE_END(stat);
     if (err != 0) {
       return;  // error info is in ctx
     }
 
     Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
     args.GetReturnValue().Set(arr);
   }
 }
@@ -849,20 +856,21 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   const int argc = args.Length();
-  CHECK_GE(argc, 2);
+  CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
-  if (req_wrap_async != nullptr) {  // lstat(path, req)
+  bool use_bigint = args[1]->IsTrue();
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  if (req_wrap_async != nullptr) {  // lstat(path, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "lstat", UTF8, AfterStat,
               uv_fs_lstat, *path);
-  } else {  // lstat(path, undefined, ctx)
-    CHECK_EQ(argc, 3);
+  } else {  // lstat(path, use_bigint, undefined, ctx)
+    CHECK_EQ(argc, 4);
     FSReqWrapSync req_wrap_sync;
     FS_SYNC_TRACE_BEGIN(lstat);
-    int err = SyncCall(env, args[2], &req_wrap_sync, "lstat", uv_fs_lstat,
+    int err = SyncCall(env, args[3], &req_wrap_sync, "lstat", uv_fs_lstat,
                        *path);
     FS_SYNC_TRACE_END(lstat);
     if (err != 0) {
@@ -870,7 +878,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
     }
 
     Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
     args.GetReturnValue().Set(arr);
   }
 }
@@ -884,22 +892,23 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
   int fd = args[0].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
-  if (req_wrap_async != nullptr) {  // fstat(fd, req)
+  bool use_bigint = args[1]->IsTrue();
+  FSReqBase* req_wrap_async = GetReqWrap(env, args[2], use_bigint);
+  if (req_wrap_async != nullptr) {  // fstat(fd, use_bigint, req)
     AsyncCall(env, req_wrap_async, args, "fstat", UTF8, AfterStat,
               uv_fs_fstat, fd);
-  } else {  // fstat(fd, undefined, ctx)
-    CHECK_EQ(argc, 3);
+  } else {  // fstat(fd, use_bigint, undefined, ctx)
+    CHECK_EQ(argc, 4);
     FSReqWrapSync req_wrap_sync;
     FS_SYNC_TRACE_BEGIN(fstat);
-    int err = SyncCall(env, args[2], &req_wrap_sync, "fstat", uv_fs_fstat, fd);
+    int err = SyncCall(env, args[3], &req_wrap_sync, "fstat", uv_fs_fstat, fd);
     FS_SYNC_TRACE_END(fstat);
     if (err != 0) {
       return;  // error info is in ctx
     }
 
     Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
     args.GetReturnValue().Set(arr);
   }
 }
@@ -1910,6 +1919,10 @@ void Initialize(Local<Object> target,
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "statValues"),
               env->fs_stats_field_array()->GetJSArray()).FromJust();
+
+  target->Set(context,
+              FIXED_ONE_BYTE_STRING(env->isolate(), "bigintStatValues"),
+              env->fs_stats_field_bigint_array()->GetJSArray()).FromJust();
 
   StatWatcher::Initialize(env, target);
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -26,8 +26,9 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
  public:
   typedef MaybeStackBuffer<char, 64> FSReqBuffer;
 
-  FSReqBase(Environment* env, Local<Object> req, AsyncWrap::ProviderType type)
-      : ReqWrap(env, req, type) {
+  FSReqBase(Environment* env, Local<Object> req, AsyncWrap::ProviderType type,
+            bool use_bigint)
+      : ReqWrap(env, req, type), use_bigint_(use_bigint) {
   }
 
   void Init(const char* syscall,
@@ -66,11 +67,13 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
   enum encoding encoding() const { return encoding_; }
 
   size_t self_size() const override { return sizeof(*this); }
+  bool use_bigint() const { return use_bigint_; }
 
  private:
   enum encoding encoding_ = UTF8;
   bool has_data_ = false;
   const char* syscall_ = nullptr;
+  bool use_bigint_ = false;
 
   // Typically, the content of buffer_ is something like a file name, so
   // something around 64 bytes should be enough.
@@ -81,8 +84,8 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
 
 class FSReqWrap : public FSReqBase {
  public:
-  FSReqWrap(Environment* env, Local<Object> req)
-      : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQWRAP) { }
+  FSReqWrap(Environment* env, Local<Object> req, bool use_bigint)
+      : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQWRAP, use_bigint) { }
 
   void Reject(Local<Value> reject) override;
   void Resolve(Local<Value> value) override;
@@ -96,11 +99,12 @@ class FSReqWrap : public FSReqBase {
 template <typename NativeT = double, typename V8T = v8::Float64Array>
 class FSReqPromise : public FSReqBase {
  public:
-  explicit FSReqPromise(Environment* env)
+  explicit FSReqPromise(Environment* env, bool use_bigint)
       : FSReqBase(env,
                   env->fsreqpromise_constructor_template()
                       ->NewInstance(env->context()).ToLocalChecked(),
-                  AsyncWrap::PROVIDER_FSREQPROMISE),
+                  AsyncWrap::PROVIDER_FSREQPROMISE,
+                  use_bigint),
         stats_field_array_(env->isolate(), env->kFsStatsFieldsLength) {
     auto resolver = Promise::Resolver::New(env->context()).ToLocalChecked();
     object()->Set(env->context(), env->promise_string(),
@@ -135,8 +139,7 @@ class FSReqPromise : public FSReqBase {
   }
 
   void ResolveStat(const uv_stat_t* stat) override {
-    node::FillStatsArray(&stats_field_array_, stat);
-    Resolve(stats_field_array_.GetJSArray());
+    Resolve(node::FillStatsArray(&stats_field_array_, stat));
   }
 
   void SetReturnValue(const FunctionCallbackInfo<Value>& args) override {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -352,9 +352,15 @@ v8::Local<v8::Value> FillStatsArray(AliasedBuffer<NativeT, V8T>* fields_ptr,
 }
 
 inline v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
-                                                 const uv_stat_t* s,
-                                                 int offset = 0) {
-  return node::FillStatsArray(env->fs_stats_field_array(), s, offset);
+                                          const uv_stat_t* s,
+                                          bool use_bigint = false,
+                                          int offset = 0) {
+  if (use_bigint) {
+    return node::FillStatsArray(
+        env->fs_stats_field_bigint_array(), s, offset);
+  } else {
+    return node::FillStatsArray(env->fs_stats_field_array(), s, offset);
+  }
 }
 
 void SetupBootstrapObject(Environment* env,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -352,9 +352,9 @@ v8::Local<v8::Value> FillStatsArray(AliasedBuffer<NativeT, V8T>* fields_ptr,
 }
 
 inline v8::Local<v8::Value> FillGlobalStatsArray(Environment* env,
-                                          const uv_stat_t* s,
-                                          bool use_bigint = false,
-                                          int offset = 0) {
+                                                 const uv_stat_t* s,
+                                                 bool use_bigint = false,
+                                                 int offset = 0) {
   if (use_bigint) {
     return node::FillStatsArray(
         env->fs_stats_field_bigint_array(), s, offset);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -325,14 +325,14 @@ v8::Local<v8::Value> FillStatsArray(AliasedBuffer<NativeT, V8T>* fields_ptr,
 #if defined(__POSIX__)
   fields[offset + 6] = s->st_blksize;
 #else
-  fields[offset + 6] = -1;
+  fields[offset + 6] = 0;
 #endif
   fields[offset + 7] = s->st_ino;
   fields[offset + 8] = s->st_size;
 #if defined(__POSIX__)
   fields[offset + 9] = s->st_blocks;
 #else
-  fields[offset + 9] = -1;
+  fields[offset + 9] = 0;
 #endif
 // Dates.
 // NO-LINT because the fields are 'long' and we just want to cast to `unsigned`

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -39,7 +39,7 @@ class StatWatcher : public AsyncWrap {
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
-  StatWatcher(Environment* env, v8::Local<v8::Object> wrap);
+  StatWatcher(Environment* env, v8::Local<v8::Object> wrap, bool use_bigint);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -57,6 +57,7 @@ class StatWatcher : public AsyncWrap {
   bool IsActive();
 
   uv_fs_poll_t* watcher_;
+  bool use_bigint_;
 };
 
 }  // namespace node

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -57,7 +57,7 @@ class StatWatcher : public AsyncWrap {
   bool IsActive();
 
   uv_fs_poll_t* watcher_;
-  bool use_bigint_;
+  const bool use_bigint_;
 };
 
 }  // namespace node

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -1,0 +1,138 @@
+// Flags: --harmony-bigint
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const promiseFs = require('fs').promises;
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const { isDate } = require('util').types;
+
+common.crashOnUnhandledRejection();
+tmpdir.refresh();
+
+const fn = path.join(tmpdir.path, 'test-file');
+fs.writeFileSync(fn, 'test');
+
+const link = path.join(tmpdir.path, 'symbolic-link');
+fs.symlinkSync(fn, link);
+
+function verifyStats(bigintStats, numStats) {
+  for (const key of Object.keys(numStats)) {
+    const val = numStats[key];
+    if (isDate(val)) {
+      const time = val.getTime();
+      const time2 = bigintStats[key].getTime();
+      assert(
+        Math.abs(time - time2) < 2,
+        `difference of ${key}.getTime() should < 2.\n` +
+        `Number version ${time}, BigInt version ${time2}n`);
+    } else if (key === 'mode') {
+      // eslint-disable-next-line no-undef
+      assert.strictEqual(bigintStats[key], BigInt(val));
+      assert.strictEqual(
+        bigintStats.isBlockDevice(),
+        numStats.isBlockDevice()
+      );
+      assert.strictEqual(
+        bigintStats.isCharacterDevice(),
+        numStats.isCharacterDevice()
+      );
+      assert.strictEqual(
+        bigintStats.isDirectory(),
+        numStats.isDirectory()
+      );
+      assert.strictEqual(
+        bigintStats.isFIFO(),
+        numStats.isFIFO()
+      );
+      assert.strictEqual(
+        bigintStats.isFile(),
+        numStats.isFile()
+      );
+      assert.strictEqual(
+        bigintStats.isSocket(),
+        numStats.isSocket()
+      );
+      assert.strictEqual(
+        bigintStats.isSymbolicLink(),
+        numStats.isSymbolicLink()
+      );
+    } else if (Number.isSafeInteger(val)) {
+      // eslint-disable-next-line no-undef
+      assert.strictEqual(bigintStats[key], BigInt(val));
+    } else {
+      assert(
+        Math.abs(Number(bigintStats[key]) - val) < 1,
+        `${key} is not a safe integer, difference should < 1.\n` +
+        `Number version ${val}, BigInt version ${bigintStats[key]}n`);
+    }
+  }
+}
+
+{
+  const bigintStats = fs.statSync(fn, { bigint: true });
+  const numStats = fs.statSync(fn);
+  verifyStats(bigintStats, numStats);
+}
+
+{
+  const bigintStats = fs.lstatSync(link, { bigint: true });
+  const numStats = fs.lstatSync(link);
+  verifyStats(bigintStats, numStats);
+}
+
+{
+  const fd = fs.openSync(fn, 'r');
+  const bigintStats = fs.fstatSync(fd, { bigint: true });
+  const numStats = fs.fstatSync(fd);
+  verifyStats(bigintStats, numStats);
+  fs.closeSync(fd);
+}
+
+{
+  fs.stat(fn, { bigint: true }, (err, bigintStats) => {
+    fs.stat(fn, (err, numStats) => {
+      verifyStats(bigintStats, numStats);
+    });
+  });
+}
+
+{
+  fs.lstat(link, { bigint: true }, (err, bigintStats) => {
+    fs.lstat(link, (err, numStats) => {
+      verifyStats(bigintStats, numStats);
+    });
+  });
+}
+
+{
+  const fd = fs.openSync(fn, 'r');
+  fs.fstat(fd, { bigint: true }, (err, bigintStats) => {
+    fs.fstat(fd, (err, numStats) => {
+      verifyStats(bigintStats, numStats);
+      fs.closeSync(fd);
+    });
+  });
+}
+
+(async function() {
+  const bigintStats = await promiseFs.stat(fn, { bigint: true });
+  const numStats = await promiseFs.stat(fn);
+  verifyStats(bigintStats, numStats);
+})();
+
+(async function() {
+  const bigintStats = await promiseFs.lstat(link, { bigint: true });
+  const numStats = await promiseFs.lstat(link);
+  verifyStats(bigintStats, numStats);
+})();
+
+(async function() {
+  const handle = await promiseFs.open(fn, 'r');
+  const bigintStats = await handle.stat({ bigint: true });
+  const numStats = await handle.stat();
+  verifyStats(bigintStats, numStats);
+  await handle.close();
+})();

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -40,7 +40,7 @@ fs.writeSync = function() {
   throw new Error('BAM');
 };
 
-process.binding('fs').fstat = function(fd, _, ctx) {
+process.binding('fs').fstat = function(fd, bigint, _, ctx) {
   ctx.errno = uv.UV_EBADF;
   ctx.syscall = 'fstat';
 };

--- a/test/parallel/test-fs-watchfile-bigint.js
+++ b/test/parallel/test-fs-watchfile-bigint.js
@@ -1,0 +1,64 @@
+// Flags: --harmony-bigint
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
+
+const enoentFile = path.join(tmpdir.path, 'non-existent-file');
+const expectedStatObject = new fs.Stats(
+  0n,                                        // dev
+  0n,                                        // mode
+  0n,                                        // nlink
+  0n,                                        // uid
+  0n,                                        // gid
+  0n,                                        // rdev
+  common.isWindows ? undefined : 0n,         // blksize
+  0n,                                        // ino
+  0n,                                        // size
+  common.isWindows ? undefined : 0n,         // blocks
+  0n,                                        // atim_msec
+  0n,                                        // mtim_msec
+  0n,                                        // ctim_msec
+  0n                                         // birthtim_msec
+);
+
+tmpdir.refresh();
+
+// If the file initially didn't exist, and gets created at a later point of
+// time, the callback should be invoked again with proper values in stat object
+let fileExists = false;
+const options = { interval: 0, bigint: true };
+
+const watcher =
+  fs.watchFile(enoentFile, options, common.mustCall((curr, prev) => {
+    if (!fileExists) {
+      // If the file does not exist, all the fields should be zero and the date
+      // fields should be UNIX EPOCH time
+      assert.deepStrictEqual(curr, expectedStatObject);
+      assert.deepStrictEqual(prev, expectedStatObject);
+      // Create the file now, so that the callback will be called back once the
+      // event loop notices it.
+      fs.closeSync(fs.openSync(enoentFile, 'w'));
+      fileExists = true;
+    } else {
+      // If the ino (inode) value is greater than zero, it means that the file
+      // is present in the filesystem and it has a valid inode number.
+      assert(curr.ino > 0n);
+      // As the file just got created, previous ino value should be lesser than
+      // or equal to zero (non-existent file).
+      assert(prev.ino <= 0n);
+      // Stop watching the file
+      fs.unwatchFile(enoentFile);
+      watcher.stop();  // stopping a stopped watcher should be a noop
+    }
+  }, 2));
+
+// 'stop' should only be emitted once - stopping a stopped watcher should
+// not trigger a 'stop' event.
+watcher.on('stop', common.mustCall(function onStop() {}));
+
+watcher.start();  // starting a started watcher should be a noop

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -31,6 +31,8 @@ const customTypesMap = {
 
   'AsyncIterator': 'https://github.com/tc39/proposal-async-iteration',
 
+  'bigint': 'https://github.com/tc39/proposal-bigint',
+
   'Iterable':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterable_protocol`,
   'Iterator':


### PR DESCRIPTION
- fs: support BigInt in fs.*stat and fs.watchFile
  Add the `bigint: true` option to all the `fs.*stat` methods and
  `fs.watchFile`.
- doc: document BigInt support in fs.Stats

I chose to expose the BigInt variant via `bigint: true` in the option object because right now there are no support of a Date class with higher precision - the old Date is Number-based and can lose precision when being constructed out of a 64bit ms value. The plan is that when JS does get a better Date e.g. [Temporal](https://github.com/tc39/proposal-temporal) (see https://github.com/tc39/proposal-bigint/issues/136), we will be able to support `temporal: true`.

The `--harmony-bigint` flag is necessary until v8 6.7 lands.

Fixes: https://github.com/nodejs/node/issues/12115

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
