### PR TITLE
test: remove crypto.DEFAULT_ENCODING usage

### DIFF
--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+// Flags: --expose-internals
+
 // This is the same as test/simple/test-crypto, but from before the shift
 // to use buffers by default.
 
@@ -36,7 +38,7 @@ const tls = require('tls');
 const fixtures = require('../common/fixtures');
 const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
 
-crypto.DEFAULT_ENCODING = 'latin1';
+require('internal/crypto/util').setDefaultEncoding('latin1');
 
 // Test Certificates
 const certPem = fixtures.readSync('test_cert.pem', 'ascii');

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -29,8 +29,6 @@ const crypto = require('crypto');
 const { Certificate } = crypto;
 const fixtures = require('../common/fixtures');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 // Test Certificates
 const spkacValid = fixtures.readSync('spkac.valid');
 const spkacFail = fixtures.readSync('spkac.fail');

--- a/test/parallel/test-crypto-ecb.js
+++ b/test/parallel/test-crypto-ecb.js
@@ -30,8 +30,6 @@ if (common.hasFipsCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 // Testing whether EVP_CipherInit_ex is functioning correctly.
 // Reference: bug#1997
 

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -27,8 +27,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 const iv = Buffer.from('00000000000000000000000000000000', 'hex');
 const key = Buffer.from('0123456789abcdef0123456789abcdef' +
                         '0123456789abcdef0123456789abcdef', 'hex');

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -27,8 +27,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 // Input data.
 const ODD_LENGTH_PLAIN = 'Hello node world!';
 const EVEN_LENGTH_PLAIN = 'Hello node world!AbC09876dDeFgHi';

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -32,8 +32,6 @@ const { kMaxLength } = require('buffer');
 const kMaxUint32 = Math.pow(2, 32) - 1;
 const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 // bump, we register a lot of exit listeners
 process.setMaxListeners(256);
 

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -29,8 +29,6 @@ const crypto = require('crypto');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 const certPem = fixtures.readSync('test_cert.pem', 'ascii');
 
 const options = {

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -30,8 +30,6 @@ const crypto = require('crypto');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
-crypto.DEFAULT_ENCODING = 'buffer';
-
 // Test Certificates
 const caPem = fixtures.readSync('test_ca.pem', 'ascii');
 const certPem = fixtures.readSync('test_cert.pem', 'ascii');


### PR DESCRIPTION
This commit removes the usage of the deprectated
`crypto.DEFAULT_ENCODING`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
