### PR TITLE
test: add checkMethods function for Certificate

### DIFF
--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -36,9 +36,7 @@ const spkacValid = fixtures.readSync('spkac.valid');
 const spkacFail = fixtures.readSync('spkac.fail');
 const spkacPem = fixtures.readSync('spkac.pem');
 
-{
-  // Test instance methods
-  const certificate = new Certificate();
+function checkMethods(certificate) {
 
   assert.strictEqual(certificate.verifySpkac(spkacValid), true);
   assert.strictEqual(certificate.verifySpkac(spkacFail), false);
@@ -57,21 +55,13 @@ const spkacPem = fixtures.readSync('spkac.pem');
 }
 
 {
+  // Test instance methods
+  checkMethods(new Certificate());
+}
+
+{
   // Test static methods
-  assert.strictEqual(Certificate.verifySpkac(spkacValid), true);
-  assert.strictEqual(Certificate.verifySpkac(spkacFail), false);
-
-  assert.strictEqual(
-    stripLineEndings(Certificate.exportPublicKey(spkacValid).toString('utf8')),
-    stripLineEndings(spkacPem.toString('utf8'))
-  );
-  assert.strictEqual(Certificate.exportPublicKey(spkacFail), '');
-
-  assert.strictEqual(
-    Certificate.exportChallenge(spkacValid).toString('utf8'),
-    'fb9ab814-6677-42a4-a60c-f905d1a6924d'
-  );
-  assert.strictEqual(Certificate.exportChallenge(spkacFail), '');
+  checkMethods(Certificate);
 }
 
 function stripLineEndings(obj) {


### PR DESCRIPTION
This commit adds a checkMethods function so that it can be reused to
avoid duplicating the same code for instance methods, and static
methods of the Certificate object.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
