### PR TITLE
crypto: use kNoAuthTagLength in InitAuthenticated

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2629,7 +2629,7 @@ void CipherBase::New(const FunctionCallbackInfo<Value>& args) {
 void CipherBase::Init(const char* cipher_type,
                       const char* key_buf,
                       int key_buf_len,
-                      int auth_tag_len) {
+                      unsigned int auth_tag_len) {
   HandleScope scope(env()->isolate());
 
 #ifdef NODE_FIPS_MODE
@@ -2700,10 +2700,16 @@ void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
   const node::Utf8Value cipher_type(args.GetIsolate(), args[0]);
   const char* key_buf = Buffer::Data(args[1]);
   ssize_t key_buf_len = Buffer::Length(args[1]);
-  CHECK(args[2]->IsInt32());
+
   // Don't assign to cipher->auth_tag_len_ directly; the value might not
   // represent a valid length at this point.
-  int auth_tag_len = args[2].As<v8::Int32>()->Value();
+  unsigned int auth_tag_len;
+  if (args[2]->IsUint32()) {
+    auth_tag_len = args[2]->Uint32Value();
+  } else {
+    CHECK(args[2]->IsInt32() && args[2]->Int32Value() == -1);
+    auth_tag_len = kNoAuthTagLength;
+  }
 
   cipher->Init(*cipher_type, key_buf, key_buf_len, auth_tag_len);
 }
@@ -2714,7 +2720,7 @@ void CipherBase::InitIv(const char* cipher_type,
                         int key_len,
                         const char* iv,
                         int iv_len,
-                        int auth_tag_len) {
+                        unsigned int auth_tag_len) {
   HandleScope scope(env()->isolate());
 
   const EVP_CIPHER* const cipher = EVP_get_cipherbyname(cipher_type);
@@ -2788,10 +2794,16 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
     iv_buf = Buffer::Data(args[2]);
     iv_len = Buffer::Length(args[2]);
   }
-  CHECK(args[3]->IsInt32());
+
   // Don't assign to cipher->auth_tag_len_ directly; the value might not
   // represent a valid length at this point.
-  int auth_tag_len = args[3].As<v8::Int32>()->Value();
+  unsigned int auth_tag_len;
+  if (args[3]->IsUint32()) {
+    auth_tag_len = args[3]->Uint32Value();
+  } else {
+    CHECK(args[3]->IsInt32() && args[3]->Int32Value() == -1);
+    auth_tag_len = kNoAuthTagLength;
+  }
 
   cipher->InitIv(*cipher_type, key_buf, key_len, iv_buf, iv_len, auth_tag_len);
 }
@@ -2802,7 +2814,7 @@ static bool IsValidGCMTagLength(unsigned int tag_len) {
 }
 
 bool CipherBase::InitAuthenticated(const char *cipher_type, int iv_len,
-                                   int auth_tag_len) {
+                                   unsigned int auth_tag_len) {
   CHECK(IsAuthenticatedMode());
 
   // TODO(tniessen) Use EVP_CTRL_AEAD_SET_IVLEN when migrating to OpenSSL 1.1.0
@@ -2815,7 +2827,7 @@ bool CipherBase::InitAuthenticated(const char *cipher_type, int iv_len,
 
   const int mode = EVP_CIPHER_CTX_mode(ctx_);
   if (mode == EVP_CIPH_CCM_MODE) {
-    if (auth_tag_len < 0) {
+    if (auth_tag_len == kNoAuthTagLength) {
       char msg[128];
       snprintf(msg, sizeof(msg), "authTagLength required for %s", cipher_type);
       env()->ThrowError(msg);
@@ -2850,7 +2862,7 @@ bool CipherBase::InitAuthenticated(const char *cipher_type, int iv_len,
   } else {
     CHECK_EQ(mode, EVP_CIPH_GCM_MODE);
 
-    if (auth_tag_len >= 0) {
+    if (auth_tag_len != kNoAuthTagLength) {
       if (!IsValidGCMTagLength(auth_tag_len)) {
         char msg[50];
         snprintf(msg, sizeof(msg),

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2705,9 +2705,9 @@ void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
   // represent a valid length at this point.
   unsigned int auth_tag_len;
   if (args[2]->IsUint32()) {
-    auth_tag_len = args[2]->Uint32Value();
+    auth_tag_len = args[2].As<v8::Uint32>()->Value();
   } else {
-    CHECK(args[2]->IsInt32() && args[2]->Int32Value() == -1);
+    CHECK(args[2]->IsInt32() && args[2].As<v8::Int32>()->Value() == -1);
     auth_tag_len = kNoAuthTagLength;
   }
 
@@ -2799,9 +2799,9 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   // represent a valid length at this point.
   unsigned int auth_tag_len;
   if (args[3]->IsUint32()) {
-    auth_tag_len = args[3]->Uint32Value();
+    auth_tag_len = args[3].As<v8::Uint32>()->Value();
   } else {
-    CHECK(args[3]->IsInt32() && args[3]->Int32Value() == -1);
+    CHECK(args[3]->IsInt32() && args[3].As<v8::Int32>()->Value() == -1);
     auth_tag_len = kNoAuthTagLength;
   }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -72,6 +72,7 @@ using v8::External;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
@@ -84,6 +85,7 @@ using v8::PropertyAttribute;
 using v8::ReadOnly;
 using v8::Signature;
 using v8::String;
+using v8::Uint32;
 using v8::Value;
 
 
@@ -2705,9 +2707,9 @@ void CipherBase::Init(const FunctionCallbackInfo<Value>& args) {
   // represent a valid length at this point.
   unsigned int auth_tag_len;
   if (args[2]->IsUint32()) {
-    auth_tag_len = args[2].As<v8::Uint32>()->Value();
+    auth_tag_len = args[2].As<Uint32>()->Value();
   } else {
-    CHECK(args[2]->IsInt32() && args[2].As<v8::Int32>()->Value() == -1);
+    CHECK(args[2]->IsInt32() && args[2].As<Int32>()->Value() == -1);
     auth_tag_len = kNoAuthTagLength;
   }
 
@@ -2799,9 +2801,9 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   // represent a valid length at this point.
   unsigned int auth_tag_len;
   if (args[3]->IsUint32()) {
-    auth_tag_len = args[3].As<v8::Uint32>()->Value();
+    auth_tag_len = args[3].As<Uint32>()->Value();
   } else {
-    CHECK(args[3]->IsInt32() && args[3].As<v8::Int32>()->Value() == -1);
+    CHECK(args[3]->IsInt32() && args[3].As<Int32>()->Value() == -1);
     auth_tag_len = kNoAuthTagLength;
   }
 
@@ -3002,7 +3004,7 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 2);
   CHECK(args[1]->IsInt32());
-  int plaintext_len = args[1].As<v8::Int32>()->Value();
+  int plaintext_len = args[1].As<Int32>()->Value();
 
   if (!cipher->SetAAD(Buffer::Data(args[0]), Buffer::Length(args[0]),
                       plaintext_len))

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -364,14 +364,15 @@ class CipherBase : public BaseObject {
   void Init(const char* cipher_type,
             const char* key_buf,
             int key_buf_len,
-            int auth_tag_len);
+            unsigned int auth_tag_len);
   void InitIv(const char* cipher_type,
               const char* key,
               int key_len,
               const char* iv,
               int iv_len,
-              int auth_tag_len);
-  bool InitAuthenticated(const char *cipher_type, int iv_len, int auth_tag_len);
+              unsigned int auth_tag_len);
+  bool InitAuthenticated(const char *cipher_type, int iv_len,
+                         unsigned int auth_tag_len);
   bool CheckCCMMessageLength(int message_len);
   UpdateResult Update(const char* data, int len, unsigned char** out,
                       int* out_len);


### PR DESCRIPTION
As suggested by @bnoordhuis in https://github.com/nodejs/node/pull/20039, this changes `InitAuthenticated` to accept an `unsigned int auth_tag_len`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
