### PR TITLE
http: client aborted should be boolean.

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -529,10 +529,16 @@ in the response to be dropped and the socket to be destroyed.
 ### request.aborted
 <!-- YAML
 added: v0.11.14
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/20230
+    description: The aborted property is no longer a timestamp number.
 -->
 
-If a request has been aborted, this value is the time when the request was
-aborted, in milliseconds since 1 January 1970 00:00:00 UTC.
+* {boolean}
+
+The `request.aborted` property will be `true` if the request has
+been aborted.
 
 ### request.connection
 <!-- YAML

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -165,7 +165,7 @@ function ClientRequest(options, cb) {
 
   this._ended = false;
   this.res = null;
-  this.aborted = undefined;
+  this.aborted = false;
   this.timeoutCb = null;
   this.upgradeOrConnect = false;
   this.parser = null;
@@ -291,11 +291,7 @@ ClientRequest.prototype.abort = function abort() {
   if (!this.aborted) {
     process.nextTick(emitAbortNT.bind(this));
   }
-
-  // Mark as aborting so we can avoid sending queued request data
-  // This is used as a truthy flag elsewhere. The use of Date.now is for
-  // debugging purposes only.
-  this.aborted = Date.now();
+  this.aborted = true;
 
   // If we're aborting, we don't care about any more response data.
   if (this.res) {

--- a/test/parallel/test-http-abort-stream-end.js
+++ b/test/parallel/test-http-abort-stream-end.js
@@ -38,21 +38,20 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end();
 }));
 
-let aborted = false;
 server.listen(0, () => {
-
   const res = common.mustCall((res) => {
     res.on('data', (chunk) => {
       size += chunk.length;
-      assert(!aborted, 'got data after abort');
+      assert(!req.aborted, 'got data after abort');
       if (size > maxSize) {
-        aborted = true;
         req.abort();
+        assert.strictEqual(req.aborted, true);
         size = maxSize;
       }
     });
 
     req.on('abort', common.mustCall(() => assert.strictEqual(size, maxSize)));
+    assert.strictEqual(req.aborted, false);
   });
 
   const req = http.get(`http://localhost:${server.address().port}`, res);


### PR DESCRIPTION
This is a semver-major.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)