### PR TITLE
src: fix compiler warnings in node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2798,7 +2798,7 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
 
 
 static bool IsValidGCMTagLength(unsigned int tag_len) {
-  return tag_len == 4 || tag_len == 8 || tag_len >= 12 && tag_len <= 16;
+  return tag_len == 4 || tag_len == 8 || (tag_len >= 12 && tag_len <= 16);
 }
 
 bool CipherBase::InitAuthenticated(const char *cipher_type, int iv_len,
@@ -2922,8 +2922,8 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   unsigned int tag_len = Buffer::Length(args[0]);
   const int mode = EVP_CIPHER_CTX_mode(cipher->ctx_);
   if (mode == EVP_CIPH_GCM_MODE) {
-    if (cipher->auth_tag_len_ != kNoAuthTagLength &&
-        cipher->auth_tag_len_ != tag_len ||
+    if ((cipher->auth_tag_len_ != kNoAuthTagLength &&
+         cipher->auth_tag_len_ != tag_len) ||
         !IsValidGCMTagLength(tag_len)) {
       char msg[50];
       snprintf(msg, sizeof(msg),


### PR DESCRIPTION
Add parentheses, like my compiler suggests.

In the `IsValidGCMTagLength()` case I’m pretty sure that this
grouping is the correct one, because it matches the earlier
code; in the other case it would be good to have explicit confirmation.

Refs: https://github.com/nodejs/node/pull/20039

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
