### PR TITLE
doc: improve docs for Http2Session:frameError

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -159,17 +159,15 @@ an `Http2Session`.
 added: v8.4.0
 -->
 
+* `type` {integer} The frame type.
+* `code` {integer} The error code.
+* `id` {integer} The stream id (or `0` if the frame isn't associated with a
+  stream).
+
 The `'frameError'` event is emitted when an error occurs while attempting to
 send a frame on the session. If the frame that could not be sent is associated
 with a specific `Http2Stream`, an attempt to emit `'frameError'` event on the
 `Http2Stream` is made.
-
-When invoked, the handler function will receive three arguments:
-
-* An integer identifying the frame type.
-* An integer identifying the error code.
-* An integer identifying the stream (or 0 if the frame is not associated with
-  a stream).
 
 If the `'frameError'` event is associated with a stream, the stream will be
 closed and destroyed immediately following the `'frameError'` event. If the


### PR DESCRIPTION
Improve documentation regarding the callback parameters for the
frameError event for instances of Http2Session, making it inline with
the currently accepted structure, like the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @vsemozhetbyt @mcollina @nodejs/http2 