### PR TITLE
src: expose untampered rawDebug and macro for it

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -40,3 +40,5 @@ globals:
   DCHECK_LE: false
   DCHECK_LT: false
   DCHECK_NE: false
+  DLOG: false
+  internalBinding: false

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -41,7 +41,6 @@ const {
 // that test/parallel/test-buffer-bindingobj-no-zerofill.js is written.
 let isAnyArrayBuffer;
 try {
-  const { internalBinding } = require('internal/bootstrap/loaders');
   isAnyArrayBuffer = internalBinding('types').isAnyArrayBuffer;
 } catch (e) {
   isAnyArrayBuffer = require('util').types.isAnyArrayBuffer;

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -34,7 +34,6 @@ const {
   ERR_UNHANDLED_ERROR
 } = require('internal/errors').codes;
 const { createHook } = require('async_hooks');
-const { internalBinding } = require('internal/bootstrap/loaders');
 
 // overwrite process.domain with a getter/setter that will allow for more
 // effective optimizations

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -189,7 +189,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, process) {',
+    '(function (exports, require, module, process, internalBinding) {',
     '\n});'
   ];
 
@@ -206,7 +206,7 @@
       const requireFn = this.id.startsWith('internal/deps/') ?
         NativeModule.requireForDeps :
         NativeModule.require;
-      fn(this.exports, requireFn, this, process);
+      fn(this.exports, requireFn, this, process, internalBinding);
 
       this.loaded = true;
     } finally {

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -23,7 +23,6 @@ const {
 
 const { isArrayBufferView } = require('internal/util/types');
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   isArrayBuffer
 } = internalBinding('types');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -4,7 +4,6 @@
 
 require('internal/util').assertCrypto();
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
 const { UV_EOF } = process.binding('uv');
 const http = require('http');

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const { ModuleWrap } = internalBinding('module_wrap');
 const debug = require('util').debuglog('esm');
 const ArrayJoin = Function.call.bind(Array.prototype.join);

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -3,7 +3,7 @@
 const { URL } = require('url');
 const CJSmodule = require('internal/modules/cjs/loader');
 const internalFS = require('internal/fs');
-const { NativeModule, internalBinding } = require('internal/bootstrap/loaders');
+const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { realpathSync } = require('fs');
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const { ModuleWrap } = internalBinding('module_wrap');
 const { SafeSet, SafePromise } = require('internal/safe_globals');
 const { decorateErrorStack } = require('internal/util');

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { NativeModule, internalBinding } = require('internal/bootstrap/loaders');
+const { NativeModule } = require('internal/bootstrap/loaders');
 const { ModuleWrap } = internalBinding('module_wrap');
 const {
   stripShebang,

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   setImportModuleDynamicallyCallback,
   setInitializeImportMetaObjectCallback

--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -8,7 +8,6 @@ process.emitWarning(
 // These exports should be scoped as specifically as possible
 // to avoid exposing APIs because even with that warning and
 // this file being internal people will still try to abuse it.
-const { internalBinding } = require('internal/bootstrap/loaders');
 module.exports = {
   ModuleWrap: internalBinding('module_wrap').ModuleWrap,
 };

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -2,7 +2,6 @@
 
 const { compare } = process.binding('buffer');
 const { isArrayBufferView } = require('internal/util/types');
-const { internalBinding } = require('internal/bootstrap/loaders');
 const { isDate, isMap, isRegExp, isSet } = internalBinding('types');
 
 function objectToString(o) {

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const { emitExperimentalWarning } = require('internal/util');
 const { URL } = require('internal/url');
 const { isContext } = process.binding('contextify');

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   kIncompleteCharactersStart,
   kIncompleteCharactersEnd,

--- a/lib/util.js
+++ b/lib/util.js
@@ -44,7 +44,6 @@ const {
   kRejected,
 } = process.binding('util');
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const types = internalBinding('types');
 Object.assign(types, require('internal/util/types'));
 const {

--- a/node.gyp
+++ b/node.gyp
@@ -746,10 +746,10 @@
               'inputs': [ 'src/noperfctr_macros.py' ]
             }],
             [ 'node_debug_lib=="false"', {
-              'inputs': [ 'tools/nodcheck_macros.py' ]
+              'inputs': [ 'tools/nodebug_macros.py' ]
             }],
             [ 'node_debug_lib=="true"', {
-              'inputs': [ 'tools/dcheck_macros.py' ]
+              'inputs': [ 'tools/debug_macros.py' ]
             }]
           ],
           'action': [

--- a/src/node.cc
+++ b/src/node.cc
@@ -3317,6 +3317,12 @@ static void RawDebug(const FunctionCallbackInfo<Value>& args) {
   PrintErrorString("%s\n", *message);
   fflush(stderr);
 }
+static void InitializeInternalDebug(
+    Local<Object> target, Local<Value>, Local<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  env->SetMethod(target, "debug", RawDebug);
+}
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(debug, InitializeInternalDebug);
 
 
 static Local<Function> GetBootstrapper(Environment* env, Local<String> source,
@@ -4672,6 +4678,8 @@ void RegisterBuiltinModules() {
 #define V(modname) _register_##modname();
   NODE_BUILTIN_MODULES(V)
 #undef V
+  // defined in this file
+  _register_debug();
 }
 
 }  // namespace node

--- a/tools/debug_macros.py
+++ b/tools/debug_macros.py
@@ -1,4 +1,6 @@
-macro DCHECK(x) = do { if (!(x)) (process._rawDebug("DCHECK: x == true"), process.abort()) } while (0);
+macro DLOG(x) = internalBinding("debug").debug(x);
+
+macro DCHECK(x) = do { if (!(x)) (DLOG("DCHECK: x == true"), process.abort()) } while (0);
 macro DCHECK_EQ(a, b) = DCHECK((a) === (b));
 macro DCHECK_GE(a, b) = DCHECK((a) >= (b));
 macro DCHECK_GT(a, b) = DCHECK((a) > (b));

--- a/tools/nodcheck_macros.py
+++ b/tools/nodcheck_macros.py
@@ -1,7 +1,0 @@
-macro DCHECK(x) = void(x);
-macro DCHECK_EQ(a, b) = void(a, b);
-macro DCHECK_GE(a, b) = void(a, b);
-macro DCHECK_GT(a, b) = void(a, b);
-macro DCHECK_LE(a, b) = void(a, b);
-macro DCHECK_LT(a, b) = void(a, b);
-macro DCHECK_NE(a, b) = void(a, b);

--- a/tools/nodebug_macros.py
+++ b/tools/nodebug_macros.py
@@ -1,0 +1,9 @@
+macro DLOG(x) = void(0);
+
+macro DCHECK(x) = void(0);
+macro DCHECK_EQ(a, b) = void(0);
+macro DCHECK_GE(a, b) = void(0);
+macro DCHECK_GT(a, b) = void(0);
+macro DCHECK_LE(a, b) = void(0);
+macro DCHECK_LT(a, b) = void(0);
+macro DCHECK_NE(a, b) = void(0);


### PR DESCRIPTION
process._rawDebug pretty much becomes useless by its own definition after it gets overwritten to use util.inspect and i ran into trouble with that multiple times so i re-exposed it as an internal binding and made a macro for it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
