### PR TITLE
src: use snake_case_ for private member dh

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -572,8 +572,8 @@ class PublicKeyCipher {
 class DiffieHellman : public BaseObject {
  public:
   ~DiffieHellman() override {
-    if (dh != nullptr) {
-      DH_free(dh);
+    if (dh_ != nullptr) {
+      DH_free(dh_);
     }
   }
 
@@ -602,7 +602,7 @@ class DiffieHellman : public BaseObject {
       : BaseObject(env, wrap),
         initialised_(false),
         verifyError_(0),
-        dh(nullptr) {
+        dh_(nullptr) {
     MakeWeak<DiffieHellman>(this);
   }
 
@@ -616,7 +616,7 @@ class DiffieHellman : public BaseObject {
 
   bool initialised_;
   int verifyError_;
-  DH* dh;
+  DH* dh_;
 };
 
 class ECDH : public BaseObject {


### PR DESCRIPTION
This commit renames the private member `dh` in the DiffieHellman class to
`dh_` for consistency with CPP_STYLE_GUIDE.md.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
