### PR TITLE
crypto: simplify diffiehellman getFormat function

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -222,9 +222,9 @@ function getFormat(format) {
   if (format) {
     if (format === 'compressed')
       return POINT_CONVERSION_COMPRESSED;
-    else if (format === 'hybrid')
+    if (format === 'hybrid')
       return POINT_CONVERSION_HYBRID;
-    else if (format !== 'uncompressed')
+    if (format !== 'uncompressed')
       throw new ERR_CRYPTO_ECDH_INVALID_FORMAT(format);
   }
   return POINT_CONVERSION_UNCOMPRESSED;

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -224,7 +224,6 @@ function getFormat(format) {
       return POINT_CONVERSION_COMPRESSED;
     else if (format === 'hybrid')
       return POINT_CONVERSION_HYBRID;
-    // Default
     else if (format !== 'uncompressed')
       throw new ERR_CRYPTO_ECDH_INVALID_FORMAT(format);
   }

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -219,21 +219,16 @@ function encode(buffer, encoding) {
 }
 
 function getFormat(format) {
-  let f;
   if (format) {
     if (format === 'compressed')
-      f = POINT_CONVERSION_COMPRESSED;
+      return POINT_CONVERSION_COMPRESSED;
     else if (format === 'hybrid')
-      f = POINT_CONVERSION_HYBRID;
+      return POINT_CONVERSION_HYBRID;
     // Default
-    else if (format === 'uncompressed')
-      f = POINT_CONVERSION_UNCOMPRESSED;
-    else
+    else if (format !== 'uncompressed')
       throw new ERR_CRYPTO_ECDH_INVALID_FORMAT(format);
-  } else {
-    f = POINT_CONVERSION_UNCOMPRESSED;
   }
-  return f;
+  return POINT_CONVERSION_UNCOMPRESSED;
 }
 
 module.exports = {


### PR DESCRIPTION
This commit aims to simplify the getFormat function in
diffiehellman.js.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
