### PR TITLE
crypto: add getIntOption function to reduce dupl

### DIFF
--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -53,6 +53,25 @@ Sign.prototype.update = function update(data, encoding) {
   return this;
 };
 
+function getPadding(options) {
+  return getIntOption('padding', RSA_PKCS1_PADDING, options);
+}
+
+function getSaltLength(options) {
+  return getIntOption('saltLength', RSA_PSS_SALTLEN_AUTO, options);
+}
+
+function getIntOption(name, defaultValue, options) {
+  if (options.hasOwnProperty(name)) {
+    if (options[name] === options[name] >> 0) {
+      return options[name];
+    } else {
+      throw new ERR_INVALID_OPT_VALUE(name, options[name]);
+    }
+  }
+  return defaultValue;
+}
+
 Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
@@ -61,23 +80,9 @@ Sign.prototype.sign = function sign(options, encoding) {
   var passphrase = options.passphrase || null;
 
   // Options specific to RSA
-  var rsaPadding = RSA_PKCS1_PADDING;
-  if (options.hasOwnProperty('padding')) {
-    if (options.padding === options.padding >> 0) {
-      rsaPadding = options.padding;
-    } else {
-      throw new ERR_INVALID_OPT_VALUE('padding', options.padding);
-    }
-  }
+  var rsaPadding = getPadding(options);
 
-  var pssSaltLength = RSA_PSS_SALTLEN_AUTO;
-  if (options.hasOwnProperty('saltLength')) {
-    if (options.saltLength === options.saltLength >> 0) {
-      pssSaltLength = options.saltLength;
-    } else {
-      throw new ERR_INVALID_OPT_VALUE('saltLength', options.saltLength);
-    }
-  }
+  var pssSaltLength = getSaltLength(options);
 
   key = toBuf(key);
   if (!isArrayBufferView(key)) {
@@ -119,23 +124,9 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   sigEncoding = sigEncoding || getDefaultEncoding();
 
   // Options specific to RSA
-  var rsaPadding = RSA_PKCS1_PADDING;
-  if (options.hasOwnProperty('padding')) {
-    if (options.padding === options.padding >> 0) {
-      rsaPadding = options.padding;
-    } else {
-      throw new ERR_INVALID_OPT_VALUE('padding', options.padding);
-    }
-  }
+  var rsaPadding = getPadding(options);
 
-  var pssSaltLength = RSA_PSS_SALTLEN_AUTO;
-  if (options.hasOwnProperty('saltLength')) {
-    if (options.saltLength === options.saltLength >> 0) {
-      pssSaltLength = options.saltLength;
-    } else {
-      throw new ERR_INVALID_OPT_VALUE('saltLength', options.saltLength);
-    }
-  }
+  var pssSaltLength = getSaltLength(options);
 
   key = toBuf(key);
   if (!isArrayBufferView(key)) {


### PR DESCRIPTION
This commit adds a getIntOption function to reduce the code duplicated
for getting the padding, and saltLength options.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
