### PR TITLE
process: remove setupRawDebug

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -67,7 +67,6 @@
     NativeModule.require('internal/inspector_async_hook').setup();
 
     _process.setupChannel();
-    _process.setupRawDebug();
 
     const browserGlobals = !process._noBrowserGlobals;
     if (browserGlobals) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -12,7 +12,6 @@ const {
     ERR_UNKNOWN_SIGNAL
   }
 } = require('internal/errors');
-const util = require('util');
 const constants = process.binding('constants').os.signals;
 const assert = require('assert').strict;
 const { deprecate } = require('internal/util');
@@ -249,14 +248,6 @@ function setupChannel() {
 }
 
 
-function setupRawDebug() {
-  const rawDebug = process._rawDebug;
-  process._rawDebug = function() {
-    rawDebug(util.format.apply(null, arguments));
-  };
-}
-
-
 function setupUncaughtExceptionCapture(exceptionHandlerState) {
   // This is a typed array for faster communication with JS.
   const shouldAbortOnUncaughtToggle = process._shouldAbortOnUncaughtToggle;
@@ -292,6 +283,5 @@ module.exports = {
   setupKillAndExit,
   setupSignalHandlers,
   setupChannel,
-  setupRawDebug,
   setupUncaughtExceptionCapture
 };


### PR DESCRIPTION
process._rawDebug pretty much becomes useless by its own definition (a method to log withour running any js) after it gets overwritten to use util.inspect and i ran into trouble with that multiple times.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
