### PR TITLE
util: fix isInsideNodeModules inside error

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -356,16 +356,17 @@ function isInsideNodeModules() {
 
   // Iterate over all stack frames and look for the first one not coming
   // from inside Node.js itself:
-  for (const frame of stack) {
-    const filename = frame.getFileName();
-    // If a filename does not start with / or contain \,
-    // it's likely from Node.js core.
-    if (!/^\/|\\/.test(filename))
-      continue;
-    return kNodeModulesRE.test(filename);
+  if (Array.isArray(stack)) {
+    for (const frame of stack) {
+      const filename = frame.getFileName();
+      // If a filename does not start with / or contain \,
+      // it's likely from Node.js core.
+      if (!/^\/|\\/.test(filename))
+        continue;
+      return kNodeModulesRE.test(filename);
+    }
   }
-
-  return false;  // This should be unreachable.
+  return false;
 }
 
 

--- a/test/parallel/test-buffer-constructor-deprecation-error.js
+++ b/test/parallel/test-buffer-constructor-deprecation-error.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+
+const bufferWarning = 'Buffer() is deprecated due to security and usability ' +
+                      'issues. Please use the Buffer.alloc(), ' +
+                      'Buffer.allocUnsafe(), or Buffer.from() methods instead.';
+
+common.expectWarning('DeprecationWarning', bufferWarning, 'DEP0005');
+
+// This is used to make sure that a warning is only emitted once even though
+// `new Buffer()` is called twice.
+process.on('warning', common.mustCall());
+
+Error.prepareStackTrace = (err, trace) => new Buffer(10);
+
+new Error().stack;


### PR DESCRIPTION
When isInsideNodeModules gets called while already processing
another stack trace, V8 will not call prepareStackTrace again.
This used to cause Node.js to just crash — fix it by checking
for expected return type of the stack (Array).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
