### PR TITLE
n-api: fix inheritance

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -849,6 +849,72 @@ napi_status ConcludeDeferred(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
+static napi_status
+DefineSingleProperty(napi_env env,
+                     v8::Isolate* isolate,
+                     v8::Local<v8::Context> context,
+                     v8::Local<v8::Object> obj,
+                     const napi_property_descriptor* p) {
+  v8::Local<v8::Name> property_name;
+  napi_status status =
+      v8impl::V8NameFromPropertyDescriptor(env, p, &property_name);
+
+  if (status != napi_ok) {
+    return napi_set_last_error(env, status);
+  }
+
+  v8::PropertyAttribute attributes =
+      v8impl::V8PropertyAttributesFromDescriptor(p);
+
+  if (p->getter != nullptr || p->setter != nullptr) {
+    v8::Local<v8::Object> cbdata = v8impl::CreateAccessorCallbackData(
+      env,
+      p->getter,
+      p->setter,
+      p->data);
+
+    auto set_maybe = obj->SetAccessor(
+      context,
+      property_name,
+      p->getter ? v8impl::GetterCallbackWrapper::Invoke : nullptr,
+      p->setter ? v8impl::SetterCallbackWrapper::Invoke : nullptr,
+      cbdata,
+      v8::AccessControl::DEFAULT,
+      attributes);
+
+    if (!set_maybe.FromMaybe(false)) {
+      return napi_set_last_error(env, napi_invalid_arg);
+    }
+  } else if (p->method != nullptr) {
+    v8::Local<v8::Object> cbdata =
+        v8impl::CreateFunctionCallbackData(env, p->method, p->data);
+
+    RETURN_STATUS_IF_FALSE(env, !cbdata.IsEmpty(), napi_generic_failure);
+
+    v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(
+        isolate, v8impl::FunctionCallbackWrapper::Invoke, cbdata);
+
+    auto define_maybe = obj->DefineOwnProperty(
+      context, property_name, t->GetFunction(), attributes);
+
+    if (!define_maybe.FromMaybe(false)) {
+      return napi_set_last_error(env, napi_generic_failure);
+    }
+  } else {
+    v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(p->value);
+
+    auto define_maybe =
+        obj->DefineOwnProperty(context, property_name, value, attributes);
+
+    if (!define_maybe.FromMaybe(false)) {
+      return napi_set_last_error(env, napi_invalid_arg);
+    }
+  }
+
+  // Not setting last error if everything is OK. Let the top-level API do that.
+  return napi_ok;
+}
+
 }  // end of namespace v8impl
 
 // Intercepts the Node-V8 module registration callback. Converts parameters
@@ -1446,62 +1512,10 @@ napi_status napi_define_properties(napi_env env,
   CHECK_TO_OBJECT(env, context, obj, object);
 
   for (size_t i = 0; i < property_count; i++) {
-    const napi_property_descriptor* p = &properties[i];
-
-    v8::Local<v8::Name> property_name;
-    napi_status status =
-        v8impl::V8NameFromPropertyDescriptor(env, p, &property_name);
-
+    napi_status status = v8impl::DefineSingleProperty(env, isolate, context,
+        obj, properties + i);
     if (status != napi_ok) {
-      return napi_set_last_error(env, status);
-    }
-
-    v8::PropertyAttribute attributes =
-        v8impl::V8PropertyAttributesFromDescriptor(p);
-
-    if (p->getter != nullptr || p->setter != nullptr) {
-      v8::Local<v8::Object> cbdata = v8impl::CreateAccessorCallbackData(
-        env,
-        p->getter,
-        p->setter,
-        p->data);
-
-      auto set_maybe = obj->SetAccessor(
-        context,
-        property_name,
-        p->getter ? v8impl::GetterCallbackWrapper::Invoke : nullptr,
-        p->setter ? v8impl::SetterCallbackWrapper::Invoke : nullptr,
-        cbdata,
-        v8::AccessControl::DEFAULT,
-        attributes);
-
-      if (!set_maybe.FromMaybe(false)) {
-        return napi_set_last_error(env, napi_invalid_arg);
-      }
-    } else if (p->method != nullptr) {
-      v8::Local<v8::Object> cbdata =
-          v8impl::CreateFunctionCallbackData(env, p->method, p->data);
-
-      RETURN_STATUS_IF_FALSE(env, !cbdata.IsEmpty(), napi_generic_failure);
-
-      v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(
-          isolate, v8impl::FunctionCallbackWrapper::Invoke, cbdata);
-
-      auto define_maybe = obj->DefineOwnProperty(
-        context, property_name, t->GetFunction(), attributes);
-
-      if (!define_maybe.FromMaybe(false)) {
-        return napi_set_last_error(env, napi_generic_failure);
-      }
-    } else {
-      v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(p->value);
-
-      auto define_maybe =
-          obj->DefineOwnProperty(context, property_name, value, attributes);
-
-      if (!define_maybe.FromMaybe(false)) {
-        return napi_set_last_error(env, napi_invalid_arg);
-      }
+      return status;
     }
   }
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1129,9 +1129,9 @@ napi_status napi_define_class(napi_env env,
   CHECK_NEW_FROM_UTF8_LEN(env, name_string, utf8name, length);
   tpl->SetClassName(name_string);
 
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Value> v8_result_value = tpl->GetFunction();
-  v8::Local<v8::Object> v8_result_object = v8_result_value.As<v8::Object>();
+  auto context = isolate->GetCurrentContext();
+  auto v8_result_value = tpl->GetFunction();
+  auto v8_result_object = v8_result_value.As<v8::Object>();
   *result = v8impl::JsValueFromV8LocalValue(scope.Escape(v8_result_value));
 
   napi_value proto;

--- a/test/addons-napi/test_inheritance/binding.gyp
+++ b/test/addons-napi/test_inheritance/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'test_inheritance',
+      'sources': [ 'test_inheritance.c' ]
+    }
+  ]
+}

--- a/test/addons-napi/test_inheritance/test.js
+++ b/test/addons-napi/test_inheritance/test.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../../common');
-const test_inheritance = require(`./build/${common.buildType}/test_inheritance`);
+const test_inheritance =
+    require(`./build/${common.buildType}/test_inheritance`);
 const x = new test_inheritance.Subclass();
 x.superclassMethod();

--- a/test/addons-napi/test_inheritance/test.js
+++ b/test/addons-napi/test_inheritance/test.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../../common');
+const test_inheritance = require(`./build/${common.buildType}/test_inheritance`);
+
+const classes = test_inheritance.createClasses();
+
+const x = new classes.Subclass();
+
+x.superclassMethod();

--- a/test/addons-napi/test_inheritance/test.js
+++ b/test/addons-napi/test_inheritance/test.js
@@ -1,9 +1,5 @@
 'use strict';
 const common = require('../../common');
 const test_inheritance = require(`./build/${common.buildType}/test_inheritance`);
-
-const classes = test_inheritance.createClasses();
-
-const x = new classes.Subclass();
-
+const x = new test_inheritance.Subclass();
 x.superclassMethod();

--- a/test/addons-napi/test_inheritance/test_inheritance.c
+++ b/test/addons-napi/test_inheritance/test_inheritance.c
@@ -60,11 +60,11 @@ static napi_value SubclassConstructor(napi_env env, napi_callback_info info) {
   RETURN_UNDEFINED(env);
 }
 
-static napi_value CreateClasses(napi_env env, napi_callback_info info) {
+static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor superclass_descriptors[] = {
     DECLARE_NAPI_PROPERTY("superclassMethod", SuperclassMethod),
   };
-  napi_value superclass, subclass, result;
+  napi_value superclass, subclass;
 
   NAPI_CALL(env, napi_define_class(env, "Superclass", NAPI_AUTO_LENGTH,
       SuperclassConstructor, NULL,
@@ -76,23 +76,7 @@ static napi_value CreateClasses(napi_env env, napi_callback_info info) {
 
   NAPI_CALL(env, napi_inherit(env, subclass, superclass));
 
-  NAPI_CALL(env, napi_create_object(env, &result));
-
-  NAPI_CALL(env, napi_set_named_property(env, result, "Subclass", subclass));
-
-  NAPI_CALL(env,
-      napi_set_named_property(env, result, "Superclass", superclass));
-
-  return result;
-}
-
-static napi_value Init(napi_env env, napi_value exports) {
-  napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("createClasses", CreateClasses),
-  };
-
-  NAPI_CALL(env, napi_define_properties(
-      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "Subclass", subclass));
 
   return exports;
 }

--- a/test/addons-napi/test_inheritance/test_inheritance.c
+++ b/test/addons-napi/test_inheritance/test_inheritance.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+
+#include "node_api.h"
+#include "../common.h"
+
+#define NAPI_CALL_BASIC(env, call)                                              \
+  do {                                                                          \
+    napi_status status = call;                                                  \
+    if (status != napi_ok) {                                                    \
+      return status;                                                            \
+    }                                                                           \
+  } while(0)
+
+#define RETURN_UNDEFINED(env)                                                   \
+  do {                                                                          \
+    napi_value undefined;                                                       \
+    NAPI_CALL((env), napi_get_undefined((env), &undefined));                    \
+    return undefined;                                                           \
+  } while(0)
+
+static napi_status
+napi_inherit(napi_env env, napi_value subclass, napi_value superclass) {
+  napi_value global, object_class, set_proto;
+  napi_value argv[2];
+
+  NAPI_CALL_BASIC(env, napi_get_global(env, &global));
+  NAPI_CALL_BASIC(env,
+      napi_get_named_property(env, global, "Object", &object_class));
+  NAPI_CALL_BASIC(env,
+      napi_get_named_property(env, object_class, "setPrototypeOf", &set_proto));
+
+  NAPI_CALL_BASIC(env,
+      napi_get_named_property(env, subclass, "prototype", &argv[0]));
+  NAPI_CALL_BASIC(env,
+      napi_get_named_property(env, superclass, "prototype", &argv[1]));
+  NAPI_CALL_BASIC(env,
+      napi_call_function(env, object_class, set_proto, 2, argv, NULL));
+
+  argv[0] = subclass;
+  argv[1] = superclass;
+  NAPI_CALL_BASIC(env,
+      napi_call_function(env, object_class, set_proto, 2, argv, NULL));
+
+  return napi_ok;
+}
+
+static napi_value SuperclassConstructor(napi_env env, napi_callback_info info) {
+  fprintf(stderr, "SuperclassConstructor\n");
+  RETURN_UNDEFINED(env);
+}
+
+static napi_value SuperclassMethod(napi_env env, napi_callback_info info) {
+  fprintf(stderr, "SuperclassMethod\n");
+  RETURN_UNDEFINED(env);
+}
+
+static napi_value SubclassConstructor(napi_env env, napi_callback_info info) {
+  SuperclassConstructor(env, info);
+  fprintf(stderr, "SubclassConstructor\n");
+  RETURN_UNDEFINED(env);
+}
+
+static napi_value CreateClasses(napi_env env, napi_callback_info info) {
+  napi_property_descriptor superclass_descriptors[] = {
+    DECLARE_NAPI_PROPERTY("superclassMethod", SuperclassMethod),
+  };
+  napi_value superclass, subclass, result;
+
+  NAPI_CALL(env, napi_define_class(env, "Superclass", NAPI_AUTO_LENGTH,
+      SuperclassConstructor, NULL,
+      sizeof(superclass_descriptors) / sizeof(*superclass_descriptors),
+      superclass_descriptors, &superclass));
+
+  NAPI_CALL(env, napi_define_class(env, "Subclass", NAPI_AUTO_LENGTH,
+    SubclassConstructor, NULL, 0, NULL, &subclass));
+
+  NAPI_CALL(env, napi_inherit(env, subclass, superclass));
+
+  NAPI_CALL(env, napi_create_object(env, &result));
+
+  NAPI_CALL(env, napi_set_named_property(env, result, "Subclass", subclass));
+
+  NAPI_CALL(env,
+      napi_set_named_property(env, result, "Superclass", superclass));
+
+  return result;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("createClasses", CreateClasses),
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
In `napi_define_class()` we assign prototype properties to `InstanceTemplate`. This seems to cause an `Illegal invocation` exception when attempting to call a method on an object which is inherited from its parent class.

OTOH if we retrieve the `"prototype"` property of the class and assign prototype properties to the resulting object, following the prototype chain and retrieving the method and invoking it from the parent class' prototype works.

This problem has been discussed in https://github.com/nodejs/node-addon-api/issues/246.

Should there be a distinction between assigning properties to a `FunctionTemplate`'s `InstanceTemplate` and to the object residing at the resulting function's `"prototype"` property?

@TimothyGu @hashseed what do you think?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
