### PR TITLE
fs/promises: ensure options.flag is defaulted to 'r' in readFile

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -139,7 +139,7 @@ async function readFileHandle(filehandle, options) {
   }
 
   if (size === 0)
-    return Buffer.alloc(0);
+    return options.encoding ? '' : Buffer.alloc(0);
 
   if (size > kMaxLength)
     throw new ERR_FS_FILE_TOO_LARGE(size);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -463,11 +463,12 @@ async function appendFile(path, data, options) {
 
 async function readFile(path, options) {
   options = getOptions(options, { flag: 'r' });
+  const flag = options.flag || 'r';
 
   if (path instanceof FileHandle)
     return readFileHandle(path, options);
 
-  const fd = await open(path, options.flag, 0o666);
+  const fd = await open(path, flag, 0o666);
   return readFileHandle(fd, options).finally(fd.close.bind(fd));
 }
 

--- a/test/parallel/test-fs-promises-readfile-empty.js
+++ b/test/parallel/test-fs-promises-readfile-empty.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+const { promises: fs } = require('fs');
+const fixtures = require('../common/fixtures');
+
+const fn = fixtures.path('empty.txt');
+
+fs.readFile(fn)
+  .then(assert.ok);
+
+fs.readFile(fn, 'utf8')
+  .then(assert.strictEqual.bind(this, ''));
+
+fs.readFile(fn, { encoding: 'utf8' })
+  .then(assert.strictEqual.bind(this, ''));

--- a/test/parallel/test-fs-promises-readfile-empty.js
+++ b/test/parallel/test-fs-promises-readfile-empty.js
@@ -7,6 +7,8 @@ const fixtures = require('../common/fixtures');
 
 const fn = fixtures.path('empty.txt');
 
+common.crashOnUnhandledRejection();
+
 fs.readFile(fn)
   .then(assert.ok);
 

--- a/test/parallel/test-fs-promises-readfile-empty.js
+++ b/test/parallel/test-fs-promises-readfile-empty.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
 const assert = require('assert');
 const { promises: fs } = require('fs');

--- a/test/parallel/test-fs-readfile-empty.js
+++ b/test/parallel/test-fs-readfile-empty.js
@@ -38,5 +38,9 @@ fs.readFile(fn, 'utf8', function(err, data) {
   assert.strictEqual('', data);
 });
 
+fs.readFile(fn, { encoding: 'utf8' }, function(err, data) {
+  assert.strictEqual('', data);
+});
+
 assert.ok(fs.readFileSync(fn));
 assert.strictEqual('', fs.readFileSync(fn, 'utf8'));


### PR DESCRIPTION
When passing `{}` or `{ encoding: 'utf8' }` as options to readFile, the
flag is not defaulted to 'r' unlike normal fs. This fix makes
(fs/promises).readFile() act consistently with fs.readFile().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
