### PR TITLE
doc: fix net.Socket link inconsistencies

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -77,8 +77,8 @@ Note that `CTRL`+`C` will no longer cause a `SIGINT` when in this mode.
 added: v0.5.8
 -->
 
-The `tty.WriteStream` class is a subclass of [`net.Socket`][] that represents the
-writable side of a TTY. In normal circumstances, [`process.stdout`][] and
+The `tty.WriteStream` class is a subclass of [`net.Socket`][] that represents
+the writable side of a TTY. In normal circumstances, [`process.stdout`][] and
 [`process.stderr`][] will be the only `tty.WriteStream` instances created for a
 Node.js process and there should be no reason to create additional instances.
 


### PR DESCRIPTION
Adds a link to `net.Socket` in the docs for `tty.WriteStream` to be consistent with `tty.ReadStream`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
