### PR TITLE
tls: fix getEphemeralKeyInfo to support X25519

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2117,7 +2117,8 @@ void SSLWrap<Base>::GetEphemeralKeyInfo(
   EVP_PKEY* key;
 
   if (SSL_get_server_tmp_key(w->ssl_, &key)) {
-    switch (EVP_PKEY_id(key)) {
+    int kid = EVP_PKEY_id(key);
+    switch (kid) {
       case EVP_PKEY_DH:
         info->Set(context, env->type_string(),
                   FIXED_ONE_BYTE_STRING(env->isolate(), "DH")).FromJust();
@@ -2125,15 +2126,24 @@ void SSLWrap<Base>::GetEphemeralKeyInfo(
                   Integer::New(env->isolate(), EVP_PKEY_bits(key))).FromJust();
         break;
       case EVP_PKEY_EC:
+      // TODO(shigeki) Change this to EVP_PKEY_X25519 and add EVP_PKEY_X448
+      // after upgrading to 1.1.1.
+      case NID_X25519:
         {
-          EC_KEY* ec = EVP_PKEY_get1_EC_KEY(key);
-          int nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
-          EC_KEY_free(ec);
+          const char *curve_name;
+          if (kid == EVP_PKEY_EC) {
+            EC_KEY* ec = EVP_PKEY_get1_EC_KEY(key);
+            int nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
+            curve_name = OBJ_nid2sn(nid);
+            EC_KEY_free(ec);
+          } else {
+            curve_name = OBJ_nid2sn(kid);
+          }
           info->Set(context, env->type_string(),
                     FIXED_ONE_BYTE_STRING(env->isolate(), "ECDH")).FromJust();
           info->Set(context, env->name_string(),
                     OneByteString(args.GetIsolate(),
-                                  OBJ_nid2sn(nid))).FromJust();
+                                  curve_name)).FromJust();
           info->Set(context, env->size_string(),
                     Integer::New(env->isolate(),
                                  EVP_PKEY_bits(key))).FromJust();

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -44,6 +44,8 @@
 #endif  // !OPENSSL_NO_ENGINE
 #include <openssl/err.h>
 #include <openssl/evp.h>
+// TODO(shigeki) Remove this after upgrading to 1.1.1
+#include <openssl/obj_mac.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -82,7 +82,12 @@ function testECDHE256() {
 }
 
 function testECDHE512() {
-  test(521, 'ECDH', 'secp521r1', null);
+  test(521, 'ECDH', 'secp521r1', testX25519);
+  ntests++;
+}
+
+function testX25519() {
+  test(253, 'ECDH', 'X25519', null);
   ntests++;
 }
 
@@ -90,5 +95,5 @@ testNOT_PFS();
 
 process.on('exit', function() {
   assert.strictEqual(ntests, nsuccess);
-  assert.strictEqual(ntests, 5);
+  assert.strictEqual(ntests, 6);
 });


### PR DESCRIPTION
`EVP_PKEY_EC` only covers ANSI X9.62 curves not IETF ones(curve25519 and curve448). 
This fixes to add support of X25519 in `tlsSocket.getEphemeralKeyInfo()`.
X448 should be added in the future upgrade to OpenSSL-1.1.1.

Fixes: https://github.com/nodejs/node/issues/20262
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CC @bnoordhuis 