### PR TITLE
tls: specify options.name in validateKeyCert

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -56,11 +56,10 @@ function SecureContext(secureProtocol, secureOptions, context) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
-function validateKeyCert(value, type) {
+function validateKeyCert(name, value) {
   if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(
-      // TODO(BridgeAR): Change this to `options.${type}`
-      type,
+      `options.${name}`,
       ['string', 'Buffer', 'TypedArray', 'DataView'],
       value
     );
@@ -100,11 +99,11 @@ exports.createSecureContext = function createSecureContext(options, context) {
     if (Array.isArray(ca)) {
       for (i = 0; i < ca.length; ++i) {
         val = ca[i];
-        validateKeyCert(val, 'ca');
+        validateKeyCert('ca', val);
         c.context.addCACert(val);
       }
     } else {
-      validateKeyCert(ca, 'ca');
+      validateKeyCert('ca', ca);
       c.context.addCACert(ca);
     }
   } else {
@@ -116,11 +115,11 @@ exports.createSecureContext = function createSecureContext(options, context) {
     if (Array.isArray(cert)) {
       for (i = 0; i < cert.length; ++i) {
         val = cert[i];
-        validateKeyCert(val, 'cert');
+        validateKeyCert('cert', val);
         c.context.setCert(val);
       }
     } else {
-      validateKeyCert(cert, 'cert');
+      validateKeyCert('cert', cert);
       c.context.setCert(cert);
     }
   }
@@ -137,11 +136,11 @@ exports.createSecureContext = function createSecureContext(options, context) {
         val = key[i];
         // eslint-disable-next-line eqeqeq
         const pem = (val != undefined && val.pem !== undefined ? val.pem : val);
-        validateKeyCert(pem, 'key');
+        validateKeyCert('key', pem);
         c.context.setKey(pem, val.passphrase || passphrase);
       }
     } else {
-      validateKeyCert(key, 'key');
+      validateKeyCert('key', key);
       c.context.setKey(key, passphrase);
     }
   }

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -88,7 +88,7 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "key" argument must be one of type string, Buffer, ' +
+    message: 'The "options.key" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });
 });
@@ -113,8 +113,8 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "cert" argument must be one of type string, Buffer, ' +
-             `TypedArray, or DataView. Received type ${type}`
+    message: 'The "options.cert" property must be one of type string, Buffer,' +
+             ` TypedArray, or DataView. Received type ${type}`
   });
 });
 
@@ -147,7 +147,7 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-    message: 'The "ca" argument must be one of type string, Buffer, ' +
+    message: 'The "options.ca" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });
 });

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -86,7 +86,7 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "key" argument must be one of type string, Buffer, ' +
+    message: 'The "options.key" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });
 });
@@ -111,8 +111,8 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "cert" argument must be one of type string, Buffer, ' +
-             `TypedArray, or DataView. Received type ${type}`
+    message: 'The "options.cert" property must be one of type string, Buffer,' +
+             ` TypedArray, or DataView. Received type ${type}`
   });
 });
 
@@ -145,7 +145,7 @@ const caArrDataView = toDataView(caCert);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "ca" argument must be one of type string, Buffer, ' +
+    message: 'The "options.ca" property must be one of type string, Buffer, ' +
              `TypedArray, or DataView. Received type ${type}`
   });
 });


### PR DESCRIPTION
This commit addresses a TODO added by Ruben Bridgewater in commit
c6b6c92185316e13738e6fa931fdd5303e381e46 ("lib: always show
ERR_INVALID_ARG_TYPE received part") which was to prefix the name of
the invalid argument with 'options.'.

This commit also switches the order of the parameters to validateKeyCert
to be consistent with other validators.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
