### PR TITLE
src: use EnqueueMicrotask for tls writes

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -291,12 +291,22 @@ void TLSWrap::EncOut() {
 
   NODE_COUNT_NET_BYTES_SENT(write_size_);
 
-  if (!res.async) {
-    // Simulate asynchronous finishing, TLS cannot handle this at the moment.
-    env()->isolate()->EnqueueMicrotask([](void* data) {
-      static_cast<TLSWrap*>(data)->OnStreamAfterWrite(nullptr, 0);
-    }, this);
-  }
+  if (!res.async)
+    SyncAfterWrite();
+}
+
+// Simulate asynchronous finishing, TLS cannot handle this at the moment.
+void TLSWrap::SyncAfterWrite() {
+  env()->isolate()->EnqueueMicrotask([](void* data) {
+    TLSWrap* wrap = static_cast<TLSWrap*>(data);
+    wrap->MakeWeak(wrap);
+    wrap->OnStreamAfterWrite(nullptr, 0);
+  }, this);
+  ClearWeak();
+  // This is a cheap way for us to ensure that microtasks will get to run
+  // at some point in the near future.
+  if (env()->immediate_info()->count() == 0)
+    env()->SetImmediate([](Environment* env, void* data) {}, this);
 }
 
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -292,12 +292,10 @@ void TLSWrap::EncOut() {
   NODE_COUNT_NET_BYTES_SENT(write_size_);
 
   if (!res.async) {
-    HandleScope handle_scope(env()->isolate());
-
     // Simulate asynchronous finishing, TLS cannot handle this at the moment.
-    env()->SetImmediate([](Environment* env, void* data) {
+    env()->isolate()->EnqueueMicrotask([](void* data) {
       static_cast<TLSWrap*>(data)->OnStreamAfterWrite(nullptr, 0);
-    }, this, object());
+    }, this);
   }
 }
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -164,6 +164,8 @@ class TLSWrap : public AsyncWrap,
   bool eof_;
 
  private:
+  void SyncAfterWrite();
+
   static void GetWriteQueueSize(
       const v8::FunctionCallbackInfo<v8::Value>& info);
 };


### PR DESCRIPTION
Instead of using `SetImmediate`, use `EnqueueMicrotask` as it appears to be significantly more performant in certain cases and even in the optimal case yields roughly 10% higher throughput.

Not sure if there are any potential downsides here (in terms of using `EnqueueMicrotask`) that we need to watch out for.

Here are some rough stats when using write callbacks as the original test:

With SetImmediate:
> Elapsed 5 s, sent 8 MB (2 MB/s), received 8 MB (2 MB/s)
Elapsed 10 s, sent 16 MB (2 MB/s), received 16 MB (2 MB/s)
Elapsed 15 s, sent 23 MB (2 MB/s), received 23 MB (2 MB/s)
Elapsed 20 s, sent 31 MB (2 MB/s), received 31 MB (2 MB/s)

With EnqueueMicrotask:
> Elapsed 5 s, sent 17 MB (3 MB/s), received 16 MB (3 MB/s)
Elapsed 10 s, sent 32 MB (3 MB/s), received 32 MB (3 MB/s)
Elapsed 15 s, sent 48 MB (3 MB/s), received 48 MB (3 MB/s)
Elapsed 20 s, sent 64 MB (3 MB/s), received 63 MB (3 MB/s)

And here's the performance when using `drain` and the usual streams buffering:

With SetImmediate:
> Elapsed 5 s, received 53 MB (11 MB/s)
Elapsed 10 s, received 108 MB (11 MB/s)
Elapsed 15 s, received 162 MB (11 MB/s)
Elapsed 20 s, received 217 MB (11 MB/s)

With EnqueueMicrotask:
> Elapsed 5 s, received 59 MB (12 MB/s)
Elapsed 10 s, received 120 MB (12 MB/s)
Elapsed 15 s, received 180 MB (12 MB/s)
Elapsed 20 s, received 241 MB (12 MB/s)

Refs: https://github.com/nodejs/node/issues/20263

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
