### PR TITLE
doc: add emitter.off to events.md

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -372,6 +372,17 @@ console.log(util.inspect(server.listeners('connection')));
 // Prints: [ [Function] ]
 ```
 
+### emitter.off(eventName, listener)
+<!-- YAML
+added: v10.0.0
+-->
+
+* `eventName` {string|symbol}
+* `listener` {Function}
+* Returns: {EventEmitter}
+
+Alias for `emitter.removeListener(eventName, listener)`.
+
 ### emitter.on(eventName, listener)
 <!-- YAML
 added: v0.1.101

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -381,7 +381,7 @@ added: v10.0.0
 * `listener` {Function}
 * Returns: {EventEmitter}
 
-Alias for `emitter.removeListener(eventName, listener)`.
+Alias for [`emitter.removeListener()`][].
 
 ### emitter.on(eventName, listener)
 <!-- YAML
@@ -637,6 +637,7 @@ emitter.emit('log');
 [`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
 [`domain`]: domain.html
 [`emitter.listenerCount()`]: #events_emitter_listenercount_eventname
+[`emitter.removeListener()`]: #events_emitter_removelistener_eventname_listener
 [`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server


### PR DESCRIPTION
`emitter.off` is not listed in the current document. This patch adds that to the events.md.

Refs: #17156

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
