### PR TITLE
build: do not depend on `cp` in `PATH`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -680,13 +680,13 @@
       'toolsets': ['host'],
       'conditions': [
         [ 'v8_enable_inspector==1', {
-          'actions': [
+          'copies': [
             {
-              'action_name': 'v8_inspector_copy_protocol_to_intermediate_folder',
-              'inputs': [ 'deps/v8/src/inspector/js_protocol.pdl' ],
-              'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/js_protocol.pdl' ],
-              'action': [ 'cp', '<@(_inputs)', '<(SHARED_INTERMEDIATE_DIR)' ],
-            },
+              'destination': '<(SHARED_INTERMEDIATE_DIR)',
+              'files': ['deps/v8/src/inspector/js_protocol.pdl']
+            }
+          ],
+          'actions': [
             {
               'action_name': 'v8_inspector_convert_protocol_to_json',
               'inputs': [


### PR DESCRIPTION
Use gyp’s own copying mechanism instead.

It’s not really clear which UNIX utils exactly are needed to build on
Windows, but this is an easier fix (at least for me) than figuring
out how to get `cp` into the `PATH` in all cases, and judging
from the issue I’m not the only one who ran into this.

Fixes: https://github.com/nodejs/node/issues/20272

/cc @fs-eire

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
