### PR TITLE
child_process: fix leak when passing http sockets

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -31,6 +31,8 @@ const SocketList = require('internal/socket_list');
 const { convertToValidSignal } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 const spawn_sync = process.binding('spawn_sync');
+const { HTTPParser } = process.binding('http_parser');
+const { freeParser } = require('_http_common');
 
 const {
   UV_EACCES,
@@ -107,6 +109,14 @@ const handleConversion = {
       if (!options.keepOpen) {
         handle.onread = nop;
         socket._handle = null;
+        socket.setTimeout(0);
+        // In case of an HTTP connection socket, release the associated
+        // resources
+        if (socket.parser && socket.parser instanceof HTTPParser) {
+          freeParser(socket.parser, null, socket);
+          if (socket._httpMessage)
+            socket._httpMessage.detachSocket(socket);
+        }
       }
 
       return handle;

--- a/test/parallel/test-child-process-http-socket-leak.js
+++ b/test/parallel/test-child-process-http-socket-leak.js
@@ -1,0 +1,56 @@
+// Flags: --expose_internals
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { fork } = require('child_process');
+const http = require('http');
+const { kTimeout } = require('internal/timers');
+
+if (process.argv[2] === 'child') {
+  process.once('message', (req, socket) => {
+    const res = new http.ServerResponse(req);
+    res.assignSocket(socket);
+    res.end();
+  });
+
+  process.send('ready');
+  return;
+}
+
+let child;
+let socket;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  const r = {
+    method: req.method,
+    headers: req.headers,
+    path: req.path,
+    httpVersionMajor: req.httpVersionMajor,
+    query: req.query,
+  };
+
+  socket = res.socket;
+  child.send(r, socket);
+  server.close();
+}));
+
+server.listen(0, common.mustCall(() => {
+  child = fork(__filename, [ 'child' ]);
+  child.once('message', (msg) => {
+    assert.strictEqual(msg, 'ready');
+    const req = http.request({
+      port: server.address().port,
+    }, common.mustCall((res) => {
+      res.on('data', () => {});
+      res.on('end', common.mustCall(() => {
+        assert.strictEqual(socket[kTimeout]._idleTimeout, -1);
+        assert.strictEqual(socket.parser, null);
+        assert.strictEqual(socket._httpMessage, null);
+      }));
+    }));
+
+    req.end();
+  });
+}));


### PR DESCRIPTION
After passing an HTTP socket, release its associated resources.

Fixes: https://github.com/nodejs/node/issues/15651

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
