### PR TITLE
tools: simplify HTML generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ tools/doc/node_modules/js-yaml/package.json:
 
 gen-json = tools/doc/generate.js --format=json $< > $@
 gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html \
-			--template=doc/template.html --analytics=$(DOCS_ANALYTICS) $< > $@
+			--analytics=$(DOCS_ANALYTICS) $< > $@
 
 out/doc/api/%.json: doc/api/%.md
 	$(call available-node, $(gen-json))

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -10,7 +10,6 @@ try {
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const fixtures = require('../common/fixtures');
 const processIncludes = require('../../tools/doc/preprocess.js');
 const html = require('../../tools/doc/html.js');
@@ -107,7 +106,6 @@ testData.forEach((item) => {
         {
           input: preprocessed,
           filename: 'foo',
-          template: path.resolve(__dirname, '../../doc/template.html'),
           nodeVersion: process.version,
           analytics: item.analyticsId,
         },

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -29,7 +29,6 @@ const fs = require('fs');
 
 const args = process.argv.slice(2);
 let format = 'json';
-let template = null;
 let filename = null;
 let nodeVersion = null;
 let analytics = null;
@@ -39,8 +38,6 @@ args.forEach(function(arg) {
     filename = arg;
   } else if (arg.startsWith('--format=')) {
     format = arg.replace(/^--format=/, '');
-  } else if (arg.startsWith('--template=')) {
-    template = arg.replace(/^--template=/, '');
   } else if (arg.startsWith('--node-version=')) {
     nodeVersion = arg.replace(/^--node-version=/, '');
   } else if (arg.startsWith('--analytics=')) {
@@ -71,7 +68,7 @@ function next(er, input) {
       break;
 
     case 'html':
-      require('./html')({ input, filename, template, nodeVersion, analytics },
+      require('./html')({ input, filename, nodeVersion, analytics },
                         (err, html) => {
                           if (err) throw err;
                           console.log(html);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

In `tools/doc/html.js` we have 3 operations that have little benefit but complicate the file significantly.

1. Asynchronous loading of `doc/template.html`.
2. Asynchronous loading of `doc/api/_toc.md`.
3. Requiring `tools/doc/preprocess.js` and calling its main function.

While doing 1 and 2 asynchronously can have a performance benefit, it is rather small (both files are ~1.5 KB). Besides, the downsides are significant:

1. `tools/doc/html.js` is required in `tools/doc/generate.js` and `test/doctool/test-doctool-html.js`. While the first script calls the main function once per requiring, the second script calls it many times and all these times the same `doc/template.html` is loaded needlessly.

2. Asynchronous loading of `doc/ap/_toc.md` makes the script overcomplicated to the extent of this comment:

https://github.com/nodejs/node/blob/2a30bfe295eadbdaea3675447b9fe743c622b47b/tools/doc/html.js#L45

3. The main aim of the `tools/doc/preprocess.js` is processing `@include` instructions. Also, as one goes, it strips special comments. There are no  `@include` instructions in `doc/ap/_toc.md` so the requiring this module is excessiveness.

This PR try to eliminate all downsides in this way:

1. As we have only one HTML template, we can exclude it as an option from cli chain, incorporate its path in `tools/doc/html.js` and preload it synchronously once per module initialization.

2. We can preload `doc/api/_toc.md` synchronously and delete a huge async machinery.

3. We can replace `tools/doc/preprocess.js` requiring with one-liner comment stripping in place.

This PR reduces the code almost by 50 lines producing the same result.

Please, ignore any remaining stylistic issues while reviewing the changes: I am going to modernize and optimize the whole script after this PR. This change is singled out to not mingle logic refactoring with many small changes scattering over the file.