### PR TITLE
doc: remove os.uptime() Windows note

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -381,14 +381,16 @@ systems.
 ## os.uptime()
 <!-- YAML
 added: v0.3.3
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/20129
+    description: The result of this function no longer contains a fraction
+                 component on Windows.
 -->
 
 * Returns: {integer}
 
 The `os.uptime()` method returns the system uptime in number of seconds.
-
-On Windows the returned value includes fractions of a second. Use `Math.floor()`
-to get whole seconds.
 
 ## os.userInfo([options])
 <!-- YAML


### PR DESCRIPTION
The libuv 1.20.2 update in Node 10 aligned the Windows behavior of `os.uptime()` with that of other operating systems. The return value no longer contains a fraction component.

Refs: https://github.com/nodejs/node/pull/20129

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
