### PR TITLE
tools: remove redundant RegExp flag

### DIFF
--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 
 const includeExpr = /^@include\s+([\w-]+)(?:\.md)?$/gmi;
-const commentExpr = /^@\/\/.*$/gmi;
+const commentExpr = /^@\/\/.*$/gm;
 
 function processIncludes(inputFile, input, cb) {
   const includes = input.match(includeExpr);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
