### PR TITLE
doc: unify and dedupe returned values in timers.md

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -28,7 +28,7 @@ functions that can be used to control this default behavior.
 added: v9.7.0
 -->
 
-* Returns: {Immediate}
+* Returns: {Immediate} a reference to `immediate`
 
 When called, requests that the Node.js event loop *not* exit so long as the
 `Immediate` is active. Calling `immediate.ref()` multiple times will have no
@@ -37,21 +37,17 @@ effect.
 By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
 to call `immediate.ref()` unless `immediate.unref()` had been called previously.
 
-Returns a reference to the `Immediate`.
-
 ### immediate.unref()
 <!-- YAML
 added: v9.7.0
 -->
 
-* Returns: {Immediate}
+* Returns: {Immediate} a reference to `immediate`
 
 When called, the active `Immediate` object will not require the Node.js event
 loop to remain active. If there is no other activity keeping the event loop
 running, the process may exit before the `Immediate` object's callback is
 invoked. Calling `immediate.unref()` multiple times will have no effect.
-
-Returns a reference to the `Immediate`.
 
 ## Class: Timeout
 
@@ -70,7 +66,7 @@ control this default behavior.
 added: v0.9.1
 -->
 
-* Returns: {Timeout}
+* Returns: {Timeout} a reference to `timeout`
 
 When called, requests that the Node.js event loop *not* exit so long as the
 `Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
@@ -78,14 +74,12 @@ When called, requests that the Node.js event loop *not* exit so long as the
 By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
 to call `timeout.ref()` unless `timeout.unref()` had been called previously.
 
-Returns a reference to the `Timeout`.
-
 ### timeout.unref()
 <!-- YAML
 added: v0.9.1
 -->
 
-* Returns: {Timeout}
+* Returns: {Timeout} a reference to `timeout`
 
 When called, the active `Timeout` object will not require the Node.js event loop
 to remain active. If there is no other activity keeping the event loop running,
@@ -95,8 +89,6 @@ the process may exit before the `Timeout` object's callback is invoked. Calling
 Calling `timeout.unref()` creates an internal timer that will wake the Node.js
 event loop. Creating too many of these can adversely impact performance
 of the Node.js application.
-
-Returns a reference to the `Timeout`.
 
 ## Scheduling Timers
 
@@ -113,9 +105,10 @@ added: v0.9.1
 * `callback` {Function} The function to call at the end of this turn of
   [the Node.js Event Loop]
 * `...args` {any} Optional arguments to pass when the `callback` is called.
+* Returns: {Immediate} for use with [`clearImmediate()`][]
 
 Schedules the "immediate" execution of the `callback` after I/O events'
-callbacks. Returns an `Immediate` for use with [`clearImmediate()`][].
+callbacks.
 
 When multiple calls to `setImmediate()` are made, the `callback` functions are
 queued for execution in the order in which they are created. The entire callback
@@ -155,10 +148,9 @@ added: v0.0.1
 * `delay` {number} The number of milliseconds to wait before calling the
   `callback`.
 * `...args` {any} Optional arguments to pass when the `callback` is called.
-* Returns: {Timeout}
+* Returns: {Timeout} for use with [`clearInterval()`][]
 
 Schedules repeated execution of `callback` every `delay` milliseconds.
-Returns a `Timeout` for use with [`clearInterval()`][].
 
 When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
 set to `1`.
@@ -174,10 +166,9 @@ added: v0.0.1
 * `delay` {number} The number of milliseconds to wait before calling the
   `callback`.
 * `...args` {any} Optional arguments to pass when the `callback` is called.
-* Returns: {Timeout}
+* Returns: {Timeout} for use with [`clearTimeout()`][]
 
 Schedules execution of a one-time `callback` after `delay` milliseconds.
-Returns a `Timeout` for use with [`clearTimeout()`][].
 
 The `callback` will likely not be invoked in precisely `delay` milliseconds.
 Node.js makes no guarantees about the exact timing of when callbacks will fire,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
