### PR TITLE
http2: fix ping callback

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -716,8 +716,11 @@ const proxySocketHandler = {
 // data received on the PING acknowlegement.
 function pingCallback(cb) {
   return function pingCallback(ack, duration, payload) {
-    const err = ack ? null : new ERR_HTTP2_PING_CANCEL();
-    cb(err, duration, payload);
+    if (ack) {
+      cb(null, duration, payload);
+    } else {
+      cb(new ERR_HTTP2_PING_CANCEL());
+    }
   };
 }
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -708,6 +708,11 @@ exports.expectsError = function expectsError(fn, settings, exact) {
   }
 
   function innerFn(error) {
+    if (arguments.length !== 1) {
+      // Do not use `assert.strictEqual()` to prevent `util.inspect` from
+      // always being called.
+      assert.fail(`Expected one argument, got ${util.inspect(arguments)}`);
+    }
     const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
     assert.strictEqual(descriptor.enumerable,
                        false, 'The error message should be non-enumerable');


### PR DESCRIPTION
In case there was no ack, the callback would have returned
more than the error as return value. This makes sure that is not
the case anymore.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
