### PR TITLE
docs: improve assert docs

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -383,7 +383,7 @@ weakMap3.unequal = true;
 assert.deepStrictEqual(weakMap1, weakMap2);
 // OK, because it is impossible to compare the entries
 
-// Fail because weakMap3 has a property that weakMap1 does not contain:
+// Fails because weakMap3 has a property that weakMap1 does not contain:
 assert.deepStrictEqual(weakMap1, weakMap3);
 // AssertionError: Input A expected to strictly deep-equal input B:
 // + expected - actual
@@ -666,8 +666,8 @@ changes:
 
 Throws `value` if `value` is not `undefined` or `null`. This is useful when
 testing the `error` argument in callbacks. The stack trace contains all frames
-from the error passed to `ifError` including the potential new frames for
-`ifError` itself. See below for an example.
+from the error passed to `ifError()` including the potential new frames for
+`ifError()` itself. See below for an example.
 
 ```js
 const assert = require('assert').strict;
@@ -921,7 +921,7 @@ assert.ok(1);
 // OK
 
 assert.ok();
-// AssertionError: No value argument passed to `assert.ok`.
+// AssertionError: No value argument passed to `assert.ok()`.
 
 assert.ok(false, 'it\'s false');
 // AssertionError: it's false"

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -921,10 +921,10 @@ assert.ok(1);
 // OK
 
 assert.ok();
-// AssertionError: No value argument passed to `assert.ok()`.
+// AssertionError: No value argument passed to `assert.ok()`
 
 assert.ok(false, 'it\'s false');
-// AssertionError: it's false"
+// AssertionError: it's false
 
 // In the repl:
 assert.ok(typeof 123 === 'string');
@@ -1076,6 +1076,34 @@ each property will be tested for including the non-enumerable `message` and
 If specified, `message` will be the message provided by the `AssertionError` if
 the block fails to throw.
 
+Custom error object / error instance:
+
+```js
+const err = new TypeError('Wrong value');
+err.code = 404;
+
+assert.throws(
+  () => {
+    throw err;
+  },
+  {
+    name: 'TypeError',
+    message: 'Wrong value'
+    // Note that only properties on the error object will be tested!
+  }
+);
+
+// Fails due to the different `message` and `name` properties:
+assert.throws(
+  () => {
+    const otherErr = new Error('Not found');
+    otherErr.code = 404;
+    throw otherErr;
+  },
+  err // This tests for `message`, `name` and `code`.
+);
+```
+
 Validate instanceof using constructor:
 
 ```js
@@ -1114,34 +1142,6 @@ assert.throws(
     }
   },
   'unexpected error'
-);
-```
-
-Custom error object / error instance:
-
-```js
-const err = new TypeError('Wrong value');
-err.code = 404;
-
-assert.throws(
-  () => {
-    throw err;
-  },
-  {
-    name: 'TypeError',
-    message: 'Wrong value'
-    // Note that only properties on the error object will be tested!
-  }
-);
-
-// Fails due to the different `message` and `name` properties:
-assert.throws(
-  () => {
-    const otherErr = new Error('Not found');
-    otherErr.code = 404;
-    throw otherErr;
-  },
-  err // This tests for `message`, `name` and `code`.
 );
 ```
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -102,31 +102,25 @@ It can be accessed using:
 const assert = require('assert').strict;
 ```
 
-Example error diff (the `expected`, `actual`, and `Lines skipped` will be on a
-single row):
+Example error diff:
 
 ```js
 const assert = require('assert').strict;
 
 assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
-```
-
-```diff
-AssertionError [ERR_ASSERTION]: Input A expected to strictly deep-equal input B:
-+ expected
-- actual
-... Lines skipped
-
-  [
-    [
-...
-      2,
--     3
-+     '3'
-    ],
-...
-    5
-  ]
+// AssertionError: Input A expected to strictly deep-equal input B:
+// + expected - actual ... Lines skipped
+//
+//   [
+//     [
+// ...
+//       2,
+// -     3
+// +     '3'
+//     ],
+// ...
+//     5
+//   ]
 ```
 
 To deactivate the colors, use the `NODE_DISABLE_COLORS` environment variable.


### PR DESCRIPTION
This improves the error example output by reflecting the current
state. It also makes sure the examples are up to date in general.
`assert.throws` clarified the `ERR_AMBIGUOUS_ARGUMENT` error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
