### PR TITLE
dns: report out of memory properly

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -28,7 +28,6 @@ const READABLE_OPERATOR = {
 
 const {
   errmap,
-  UV_EAI_MEMORY,
   UV_EAI_NODATA,
   UV_EAI_NONAME
 } = process.binding('uv');
@@ -639,9 +638,7 @@ function dnsException(code, syscall, hostname) {
   if (typeof code === 'number') {
     // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
     // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-    if (code === UV_EAI_MEMORY ||
-        code === UV_EAI_NODATA ||
-        code === UV_EAI_NONAME) {
+    if (code === UV_EAI_NODATA || code === UV_EAI_NONAME) {
       code = 'ENOTFOUND'; // Fabricated error name.
     } else {
       code = lazyInternalUtil().getSystemErrorName(code);

--- a/test/parallel/test-dns-memory-error.js
+++ b/test/parallel/test-dns-memory-error.js
@@ -1,0 +1,15 @@
+// Flags: --expose-internals
+'use strict';
+
+// Check that if libuv reports a memory error on a DNS query, that the memory
+// error is passed through and not replaced with ENOTFOUND.
+
+require('../common');
+
+const assert = require('assert');
+const errors = require('internal/errors');
+
+const { UV_EAI_MEMORY } = process.binding('uv');
+const memoryError = errors.dnsException(UV_EAI_MEMORY, 'fhqwhgads');
+
+assert.strictEqual(memoryError.code, 'EAI_MEMORY');

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const http = require('http');
 const https = require('https');
 
-const host = '*'.repeat(250);
+const host = '*'.repeat(64);
 const MAX_TRIES = 5;
 
 let errCode = 'ENOTFOUND';

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const http = require('http');
 const https = require('https');
 
-const host = '*'.repeat(256);
+const host = '*'.repeat(250);
 const MAX_TRIES = 5;
 
 let errCode = 'ENOTFOUND';

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -25,7 +25,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const host = '*'.repeat(256);
+const host = '*'.repeat(64);
 const errCode = common.isOpenBSD ? 'EAI_FAIL' : 'ENOTFOUND';
 
 const socket = net.connect(42, host, common.mustNotCall());


### PR DESCRIPTION
This addresses a part of a TODO by properly reporting an out of
memory error to the user instead of reporting `ENOTFOUND`.

I only changed this single entry as this is super rare and should be `safe` to change.
Since it is a OOM, we also have no test for it.

The other two are likely used a lot and a lot of userland code will rely on that.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
