### PR TITLE
n-api: remove unused Test function

### DIFF
--- a/test/addons-napi/test_symbol/test_symbol.c
+++ b/test/addons-napi/test_symbol/test_symbol.c
@@ -1,31 +1,6 @@
 #include <node_api.h>
 #include "../common.h"
 
-static napi_value Test(napi_env env, napi_callback_info info) {
-  size_t argc = 1;
-  napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
-
-  napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
-
-  NAPI_ASSERT(env, valuetype == napi_symbol,
-      "Wrong type of arguments. Expects a symbol.");
-
-  char buffer[128];
-  size_t buffer_size = 128;
-
-  NAPI_CALL(env, napi_get_value_string_utf8(
-      env, args[0], buffer, buffer_size, NULL));
-
-  napi_value output;
-  NAPI_CALL(env, napi_create_string_utf8(env, buffer, buffer_size, &output));
-
-  return output;
-}
-
 static napi_value New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];


### PR DESCRIPTION
Currently when building the following warning is emitted:
```console
../test_symbol.c:4:19:
warning: unused function 'Test' [-Wunused-function]
static napi_value Test(napi_env env, napi_callback_info info) {
                  ^
1 warning generated.
```
This commit removes this unused function.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
