### PR TITLE
stream: fix error handling with async iteration

### DIFF
--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -58,7 +58,7 @@ function onError(iter, err) {
     iter[kLastReject] = null;
     reject(err);
   }
-  iter.error = err;
+  iter[kError] = err;
 }
 
 function wrapForNext(lastPromise, iter) {

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -116,6 +116,23 @@ async function tests() {
   })();
 
   await (async function() {
+    console.log('call next() after error');
+    const readable = new Readable({
+      read() {}
+    })
+
+    let err
+    try {
+      const iterator = readable[Symbol.asyncIterator]();
+      readable.destroy(new Error('kaboom'));
+      await iterator.next();
+    } catch (e) {
+      err = e;
+    }
+    assert.strictEqual(err.message, 'kaboom');
+  })();
+
+  await (async function() {
     console.log('read object mode');
     const max = 42;
     let readed = 0;


### PR DESCRIPTION
Fix an issue when an error was emitted by the stream before
`iterator.next()` is called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I don't have the time to figure out how to run the tests, sorry.

/cc @mcollina 