### PR TITLE
fs: use isUint32 in isFd

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -152,7 +152,7 @@ function makeStatsCallback(cb) {
 }
 
 function isFd(path) {
-  return (path >>> 0) === path;
+  return isUint32(path);
 }
 
 fs.Stats = Stats;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -151,9 +151,7 @@ function makeStatsCallback(cb) {
   };
 }
 
-function isFd(path) {
-  return isUint32(path);
-}
+const isFd = isUint32;
 
 fs.Stats = Stats;
 


### PR DESCRIPTION
This commit updates the isFd function to call isUint32 instead of
doing the same thing. I was tempted to remove isFd and just use isUint32
instead but wanted to get some feedback from others regarding
readablity.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
