### PR TITLE
lib: remove parameter from catch where not used

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -43,7 +43,7 @@ let isAnyArrayBuffer;
 try {
   const { internalBinding } = require('internal/bootstrap/loaders');
   isAnyArrayBuffer = internalBinding('types').isAnyArrayBuffer;
-} catch (e) {
+} catch {
   isAnyArrayBuffer = require('util').types.isAnyArrayBuffer;
 }
 const {

--- a/lib/events.js
+++ b/lib/events.js
@@ -160,7 +160,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
           value: enhanceStackTrace.bind(null, er, capture),
           configurable: true
         });
-      } catch (e) {}
+      } catch {}
 
       // Note: The comments on the `throw` lines are intentional, they show
       // up in Node's output if this results in an unhandled exception.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -209,7 +209,7 @@ fs.exists = function(path, callback) {
 
   try {
     fs.access(path, fs.FS_OK, suppressedCallback);
-  } catch (err) {
+  } catch {
     return callback(false);
   }
 };
@@ -232,7 +232,7 @@ fs.existsSync = function(path) {
   try {
     fs.accessSync(path, fs.FS_OK);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 };

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -441,14 +441,14 @@
             process._exiting = true;
             process.emit('exit', 1);
           }
-        } catch (er) {
+        } catch {
           // nothing to be done about it at this point.
         }
         try {
           const { kExpandStackSymbol } = NativeModule.require('internal/util');
           if (typeof er[kExpandStackSymbol] === 'function')
             er[kExpandStackSymbol]();
-        } catch (er) {}
+        } catch {}
         return false;
       }
 
@@ -508,7 +508,7 @@
   function tryGetCwd(path) {
     try {
       return process.cwd();
-    } catch (ex) {
+    } catch {
       // getcwd(3) can fail if the current working directory has been deleted.
       // Fall back to the directory name of the (absolute) executable path.
       // It's not really correct but what are the alternatives?

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -35,7 +35,7 @@ function search(target, base) {
         new URL('./', questionedBase).pathname);
       const found = CJSmodule._resolveFilename(target, tmpMod);
       error = new ERR_MODULE_RESOLUTION_LEGACY(target, base, found);
-    } catch (problemChecking) {
+    } catch {
       // ignore
     }
     throw error;

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -50,7 +50,7 @@ function emitWarning(uid, reason) {
     } else {
       process.emitWarning(safeToString(reason), unhandledRejectionErrName);
     }
-  } catch (e) {
+  } catch {
     // ignored
   }
 
@@ -66,7 +66,7 @@ function emitWarning(uid, reason) {
     if (reason instanceof Error) {
       warning.stack = reason.stack;
     }
-  } catch (err) {
+  } catch {
     // ignored
   }
   process.emitWarning(warning);

--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -69,7 +69,7 @@ function processTopLevelAwait(src) {
   let root;
   try {
     root = acorn.parse(wrapped, { ecmaVersion: 8 });
-  } catch (err) {
+  } catch {
     return null;
   }
   const body = root.body[0].expression.callee.body;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -450,7 +450,7 @@ Object.defineProperties(URL.prototype, {
           if (ctx.path.length > 0) {
             try {
               return (new URL(ctx.path[0])).origin;
-            } catch (err) {
+            } catch {
               // fall through... do nothing
             }
           }

--- a/lib/internal/util/inspector.js
+++ b/lib/internal/util/inspector.js
@@ -15,7 +15,7 @@ function sendInspectorCommand(cb, onError) {
     } finally {
       session.disconnect();
     }
-  } catch (e) {
+  } catch {
     return onError();
   }
 }

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -63,7 +63,7 @@ const quit = process.exit;
 const logFile = arguments[arguments.length - 1];
 try {
   fs.accessSync(logFile);
-} catch(e) {
+} catch {
   console.error('Please provide a valid isolate file as the final argument.');
   process.exit(1);
 }
@@ -140,7 +140,7 @@ function macCppfiltNm(out) {
     filtered = cp.spawnSync('c++filt', [ '-p' , '-i' ], {
       input: entries.join('\n')
     }).stdout.toString();
-  } catch (e) {
+  } catch {
     return out;
   }
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -109,7 +109,7 @@ function unescapeBuffer(s, decodeSpaces) {
 function qsUnescape(s, decodeSpaces) {
   try {
     return decodeURIComponent(s);
-  } catch (e) {
+  } catch {
     return QueryString.unescapeBuffer(s, decodeSpaces).toString();
   }
 }
@@ -448,7 +448,7 @@ function parse(qs, sep, eq, options) {
 function decodeStr(s, decoder) {
   try {
     return decoder(s);
-  } catch (e) {
+  } catch {
     return QueryString.unescape(s, true);
   }
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -94,7 +94,7 @@ const kContextId = Symbol('contextId');
 try {
   // Hack for require.resolve("./relative") to work properly.
   module.filename = path.resolve('repl');
-} catch (e) {
+} catch {
   // path.resolve('repl') fails when the current working directory has been
   // deleted.  Fall back to the directory name of the (absolute) executable
   // path.  It's not really correct but what are the alternatives?
@@ -1024,7 +1024,7 @@ function complete(line, callback) {
       dir = path.resolve(paths[i], subdir);
       try {
         files = fs.readdirSync(dir);
-      } catch (e) {
+      } catch {
         continue;
       }
       for (f = 0; f < files.length; f++) {
@@ -1038,14 +1038,14 @@ function complete(line, callback) {
         abs = path.resolve(dir, name);
         try {
           isDirectory = fs.statSync(abs).isDirectory();
-        } catch (e) {
+        } catch {
           continue;
         }
         if (isDirectory) {
           group.push(subdir + name + '/');
           try {
             subfiles = fs.readdirSync(abs);
-          } catch (e) {
+          } catch {
             continue;
           }
           for (s = 0; s < subfiles.length; s++) {
@@ -1127,13 +1127,13 @@ function complete(line, callback) {
           });
         }
       } else {
-        const evalExpr = `try { ${expr} } catch (e) {}`;
+        const evalExpr = `try { ${expr} } catch {}`;
         this.eval(evalExpr, this.context, 'repl', (e, obj) => {
           if (obj != null) {
             if (typeof obj === 'object' || typeof obj === 'function') {
               try {
                 memberGroups.push(filteredOwnPropertyNames.call(this, obj));
-              } catch (ex) {
+              } catch {
                 // Probably a Proxy object without `getOwnPropertyNames` trap.
                 // We simply ignore it here, as we don't want to break the
                 // autocompletion. Fixes the bug
@@ -1158,7 +1158,7 @@ function complete(line, callback) {
                   break;
                 }
               }
-            } catch (e) {}
+            } catch {}
           }
 
           if (memberGroups.length) {
@@ -1431,7 +1431,7 @@ function defineDefaultCommands(repl) {
       try {
         fs.writeFileSync(file, this.lines.join('\n') + '\n');
         this.outputStream.write('Session saved to:' + file + '\n');
-      } catch (e) {
+      } catch {
         this.outputStream.write('Failed to save:' + file + '\n');
       }
       this.displayPrompt();
@@ -1457,7 +1457,7 @@ function defineDefaultCommands(repl) {
           this.outputStream.write('Failed to load:' + file +
                                   ' is not a valid file\n');
         }
-      } catch (e) {
+      } catch {
         this.outputStream.write('Failed to load:' + file + '\n');
       }
       this.displayPrompt();

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -51,7 +51,7 @@ try {
     // returns undefined for Node < 7.4.0.
     Stream._isUint8Array = process.binding('util').isUint8Array;
   }
-} catch (e) {
+} catch {
 }
 
 if (!Stream._isUint8Array) {
@@ -71,7 +71,7 @@ if (version[0] === 0 && version[1] < 12) {
                                            chunk.byteOffset,
                                            chunk.byteLength);
     };
-  } catch (e) {
+  } catch {
   }
 
   if (!Stream._uint8ArrayToBuffer) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -550,7 +550,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
       // The .valueOf() call can fail for a multitude of reasons
       try {
         raw = value.valueOf();
-      } catch (e) { /* ignore */ }
+      } catch { /* ignore */ }
 
       if (typeof raw === 'string') {
         const formatted = formatPrimitive(stylizeNoColor, raw, ctx);
@@ -643,7 +643,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
       // The .valueOf() call can fail for a multitude of reasons
       try {
         raw = value.valueOf();
-      } catch (e) { /* ignore */ }
+      } catch { /* ignore */ }
 
       if (typeof raw === 'number') {
         // Make boxed primitive Numbers look like such

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -487,7 +487,7 @@ exports.fileExists = function(pathname) {
   try {
     fs.accessSync(pathname);
     return true;
-  } catch (err) {
+  } catch {
     return false;
   }
 };
@@ -514,7 +514,7 @@ exports.canCreateSymLink = function() {
     try {
       const output = execSync(`${whoamiPath} /priv`, { timout: 1000 });
       return output.includes('SeCreateSymbolicLinkPrivilege');
-    } catch (e) {
+    } catch {
       return false;
     }
   }
@@ -613,7 +613,7 @@ exports.isAlive = function isAlive(pid) {
   try {
     process.kill(pid, 'SIGCONT');
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 };
@@ -831,7 +831,7 @@ exports.getTTYfd = function getTTYfd() {
   if (ttyFd === undefined) {
     try {
       return fs.openSync('/dev/tty');
-    } catch (e) {
+    } catch {
       // There aren't any tty fd's available to use.
       return -1;
     }
@@ -869,7 +869,7 @@ exports.runWithInvalidFD = function(func) {
   // be an valid one.
   try {
     while (fs.fstatSync(fd--) && fd > 0);
-  } catch (e) {
+  } catch {
     return func(fd);
   }
 

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -4,7 +4,7 @@ const common = require('../common');
 // The doctool currently uses js-yaml from the tool/node_modules/eslint/ tree.
 try {
   require('../../tools/node_modules/eslint/node_modules/js-yaml');
-} catch (e) {
+} catch {
   common.skip('missing js-yaml (eslint not present)');
 }
 

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -4,7 +4,7 @@ const common = require('../common');
 // The doctool currently uses js-yaml from the tool/node_modules/eslint/ tree.
 try {
   require('../../tools/node_modules/eslint/node_modules/js-yaml');
-} catch (e) {
+} catch {
   common.skip('missing js-yaml (eslint not present)');
 }
 

--- a/test/fixtures/catch-stdout-error.js
+++ b/test/fixtures/catch-stdout-error.js
@@ -22,7 +22,7 @@
 function write() {
   try {
     process.stdout.write('Hello, world\n');
-  } catch (ex) {
+  } catch {
     throw new Error('this should never happen');
   }
   setImmediate(function() {

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -182,7 +182,7 @@ if (process.argv[2] !== 'child') {
     const buf = messages[i++];
 
     if (!buf) {
-      try { sendSocket.close(); } catch (e) {}
+      try { sendSocket.close(); } catch {}
       return;
     }
 

--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -170,7 +170,7 @@ if (process.argv[2] !== 'child') {
     const buf = messages[i++];
 
     if (!buf) {
-      try { sendSocket.close(); } catch (e) {}
+      try { sendSocket.close(); } catch {}
       return;
     }
 

--- a/test/known_issues/test-url-parse-conformance.js
+++ b/test/known_issues/test-url-parse-conformance.js
@@ -40,12 +40,12 @@ tests.forEach((test) => {
         assert.strictEqual(test.pathname, parsed.pathname || '/');
         assert.strictEqual(test.search, parsed.search || '');
         assert.strictEqual(test.hash, parsed.hash || '');
-      } catch (err) {
+      } catch {
         // For now, we're just interested in the number of failures.
         failed++;
       }
     }
-  } catch (err) {
+  } catch {
     // If Parse failed and it wasn't supposed to, treat it as a failure.
     if (!test.failure)
       failed++;

--- a/test/message/vm_dont_display_runtime_error.js
+++ b/test/message/vm_dont_display_runtime_error.js
@@ -30,7 +30,7 @@ try {
     filename: 'test.vm',
     displayErrors: false
   });
-} catch (e) {}
+} catch {}
 
 console.error('middle');
 

--- a/test/message/vm_dont_display_syntax_error.js
+++ b/test/message/vm_dont_display_syntax_error.js
@@ -30,7 +30,7 @@ try {
     filename: 'test.vm',
     displayErrors: false
   });
-} catch (e) {}
+} catch {}
 
 console.error('middle');
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -166,7 +166,7 @@ assert.throws(
       },
       Array
     );
-  } catch (e) {
+  } catch {
     threw = true;
   }
   assert.ok(threw, 'wrong constructor validation');

--- a/test/parallel/test-buffer-failed-alloc-typed-arrays.js
+++ b/test/parallel/test-buffer-failed-alloc-typed-arrays.js
@@ -26,7 +26,7 @@ for (const allocator of allocators) {
       // These allocations are known to fail. If they do,
       // Uint32Array should still produce a zeroed out result.
       allocator(size);
-    } catch (e) {
+    } catch {
       assert.deepStrictEqual(new Uint32Array(10), zeroArray);
     }
   }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -159,13 +159,13 @@ testCipher2(Buffer.from('0123456789abcdef'));
 // not assert. See https://github.com/nodejs/node-v0.x-archive/issues/4886.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');
-  try { c.final('xxx'); } catch (e) { /* Ignore. */ }
-  try { c.final('xxx'); } catch (e) { /* Ignore. */ }
-  try { c.final('xxx'); } catch (e) { /* Ignore. */ }
+  try { c.final('xxx'); } catch { /* Ignore. */ }
+  try { c.final('xxx'); } catch { /* Ignore. */ }
+  try { c.final('xxx'); } catch { /* Ignore. */ }
   const d = crypto.createDecipher('aes-256-cbc', 'secret');
-  try { d.final('xxx'); } catch (e) { /* Ignore. */ }
-  try { d.final('xxx'); } catch (e) { /* Ignore. */ }
-  try { d.final('xxx'); } catch (e) { /* Ignore. */ }
+  try { d.final('xxx'); } catch { /* Ignore. */ }
+  try { d.final('xxx'); } catch { /* Ignore. */ }
+  try { d.final('xxx'); } catch { /* Ignore. */ }
 }
 
 // Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -50,7 +50,7 @@ if (process.argv[2] === 'child') {
       if (process.argv.includes('useTryCatch')) {
         try {
           throw new Error(domainErrHandlerExMessage);
-        } catch (e) {
+        } catch {
         }
       } else {
         throw new Error(domainErrHandlerExMessage);

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -56,7 +56,7 @@ process.on('exit', function() {
 function removeTestFile() {
   try {
     fs.unlinkSync(filepath);
-  } catch (e) {}
+  } catch {}
 }
 
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -53,7 +53,7 @@ if (!common.isWindows && process.getuid() === 0) {
   try {
     process.setuid('nobody');
     hasWriteAccessForReadonlyFile = false;
-  } catch (err) {
+  } catch {
   }
 }
 

--- a/test/parallel/test-fs-realpath-pipe.js
+++ b/test/parallel/test-fs-realpath-pipe.js
@@ -22,7 +22,7 @@ for (const code of [
     if (require('fs').realpathSync('/dev/stdin')) {
       process.exit(2);
     }
-  } catch (e) {
+  } catch {
     process.exit(1);
   }`
 ]) {

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -55,7 +55,7 @@ if (common.isWindows) {
       }
       runTest();
     });
-  } catch (er) {
+  } catch {
     // better safe than sorry
     skipSymlinks = true;
     process.nextTick(runTest);
@@ -114,7 +114,7 @@ function test_simple_relative_symlink(realpath, realpathSync, callback) {
   [
     [entry, `../${path.basename(tmpDir)}/cycles/root.js`]
   ].forEach(function(t) {
-    try { fs.unlinkSync(t[0]); } catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch {}
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], t[0], 'file');
     fs.symlinkSync(t[1], t[0], 'file');
     unlink.push(t[0]);
@@ -140,7 +140,7 @@ function test_simple_absolute_symlink(realpath, realpathSync, callback) {
   [
     [entry, expected]
   ].forEach(function(t) {
-    try { fs.unlinkSync(t[0]); } catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch {}
     console.error('fs.symlinkSync(%j, %j, %j)', t[1], t[0], type);
     fs.symlinkSync(t[1], t[0], type);
     unlink.push(t[0]);
@@ -165,13 +165,13 @@ function test_deep_relative_file_symlink(realpath, realpathSync, callback) {
                                 expected);
   const linkPath1 = path.join(targetsAbsDir,
                               'nested-index', 'one', 'symlink1.js');
-  try { fs.unlinkSync(linkPath1); } catch (e) {}
+  try { fs.unlinkSync(linkPath1); } catch {}
   fs.symlinkSync(linkData1, linkPath1, 'file');
 
   const linkData2 = '../one/symlink1.js';
   const entry = path.join(targetsAbsDir,
                           'nested-index', 'two', 'symlink1-b.js');
-  try { fs.unlinkSync(entry); } catch (e) {}
+  try { fs.unlinkSync(entry); } catch {}
   fs.symlinkSync(linkData2, entry, 'file');
   unlink.push(linkPath1);
   unlink.push(entry);
@@ -192,13 +192,13 @@ function test_deep_relative_dir_symlink(realpath, realpathSync, callback) {
   const path1b = path.join(targetsAbsDir, 'nested-index', 'one');
   const linkPath1b = path.join(path1b, 'symlink1-dir');
   const linkData1b = path.relative(path1b, expected);
-  try { fs.unlinkSync(linkPath1b); } catch (e) {}
+  try { fs.unlinkSync(linkPath1b); } catch {}
   fs.symlinkSync(linkData1b, linkPath1b, 'dir');
 
   const linkData2b = '../one/symlink1-dir';
   const entry = path.join(targetsAbsDir,
                           'nested-index', 'two', 'symlink12-dir');
-  try { fs.unlinkSync(entry); } catch (e) {}
+  try { fs.unlinkSync(entry); } catch {}
   fs.symlinkSync(linkData2b, entry, 'dir');
   unlink.push(linkPath1b);
   unlink.push(entry);
@@ -222,7 +222,7 @@ function test_cyclic_link_protection(realpath, realpathSync, callback) {
     [path.join(tmpDir, '/cycles/realpath-3b'), '../cycles/realpath-3c'],
     [path.join(tmpDir, '/cycles/realpath-3c'), '../cycles/realpath-3a']
   ].forEach(function(t) {
-    try { fs.unlinkSync(t[0]); } catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch {}
     fs.symlinkSync(t[1], t[0], 'dir');
     unlink.push(t[0]);
   });
@@ -249,7 +249,7 @@ function test_cyclic_link_overprotection(realpath, realpathSync, callback) {
   const link = `${folder}/cycles`;
   let testPath = cycles;
   testPath += '/folder/cycles'.repeat(10);
-  try { fs.unlinkSync(link); } catch (ex) {}
+  try { fs.unlinkSync(link); } catch {}
   fs.symlinkSync(cycles, link, 'dir');
   unlink.push(link);
   assertEqualPath(realpathSync(testPath), path.resolve(expected));
@@ -277,7 +277,7 @@ function test_relative_input_cwd(realpath, realpathSync, callback) {
   ].forEach(function(t) {
     const fn = t[0];
     console.error('fn=%j', fn);
-    try { fs.unlinkSync(fn); } catch (e) {}
+    try { fs.unlinkSync(fn); } catch {}
     const b = path.basename(t[1]);
     const type = (b === 'root.js' ? 'file' : 'dir');
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], fn, type);
@@ -316,8 +316,8 @@ function test_deep_symlink_mix(realpath, realpathSync, callback) {
   $tmpDir/targets/cycles/root.js (hard)
   */
   const entry = tmp('node-test-realpath-f1');
-  try { fs.unlinkSync(tmp('node-test-realpath-d2/foo')); } catch (e) {}
-  try { fs.rmdirSync(tmp('node-test-realpath-d2')); } catch (e) {}
+  try { fs.unlinkSync(tmp('node-test-realpath-d2/foo')); } catch {}
+  try { fs.rmdirSync(tmp('node-test-realpath-d2')); } catch {}
   fs.mkdirSync(tmp('node-test-realpath-d2'), 0o700);
   try {
     [
@@ -332,7 +332,7 @@ function test_deep_symlink_mix(realpath, realpathSync, callback) {
       [`${targetsAbsDir}/nested-index/two/realpath-c`,
        `${tmpDir}/cycles/root.js`]
     ].forEach(function(t) {
-      try { fs.unlinkSync(t[0]); } catch (e) {}
+      try { fs.unlinkSync(t[0]); } catch {}
       fs.symlinkSync(t[1], t[0]);
       unlink.push(t[0]);
     });
@@ -443,14 +443,14 @@ function test_abs_with_kids(realpath, realpathSync, cb) {
     ['/a/b/c/x.txt',
      '/a/link'
     ].forEach(function(file) {
-      try { fs.unlinkSync(root + file); } catch (ex) {}
+      try { fs.unlinkSync(root + file); } catch {}
     });
     ['/a/b/c',
      '/a/b',
      '/a',
      ''
     ].forEach(function(folder) {
-      try { fs.rmdirSync(root + folder); } catch (ex) {}
+      try { fs.rmdirSync(root + folder); } catch {}
     });
   }
   function setup() {

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -25,7 +25,7 @@ server.on('stream', (stream) => {
   // Get first known bad file descriptor.
   try {
     while (fs.fstatSync(++fd));
-  } catch (e) {
+  } catch {
     // do nothing; we now have an invalid fd
   }
 

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -69,7 +69,7 @@ function test() {
         process.kill(child.pid, 'SIGKILL');
         try {
           parent.kill();
-        } catch (e) {}
+        } catch {}
 
         assert.strictEqual(s, 'hello from child\n');
         assert.strictEqual(res.statusCode, 200);

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -69,7 +69,7 @@ function test() {
         process.kill(child.pid, 'SIGKILL');
         try {
           parent.kill();
-        } catch (e) {}
+        } catch {}
 
         assert.strictEqual(s, 'hello from child\n');
         assert.strictEqual(res.statusCode, 200);

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -34,7 +34,7 @@ let invalidFd = 2;
 // Get first known bad file descriptor.
 try {
   while (fs.fstatSync(++invalidFd));
-} catch (e) {
+} catch {
   // do nothing; we now have an invalid fd
 }
 

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -45,7 +45,7 @@ if (common.isWindows) {
   try {
     // If MUI != 'en' we'll ignore the content of the message
     localeOk = execSync(powerShellFindMUI).toString('utf8').trim() === 'en';
-  } catch (_) {
+  } catch {
     // It's only a best effort try to find the MUI
   }
 }

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -509,7 +509,7 @@ function isWarned(emitter) {
     });
     try {
       fi.emit('data', 'fooX');
-    } catch (e) { }
+    } catch { }
     fi.emit('data', 'bar');
     assert.strictEqual(keys.join(''), 'fooXbar');
     rli.close();

--- a/test/parallel/test-repl-syntax-error-handling.js
+++ b/test/parallel/test-repl-syntax-error-handling.js
@@ -63,7 +63,7 @@ function child() {
   let caught;
   try {
     vm.runInThisContext('haf!@##&$!@$*!@', { displayErrors: false });
-  } catch (er) {
+  } catch {
     caught = true;
   }
   assert(caught);

--- a/test/parallel/test-require-deps-deprecation.js
+++ b/test/parallel/test-require-deps-deprecation.js
@@ -36,7 +36,7 @@ common.expectWarning('DeprecationWarning', deprecatedModules.map((m) => {
 for (const m of deprecatedModules) {
   try {
     require(m);
-  } catch (err) {}
+  } catch {}
 }
 
 // Instead of checking require, check that resolve isn't pointing toward a

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -27,7 +27,7 @@ child.stderr.on('data', function(c) {
 child.on('close', common.mustCall(function(code) {
   try {
     output = JSON.parse(output);
-  } catch (er) {
+  } catch {
     console.error(output);
     process.exit(1);
   }

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -19,7 +19,7 @@ function test(size, useBuffer, cb) {
 
   try {
     fs.unlinkSync(tmpFile);
-  } catch (e) {}
+  } catch {}
 
   console.log(`${size} chars to ${tmpFile}...`);
 

--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -19,7 +19,7 @@ if (common.isWindows) {
     if (!o.includes('SeCreateSymbolicLinkPrivilege')) {
       skipSymlinks = true;
     }
-  } catch (er) {
+  } catch {
     // better safe than sorry
     skipSymlinks = true;
   }

--- a/test/parallel/test-vm-low-stack-space.js
+++ b/test/parallel/test-vm-low-stack-space.js
@@ -6,7 +6,7 @@ const vm = require('vm');
 function a() {
   try {
     return a();
-  } catch (e) {
+  } catch {
     // Throw an exception as near to the recursion-based RangeError as possible.
     return vm.runInThisContext('() => 42')();
   }
@@ -17,7 +17,7 @@ assert.strictEqual(a(), 42);
 function b() {
   try {
     return b();
-  } catch (e) {
+  } catch {
     // This writes a lot of noise to stderr, but it still works.
     return vm.runInNewContext('() => 42')();
   }

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -98,7 +98,7 @@ async function checkModuleState() {
     const m = new Module('import "foo";');
     try {
       await m.link(common.mustCall(() => ({})));
-    } catch (err) {
+    } catch {
       assert.strictEqual(m.linkingStatus, 'errored');
       m.instantiate();
     }
@@ -210,7 +210,7 @@ async function checkLinking() {
     const erroredModule = new Module('import "foo";');
     try {
       await erroredModule.link(common.mustCall(() => ({})));
-    } catch (err) {
+    } catch {
       // ignored
     } finally {
       assert.strictEqual(erroredModule.linkingStatus, 'errored');

--- a/test/parallel/test-vm-parse-abort-on-uncaught-exception.js
+++ b/test/parallel/test-vm-parse-abort-on-uncaught-exception.js
@@ -7,8 +7,8 @@ const vm = require('vm');
 
 try {
   new vm.Script({ toString() { throw new Error('foo'); } }, {});
-} catch (err) {}
+} catch {}
 
 try {
   new vm.Script('[', {});
-} catch (err) {}
+} catch {}

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -34,7 +34,7 @@ let nevents = 0;
 
 try {
   fs.unlinkSync(FILENAME);
-} catch (e) {
+} catch {
   // swallow
 }
 

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -31,13 +31,13 @@ const testsubdir = path.join(testDir, 'testsubdir');
 const filepath = path.join(testsubdir, 'watch.txt');
 
 function cleanup() {
-  try { fs.unlinkSync(filepath); } catch (e) { }
-  try { fs.rmdirSync(testsubdir); } catch (e) { }
+  try { fs.unlinkSync(filepath); } catch { }
+  try { fs.rmdirSync(testsubdir); } catch { }
 }
 process.on('exit', cleanup);
 cleanup();
 
-try { fs.mkdirSync(testsubdir, 0o700); } catch (e) {}
+try { fs.mkdirSync(testsubdir, 0o700); } catch {}
 
 // Need a grace period, else the mkdirSync() above fires off an event.
 setTimeout(function() {

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -37,7 +37,7 @@ assert(ok, 'Run this test with --max_old_space_size=32.');
 const interval = setInterval(function() {
   try {
     vm.runInNewContext('throw 1;');
-  } catch (e) {
+  } catch {
   }
 
   const rss = process.memoryUsage().rss;

--- a/test/pummel/test-vm-race.js
+++ b/test/pummel/test-vm-race.js
@@ -25,7 +25,7 @@ do {
   try {
     script.runInContext(context, { timeout: 5 });
     ++sandbox.timeout;
-  } catch (err) {
+  } catch {
     --sandbox.timeout;
   }
 } while (Date.now() < giveUp);

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -48,7 +48,7 @@ stream.on('finish', common.mustCall(function() {
 function destroy() {
   try {
     fs.unlinkSync(file);
-  } catch (err) {
+  } catch {
     // it may not exist
   }
 }

--- a/test/sequential/test-inspector-bindings.js
+++ b/test/sequential/test-inspector-bindings.js
@@ -81,7 +81,7 @@ function testSampleDebugSession() {
   try {
     secondSession.connect();
     secondSessionOpened = true;
-  } catch (error) {
+  } catch {
     // expected as the session already exists
   }
   assert.strictEqual(secondSessionOpened, false);


### PR DESCRIPTION
This commit removes the exception object from catch clauses where is it
not used.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
