### PR TITLE
doc: improve parameters for Http2Session:goaway event

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -185,8 +185,7 @@ added: v8.4.0
 * `opaqueData` {Buffer} If additional opaque data was included in the `GOAWAY`
   frame, a `Buffer` instance will be passed containing that data.
 
-The `'goaway'` event is emitted when a `GOAWAY` frame is received. When invoked,
-the handler function will receive three arguments:
+The `'goaway'` event is emitted when a `GOAWAY` frame is received.
 
 The `Http2Session` instance will be shut down automatically when the `'goaway'`
 event is emitted.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -179,14 +179,14 @@ immediately following the `'frameError'` event.
 added: v8.4.0
 -->
 
-The `'goaway'` event is emitted when a `GOAWAY` frame is received. When invoked,
-the handler function will receive three arguments:
-
 * `errorCode` {number} The HTTP/2 error code specified in the `GOAWAY` frame.
 * `lastStreamID` {number} The ID of the last stream the remote peer successfully
   processed (or `0` if no ID is specified).
 * `opaqueData` {Buffer} If additional opaque data was included in the `GOAWAY`
   frame, a `Buffer` instance will be passed containing that data.
+
+The `'goaway'` event is emitted when a `GOAWAY` frame is received. When invoked,
+the handler function will receive three arguments:
 
 The `Http2Session` instance will be shut down automatically when the `'goaway'`
 event is emitted.


### PR DESCRIPTION
Improve parameters for the callback for the Http2Session:connect event inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mcollina @nodejs/http2 @vsemozhetbyt 