### PR TITLE
test: use fs.copyFileSync()

### DIFF
--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
+const { COPYFILE_FICLONE } = fs.constants;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const msg = { test: 'this' };
@@ -44,7 +45,7 @@ if (process.env.FORK) {
   } catch (e) {
     if (e.code !== 'ENOENT') throw e;
   }
-  fs.writeFileSync(copyPath, fs.readFileSync(nodePath));
+  fs.copyFileSync(nodePath, copyPath, COPYFILE_FICLONE);
   fs.chmodSync(copyPath, '0755');
 
   // slow but simple

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -4,6 +4,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
+const { COPYFILE_FICLONE } = fs.constants;
 const child_process = require('child_process');
 const pkgName = 'foo';
 const { addLibraryPath } = require('../common/shared-lib-util');
@@ -28,7 +29,7 @@ if (process.argv[2] === 'child') {
     testExecPath = path.join(prefixBinPath, path.basename(process.execPath));
   }
   const mode = fs.statSync(process.execPath).mode;
-  fs.writeFileSync(testExecPath, fs.readFileSync(process.execPath));
+  fs.copyFileSync(process.execPath, testExecPath, COPYFILE_FICLONE);
   fs.chmodSync(testExecPath, mode);
 
   const runTest = (expectedString, env) => {


### PR DESCRIPTION
These tests copy the node binary into the temp dir. Use the potentially more efficient `fs.copyFileSync()` instead of reading the whole file in and writing the whole file out in JavaScript.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
