### PR TITLE
test: remove unnecessary strictEqual() argument from remoteClose()

### DIFF
--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -92,8 +92,7 @@ function remoteClose() {
         // waiting remote server close the socket
         setTimeout(common.mustCall(() => {
           assert.strictEqual(agent.sockets[name], undefined);
-          assert.strictEqual(agent.freeSockets[name], undefined,
-                             'freeSockets is not empty');
+          assert.strictEqual(agent.freeSockets[name], undefined);
           remoteError();
         }), common.platformTimeout(200));
       }));


### PR DESCRIPTION
On the `remoteClose()` test, removing the string literal message on the third argument from `assert.strictEqual()`, allows for the value of agent.freeSockets[name] to get printed.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc: @Trott 