### PR TITLE
benchmark: add secure-pair benchmark

### DIFF
--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -53,7 +53,7 @@ function main({ dur, size, securing }) {
         write();
       });
       conn.on('error', (e) => {
-        throw new Error('Client error: ' + e);
+        throw new Error(`Client error: ${e}`);
       });
 
       function write() {
@@ -83,7 +83,7 @@ function main({ dur, size, securing }) {
     conn.pipe(serverPair.encrypted);
     serverPair.encrypted.pipe(conn);
     serverPair.on('error', (error) => {
-      throw new Error('Pair error: ' + error);
+      throw new Error(`Pair error: ${error}`);
     });
     serverPair.cleartext.pipe(client);
   }
@@ -91,7 +91,7 @@ function main({ dur, size, securing }) {
   function secureTLSSocket(conn, client) {
     const serverSocket = new tls.TLSSocket(conn, options);
     serverSocket.on('error', (e) => {
-      throw new Error('Socket error: ' + e);
+      throw new Error(`Socket error: ${e}`);
     });
     serverSocket.pipe(client);
   }

--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -78,8 +78,8 @@ function main({ dur, size, securing }) {
   }
 
   function securePair(conn, client) {
-    const serverCtxt = tls.createSecureContext(options);
-    const serverPair = tls.createSecurePair(serverCtxt, true, true, false);
+    const serverCtx = tls.createSecureContext(options);
+    const serverPair = tls.createSecurePair(serverCtx, true, true, false);
     conn.pipe(serverPair.encrypted);
     serverPair.encrypted.pipe(conn);
     serverPair.on('error', (error) => {

--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -1,0 +1,105 @@
+'use strict';
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  dur: [5],
+  securing: ['SecurePair', 'TLSSocket'],
+  size: [2, 1024, 1024 * 1024]
+});
+
+const fs = require('fs');
+const tls = require('tls');
+const net = require('net');
+const path = require('path');
+
+const cert_dir = path.resolve(__dirname, '../../test/fixtures');
+const REDIRECT_PORT = 28347;
+
+function main({ dur, size, securing }) {
+  const chunk = Buffer.alloc(size, 'b');
+
+  const options = {
+    key: fs.readFileSync(`${cert_dir}/test_key.pem`),
+    cert: fs.readFileSync(`${cert_dir}/test_cert.pem`),
+    ca: [ fs.readFileSync(`${cert_dir}/test_ca.pem`) ],
+    ciphers: 'AES256-GCM-SHA384',
+    isServer: true,
+    requestCert: true,
+    rejectUnauthorized: true,
+  };
+
+  const server = net.createServer(onRedirectConnection);
+  server.listen(REDIRECT_PORT, () => {
+    const proxy = net.createServer(onProxyConnection);
+    proxy.listen(common.PORT, () => {
+      const clientOptions = {
+        port: common.PORT,
+        ca: options.ca,
+        key: options.key,
+        cert: options.cert,
+        isServer: false,
+        rejectUnauthorized: false,
+      };
+      const conn = tls.connect(clientOptions, () => {
+        setTimeout(() => {
+          const mbits = (received * 8) / (1024 * 1024);
+          bench.end(mbits);
+          if (conn)
+            conn.destroy();
+          server.close();
+          proxy.close();
+        }, dur * 1000);
+        bench.start();
+        conn.on('drain', write);
+        write();
+      });
+      conn.on('error', (e) => {
+        throw new Error('Client error: ' + e);
+      });
+
+      function write() {
+        while (false !== conn.write(chunk));
+      }
+    });
+  });
+
+  function onProxyConnection(conn) {
+    const client = net.connect(REDIRECT_PORT, () => {
+      switch (securing) {
+        case 'SecurePair':
+          securePair(conn, client);
+          break;
+        case 'TLSSocket':
+          secureTLSSocket(conn, client);
+          break;
+        default:
+          throw new Error('Invalid securing method');
+      }
+    });
+  }
+
+  function securePair(conn, client) {
+    const serverCtxt = tls.createSecureContext(options);
+    const serverPair = tls.createSecurePair(serverCtxt, true, true, false);
+    conn.pipe(serverPair.encrypted);
+    serverPair.encrypted.pipe(conn);
+    serverPair.on('error', (error) => {
+      throw new Error('Pair error: ' + error);
+    });
+    serverPair.cleartext.pipe(client);
+  }
+
+  function secureTLSSocket(conn, client) {
+    const serverSocket = new tls.TLSSocket(conn, options);
+    serverSocket.on('error', (e) => {
+      throw new Error('Socket error: ' + e);
+    });
+    serverSocket.pipe(client);
+  }
+
+  let received = 0;
+  function onRedirectConnection(conn) {
+    conn.on('data', (chunk) => {
+      received += chunk.length;
+    });
+  }
+}

--- a/test/sequential/test-benchmark-tls.js
+++ b/test/sequential/test-benchmark-tls.js
@@ -20,6 +20,7 @@ runBenchmark('tls',
                'dur=0.1',
                'n=1',
                'size=2',
+               'securing=SecurePair',
                'type=asc'
              ],
              {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Adds a benchmark to compare `tls.createSecurePair()` with `new tls.TLSSocket()`. The first option is deprecated, while the second is the recommended way forward for securing existing server sockets. A proxy server is placed between the client and the server to evidence any performance issues with socket events.

#### Results v8.11.1

`tls.createSecurePair()` with Node.js v8.11.1 is quite faster than `new tls.TLSSocket()`:

```
 $ node benchmark/tls/secure-pair.js 
tls/secure-pair.js size=2 securing="SecurePair" dur=5: 15.94602188948082
tls/secure-pair.js size=1024 securing="SecurePair" dur=5: 2,060.951341694148
tls/secure-pair.js size=1048576 securing="SecurePair" dur=5: 3,234.913943348519
tls/secure-pair.js size=2 securing="TLSSocket" dur=5: 3.1348338992549807
tls/secure-pair.js size=1024 securing="TLSSocket" dur=5: 1,020.9719597316911
tls/secure-pair.js size=1048576 securing="TLSSocket" dur=5: 3,704.526017262844
```

Deprecation warnings have been removed from the output. Test machine is a dual-core Lenovo X1 Carbon with Ubuntu 17.10.

There is a performance regression using `new tls.TLSSocket()` for small packet sizes:

* For 2 bytes throughput goes from 16 bytes per iteration to around 3.
* For 1 KB throughput goes from 2 KB per iteration to 1 KB.
* For 1 MB throughput actually increases, which is to be expected since there are less streams to pipe there.

The results point to an inefficiency in small packets, and experimentally it appears that while `SecurePair` buffers data, `TLSSocket` doesn't: the number of bytes per iteration is quite similar to the number of bytes per packet sent.

#### Results Using `master`

Also, a performance regression has been reported in https://github.com/nodejs/node/issues/20263 for v10.0.0, in which removes the old legacy code for `tls.createSecurePair()` using instead `new tls.TLSSocket()` underneath. So using the latest in `master` (node v11.0.0-pre):

```
 $ ./node benchmark/tls/secure-pair.js 
tls/secure-pair.js size=2 securing="SecurePair" dur=5: 3.612850011228876
tls/secure-pair.js size=1024 securing="SecurePair" dur=5: 1,073.6013989026228
tls/secure-pair.js size=1048576 securing="SecurePair" dur=5: 3,801.1694627588176
tls/secure-pair.js size=2 securing="TLSSocket" dur=5: 3.1985467121541213
tls/secure-pair.js size=1024 securing="TLSSocket" dur=5: 1,023.6285765524207
tls/secure-pair.js size=1048576 securing="TLSSocket" dur=5: 4,079.423755357186
```

In `master` there is no performance gap between `SecurePair` and `TLSSocket`; instead they are both in the low end of the range seen with v8.11.1.

As [requested](https://github.com/nodejs/node/issues/20263#issuecomment-384308169) by @addaleax, this benchmark should work reliably on all systems since it does not vary with the number of cores or indeed with CPU load (within reason).

#### Results With #20287 

As [requested](https://github.com/nodejs/node/issues/20263#issuecomment-384670714) by @benjamingr, applying https://github.com/nodejs/node/pull/20287 by @apapirovski gives very similar numbers as without it. I don't have an explanation as to why it does not improve as expected.

```
 $ ./node benchmark/tls/secure-pair.js 
tls/secure-pair.js size=2 securing="SecurePair" dur=5: 3.4185875822957215
tls/secure-pair.js size=1024 securing="SecurePair" dur=5: 1,144.471090251163
tls/secure-pair.js size=1048576 securing="SecurePair" dur=5: 3,647.8361764068845
tls/secure-pair.js size=2 securing="TLSSocket" dur=5: 2.833589476787596
tls/secure-pair.js size=1024 securing="TLSSocket" dur=5: 1,026.9533974461256
tls/secure-pair.js size=1048576 securing="TLSSocket" dur=5: 3,879.9676141790346
```

#### Deployment Notes

PR should be safe to merge since it only adds a benchmark.