### PR TITLE
doc: remove console.table() as inspector-dependent

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -364,9 +364,7 @@ console.table(Symbol());
 
 console.table(undefined);
 // undefined
-```
 
-```js
 console.table([{ a: 1, b: 'Y' }, { a: 'Z', b: 2 }]);
 // ┌─────────┬─────┬─────┐
 // │ (index) │  a  │  b  │
@@ -374,9 +372,7 @@ console.table([{ a: 1, b: 'Y' }, { a: 'Z', b: 2 }]);
 // │    0    │  1  │ 'Y' │
 // │    1    │ 'Z' │  2  │
 // └─────────┴─────┴─────┘
-```
 
-```js
 console.table([{ a: 1, b: 'Y' }, { a: 'Z', b: 2 }], ['a']);
 // ┌─────────┬─────┐
 // │ (index) │  a  │
@@ -494,17 +490,6 @@ This method does not display anything unless used in the inspector. Stops the
 current JavaScript CPU profiling session if one has been started and prints
 the report to the **Profiles** panel of the inspector. See
 [`console.profile()`][] for an example.
-
-### console.table(array[, columns])
-<!-- YAML
-added: v8.0.0
--->
-* `array` {Array|Object}
-* `columns` {string[]} Display only selected properties of objects in the
-  `array`.
-
-This method does not display anything unless used in the inspector. Prints to
-`stdout` the array `array` formatted as a table.
 
 ### console.timeStamp([label])
 <!-- YAML


### PR DESCRIPTION
`console.table()` is implemented in Node.js core and no longer requires
the inspector for use.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
