### PR TITLE
deps: cherry-pick 76cab5f from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/test/mjsunit/es8/object-entries.js
+++ b/deps/v8/test/mjsunit/es8/object-entries.js
@@ -210,6 +210,24 @@ function TestPropertyFilter(withWarmup) {
 TestPropertyFilter();
 TestPropertyFilter(true);
 
+function TestPropertyFilter2(withWarmup) {
+  var object = { };
+  Object.defineProperty(object, "prop1", { value: 10 });
+  Object.defineProperty(object, "prop2", { value: 20 });
+  object.prop3 = 30;
+
+  if (withWarmup) {
+    for (const key in object) {}
+  }
+
+  values = Object.entries(object);
+  assertEquals(1, values.length);
+  assertEquals([
+    [ "prop3", 30 ],
+  ], values);
+}
+TestPropertyFilter2();
+TestPropertyFilter2(true);
 
 function TestWithProxy(withWarmup) {
   var obj1 = {prop1:10};


### PR DESCRIPTION
Original commit message:

    Fix Object.entries/.values with non-enumerable properties

    Iterate over all descriptors instead of bailing out early and missing
    enumerable properties later.

    Bug: chromium:836145
    Change-Id: I104f7ea89480383b6b4b9204942a166bdf8e0597
    Reviewed-on: https://chromium-review.googlesource.com/1027832
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Commit-Queue: Camillo Bruni <cbruni@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#52786}

Refs: https://github.com/v8/v8/commit/76cab5ff786bea157a6931296924384a2242da93
Fixes: https://github.com/nodejs/node/issues/20278

The merge to 6.6 was rejected in https://bugs.chromium.org/p/chromium/issues/detail?id=836145#c31.

/cc @nodejs/v8-update 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
