### PR TITLE
stream: only check options once in Duplex ctor

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -50,17 +50,19 @@ function Duplex(options) {
 
   Readable.call(this, options);
   Writable.call(this, options);
-
-  if (options && options.readable === false)
-    this.readable = false;
-
-  if (options && options.writable === false)
-    this.writable = false;
-
   this.allowHalfOpen = true;
-  if (options && options.allowHalfOpen === false) {
-    this.allowHalfOpen = false;
-    this.once('end', onend);
+
+  if (options) {
+    if (options.readable === false)
+      this.readable = false;
+
+    if (options.writable === false)
+      this.writable = false;
+
+    if (options.allowHalfOpen === false) {
+      this.allowHalfOpen = false;
+      this.once('end', onend);
+    }
   }
 }
 


### PR DESCRIPTION
This commit updates the Duplex constructor adding an if statement
checking if options is undefined, and removes the check from the
following three if statements.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
