### PR TITLE
src: opt out of DoTryWrite in TLS

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1649,6 +1649,8 @@ Http2Stream::Http2Stream(
   MakeWeak<Http2Stream>(this);
   statistics_.start_time = uv_hrtime();
 
+  stream_resource_flags_ |= StreamResource::kFlagWantsWrite;
+
   // Limit the number of header pairs
   max_header_pairs_ = session->GetMaxHeaderPairs();
   if (max_header_pairs_ == 0)

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -573,8 +573,6 @@ class Http2Stream : public AsyncWrap,
   // Required for StreamBase
   int DoShutdown(ShutdownWrap* req_wrap) override;
 
-  bool HasWantsWrite() const override { return true; }
-
   // Initiate a response on this stream.
   int SubmitResponse(nghttp2_nv* nva, size_t len, int options);
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -78,6 +78,10 @@ inline StreamResource::~StreamResource() {
   }
 }
 
+inline void StreamResource::DisableDoTryWrite() {
+  stream_resource_flags_ &= ~kFlagDoTryWrite;
+}
+
 inline void StreamResource::PushStreamListener(StreamListener* listener) {
   CHECK_NE(listener, nullptr);
   CHECK_EQ(listener->stream_, nullptr);
@@ -199,7 +203,7 @@ inline StreamWriteResult StreamBase::Write(
     total_bytes += bufs[i].len;
   bytes_written_ += total_bytes;
 
-  if (send_handle == nullptr) {
+  if (HasDoTryWrite() && send_handle == nullptr) {
     err = DoTryWrite(&bufs, &count);
     if (err != 0 || count == 0) {
       return StreamWriteResult { false, err, nullptr, total_bytes };

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -228,7 +228,8 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
   size_t synchronously_written = 0;
   uv_buf_t buf;
 
-  bool try_write = storage_size <= sizeof(stack_storage) &&
+  bool try_write = HasDoTryWrite() &&
+                   storage_size <= sizeof(stack_storage) &&
                    (!IsIPCPipe() || send_handle_obj.IsEmpty());
   if (try_write) {
     data_size = StringBytes::Write(env->isolate(),

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -265,7 +265,7 @@ class StreamResource {
   uint64_t bytes_read_ = 0;
   uint64_t bytes_written_ = 0;
 
-  int stream_resource_flags_ = kFlagNone;
+  unsigned int stream_resource_flags_ = kFlagNone;
 
   friend class StreamListener;
 };

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -93,6 +93,7 @@ LibuvStreamWrap::LibuvStreamWrap(Environment* env,
                  provider),
       StreamBase(env),
       stream_(stream) {
+  stream_resource_flags_ |= StreamResource::kFlagDoTryWrite;
 }
 
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -104,7 +104,7 @@ class TLSWrap : public AsyncWrap,
   void EncOut();
   bool ClearIn();
   void ClearOut();
-  bool InvokeQueued(int status, const char* error_str = nullptr);
+  void InvokeQueued(int status, const char* error_str = nullptr);
 
   inline void Cycle() {
     // Prevent recursion
@@ -151,8 +151,6 @@ class TLSWrap : public AsyncWrap,
   std::vector<uv_buf_t> pending_cleartext_input_;
   size_t write_size_;
   WriteWrap* current_write_ = nullptr;
-  WriteWrap* current_empty_write_ = nullptr;
-  bool write_callback_scheduled_ = false;
   bool started_;
   bool established_;
   bool shutdown_;

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -62,7 +62,7 @@ function onexit() {
         id: 'getaddrinforeq:1', triggerAsyncId: 'tls:1' },
       { type: 'TCPCONNECTWRAP',
         id: 'tcpconnect:1', triggerAsyncId: 'tcp:1' },
-      { type: 'WRITEWRAP', id: 'write:1', triggerAsyncId: 'tcpconnect:1' },
+      { type: 'WRITEWRAP', id: 'write:1', triggerAsyncId: 'tcp:1' },
       { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcpserver:1' },
       { type: 'TLSWRAP', id: 'tls:2', triggerAsyncId: 'tcpserver:1' },
       { type: 'TIMERWRAP', id: 'timer:1', triggerAsyncId: 'tcpserver:1' },


### PR DESCRIPTION
Since TLS writes are always async anyway, create a mechanism to opt out of DoTryWrite on StreamResources so that consumers can disable this feature for their underlying streams.

This yields roughly 30% improvement on throughput when using mid-sized writes (256 bytes to 16kb), with smaller improvements for smaller chunk sizes and no difference for large sizes (since they are already always async anyway). It also removes the need to simulate an async finish using `SetImmediate` thus simplifying the TLS implementation a little.

Long-term I'm hoping to make this the default for most net sockets too (eg http & h2c) because it makes the throughput MUCH better (we're talking upwards of 100% improvement) but currently there's a roughly 5% regression for the most common usage of http which is just doing `res.write(); res.end();` (or just `res.end()`). If we could find somewhere else we can gain that loss back then IMO this would be a good next step.

This PR is an improvement on https://github.com/nodejs/node/pull/20287. If anyone has any cleaner suggestions (a more C++ way) of accomplishing this same thing, I'm all ears. I'm definitely more at home on the JS side still.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
