### PR TITLE
doc: remove superfluous URL require statement

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -132,8 +132,6 @@ and a `base` is provided, it is advised to validate that the `origin` of
 the `URL` object is what is expected.
 
 ```js
-const { URL } = require('url');
-
 let myURL = new URL('http://anotherExample.org/', 'https://example.org/');
 // http://anotherexample.org/
 


### PR DESCRIPTION
Since v10.0.0, the `URL` class is available on the global object, so
using a `require` statement to access it is no longer necessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
