### PR TITLE
tools: fix TypeError from `test.py --time`

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1749,7 +1749,7 @@ def Main():
     timed_tests.sort(lambda a, b: a.CompareTime(b))
     index = 1
     for entry in timed_tests[:20]:
-      t = FormatTime(entry.duration)
+      t = FormatTime(entry.duration.total_seconds())
       sys.stderr.write("%4i (%s) %s\n" % (index, t, entry.GetLabel()))
       index += 1
 


### PR DESCRIPTION
Calculated durations are timedelta objects but the FormatTime function
is expecting a number in seconds.

Fixes: https://github.com/nodejs/node/issues/20341

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
