### PR TITLE
crypto: allocate more memory for cipher.update()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3023,13 +3023,27 @@ CipherBase::UpdateResult CipherBase::Update(const char* data,
     auth_tag_set_ = true;
   }
 
-  *out_len = len + EVP_CIPHER_CTX_block_size(ctx_);
-  *out = Malloc<unsigned char>(static_cast<size_t>(*out_len));
+  *out_len = 0;
+  int buff_len = len + EVP_CIPHER_CTX_block_size(ctx_);
+  // For key wrapping algorithms, get output size by calling
+  // EVP_CipherUpdate() with null output.
+  if (mode == EVP_CIPH_WRAP_MODE &&
+      EVP_CipherUpdate(ctx_,
+                       nullptr,
+                       &buff_len,
+                       reinterpret_cast<const unsigned char*>(data),
+                       len) != 1) {
+    return kErrorState;
+  }
+
+  *out = Malloc<unsigned char>(buff_len);
   int r = EVP_CipherUpdate(ctx_,
                            *out,
                            out_len,
                            reinterpret_cast<const unsigned char*>(data),
                            len);
+
+  CHECK_LE(*out_len, buff_len);
 
   // When in CCM mode, EVP_CipherUpdate will fail if the authentication tag is
   // invalid. In that case, remember the error and throw in final().

--- a/test/parallel/test-crypto-des3-wrap.js
+++ b/test/parallel/test-crypto-des3-wrap.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+// Test case for des-ede3 wrap/unwrap. des3-wrap needs extra 2x blocksize
+// then plaintext to store ciphertext.
+const test = {
+  key: Buffer.from('3c08e25be22352910671cfe4ba3652b1220a8a7769b490ba', 'hex'),
+  iv: Buffer.alloc(0),
+  plaintext: '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBG' +
+    'WWELweCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZU' +
+    'JjAfaFg**'
+};
+
+const cipher = crypto.createCipheriv('des3-wrap', test.key, test.iv);
+const ciphertext = cipher.update(test.plaintext, 'utf8');
+
+const decipher = crypto.createDecipheriv('des3-wrap', test.key, test.iv);
+const msg = decipher.update(ciphertext, 'buffer', 'utf8');
+
+assert.strictEqual(msg, test.plaintext);


### PR DESCRIPTION
For some algorithms, they need extra 2x blocksize to store the ciphertext in
order to avoid invalid write. Also add a test case to verify it.

refs: https://github.com/nodejs/node/issues/19655

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
