### PR TITLE
doc: add parameters for settings events

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -195,7 +195,7 @@ event is emitted.
 added: v8.4.0
 -->
 
-* `settings` {Object} A copy of the `SETTINGS` frame received.
+* `settings` {HTTP/2 Settings Object} A copy of the `SETTINGS` frame received.
 
 The `'localSettings'` event is emitted when an acknowledgment `SETTINGS` frame
 has been received.
@@ -216,7 +216,7 @@ session.on('localSettings', (settings) => {
 added: v8.4.0
 -->
 
-* `settings` {Object} A copy of the `SETTINGS` frame received.
+* `settings` {HTTP/2 Settings Object} A copy of the `SETTINGS` frame received.
 
 The `'remoteSettings'` event is emitted when a new `SETTINGS` frame is received
 from the connected peer.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -195,9 +195,10 @@ event is emitted.
 added: v8.4.0
 -->
 
+* `settings` {Object} A copy of the `SETTINGS` frame received.
+
 The `'localSettings'` event is emitted when an acknowledgment `SETTINGS` frame
-has been received. When invoked, the handler function will receive a copy of
-the local settings.
+has been received.
 
 When using `http2session.settings()` to submit new settings, the modified
 settings do not take effect until the `'localSettings'` event is emitted.
@@ -215,9 +216,10 @@ session.on('localSettings', (settings) => {
 added: v8.4.0
 -->
 
+* `settings` {Object} A copy of the `SETTINGS` frame received.
+
 The `'remoteSettings'` event is emitted when a new `SETTINGS` frame is received
-from the connected peer. When invoked, the handler function will receive a copy
-of the remote settings.
+from the connected peer.
 
 ```js
 session.on('remoteSettings', (settings) => {


### PR DESCRIPTION
Add parameters for the callback for the Http2Session:localSettings event
and Http2Session:remoteSettings event inline with the pattern in the rest
of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/http2 @mcollina @vsemozhetbyt 