### PR TITLE
tools: add eslint check for skipIfEslintMissing

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -13,6 +13,7 @@ rules:
   node-core/prefer-common-expectserror: error
   node-core/prefer-common-mustnotcall: error
   node-core/crypto-check: error
+  node-core/eslint-check: error
   node-core/inspector-check: error
   node-core/number-isnan: error
   ## common module is mandatory in tests

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -494,7 +494,7 @@ exports.fileExists = function(pathname) {
 
 exports.skipIfEslintMissing = function() {
   if (!exports.fileExists(
-    path.join('..', '..', 'tools', 'node_modules', 'eslint')
+    path.join(__dirname, '..', '..', 'tools', 'node_modules', 'eslint')
   )) {
     exports.skip('missing ESLint');
   }

--- a/test/parallel/test-eslint-alphabetize-errors.js
+++ b/test/parallel/test-eslint-alphabetize-errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/alphabetize-errors');

--- a/test/parallel/test-eslint-buffer-constructor.js
+++ b/test/parallel/test-eslint-buffer-constructor.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/buffer-constructor');

--- a/test/parallel/test-eslint-documented-errors.js
+++ b/test/parallel/test-eslint-documented-errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/documented-errors');

--- a/test/parallel/test-eslint-eslint-check.js
+++ b/test/parallel/test-eslint-eslint-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/eslint-check');
+
+const message = 'Please add a skipIfEslintMissing() call to allow this ' +
+                'test to be skipped when Node.js is built ' +
+                'from a source tarball.';
+
+new RuleTester().run('eslint-check', rule, {
+  valid: [
+    'foo;',
+    'require("common")\n' +
+      'common.skipIfEslintMissing();\n' +
+      'require("../../tools/node_modules/eslint")'
+  ],
+  invalid: [
+    {
+      code: 'require("common")\n' +
+            'require("../../tools/node_modules/eslint").RuleTester',
+      errors: [{ message }],
+      output: 'require("common")\n' +
+              'common.skipIfEslintMissing();\n' +
+              'require("../../tools/node_modules/eslint").RuleTester'
+    }
+  ]
+});

--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -1,12 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/inspector-check');
 
 const message = 'Please add a skipIfInspectorDisabled() call to allow this ' +
-                'test to be skippped when Node is built ' +
+                'test to be skipped when Node is built ' +
                 '\'--without-inspector\'.';
 
 new RuleTester().run('inspector-check', rule, {

--- a/test/parallel/test-eslint-require-buffer.js
+++ b/test/parallel/test-eslint-require-buffer.js
@@ -11,7 +11,7 @@ const ruleTester = new RuleTester({
   env: { node: true }
 });
 
-const message = "Use const Buffer = require('buffer').Buffer; " +
+const message = "Use const { Buffer } = require('buffer'); " +
                 'at the beginning of this file';
 
 const useStrict = '\'use strict\';\n\n';

--- a/tools/eslint-rules/eslint-check.js
+++ b/tools/eslint-rules/eslint-check.js
@@ -1,7 +1,6 @@
 /**
- * @fileoverview Check that common.skipIfInspectorDisabled is used if
- *               the inspector module is required.
- * @author Daniel Bevenius <daniel.bevenius@gmail.com>
+ * @fileoverview Check that common.skipIfEslintMissing is used if
+ *               the eslint module is required.
  */
 'use strict';
 
@@ -10,16 +9,16 @@ const utils = require('./rules-utils.js');
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-const msg = 'Please add a skipIfInspectorDisabled() call to allow this ' +
-            'test to be skipped when Node is built \'--without-inspector\'.';
+const msg = 'Please add a skipIfEslintMissing() call to allow this test to ' +
+            'be skipped when Node.js is built from a source tarball.';
 
 module.exports = function(context) {
   const missingCheckNodes = [];
   var commonModuleNode = null;
-  var hasInspectorCheck = false;
+  var hasEslintCheck = false;
 
-  function testInspectorUsage(context, node) {
-    if (utils.isRequired(node, ['inspector'])) {
+  function testEslintUsage(context, node) {
+    if (utils.isRequired(node, ['../../tools/node_modules/eslint'])) {
       missingCheckNodes.push(node);
     }
 
@@ -29,13 +28,13 @@ module.exports = function(context) {
   }
 
   function checkMemberExpression(context, node) {
-    if (utils.usesCommonProperty(node, ['skipIfInspectorDisabled'])) {
-      hasInspectorCheck = true;
+    if (utils.usesCommonProperty(node, ['skipIfEslintMissing'])) {
+      hasEslintCheck = true;
     }
   }
 
   function reportIfMissing(context) {
-    if (!hasInspectorCheck) {
+    if (!hasEslintCheck) {
       missingCheckNodes.forEach((node) => {
         context.report({
           node,
@@ -44,7 +43,7 @@ module.exports = function(context) {
             if (commonModuleNode) {
               return fixer.insertTextAfter(
                 commonModuleNode,
-                '\ncommon.skipIfInspectorDisabled();'
+                '\ncommon.skipIfEslintMissing();'
               );
             }
           }
@@ -54,7 +53,7 @@ module.exports = function(context) {
   }
 
   return {
-    'CallExpression': (node) => testInspectorUsage(context, node),
+    'CallExpression': (node) => testEslintUsage(context, node),
     'MemberExpression': (node) => checkMemberExpression(context, node),
     'Program:exit': (node) => reportIfMissing(context, node)
   };


### PR DESCRIPTION
Add a custom eslint rule to check for `common.skipIfEslintMissing()` to
allow tests to run from source tarballs that do not include eslint.

Fix up tests that were failing the new check.

Refs: https://github.com/nodejs/node/issues/20336#issuecomment-385046748

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
