### PR TITLE
http2: compat don't make unnecessary copy of trailers

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -99,8 +99,8 @@ function onStreamData(chunk) {
 function onStreamTrailers(trailers, flags, rawTrailers) {
   const request = this[kRequest];
   if (request !== undefined) {
-    Object.assign(request[kTrailers], trailers);
-    request[kRawTrailers].push(...rawTrailers);
+    request[kTrailers] = trailers;
+    request[kRawTrailers] = rawTrailers;
   }
 }
 


### PR DESCRIPTION
Not sure why the trailer objects are copied here? Might as well just use a reference, no?

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
