### PR TITLE
http,http2: throw invalid arg for writeHead headers arg

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -200,14 +200,14 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 };
 
 ServerResponse.prototype.writeHead = writeHead;
-function writeHead(statusCode, reason, obj) {
+function writeHead(statusCode, reason, headers) {
   var originalStatusCode = statusCode;
+  var obj = headers;
 
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999) {
     throw new ERR_HTTP_INVALID_STATUS_CODE(originalStatusCode);
   }
-
 
   if (typeof reason === 'string') {
     // writeHead(statusCode, reasonPhrase[, headers])
@@ -220,18 +220,22 @@ function writeHead(statusCode, reason, obj) {
   }
   this.statusCode = statusCode;
 
-  var headers;
+  headers = undefined;
   if (this[outHeadersKey]) {
     // Slow-case: when progressive API and header fields are passed.
-    var k;
-    if (obj) {
-      var keys = Object.keys(obj);
-      for (var i = 0; i < keys.length; i++) {
-        k = keys[i];
-        if (k) this.setHeader(k, obj[k]);
+    let key;
+    if (typeof obj === 'object' && obj !== null) {
+      let keys = Object.keys(obj);
+      for (let i = 0; i < keys.length; i++) {
+        key = keys[i];
+        if (key)
+          this.setHeader(key, obj[key]);
       }
+    } else if (obj) {
+      throw new ERR_INVALID_ARG_TYPE('headers', 'object', obj);
     }
-    if (k === undefined && this._header) {
+
+    if (key === undefined && this._header) {
       throw new ERR_HTTP_HEADERS_SENT('render');
     }
     // only progressive api is used

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -550,13 +550,20 @@ class Http2ServerResponse extends Stream {
     if (headers === undefined && typeof statusMessage === 'object')
       headers = statusMessage;
 
-    if (typeof headers === 'object') {
+    let key;
+    if (typeof headers === 'object' && headers !== null) {
       const keys = Object.keys(headers);
-      let key = '';
-      for (var i = 0; i < keys.length; i++) {
+      for (let i = 0; i < keys.length; i++) {
         key = keys[i];
-        this[kSetHeader](key, headers[key]);
+        if (key)
+          this[kSetHeader](key, headers[key]);
       }
+    } else if (headers) {
+      throw new ERR_INVALID_ARG_TYPE('headers', 'object', headers);
+    }
+
+    if (key === undefined && this._header) {
+      throw new ERR_HTTP_HEADERS_SENT('render');
     }
 
     state.statusCode = statusCode;


### PR DESCRIPTION
Throw if something other than an object is passed to `writeHead` instead of quietly ignoring it.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
