### PR TITLE
doc: clearer doc-only deprecations

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -417,12 +417,12 @@ longer be used.
 Node.js uses three Deprecation levels:
 
 * *Documentation-Only Deprecation* refers to elements of the Public API that
-  should be avoided by developers and that might be staged for deprecation in a
-  future Node.js major release. An explicit notice indicating the deprecation
-  status is added to the API documentation but no functional changes are
-  implemented in the code. There will be no runtime deprecation warnings emitted
-  for such deprecations at runtime by default. Documentation-only deprecations
-  may trigger a runtime warning when Node.js is started with the
+  should be avoided by developers and that might be staged for a runtime
+  deprecation in a future Node.js major release. An explicit notice indicating
+  the deprecation status is added to the API documentation but no functional
+  changes are implemented in the code. By default there will be no deprecation
+  warnings emitted for such deprecations at runtime. Documentation-only
+  deprecations may trigger a runtime warning when Node.js is started with the
   [`--pending-deprecation`][] flag or the `NODE_PENDING_DEPRECATION=1`
   environment variable is set.
 


### PR DESCRIPTION
Explicitely mention that a documentation only deprecation does not
always imply that it will be staged for deprecation in a future
Node.js major release. It is mainly there to tell developers that
a specific API should be avoided.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
