### PR TITLE
doc: fix manpage warning

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -384,4 +384,3 @@ IRC (Node.js core development):
 .Sh AUTHORS
 Written and maintained by 1000+ contributors:
 .Sy https://github.com/nodejs/node/blob/master/AUTHORS
-.


### PR DESCRIPTION
This fixes mdoc warning: Empty input line #389 that can be seen by doing
`LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z ./doc/node.1 > /dev/null`
