### PR TITLE
src: avoid `std::make_unique`

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -367,8 +367,9 @@ class NodeInspectorClient : public V8InspectorClient {
   int connectFrontend(std::unique_ptr<InspectorSessionDelegate> delegate) {
     events_dispatched_ = true;
     int session_id = next_session_id_++;
-    channels_[session_id] =
-        std::make_unique<ChannelImpl>(client_, std::move(delegate));
+    // TODO(addaleax): Revert back to using make_unique once we get issues
+    // with CI resolved (i.e. revert the patch that added this comment).
+    channels_[session_id].reset(new ChannelImpl(client_, std::move(delegate)));
     return session_id;
   }
 
@@ -569,7 +570,8 @@ void Agent::Stop() {
 std::unique_ptr<InspectorSession> Agent::Connect(
     std::unique_ptr<InspectorSessionDelegate> delegate) {
   int session_id = client_->connectFrontend(std::move(delegate));
-  return std::make_unique<InspectorSession>(session_id, client_);
+  return std::unique_ptr<InspectorSession>(
+      new InspectorSession(session_id, client_));
 }
 
 void Agent::WaitForDisconnect() {

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -357,8 +357,8 @@ std::vector<std::string> InspectorIo::GetTargetIds() const {
 TransportAction InspectorIo::Attach(int session_id) {
   Agent* agent = parent_env_->inspector_agent();
   fprintf(stderr, "Debugger attached.\n");
-  sessions_[session_id] =
-      agent->Connect(std::make_unique<IoSessionDelegate>(this, session_id));
+  sessions_[session_id] = agent->Connect(std::unique_ptr<IoSessionDelegate>(
+      new IoSessionDelegate(this, session_id)));
   return TransportAction::kAcceptSession;
 }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -66,8 +66,8 @@ class JSBindingsConnection : public AsyncWrap {
                          callback_(env->isolate(), callback) {
     Wrap(wrap, this);
     Agent* inspector = env->inspector_agent();
-    session_ = inspector->Connect(
-        std::make_unique<JSBindingsSessionDelegate>(env, this));
+    session_ = inspector->Connect(std::unique_ptr<JSBindingsSessionDelegate>(
+        new JSBindingsSessionDelegate(env, this)));
   }
 
   void OnMessage(Local<Value> value) {


### PR DESCRIPTION
Work around https://github.com/nodejs/build/issues/1254, which
effectively breaks stress test CI and CITGM, by avoiding
`std::make_unique` for now.

This workaround should be reverted once that issue is resolved.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
