### PR TITLE
tools: dedupe property access in doc/type-parser

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -130,7 +130,7 @@ function toLink(typeInput) {
   typeTexts.forEach((typeText) => {
     typeText = typeText.trim();
     if (typeText) {
-      let typeUrl = null;
+      let typeUrl;
 
       // To support type[], type[][] etc., we store the full string
       // and use the bracket-less version to lookup the type URL.
@@ -143,7 +143,7 @@ function toLink(typeInput) {
         typeUrl = `${jsDataStructuresUrl}#${primitive}_type`;
       } else if (jsGlobalTypes.includes(typeText)) {
         typeUrl = `${jsGlobalObjectsUrl}${typeText}`;
-      } else if (customTypesMap[typeText]) {
+      } else {
         typeUrl = customTypesMap[typeText];
       }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

There is no need to get this property twice in this rather hot spot: if there is no such key, the `typeUrl` will be `undefined`, which suffices for the boolean check in the next line.

For consistency, `undefined` can also be made the default value.