### PR TITLE
build: fix 'gas_version' check on localized environments

### DIFF
--- a/configure
+++ b/configure
@@ -676,11 +676,13 @@ def get_xcode_version(cc):
 
 def get_gas_version(cc):
   try:
+    custom_env = os.environ.copy()
+    custom_env["LC_ALL"] = "en_US"
     proc = subprocess.Popen(shlex.split(cc) + ['-Wa,-v', '-c', '-o',
                                                '/dev/null', '-x',
                                                'assembler',  '/dev/null'],
                             stdin=subprocess.PIPE, stderr=subprocess.PIPE,
-                            stdout=subprocess.PIPE)
+                            stdout=subprocess.PIPE, env=custom_env)
   except OSError:
     error('''No acceptable C compiler found!
 


### PR DESCRIPTION
Some GNU assembler versions got localized outputs like...

```
Gnu assembler versão 2.30 (x86_64-linux-gnu) usando versão BFD (GNU Binutils for Ubuntu) 2.30
```

failing regex checker and the whole configure process.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
