### PR TITLE
doc: specify types of listener parameter

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -84,7 +84,8 @@ process.on('exit', (code) => {
 added: v0.5.10
 -->
 
-* `message` {Object} a parsed JSON object or primitive value.
+* `message` { Object | boolean | number | string | null } a parsed JSON object
+  or a serializable primitive value.
 * `sendHandle` {net.Server|net.Socket} a [`net.Server`][] or [`net.Socket`][]
   object, or undefined.
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

We cannot manage with `{any}` because `message` cannot be of `Symbol` or `undefined` types.
