### PR TITLE
fs: promises fixes

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -390,7 +390,7 @@ async function lchown(path, uid, gid) {
   if (O_SYMLINK !== undefined) {
     const fd = await open(path,
                           O_WRONLY | O_SYMLINK);
-    return fchmod(fd, uid, gid).finally(fd.close.bind(fd));
+    return fchown(fd, uid, gid).finally(fd.close.bind(fd));
   }
   throw new ERR_METHOD_NOT_IMPLEMENTED();
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This fixes two errors in `fs/promises`:
1. Removes the leftovers from `write(fd, string[, position[, encoding]], callback)` signature arg-shifting to find `callback` — that variable was unused and that logic was corrupting `encoding`.
2. `chown` should do chown, not chmod.

Sorry, this doesn't include tests — I would appreciate some help there. In general, `fs/promises` test coverage is poor, and this PR isn't aimed at that (yet). Also, #19811 aims to increase the test covereage for `fs/promises`.

Perhaps #20406 need to be resolved first — the first patch fixes technically _undocumented_ behavior and I am not sure we should be testing it or removing it.