### PR TITLE
doc: mitigate `marked` bug

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -192,7 +192,8 @@ Possible signatures:
 * [`server.listen(options[, callback])`][`server.listen(options)`]
 * [`server.listen(path[, backlog][, callback])`][`server.listen(path)`]
   for [IPC][] servers
-* [`server.listen([port[, host[, backlog]]][, callback])`][`server.listen(port, host)`]
+* <a href="#net_server_listen_port_host_backlog_callback">
+  <code>server.listen([port[, host[, backlog]]][, callback])</code></a>
   for TCP servers
 
 This function is asynchronous. When the server starts listening, the
@@ -264,7 +265,8 @@ added: v0.11.14
 * Returns: {net.Server}
 
 If `port` is specified, it behaves the same as
-[`server.listen([port[, host[, backlog]]][, callback])`][`server.listen(port, host)`].
+<a href="#net_server_listen_port_host_backlog_callback">
+<code>server.listen([port[, host[, backlog]]][, callback])</code></a>.
 Otherwise, if `path` is specified, it behaves the same as
 [`server.listen(path[, backlog][, callback])`][`server.listen(path)`].
 If none of them is specified, an error will be thrown.
@@ -1136,7 +1138,6 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`server.listen(handle)`]: #net_server_listen_handle_backlog_callback
 [`server.listen(options)`]: #net_server_listen_options_callback
 [`server.listen(path)`]: #net_server_listen_path_backlog_callback
-[`server.listen(port, host)`]: #net_server_listen_port_host_backlog_callback
 [`socket.connect()`]: #net_socket_connect
 [`socket.connect(options)`]: #net_socket_connect_options_connectlistener
 [`socket.connect(path)`]: #net_socket_connect_path_connectlistener


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

### Status quo

3cb8e64e85c4b50c1154994374e13cb34adc9dd5 + 647954d0a045c72fc6b22afcfd89daa72d81bab3 have fixed a method signature, but caused link rendering issues in 2 places of the HTML doc:

* see this nightly doc [section](https://nodejs.org/download/nightly/v11.0.0-nightly20180429b55a11d1b1/docs/api/net.html#net_server_listen) or a screenshot [with the issue in red frame](https://user-images.githubusercontent.com/10393198/39411316-63ce8962-4c10-11e8-9202-64c266401787.png).

* see this nightly doc [section](https://nodejs.org/download/nightly/v11.0.0-nightly20180429b55a11d1b1/docs/api/net.html#net_server_listen_options_callback) or a screenshot [with the issue in red frame](https://user-images.githubusercontent.com/10393198/39411337-c4b97552-4c10-11e8-893f-87e542649d28.png).

In the GitHub docs, both links are rendered properly: see [here](https://github.com/nodejs/node/blob/b92c6563024044c34b48165270e8464499e3c0bb/doc/api/net.md#serverlisten) and [here](https://github.com/nodejs/node/blob/b92c6563024044c34b48165270e8464499e3c0bb/doc/api/net.md#serverlistenoptions-callback).

### The cause

We have rather an old version of `marked` module and it seems it has a parsing bug for this pattern:
* link text in code backticks
* with two sibling pairs of square brackets
* with one or more nested square brackets in the first sibling.

Minimal reproduction:
```js
'use strict';

const marked = require('tools/doc/node_modules/marked/');

const md = `
A [\`[[]][]\`][ref].

[ref]: #hash
`;

const tokens = marked.lexer(md);
console.log(tokens);

const html = marked.parser(tokens);
console.log(`\n${html}`);
```
```js
[ { type: 'paragraph', text: 'A [`[[]][]`][ref].' },
  links: { ref: { href: '#hash', title: undefined } } ]

<p>A [<code>[[]][]</code>]<a href="#hash">ref</a>.</p>
```
In this case, `marked` renders the first link part as a code fragment in non-code square brackets, and then renders the second part as a link inferring both the text and the URL from it.

### What can we do

The bug is fixed in `marked` master. Compare the output from the tip-of-tree:
```js
[ { type: 'text', text: 'A [`[[]][]`][ref].' },
  { type: 'space' },
  links: { ref: { href: '#hash', title: undefined } } ]

<p>A <a href="#hash"><code>[[]][]</code></a>.</p>
```

But it seems we cannot update now as `marked` is still unstable, has possible new bugs and experiences turbulent renewal (see [issue](https://github.com/markedjs/marked/issues/1179) with a comment).

So we can use this workaround till `marked` 1.0 is released. See screenshots of fixed links and [here](https://user-images.githubusercontent.com/10393198/39411594-b6ec97ec-4c15-11e8-9b83-f4edc1b3b173.png) and [here](https://user-images.githubusercontent.com/10393198/39411595-b9b9e10a-4c15-11e8-917b-fbc628d22a5f.png).

If we should add any HTML comments in these places with PR URL or TODO instructions, please, suggest the wording and format.

cc @nodejs/documentation