### PR TITLE
doc: remove "has been known" tentativeness

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -489,8 +489,7 @@ The TSC should serve as the final arbiter where required.
 1. Never use GitHub's green ["Merge Pull Request"][] button. Reasons for not
    using the web interface button:
    * The merge method will add an unnecessary merge commit.
-   * The squash & merge method has been known to add metadata to the commit
-     title (the PR #).
+   * The squash & merge method can add metadata (the PR #) to the commit title.
    * If more than one author has contributed to the PR, keep the most recent
      author when squashing.
 1. Make sure the CI is done and the result is green. If the CI is not green,


### PR DESCRIPTION
Remove unnecessary "has been known to" tentativeness from
COLLABORATOR_GUIDE.md. "has been known to" is an awkward replacement for
"can" or "might" or "sometimes does" or "does". Pick the right one and
use it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
