### PR TITLE
doc: remove squash guideline from onboarding doc

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -599,7 +599,7 @@ whether the failure was caused by the changes in the Pull Request.
 
 ### Commit Squashing
 
-In most cases, do not squash commits that you add to your pull request during
+In most cases, do not squash commits that you add to your Pull Request during
 the review process. When the commits in your Pull Request land, they may be
 squashed into one commit per logical change. Metadata will be added to the
 commit message (including links to the Pull Request, links to relevant issues,

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -599,9 +599,10 @@ whether the failure was caused by the changes in the Pull Request.
 
 ### Commit Squashing
 
-When the commits in your Pull Request land, they may be squashed
-into one commit per logical change. Metadata will be added to the commit
-message (including links to the Pull Request, links to relevant issues,
+In most cases, do not squash commits that you add to your pull request during
+the review process. When the commits in your Pull Request land, they may be
+squashed into one commit per logical change. Metadata will be added to the
+commit message (including links to the Pull Request, links to relevant issues,
 and the names of the reviewers). The commit history of your Pull Request,
 however, will stay intact on the Pull Request page.
 

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -97,4 +97,3 @@ to update from nodejs/node:
 ## Best practices
 
 * When making PRs, spend time writing a thorough description.
-* Usually only squash at the end of your work.


### PR DESCRIPTION
Although I agree with the guideline people should generally not squash
commits in a pull request until the end (in other words, until it's time
to land the PR), it is clear from comments and actions in the issue
tracker that many do not share that view. This is fine by me, but I do
think that we should our documentation should reflect our practices
rather than being an aspirational statement.

If we *do* wish to preserve this recommendation, it probably belongs in
another document anyway as this is not a recommendation for
Collaborators only but for anyone opening a pull request.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
