### PR TITLE
streams: refactor getHighWaterMark in state.js

### DIFF
--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -10,7 +10,7 @@ function highWaterMarkFrom(options, isDuplex, duplexKey) {
 function getHighWaterMark(state, options, duplexKey, isDuplex) {
   const hwm = highWaterMarkFrom(options, isDuplex, duplexKey);
   if (hwm != null) {
-    if (typeof hwm !== 'number' || !(hwm >= 0)) {
+    if (!Number.isInteger(hwm) || hwm < 0) {
       const name = isDuplex ? duplexKey : 'highWaterMark';
       throw new ERR_INVALID_OPT_VALUE(name, hwm);
     }


### PR DESCRIPTION
This commit aims to reduce some code duplication in state.js


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
