### PR TITLE
http2: reduce require calls in http2/core

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -68,10 +68,13 @@ const { onServerStream,
         Http2ServerResponse,
 } = require('internal/http2/compat');
 const { utcDate } = require('internal/http');
-const { promisify } = require('internal/util');
+const {
+  promisify,
+  customInspectSymbol: kInspect
+} = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
-const { _connectionListener: httpConnectionListener } = require('http');
+const { _connectionListener: httpConnectionListener } = http;
 const { createPromise, promiseResolve } = process.binding('util');
 const debug = util.debuglog('http2');
 
@@ -119,7 +122,6 @@ const { constants, nameForErrorCode } = binding;
 const NETServer = net.Server;
 const TLSServer = tls.Server;
 
-const kInspect = require('internal/util').customInspectSymbol;
 const { kIncomingMessage } = require('_http_common');
 const { kServerResponse } = require('_http_server');
 


### PR DESCRIPTION
This commit removes unnecesary requires of http and internal/util in
http2/core.js


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
