### PR TITLE
http2: rename http2_state class to Http2State

### DIFF
--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -12,6 +12,7 @@
   * [CamelCase for methods, functions, and classes](#camelcase-for-methods-functions-and-classes)
   * [snake\_case for local variables and parameters](#snake_case-for-local-variables-and-parameters)
   * [snake\_case\_ for private class fields](#snake_case_-for-private-class-fields)
+  * [snake\_case\_ for C-like structs](#snake_case_-for-c-like-structs)
   * [Space after `template`](#space-after-template)
 * [Memory Management](#memory-management)
   * [Memory allocation](#memory-allocation)
@@ -145,6 +146,15 @@ class Foo {
  private:
   int counter_ = 0;
 };
+```
+
+## snake\_case\_ for C-like structs
+For plain C-like structs snake_case can be used.
+
+```c++
+struct foo_bar {
+  int name;
+}
 ```
 
 ## Space after `template`

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -482,12 +482,12 @@ inline void Environment::set_http_parser_buffer_in_use(bool in_use) {
   http_parser_buffer_in_use_ = in_use;
 }
 
-inline http2::http2_state* Environment::http2_state() const {
+inline http2::Http2State* Environment::http2_state() const {
   return http2_state_.get();
 }
 
 inline void Environment::set_http2_state(
-    std::unique_ptr<http2::http2_state> buffer) {
+    std::unique_ptr<http2::Http2State> buffer) {
   CHECK(!http2_state_);  // Should be set only once.
   http2_state_ = std::move(buffer);
 }

--- a/src/env.h
+++ b/src/env.h
@@ -643,8 +643,8 @@ class Environment {
   inline bool http_parser_buffer_in_use() const;
   inline void set_http_parser_buffer_in_use(bool in_use);
 
-  inline http2::http2_state* http2_state() const;
-  inline void set_http2_state(std::unique_ptr<http2::http2_state> state);
+  inline http2::Http2State* http2_state() const;
+  inline void set_http2_state(std::unique_ptr<http2::Http2State> state);
 
   inline AliasedBuffer<double, v8::Float64Array>* fs_stats_field_array();
 
@@ -829,7 +829,7 @@ class Environment {
 
   char* http_parser_buffer_;
   bool http_parser_buffer_in_use_ = false;
-  std::unique_ptr<http2::http2_state> http2_state_;
+  std::unique_ptr<http2::Http2State> http2_state_;
 
   AliasedBuffer<double, v8::Float64Array> fs_stats_field_array_;
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2660,7 +2660,7 @@ void Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
 
-  std::unique_ptr<http2_state> state(new http2_state(isolate));
+  std::unique_ptr<Http2State> state(new Http2State(isolate));
 
 #define SET_STATE_TYPEDARRAY(name, field)             \
   target->Set(context,                                \

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -84,9 +84,9 @@ namespace http2 {
     IDX_SESSION_STATS_COUNT
   };
 
-class http2_state {
+class Http2State {
  public:
-  explicit http2_state(v8::Isolate* isolate) :
+  explicit Http2State(v8::Isolate* isolate) :
     root_buffer(
       isolate,
       sizeof(http2_state_internal)),


### PR DESCRIPTION
This commit renames the http2_state class to follow the guidelines in
CPP_STYLE_GUIDE.md.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
