### PR TITLE
n-api: document that native strings are copied

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1541,7 +1541,7 @@ napi_status napi_create_string_latin1(napi_env env,
 Returns `napi_ok` if the API succeeded.
 
 This API creates a JavaScript `String` object from a ISO-8859-1-encoded C
-string.
+string. The native string is copied.
 
 The JavaScript `String` type is described in
 [Section 6.1.4][] of the ECMAScript Language Specification.
@@ -1566,6 +1566,7 @@ napi_status napi_create_string_utf16(napi_env env,
 Returns `napi_ok` if the API succeeded.
 
 This API creates a JavaScript `String` object from a UTF16-LE-encoded C string.
+The native string is copied.
 
 The JavaScript `String` type is described in
 [Section 6.1.4][] of the ECMAScript Language Specification.
@@ -1590,6 +1591,7 @@ if it is null-terminated.
 Returns `napi_ok` if the API succeeded.
 
 This API creates a JavaScript `String` object from a UTF8-encoded C string.
+The native string is copied.
 
 The JavaScript `String` type is described in
 [Section 6.1.4][] of the ECMAScript Language Specification.


### PR DESCRIPTION
Mention that a copy is made of the native string by the
napi_create_string_* APIs.

Fixes: https://github.com/nodejs/abi-stable-node/issues/304

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
