### PR TITLE
n-api: refine napi_get_property_names() doc

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2520,7 +2520,9 @@ and [`napi_get_element`][].
 
 Returns `napi_ok` if the API succeeded.
 
-This API returns the array of properties for the `Object` passed in.
+This API returns the names of the enumerable properties of `object` as an array
+of strings. The properties of `object` whose key is a symbol will not be
+included.
 
 #### napi_set_property
 <!-- YAML


### PR DESCRIPTION
Document that only enumerable, string-keyed properties are returned.

Fixes: https://github.com/nodejs/abi-stable-node/issues/307

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
