### PR TITLE
doc: modified docs to reflect how to invoke gc on Wrapping C++ objects

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -708,6 +708,13 @@ console.log(obj.plusOne());
 // Prints: 13
 ```
 
+When it comes to destructing wrapper objects, garbage collector can execute
+forcefully using V8 command line flags ` --gc_global ` and ` gc_interval `,
+where ` --gc_global ` forces V8 to perform a full garbage collection and
+` gc_interval ` forces V8 to perform garbage collection after a given amount
+of allocations. Although, it is recommended to limit V8 command line flags
+for testing purposes only, since these are primarily debug flags.
+
 ### Factory of wrapped objects
 
 Alternatively, it is possible to use a factory pattern to avoid explicitly

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -708,12 +708,12 @@ console.log(obj.plusOne());
 // Prints: 13
 ```
 
-When it comes to destructing wrapper objects, garbage collector can execute
-forcefully using V8 command line flags ` --gc_global ` and ` --gc_interval `,
-where ` --gc_global ` forces V8 to perform a full garbage collection and
-` --gc_interval ` forces V8 to perform garbage collection after a given amount
-of allocations. Although, it is recommended to limit V8 command line flags
-for testing purposes only, since these are primarily debug flags.
+The destructor for a wrapper object will run when the object is 
+garbage-collected. For destructor testing, there are command-line flags that
+can be used to make it possible to force garbage collection. These flags are
+provided by the underlying V8 JavaScript engine. They are subjected to change
+or removal at any time. They are not documented by Node.js or V8, and they
+should never be used outside of testing.
 
 ### Factory of wrapped objects
 

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -709,9 +709,9 @@ console.log(obj.plusOne());
 ```
 
 When it comes to destructing wrapper objects, garbage collector can execute
-forcefully using V8 command line flags ` --gc_global ` and ` gc_interval `,
+forcefully using V8 command line flags ` --gc_global ` and ` --gc_interval `,
 where ` --gc_global ` forces V8 to perform a full garbage collection and
-` gc_interval ` forces V8 to perform garbage collection after a given amount
+` --gc_interval ` forces V8 to perform garbage collection after a given amount
 of allocations. Although, it is recommended to limit V8 command line flags
 for testing purposes only, since these are primarily debug flags.
 

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -711,7 +711,7 @@ console.log(obj.plusOne());
 The destructor for a wrapper object will run when the object is 
 garbage-collected. For destructor testing, there are command-line flags that
 can be used to make it possible to force garbage collection. These flags are
-provided by the underlying V8 JavaScript engine. They are subjected to change
+provided by the underlying V8 JavaScript engine. They are subject to change
 or removal at any time. They are not documented by Node.js or V8, and they
 should never be used outside of testing.
 


### PR DESCRIPTION
Currently the documentation for Wrapping C++ Objects doesn't explain
how to destruct an object by explicitly invoking the garbage collector.
This commit includes a modification to docs that explains how to force
the garbage collector to clear objects using V8's command line flags.

Fixes: https://github.com/nodejs/node/issues/19876

##### Checklist

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
