### PR TITLE
src: fix inconsistency in extern declaration

### DIFF
--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -119,7 +119,7 @@ PPERF_COUNTERSET_INSTANCE perfctr_instance;
 namespace node {
 
 
-EXTERN_C DECLSPEC_SELECTANY HANDLE NodeCounterProvider = nullptr;
+HANDLE NodeCounterProvider = nullptr;
 
 void InitPerfCountersWin32() {
   ULONG status;


### PR DESCRIPTION
NodeCounterProvider is declared as `extern` but defined as `EXTERN_C`.
This confuses clang-cl.

Refs: https://github.com/nodejs/node/issues/19630

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


