### PR TITLE
stream: ensure Stream.pipeline re-emits errors without callback

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -19,7 +19,10 @@ function once(callback) {
   };
 }
 
-function noop() {}
+function noop(err) {
+  // Rethrow the error if it exists to avoid swallowing it
+  if (err) throw err;
+}
 
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';


### PR DESCRIPTION
Fixes an issue where Stream.pipeline wouldn't re-emit errors
on a stream if no callback was specified, thus swallowing
said errors.

Fixes: https://github.com/nodejs/node/issues/20303

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
