### PR TITLE
test, fs: introduce helper function to test fs.* methods as fsPromises.* methods

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -120,10 +120,32 @@ an expected warning does not have a code then `common.noWarnCode` can be used
 to indicate this.
 
 ### fileExists(pathname)
-* pathname [&lt;string>]
+* `pathname` [&lt;string>]
 * return [&lt;boolean>]
 
 Checks if `pathname` exists
+
+### fsTest(method, args, options)
+* `method` [&lt;string>]
+* `args` [&lt;Array>]
+* `options` [&lt;Object>]
+
+Run both `fs[method]()` and `fsPromises[method]()` passing `args`.
+`util.callbackify()` is used to convert the `fsPromises` version of the method
+into one that takes a callback. The last value in `args` must be a callback that
+is expected to run once for each of the two invocations.
+
+The `options` object may contain a `setup` property that is a function that is
+run before each test. This function might refresh the temporary directory if
+both tests need to use it, for example. The `options` object may also contain a
+`throws` property that is a boolean indicating if the `fs[method]()` function is
+expected to throw. The `fsPromises[method]()` function will be expected to
+reject. Lastly, the `options` object may contain a `differentFiles` array. If
+`differentFiles` is included, then the first element is inserted as the first
+argument (typically the path to a file) when testing the callback-based API and
+the second element is inserted as the first argument when testing the
+Promise-based API. This can be useful when testing APIs that modify the target
+file.
 
 ### getArrayBufferViews(buf)
 * `buf` [&lt;Buffer>]

--- a/test/parallel/test-fs-assert-encoding-error.js
+++ b/test/parallel/test-fs-assert-encoding-error.js
@@ -7,43 +7,41 @@ const options = 'test';
 const expectedError = common.expectsError({
   code: 'ERR_INVALID_OPT_VALUE_ENCODING',
   type: TypeError,
-}, 17);
+}, 24);
 
-assert.throws(() => {
-  fs.readFile('path', options, common.mustNotCall());
-}, expectedError);
+common.fsTest('readFile', ['path', options, expectedError], { throws: true });
 
 assert.throws(() => {
   fs.readFileSync('path', options);
 }, expectedError);
 
-assert.throws(() => {
-  fs.readdir('path', options, common.mustNotCall());
-}, expectedError);
+common.fsTest('readdir', ['path', options, expectedError], { throws: true });
 
 assert.throws(() => {
   fs.readdirSync('path', options);
 }, expectedError);
 
-assert.throws(() => {
-  fs.readlink('path', options, common.mustNotCall());
-}, expectedError);
+common.fsTest('readlink', ['path', options, expectedError], { throws: true });
 
 assert.throws(() => {
   fs.readlinkSync('path', options);
 }, expectedError);
 
-assert.throws(() => {
-  fs.writeFile('path', 'data', options, common.mustNotCall());
-}, expectedError);
+common.fsTest(
+  'writeFile',
+  ['path', 'data', options, expectedError],
+  { throws: true }
+);
 
 assert.throws(() => {
   fs.writeFileSync('path', 'data', options);
 }, expectedError);
 
-assert.throws(() => {
-  fs.appendFile('path', 'data', options, common.mustNotCall());
-}, expectedError);
+common.fsTest(
+  'appendFile',
+  ['path', 'data', options, expectedError],
+  { throws: true }
+);
 
 assert.throws(() => {
   fs.appendFileSync('path', 'data', options);
@@ -53,17 +51,13 @@ assert.throws(() => {
   fs.watch('path', options, common.mustNotCall());
 }, expectedError);
 
-assert.throws(() => {
-  fs.realpath('path', options, common.mustNotCall());
-}, expectedError);
+common.fsTest('realpath', ['path', options, expectedError], { throws: true });
 
 assert.throws(() => {
   fs.realpathSync('path', options);
 }, expectedError);
 
-assert.throws(() => {
-  fs.mkdtemp('path', options, common.mustNotCall());
-}, expectedError);
+common.fsTest('mkdtemp', ['path', options, expectedError], { throws: true });
 
 assert.throws(() => {
   fs.mkdtempSync('path', options);

--- a/test/parallel/test-fs-chown-type-check.js
+++ b/test/parallel/test-fs-chown-type-check.js
@@ -1,16 +1,17 @@
 'use strict';
 
 const common = require('../common');
+
+const assert = require('assert');
 const fs = require('fs');
 
 [false, 1, {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.chown(i, 1, 1, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
+  const checkErr = (e) => {
+    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+    assert.ok(e instanceof TypeError);
+    return true;
+  };
+  common.fsTest('chown', [i, 1, 1, checkErr], { throws: true });
   common.expectsError(
     () => fs.chownSync(i, 1, 1),
     {
@@ -21,20 +22,18 @@ const fs = require('fs');
 });
 
 [false, 'test', {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.chown('not_a_file_that_exists', i, 1, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
+  const checkErr = (e) => {
+    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+    assert.ok(e instanceof TypeError);
+    return true;
+  };
+  common.fsTest(
+    'chown', ['not_a_file_that_exists', i, 1, checkErr], { throws: true }
   );
-  common.expectsError(
-    () => fs.chown('not_a_file_that_exists', 1, i, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
+  common.fsTest(
+    'chown', ['not_a_file_that_exists', 1, i, checkErr], { throws: true }
   );
+
   common.expectsError(
     () => fs.chownSync('not_a_file_that_exists', i, 1),
     {

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -1,42 +1,44 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
-const tmpdir = require('../common/tmpdir');
-tmpdir.refresh();
+{
+  // Loading tmpdir module here because asynchronous nature of tests means that
+  // it will be subject to race conditions if used elsewhere in the test file.
+  const tmpdir = require('../common/tmpdir');
+  // test creating and reading hard link
+  const srcPath = path.join(tmpdir.path, 'hardlink-target.txt');
+  const dstPath = path.join(tmpdir.path, 'link1.js');
 
-// test creating and reading hard link
-const srcPath = path.join(tmpdir.path, 'hardlink-target.txt');
-const dstPath = path.join(tmpdir.path, 'link1.js');
-fs.writeFileSync(srcPath, 'hello world');
+  function callback(err) {
+    assert.ifError(err);
+    const dstContent = fs.readFileSync(dstPath, 'utf8');
+    assert.strictEqual(dstContent, 'hello world');
+  }
 
-function callback(err) {
-  assert.ifError(err);
-  const dstContent = fs.readFileSync(dstPath, 'utf8');
-  assert.strictEqual('hello world', dstContent);
+  const args = [srcPath, dstPath, callback];
+
+  const setup = () => {
+    tmpdir.refresh();
+    fs.writeFileSync(srcPath, 'hello world');
+  };
+
+  common.fsTest('link', args, { setup });
 }
-
-fs.link(srcPath, dstPath, common.mustCall(callback));
 
 // test error outputs
 
+const expectedError = (e) => {
+  assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+  assert.ok(e instanceof TypeError);
+};
+
 [false, 1, [], {}, null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.link(i, '', common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
-  common.expectsError(
-    () => fs.link('', i, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
+  common.fsTest('link', [i, '', expectedError], { throws: true });
+  common.fsTest('link', ['', i, expectedError], { throws: true });
   common.expectsError(
     () => fs.linkSync(i, ''),
     {

--- a/test/parallel/test-fs-unlink-type-check.js
+++ b/test/parallel/test-fs-unlink-type-check.js
@@ -1,16 +1,17 @@
 'use strict';
 
 const common = require('../common');
+
+const assert = require('assert');
 const fs = require('fs');
 
+const expectedError = (e) => {
+  assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+  assert.ok(e instanceof TypeError);
+};
+
 [false, 1, {}, [], null, undefined].forEach((i) => {
-  common.expectsError(
-    () => fs.unlink(i, common.mustNotCall()),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError
-    }
-  );
+  common.fsTest('unlink', [i, expectedError], { throws: true });
   common.expectsError(
     () => fs.unlinkSync(i),
     {

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -29,20 +29,23 @@ for (let i = 0; i < 201; i++) {
 }
 
 stream.end();
+
+function checkResults(err, buf) {
+  assert.ok(err instanceof Error);
+  if (err.message !== 'Array buffer allocation failed') {
+    const stringLengthHex = kStringMaxLength.toString(16);
+    common.expectsError({
+      message: 'Cannot create a string longer than ' +
+               `0x${stringLengthHex} characters`,
+      code: 'ERR_STRING_TOO_LONG',
+      type: Error
+    })(err);
+  }
+  assert.strictEqual(buf, undefined);
+}
+
 stream.on('finish', common.mustCall(function() {
-  fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
-    assert.ok(err instanceof Error);
-    if (err.message !== 'Array buffer allocation failed') {
-      const stringLengthHex = kStringMaxLength.toString(16);
-      common.expectsError({
-        message: 'Cannot create a string longer than ' +
-                 `0x${stringLengthHex} characters`,
-        code: 'ERR_STRING_TOO_LONG',
-        type: Error
-      })(err);
-    }
-    assert.strictEqual(buf, undefined);
-  }));
+  common.fsTest('readFile', [file, 'utf8', checkResults]);
 }));
 
 function destroy() {


### PR DESCRIPTION
Introduce `common.fsTest()` helper function which (hopefully) makes it easy to repurpose all `test-fs-*` tests to also test equivalent functionality in `fsPromises.*` methods. As a proof-of-concept, use the helper function in test-fs-access and test-fs-link. If people think this is a reasonable approach, the remaining 131 test-fs-* files can probably be done relatively quickly.

@ChALkeR @jasnell @nodejs/testing @nodejs/fs 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
