### PR TITLE
console: console.time() should not reset a timer when it exists

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -225,6 +225,10 @@ Console.prototype.dir = function dir(object, options) {
 Console.prototype.time = function time(label = 'default') {
   // Coerces everything other than Symbol to a string
   label = `${label}`;
+  if (this._times.has(label)) {
+    process.emitWarning(`Label '${label}' already exists for console.time()`);
+    return;
+  }
   this._times.set(label, process.hrtime());
 };
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -138,6 +138,20 @@ console.timeEnd();
 console.time(NaN);
 console.timeEnd(NaN);
 
+// make sure calling time twice without timeEnd doesn't reset the timer.
+console.time('test');
+const time = console._times.get('test');
+setTimeout(() => {
+  assert.deepStrictEqual(console._times.get('test'), time);
+  common.expectWarning(
+    'Warning',
+    'Label \'test\' already exists for console.time()',
+    common.noWarnCode);
+  console.time('test');
+  console.timeEnd('test');
+}, 1);
+
+
 console.assert(false, '%s should', 'console.assert', 'not throw');
 assert.strictEqual(errStrings[errStrings.length - 1],
                    'Assertion failed: console.assert should not throw\n');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20440
Refs: https://console.spec.whatwg.org/#time

@domfarolino 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
