### PR TITLE
src: add API to get MultiIsolatePlatform used in node main thread

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4425,6 +4425,11 @@ void FreeEnvironment(Environment* env) {
 }
 
 
+MultiIsolatePlatform* GetNodeMultiIsolatePlatform() {
+  return v8_platform.Platform();
+}
+
+
 MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     v8::TracingController* tracing_controller) {

--- a/src/node.h
+++ b/src/node.h
@@ -251,6 +251,10 @@ NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
 NODE_EXTERN void LoadEnvironment(Environment* env);
 NODE_EXTERN void FreeEnvironment(Environment* env);
 
+// This returns the MultiIsolatePlatform used by node main.
+// If NODE_USE_V8_PLATFORM is not defined, it will return nullptr.
+NODE_EXTERN MultiIsolatePlatform* GetNodeMultiIsolatePlatform();
+
 NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     v8::TracingController* tracing_controller);


### PR DESCRIPTION
This is used to support multi-thread JavaScript by node addon as below. 
A node addon can be created to initialize v8 Isolates in separate threads, which is used to run JavaScript in multi-thread. It requires the MultiIsolatePlatform (used in the node main thread) to register those isolates respectively. 

As an example you may concern, when we try to re-implement [napajs Worker::WorkerThreadFunc](https://github.com/helloshuangzi/napajs/blob/v0.4.x-prototype.raw/src/zone/worker.cpp) by node public APIs, it seems node::GetNodeMultiIsolatePlatform is a missing piece from node API.

#20239 is also an issue about this topic. @fs-eire

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
