### PR TITLE
doc: multiple minor fixes to fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3233,10 +3233,6 @@ The callback will receive the arguments `(err, written, string)` where `written`
 specifies how many _bytes_ the passed string required to be written. Note that
 bytes written is not the same as string characters. See [`Buffer.byteLength`][].
 
-Unlike when writing `buffer`, the entire string must be written. No substring
-may be specified. This is because the byte offset of the resulting data may not
-be the same as the string offset.
-
 Note that it is unsafe to use `fs.write` multiple times on the same file
 without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1316,9 +1316,8 @@ changes:
   * `highWaterMark` {integer} **Default:** `64 * 1024`
 * Returns: {fs.ReadStream} See [Readable Streams][].
 
-Be aware that, unlike the default value set for `highWaterMark` on a
-readable stream (16 kb), the stream returned by this method has a
-default value of 64 kb for the same parameter.
+Unlike the 16 kb default `highWaterMark` for a readable stream, the stream
+returned by this method has a default `highWaterMark` of 64 kb.
 
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file. Both `start` and `end` are inclusive and

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3378,11 +3378,11 @@ and will emit a process warning, thereby helping to prevent memory leaks.
 Instances of the `FileHandle` object are created internally by the
 `fsPromises.open()` method.
 
-Unlike callback-based such as `fs.fstat()`, `fs.fchown()`, `fs.fchmod()`,
-`fs.ftruncate()`, `fs.read()`, and `fs.write()`, operations — all of which
-use a simple numeric file descriptor, all `fsPromises.*` variations use the
-`FileHandle` class in order to help protect against accidental leaking of
-unclosed file descriptors after a `Promise` is resolved or rejected.
+Unlike the callback-based API (`fs.fstat()`, `fs.fchown()`, `fs.fchmod()`, and
+so on), a numeric file descriptor is not used by the promise-based API. Instead,
+the promise-based API uses the `FileHandle` class in order to help avoid
+accidental leaking of unclosed file descriptors after a `Promise` is resolved or
+rejected.
 
 #### filehandle.appendFile(data, options)
 <!-- YAML


### PR DESCRIPTION
First commit:

    Shorten the text about the `highWaterMark` value for the stream returned
    by `fs.createReadStream()`.

Second commit:
    
    There is a paragraph explaining that `fs.write()` cannot write a
    substring of the provided string. It's not clear what `buffer` refers
    to in that paragraph or even what the purpose of the paragraph is.
    There's no suggestion elsewhere that `fs.write()` should be expected to
    have a substring feature. Remove the paragraph.

Third commit:
    
    There is a paragraph about why the promise-based API uses `FileHandle`
    rather than a numeric `fd`. Unfortunately, the paragraph is a bit of
    word-salad. Edit it for clarity, grammar, and style.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
