### PR TITLE
events: optimize condition for optimal scenario

### DIFF
--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 const events = require('events');
 
-const bench = common.createBenchmark(main, { n: [25e4] });
+const bench = common.createBenchmark(main, { n: [1e6] });
 
 function main({ n }) {
   const ee = new events.EventEmitter();

--- a/lib/events.js
+++ b/lib/events.js
@@ -236,7 +236,7 @@ function _addListener(target, type, listener, prepend) {
 
     // Check for listener leak
     m = $getMaxListeners(target);
-    if (m && m > 0 && existing.length > m && !existing.warned) {
+    if (m > 0 && existing.length > m && !existing.warned) {
       existing.warned = true;
       // No error code for this since it is a Warning
       // eslint-disable-next-line no-restricted-syntax

--- a/lib/events.js
+++ b/lib/events.js
@@ -235,22 +235,20 @@ function _addListener(target, type, listener, prepend) {
     }
 
     // Check for listener leak
-    if (!existing.warned) {
-      m = $getMaxListeners(target);
-      if (m && m > 0 && existing.length > m) {
-        existing.warned = true;
-        // No error code for this since it is a Warning
-        // eslint-disable-next-line no-restricted-syntax
-        const w = new Error('Possible EventEmitter memory leak detected. ' +
-                            `${existing.length} ${String(type)} listeners ` +
-                            'added. Use emitter.setMaxListeners() to ' +
-                            'increase limit');
-        w.name = 'MaxListenersExceededWarning';
-        w.emitter = target;
-        w.type = type;
-        w.count = existing.length;
-        process.emitWarning(w);
-      }
+    m = $getMaxListeners(target);
+    if (m && m > 0 && existing.length > m && !existing.warned) {
+      existing.warned = true;
+      // No error code for this since it is a Warning
+      // eslint-disable-next-line no-restricted-syntax
+      const w = new Error('Possible EventEmitter memory leak detected. ' +
+                          `${existing.length} ${String(type)} listeners ` +
+                          'added. Use emitter.setMaxListeners() to ' +
+                          'increase limit');
+      w.name = 'MaxListenersExceededWarning';
+      w.emitter = target;
+      w.type = type;
+      w.count = existing.length;
+      process.emitWarning(w);
     }
   }
 


### PR DESCRIPTION
Instead of always checking whether we've already warned about a possible EventEmitter memory leak, first run the rest of the code as accessing custom properties on an Array is decently slow.

I believe it makes more sense to optimize for well written user-code than code that is already attaching too many listeners and getting this warning, without having set a higher number of maxListeners.

I've also adjusted the benchmark to be a bit more representative as there's too much noise with the current iteration count.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
