### PR TITLE
util: improve spliceOne perf

### DIFF
--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -4,18 +4,29 @@ const common = require('../common');
 
 const bench = common.createBenchmark(main, {
   n: [1e7],
+  pos: ['start', 'middle', 'end'],
   size: [10, 100, 500],
 }, { flags: ['--expose-internals'] });
 
-function main({ n, size, type }) {
+function main({ n, pos, size }) {
   const { spliceOne } = require('internal/util');
   const arr = new Array(size);
   arr.fill('');
-  const pos = Math.floor(size / 2);
+  let index;
+  switch (pos) {
+    case 'end':
+      index = size - 1;
+      break;
+    case 'middle':
+      index = Math.floor(size / 2);
+      break;
+    default: // start
+      index = 0;
+  }
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    spliceOne(arr, pos);
+    spliceOne(arr, index);
     arr.push('');
   }
   bench.end(n);

--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  size: [10, 100, 500],
+}, { flags: ['--expose-internals'] });
+
+function main({ n, size, type }) {
+  const { spliceOne } = require('internal/util');
+  const arr = new Array(size);
+  arr.fill('');
+  const pos = Math.floor(size / 2);
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    spliceOne(arr, pos);
+    arr.push('');
+  }
+  bench.end(n);
+}

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -322,8 +322,8 @@ function join(output, separator) {
   return str;
 }
 
-// Depending on the size of the array, this is anywhere between 1.5-10x
-// faster than the two-arg version of Array#splice()
+// As of V8 6.6, depending on the size of the array, this is anywhere
+// between 1.5-10x faster than the two-arg version of Array#splice()
 function spliceOne(list, index) {
   for (; index + 1 < list.length; index++)
     list[index] = list[index + 1];

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -322,10 +322,11 @@ function join(output, separator) {
   return str;
 }
 
-// About 1.5x faster than the two-arg version of Array#splice().
+// Depending on the size of the array, this is anywhere between 1.5-10x
+// faster than the two-arg version of Array#splice()
 function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
+  for (; index + 1 < list.length; index++)
+    list[index] = list[index + 1];
   list.pop();
 }
 

--- a/test/parallel/test-benchmark-util.js
+++ b/test/parallel/test-benchmark-util.js
@@ -10,6 +10,8 @@ runBenchmark('util',
               'method=Array',
               'n=1',
               'option=none',
+              'pos=start',
+              'size=1',
               'type=',
               'version=native'],
              { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Do less variable allocations and reassignments inside `spliceOne` since it's relied on by some performance sensitive code. This also adds a benchmark for `spliceOne`.

```
                                   confidence improvement accuracy (*)   (**)  (***)
util/splice.js size=10 n=10000000          **      2.95 %       ±1.83% ±2.46% ±3.26%
util/splice.js size=100 n=10000000        ***     10.68 %       ±1.46% ±1.98% ±2.66%
util/splice.js size=500 n=10000000        ***     11.26 %       ±1.23% ±1.65% ±2.19%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
