### PR TITLE
src: refactor `BaseObject` internal field management

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -123,8 +123,8 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
   Local<Object> object = wrapper.As<Object>();
   CHECK_GT(object->InternalFieldCount(), 0);
 
-  AsyncWrap* wrap = Unwrap<AsyncWrap>(object);
-  if (wrap == nullptr) return nullptr;  // ClearWrap() already called.
+  AsyncWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, object, nullptr);
 
   return new RetainedAsyncInfo(class_id, wrap);
 }
@@ -231,7 +231,7 @@ class PromiseWrap : public AsyncWrap {
  public:
   PromiseWrap(Environment* env, Local<Object> object, bool silent)
       : AsyncWrap(env, object, PROVIDER_PROMISE, -1, silent) {
-    MakeWeak(this);
+    MakeWeak();
   }
   size_t self_size() const override { return sizeof(*this); }
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -74,7 +74,7 @@ BaseObject* BaseObject::FromJSObject(v8::Local<v8::Object> obj) {
 }
 
 
-template<typename T>
+template <typename T>
 T* BaseObject::FromJSObject(v8::Local<v8::Object> object) {
   return static_cast<T*>(FromJSObject(object));
 }

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -42,11 +42,14 @@ BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
 
 BaseObject::~BaseObject() {
   if (persistent_handle_.IsEmpty()) {
-    // This most likely happened because the weak callback below
+    // This most likely happened because the weak callback below cleared it.
     return;
   }
 
-  object()->SetAlignedPointerInInternalField(0, nullptr);
+  {
+    v8::HandleScope handle_scope(env_->isolate());
+    object()->SetAlignedPointerInInternalField(0, nullptr);
+  }
 }
 
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -31,52 +31,85 @@
 
 namespace node {
 
-inline BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
+BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
     : persistent_handle_(env->isolate(), handle),
       env_(env) {
   CHECK_EQ(false, handle.IsEmpty());
-  // The zero field holds a pointer to the handle. Immediately set it to
-  // nullptr in case it's accessed by the user before construction is complete.
-  if (handle->InternalFieldCount() > 0)
-    handle->SetAlignedPointerInInternalField(0, nullptr);
+  CHECK_GT(handle->InternalFieldCount(), 0);
+  handle->SetAlignedPointerInInternalField(0, static_cast<void*>(this));
 }
 
 
-inline Persistent<v8::Object>& BaseObject::persistent() {
+BaseObject::~BaseObject() {
+  if (persistent_handle_.IsEmpty()) {
+    // This most likely happened because the weak callback below
+    return;
+  }
+
+  object()->SetAlignedPointerInInternalField(0, nullptr);
+}
+
+
+Persistent<v8::Object>& BaseObject::persistent() {
   return persistent_handle_;
 }
 
 
-inline v8::Local<v8::Object> BaseObject::object() {
+v8::Local<v8::Object> BaseObject::object() {
   return PersistentToLocal(env_->isolate(), persistent_handle_);
 }
 
 
-inline Environment* BaseObject::env() const {
+Environment* BaseObject::env() const {
   return env_;
 }
 
 
-template <typename Type>
-inline void BaseObject::WeakCallback(
-    const v8::WeakCallbackInfo<Type>& data) {
-  delete data.GetParameter();
+BaseObject* BaseObject::FromJSObject(v8::Local<v8::Object> obj) {
+  CHECK_GT(obj->InternalFieldCount(), 0);
+  return static_cast<BaseObject*>(obj->GetAlignedPointerFromInternalField(0));
 }
 
 
-template <typename Type>
-inline void BaseObject::MakeWeak(Type* ptr) {
-  v8::HandleScope scope(env_->isolate());
-  v8::Local<v8::Object> handle = object();
-  CHECK_GT(handle->InternalFieldCount(), 0);
-  Wrap(handle, ptr);
-  persistent_handle_.SetWeak<Type>(ptr, WeakCallback<Type>,
-                                   v8::WeakCallbackType::kParameter);
+template<typename T>
+T* BaseObject::FromJSObject(v8::Local<v8::Object> object) {
+  return static_cast<T*>(FromJSObject(object));
 }
 
 
-inline void BaseObject::ClearWeak() {
+void BaseObject::MakeWeak() {
+  persistent_handle_.SetWeak(
+      this,
+      [](const v8::WeakCallbackInfo<BaseObject>& data) {
+        BaseObject* obj = data.GetParameter();
+        // Clear the persistent handle so that ~BaseObject() doesn't attempt
+        // to mess with internal fields, since the JS object may have
+        // transitioned into an invalid state.
+        // Refs: https://github.com/nodejs/node/issues/18897
+        obj->persistent_handle_.Reset();
+        delete obj;
+      }, v8::WeakCallbackType::kParameter);
+}
+
+
+void BaseObject::ClearWeak() {
   persistent_handle_.ClearWeak();
+}
+
+
+v8::Local<v8::FunctionTemplate>
+BaseObject::MakeLazilyInitializedJSTemplate(Environment* env) {
+  auto constructor = [](const v8::FunctionCallbackInfo<v8::Value>& args) {
+#ifdef DEBUG
+    CHECK(args.IsConstructCall());
+    CHECK_GT(args.This()->InternalFieldCount(), 0);
+#endif
+    args.This()->SetAlignedPointerInInternalField(0, nullptr);
+  };
+
+  v8::Local<v8::FunctionTemplate> t = env->NewFunctionTemplate(constructor);
+  t->InstanceTemplate()->SetInternalFieldCount(1);
+  return t;
 }
 
 }  // namespace node

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -33,8 +33,10 @@ class Environment;
 
 class BaseObject {
  public:
+  // Associates this object with `handle`. It uses the 0th internal field for
+  // that, and in particular aborts if there is no such field.
   inline BaseObject(Environment* env, v8::Local<v8::Object> handle);
-  virtual ~BaseObject() = default;
+  virtual inline ~BaseObject();
 
   // Returns the wrapped object.  Returns an empty handle when
   // persistent.IsEmpty() is true.
@@ -44,22 +46,29 @@ class BaseObject {
 
   inline Environment* env() const;
 
-  // The handle_ must have an internal field count > 0, and the first
-  // index is reserved for a pointer to this class. This is an
-  // implicit requirement, but Node does not have a case where it's
-  // required that MakeWeak() be called and the internal field not
-  // be set.
-  template <typename Type>
-  inline void MakeWeak(Type* ptr);
+  // Get a BaseObject* pointer, or subclass pointer, for the JS object that
+  // was also passed to the `BaseObject()` constructor initially.
+  // This may return `nullptr` if the C++ object has not been constructed yet,
+  // e.g. when the JS object used `MakeLazilyInitializedJSTemplate`.
+  static inline BaseObject* FromJSObject(v8::Local<v8::Object> object);
+  template<typename T>
+  static inline T* FromJSObject(v8::Local<v8::Object> object);
 
+  // Make the `Persistent` a weak reference and, `delete` this object once
+  // the JS object has been garbage collected.
+  inline void MakeWeak();
+
+  // Undo `MakeWeak()`, i.e. turn this into a strong reference.
   inline void ClearWeak();
+
+  // Utility to create a FunctionTemplate with one internal field (used for
+  // the `BaseObject*` pointer) and a constructor that initializes that field
+  // to `nullptr`.
+  static inline v8::Local<v8::FunctionTemplate> MakeLazilyInitializedJSTemplate(
+      Environment* env);
 
  private:
   BaseObject();
-
-  template <typename Type>
-  static inline void WeakCallback(
-      const v8::WeakCallbackInfo<Type>& data);
 
   // persistent_handle_ needs to be at a fixed offset from the start of the
   // class because it is used by src/node_postmortem_metadata.cc to calculate
@@ -70,6 +79,22 @@ class BaseObject {
   Persistent<v8::Object> persistent_handle_;
   Environment* env_;
 };
+
+
+// Global alias for FromJSObject() to avoid churn.
+template<typename T>
+inline T* Unwrap(v8::Local<v8::Object> obj) {
+  return BaseObject::FromJSObject<T>(obj);
+}
+
+
+#define ASSIGN_OR_RETURN_UNWRAP(ptr, obj, ...)                                \
+  do {                                                                        \
+    *ptr = static_cast<typename std::remove_reference<decltype(*ptr)>::type>( \
+        BaseObject::FromJSObject(obj));                                       \
+    if (*ptr == nullptr)                                                      \
+      return __VA_ARGS__;                                                     \
+  } while (0)
 
 }  // namespace node
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -26,6 +26,7 @@
 
 #include "node_persistent.h"
 #include "v8.h"
+#include <type_traits>  // std::remove_reference
 
 namespace node {
 
@@ -51,7 +52,7 @@ class BaseObject {
   // This may return `nullptr` if the C++ object has not been constructed yet,
   // e.g. when the JS object used `MakeLazilyInitializedJSTemplate`.
   static inline BaseObject* FromJSObject(v8::Local<v8::Object> object);
-  template<typename T>
+  template <typename T>
   static inline T* FromJSObject(v8::Local<v8::Object> object);
 
   // Make the `Persistent` a weak reference and, `delete` this object once
@@ -82,7 +83,7 @@ class BaseObject {
 
 
 // Global alias for FromJSObject() to avoid churn.
-template<typename T>
+template <typename T>
 inline T* Unwrap(v8::Local<v8::Object> obj) {
   return BaseObject::FromJSObject<T>(obj);
 }

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -13,12 +13,6 @@ using v8::Object;
 ConnectWrap::ConnectWrap(Environment* env,
     Local<Object> req_wrap_obj,
     AsyncWrap::ProviderType provider) : ReqWrap(env, req_wrap_obj, provider) {
-  Wrap(req_wrap_obj, this);
-}
-
-
-ConnectWrap::~ConnectWrap() {
-  ClearWrap(object());
 }
 
 }  // namespace node

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -15,7 +15,6 @@ class ConnectWrap : public ReqWrap<uv_connect_t> {
   ConnectWrap(Environment* env,
               v8::Local<v8::Object> req_wrap_obj,
               AsyncWrap::ProviderType provider);
-  ~ConnectWrap();
 
   size_t self_size() const override { return sizeof(*this); }
 };

--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -29,7 +29,6 @@ class ConnectionWrap : public LibuvStreamWrap {
   UVType handle_;
 };
 
-
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -131,7 +131,7 @@ void FSEventWrap::New(const FunctionCallbackInfo<Value>& args) {
 void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
+  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
   CHECK_NE(wrap, nullptr);
   CHECK(!wrap->initialized_);
 

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -93,7 +93,6 @@ HandleWrap::HandleWrap(Environment* env,
       handle_(handle) {
   handle_->data = this;
   HandleScope scope(env->isolate());
-  Wrap(object, this);
   env->handle_wrap_queue()->PushBack(this);
 }
 
@@ -114,7 +113,6 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   if (have_close_callback)
     wrap->MakeCallback(env->onclose_string(), 0, nullptr);
 
-  ClearWrap(wrap->object());
   delete wrap;
 }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -64,7 +64,6 @@ class JSBindingsConnection : public AsyncWrap {
                        Local<Function> callback)
                        : AsyncWrap(env, wrap, PROVIDER_INSPECTORJSBINDING),
                          callback_(env->isolate(), callback) {
-    Wrap(wrap, this);
     Agent* inspector = env->inspector_agent();
     session_ = inspector->Connect(std::unique_ptr<JSBindingsSessionDelegate>(
         new JSBindingsSessionDelegate(env, this)));
@@ -83,9 +82,6 @@ class JSBindingsConnection : public AsyncWrap {
 
   void Disconnect() {
     session_.reset();
-    if (!persistent().IsEmpty()) {
-      ClearWrap(object());
-    }
     delete this;
   }
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -24,12 +24,7 @@ using v8::Value;
 JSStream::JSStream(Environment* env, Local<Object> obj)
     : AsyncWrap(env, obj, AsyncWrap::PROVIDER_JSSTREAM),
       StreamBase(env) {
-  node::Wrap(obj, this);
-  MakeWeak<JSStream>(this);
-}
-
-
-JSStream::~JSStream() {
+  MakeWeak();
 }
 
 

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -16,8 +16,6 @@ class JSStream : public AsyncWrap, public StreamBase {
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context);
 
-  ~JSStream();
-
   bool IsAlive() override;
   bool IsClosing() override;
   int ReadStart() override;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -158,7 +158,6 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   obj->context_.Reset(isolate, context);
 
   env->module_map.emplace(module->GetIdentityHash(), obj);
-  Wrap(that, obj);
 
   that->SetIntegrityLevel(context, IntegrityLevel::kFrozen);
   args.GetReturnValue().Set(that);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -121,7 +121,7 @@ Local<Value> ContextifyContext::CreateDataWrapper(Environment* env) {
   if (wrapper.IsEmpty())
     return scope.Escape(Local<Value>::New(env->isolate(), Local<Value>()));
 
-  Wrap(wrapper, this);
+  wrapper->SetAlignedPointerInInternalField(0, this);
   return scope.Escape(wrapper);
 }
 
@@ -292,11 +292,18 @@ ContextifyContext* ContextifyContext::ContextFromContextifiedSandbox(
 }
 
 // static
+template <typename T>
+ContextifyContext* ContextifyContext::Get(const PropertyCallbackInfo<T>& args) {
+  Local<Value> data = args.Data();
+  return static_cast<ContextifyContext*>(
+      data.As<Object>()->GetAlignedPointerFromInternalField(0));
+}
+
+// static
 void ContextifyContext::PropertyGetterCallback(
     Local<Name> property,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -325,8 +332,7 @@ void ContextifyContext::PropertySetterCallback(
     Local<Name> property,
     Local<Value> value,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -386,8 +392,7 @@ void ContextifyContext::PropertySetterCallback(
 void ContextifyContext::PropertyDescriptorCallback(
     Local<Name> property,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -409,8 +414,7 @@ void ContextifyContext::PropertyDefinerCallback(
     Local<Name> property,
     const PropertyDescriptor& desc,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -472,8 +476,7 @@ void ContextifyContext::PropertyDefinerCallback(
 void ContextifyContext::PropertyDeleterCallback(
     Local<Name> property,
     const PropertyCallbackInfo<Boolean>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -492,8 +495,7 @@ void ContextifyContext::PropertyDeleterCallback(
 // static
 void ContextifyContext::PropertyEnumeratorCallback(
     const PropertyCallbackInfo<Array>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -506,8 +508,7 @@ void ContextifyContext::PropertyEnumeratorCallback(
 void ContextifyContext::IndexedPropertyGetterCallback(
     uint32_t index,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -522,8 +523,7 @@ void ContextifyContext::IndexedPropertySetterCallback(
     uint32_t index,
     Local<Value> value,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -537,8 +537,7 @@ void ContextifyContext::IndexedPropertySetterCallback(
 void ContextifyContext::IndexedPropertyDescriptorCallback(
     uint32_t index,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -553,8 +552,7 @@ void ContextifyContext::IndexedPropertyDefinerCallback(
     uint32_t index,
     const PropertyDescriptor& desc,
     const PropertyCallbackInfo<Value>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())
@@ -568,8 +566,7 @@ void ContextifyContext::IndexedPropertyDefinerCallback(
 void ContextifyContext::IndexedPropertyDeleterCallback(
     uint32_t index,
     const PropertyCallbackInfo<Boolean>& args) {
-  ContextifyContext* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Data().As<Object>());
+  ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
   if (ctx->context_.IsEmpty())

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -885,7 +885,7 @@ class ContextifyScript : public BaseObject {
 
   ContextifyScript(Environment* env, Local<Object> object)
       : BaseObject(env, object) {
-    MakeWeak<ContextifyScript>(this);
+    MakeWeak();
   }
 };
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -55,6 +55,9 @@ class ContextifyContext {
         context()->GetEmbedderData(ContextEmbedderIndex::kSandboxObject));
   }
 
+  template <typename T>
+  static ContextifyContext* Get(const v8::PropertyCallbackInfo<T>& args);
+
  private:
   static void MakeContext(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void IsContext(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4690,7 +4690,6 @@ class PBKDF2Request : public AsyncWrap {
         keylen_(keylen),
         key_(node::Malloc(keylen)),
         iter_(iter) {
-    Wrap(object, this);
   }
 
   ~PBKDF2Request() override {
@@ -4705,8 +4704,6 @@ class PBKDF2Request : public AsyncWrap {
     free(key_);
     key_ = nullptr;
     keylen_ = 0;
-
-    ClearWrap(object());
   }
 
   uv_work_t* work_req() {
@@ -4868,11 +4865,6 @@ class RandomBytesRequest : public AsyncWrap {
         size_(size),
         data_(data),
         free_mode_(free_mode) {
-    Wrap(object, this);
-  }
-
-  ~RandomBytesRequest() override {
-    ClearWrap(object());
   }
 
   uv_work_t* work_req() {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -175,7 +175,7 @@ class SecureContext : public BaseObject {
         ctx_(nullptr),
         cert_(nullptr),
         issuer_(nullptr) {
-    MakeWeak<SecureContext>(this);
+    MakeWeak();
     env->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
   }
 
@@ -403,7 +403,7 @@ class CipherBase : public BaseObject {
         auth_tag_set_(false),
         auth_tag_len_(kNoAuthTagLength),
         pending_auth_failed_(false) {
-    MakeWeak<CipherBase>(this);
+    MakeWeak();
   }
 
  private:
@@ -434,7 +434,7 @@ class Hmac : public BaseObject {
   Hmac(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
         ctx_(nullptr) {
-    MakeWeak<Hmac>(this);
+    MakeWeak();
   }
 
  private:
@@ -459,7 +459,7 @@ class Hash : public BaseObject {
       : BaseObject(env, wrap),
         mdctx_(nullptr),
         finalized_(false) {
-    MakeWeak<Hash>(this);
+    MakeWeak();
   }
 
  private:
@@ -514,7 +514,7 @@ class Sign : public SignBase {
   static void SignFinal(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   Sign(Environment* env, v8::Local<v8::Object> wrap) : SignBase(env, wrap) {
-    MakeWeak<Sign>(this);
+    MakeWeak();
   }
 };
 
@@ -537,7 +537,7 @@ class Verify : public SignBase {
   static void VerifyFinal(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   Verify(Environment* env, v8::Local<v8::Object> wrap) : SignBase(env, wrap) {
-    MakeWeak<Verify>(this);
+    MakeWeak();
   }
 };
 
@@ -605,7 +605,7 @@ class DiffieHellman : public BaseObject {
         initialised_(false),
         verifyError_(0),
         dh(nullptr) {
-    MakeWeak<DiffieHellman>(this);
+    MakeWeak();
   }
 
  private:
@@ -641,7 +641,7 @@ class ECDH : public BaseObject {
       : BaseObject(env, wrap),
         key_(key),
         group_(EC_KEY_get0_group(key_)) {
-    MakeWeak<ECDH>(this);
+    MakeWeak();
     CHECK_NE(group_, nullptr);
   }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -99,7 +99,7 @@ FileHandle::FileHandle(Environment* env, int fd, Local<Object> obj)
                 AsyncWrap::PROVIDER_FILEHANDLE),
       StreamBase(env),
       fd_(fd) {
-  MakeWeak<FileHandle>(this);
+  MakeWeak();
   v8::PropertyAttribute attr =
       static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
   object()->DefineOwnProperty(env->context(),

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -28,11 +28,6 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
 
   FSReqBase(Environment* env, Local<Object> req, AsyncWrap::ProviderType type)
       : ReqWrap(env, req, type) {
-    Wrap(object(), this);
-  }
-
-  virtual ~FSReqBase() {
-    ClearWrap(object());
   }
 
   void Init(const char* syscall,
@@ -249,10 +244,10 @@ class FileHandle : public AsyncWrap, public StreamBase {
                   env->fdclose_constructor_template()
                       ->NewInstance(env->context()).ToLocalChecked(),
                   AsyncWrap::PROVIDER_FILEHANDLECLOSEREQ) {
-      Wrap(object(), this);
       promise_.Reset(env->isolate(), promise);
       ref_.Reset(env->isolate(), ref);
     }
+
     ~CloseReq() {
       uv_fs_req_cleanup(req());
       promise_.Reset();

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -244,11 +244,6 @@ Http2Session::Http2Settings::Http2Settings(
   Init();
 }
 
-Http2Session::Http2Settings::~Http2Settings() {
-  if (!object().IsEmpty())
-    ClearWrap(object());
-}
-
 // Generates a Buffer that contains the serialized payload of a SETTINGS
 // frame. This can be used, for instance, to create the Base64-encoded
 // content of an Http2-Settings header field.
@@ -458,7 +453,7 @@ Http2Session::Http2Session(Environment* env,
                            nghttp2_session_type type)
     : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTP2SESSION),
       session_type_(type) {
-  MakeWeak<Http2Session>(this);
+  MakeWeak();
   statistics_.start_time = uv_hrtime();
 
   // Capture the configuration options for this session
@@ -1668,7 +1663,7 @@ Http2Stream::Http2Stream(
                    session_(session),
                    id_(id),
                    current_headers_category_(category) {
-  MakeWeak<Http2Stream>(this);
+  MakeWeak();
   statistics_.start_time = uv_hrtime();
 
   // Limit the number of header pairs
@@ -2614,11 +2609,6 @@ Http2Session::Http2Ping::Http2Ping(
                     AsyncWrap::PROVIDER_HTTP2PING),
           session_(session),
           startTime_(uv_hrtime()) { }
-
-Http2Session::Http2Ping::~Http2Ping() {
-  if (!object().IsEmpty())
-    ClearWrap(object());
-}
 
 void Http2Session::Http2Ping::Send(uint8_t* payload) {
   uint8_t data[8];

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -1149,7 +1149,6 @@ class Http2StreamPerformanceEntry : public PerformanceEntry {
 class Http2Session::Http2Ping : public AsyncWrap {
  public:
   explicit Http2Ping(Http2Session* session);
-  ~Http2Ping();
 
   size_t self_size() const override { return sizeof(*this); }
 
@@ -1170,7 +1169,6 @@ class Http2Session::Http2Settings : public AsyncWrap {
  public:
   explicit Http2Settings(Environment* env);
   explicit Http2Settings(Http2Session* session);
-  ~Http2Settings();
 
   size_t self_size() const override { return sizeof(*this); }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -151,13 +151,7 @@ class Parser : public AsyncWrap, public StreamListener {
       : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTPPARSER),
         current_buffer_len_(0),
         current_buffer_data_(nullptr) {
-    Wrap(object(), this);
     Init(type);
-  }
-
-
-  ~Parser() override {
-    ClearWrap(object());
   }
 
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -259,7 +259,7 @@ class ConverterObject : public BaseObject, Converter {
                   BaseObject(env, wrap),
                   Converter(converter, sub),
                   ignoreBOM_(ignoreBOM) {
-    MakeWeak<ConverterObject>(this);
+    MakeWeak();
 
     switch (ucnv_getType(converter)) {
       case UCNV_UTF8:

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -244,9 +244,10 @@ v8::Local<v8::Object> AddressToJS(
 
 template <typename T, int (*F)(const typename T::HandleType*, sockaddr*, int*)>
 void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  T* const wrap = Unwrap<T>(args.Holder());
-  if (wrap == nullptr)
-    return args.GetReturnValue().Set(UV_EBADF);
+  T* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap,
+                          args.Holder(),
+                          args.GetReturnValue().Set(UV_EBADF));
   CHECK(args[0]->IsObject());
   sockaddr_storage storage;
   int addrlen = sizeof(storage);

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -86,7 +86,7 @@ class DeserializerContext : public BaseObject,
 SerializerContext::SerializerContext(Environment* env, Local<Object> wrap)
   : BaseObject(env, wrap),
     serializer_(env->isolate(), this) {
-  MakeWeak<SerializerContext>(this);
+  MakeWeak();
 }
 
 void SerializerContext::ThrowDataCloneError(Local<String> message) {
@@ -274,7 +274,7 @@ DeserializerContext::DeserializerContext(Environment* env,
     deserializer_(env->isolate(), data_, length_, this) {
   object()->Set(env->context(), env->buffer_string(), buffer).FromJust();
 
-  MakeWeak<DeserializerContext>(this);
+  MakeWeak();
 }
 
 MaybeLocal<Object> DeserializerContext::ReadHostObject(Isolate* isolate) {

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -83,8 +83,7 @@ static void Delete(uv_handle_t* handle) {
 StatWatcher::StatWatcher(Environment* env, Local<Object> wrap)
     : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_STATWATCHER),
       watcher_(new uv_fs_poll_t) {
-  MakeWeak<StatWatcher>(this);
-  Wrap(wrap, this);
+  MakeWeak();
   uv_fs_poll_init(env->event_loop(), watcher_);
   watcher_->data = static_cast<void*>(this);
 }
@@ -191,7 +190,7 @@ void StatWatcher::Stop(const FunctionCallbackInfo<Value>& args) {
 
 void StatWatcher::Stop() {
   uv_fs_poll_stop(watcher_);
-  MakeWeak<StatWatcher>(this);
+  MakeWeak();
 }
 
 

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -37,7 +37,7 @@ class NodeCategorySet : public BaseObject {
                   Local<Object> wrap,
                   std::set<std::string> categories) :
         BaseObject(env, wrap), categories_(categories) {
-    MakeWeak<NodeCategorySet>(this);
+    MakeWeak();
   }
 
   bool enabled_ = false;

--- a/src/node_wrap.h
+++ b/src/node_wrap.h
@@ -33,6 +33,8 @@
 
 namespace node {
 
+// TODO(addaleax): Use real inheritance for the JS object templates to avoid
+// this unnecessary case switching.
 #define WITH_GENERIC_UV_STREAM(env, obj, BODY, ELSE)                          \
     do {                                                                      \
       if (env->tcp_constructor_template().IsEmpty() == false &&               \

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -89,8 +89,6 @@ class ZCtx : public AsyncWrap {
         refs_(0),
         gzip_id_bytes_read_(0),
         write_result_(nullptr) {
-    MakeWeak<ZCtx>(this);
-    Wrap(wrap, this);
   }
 
 
@@ -662,7 +660,7 @@ class ZCtx : public AsyncWrap {
   void Unref() {
     CHECK_GT(refs_, 0);
     if (--refs_ == 0) {
-      MakeWeak<ZCtx>(this);
+      MakeWeak();
     }
   }
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -102,12 +102,7 @@ void PipeWrap::Initialize(Local<Object> target,
   env->set_pipe_constructor_template(t);
 
   // Create FunctionTemplate for PipeConnectWrap.
-  auto constructor = [](const FunctionCallbackInfo<Value>& args) {
-    CHECK(args.IsConstructCall());
-    ClearWrap(args.This());
-  };
-  auto cwt = FunctionTemplate::New(env->isolate(), constructor);
-  cwt->InstanceTemplate()->SetInternalFieldCount(1);
+  auto cwt = BaseObject::MakeLazilyInitializedJSTemplate(env);
   AsyncWrap::AddWrapMethods(env, cwt);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap");

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -243,12 +243,6 @@ SimpleShutdownWrap<OtherBase>::SimpleShutdownWrap(
     OtherBase(stream->stream_env(),
               req_wrap_obj,
               AsyncWrap::PROVIDER_SHUTDOWNWRAP) {
-  Wrap(req_wrap_obj, static_cast<AsyncWrap*>(this));
-}
-
-template <typename OtherBase>
-SimpleShutdownWrap<OtherBase>::~SimpleShutdownWrap() {
-  ClearWrap(static_cast<AsyncWrap*>(this)->object());
 }
 
 inline ShutdownWrap* StreamBase::CreateShutdownWrap(
@@ -264,12 +258,6 @@ SimpleWriteWrap<OtherBase>::SimpleWriteWrap(
     OtherBase(stream->stream_env(),
               req_wrap_obj,
               AsyncWrap::PROVIDER_WRITEWRAP) {
-  Wrap(req_wrap_obj, static_cast<AsyncWrap*>(this));
-}
-
-template <typename OtherBase>
-SimpleWriteWrap<OtherBase>::~SimpleWriteWrap() {
-  ClearWrap(static_cast<AsyncWrap*>(this)->object());
 }
 
 inline WriteWrap* StreamBase::CreateWriteWrap(
@@ -461,7 +449,7 @@ inline void StreamReq::ResetObject(v8::Local<v8::Object> obj) {
 #ifdef DEBUG
   CHECK_GT(obj->InternalFieldCount(), StreamReq::kStreamReqField);
 #endif
-  ClearWrap(obj);
+  obj->SetAlignedPointerInInternalField(0, nullptr);  // BaseObject field.
   obj->SetAlignedPointerInInternalField(StreamReq::kStreamReqField, nullptr);
 }
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -286,12 +286,6 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
   uv_stream_t* send_handle = nullptr;
 
   if (IsIPCPipe() && !send_handle_obj.IsEmpty()) {
-    // TODO(addaleax): This relies on the fact that HandleWrap comes first
-    // as a superclass of each individual subclass.
-    // There are similar assumptions in other places in the code base.
-    // A better idea would be having all BaseObject's internal pointers
-    // refer to the BaseObject* itself; this would require refactoring
-    // throughout the code base but makes Node rely much less on C++ quirks.
     HandleWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, send_handle_obj, UV_EINVAL);
     send_handle = reinterpret_cast<uv_stream_t*>(wrap->GetHandle());

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -351,7 +351,6 @@ class SimpleShutdownWrap : public ShutdownWrap, public OtherBase {
  public:
   SimpleShutdownWrap(StreamBase* stream,
                      v8::Local<v8::Object> req_wrap_obj);
-  ~SimpleShutdownWrap();
 
   AsyncWrap* GetAsyncWrap() override { return this; }
   size_t self_size() const override { return sizeof(*this); }
@@ -362,7 +361,6 @@ class SimpleWriteWrap : public WriteWrap, public OtherBase {
  public:
   SimpleWriteWrap(StreamBase* stream,
                   v8::Local<v8::Object> req_wrap_obj);
-  ~SimpleWriteWrap();
 
   AsyncWrap* GetAsyncWrap() override { return this; }
   size_t self_size() const override { return sizeof(*this) + StorageSize(); }

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -17,7 +17,7 @@ StreamPipe::StreamPipe(StreamBase* source,
                        StreamBase* sink,
                        Local<Object> obj)
     : AsyncWrap(source->stream_env(), obj, AsyncWrap::PROVIDER_STREAMPIPE) {
-  MakeWeak(this);
+  MakeWeak();
 
   CHECK_NE(sink, nullptr);
   CHECK_NE(source, nullptr);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -26,7 +26,6 @@
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_internals.h"
-#include "node_wrap.h"
 #include "connect_wrap.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
@@ -117,12 +116,8 @@ void TCPWrap::Initialize(Local<Object> target,
   env->set_tcp_constructor_template(t);
 
   // Create FunctionTemplate for TCPConnectWrap.
-  auto constructor = [](const FunctionCallbackInfo<Value>& args) {
-    CHECK(args.IsConstructCall());
-    ClearWrap(args.This());
-  };
-  auto cwt = FunctionTemplate::New(env->isolate(), constructor);
-  cwt->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<FunctionTemplate> cwt =
+      BaseObject::MakeLazilyInitializedJSTemplate(env);
   AsyncWrap::AddWrapMethods(env, cwt);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap");

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -115,7 +115,8 @@ class TimerWrap : public HandleWrap {
   }
 
   static void Start(const FunctionCallbackInfo<Value>& args) {
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
+    TimerWrap* wrap;
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
     CHECK(HandleWrap::IsAlive(wrap));
 
@@ -125,7 +126,8 @@ class TimerWrap : public HandleWrap {
   }
 
   static void Stop(const FunctionCallbackInfo<Value>& args) {
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
+    TimerWrap* wrap;
+    ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
     CHECK(HandleWrap::IsAlive(wrap));
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -68,8 +68,7 @@ TLSWrap::TLSWrap(Environment* env,
       shutdown_(false),
       cycle_depth_(0),
       eof_(false) {
-  node::Wrap(object(), this);
-  MakeWeak(this);
+  MakeWeak();
 
   // sc comes from an Unwrap. Make sure it was assigned.
   CHECK_NE(sc, nullptr);
@@ -873,16 +872,9 @@ void TLSWrap::Initialize(Local<Object> target,
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);
 
-  auto constructor = [](const FunctionCallbackInfo<Value>& args) {
-    CHECK(args.IsConstructCall());
-    args.This()->SetAlignedPointerInInternalField(0, nullptr);
-  };
-
+  Local<FunctionTemplate> t = BaseObject::MakeLazilyInitializedJSTemplate(env);
   Local<String> tlsWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "TLSWrap");
-
-  auto t = env->NewFunctionTemplate(constructor);
-  t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(tlsWrapString);
 
   Local<FunctionTemplate> get_write_queue_size =

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -53,7 +53,6 @@ using AsyncHooks = Environment::AsyncHooks;
 class SendWrap : public ReqWrap<uv_udp_send_t> {
  public:
   SendWrap(Environment* env, Local<Object> req_wrap_obj, bool have_callback);
-  ~SendWrap();
   inline bool have_callback() const;
   size_t msg_size;
   size_t self_size() const override { return sizeof(*this); }
@@ -67,23 +66,11 @@ SendWrap::SendWrap(Environment* env,
                    bool have_callback)
     : ReqWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_UDPSENDWRAP),
       have_callback_(have_callback) {
-  Wrap(req_wrap_obj, this);
-}
-
-
-SendWrap::~SendWrap() {
-  ClearWrap(object());
 }
 
 
 inline bool SendWrap::have_callback() const {
   return have_callback_;
-}
-
-
-static void NewSendWrap(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args.IsConstructCall());
-  ClearWrap(args.This());
 }
 
 
@@ -153,8 +140,7 @@ void UDPWrap::Initialize(Local<Object> target,
 
   // Create FunctionTemplate for SendWrap
   Local<FunctionTemplate> swt =
-      FunctionTemplate::New(env->isolate(), NewSendWrap);
-  swt->InstanceTemplate()->SetInternalFieldCount(1);
+      BaseObject::MakeLazilyInitializedJSTemplate(env);
   AsyncWrap::AddWrapMethods(env, swt);
   Local<String> sendWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap");

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -217,25 +217,6 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                     length).ToLocalChecked();
 }
 
-template <typename TypeName>
-void Wrap(v8::Local<v8::Object> object, TypeName* pointer) {
-  CHECK_EQ(false, object.IsEmpty());
-  CHECK_GT(object->InternalFieldCount(), 0);
-  object->SetAlignedPointerInInternalField(0, pointer);
-}
-
-void ClearWrap(v8::Local<v8::Object> object) {
-  Wrap<void>(object, nullptr);
-}
-
-template <typename TypeName>
-TypeName* Unwrap(v8::Local<v8::Object> object) {
-  CHECK_EQ(false, object.IsEmpty());
-  CHECK_GT(object->InternalFieldCount(), 0);
-  void* pointer = object->GetAlignedPointerFromInternalField(0);
-  return static_cast<TypeName*>(pointer);
-}
-
 void SwapBytes16(char* data, size_t nbytes) {
   CHECK_EQ(nbytes % 2, 0);
 

--- a/src/util.h
+++ b/src/util.h
@@ -35,7 +35,6 @@
 #include <string.h>
 
 #include <functional>  // std::function
-#include <type_traits>  // std::remove_reference
 
 namespace node {
 

--- a/src/util.h
+++ b/src/util.h
@@ -84,8 +84,6 @@ NO_RETURN void Abort();
 NO_RETURN void Assert(const char* const (*args)[4]);
 void DumpBacktrace(FILE* fp);
 
-template <typename T> using remove_reference = std::remove_reference<T>;
-
 #define FIXED_ONE_BYTE_STRING(isolate, string)                                \
   (node::OneByteString((isolate), (string), sizeof(string) - 1))
 
@@ -134,14 +132,6 @@ template <typename T> using remove_reference = std::remove_reference<T>;
 #define CHECK_NE(a, b) CHECK((a) != (b))
 
 #define UNREACHABLE() ABORT()
-
-#define ASSIGN_OR_RETURN_UNWRAP(ptr, obj, ...)                                \
-  do {                                                                        \
-    *ptr =                                                                    \
-        Unwrap<typename node::remove_reference<decltype(**ptr)>::type>(obj);  \
-    if (*ptr == nullptr)                                                      \
-      return __VA_ARGS__;                                                     \
-  } while (0)
 
 // TAILQ-style intrusive list node.
 template <typename T>
@@ -249,13 +239,6 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const unsigned char* data,
                                            int length = -1);
-
-inline void Wrap(v8::Local<v8::Object> object, void* pointer);
-
-inline void ClearWrap(v8::Local<v8::Object> object);
-
-template <typename TypeName>
-inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
 // Swaps bytes in place. nbytes is the number of bytes to swap and must be a
 // multiple of the word size (checked by function).

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -72,7 +72,11 @@ TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
   const Argv argv;
   Env env{handle_scope, argv};
 
-  v8::Local<v8::Object> object = v8::Object::New(isolate_);
+  v8::Local<v8::ObjectTemplate> obj_templ = v8::ObjectTemplate::New(isolate_);
+  obj_templ->SetInternalFieldCount(1);
+
+  v8::Local<v8::Object> object =
+      obj_templ->NewInstance(env.context()).ToLocalChecked();
   node::BaseObject obj(*env, object);
 
   auto expected = reinterpret_cast<uintptr_t>(&obj.persistent());


### PR DESCRIPTION
* **src: access `ContextifyContext*` more directly in property cbs**

* **src: refactor `BaseObject` internal field management**
    
    - Instead of storing a pointer whose type refers to the specific
      subclass of `BaseObject`, just store a `BaseObject*` directly.
      This means in particular that one can cast to classes along
      the way of the inheritance chain without issues, and that
      `BaseObject*` no longer needs to be the first superclass
      in the case of multiple inheritance.
    
      In particular, this renders hack-y solutions to this problem (like
      ddc19be6de1ba263d9c175b2760696e7b9918b25) obsolete and addresses
      a `TODO` comment of mine.
    
    - Move wrapping/unwrapping methods to the `BaseObject` class.
      We use these almost exclusively for `BaseObject`s, and I hope
      that this gives a better idea of how (and for what) these are used
      in our code.
    
    - Perform initialization/deinitialization of the internal field
      in the `BaseObject*` constructor/destructor. This makes the code
      a bit more obviously correct, avoids explicit calls for this
      in subclass constructors, and in particular allows us to avoid
      crash situations when we previously called `ClearWrap()`
      during GC.
    
      This also means that we enforce that the object passed to the
      `BaseObject` constructor needs to have an internal field.
      This is the only reason for the test change.
    
    - Change the signature of `MakeWeak()` to not require a pointer
      argument. Previously, this would always have been the same
      as `this`, and no other value made sense. Also, the parameter
      was something that I personally found somewhat confusing
      when becoming familiar with Node’s code.
    
    - Add a `TODO` comment that motivates switching to real inheritance
      for the JS types we expose from the native side. This patch
      brings us a lot closer to being able to do that.
    
    - Some less significant drive-by cleanup.
    
    Since we *effectively* already store the `BaseObject*` pointer
    anyway since ddc19be6de1ba263d9c175b2760696e7b9918b25, I do not
    think that this is going to have any impact on diagnostic tooling.
    
    Fixes: https://github.com/nodejs/node/issues/18897


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
