### PR TITLE
doc: update examples of the final "callback" argument for fs.access()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -771,7 +771,8 @@ fs.access('./package.json', fs.constants.F_OK, (err) => {
 
 // Check if `package.json` file is readable.
 fs.access('./package.json', fs.constants.R_OK, (err) => {
-  console.log(err ? 'package.json is not readable' : 'package.json is readable');
+  console
+    .log(err ? 'package.json is not readable' : 'package.json is readable');
 });
 
 // Check if `package.json` is writable.
@@ -783,7 +784,8 @@ fs.access('./package.json', fs.constants.W_OK, (err) => {
   );
 });
 
-// Check if `package.json` exists in the current directory, and if it is writable.
+// Check if `package.json` exists in the current directory, and if it is
+// writable.
 fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
   // If there is an error, print the error in console and exit.
   const isNonExistenceError = err && err.code === 'ENOENT';

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -761,7 +761,7 @@ no effect on Windows (will behave like `fs.constants.F_OK`).
 The final argument, `callback`, is a callback function that is invoked with
 a possible error argument. If any of the accessibility checks fail, the error
 argument will be an `Error` object. The following examples check if
-`package.json` exists, and/or if it could be written to.
+`package.json` exists, and if it is readable or writable.
 
 ```js
 // Check if `package.json` exists in the current directory.
@@ -769,22 +769,21 @@ fs.access('./package.json', fs.constants.F_OK, (err) => {
   console.log(err ? 'package.json does not exist' : 'package.json exists');
 });
 
-// Check if package.json file could be read.
+// Check if `package.json` file is readable.
 fs.access('./package.json', fs.constants.R_OK, (err) => {
-  console.log(err ? 'package.json could not be read' : 'package.json read');
+  console.log(err ? 'package.json is not readable' : 'package.json is readable');
 });
 
-// Check if `package.json` could be written to.
+// Check if `package.json` is writable.
 fs.access('./package.json', fs.constants.W_OK, (err) => {
   console.log(
     err ?
-      'package.json could not be written to' :
-      'package.json could be written to'
+      'package.json is not writable' :
+      'package.json is writable'
   );
 });
 
-// Check if `package.json` exists in the current directory and it could be
-// written to.
+// Check if `package.json` exists in the current directory, and if it is writable.
 fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
   // If there is an error, print the error in console and exit.
   const isNonExistenceError = err && err.code === 'ENOENT';
@@ -797,7 +796,7 @@ fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
         'package.json is read-only'
     );
   } else {
-    console.log('package.json exists, and it could be written to');
+    console.log('package.json exists, and it is writable');
   }
 });
 ```

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -760,12 +760,45 @@ no effect on Windows (will behave like `fs.constants.F_OK`).
 
 The final argument, `callback`, is a callback function that is invoked with
 a possible error argument. If any of the accessibility checks fail, the error
-argument will be an `Error` object. The following example checks if the file
-`/etc/passwd` can be read and written by the current process.
+argument will be an `Error` object. The following examples check if
+`package.json` exists, and/or if it could be written to.
 
 ```js
-fs.access('/etc/passwd', fs.constants.R_OK | fs.constants.W_OK, (err) => {
-  console.log(err ? 'no access!' : 'can read/write');
+// Check if `package.json` exists in the current directory.
+fs.access('./package.json', fs.constants.F_OK, (err) => {
+  console.log(err ? 'package.json does not exist' : 'package.json exists');
+});
+
+// Check if package.json file could be read.
+fs.access('./package.json', fs.constants.R_OK, (err) => {
+  console.log(err ? 'package.json could not be read' : 'package.json read');
+});
+
+// Check if `package.json` could be written to.
+fs.access('./package.json', fs.constants.W_OK, (err) => {
+  console.log(
+    err ?
+      'package.json could not be written to' :
+      'package.json could be written to'
+  );
+});
+
+// Check if `package.json` exists in the current directory and it could be
+// written to.
+fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
+  // If there is an error, print the error in console and exit.
+  const isNonExistenceError = err && err.code === 'ENOENT';
+  const isReadOnlyError = err && err.code === 'EPERM';
+
+  if (isNonExistenceError || isReadOnlyError) {
+    console.error(
+      isNonExistenceError ?
+        'package.json does not exist' :
+        'package.json is read-only'
+    );
+  } else {
+    console.log('package.json exists, and it could be written to');
+  }
 });
 ```
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -767,22 +767,22 @@ argument will be an `Error` object. The following examples check if
 const file = 'package.json';
 
 // Check if the file exists in the current directory.
-fs.access('./package.json', fs.constants.F_OK, (err) => {
+fs.access(file, fs.constants.F_OK, (err) => {
   console.log(`${file} ${err ? 'does not exist' : 'exists'}`);
 });
 
 // Check if the file is readable.
-fs.access('./package.json', fs.constants.R_OK, (err) => {
+fs.access(file, fs.constants.R_OK, (err) => {
   console.log(`${file} ${err ? 'is not readable' : 'is readable'}`);
 });
 
 // Check if the file is writable.
-fs.access('./package.json', fs.constants.W_OK, (err) => {
+fs.access(file, fs.constants.W_OK, (err) => {
   console.log(`${file} ${err ? 'is not writable' : 'is writable'}`);
 });
 
 // Check if the file exists in the current directory, and if it is writable.
-fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
+fs.access(file, fs.constants.F_OK | fs.constants.W_OK, (err) => {
   if (err) {
     console.error(
       `${file} ${err.code === 'ENOENT' ? 'does not exist' : 'is read-only'}`);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -764,41 +764,30 @@ argument will be an `Error` object. The following examples check if
 `package.json` exists, and if it is readable or writable.
 
 ```js
-// Check if `package.json` exists in the current directory.
+const file = 'package.json';
+
+// Check if the file exists in the current directory.
 fs.access('./package.json', fs.constants.F_OK, (err) => {
-  console.log(err ? 'package.json does not exist' : 'package.json exists');
+  console.log(`${file} ${err ? 'does not exist' : 'exists'}`);
 });
 
-// Check if `package.json` file is readable.
+// Check if the file is readable.
 fs.access('./package.json', fs.constants.R_OK, (err) => {
-  console
-    .log(err ? 'package.json is not readable' : 'package.json is readable');
+  console.log(`${file} ${err ? 'is not readable' : 'is readable'}`);
 });
 
-// Check if `package.json` is writable.
+// Check if the file is writable.
 fs.access('./package.json', fs.constants.W_OK, (err) => {
-  console.log(
-    err ?
-      'package.json is not writable' :
-      'package.json is writable'
-  );
+  console.log(`${file} ${err ? 'is not writable' : 'is writable'}`);
 });
 
-// Check if `package.json` exists in the current directory, and if it is
-// writable.
+// Check if the file exists in the current directory, and if it is writable.
 fs.access('./package.json', fs.constants.F_OK | fs.constants.W_OK, (err) => {
-  // If there is an error, print the error in console and exit.
-  const isNonExistenceError = err && err.code === 'ENOENT';
-  const isReadOnlyError = err && err.code === 'EPERM';
-
-  if (isNonExistenceError || isReadOnlyError) {
+  if (err) {
     console.error(
-      isNonExistenceError ?
-        'package.json does not exist' :
-        'package.json is read-only'
-    );
+      `${file} ${err.code === 'ENOENT' ? 'does not exist' : 'is read-only'}`);
   } else {
-    console.log('package.json exists, and it is writable');
+    console.log(`${file} exists, and it is writable`);
   }
 });
 ```


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: #17508

Per this following comment (_as the origin of the aspiration to help out #17508_), I've confirmed with the @ gireeshpunathil, and worked with the suggested content of #17578.
> #17578 was never landed but has enough content in for a first timer to pick and progress.

Hope that the attempted `fs.access` snippets look okay in the PR. Happy to update according to review feedback. Thanks for reviewing in advance.