### PR TITLE
benchmark: fix next-tick-depth

### DIFF
--- a/benchmark/process/next-tick-depth-args.js
+++ b/benchmark/process/next-tick-depth-args.js
@@ -8,13 +8,14 @@ const bench = common.createBenchmark(main, {
 process.maxTickDepth = Infinity;
 
 function main({ n }) {
+  let counter = n;
   function cb4(arg1, arg2, arg3, arg4) {
-    if (--n) {
-      if (n % 4 === 0)
+    if (--counter) {
+      if (counter % 4 === 0)
         process.nextTick(cb4, 3.14, 1024, true, false);
-      else if (n % 3 === 0)
+      else if (counter % 3 === 0)
         process.nextTick(cb3, 512, true, null);
-      else if (n % 2 === 0)
+      else if (counter % 2 === 0)
         process.nextTick(cb2, false, 5.1);
       else
         process.nextTick(cb1, 0);
@@ -22,12 +23,12 @@ function main({ n }) {
       bench.end(n);
   }
   function cb3(arg1, arg2, arg3) {
-    if (--n) {
-      if (n % 4 === 0)
+    if (--counter) {
+      if (counter % 4 === 0)
         process.nextTick(cb4, 3.14, 1024, true, false);
-      else if (n % 3 === 0)
+      else if (counter % 3 === 0)
         process.nextTick(cb3, 512, true, null);
-      else if (n % 2 === 0)
+      else if (counter % 2 === 0)
         process.nextTick(cb2, false, 5.1);
       else
         process.nextTick(cb1, 0);
@@ -35,12 +36,12 @@ function main({ n }) {
       bench.end(n);
   }
   function cb2(arg1, arg2) {
-    if (--n) {
-      if (n % 4 === 0)
+    if (--counter) {
+      if (counter % 4 === 0)
         process.nextTick(cb4, 3.14, 1024, true, false);
-      else if (n % 3 === 0)
+      else if (counter % 3 === 0)
         process.nextTick(cb3, 512, true, null);
-      else if (n % 2 === 0)
+      else if (counter % 2 === 0)
         process.nextTick(cb2, false, 5.1);
       else
         process.nextTick(cb1, 0);
@@ -48,12 +49,12 @@ function main({ n }) {
       bench.end(n);
   }
   function cb1(arg1) {
-    if (--n) {
-      if (n % 4 === 0)
+    if (--counter) {
+      if (counter % 4 === 0)
         process.nextTick(cb4, 3.14, 1024, true, false);
-      else if (n % 3 === 0)
+      else if (counter % 3 === 0)
         process.nextTick(cb3, 512, true, null);
-      else if (n % 2 === 0)
+      else if (counter % 2 === 0)
         process.nextTick(cb2, false, 5.1);
       else
         process.nextTick(cb1, 0);

--- a/benchmark/process/next-tick-depth.js
+++ b/benchmark/process/next-tick-depth.js
@@ -7,11 +7,11 @@ const bench = common.createBenchmark(main, {
 process.maxTickDepth = Infinity;
 
 function main({ n }) {
-
+  let counter = n;
   bench.start();
   process.nextTick(onNextTick);
   function onNextTick() {
-    if (--n)
+    if (--counter)
       process.nextTick(onNextTick);
     else
       bench.end(n);


### PR DESCRIPTION
A recent change made this benchmark fail by always finishing with 0 iterations. Restore a counter variable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
