### PR TITLE
benchmark: track exec time in next-tick-exec

### DIFF
--- a/benchmark/process/next-tick-exec-args.js
+++ b/benchmark/process/next-tick-exec-args.js
@@ -5,8 +5,11 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
+  function onNextTick(i) {
+    if (i + 1 === n)
+      bench.end(n);
+  }
 
-  bench.start();
   for (var i = 0; i < n; i++) {
     if (i % 4 === 0)
       process.nextTick(onNextTick, i, true, 10, 'test');
@@ -17,8 +20,6 @@ function main({ n }) {
     else
       process.nextTick(onNextTick, i);
   }
-  function onNextTick(i) {
-    if (i + 1 === n)
-      bench.end(n);
-  }
+
+  bench.start();
 }

--- a/benchmark/process/next-tick-exec.js
+++ b/benchmark/process/next-tick-exec.js
@@ -5,13 +5,14 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
-
-  bench.start();
-  for (var i = 0; i < n; i++) {
-    process.nextTick(onNextTick, i);
-  }
   function onNextTick(i) {
     if (i + 1 === n)
       bench.end(n);
   }
+
+  for (var i = 0; i < n; i++) {
+    process.nextTick(onNextTick, i);
+  }
+
+  bench.start();
 }


### PR DESCRIPTION
The next-tick-exec benchmarks were meant to track nextTick execution time but due to an error (on my part... 😆), they actually track addition and execution.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
