### PR TITLE
http: client add destroy as alias to abort

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -526,6 +526,13 @@ added: v0.3.8
 Marks the request as aborting. Calling this will cause remaining data
 in the response to be dropped and the socket to be destroyed.
 
+### request.destroy()
+<!-- YAML
+added: REPLACEME
+-->
+
+Alias for `request.abort`.
+
 ### request.aborted
 <!-- YAML
 added: v0.11.14

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -314,11 +314,11 @@ ClientRequest.prototype.abort = function abort() {
   }
 };
 
+ClientRequest.prototype.destroy = ClientRequest.prototype.abort;
 
 function emitAbortNT() {
   this.emit('abort');
 }
-
 
 function createHangUpError() {
   // eslint-disable-next-line no-restricted-syntax
@@ -326,7 +326,6 @@ function createHangUpError() {
   error.code = 'ECONNRESET';
   return error;
 }
-
 
 function socketCloseListener() {
   var socket = this;

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const http = require('http');
 const Countdown = require('../common/countdown');
+const assert = require('assert');
 
 const N = 8;
 
@@ -38,7 +39,10 @@ server.listen(0, common.mustCall(() => {
 
   const requests = [];
   const reqCountdown = new Countdown(N, () => {
-    requests.forEach((req) => req.abort());
+    requests.forEach((req) => {
+      assert.strictEqual(req.abort, req.destroy);
+      req.abort();
+    });
   });
 
   const options = { port: server.address().port };


### PR DESCRIPTION
ClientRequest wants to be a Writable stream. Therefore it should have a `destroy` method which I believe could simply be an alias to `abort`. For now at least...

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
