### PR TITLE
tls: cleanup onhandshakestart callback

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -62,32 +62,28 @@ const noop = () => {};
 function onhandshakestart(now) {
   debug('onhandshakestart');
 
-  assert(now >= this.lastHandshakeTime);
+  const { lastHandshakeTime } = this;
+  assert(now >= lastHandshakeTime);
 
-  const owner = this.owner;
-
-  if ((now - this.lastHandshakeTime) >= tls.CLIENT_RENEG_WINDOW * 1000) {
-    this.handshakes = 0;
-  }
-
-  const first = (this.lastHandshakeTime === 0);
   this.lastHandshakeTime = now;
-  if (first) return;
 
-  if (++this.handshakes > tls.CLIENT_RENEG_LIMIT) {
-    // Defer the error event to the next tick. We're being called from OpenSSL's
-    // state machine and OpenSSL is not re-entrant. We cannot allow the user's
-    // callback to destroy the connection right now, it would crash and burn.
-    setImmediate(emitSessionAttackError, owner);
+  // If this is the first handshake we can skip the rest of the checks.
+  if (lastHandshakeTime === 0)
+    return;
+
+  if ((now - lastHandshakeTime) >= tls.CLIENT_RENEG_WINDOW * 1000)
+    this.handshakes = 1;
+  else
+    this.handshakes++;
+
+  const { owner } = this;
+  if (this.handshakes > tls.CLIENT_RENEG_LIMIT) {
+    owner._emitTLSError(new ERR_TLS_SESSION_ATTACK());
+    return;
   }
 
-  if (owner[kDisableRenegotiation] && this.handshakes > 0) {
+  if (owner[kDisableRenegotiation])
     owner._emitTLSError(new ERR_TLS_RENEGOTIATION_DISABLED());
-  }
-}
-
-function emitSessionAttackError(socket) {
-  socket._emitTLSError(new ERR_TLS_SESSION_ATTACK());
 }
 
 function onhandshakedone() {


### PR DESCRIPTION
Re-arrange and cleanup the flow of the onhandshakestart to be
more clear and less repetitive. Exit early in the case of a
first ever handshake for a given connection.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
