### PR TITLE
deps: cherry-pick ca76392 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/builtins/builtins-async-gen.cc
+++ b/deps/v8/src/builtins/builtins-async-gen.cc
@@ -44,7 +44,7 @@ void AsyncBuiltinsAssembler::Await(Node* context, Node* generator, Node* value,
   // When debugging, we need to link from the {generator} to the
   // {outer_promise} of the async function/generator.
   Label done(this);
-  GotoIfNot(IsDebugActive(), &done);
+  GotoIfNot(IsPromiseHookEnabledOrDebugIsActive(), &done);
   CallRuntime(Runtime::kSetProperty, native_context, generator,
               LoadRoot(Heap::kgenerator_outer_promise_symbolRootIndex),
               outer_promise, SmiConstant(LanguageMode::kStrict));

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -18107,6 +18107,12 @@ TEST(PromiseHook) {
   CHECK_EQ(v8::Promise::kFulfilled, GetPromise("p")->State());
   CHECK_EQ(9, promise_hook_data->promise_hook_count);
 
+  promise_hook_data->Reset();
+  source = "(async() => await p)();\n";
+
+  CompileRun(source);
+  CHECK_EQ(11, promise_hook_data->promise_hook_count);
+
   delete promise_hook_data;
   isolate->SetPromiseHook(nullptr);
 }

--- a/test/parallel/test-async-hooks-async-await-regression.js
+++ b/test/parallel/test-async-hooks-async-await-regression.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+
+const async_hooks = require('async_hooks');
+const assert = require('assert');
+
+common.crashOnUnhandledRejection();
+
+const asyncIds = [];
+
+async_hooks.createHook({
+  init: (asyncId, type, triggerAsyncId, resource) => {
+    asyncIds.push(`${triggerAsyncId} => ${asyncId}`);
+  }
+}).enable();
+
+async function main() {
+  console.log('hello');
+  await null;
+  console.log('world');
+}
+
+main().then(() => assert.deepStrictEqual(
+  asyncIds, [ '1 => 3', '1 => 4', '1 => 5', '3 => 6', '3 => 7' ]));

--- a/test/parallel/test-async-hooks-async-await-regression.js
+++ b/test/parallel/test-async-hooks-async-await-regression.js
@@ -11,7 +11,7 @@ const asyncIds = [];
 
 async_hooks.createHook({
   init: (asyncId, type, triggerAsyncId, resource) => {
-    asyncIds.push(`${triggerAsyncId} => ${asyncId}`);
+    asyncIds.push([triggerAsyncId, asyncId]);
   }
 }).enable();
 
@@ -21,5 +21,14 @@ async function main() {
   console.log('world');
 }
 
-main().then(() => assert.deepStrictEqual(
-  asyncIds, [ '1 => 3', '1 => 4', '1 => 5', '3 => 6', '3 => 7' ]));
+main().then(() => {
+  // Verify correct relationship between ids, e.g.:
+  // '1 => 3', '1 => 4', '1 => 5', '3 => 6', '3 => 7'
+  assert.strictEqual(asyncIds[0][0], asyncIds[1][0]);
+  assert.strictEqual(asyncIds[0][0], asyncIds[2][0]);
+  assert.strictEqual(asyncIds[0][1], asyncIds[3][0]);
+  assert.strictEqual(asyncIds[0][1], asyncIds[4][0]);
+  assert.strictEqual(asyncIds[0][1] + 1, asyncIds[1][1]);
+  assert.strictEqual(asyncIds[0][1] + 2, asyncIds[2][1]);
+  assert.strictEqual(asyncIds[3][1] + 1, asyncIds[4][1]);
+});


### PR DESCRIPTION
Original commit message:

    Correctly run before/after hooks for await.

    This fixes a bug where we didn't run before/after hooks for await when
    the debugger is not active, as reported downstream in
    https://github.com/nodejs/node/issues/20274

    Change-Id: I1948d1884c591418d87ffd1d0ccb2bebf4e908f1
    Reviewed-on: https://chromium-review.googlesource.com/1039386
    Commit-Queue: Benedikt Meurer <bmeurer@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#52909}

Refs: v8/v8@ca76392
Fixes: #20274

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
