### PR TITLE
doc: add missing periods in documentation.md

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -35,24 +35,22 @@ and in the process of being redesigned.
 The stability indices are as follows:
 
 ```txt
-Stability: 0 - Deprecated
-This feature is known to be problematic, and changes may be planned. Do
-not rely on it. Use of the feature may cause warnings to be emitted.
-Backwards compatibility across major versions should not be expected.
+Stability: 0 - Deprecated. This feature is known to be problematic, and changes
+may be planned. Do not rely on it. Use of the feature may cause warnings to be
+emitted. Backwards compatibility across major versions should not be expected.
 ```
 
 ```txt
-Stability: 1 - Experimental
-This feature is still under active development and subject to non-backwards
-compatible changes, or even removal, in any future version. Use of the feature
-is not recommended in production environments. Experimental features are not
-subject to the Node.js Semantic Versioning model.
+Stability: 1 - Experimental. This feature is still under active development and
+subject to non-backwards compatible changes, or even removal, in any future
+version. Use of the feature is not recommended in production environments.
+Experimental features are not subject to the Node.js Semantic Versioning model.
 ```
 
 ```txt
-Stability: 2 - Stable
-The API has proven satisfactory. Compatibility with the npm ecosystem
-is a high priority, and will not be broken unless absolutely necessary.
+Stability: 2 - Stable. The API has proven satisfactory. Compatibility with the
+npm ecosystem is a high priority, and will not be broken unless absolutely
+necessary.
 ```
 
 Caution must be used when making use of `Experimental` features, particularly


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Our MD-2-HTML converter replaces line breaks with spaces in these fragments so the result becomes less readable after that without periods.

Before this PR:

![s1](https://user-images.githubusercontent.com/10393198/39527167-78ecb2ae-4e29-11e8-9ac2-4efb7e814822.png)

After this PR:

![s2](https://user-images.githubusercontent.com/10393198/39527181-7cae4362-4e29-11e8-8903-11740139caf8.png)
