### PR TITLE
doc: update Collaborator Guide reference

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -35,7 +35,7 @@ so that you can make the actual changes. This is where we will start.
   * [Getting Approvals for your Pull Request](#getting-approvals-for-your-pull-request)
   * [CI Testing](#ci-testing)
   * [Waiting Until the Pull Request Gets Landed](#waiting-until-the-pull-request-gets-landed)
-  * [Check Out the Collaborator's Guide](#check-out-the-collaborators-guide)
+  * [Check Out the Collaborator Guide](#check-out-the-collaborator-guide)
 
 ## Dependencies
 
@@ -644,17 +644,17 @@ doesn't need to wait. A Pull Request may well take longer to be
 merged in. All these precautions are important because Node.js is
 widely used, so don't be discouraged!
 
-### Check Out the Collaborator's Guide
+### Check Out the Collaborator Guide
 
-If you want to know more about the code review and the landing process,
-you can take a look at the
-[collaborator's guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md).
+If you want to know more about the code review and the landing process, see the
+[Collaborator Guide][].
 
 [approved]: #getting-approvals-for-your-pull-request
 [benchmark results]: ../writing-and-running-benchmarks.md
 [Building guide]: ../../../BUILDING.md
 [CI (Continuous Integration) test run]: #ci-testing
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
+[Collaborator Guide]: ../../../COLLABORATOR_GUIDE.md
 [guide for writing tests in Node.js]: ../writing-tests.md
 [https://ci.nodejs.org/]: https://ci.nodejs.org/
 [IRC in the #node-dev channel]: https://webchat.freenode.net?channels=node-dev&uio=d4


### PR DESCRIPTION
In pull-requests.md:

* Refer to the Collaborator Guide as Collaborator Guide and not
  Collaborator's Guide. That is how the doc describes itself and we
  should be consistent.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
