### PR TITLE
url: call `onParsePortComplete` on null port from `onParseHostComplete`

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -276,8 +276,7 @@ function onParsePortComplete(flags, protocol, username, password,
 function onParseHostComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
   onParseHostnameComplete.apply(this, arguments);
-  if (port !== null)
-    onParsePortComplete.apply(this, arguments);
+  onParsePortComplete.apply(this, arguments);
 }
 
 function onParsePathComplete(flags, protocol, username, password,
@@ -541,7 +540,7 @@ Object.defineProperties(URL.prototype, {
     set(host) {
       const ctx = this[context];
       // toUSVString is not needed.
-      host = `${host}`;
+      host = `${host}`.replace(/:+$/, '');
       if (this[cannotBeBase]) {
         // Cannot set the host if cannot-be-base is set
         return;


### PR DESCRIPTION
Call `onParsePortComplete` on null port from `onParseHostComplete` to
set url’s port to null, if port is url’s scheme’s default port,
and to port otherwise, as specified in the spec.

Also, trim all trailing `:` from `host` in the setter to fix
regressions caused by the change.

Refs: https://url.spec.whatwg.org/#port-state
Fixes: https://github.com/nodejs/node/issues/20465

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
