### PR TITLE
assert: validate input stricter

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -28,6 +28,7 @@ const {
 const { codes: {
   ERR_AMBIGUOUS_ARGUMENT,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_RETURN_VALUE
 } } = require('internal/errors');
 const { AssertionError, errorCache } = require('internal/assert');
@@ -414,12 +415,6 @@ function expectedException(actual, expected, msg) {
       );
     }
 
-    // TODO: Disallow primitives as error argument.
-    // This is here to prevent a breaking change.
-    if (typeof expected !== 'object') {
-      return true;
-    }
-
     // Handle primitives properly.
     if (typeof actual !== 'object' || actual === null) {
       const err = new AssertionError({
@@ -438,6 +433,9 @@ function expectedException(actual, expected, msg) {
     // as well.
     if (expected instanceof Error) {
       keys.push('name', 'message');
+    } else if (keys.length === 0) {
+      throw new ERR_INVALID_ARG_VALUE('error',
+                                      expected, 'may not be an empty object');
     }
     for (const key of keys) {
       if (typeof actual[key] === 'string' &&
@@ -527,6 +525,12 @@ function expectsError(stackStartFn, actual, error, message) {
     }
     message = error;
     error = undefined;
+  } else if (error != null &&
+             typeof error !== 'object' &&
+             typeof error !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('error',
+                                   ['Object', 'Error', 'Function', 'RegExp'],
+                                   error);
   }
 
   if (actual === NO_EXCEPTION_SENTINEL) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -772,6 +772,21 @@ common.expectsError(
   }
 );
 
+[
+  1,
+  false,
+  Symbol()
+].forEach((input) => {
+  assert.throws(
+    () => assert.throws(() => {}, input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "error" argument must be one of type Object, Error, ' +
+               `Function, or RegExp. Received type ${typeof input}`
+    }
+  );
+});
+
 {
   const errFn = () => {
     const err = new TypeError('Wrong value');
@@ -870,6 +885,14 @@ common.expectsError(
     }
   );
 }
+
+assert.throws(
+  () => assert.throws(() => { throw new Error(); }, {}),
+  {
+    message: "The argument 'error' may not be an empty object. Received {}",
+    code: 'ERR_INVALID_ARG_VALUE'
+  }
+);
 
 assert.throws(
   () => a.throws(
@@ -981,7 +1004,3 @@ assert.throws(
     }
   );
 }
-
-// TODO: This case is only there to make sure there is no breaking change.
-// eslint-disable-next-line no-restricted-syntax, no-throw-literal
-assert.throws(() => { throw 4; }, 4);


### PR DESCRIPTION
This makes sure invalid `error` objects are not ignored when using
`assert.throws` and `assert.rejects`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
