### PR TITLE
assert: make sure throws is able to handle primitives

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -385,16 +385,16 @@ function compareExceptionKey(actual, expected, key, message, keys) {
       const a = new Comparison(actual, keys);
       const b = new Comparison(expected, keys, actual);
 
-      const tmpLimit = Error.stackTraceLimit;
-      Error.stackTraceLimit = 0;
       const err = new AssertionError({
         actual: a,
         expected: b,
         operator: 'deepStrictEqual',
         stackStartFn: assert.throws
       });
-      Error.stackTraceLimit = tmpLimit;
-      message = err.message;
+      err.actual = actual;
+      err.expected = expected;
+      err.operator = 'throws';
+      throw err;
     }
     innerFail({
       actual,
@@ -408,7 +408,7 @@ function compareExceptionKey(actual, expected, key, message, keys) {
 
 function expectedException(actual, expected, msg) {
   if (typeof expected !== 'function') {
-    if (expected instanceof RegExp)
+    if (isRegExp(expected))
       return expected.test(actual);
     // assert.doesNotThrow does not accept objects.
     if (arguments.length === 2) {
@@ -416,6 +416,26 @@ function expectedException(actual, expected, msg) {
         'expected', ['Function', 'RegExp'], expected
       );
     }
+
+    // TODO: Disallow primitives as error argument.
+    // This is here to prevent a breaking change.
+    if (typeof expected !== 'object') {
+      return true;
+    }
+
+    // Handle primitives properly.
+    if (typeof actual !== 'object' || actual === null) {
+      const err = new AssertionError({
+        actual,
+        expected,
+        message: msg,
+        operator: 'deepStrictEqual',
+        stackStartFn: assert.throws
+      });
+      err.operator = 'throws';
+      throw err;
+    }
+
     const keys = Object.keys(expected);
     // Special handle errors to make sure the name and the message are compared
     // as well.

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -1,6 +1,6 @@
 assert.js:*
-  throw new AssertionError(obj);
-  ^
+      throw err;
+      ^
 
 AssertionError [ERR_ASSERTION]: Input A expected to strictly deep-equal input B:
 + expected - actual


### PR DESCRIPTION
This fixes some possible issues with `assert.throws` in combination
with an validation object. It will now properly handle primitive
values being thrown as error.

It also makes sure the `generatedMessage` property is properly set
if `assert.throws` is used in combination with an validation object
and improves the error performance in such cases by only creating
the error once.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
