### PR TITLE
assert: accept regular expressions to validate

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -35,7 +35,7 @@ const {
   }
 } = require('internal/errors');
 const { openSync, closeSync, readSync } = require('fs');
-const { inspect, types: { isPromise } } = require('util');
+const { inspect, types: { isPromise, isRegExp } } = require('util');
 const { EOL } = require('os');
 const { NativeModule } = require('internal/bootstrap/loaders');
 
@@ -362,10 +362,18 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
 };
 
 class Comparison {
-  constructor(obj, keys) {
+  constructor(obj, keys, actual) {
     for (const key of keys) {
-      if (key in obj)
-        this[key] = obj[key];
+      if (key in obj) {
+        if (actual !== undefined &&
+            typeof actual[key] === 'string' &&
+            isRegExp(obj[key]) &&
+            obj[key].test(actual[key])) {
+          this[key] = actual[key];
+        } else {
+          this[key] = obj[key];
+        }
+      }
     }
   }
 }
@@ -375,7 +383,7 @@ function compareExceptionKey(actual, expected, key, message, keys) {
     if (!message) {
       // Create placeholder objects to create a nice output.
       const a = new Comparison(actual, keys);
-      const b = new Comparison(expected, keys);
+      const b = new Comparison(expected, keys, actual);
 
       const tmpLimit = Error.stackTraceLimit;
       Error.stackTraceLimit = 0;
@@ -415,6 +423,11 @@ function expectedException(actual, expected, msg) {
       keys.push('name', 'message');
     }
     for (const key of keys) {
+      if (typeof actual[key] === 'string' &&
+          isRegExp(expected[key]) &&
+          expected[key].test(actual[key])) {
+        continue;
+      }
       compareExceptionKey(actual, expected, key, msg, keys);
     }
     return true;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -914,3 +914,29 @@ assert.throws(
     }
   );
 }
+
+assert.throws(
+  () => { throw new TypeError('foobar'); },
+  {
+    message: /foo/,
+    name: /^TypeError$/
+  }
+);
+
+assert.throws(
+  () => assert.throws(
+    () => { throw new TypeError('foobar'); },
+    {
+      message: /fooa/,
+      name: /^TypeError$/
+    }
+  ),
+  {
+    message: `${start}\n${actExp}\n\n` +
+             '  Comparison {\n' +
+             "-   message: 'foobar',\n" +
+             '+   message: /fooa/,\n' +
+             "    name: 'TypeError'\n" +
+             '  }'
+  }
+);


### PR DESCRIPTION
This makes sure regular expressions on validation objects validate
against strings when used with `assert.throws` and `assert.rejects`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
