### PR TITLE
test: fix up N-API error test

### DIFF
--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -61,9 +61,12 @@ assert.throws(() => {
 }, /^TypeError: type error$/);
 
 function testThrowArbitrary(value) {
-  assert.throws(() => {
-    test_error.throwArbitrary(value);
-  }, value);
+  assert.throws(
+    () => test_error.throwArbitrary(value),
+    (err) => {
+      assert.strictEqual(err, value);
+      return true;
+    });
 }
 
 testThrowArbitrary(42);
@@ -71,6 +74,10 @@ testThrowArbitrary({});
 testThrowArbitrary([]);
 testThrowArbitrary(Symbol('xyzzy'));
 testThrowArbitrary(true);
+testThrowArbitrary('ball');
+testThrowArbitrary(undefined);
+testThrowArbitrary(null);
+testThrowArbitrary(NaN);
 
 common.expectsError(
   () => test_error.throwErrorCode(),


### PR DESCRIPTION
Replace assert.throws() with an explicit try/catch in order to catch
the thrown value and be able to compare it strictly to an expected
value.

Re: https://github.com/nodejs/node/pull/20428#issuecomment-386160684

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
