### PR TITLE
net: remove hasCallback from listen function

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1416,8 +1416,7 @@ Server.prototype.listen = function(...args) {
     throw new ERR_SERVER_ALREADY_LISTEN();
   }
 
-  var hasCallback = (cb !== null);
-  if (hasCallback) {
+  if (cb !== null) {
     this.once('listening', cb);
   }
   var backlogFromArgs =


### PR DESCRIPTION
This commit removes hasCallback which is declared as var but
only used once in the line following the declaration and never
reassigned.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
