### PR TITLE
tls: remove sharedCreds in Server constructor

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -875,7 +875,7 @@ function Server(options, listener) {
   // Handle option defaults:
   this.setOptions(options);
 
-  var sharedCreds = tls.createSecureContext({
+  this._sharedCreds = tls.createSecureContext({
     pfx: this.pfx,
     key: this.key,
     passphrase: this.passphrase,
@@ -891,7 +891,6 @@ function Server(options, listener) {
     crl: this.crl,
     sessionIdContext: this.sessionIdContext
   });
-  this._sharedCreds = sharedCreds;
 
   this[kHandshakeTimeout] = options.handshakeTimeout || (120 * 1000);
   this[kSNICallback] = options.SNICallback;
@@ -902,11 +901,11 @@ function Server(options, listener) {
   }
 
   if (this.sessionTimeout) {
-    sharedCreds.context.setSessionTimeout(this.sessionTimeout);
+    this._sharedCreds.context.setSessionTimeout(this.sessionTimeout);
   }
 
   if (this.ticketKeys) {
-    sharedCreds.context.setTicketKeys(this.ticketKeys);
+    this._sharedCreds.context.setTicketKeys(this.ticketKeys);
   }
 
   // constructor call


### PR DESCRIPTION
This commit removes the var sharedCreds which is just reassigned to
this._sharedCreds in the following line.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
