### PR TITLE
test: add fs/promises filehandle stat test

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-stat.js
+++ b/test/parallel/test-fs-promises-file-handle-stat.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs/promises
+// FileHandle.stat method.
+
+const { open } = require('fs/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
+
+async function validateStat() {
+  const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
+  const fileHandle = await open(filePath, 'w+');
+  const stats = await fileHandle.stat();
+  assert.ok(stats.mtime instanceof Date);
+}
+
+validateStat()
+  .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-stat.js
+++ b/test/parallel/test-fs-promises-file-handle-stat.js
@@ -9,13 +9,12 @@ const { open } = require('fs/promises');
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
-const tmpDir = tmpdir.path;
 
 tmpdir.refresh();
 common.crashOnUnhandledRejection();
 
 async function validateStat() {
-  const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
+  const filePath = path.resolve(tmpdir.path, 'tmp-read-file.txt');
   const fileHandle = await open(filePath, 'w+');
   const stats = await fileHandle.stat();
   assert.ok(stats.mtime instanceof Date);


### PR DESCRIPTION
Added test for fs/promises filehandle stat.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
