### PR TITLE
url: fix WHATWG URL host formatting error caused by port string

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -388,7 +388,7 @@ Object.defineProperties(URL.prototype, {
       }, options);
       const ctx = this[context];
       var ret = ctx.scheme;
-      if (ctx.hostname !== null) {
+      if (ctx.host !== null) {
         ret += '//';
         const has_username = ctx.username !== '';
         const has_password = ctx.password !== '';
@@ -401,7 +401,7 @@ Object.defineProperties(URL.prototype, {
         }
         ret += options.unicode ?
           domainToUnicode(this.hostname) : this.hostname;
-        if (ctx.port !== '')
+        if (ctx.port !== null)
           ret += `:${ctx.port}`;
       } else if (ctx.scheme === 'file:') {
         ret += '//';

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -388,7 +388,7 @@ Object.defineProperties(URL.prototype, {
       }, options);
       const ctx = this[context];
       var ret = ctx.scheme;
-      if (ctx.host !== null) {
+      if (ctx.hostname !== null) {
         ret += '//';
         const has_username = ctx.username !== '';
         const has_password = ctx.password !== '';
@@ -400,7 +400,9 @@ Object.defineProperties(URL.prototype, {
           ret += '@';
         }
         ret += options.unicode ?
-          domainToUnicode(this.host) : this.host;
+          domainToUnicode(this.hostname) : this.hostname;
+        if (ctx.port !== '')
+          ret += `:${ctx.port}`
       } else if (ctx.scheme === 'file:') {
         ret += '//';
       }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -402,7 +402,7 @@ Object.defineProperties(URL.prototype, {
         ret += options.unicode ?
           domainToUnicode(this.hostname) : this.hostname;
         if (ctx.port !== '')
-          ret += `:${ctx.port}`
+          ret += `:${ctx.port}`;
       } else if (ctx.scheme === 'file:') {
         ret += '//';
       }

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -111,3 +111,8 @@ assert.strictEqual(
   url.format(myURL, { unicode: 0 }),
   'http://xn--lck1c3crb1723bpq4a.com/a?a=b#c'
 );
+
+assert.strictEqual(
+  url.format(new URL('http://xn--0zwm56d.com:8080/path'), { unicode: true }),
+  'http://测试.com:8080/path'
+);


### PR DESCRIPTION
The current [url.format](https://github.com/nodejs/node/blob/master/lib/internal/url.js#L376) implementation will return an invalid URL string without the host if there is a port and `unicode: true`.

This unexpected behavior is caused by [domainToUnicode](https://github.com/nodejs/node/blob/master/lib/internal/url.js#L1303), which expects a **hostname** instead of a **host** string according to [node_url.cc](https://github.com/nodejs/node/blob/master/src/node_url.cc#L941).

For example: `url.domainToUnicode('xn--3kq375bonc.com')` will be correctly converted into Chinese `'搞事情.com'`, but `url.domainToUnicode('xn--3kq375bonc.com:80')` would produce an empty string.

##### Code to reproduce

```javascript
'use strict';

const {format, URL} = require('url');

const myURL = new URL('http://examlpe.com:8080/path');

console.log(format(myURL, {unicode: false}));
// OK: 'http://examlpe.com:8080/path'

console.log(format(myURL, {unicode: true}));
// Error: 'http:///path' <-- the host is missing!
```
##### References

1. RFC [3986](https://tools.ietf.org/html/rfc3986) - Uniform Resource Identifier (URI): Generic Syntax
2. RFC [3987](https://tools.ietf.org/html/rfc3987) - Internationalized Resource Identifiers (IRIs)
3. https://url.spec.whatwg.org/#concept-host

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)