### PR TITLE
test: fix setHeader call on outgoingMessage in test-http-outgoing-proto

### DIFF
--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -42,7 +42,8 @@ common.expectsError(() => {
 
 common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage.setHeader.call({ _header: 'test' }, 'test', 'value');
+  outgoingMessage._header = 'test';
+  outgoingMessage.setHeader('test', 'value');
 }, {
   code: 'ERR_HTTP_HEADERS_SENT',
   type: Error,


### PR DESCRIPTION
This bug was found while attempting to provide a setHeaders feature in the following ref.
Refs: https://github.com/nodejs/node/issues/12877

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
