### PR TITLE
console: console.table() uses colored inspect

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -319,15 +319,6 @@ const iterKey = '(iteration index)';
 
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
-const inspect = (v) => {
-  const opt = { depth: 0, maxArrayLength: 3 };
-  if (v !== null && typeof v === 'object' &&
-      !isArray(v) && ObjectKeys(v).length > 2)
-    opt.depth = -1;
-  return util.inspect(v, opt);
-};
-
-const getIndexArray = (length) => ArrayFrom({ length }, (_, i) => inspect(i));
 
 // https://console.spec.whatwg.org/#table
 Console.prototype.table = function(tabularData, properties) {
@@ -339,6 +330,16 @@ Console.prototype.table = function(tabularData, properties) {
     return this.log(tabularData);
 
   const final = (k, v) => this.log(cliTable(k, v));
+
+  const inspect = (v) => {
+    const opt = { depth: 0, maxArrayLength: 3 };
+    if (v !== null && typeof v === 'object' &&
+      !isArray(v) && ObjectKeys(v).length > 2)
+      opt.depth = -1;
+    Object.assign(opt, this[kGetInspectOptions](this._stdout));
+    return util.inspect(v, opt);
+  };
+  const getIndexArray = (length) => ArrayFrom({ length }, (_, i) => inspect(i));
 
   const mapIter = isMapIterator(tabularData);
   if (mapIter)


### PR DESCRIPTION
This makes `console.table()` inspect objects with color if available like `console.log`.

Currently `console.table` with `true`, `false`, `null` or `undefined` shows colored values because it calls `console.log` internally.

![2018-05-04 12 58 25](https://user-images.githubusercontent.com/6679325/39612481-dda2cd7e-4f9a-11e8-9f5b-517f854b0d42.png)

However `console.table` with objects does not show colored value at all.

![2018-05-04 12 59 48](https://user-images.githubusercontent.com/6679325/39612507-0d92b760-4f9b-11e8-87fb-5bad37f8de1f.png)

It seems a bug and I wish `console.table` shows colored values.

![2018-05-04 13 16 29](https://user-images.githubusercontent.com/6679325/39612793-63f1467e-4f9d-11e8-9c79-582b2fb158c7.png)

I'm first time contributor. I have a questions: Is this PR change just a bug fixing? -- Or breaking change?
Probably it is the important concern of `nodejs/node`, which is used for versioning. I can't determine that. What do you think?

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
