### PR TITLE
test: fix tests with symlink

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -518,6 +518,8 @@ exports.canCreateSymLink = function() {
       return false;
     }
   }
+  // On non-Windows platforms, this always returns `true`
+  return true;
 };
 
 exports.getCallSite = function getCallSite(top) {


### PR DESCRIPTION
test/README.md indicates that `canCreateSymlink` in test/common/index.js
always returns `true` on non-Windows platforms.
Now, this function always returns nothing on non-Windows platforms.

ref: https://github.com/nodejs/node/tree/master/test/common#cancreatesymlink

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
