### PR TITLE
build: add '-z relro -z now' linker flags

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -291,7 +291,10 @@
     [ 'OS=="sunos"', {
       'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
     }],
-
+    [ 'OS in "freebsd linux"', {
+      'ldflags': [ '-Wl,-z,relro',
+                   '-Wl,-z,now' ]
+    }],
     [ 'node_use_openssl=="true"', {
       'defines': [ 'HAVE_OPENSSL=1' ],
       'conditions': [


### PR DESCRIPTION
These flags could make some sections and the GOT entries of node
process read only to avoid being modified after dynamic linking is
done, thus the security could be enhanced.

Fixes: https://github.com/nodejs/node/issues/20122

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
