### PR TITLE
tools: remove redundant code in doc/html.js

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -29,11 +29,11 @@ const testData = [
     file: fixtures.path('order_of_end_tags_5873.md'),
     html: '<h3>ClassMethod: Buffer.from(array) <span> ' +
       '<a class="mark" href="#foo_class_method_buffer_from_array" ' +
-      'id="foo_class_method_buffer_from_array">#</a> </span> </h3><div' +
-      'class="signature"><ul><li><code>array</code><a ' +
+      'id="foo_class_method_buffer_from_array">#</a> </span> </h3>' +
+      '<ul><li><code>array</code><a ' +
       'href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/' +
       'Reference/Global_Objects/Array" class="type">&lt;Array&gt;</a></li>' +
-      '</ul></div>'
+      '</ul>'
   },
   {
     file: fixtures.path('doc_with_yaml.md'),

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -93,7 +93,7 @@ function render(opts, cb) {
   filename = path.basename(filename, '.md');
 
   parseText(lexed);
-  lexed = parseLists(lexed);
+  lexed = preprocessElements(lexed);
 
   // Generate the table of contents.
   // This mutates the lexed contents in-place.
@@ -231,25 +231,28 @@ function parseText(lexed) {
   });
 }
 
-// Just update the list item text in-place.
-// Lists that come right after a heading are what we're after.
-function parseLists(input) {
+// Preprocess stability blockquotes and YAML blocks.
+function preprocessElements(input) {
   var state = null;
-  const savedState = [];
-  var depth = 0;
   const output = [];
   let headingIndex = -1;
   let heading = null;
 
   output.links = input.links;
   input.forEach(function(tok, index) {
+    if (tok.type === 'heading') {
+      headingIndex = index;
+      heading = tok;
+    }
+    if (tok.type === 'html' && common.isYAMLBlock(tok.text)) {
+      tok.text = parseYAML(tok.text);
+    }
     if (tok.type === 'blockquote_start') {
-      savedState.push(state);
       state = 'MAYBE_STABILITY_BQ';
       return;
     }
     if (tok.type === 'blockquote_end' && state === 'MAYBE_STABILITY_BQ') {
-      state = savedState.pop();
+      state = null;
       return;
     }
     if ((tok.type === 'paragraph' && state === 'MAYBE_STABILITY_BQ') ||
@@ -271,50 +274,7 @@ function parseLists(input) {
         return;
       } else if (state === 'MAYBE_STABILITY_BQ') {
         output.push({ type: 'blockquote_start' });
-        state = savedState.pop();
-      }
-    }
-    if (state === null ||
-      (state === 'AFTERHEADING' && tok.type === 'heading')) {
-      if (tok.type === 'heading') {
-        headingIndex = index;
-        heading = tok;
-        state = 'AFTERHEADING';
-      }
-      output.push(tok);
-      return;
-    }
-    if (state === 'AFTERHEADING') {
-      if (tok.type === 'list_start') {
-        state = 'LIST';
-        if (depth === 0) {
-          output.push({ type: 'html', text: '<div class="signature">' });
-        }
-        depth++;
-        output.push(tok);
-        return;
-      }
-      if (tok.type === 'html' && common.isYAMLBlock(tok.text)) {
-        tok.text = parseYAML(tok.text);
-      }
-      state = null;
-      output.push(tok);
-      return;
-    }
-    if (state === 'LIST') {
-      if (tok.type === 'list_start') {
-        depth++;
-        output.push(tok);
-        return;
-      }
-      if (tok.type === 'list_end') {
-        depth--;
-        output.push(tok);
-        if (depth === 0) {
-          state = null;
-          output.push({ type: 'html', text: '</div>' });
-        }
-        return;
+        state = null;
       }
     }
     output.push(tok);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

### Status quo

Currently, `parseLists()` function in `tools/doc/html.js` has some flaws:

1. It tries to add `<div class="signature">...</div>` elements around lists of signature types (function parameters, returned values, property types). However, we have no such class in our `api_assets\style.css`, so this wrapping list blocks in `DIV` blocks is redundant.
2. Due to a logic error, only lists without YAML blocks between heading and list are wrapped. This produces mostly false-positive and false-negative results (most signature lists are not wrapped, many non-signature lists are wrapped).
3. Logic scaffolding for this wrapping overcomplicates this function.
4. Processing of YAML blocks depends on unneeded restriction: only YAML blocks straight after heading are processed (currently, it seems we have no other ones, but we may have others in future).

### Fixing strategy

1. Remove redundant `DIV` wrapping for lists.
2. Remove connected logic scaffolding.
3. Process all YAML blocks regardless of their place.
4. Simplify overall logic for remaining function code.
5. Reorder conditional blocks to reflect processed source structure.
6. Update comment and function name to describe function destination more correctly.
7. Update test.

This PR reduces code by 40 lines and docs size by ~7.5 KB. Only `<div class="signature">...</div>` wrappers are removed from docs, no other changes are found in results.

The visible styles of wrapped and unwrapped lists are identical:

![s1](https://user-images.githubusercontent.com/10393198/39622243-18eb740e-4f9a-11e8-81db-446da003da05.png)

![s2](https://user-images.githubusercontent.com/10393198/39622244-19234c6c-4f9a-11e8-8aa3-ccbdcbc28d3a.png)

cc @nodejs/documentation