### PR TITLE
doc: update deprecations info in COLLABORATOR_GUIDE

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -463,11 +463,8 @@ Runtime Deprecation cycle. However, there is no requirement that deprecated
 code must progress ultimately to *End-of-Life*. Documentation-only and runtime
 deprecations may remain indefinitely.
 
-A best effort will be made to communicate pending deprecations and associated
-mitigations with the ecosystem as soon as possible (preferably before the pull
-request adding the deprecation lands on the master branch). All deprecations
-included in a Node.js release should be listed prominently in the "Notable
-Changes" section of the release notes.
+Use the `notable-change` label on all pull requests that add a new deprecation
+or move an existing deprecation to a new deprecation level.
 
 ### Involving the TSC
 


### PR DESCRIPTION
The deprecations section in the COLLABORATOR_GUIDE is a bit long-winded
and repetitive. It also includes some aspirational items that appear
worded to create "an impression that a specific or meaningful statement
has been made, when instead only a vague or ambiguous claim has actually
been communicated." (Putting it in quotes because I'm copying it from
Wikipedia.)

This commit edits the text to make it more concise and meaningful.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
