### PR TITLE
doc: add trace category for fs sync methods

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -23,6 +23,7 @@ The available categories are:
     measures and marks.
   * `node.perf.timerify` - Enables capture of only Performance API timerify
     measurements.
+* `node.fs.sync` - Enables capture of trace data for file system sync methods.
 * `v8` - The [V8] events are GC, compiling, and execution related.
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.


### PR DESCRIPTION
Add the trace category for file system synchronous methods to
documentation so the users can enable it when they want to look
into file system sync method trace data.

Refs: https://github.com/nodejs/node/pull/19649

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
