### PR TITLE
test: add fs/promises filehandle sync() and datasync() tests.

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 
-const { access, copyFile, open, read, write } = require('fs/promises');
+const { access, copyFile, open } = require('fs/promises');
 const path = require('path');
 
 common.crashOnUnhandledRejection();
@@ -18,8 +18,8 @@ async function validateSync() {
   await handle.datasync();
   await handle.sync();
   const buf = Buffer.from('hello world');
-  await write(handle, buf);
-  const ret = await read(handle, Buffer.alloc(11), 0, 11, 0);
+  await handle.write(buf);
+  const ret = await handle.read(Buffer.alloc(11), 0, 11, 0);
   assert.strictEqual(ret.bytesRead, 11);
   assert.deepStrictEqual(ret.buffer, buf);
 }

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -24,4 +24,4 @@ async function validateSync() {
   assert.deepStrictEqual(ret.buffer, buf);
 }
 
-validateSync().then(common.mustCall());
+validateSync();

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+
+const { access, copyFile, open, read, write } = require('fs/promises');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+async function validateSync() {
+  tmpdir.refresh();
+  const dest = path.resolve(tmpdir.path, 'baz.js');
+  await copyFile(fixtures.path('baz.js'), dest);
+  await access(dest, 'r');
+  const handle = await open(dest, 'r+');
+  await handle.datasync();
+  await handle.sync();
+  const buf = Buffer.from('hello world');
+  await write(handle, buf);
+  const ret = await read(handle, Buffer.alloc(11), 0, 11, 0);
+  assert.strictEqual(ret.bytesRead, 11);
+  assert.deepStrictEqual(ret.buffer, buf);
+}
+
+validateSync().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 
-const { access, copyFile, open } = require('fs/promises');
+const { access, copyFile, open } = require('fs').promises;
 const path = require('path');
 
 common.crashOnUnhandledRejection();


### PR DESCRIPTION
To increase test coverage for fs/promises,
added tests for filehandle.sync and filehandle.datasync.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
