### PR TITLE
clarification: not EventEmitter but its instance

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -45,20 +45,20 @@ myEmitter.emit('event');
 
 The `eventEmitter.emit()` method allows an arbitrary set of arguments to be
 passed to the listener functions. It is important to keep in mind that when an
-ordinary listener function is called by the `EventEmitter`, the standard `this`
-keyword is intentionally set to reference the `EventEmitter` to which the
+ordinary listener function is called, the standard `this`
+keyword is intentionally set to reference the `EventEmitter` instance to which the
 listener is attached.
 
 ```js
 const myEmitter = new MyEmitter();
 myEmitter.on('event', function(a, b) {
-  console.log(a, b, this);
+  console.log(a, b, this, this === myEmitter);
   // Prints:
   //   a b MyEmitter {
   //     domain: null,
   //     _events: { event: [Function] },
   //     _eventsCount: 1,
-  //     _maxListeners: undefined }
+  //     _maxListeners: undefined } true
 });
 myEmitter.emit('event', 'a', 'b');
 ```

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -44,9 +44,9 @@ myEmitter.emit('event');
 ## Passing arguments and `this` to listeners
 
 The `eventEmitter.emit()` method allows an arbitrary set of arguments to be
-passed to the listener functions. It is important to keep in mind that when an
-ordinary listener function is called, the standard `this`
-keyword is intentionally set to reference the `EventEmitter` instance to which the
+passed to the listener functions. It is important to keep in mind that when
+an ordinary listener function is called, the standard `this` keyword
+is intentionally set to reference the `EventEmitter` instance to which the
 listener is attached.
 
 ```js


### PR DESCRIPTION
this === eventEmitter or this === instance of EventEmitter, but it's this is not EventEmitter.
Maybe adding this=== myEmitter to an example down below is redundant so feel free to modify it as well or rather keep it unchanged.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
