### PR TITLE
test: use common.canCreateSymLink() consistently

### DIFF
--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -27,11 +27,10 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const exec = require('child_process').exec;
 let async_completed = 0;
 let async_expected = 0;
 const unlink = [];
-let skipSymlinks = false;
+const skipSymlinks = !common.canCreateSymLink();
 const tmpDir = tmpdir.path;
 
 tmpdir.refresh();
@@ -45,25 +44,9 @@ if (common.isWindows) {
     assert
       .strictEqual(path_left.toLowerCase(), path_right.toLowerCase(), message);
   };
-
-  // On Windows, creating symlinks requires admin privileges.
-  // We'll only try to run symlink test if we have enough privileges.
-  try {
-    exec('whoami /priv', function(err, o) {
-      if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
-        skipSymlinks = true;
-      }
-      runTest();
-    });
-  } catch (er) {
-    // better safe than sorry
-    skipSymlinks = true;
-    process.nextTick(runTest);
-  }
-} else {
-  process.nextTick(runTest);
 }
 
+process.nextTick(runTest);
 
 function tmp(p) {
   return path.join(tmpDir, p);

--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -9,21 +9,8 @@ const traceFile = 'node_trace.1.log';
 
 let gid = 1;
 let uid = 1;
-let skipSymlinks = false;
 
-// On Windows, creating symlinks requires admin privileges.
-// We'll check if we have enough privileges.
-if (common.isWindows) {
-  try {
-    const o = cp.execSync('whoami /priv');
-    if (!o.includes('SeCreateSymbolicLinkPrivilege')) {
-      skipSymlinks = true;
-    }
-  } catch (er) {
-    // better safe than sorry
-    skipSymlinks = true;
-  }
-} else {
+if (!common.isWindows) {
   gid = process.getgid();
   uid = process.getuid();
 }
@@ -111,7 +98,7 @@ tests['fs.sync.write'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
 
 // On windows, we need permissions to test symlink and readlink.
 // We'll only try to run these tests if we have enough privileges.
-if (!skipSymlinks) {
+if (common.canCreateSymLink()) {
   tests['fs.sync.symlink'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                              'fs.symlinkSync("fs.txt", "linkx");' +
                              'fs.unlinkSync("linkx");' +


### PR DESCRIPTION
This commit replaces two ad hoc symlink permission tests with `common.canCreateSymLink()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
