### PR TITLE
doc: add parameters for Http2Session:stream event

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -235,7 +235,8 @@ added: v8.4.0
 * `stream` {Http2Stream} A reference to the stream
 * `headers` {HTTP/2 Headers Object} An object describing the headers
 * `flags` {number} The associated numeric flags
-* `rawHeaders` {Array} An array containing the raw header name value pairs
+* `rawHeaders` {Array} An array containing the raw header names followed by
+  their respective values.
 
 The `'stream'` event is emitted when a new `Http2Stream` is created.
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -232,10 +232,12 @@ session.on('remoteSettings', (settings) => {
 added: v8.4.0
 -->
 
-The `'stream'` event is emitted when a new `Http2Stream` is created. When
-invoked, the handler function will receive a reference to the `Http2Stream`
-object, a [HTTP/2 Headers Object][], and numeric flags associated with the
-creation of the stream.
+* `stream` {Http2Stream} A reference to the stream
+* `headers` {HTTP/2 Headers Object} An object describing the headers
+* `flags` {number} The associated numeric flags
+* `rawHeaders` {Array} An array containing the raw header name value pairs
+
+The `'stream'` event is emitted when a new `Http2Stream` is created.
 
 ```js
 const http2 = require('http2');


### PR DESCRIPTION
Add parameters for the callback for the Http2Session:stream event
inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

P.S. I was kinda confused regarding the type of the `flags` variable, so I set it to `Number` for now.

/cc @nodejs/http2 @mcollina @vsemozhetbyt 