### PR TITLE
fs: refactor promises version of lchown and lchmod

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -378,21 +378,19 @@ async function chmod(path, mode) {
 }
 
 async function lchmod(path, mode) {
-  if (O_SYMLINK !== undefined) {
-    const fd = await open(path,
-                          O_WRONLY | O_SYMLINK);
-    return fchmod(fd, mode).finally(fd.close.bind(fd));
-  }
-  throw new ERR_METHOD_NOT_IMPLEMENTED();
+  if (O_SYMLINK === undefined)
+    throw new ERR_METHOD_NOT_IMPLEMENTED();
+
+  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  return fchmod(fd, mode).finally(fd.close.bind(fd));
 }
 
 async function lchown(path, uid, gid) {
-  if (O_SYMLINK !== undefined) {
-    const fd = await open(path,
-                          O_WRONLY | O_SYMLINK);
-    return fchown(fd, uid, gid).finally(fd.close.bind(fd));
-  }
-  throw new ERR_METHOD_NOT_IMPLEMENTED();
+  if (O_SYMLINK === undefined)
+    throw new ERR_METHOD_NOT_IMPLEMENTED();
+
+  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  return fchown(fd, uid, gid).finally(fd.close.bind(fd));
 }
 
 async function fchown(handle, uid, gid) {


### PR DESCRIPTION
Check for platform support first to save a level of indentation. This is just a style thing, but it simplifies the code a bit IMO.

In case anyone points it out in the diff, `lchown()` is currently calling `fchmod()` (incorrectly). I didn't update it because @ChALkeR has a fix for it in #20407.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
