### PR TITLE
doc, tools: unify stability signatures

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -34,24 +34,24 @@ and in the process of being redesigned.
 
 The stability indices are as follows:
 
-```txt
-Stability: 0 - Deprecated. This feature is known to be problematic, and changes
-may be planned. Do not rely on it. Use of the feature may cause warnings to be
-emitted. Backwards compatibility across major versions should not be expected.
-```
+> Stability: 0 - Deprecated. This feature is known to be problematic, and
+> changes may be planned. Do not rely on it. Use of the feature may cause
+> warnings to be emitted. Backwards compatibility across major versions should
+> not be expected.
 
-```txt
-Stability: 1 - Experimental. This feature is still under active development and
-subject to non-backwards compatible changes, or even removal, in any future
-version. Use of the feature is not recommended in production environments.
-Experimental features are not subject to the Node.js Semantic Versioning model.
-```
+<!-- separator -->
 
-```txt
-Stability: 2 - Stable. The API has proven satisfactory. Compatibility with the
-npm ecosystem is a high priority, and will not be broken unless absolutely
-necessary.
-```
+> Stability: 1 - Experimental. This feature is still under active development
+> and subject to non-backwards compatible changes, or even removal, in any
+> future version. Use of the feature is not recommended in production
+> environments. Experimental features are not subject to the Node.js Semantic
+> Versioning model.
+
+<!-- separator -->
+
+> Stability: 2 - Stable. The API has proven satisfactory. Compatibility with the
+> npm ecosystem is a high priority, and will not be broken unless absolutely
+> necessary.
 
 Caution must be used when making use of `Experimental` features, particularly
 within modules that may be used as dependencies (or dependencies of

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -252,8 +252,7 @@ function parseLists(input) {
       state = savedState.pop();
       return;
     }
-    if ((tok.type === 'paragraph' && state === 'MAYBE_STABILITY_BQ') ||
-      tok.type === 'code') {
+    if (tok.type === 'paragraph' && state === 'MAYBE_STABILITY_BQ') {
       if (tok.text.match(/Stability:.*/g)) {
         const stabilityMatch = tok.text.match(STABILITY_TEXT_REG_EXP);
         const stability = Number(stabilityMatch[2]);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Currently, we format all stability signatures in blockquotes except just this place in `documentation.md`, where they are wrapped in code elements. I can assume that the cause is that markdown glues consecutive blockquotes into one element, which seems wrong for this fragment.

However, this divergence makes our MD-2-HTML converter check all the code elements for stability signatures, which is rather a significant overhead.

So this PR unifies stability signatures (separating consecutive blockquotes by comments) and frees the converter from the excess checks.

The visible result is completely identical to the previous one.