### PR TITLE
test: fix flaky http2-flow-control test

### DIFF
--- a/test/parallel/test-http2-misbehaving-flow-control-paused.js
+++ b/test/parallel/test-http2-misbehaving-flow-control-paused.js
@@ -70,8 +70,6 @@ server.on('stream', (stream) => {
     client.destroy();
   }));
   stream.on('end', common.mustNotCall());
-  stream.respond();
-  stream.end('ok');
 });
 
 server.listen(0, () => {


### PR DESCRIPTION
Due to various race conditions, calling `respond` and `end` in this test can cause it to be flaky. It also wasn't necessary for the test to do its job.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
