### PR TITLE
test: fix assertion in test-console

### DIFF
--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -142,12 +142,12 @@ console.timeEnd(NaN);
 console.time('test');
 const time = console._times.get('test');
 setTimeout(() => {
-  assert.deepStrictEqual(console._times.get('test'), time);
   common.expectWarning(
     'Warning',
     'Label \'test\' already exists for console.time()',
     common.noWarnCode);
   console.time('test');
+  assert.deepStrictEqual(console._times.get('test'), time);
   console.timeEnd('test');
 }, 1);
 


### PR DESCRIPTION
Move the assertion after the second call to `console.time()` to
actually make sure that the time is not reset.

Refs: https://github.com/nodejs/node/pull/20442

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
