### PR TITLE
fs: use _final() for fs.WriteStream

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2198,17 +2198,17 @@ function WriteStream(path, options) {
 
   if (typeof this.fd !== 'number')
     this.open();
-
-  // dispose on finish.
-  this.once('finish', function() {
-    if (this.autoClose) {
-      this.destroy();
-    }
-  });
 }
 
 fs.FileWriteStream = fs.WriteStream; // support the legacy name
 
+WriteStream.prototype._final = function(callback) {
+  if (this.autoClose) {
+    this.destroy();
+  }
+
+  callback();
+};
 
 WriteStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {


### PR DESCRIPTION
use _final() method instead of once 'finish' event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
