### PR TITLE
lib: add crypto.rollMyOwn

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -728,6 +728,12 @@ An invalid [crypto digest algorithm][] was specified.
 A crypto method was used on an object that was in an invalid state. For
 instance, calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
 
+<a id="ERR_CRYPTO_ROLL_MY_OWN"></a>
+### ERR_CRYPTO_ROLL_MY_OWN
+
+The `rollMyOwn` function from the `crypto` module was called. This is a fun
+easter egg to remind you to never roll your own cryptographic library.
+
 <a id="ERR_CRYPTO_SIGN_KEY_REQUIRED"></a>
 ### ERR_CRYPTO_SIGN_KEY_REQUIRED
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -32,7 +32,8 @@ assertCrypto();
 
 const {
   ERR_CRYPTO_FIPS_FORCED,
-  ERR_CRYPTO_FIPS_UNAVAILABLE
+  ERR_CRYPTO_FIPS_UNAVAILABLE,
+  ERR_CRYPTO_ROLL_MY_OWN
 } = require('internal/errors').codes;
 const constants = process.binding('constants').crypto;
 const {
@@ -133,6 +134,10 @@ function createVerify(algorithm, options) {
   return new Verify(algorithm, options);
 }
 
+function rollMyOwn() {
+  throw new ERR_CRYPTO_ROLL_MY_OWN();
+}
+
 module.exports = exports = {
   // Methods
   _toBuf: toBuf,
@@ -162,6 +167,7 @@ module.exports = exports = {
   randomBytes,
   randomFill,
   randomFillSync,
+  rollMyOwn,
   rng: randomBytes,
   setEngine,
   timingSafeEqual,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -752,6 +752,7 @@ E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s', TypeError);
 E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s', Error);
 
 // Switch to TypeError. The current implementation does not seem right.
+E('ERR_CRYPTO_ROLL_MY_OWN', 'Don\'t do it', Error);
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
   'Input buffers must have the same length', RangeError);

--- a/test/parallel/test-crypto-roll-my-own.js
+++ b/test/parallel/test-crypto-roll-my-own.js
@@ -1,0 +1,40 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+// This test ensures that the crypto rollMyOwn function throws the
+// appropriate error.
+
+const errObj = {
+  code: 'ERR_CRYPTO_ROLL_MY_OWN',
+  name: 'Error [ERR_CRYPTO_ROLL_MY_OWN]',
+  message: 'Don\'t do it'
+};
+assert.throws(crypto.rollMyOwn, errObj);
+


### PR DESCRIPTION
Add an easter egg from something that was mentioned over and over again to me in a security class in college that I thought would be a fun addition to remind you (and a way to remind the world) not to roll your own crypto.

![image](https://user-images.githubusercontent.com/1797812/39689929-00caf844-519e-11e8-8b78-a7f21d6c8ba4.png)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
