### PR TITLE
src: rename handle parameter object

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -31,12 +31,12 @@
 
 namespace node {
 
-BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
-    : persistent_handle_(env->isolate(), handle),
+BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> object)
+    : persistent_handle_(env->isolate(), object),
       env_(env) {
-  CHECK_EQ(false, handle.IsEmpty());
-  CHECK_GT(handle->InternalFieldCount(), 0);
-  handle->SetAlignedPointerInInternalField(0, static_cast<void*>(this));
+  CHECK_EQ(false, object.IsEmpty());
+  CHECK_GT(object->InternalFieldCount(), 0);
+  object->SetAlignedPointerInInternalField(0, static_cast<void*>(this));
 }
 
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -34,7 +34,7 @@ class Environment;
 
 class BaseObject {
  public:
-  // Associates this object with `handle`. It uses the 0th internal field for
+  // Associates this object with `object`. It uses the 0th internal field for
   // that, and in particular aborts if there is no such field.
   inline BaseObject(Environment* env, v8::Local<v8::Object> object);
   virtual inline ~BaseObject();

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -36,7 +36,7 @@ class BaseObject {
  public:
   // Associates this object with `handle`. It uses the 0th internal field for
   // that, and in particular aborts if there is no such field.
-  inline BaseObject(Environment* env, v8::Local<v8::Object> handle);
+  inline BaseObject(Environment* env, v8::Local<v8::Object> object);
   virtual inline ~BaseObject();
 
   // Returns the wrapped object.  Returns an empty handle when


### PR DESCRIPTION
This commit renames the handle parameter for the BaseObject constructor
to object instead of handle.

The motivation for doing this is that when stepping through an
inheritance chain it can sometimes be a little confusing when
HandleWrap is in involved. HandleWrap has a handle parameter
but calls the object that is passed to AsyncWrap object, but
then when you end up in BaseObject it is named handle.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
