### PR TITLE
src: don't create Undefined if not needed

### DIFF
--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -45,10 +45,7 @@ void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
   // uv_close() on the handle.
   CHECK_EQ(wrap_data->persistent().IsEmpty(), false);
 
-  Local<Value> argv[] = {
-    Integer::New(env->isolate(), status),
-    Undefined(env->isolate())
-  };
+  Local<Value> client_handle;
 
   if (status == 0) {
     // Instantiate the client javascript object and handle.
@@ -59,17 +56,20 @@ void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
     // Unwrap the client javascript object.
     WrapType* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, client_obj);
-    uv_stream_t* client_handle =
-        reinterpret_cast<uv_stream_t*>(&wrap->handle_);
+    uv_stream_t* client = reinterpret_cast<uv_stream_t*>(&wrap->handle_);
     // uv_accept can fail if the new connection has already been closed, in
     // which case an EAGAIN (resource temporarily unavailable) will be
     // returned.
-    if (uv_accept(handle, client_handle))
+    if (uv_accept(handle, client))
       return;
 
     // Successful accept. Call the onconnection callback in JavaScript land.
-    argv[1] = client_obj;
+    client_handle = client_obj;
+  } else {
+    client_handle = Undefined(env->isolate());
   }
+
+  Local<Value> argv[] = { Integer::New(env->isolate(), status), client_handle };
   wrap_data->MakeCallback(env->onconnection_string(), arraysize(argv), argv);
 }
 


### PR DESCRIPTION
This commit moves the creation of argv and only creates an undefined
value if the passed in status was not 0.

The variable name client_handle was already used in this function but
I've change that usage so that this variable name matches the
onconnection callback functions parameter name clientHandle.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
