### PR TITLE
test: add tests for fsPromises.chown to increase coverage

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -159,7 +159,7 @@ function verifyStatObject(stat) {
     if (common.canCreateSymLink()) {
       const newLink = path.resolve(tmpDir, 'baz3.js');
       await symlink(newPath, newLink);
-      if (common.isOSX) {
+      if (!common.isWindows) {
         await lchown(newLink, process.getuid(), process.getgid());
       }
       stats = await lstat(newLink);


### PR DESCRIPTION
To increase test coverage for fs/promises, add tests for
methods chown(), filehandle.chown() and lchown().

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
