### PR TITLE
net: remove typo in setTimeout comment

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -411,7 +411,7 @@ Socket.prototype.setTimeout = function(msecs, callback) {
   // Type checking identical to timers.enroll()
   msecs = validateTimerDuration(msecs);
 
-  // Attempt to clear an existing timer lear in both cases -
+  // Attempt to clear an existing timer in both cases -
   //  even if it will be rescheduled we don't want to leak an existing timer.
   clearTimeout(this[kTimeout]);
 


### PR DESCRIPTION
This commit removes `lear` from the code comment in setTimeout. I'm not
100% sure this is a typo but I've struggled to think what it could mean.
Hopefully someone else might be able to shed some light on this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
