### PR TITLE
excised "periodically" before "emit events"

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -7,8 +7,8 @@
 <!--type=module-->
 
 Much of the Node.js core API is built around an idiomatic asynchronous
-event-driven architecture in which certain kinds of objects (called "emitters")
-periodically emit named events that cause `Function` objects ("listeners") to be
+event-driven architecture in which certain kinds of objects (called "emitters") 
+emit named events that cause `Function` objects ("listeners") to be
 called.
 
 For instance: a [`net.Server`][] object emits an event each time a peer


### PR DESCRIPTION
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]

"periodically" implies regular time intervals between emitted events, but as first example, "peer connects", implies, these time intervals may be irregular or unpredictable...or am I not understanding events right?

