### PR TITLE
tools: adds custom eslint-rule for snake-case-filenames

### DIFF
--- a/test/parallel/test-eslint-snake-case-filenames.js
+++ b/test/parallel/test-eslint-snake-case-filenames.js
@@ -7,21 +7,21 @@ common.skipIfEslintMissing();
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/snake-case-filenames');
 
-const message = 'Filename is not in snake_case.';
+const message = (filename) => `Filename ${filename} is not in snake_case.`;
 const code = 'var foo = "bar"';
 
 new RuleTester().run('snake-case-filenames', rule, {
   valid: [
     {
       code,
-      filename: 'snake-case-filename.js'
+      filename: 'lib/snake_case_filename.js'
     }
   ],
   invalid: [
     {
       code,
-      filename: 'camelCaseFilename.js',
-      errors: [{ message }]
+      filename: 'lib/kebab-case-filename.js',
+      errors: [{ ...message('kebab-case-filename.js') }]
     }
   ]
 });

--- a/tools/eslint-rules/snake-case-filenames.js
+++ b/tools/eslint-rules/snake-case-filenames.js
@@ -12,7 +12,7 @@ const path = require('path');
 
 module.exports = function(context) {
   const snakeCaseRegex = new RegExp('^[a-z_]+$');
-  const targetDirs = ['lib', 'deps', 'src'];
+  const targetDirs = ['lib'];
 
   function checkIfInTargetDir(dirName) {
     return targetDirs.filter((dir) => dirName.indexOf(dir) !== -1).length !== 0;


### PR DESCRIPTION
Closes:  #20446

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Currently WIP. Need help. 😇

 TODOs- 
- [ ] ~~add detection for `node.gyp`.~~
- [ ] ~~parse `node.gyp` for filenames.~~
- [x] check filenames against regex. ( Added target dirs ).