### PR TITLE
test: add test for fsPromises.lchmod

### DIFF
--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -141,7 +141,8 @@ function verifyStatObject(stat) {
         // lchmod is only available on macOS
         const newMode = 0o666;
         await lchmod(newLink, newMode);
-        assert.strictEqual(await lstat(newLink).mode & 0o777, newMode);
+        stats = await lstat(newLink);
+        assert.strictEqual(stats.mode & 0o777, newMode);
       }
 
 

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -12,6 +12,7 @@ const {
   chmod,
   copyFile,
   link,
+  lchmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -128,7 +129,9 @@ function verifyStatObject(stat) {
 
     if (common.canCreateSymLink()) {
       const newLink = path.resolve(tmpDir, 'baz3.js');
+      const newMode = 0o666;
       await symlink(newPath, newLink);
+      await lchmod(newLink, newMode);
 
       stats = await lstat(newLink);
       verifyStatObject(stats);
@@ -137,6 +140,7 @@ function verifyStatObject(stat) {
                          (await realpath(newLink)).toLowerCase());
       assert.strictEqual(newPath.toLowerCase(),
                          (await readlink(newLink)).toLowerCase());
+      assert.strictEqual(stats.mode & 0o777, newMode);
 
       await unlink(newLink);
     }


### PR DESCRIPTION
To increase test coverage for fs/promises,
add test for fsPromises.lchmod.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
