### PR TITLE
tools: add v10 to alternative version docs menu

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -168,6 +168,7 @@ function altDocs(filename) {
   }
 
   const versions = [
+    { num: '10.x' },
     { num: '9.x' },
     { num: '8.x', lts: true },
     { num: '7.x' },


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Before:

![1](https://user-images.githubusercontent.com/10393198/39729786-6a82cd8e-5266-11e8-95bc-2751c444640d.png)

After:

![2](https://user-images.githubusercontent.com/10393198/39729788-6e51697a-5266-11e8-9a03-daf0feaa85a5.png)
