### PR TITLE
crypto: add test case for AES key wrapping

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2998,7 +2998,7 @@ CipherBase::UpdateResult CipherBase::Update(const char* data,
   int buff_len = len + EVP_CIPHER_CTX_block_size(ctx_.get());
   // For key wrapping algorithms, get output size by calling
   // EVP_CipherUpdate() with null output.
-  if (mode == EVP_CIPH_WRAP_MODE &&
+  if (kind_ == kCipher && mode == EVP_CIPH_WRAP_MODE &&
       EVP_CipherUpdate(ctx_.get(),
                        nullptr,
                        &buff_len,

--- a/test/parallel/test-crypto-aes-wrap.js
+++ b/test/parallel/test-crypto-aes-wrap.js
@@ -1,0 +1,62 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const test = [
+  {
+    algorithm: 'aes128-wrap',
+    key: 'b26f309fbe57e9b3bb6ae5ef31d54450',
+    iv: '3fd838af4093d749',
+    text: '12345678123456781234567812345678'
+  },
+  {
+    algorithm: 'id-aes128-wrap-pad',
+    key: 'b26f309fbe57e9b3bb6ae5ef31d54450',
+    iv: '3fd838af',
+    text: '12345678123456781234567812345678123'
+  },
+  {
+    algorithm: 'aes192-wrap',
+    key: '40978085d68091f7dfca0d7dfc7a5ee76d2cc7f2f345a304',
+    iv: '3fd838af4093d749',
+    text: '12345678123456781234567812345678'
+  },
+  {
+    algorithm: 'id-aes192-wrap-pad',
+    key: '40978085d68091f7dfca0d7dfc7a5ee76d2cc7f2f345a304',
+    iv: '3fd838af',
+    text: '12345678123456781234567812345678123'
+  },
+  {
+    algorithm: 'aes256-wrap',
+    key: '29c9eab5ed5ad44134a1437fe2e673b4d88a5b7c72e68454fea08721392b7323',
+    iv: '3fd838af4093d749',
+    text: '12345678123456781234567812345678'
+  },
+  {
+    algorithm: 'id-aes256-wrap-pad',
+    key: '29c9eab5ed5ad44134a1437fe2e673b4d88a5b7c72e68454fea08721392b7323',
+    iv: '3fd838af',
+    text: '12345678123456781234567812345678123'
+  },
+];
+
+test.forEach((data) => {
+  const cipher = crypto.createCipheriv(
+    data.algorithm,
+    Buffer.from(data.key, 'hex'),
+    Buffer.from(data.iv, 'hex'));
+  const ciphertext = cipher.update(data.text, 'utf8');
+
+  const decipher = crypto.createDecipheriv(
+    data.algorithm,
+    Buffer.from(data.key, 'hex'),
+    Buffer.from(data.iv, 'hex'));
+  const msg = decipher.update(ciphertext, 'buffer', 'utf8');
+
+  assert.strictEqual(msg, data.text, `${data.algorithm} test case failed`);
+});


### PR DESCRIPTION
Add test cases for AES key wrapping and only detect output length in
cipher case. The reason being is the returned output length is
insufficient in AES key unwrapping case.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
