### PR TITLE
fs: improve fchmod{Sync} validation

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1057,7 +1057,7 @@ fs.unlinkSync = function(path) {
 };
 
 fs.fchmod = function(fd, mode, callback) {
-  validateUint32(fd, 'fd');
+  validateInt32(fd, 'fd', 0);
   mode = validateAndMaskMode(mode, 'mode');
   callback = makeCallback(callback);
 
@@ -1067,7 +1067,7 @@ fs.fchmod = function(fd, mode, callback) {
 };
 
 fs.fchmodSync = function(fd, mode) {
-  validateUint32(fd, 'fd');
+  validateInt32(fd, 'fd', 0);
   mode = validateAndMaskMode(mode, 'mode');
   const ctx = {};
   binding.fchmod(fd, mode, undefined, ctx);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -48,7 +48,8 @@ function validateAndMaskMode(value, name, def) {
   throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
 }
 
-function validateInt32(value, name) {
+function validateInt32(value, name, min = -2147483648, max = 2147483647) {
+  // The defaults for min and max correspond to the limits of 32-bit integers.
   if (!isInt32(value)) {
     let err;
     if (typeof value !== 'number') {
@@ -56,9 +57,12 @@ function validateInt32(value, name) {
     } else if (!Number.isInteger(value)) {
       err = new ERR_OUT_OF_RANGE(name, 'an integer', value);
     } else {
-      // 2 ** 31 === 2147483648
-      err = new ERR_OUT_OF_RANGE(name, '> -2147483649 && < 2147483648', value);
+      err = new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
     }
+    Error.captureStackTrace(err, validateInt32);
+    throw err;
+  } else if (value < min || value > max) {
+    const err = new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
     Error.captureStackTrace(err, validateInt32);
     throw err;
   }

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -35,12 +35,21 @@ const fs = require('fs');
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError [ERR_OUT_OF_RANGE]',
-    message: 'The value of "fd" is out of range. It must be >= 0 && < ' +
-             `${2 ** 32}. Received ${input}`
+    message: 'The value of "fd" is out of range. It must be >= 0 && <= ' +
+             `2147483647. Received ${input}`
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
-  errObj.message = errObj.message.replace('fd', 'mode');
+});
+
+[-1, 2 ** 32].forEach((input) => {
+  const errObj = {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "mode" is out of range. It must be >= 0 && < ' +
+             `4294967296. Received ${input}`
+  };
+
   assert.throws(() => fs.fchmod(1, input), errObj);
   assert.throws(() => fs.fchmodSync(1, input), errObj);
 });

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -210,7 +210,7 @@ function testFtruncate(cb) {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError [ERR_OUT_OF_RANGE]',
         message: 'The value of "len" is out of range. It must be ' +
-                  `> -2147483649 && < 2147483648. Received ${input}`
+                  `>= -2147483648 && <= 2147483647. Received ${input}`
       }
     );
   });


### PR DESCRIPTION
This commit removes the check for `mode > 0o777`. It also validates the inputs as int32s instead of uint32s, because they are ints in the binding layer. Range validation is also added to the internal validators.

Fixes: https://github.com/nodejs/node/issues/20498

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
