### PR TITLE
lib: return directly from packageMainCache

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -153,13 +153,12 @@ function readPackage(requestPath) {
   }
 
   try {
-    var pkg = packageMainCache[requestPath] = JSON.parse(json).main;
+    return packageMainCache[requestPath] = JSON.parse(json).main;
   } catch (e) {
     e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
     throw e;
   }
-  return pkg;
 }
 
 function tryPackage(requestPath, exts, isMain) {


### PR DESCRIPTION
This commit updates readPackage to return directly when calling
packageMainCache instead of storing the result in a local var
and returning later.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
