### PR TITLE
vm: move emitExperimentalWarning

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { internalBinding } = require('internal/bootstrap/loaders');
-const { emitExperimentalWarning } = require('internal/util');
 const { URL } = require('internal/url');
 const { isContext } = process.binding('contextify');
 const {
@@ -16,6 +15,7 @@ const {
 const {
   getConstructorOf,
   customInspectSymbol,
+  emitExperimentalWarning
 } = require('internal/util');
 const { SafePromise } = require('internal/safe_globals');
 const { validateInt32, validateUint32 } = require('internal/validators');


### PR DESCRIPTION
This commit moves emitExperimentalWarning into the second object
destructoring of require internal/util.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
