### PR TITLE
doc: add params for ClientHttp2Session:altsvc

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -664,23 +664,23 @@ added: v8.4.0
 added: v9.4.0
 -->
 
-* `alt`: {string}
-* `origin`: {string}
-* `streamId`: {number}
+* `alt` {string}
+* `origin` {string}
+* `stream` {number}
 
 The `'altsvc'` event is emitted whenever an `ALTSVC` frame is received by
-the client. The event is emitted with the `ALTSVC` value, origin, and stream
-ID. If no `origin` is provided in the `ALTSVC` frame, `origin` will
+the client. The event is emitted with the `ALTSVC` value, origin, and stream.
+If no `origin` is provided in the `ALTSVC` frame, `origin` will
 be an empty string.
 
 ```js
 const http2 = require('http2');
 const client = http2.connect('https://example.org');
 
-client.on('altsvc', (alt, origin, streamId) => {
+client.on('altsvc', (alt, origin, stream) => {
   console.log(alt);
   console.log(origin);
-  console.log(streamId);
+  console.log(stream);
 });
 ```
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -666,21 +666,21 @@ added: v9.4.0
 
 * `alt` {string}
 * `origin` {string}
-* `stream` {number}
+* `streamId` {number}
 
 The `'altsvc'` event is emitted whenever an `ALTSVC` frame is received by
-the client. The event is emitted with the `ALTSVC` value, origin, and stream.
-If no `origin` is provided in the `ALTSVC` frame, `origin` will
+the client. The event is emitted with the `ALTSVC` value, origin, and stream
+ID. If no `origin` is provided in the `ALTSVC` frame, `origin` will
 be an empty string.
 
 ```js
 const http2 = require('http2');
 const client = http2.connect('https://example.org');
 
-client.on('altsvc', (alt, origin, stream) => {
+client.on('altsvc', (alt, origin, streamId) => {
   console.log(alt);
   console.log(origin);
-  console.log(stream);
+  console.log(streamId);
 });
 ```
 


### PR DESCRIPTION
Add parameters for the callback for the ClientHttp2Session:altsvc
event inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mcollina @nodejs/http2 @vsemozhetbyt 

P.S. I swapped out `streamId` for `stream`, because of the following code in `lib/http2/core.js`:

```js
function onAltSvc(stream, origin, alt) {
  const session = this[kOwner];
  if (session.destroyed)
    return;
  debug(`Http2Session ${sessionName(session[kType])}: altsvc received: ` +
        `stream: ${stream}, origin: ${origin}, alt: ${alt}`);
  session[kUpdateTimer]();
  session.emit('altsvc', alt, origin, stream);
}
```

Let me know if it should be reverted.