### PR TITLE
doc: fix nits in doc/api_assets/style.css

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -29,6 +29,9 @@ h6 { font-size: 1rem }
 
 h1, h2, h3, h4, h5, h6 {
   margin: 1.5rem 0 1rem;
+  text-rendering: optimizeLegibility;
+  font-weight: 700;
+  position: relative;
 }
 
 pre, tt, code, .pre, span.type, a.type {
@@ -183,10 +186,6 @@ ol.version-picker li:last-child a {
   background-color: #4EBA0F;
 }
 
-.api_stability_3 {
-  background-color: #0084B6;
-}
-
 .api_metadata {
   font-size: .85rem;
   margin-bottom: 1rem;
@@ -226,6 +225,8 @@ table {
 
 th, td {
   border: 1px solid #aaa;
+  padding: .75rem 1rem .75rem 1rem;
+  vertical-align: top;
 }
 
 th {
@@ -257,12 +258,6 @@ dl dd {
 
 dd + dt.pre {
   margin-top: 1.6rem;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  text-rendering: optimizeLegibility;
-  font-weight: 700;
-  position: relative;
 }
 
 #apicontent {
@@ -373,9 +368,6 @@ hr {
 #toc .stability_0::after {
   background-color: #d50027;
   color: #fff;
-}
-
-#toc .stability_0::after {
   content: "deprecated";
   margin-left: .25rem;
   padding: 1px 3px;
@@ -491,11 +483,6 @@ span > .mark, span > .mark:visited {
 span > .mark:hover, span > .mark:focus, span > .mark:active {
   color: #43853d;
   background: none;
-}
-
-th, td {
-  padding: .75rem 1rem .75rem 1rem;
-  vertical-align: top;
 }
 
 th > *:last-child, td > *:last-child {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

1. Merge rule sets for identical selectors.

2. Delete impossible selector block: we have only stability indexes 0, 1, and 2, so there can't be `.api_stability_3` class. Refs: https://nodejs.org/api/documentation.html#documentation_stability_index

I suspect we have some other outdated unused selectors in this file, but I've ventured to change only these safe cases as I am not very aware of frontend things. Maybe this can be a small task for code-and-learn with frontend folks? Say, all selectors may be checked against https://nodejs.org/api/all.html with `document.querySelectorAll('selector')` in DevTools.