### PR TITLE
stream: no need to initial er with false

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -251,7 +251,7 @@ function writeAfterEnd(stream, cb) {
 // and undefined/non-string values are only allowed in object mode.
 function validChunk(stream, state, chunk, cb) {
   var valid = true;
-  var er = false;
+  var er;
 
   if (chunk === null) {
     er = new ERR_STREAM_NULL_VALUES();


### PR DESCRIPTION
initial `er` with false is unnecessarily.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
