### PR TITLE
doc: add parameters for Http2Stream:error event

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -846,6 +846,8 @@ the `http2stream.rstCode` property. If the code is any value other than
 added: v8.4.0
 -->
 
+* `error` {Error}
+
 The `'error'` event is emitted when an error occurs during the processing of
 an `Http2Stream`.
 


### PR DESCRIPTION
Add parameters for the callback for the Http2Stream:error event
inline with the pattern in the rest of the documentation.

Refs: https://github.com/nodejs/help/issues/877#issuecomment-381253464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mcollina @nodejs/http2 @vsemozhetbyt 