### PR TITLE
inspector: fix inspector::Agent::HasConnectedSessions

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -693,6 +693,8 @@ bool Agent::IsWaitingForConnect() {
 }
 
 bool Agent::HasConnectedSessions() {
+  if (client_ == nullptr)
+    return false;
   return client_->hasConnectedSessions();
 }
 


### PR DESCRIPTION
In Agent::HasConnectedSessions, return false if client_ is nullptr.
That's possible when inspector setting is skipped for embedding/addon scenarios.
It makes the code more robust at least, otherwise, crash will happen here.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
