### PR TITLE
http2: fix end without read

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -240,8 +240,6 @@ class Http2ServerRequest extends Readable {
     stream[kRequest] = this;
 
     // Pause the stream..
-    stream.pause();
-    stream.on('data', onStreamData);
     stream.on('trailers', onStreamTrailers);
     stream.on('end', onStreamEnd);
     stream.on('error', onStreamError);
@@ -308,8 +306,12 @@ class Http2ServerRequest extends Readable {
   _read(nread) {
     const state = this[kState];
     if (!state.closed) {
-      state.didRead = true;
-      process.nextTick(resumeStream, this[kStream]);
+      if (!state.didRead) {
+        state.didRead = true;
+        this[kStream].on('data', onStreamData);
+      } else {
+        process.nextTick(resumeStream, this[kStream]);
+      }
     } else {
       this.emit('error', new ERR_HTTP2_INVALID_STREAM());
     }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -350,7 +350,9 @@ function onStreamClose(code) {
     // Push a null so the stream can end whenever the client consumes
     // it completely.
     stream.push(null);
-
+    // If the client hasn't tried to consume the stream and there is no
+    // resume scheduled (which would indicate they would consume in the future),
+    // then just dump the incoming data so that the stream can be destroyed.
     if (!stream[kState].didRead && !stream._readableState.resumeScheduled)
       stream.resume();
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -351,10 +351,8 @@ function onStreamClose(code) {
     // it completely.
     stream.push(null);
 
-    // Same as net.
-    if (stream.readableLength === 0) {
-      stream.read(0);
-    }
+    if (!stream[kState].didRead && !stream._readableState.resumeScheduled)
+      stream.resume();
   }
 }
 
@@ -1796,6 +1794,8 @@ class Http2Stream extends Duplex {
     const ret = this[kHandle].trailers(headersList);
     if (ret < 0)
       this.destroy(new NghttpError(ret));
+    else
+      this[kMaybeDestroy]();
   }
 
   get closed() {

--- a/test/parallel/test-http2-compat-client-upload-reject.js
+++ b/test/parallel/test-http2-compat-client-upload-reject.js
@@ -17,17 +17,10 @@ assert(fs.existsSync(loc));
 fs.readFile(loc, common.mustCall((err, data) => {
   assert.ifError(err);
 
-  const server = http2.createServer();
-
-  server.on('stream', common.mustCall((stream) => {
-    // Wait for some data to come through.
+  const server = http2.createServer(common.mustCall((req, res) => {
     setImmediate(() => {
-      stream.on('close', common.mustCall(() => {
-        assert.strictEqual(stream.rstCode, 0);
-      }));
-
-      stream.respond({ ':status': 400 });
-      stream.end();
+      res.writeHead(400);
+      res.end();
     });
   }));
 


### PR DESCRIPTION
Adjust http2 behaviour to allow ending a stream even after some
data comes in (when the user has no intention of reading that
data). Also correctly end a stream when trailers are present.

Fixes: https://github.com/nodejs/node/issues/20060

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
