### PR TITLE
src: use struct initialisation for ContextOptions

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -222,21 +222,17 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
           env->context(),
           env->contextify_context_private_symbol()).FromJust());
 
-  ContextOptions options;
-
   CHECK(args[1]->IsString());
-  options.name = args[1].As<String>();
-
   CHECK(args[2]->IsString() || args[2]->IsUndefined());
-  if (args[2]->IsString()) {
-    options.origin = args[2].As<String>();
-  }
-
   CHECK(args[3]->IsBoolean());
-  options.allow_code_gen_strings = args[3].As<Boolean>();
-
   CHECK(args[4]->IsBoolean());
-  options.allow_code_gen_wasm = args[4].As<Boolean>();
+
+  ContextOptions options {
+    args[1].As<String>(),
+    args[2]->IsString() ? args[2].As<String>() : Local<String>(),
+    args[3].As<Boolean>(),
+    args[4].As<Boolean>()
+  };
 
   TryCatch try_catch(env->isolate());
   ContextifyContext* context = new ContextifyContext(env, sandbox, options);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -228,10 +228,10 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[4]->IsBoolean());
 
   ContextOptions options {
-    .name = args[1].As<String>(),
-    .origin = args[2]->IsString() ? args[2].As<String>() : Local<String>(),
-    .allow_code_gen_strings = args[3].As<Boolean>(),
-    .allow_code_gen_wasm = args[4].As<Boolean>()
+    args[1].As<String>(),
+    args[2]->IsString() ? args[2].As<String>() : Local<String>(),
+    args[3].As<Boolean>(),
+    args[4].As<Boolean>()
   };
 
   TryCatch try_catch(env->isolate());

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -228,10 +228,10 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[4]->IsBoolean());
 
   ContextOptions options {
-    args[1].As<String>(),
-    args[2]->IsString() ? args[2].As<String>() : Local<String>(),
-    args[3].As<Boolean>(),
-    args[4].As<Boolean>()
+    .name = args[1].As<String>(),
+    .origin = args[2]->IsString() ? args[2].As<String>() : Local<String>(),
+    .allow_code_gen_strings = args[3].As<Boolean>(),
+    .allow_code_gen_wasm = args[4].As<Boolean>()
   };
 
   TryCatch try_catch(env->isolate());


### PR DESCRIPTION
This commit updates MakeContext to use a struct initialiser to avoid
creating empty v8::Local objects.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
