### PR TITLE
[WIP] repl: Allow commands only when there is no buffered user input

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -29,9 +29,6 @@ customizable evaluation functions.
 
 The following special commands are supported by all REPL instances:
 
-* `.break` - When in the process of inputting a multi-line expression, entering
-  the `.break` command (or pressing the `<ctrl>-C` key combination) will abort
-  further input or processing of that expression.
 * `.clear` - Resets the REPL `context` to an empty object and clears any
   multi-line expression currently being input.
 * `.exit` - Close the I/O stream, causing the REPL to exit.
@@ -59,9 +56,9 @@ welcome('Node.js User');
 
 The following key combinations in the REPL have these special effects:
 
-* `<ctrl>-C` - When pressed once, has the same effect as the `.break` command.
-  When pressed twice on a blank line, has the same effect as the `.exit`
-  command.
+* `<ctrl>-C` - When pressed once, will abort further input or processing
+  of that expression. When pressed twice on a blank line,
+  has the same effect as the `.exit` command.
 * `<ctrl>-D` - Has the same effect as the `.exit` command.
 * `<tab>` - When pressed on a blank line, displays global and local (scope)
   variables. When pressed while entering other input, displays relevant

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -557,7 +557,7 @@ function REPLServer(prompt,
         sawSIGINT = false;
         return;
       }
-      self.output.write('(To exit, press ^C again or type .exit)\n');
+      self.output.write('(To exit, press ^C again or ^D or type .exit)\n');
       sawSIGINT = true;
     } else {
       sawSIGINT = false;
@@ -593,20 +593,17 @@ function REPLServer(prompt,
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (trimmedCmd) {
+    if (trimmedCmd && !self[kBufferedCommandSymbol]) {
       if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) !== '.' &&
           Number.isNaN(parseFloat(trimmedCmd))) {
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];
-        if (_parseREPLKeyword.call(self, keyword, rest) === true) {
-          return;
-        }
-        if (!self[kBufferedCommandSymbol]) {
+        if (_parseREPLKeyword.call(self, keyword, rest) !== true) {
           self.outputStream.write('Invalid REPL keyword\n');
           finish(null);
-          return;
         }
+        return;
       }
     }
 
@@ -984,7 +981,7 @@ function complete(line, callback) {
   var completionGroups = [];
   var completeOn, i, group, c;
 
-  // REPL commands (e.g. ".break").
+  // REPL commands (e.g. ".help").
   var filter;
   var match = null;
   match = line.match(/^\s*\.(\w*)$/);
@@ -1373,31 +1370,20 @@ function _turnOffEditorMode(repl) {
 }
 
 function defineDefaultCommands(repl) {
-  repl.defineCommand('break', {
-    help: 'Sometimes you get stuck, this gets you out',
-    action: function() {
-      this.clearBufferedCommand();
-      this.displayPrompt();
-    }
-  });
 
-  var clearMessage;
-  if (repl.useGlobal) {
-    clearMessage = 'Alias for .break';
-  } else {
-    clearMessage = 'Break, and also clear the local context';
-  }
-  repl.defineCommand('clear', {
-    help: clearMessage,
-    action: function() {
-      this.clearBufferedCommand();
-      if (!this.useGlobal) {
-        this.outputStream.write('Clearing context...\n');
-        this.resetContext();
+  if (!repl.useGlobal) {
+    repl.defineCommand('clear', {
+      help: 'Clear the local context',
+      action: function() {
+        this.clearBufferedCommand();
+        if (!this.useGlobal) {
+          this.outputStream.write('Clearing context...\n');
+          this.resetContext();
+        }
+        this.displayPrompt();
       }
-      this.displayPrompt();
-    }
-  });
+    });
+  }
 
   repl.defineCommand('exit', {
     help: 'Exit the repl',
@@ -1421,6 +1407,8 @@ function defineDefaultCommands(repl) {
         var line = `.${name}${cmd.help ? spaces + cmd.help : ''}\n`;
         this.outputStream.write(line);
       }
+      this.outputStream.write('\nPress ^C to abort current expression, ' +
+        '^D to exit the repl\n');
       this.displayPrompt();
     }
   });
@@ -1464,15 +1452,17 @@ function defineDefaultCommands(repl) {
     }
   });
 
-  repl.defineCommand('editor', {
-    help: 'Enter editor mode',
-    action() {
-      if (!this.terminal) return;
-      _turnOnEditorMode(this);
-      this.outputStream.write(
-        '// Entering editor mode (^D to finish, ^C to cancel)\n');
-    }
-  });
+  if (repl.terminal) {
+    repl.defineCommand('editor', {
+      help: 'Enter editor mode',
+      action() {
+        if (!this.terminal) return;
+        _turnOnEditorMode(this);
+        this.outputStream.write(
+          '// Entering editor mode (^D to finish, ^C to cancel)\n');
+      }
+    });
+  }
 }
 
 function regexpEscape(s) {


### PR DESCRIPTION
Allow REPL commands only when there is no buffered user input
```js
> (function() {
... x = { help: () => 'help received' };
... return x
...         .help ();    <-- no repl command parsing in multiline mode
.break    Sometimes you get stuck, this gets you out
.clear    Alias for .break
.editor   Enter editor mode
.exit     Exit the repl
.help     Print this help message
.load     Load JS from a file into the REPL session
.save     Save all evaluated commands in this REPL session to a file
...

```
- Removed `.break` command. User can break using ^C and `.break`
   can be a value (property/function) in the multiline code
 - `.clear` makes sense only when `useGlobal` is set to false
   while constructing repl
 - `.editor` mode is only for terminal

I'll write tests if the proposal is good to go
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included (TODO)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
