### PR TITLE
util: limit util inspect depth to 10

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -407,7 +407,7 @@ changes:
     -->
   * `maxArrayLength` {number} Specifies the maximum number of `Array`,
     [`TypedArray`][], [`WeakMap`][] and [`WeakSet`][] elements to include when
-    formatting. Set to `null` or `Infinity` to show all elements. Set to `0` or
+    formatting. Set to `Infinity` or `null` to show all elements. Set to `0` or
     negative to show no elements. **Default:** `100`.
   * `breakLength` {number} The length at which an object's keys are split
     across multiple lines. Set to `Infinity` to format an object as a single
@@ -421,8 +421,9 @@ changes:
     example below. **Default:** `true`.
   * `depth` {number} Specifies the number of visible nested `Object`s in an
     `object`. This is useful to minimize the inspection output for large
-    complicated objects. To make it recurse indefinitely pass `null` or
-    `Infinity`. **Default:** `10`.
+    complicated objects. To make it recurse almost indefinitely pass any high
+    number, `Infinity` or `null`. The real value is capped at 1000.
+    **Default:** `10`.
 * Returns: {string} The representation of passed object
 
 The `util.inspect()` method returns a string representation of `object` that is

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -363,13 +363,13 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `depth` default changed to 10.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/19259
     description: The `WeakMap` and `WeakSet` entries can now be inspected
                  as well.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17907
-    description: The `depth` default changed to `Infinity`.
   - version: v9.9.0
     pr-url: https://github.com/nodejs/node/pull/17576
     description: The `compact` option is supported now.
@@ -422,7 +422,7 @@ changes:
   * `depth` {number} Specifies the number of visible nested `Object`s in an
     `object`. This is useful to minimize the inspection output for large
     complicated objects. To make it recurse indefinitely pass `null` or
-    `Infinity`. **Default:** `Infinity`.
+    `Infinity`. **Default:** `10`.
 * Returns: {string} The representation of passed object
 
 The `util.inspect()` method returns a string representation of `object` that is

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -658,8 +658,9 @@ function dnsException(code, syscall, hostname) {
   return ex;
 }
 
-let maxStack_ErrorName;
-let maxStack_ErrorMessage;
+let maxStackErrorName;
+let maxStackErrorMessage;
+let maxStackLimit = 0;
 /**
  * Returns true if `err.name` and `err.message` are equal to engine-specific
  * values indicating max call stack size has been exceeded.
@@ -669,18 +670,29 @@ let maxStack_ErrorMessage;
  * @returns {boolean}
  */
 function isStackOverflowError(err) {
-  if (maxStack_ErrorMessage === undefined) {
+  if (maxStackErrorMessage === undefined) {
     try {
-      function overflowStack() { overflowStack(); }
+      function overflowStack() {
+        maxStackLimit++;
+        overflowStack();
+      }
       overflowStack();
     } catch (err) {
-      maxStack_ErrorMessage = err.message;
-      maxStack_ErrorName = err.name;
+      maxStackErrorMessage = err.message;
+      maxStackErrorName = err.name;
     }
   }
 
-  return err.name === maxStack_ErrorName &&
-         err.message === maxStack_ErrorMessage;
+  return err.name === maxStackErrorName &&
+         err.message === maxStackErrorMessage;
+}
+
+function getMaxStackLimit() {
+  if (maxStackLimit === 0) {
+    // Use a fake "error"
+    isStackOverflowError({ name: '', message: '' });
+  }
+  return maxStackLimit;
 }
 
 module.exports = {
@@ -689,6 +701,7 @@ module.exports = {
   exceptionWithHostPort,
   uvException,
   isStackOverflowError,
+  getMaxStackLimit,
   getMessage,
   AssertionError,
   SystemError,

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,12 +21,16 @@
 
 'use strict';
 
-const errors = require('internal/errors');
 const {
-  ERR_FALSY_VALUE_REJECTION,
-  ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE
-} = errors.codes;
+  getMaxStackLimit,
+  errnoException: _errnoException,
+  exceptionWithHostPort: _exceptionWithHostPort,
+  codes: {
+    ERR_FALSY_VALUE_REJECTION,
+    ERR_INVALID_ARG_TYPE,
+    ERR_OUT_OF_RANGE
+  }
+} = require('internal/errors');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 
@@ -104,6 +108,12 @@ const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;
 
 const readableRegExps = {};
+
+// The actual maximum stack limit has to be divided by the number of function
+// calls that are maximal necessary for each depth level. That does not seem
+// to be sufficient though, so let us just divide it by 10 and use 1000 as upper
+// limit.
+const MAX_DEPTH_LIMIT = Math.min(Math.floor(getMaxStackLimit() / 10), 1000);
 
 const MIN_LINE_LENGTH = 16;
 
@@ -287,6 +297,14 @@ function debuglog(set) {
   return debugs[set];
 }
 
+function getMaxDepth(depth) {
+  if (depth === null)
+    return MAX_DEPTH_LIMIT;
+  if (depth < MAX_DEPTH_LIMIT)
+    return depth;
+  return MAX_DEPTH_LIMIT;
+}
+
 /**
  * Echos the value of any input. Tries to print the value out
  * in the best way possible given the different types.
@@ -332,7 +350,7 @@ function inspect(value, opts) {
   }
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   if (ctx.maxArrayLength === null) ctx.maxArrayLength = Infinity;
-  return formatValue(ctx, value, ctx.depth);
+  return formatValue(ctx, value, getMaxDepth(ctx.depth));
 }
 inspect.custom = customInspectSymbol;
 
@@ -677,11 +695,9 @@ function formatValue(ctx, value, recurseTimes, ln) {
     }
   }
 
-  if (recurseTimes != null) {
-    if (recurseTimes < 0)
-      return ctx.stylize(`[${constructor || tag || 'Object'}]`, 'special');
-    recurseTimes -= 1;
-  }
+  if (recurseTimes < 0)
+    return ctx.stylize(`[${constructor || tag || 'Object'}]`, 'special');
+  recurseTimes -= 1;
 
   ctx.seen.push(value);
   const output = formatter(ctx, value, recurseTimes, keys);
@@ -1246,8 +1262,8 @@ function getSystemErrorName(err) {
 
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
-  _errnoException: errors.errnoException,
-  _exceptionWithHostPort: errors.exceptionWithHostPort,
+  _errnoException,
+  _exceptionWithHostPort,
   _extend,
   callbackify,
   debuglog,

--- a/lib/util.js
+++ b/lib/util.js
@@ -80,7 +80,7 @@ const {
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: null,
+  depth: 10,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1404,3 +1404,15 @@ util.inspect(process);
   const args = (function() { return arguments; })('a');
   assert.strictEqual(util.inspect(args), "[Arguments] { '0': 'a' }");
 }
+
+{
+  // Test that a long linked list can be inspected without throwing an error.
+  const list = {};
+  let head = list;
+  // The real cutoff value is closer to 1400 stack frames as of May 2018,
+  // but let's be generous here – even a linked listed of length 100k should be
+  // inspectable in some way.
+  for (let i = 0; i < 100000; i++)
+    head = head.next = {};
+  util.inspect(list);
+}

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1409,10 +1409,16 @@ util.inspect(process);
   // Test that a long linked list can be inspected without throwing an error.
   const list = {};
   let head = list;
-  // The real cutoff value is closer to 1400 stack frames as of May 2018,
-  // but let's be generous here – even a linked listed of length 100k should be
-  // inspectable in some way.
+  // A linked list of length 100k should be inspectable in some way, even though
+  // the real cutoff value is much lower than 100k.
   for (let i = 0; i < 100000; i++)
     head = head.next = {};
-  util.inspect(list);
+  assert.strictEqual(
+    util.inspect(list),
+    '{ next: \n   { next: \n      { next: \n         { next: \n            { ' +
+      'next: \n               { next: { next: { next: { next: { next: { ' +
+      'next: [Object] } } } } } } } } } } }'
+  );
+  const longList = util.inspect(list, { depth: Infinity });
+  assert.strictEqual(longList.match(/next/g).length, 1001);
 }


### PR DESCRIPTION
Due to the controversial change about having Infinity as limit,
this is going to change it to 10 instead. That should be a much
safer default and it should still provide the best experience for
most users. Besides that, I added a absolute limit of 1000. So
if a higher limit is passed through, it would just limit it to 1000.

Nevertheless, this is not going to prevent an application from
crashing if the passed in object is to big. For this problem, there
is another PR open: #19994.

I actually also have a alternative implementation that allows to
inspect very deep nested objects without getting a maximum
callstack size exceeded error. I was for example able to inspect
the same linked list as used here in the test up to a depth of
98000. The problem is that this will take some time and can
result in the heap memory not being sufficient anymore so the
application can crash. Since that should not be possible, having
a strong limit seems like the better approach (using a absolute
limit there will not work because we do not know the shape of
the object). I can open that PR as alternative nevertheless, if
requested.

I used the test from #20017. This PR is not semver-major because
it relies on a semver-major commit.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
