### PR TITLE
src: remove 2nd `undefined` argument in node_file.cc

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -421,7 +421,9 @@ void FSReqWrap::Resolve(Local<Value> value) {
     Null(env()->isolate()),
     value
   };
-  MakeCallback(env()->oncomplete_string(), arraysize(argv), argv);
+  MakeCallback(env()->oncomplete_string(),
+               value->IsUndefined() ? 1 : arraysize(argv),
+               argv);
 }
 
 void FSReqWrap::SetReturnValue(const FunctionCallbackInfo<Value>& args) {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -64,15 +64,21 @@ assert.strictEqual(typeof fs.X_OK, 'number');
 
 const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 
-fs.access(__filename, common.mustCall(assert.ifError));
+fs.access(__filename, common.mustCall(function(...args) {
+  assert.deepStrictEqual(args, [null]);
+}));
 fs.promises.access(__filename)
   .then(common.mustCall())
   .catch(throwNextTick);
-fs.access(__filename, fs.R_OK, common.mustCall(assert.ifError));
+fs.access(__filename, fs.R_OK, common.mustCall(function(...args) {
+  assert.deepStrictEqual(args, [null]);
+}));
 fs.promises.access(__filename, fs.R_OK)
   .then(common.mustCall())
   .catch(throwNextTick);
-fs.access(readOnlyFile, fs.F_OK | fs.R_OK, common.mustCall(assert.ifError));
+fs.access(readOnlyFile, fs.F_OK | fs.R_OK, common.mustCall(function(...args) {
+  assert.deepStrictEqual(args, [null]);
+}));
 fs.promises.access(readOnlyFile, fs.F_OK | fs.R_OK)
   .then(common.mustCall())
   .catch(throwNextTick);

--- a/test/parallel/test-fs-close.js
+++ b/test/parallel/test-fs-close.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+const fd = fs.openSync(__filename, 'r');
+
+fs.close(fd, common.mustCall(function(...args) {
+  assert.deepStrictEqual(args, [null]);
+}));


### PR DESCRIPTION
In the document for fs, there are several functions that state "No
arguments other than a possible exception are given to the completion
callback." (ex> fs.access, fs.chmod, fs.close, ..)

But, the functions are invoking the callback with two parameters (err,
undefined)

It causes problems in using several API like
[async.waterfall](https://caolan.github.io/async/docs.html#waterfall).

Fixes: https://github.com/nodejs/node/issues/20335

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
