### PR TITLE
tools: hide symbols for builtin JS files in binary

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -183,7 +183,11 @@ TEMPLATE = """
 
 namespace node {{
 
+namespace {{
+
 {definitions}
+
+}}  // anonymous namespace
 
 v8::Local<v8::String> LoadersBootstrapperSource(Environment* env) {{
   return internal_bootstrap_loaders_value.ToStringChecked(env->isolate());


### PR DESCRIPTION
Do not expose symbols like `node::internal_process_next_tick_value`,
`node::internal_process_next_tick_key` in the created `node` binary
by wrapping them in an anonymous namespace.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
