### PR TITLE
src: fix nullptr dereference for signal during startup

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -327,7 +327,8 @@ static struct {
   }
 
   void StopTracingAgent() {
-    tracing_agent_->Stop();
+    if (tracing_agent_)
+      tracing_agent_->Stop();
   }
 
   tracing::Agent* GetTracingAgent() const {


### PR DESCRIPTION
This fixes a test failure when running
`test/parallel/test-child-process-spawnsync-kill-signal.js`
under load. What would happen is that `SignalExit()` tries
to shutdown the tracing agent, which might not have been set
up by the point that Node.js receives the signal.

Example failure: https://ci.nodejs.org/job/node-test-commit-linux-containered/4300/nodes=ubuntu1604_sharedlibs_zlib_x64/consoleFull

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
