### PR TITLE
test: add tests for fsPromises.truncate and FileHandle.truncate

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-truncate.js
+++ b/test/parallel/test-fs-promises-file-handle-truncate.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const { open, readFile } = require('fs').promises;
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+common.crashOnUnhandledRejection();
+
+async function validateTruncate() {
+  const text = 'Hello world';
+  const filename = path.resolve(tmpdir.path, 'truncate-file.txt');
+  const fileHandle = await open(filename, 'w+');
+
+  const buffer = Buffer.from(text, 'utf8');
+  await fileHandle.write(buffer, 0, buffer.length);
+
+  assert.deepStrictEqual((await readFile(filename)).toString(), text);
+
+  await fileHandle.truncate(5);
+  assert.deepStrictEqual((await readFile(filename)).toString(), 'Hello');
+}
+
+validateTruncate().then(common.mustCall());

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -16,6 +16,8 @@ const {
   mkdir,
   mkdtemp,
   open,
+  read,
+  readFile,
   readdir,
   readlink,
   realpath,
@@ -23,6 +25,8 @@ const {
   rmdir,
   stat,
   symlink,
+  truncate,
+  write,
   unlink,
   utimes
 } = fsPromises;
@@ -120,6 +124,9 @@ function verifyStatObject(stat) {
     }
 
     await handle.close();
+
+    await truncate(dest, 5);
+    assert.deepStrictEqual((await readFile(dest)).toString(), 'hello');
 
     const newPath = path.resolve(tmpDir, 'baz2.js');
     await rename(dest, newPath);

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -16,7 +16,6 @@ const {
   mkdir,
   mkdtemp,
   open,
-  read,
   readFile,
   readdir,
   readlink,
@@ -26,7 +25,6 @@ const {
   stat,
   symlink,
   truncate,
-  write,
   unlink,
   utimes
 } = fsPromises;
@@ -102,6 +100,8 @@ function verifyStatObject(stat) {
     const ret2 = await handle.read(Buffer.alloc(buf2Len), 0, buf2Len, 0);
     assert.strictEqual(ret2.bytesRead, buf2Len);
     assert.deepStrictEqual(ret2.buffer, buf2);
+    await truncate(dest, 5);
+    assert.deepStrictEqual((await readFile(dest)).toString(), 'hello');
 
     await chmod(dest, 0o666);
     await handle.chmod(0o666);
@@ -124,9 +124,6 @@ function verifyStatObject(stat) {
     }
 
     await handle.close();
-
-    await truncate(dest, 5);
-    assert.deepStrictEqual((await readFile(dest)).toString(), 'hello');
 
     const newPath = path.resolve(tmpDir, 'baz2.js');
     await rename(dest, newPath);


### PR DESCRIPTION
To increase test coverage, added tests for fsPromises.truncate
and FileHandle.truncate.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
