### PR TITLE
src: add public API to create isolate and context

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4426,7 +4426,7 @@ int EmitExit(Environment* env) {
 
 
 ArrayBufferAllocator* CreateArrayBufferAllocator() {
-  return new ArrayBufferAllocator;
+  return new ArrayBufferAllocator();
 }
 
 
@@ -4623,8 +4623,8 @@ Isolate* NewIsolate(ArrayBufferAllocator* allocator) {
 inline int Start(uv_loop_t* event_loop,
                  int argc, const char* const* argv,
                  int exec_argc, const char* const* exec_argv) {
-  ArrayBufferAllocator* allocator = CreateArrayBufferAllocator();
-  Isolate* const isolate = NewIsolate(allocator);
+  std::unique_ptr<ArrayBufferAllocator> allocator(CreateArrayBufferAllocator());
+  Isolate* const isolate = NewIsolate(allocator.get());
   if (isolate == nullptr)
     return 12;  // Signal internal error.
 
@@ -4639,16 +4639,17 @@ inline int Start(uv_loop_t* event_loop,
     Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
-    IsolateData* isolate_data = CreateIsolateData(
+    std::unique_ptr<IsolateData> isolate_data(
+      CreateIsolateData(
         isolate,
         event_loop,
         v8_platform.Platform(),
-        allocator);
+        allocator.get()));
     if (track_heap_objects) {
       isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
     }
-    exit_code = Start(isolate, isolate_data, argc, argv, exec_argc, exec_argv);
-    FreeIsolateData(isolate_data);
+    exit_code =
+      Start(isolate, isolate_data.get(), argc, argv, exec_argc, exec_argv);
   }
 
   {
@@ -4658,7 +4659,6 @@ inline int Start(uv_loop_t* event_loop,
   }
 
   isolate->Dispose();
-  FreeArrayBufferAllocator(allocator);
 
   return exit_code;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -4425,15 +4425,35 @@ int EmitExit(Environment* env) {
 }
 
 
+ArrayBufferAllocator* CreateArrayBufferAllocator() {
+  return new ArrayBufferAllocator;
+}
+
+
+void FreeArrayBufferAllocator(ArrayBufferAllocator* allocator) {
+  delete allocator;
+}
+
+
 IsolateData* CreateIsolateData(Isolate* isolate, uv_loop_t* loop) {
   return new IsolateData(isolate, loop, nullptr);
 }
+
 
 IsolateData* CreateIsolateData(
     Isolate* isolate,
     uv_loop_t* loop,
     MultiIsolatePlatform* platform) {
   return new IsolateData(isolate, loop, platform);
+}
+
+
+IsolateData* CreateIsolateData(
+    Isolate* isolate,
+    uv_loop_t* loop,
+    MultiIsolatePlatform* platform,
+    ArrayBufferAllocator* allocator) {
+  return new IsolateData(isolate, loop, platform, allocator->zero_fill_field());
 }
 
 
@@ -4580,25 +4600,33 @@ bool AllowWasmCodeGenerationCallback(
   return wasm_code_gen->IsUndefined() || wasm_code_gen->IsTrue();
 }
 
-inline int Start(uv_loop_t* event_loop,
-                 int argc, const char* const* argv,
-                 int exec_argc, const char* const* exec_argv) {
+Isolate* NewIsolate(ArrayBufferAllocator* allocator) {
   Isolate::CreateParams params;
-  ArrayBufferAllocator allocator;
-  params.array_buffer_allocator = &allocator;
+  params.array_buffer_allocator = allocator;
 #ifdef NODE_ENABLE_VTUNE_PROFILING
   params.code_event_handler = vTune::GetVtuneCodeEventHandler();
 #endif
 
-  Isolate* const isolate = Isolate::New(params);
+  Isolate* isolate = Isolate::New(params);
   if (isolate == nullptr)
-    return 12;  // Signal internal error.
+    return nullptr;
 
   isolate->AddMessageListener(OnMessage);
   isolate->SetAbortOnUncaughtExceptionCallback(ShouldAbortOnUncaughtException);
   isolate->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
   isolate->SetFatalErrorHandler(OnFatalError);
   isolate->SetAllowWasmCodeGenerationCallback(AllowWasmCodeGenerationCallback);
+
+  return isolate;
+}
+
+inline int Start(uv_loop_t* event_loop,
+                 int argc, const char* const* argv,
+                 int exec_argc, const char* const* exec_argv) {
+  ArrayBufferAllocator* allocator = CreateArrayBufferAllocator();
+  Isolate* const isolate = NewIsolate(allocator);
+  if (isolate == nullptr)
+    return 12;  // Signal internal error.
 
   {
     Mutex::ScopedLock scoped_lock(node_isolate_mutex);
@@ -4611,15 +4639,16 @@ inline int Start(uv_loop_t* event_loop,
     Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
-    IsolateData isolate_data(
+    IsolateData* isolate_data = CreateIsolateData(
         isolate,
         event_loop,
         v8_platform.Platform(),
-        allocator.zero_fill_field());
+        allocator);
     if (track_heap_objects) {
       isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
     }
-    exit_code = Start(isolate, &isolate_data, argc, argv, exec_argc, exec_argv);
+    exit_code = Start(isolate, isolate_data, argc, argv, exec_argc, exec_argv);
+    FreeIsolateData(isolate_data);
   }
 
   {
@@ -4629,6 +4658,7 @@ inline int Start(uv_loop_t* event_loop,
   }
 
   isolate->Dispose();
+  FreeArrayBufferAllocator(allocator);
 
   return exit_code;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -4624,7 +4624,7 @@ inline int Start(uv_loop_t* event_loop,
                  int argc, const char* const* argv,
                  int exec_argc, const char* const* exec_argv) {
   std::unique_ptr<ArrayBufferAllocator, decltype(&FreeArrayBufferAllocator)>
-    allocator(CreateArrayBufferAllocator(), &FreeArrayBufferAllocator);
+      allocator(CreateArrayBufferAllocator(), &FreeArrayBufferAllocator);
   Isolate* const isolate = NewIsolate(allocator.get());
   if (isolate == nullptr)
     return 12;  // Signal internal error.
@@ -4641,17 +4641,17 @@ inline int Start(uv_loop_t* event_loop,
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     std::unique_ptr<IsolateData, decltype(&FreeIsolateData)> isolate_data(
-      CreateIsolateData(
-        isolate,
-        event_loop,
-        v8_platform.Platform(),
-        allocator.get()),
-      &FreeIsolateData);
+        CreateIsolateData(
+            isolate,
+            event_loop,
+            v8_platform.Platform(),
+            allocator.get()),
+        &FreeIsolateData);
     if (track_heap_objects) {
       isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
     }
     exit_code =
-      Start(isolate, isolate_data.get(), argc, argv, exec_argc, exec_argv);
+        Start(isolate, isolate_data.get(), argc, argv, exec_argc, exec_argv);
   }
 
   {

--- a/src/node.h
+++ b/src/node.h
@@ -214,6 +214,11 @@ NODE_EXTERN void Init(int* argc,
                       int* exec_argc,
                       const char*** exec_argv);
 
+class ArrayBufferAllocator;
+
+NODE_EXTERN ArrayBufferAllocator* CreateArrayBufferAllocator();
+NODE_EXTERN void FreeArrayBufferAllocator(ArrayBufferAllocator* allocator);
+
 class IsolateData;
 class Environment;
 
@@ -229,9 +234,21 @@ class MultiIsolatePlatform : public v8::Platform {
   virtual void UnregisterIsolate(IsolateData* isolate_data) = 0;
 };
 
+// Creates a new isolate with Node.js-specific settings.
+NODE_EXTERN v8::Isolate* NewIsolate(ArrayBufferAllocator* allocator);
+
+// Creates a new context with Node.js-specific tweaks.  Currently, it removes
+// the `v8BreakIterator` property from the global `Intl` object if present.
+// See https://github.com/nodejs/node/issues/14909 for more info.
+NODE_EXTERN v8::Local<v8::Context> NewContext(
+    v8::Isolate* isolate,
+    v8::Local<v8::ObjectTemplate> object_template =
+        v8::Local<v8::ObjectTemplate>());
+
 // If `platform` is passed, it will be used to register new Worker instances.
 // It can be `nullptr`, in which case creating new Workers inside of
 // Environments that use this `IsolateData` will not work.
+// TODO(helloshuangzi): switch to default parameters.
 NODE_EXTERN IsolateData* CreateIsolateData(
     v8::Isolate* isolate,
     struct uv_loop_s* loop);
@@ -239,6 +256,11 @@ NODE_EXTERN IsolateData* CreateIsolateData(
     v8::Isolate* isolate,
     struct uv_loop_s* loop,
     MultiIsolatePlatform* platform);
+NODE_EXTERN IsolateData* CreateIsolateData(
+    v8::Isolate* isolate,
+    struct uv_loop_s* loop,
+    MultiIsolatePlatform* platform,
+    ArrayBufferAllocator* allocator);
 NODE_EXTERN void FreeIsolateData(IsolateData* isolate_data);
 
 NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -227,14 +227,6 @@ inline v8::Local<TypeName> PersistentToLocal(
     v8::Isolate* isolate,
     const Persistent<TypeName>& persistent);
 
-// Creates a new context with Node.js-specific tweaks.  Currently, it removes
-// the `v8BreakIterator` property from the global `Intl` object if present.
-// See https://github.com/nodejs/node/issues/14909 for more info.
-v8::Local<v8::Context> NewContext(
-    v8::Isolate* isolate,
-    v8::Local<v8::ObjectTemplate> object_template =
-        v8::Local<v8::ObjectTemplate>());
-
 // Convert a struct sockaddr to a { address: '1.2.3.4', port: 1234 } JS object.
 // Sets address and port properties on the info object and returns it.
 // If |info| is omitted, a new object is returned.


### PR DESCRIPTION
This change is used to support addon / embedding scenarios.
An addon/embedding scenario has requirement to create isolate / context with the same setting/tweak that is used in node main thread, instead of duplicating that part of logic by themself, which may lead to conflict in the future.

Please see [this commit of napajs](https://github.com/helloshuangzi/napajs/pull/22/commits/7f1a45b90b4af928d42a8499e69b9695df16dfc3) as an example.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
