### PR TITLE
net,http2: refactor _write and _writev in net.Socket and http2.Http2Stream

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -146,6 +146,7 @@ const kSession = Symbol('session');
 const kState = Symbol('state');
 const kType = Symbol('type');
 const kUpdateTimer = Symbol('update-timer');
+const kWriteGeneric = Symbol('write-generic');
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 
@@ -1657,13 +1658,16 @@ class Http2Stream extends Duplex {
                 'bug in Node.js');
   }
 
-  _write(data, encoding, cb) {
+  [kWriteGeneric](writev, data, encoding, cb) {
     // When the Http2Stream is first created, it is corked until the
     // handle and the stream ID is assigned. However, if the user calls
     // uncork() before that happens, the Duplex will attempt to pass
     // writes through. Those need to be queued up here.
     if (this.pending) {
-      this.once('ready', this._write.bind(this, data, encoding, cb));
+      this.once(
+        'ready',
+        this[kWriteGeneric].bind(this, writev, data, encoding, cb)
+      );
       return;
     }
 
@@ -1683,41 +1687,20 @@ class Http2Stream extends Duplex {
     const req = createWriteWrap(this[kHandle], afterDoStreamWrite);
     req.stream = this[kID];
 
-    writeGeneric(this, req, data, encoding, cb);
+    if (writev)
+      writevGeneric(this, req, data, cb);
+    else
+      writeGeneric(this, req, data, encoding, cb);
 
     trackWriteState(this, req.bytes);
   }
 
+  _write(data, encoding, cb) {
+    this[kWriteGeneric](false, data, encoding, cb);
+  }
+
   _writev(data, cb) {
-    // When the Http2Stream is first created, it is corked until the
-    // handle and the stream ID is assigned. However, if the user calls
-    // uncork() before that happens, the Duplex will attempt to pass
-    // writes through. Those need to be queued up here.
-    if (this.pending) {
-      this.once('ready', this._writev.bind(this, data, cb));
-      return;
-    }
-
-    // If the stream has been destroyed, there's nothing else we can do
-    // because the handle has been destroyed. This should only be an
-    // issue if a write occurs before the 'ready' event in the case where
-    // the duplex is uncorked before the stream is ready to go. In that
-    // case, drop the data on the floor. An error should have already been
-    // emitted.
-    if (this.destroyed)
-      return;
-
-    this[kUpdateTimer]();
-
-    if (!this.headersSent)
-      this[kProceed]();
-
-    var req = createWriteWrap(this[kHandle], afterDoStreamWrite);
-    req.stream = this[kID];
-
-    writevGeneric(this, req, data, cb);
-
-    trackWriteState(this, req.bytes);
+    this[kWriteGeneric](true, data, '', cb);
   }
 
   _final(cb) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -745,12 +745,12 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   this._pendingData = null;
   this._pendingEncoding = '';
 
-  this._unrefTimer();
-
   if (!this._handle) {
     this.destroy(new ERR_SOCKET_CLOSED(), cb);
     return false;
   }
+
+  this._unrefTimer();
 
   var req = createWriteWrap(this._handle, afterWrite);
   if (writev)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

### Roadmap

- [x] Remove inconsistencies between `http2.Http2Stream._write` and `http2.Http2Stream._writev`
- [x] Move all logic into a new method `http2.Http2Stream._writeGeneric`
- [ ] Remove inconsistencies between `net.Socket._writeGeneric` and `http2.Http2Stream._writeGeneric`
- [ ] Refactor common logic into a method in the base class/method, possibly `writeGeneric` from `internal/stream_base_commons`.

/cc @addaleax @nodejs/http2 @nodejs/net 