### PR TITLE
update to require('fs/promises')

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3367,9 +3367,9 @@ Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 
 > Stability: 1 - Experimental
 
-The `fs.promises` API provides an alternative set of asynchronous file system
+The `fsPromises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
-API is accessible via `require('fs').promises`.
+API is accessible via `require('fs/promises')`.
 
 ### class: FileHandle
 <!-- YAML


### PR DESCRIPTION
reading from https://nodejs.org/api/fs.html#fs_fs_promises_api ; and tested from the node-v10 shell, it's clear that can only be accessed via require('fs/promises') not require('fs').promises ; and it's called `fsPromises` API, not `fs.promises`

```console
➸ ~/opt/node-v10.0.0-linux-x64/bin/node
> require('fs').promises
undefined
> require('fs/promises')
{ access: [AsyncFunction: access],
  copyFile: [AsyncFunction: copyFile],
  open: [AsyncFunction: open],
  read: [AsyncFunction: read],
...
```

search in the whole source code repo there's still a lot of places calling by require('fs').promises; may need a global search and replace?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
