### PR TITLE
n-api: add napi_get_promise_{state,result}

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3747,6 +3747,36 @@ napi_status napi_is_promise(napi_env env,
 - `[out] is_promise`: Flag indicating whether `promise` is a native promise
 object - that is, a promise object created by the underlying engine.
 
+### napi_get_promise_state
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_get_promise_state(napi_env env,
+                                   napi_value promise,
+                                   napi_promise_state* state);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] promise`: The promise to examine.
+- `[out] state`: The current state of the promise.
+
+### napi_get_promise_result
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_get_promise_result(napi_env env,
+                                    napi_value promise,
+                                    napi_value* result);
+```
+
+- `[in] env`: THe environment that the API is invoked under.
+- `[in] promise`: The promise to examine.
+- `[out] result`: The value that the promise was resolved or rejected with.
+
 ## Script execution
 
 N-API provides an API for executing a string containing JavaScript using the

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3528,6 +3528,49 @@ napi_status napi_is_promise(napi_env env,
   return napi_clear_last_error(env);
 }
 
+napi_status napi_get_promise_state(napi_env env,
+                                   napi_value promise,
+                                   napi_promise_state* state) {
+  NAPI_PREAMBLE(env);
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, state);
+
+  v8::Local<v8::Promise> p =
+    v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+
+  v8::Promise::PromiseState s = p->State();
+  switch (s) {
+    case v8::Promise::PromiseState::kPending:
+      *state = napi_promise_pending;
+      break;
+    case v8::Promise::PromiseState::kFulfilled:
+      *state = napi_promise_fulfilled;
+      break;
+    case v8::Promise::PromiseState::kRejected:
+      *state = napi_promise_rejected;
+      break;
+  }
+
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_get_promise_result(napi_env env,
+                                    napi_value promise,
+                                    napi_value* result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Promise> p =
+    v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+
+  *result = v8impl::JsValueFromV8LocalValue(p->Result());
+
+  return napi_clear_last_error(env);
+}
+
 napi_status napi_run_script(napi_env env,
                             napi_value script,
                             napi_value* result) {

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -592,6 +592,12 @@ NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
 NAPI_EXTERN napi_status napi_is_promise(napi_env env,
                                         napi_value promise,
                                         bool* is_promise);
+NAPI_EXTERN napi_status napi_get_promise_state(napi_env env,
+                                               napi_value promise,
+                                               napi_promise_state* state);
+NAPI_EXTERN napi_status napi_get_promise_result(napi_env env,
+                                                napi_value promise,
+                                                napi_value* result);
 
 // Memory management
 NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -75,6 +75,12 @@ typedef enum {
   napi_callback_scope_mismatch
 } napi_status;
 
+typedef enum {
+  napi_promise_pending,
+  napi_promise_fulfilled,
+  napi_promise_rejected,
+} napi_promise_state;
+
 typedef napi_value (*napi_callback)(napi_env env,
                                     napi_callback_info info);
 typedef void (*napi_finalize)(napi_env env,

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -61,3 +61,16 @@ assert.strictEqual(test_promise.isPromise('I promise!'), false);
 assert.strictEqual(test_promise.isPromise(undefined), false);
 assert.strictEqual(test_promise.isPromise(null), false);
 assert.strictEqual(test_promise.isPromise({}), false);
+
+{
+  const p = Promise.resolve(5);
+  assert.strictEqual(test_promise.getPromiseState(p), 1);
+  assert.strictEqual(test_promise.getPromiseResult(p), 5);
+}
+
+{
+  const p = Promise.reject('error');
+  p.catch(() => {});
+  assert.strictEqual(test_promise.getPromiseState(p), 2);
+  assert.strictEqual(test_promise.getPromiseResult(p), 'error');
+}

--- a/test/addons-napi/test_promise/test_promise.c
+++ b/test/addons-napi/test_promise/test_promise.c
@@ -47,11 +47,37 @@ static napi_value isPromise(napi_env env, napi_callback_info info) {
   return result;
 }
 
+static napi_value getPromiseState(napi_env env, napi_callback_info info) {
+  napi_value promise;
+  napi_promise_state state;
+  napi_value result;
+  size_t argc = 1;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &promise, NULL, NULL));
+  NAPI_CALL(env, napi_get_promise_state(env, promise, &state));
+  NAPI_CALL(env, napi_create_int32(env, state, &result));
+
+  return result;
+}
+
+static napi_value getPromiseResult(napi_env env, napi_callback_info info) {
+  napi_value promise;
+  napi_value result;
+  size_t argc = 1;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &promise, NULL, NULL));
+  NAPI_CALL(env, napi_get_promise_result(env, promise, &result));
+
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("createPromise", createPromise),
     DECLARE_NAPI_PROPERTY("concludeCurrentPromise", concludeCurrentPromise),
     DECLARE_NAPI_PROPERTY("isPromise", isPromise),
+    DECLARE_NAPI_PROPERTY("getPromiseState", getPromiseState),
+    DECLARE_NAPI_PROPERTY("getPromiseResult", getPromiseResult),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
@nodejs/n-api 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
