### PR TITLE
doc: fix stability text for n-api

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -219,7 +219,7 @@ illustration of how it can be used.
 
 ## N-API
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 N-API is an API for building native Addons. It is independent from
 the underlying JavaScript runtime (e.g. V8) and is maintained as part of


### PR DESCRIPTION
While some places list n-api as stable, the reference
in doc/api/addons.md was missed.  This fixes that
instance.

Fixes: https://github.com/nodejs/node/issues/20645

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
