### PR TITLE
util: expose the WHATWG Encoding API globally

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -764,13 +764,13 @@ The stack trace is extended to include the point in time at which the
 <a id="ERR_ENCODING_INVALID_ENCODED_DATA"></a>
 ### ERR_ENCODING_INVALID_ENCODED_DATA
 
-Data provided to `util.TextDecoder()` API was invalid according to the encoding
+Data provided to `TextDecoder()` API was invalid according to the encoding
 provided.
 
 <a id="ERR_ENCODING_NOT_SUPPORTED"></a>
 ### ERR_ENCODING_NOT_SUPPORTED
 
-Encoding provided to `util.TextDecoder()` API was not one of the
+Encoding provided to `TextDecoder()` API was not one of the
 [WHATWG Supported Encodings][].
 
 <a id="ERR_FALSY_VALUE_REJECTION"></a>

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -156,6 +156,24 @@ added: v10.0.0
 
 The WHATWG `URLSearchParams` class. See the [`URLSearchParams`][] section.
 
+## TextEncoder
+<!-- YAML
+added: v11.0.0
+-->
+
+<!-- type=global -->
+
+The WHATWG `TextEncoder` class. See the [`TextEncoder`][] section.
+
+## TextDecoder
+<!-- YAML
+added: v11.0.0
+-->
+
+<!-- type=global -->
+
+The WHATWG `TextDecoder` class. See the [`TextDecoder`][] section.
+
 [`__dirname`]: modules.html#modules_dirname
 [`__filename`]: modules.html#modules_filename
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediate
@@ -171,6 +189,8 @@ The WHATWG `URLSearchParams` class. See the [`URLSearchParams`][] section.
 [`setTimeout`]: timers.html#timers_settimeout_callback_delay_args
 [`URL`]: url.html#url_class_url
 [`URLSearchParams`]: url.html#url_class_urlsearchparams
+[`TextEncoder`]: util.html#util_class_textencoder
+[`TextDecoder`]: util.html#util_class_textdecoder
 [buffer section]: buffer.html
 [built-in objects]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 [module system documentation]: modules.html

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -771,9 +771,13 @@ added: v8.0.0
 * {symbol} that can be used to declare custom promisified variants of functions,
 see [Custom promisified functions][].
 
-## Class: util.TextDecoder
+## Class: TextDecoder
 <!-- YAML
 added: v8.3.0
+changes:
+  - version: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/TO_DO
+    description: The class is now available on the global object.
 -->
 
 An implementation of the [WHATWG Encoding Standard][] `TextDecoder` API.
@@ -908,9 +912,13 @@ thrown.
 The value will be `true` if the decoding result will include the byte order
 mark.
 
-## Class: util.TextEncoder
+## Class: TextEncoder
 <!-- YAML
 added: v8.3.0
+changes:
+  - version: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/TO_DO
+    description: The class is now available on the global object.
 -->
 
 An implementation of the [WHATWG Encoding Standard][] `TextEncoder` API. All

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -75,6 +75,7 @@
       setupGlobalTimeouts();
       setupGlobalConsole();
       setupGlobalURL();
+      setupGlobalTextEncoderDecoder();
     }
 
     // Ensure setURLConstructor() is called before the native
@@ -374,6 +375,24 @@
       },
       URLSearchParams: {
         value: URLSearchParams,
+        writable: true,
+        configurable: true,
+        enumerable: false
+      }
+    });
+  }
+
+  function setupGlobalTextEncoderDecoder() {
+    const { TextEncoder, TextDecoder } = NativeModule.require('internal/util');
+    Object.defineProperties(global, {
+      TextEncoder: {
+        value: TextEncoder,
+        writable: true,
+        configurable: true,
+        enumerable: false
+      },
+      TextDecoder: {
+        value: TextDecoder,
         writable: true,
         configurable: true,
         enumerable: false

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -73,6 +73,15 @@ export function leakedGlobals() {
     knownGlobals.push(Symbol);
   }
 
+  // WHATWG APIs
+  if (global.TextEncoder) {
+    knownGlobals.push(TextEncoder);
+  }
+
+  if (global.TextDecoder) {
+    knownGlobals.push(TextDecoder)
+  }
+
   const leaked = [];
 
   for (const val in global) {

--- a/test/parallel/test-whatwg-encoding-global.js
+++ b/test/parallel/test-whatwg-encoding-global.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { TextEncoder, TextDecoder } = require('util');
+
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(global, 'TextEncoder'),
+  {
+    value: TextEncoder,
+    writable: true,
+    configurable: true,
+    enumerable: false
+  }
+);
+
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(global, 'TextDecoder'),
+  {
+    value: TextDecoder,
+    writable: true,
+    configurable: true,
+    enumerable: false
+  }
+);


### PR DESCRIPTION
This PR makes `util.TextEncoder` and `util.TextDecoder` available on the global object.

Currently, this is work-in-progress, but I am looking for feedback.

See: https://github.com/nodejs/node/issues/20365

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
