### PR TITLE
src: add missing override to ThreadPoolWork funcs

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3377,7 +3377,7 @@ class Work : public node::AsyncResource, public node::ThreadPoolWork {
     _execute(_env, _data);
   }
 
-  void AfterThreadPoolWork(int status) {
+  void AfterThreadPoolWork(int status) override {
     if (_complete == nullptr)
       return;
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -217,11 +217,11 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
   // TODO(addaleax): Make these methods non-static. It's a significant bunch
   // of churn that's better left for a separate PR.
-  void DoThreadPoolWork() {
+  void DoThreadPoolWork() override {
     Process(this);
   }
 
-  void AfterThreadPoolWork(int status) {
+  void AfterThreadPoolWork(int status) override {
     After(this, status);
   }
 


### PR DESCRIPTION
Currently the following warnings are displayed when compiling:
```console
../src/node_api.cc:3380:8:
warning: 'AfterThreadPoolWork' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]
  void AfterThreadPoolWork(int status) {
       ^
../src/node_internals.h:513:16: note: overridden virtual function is
here
  virtual void AfterThreadPoolWork(int status) = 0;
               ^
1 warning generated.

../src/node_zlib.cc:220:8:
warning: 'DoThreadPoolWork' overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]
  void DoThreadPoolWork() {
       ^
../src/node_internals.h:512:16: note: overridden virtual function is
here
  virtual void DoThreadPoolWork() = 0;
               ^
../src/node_zlib.cc:224:8:
warning: 'AfterThreadPoolWork' overrides a member function but is
not marked 'override' [-Winconsistent-missing-override]
  void AfterThreadPoolWork(int status) {
       ^
../src/node_internals.h:513:16: note: overridden virtual function is
here
  virtual void AfterThreadPoolWork(int status) = 0;
               ^
2 warnings generated.
```
This commit adds override to the functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
