### PR TITLE
async_wrap: fix memory leak in AsyncResource

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -714,6 +714,7 @@ class AsyncResource {
 
     ~AsyncResource() {
       EmitAsyncDestroy(isolate_, async_context_);
+      resource_.Reset();
     }
 
     v8::MaybeLocal<v8::Value> MakeCallback(


### PR DESCRIPTION
Reset the persistent that keeps the resource
Object alive when the AsyncResource is being
destroyed.

Fixes: https://github.com/nodejs/node-addon-api/issues/237

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
