### PR TITLE
src: make env_ and context_ private

### DIFF
--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -17,10 +17,6 @@ struct ContextOptions {
 };
 
 class ContextifyContext {
- protected:
-  Environment* const env_;
-  Persistent<v8::Context> context_;
-
  public:
   ContextifyContext(Environment* env,
                     v8::Local<v8::Object> sandbox_obj,
@@ -99,6 +95,8 @@ class ContextifyContext {
   static void IndexedPropertyDeleterCallback(
       uint32_t index,
       const v8::PropertyCallbackInfo<v8::Boolean>& args);
+  Environment* const env_;
+  Persistent<v8::Context> context_;
 };
 
 }  // namespace contextify


### PR DESCRIPTION
This commit makes the currently protected members env_ and context_
private in node_contextify.h.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
