### PR TITLE
console: .table fall back to logging for function too

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -325,8 +325,7 @@ Console.prototype.table = function(tabularData, properties) {
   if (properties !== undefined && !ArrayIsArray(properties))
     throw new ERR_INVALID_ARG_TYPE('properties', 'Array', properties);
 
-  if (tabularData == null ||
-      (typeof tabularData !== 'object' && typeof tabularData !== 'function'))
+  if (tabularData == null || typeof tabularData !== 'object')
     return this.log(tabularData);
 
   const final = (k, v) => this.log(cliTable(k, v));

--- a/test/parallel/test-console-table.js
+++ b/test/parallel/test-console-table.js
@@ -29,6 +29,7 @@ test(undefined, 'undefined\n');
 test(false, 'false\n');
 test('hi', 'hi\n');
 test(Symbol(), 'Symbol()\n');
+test(function() {}, '[Function]\n');
 
 test([1, 2, 3], `
 ┌─────────┬────────┐


### PR DESCRIPTION
Hello @devsnek 
I prepared a pull request for https://github.com/nodejs/node/issues/20679.

---

## Overview

According to the [console.table document](https://github.com/nodejs/node/blob/master/doc/api/console.md#consoletabletabulardata-properties), it reads that it "falls back to just logging the argument if it can’t be parsed as tabular."

But it doesn't fall back when I give a function as its first argument. It logs an empty table.

Fixes: https://github.com/nodejs/node/issues/20679

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- ~[ ] documentation is changed or added~ (I think it's not necessary this time)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
