### PR TITLE
repl: changes ctrl+u to delete from cursor to line start

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -796,9 +796,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'u': // delete the whole line
-        this.cursor = 0;
-        this.line = '';
-        this._refreshLine();
+        this._deleteLineLeft();
         break;
 
       case 'k': // delete from current to end of line

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -795,7 +795,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         }
         break;
 
-      case 'u': // delete the whole line
+      case 'u': // delete from current to start of line
         this._deleteLineLeft();
         break;
 


### PR DESCRIPTION
Closes: #20145

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


##### Affected core subsystem(s)
REPL / readline