### PR TITLE
test: fix flaky test-http2-session-timeout

### DIFF
--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -37,7 +37,7 @@ server.listen(0, common.mustCall(() => {
       const diff = process.hrtime(startTime);
       const milliseconds = (diff[0] * 1e3 + diff[1] / 1e6);
       if (milliseconds < serverTimeout * 2) {
-        setTimeout(() => makeReq(), callTimeout);
+        setTimeout(makeReq, callTimeout);
       } else {
         server.removeListener('timeout', mustNotCall);
         server.close();

--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -7,7 +7,6 @@ const h2 = require('http2');
 
 const serverTimeout = common.platformTimeout(200);
 const callTimeout = common.platformTimeout(20);
-const minRuns = Math.ceil(serverTimeout / callTimeout) * 2;
 const mustNotCall = common.mustNotCall();
 
 const server = h2.createServer();
@@ -21,9 +20,10 @@ server.listen(0, common.mustCall(() => {
 
   const url = `http://localhost:${port}`;
   const client = h2.connect(url);
-  makeReq(minRuns);
+  const startTime = process.hrtime();
+  makeReq();
 
-  function makeReq(attempts) {
+  function makeReq() {
     const request = client.request({
       ':path': '/foobar',
       ':method': 'GET',
@@ -34,12 +34,14 @@ server.listen(0, common.mustCall(() => {
     request.end();
 
     request.on('end', () => {
-      if (attempts) {
-        setTimeout(() => makeReq(attempts - 1), callTimeout);
+      const diff = process.hrtime(startTime);
+      const milliseconds = (diff[0] * 1e3 + diff[1] / 1e6);
+      if (milliseconds < serverTimeout * 2) {
+        setTimeout(() => makeReq(), callTimeout);
       } else {
         server.removeListener('timeout', mustNotCall);
-        client.close();
         server.close();
+        client.close();
       }
     });
   }


### PR DESCRIPTION
Check actual expired time rather than relying on a number of calls to `setTimeout()` in test-http2-session-timeout more robust.

Fixes: https://github.com/nodejs/node/issues/20628

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
