### PR TITLE
assert: support symbols as assertion messages

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -196,7 +196,7 @@ class AssertionError extends Error {
     } = options;
 
     if (message != null) {
-      super(message);
+      super(String(message));
     } else {
       if (process.stdout.isTTY) {
         // Reset on each call to make sure we handle dynamically set environment

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -640,6 +640,16 @@ common.expectsError(
   }
 );
 
+common.expectsError(
+  () => assert(false, Symbol('foo')),
+  {
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    generatedMessage: false,
+    message: 'Symbol(foo)'
+  }
+);
+
 {
   // Test caching.
   const fs = process.binding('fs');


### PR DESCRIPTION
Currently, assertion messages are implicitly converted to strings, which causes symbols to throw. This commit adds an explicit string conversion.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
