### PR TITLE
test: disable colors in test-assert.js

### DIFF
--- a/test/parallel/test-assert-checktag.js
+++ b/test/parallel/test-assert-checktag.js
@@ -2,6 +2,12 @@
 require('../common');
 const assert = require('assert');
 
+// Disable colored output to prevent color codes from breaking assertion
+// message comparisons. This should only be an issue when process.stdout
+// is a TTY.
+if (process.stdout.isTTY)
+  process.env.NODE_DISABLE_COLORS = '1';
+
 // Turn off no-restricted-properties because we are testing deepEqual!
 /* eslint-disable no-restricted-properties */
 

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -7,6 +7,12 @@ const { AssertionError } = assert;
 const defaultMsgStart = 'Input A expected to strictly deep-equal input B:\n' +
                         '+ expected - actual';
 
+// Disable colored output to prevent color codes from breaking assertion
+// message comparisons. This should only be an issue when process.stdout
+// is a TTY.
+if (process.stdout.isTTY)
+  process.env.NODE_DISABLE_COLORS = '1';
+
 // Template tag function turning an error message into a RegExp
 // for assert.throws()
 function re(literals, ...values) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -34,6 +34,12 @@ const { writeFileSync, unlinkSync } = require('fs');
 const { inspect } = require('util');
 const a = assert;
 
+// Disable colored output to prevent color codes from breaking assertion
+// message comparisons. This should only be an issue when process.stdout
+// is a TTY.
+if (process.stdout.isTTY)
+  process.env.NODE_DISABLE_COLORS = '1';
+
 const start = 'Input A expected to strictly deep-equal input B:';
 const actExp = '+ expected - actual';
 


### PR DESCRIPTION
When `test/parallel/test-assert.js` is run with a TTY as stdout, color codes in assertion messages cause the test to fail. This commit disables colors when stdout is a TTY.

Fixes: https://github.com/nodejs/node/issues/18967

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
