### PR TITLE
stream: simplify writable's validChunk()

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -250,7 +250,6 @@ function writeAfterEnd(stream, cb) {
 // mode the stream is in. Currently this means that `null` is never accepted
 // and undefined/non-string values are only allowed in object mode.
 function validChunk(stream, state, chunk, cb) {
-  var valid = true;
   var er;
 
   if (chunk === null) {
@@ -261,9 +260,9 @@ function validChunk(stream, state, chunk, cb) {
   if (er) {
     stream.emit('error', er);
     process.nextTick(cb, er);
-    valid = false;
+    return false;
   }
-  return valid;
+  return true;
 }
 
 Writable.prototype.write = function(chunk, encoding, cb) {


### PR DESCRIPTION
In the spirit of #20607, this commit simplifies `validChunk()` by removing an unnecessary intermediate variable.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
