### PR TITLE
stream: simplify Writable.prototype.cork()

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -299,9 +299,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
 };
 
 Writable.prototype.cork = function() {
-  var state = this._writableState;
-
-  state.corked++;
+  this._writableState.corked++;
 };
 
 Writable.prototype.uncork = function() {


### PR DESCRIPTION
This commit removes an unnecessary intermediate variable.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
