### PR TITLE
test: remove deepStrictEqual() third argument, change it into a comment

### DIFF
--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -17,8 +17,8 @@ const server = net.createServer((socket) => {
 });
 
 server.on('close', common.mustCall(() => {
-  assert.deepStrictEqual(clientLocalPorts, serverRemotePorts,
-                         'client and server should agree on the ports used');
+  // client and server should agree on the ports used
+  assert.deepStrictEqual(clientLocalPorts, serverRemotePorts);
   assert.strictEqual(2, conns);
 }));
 


### PR DESCRIPTION
The call to `assert.deepStrictEqual()` has a string literal for its third argument. Unfortunately, a side effect of that is that the values of the first two arguments are not displayed if there is an `AssertionError`. That information is useful for debugging.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
