### PR TITLE
module: introduce defaultModuleName in module.js

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -48,6 +48,7 @@ const linkingStatusMap = new WeakMap();
 const initImportMetaMap = new WeakMap();
 // ModuleWrap -> vm.Module
 const wrapToModuleMap = new WeakMap();
+const defaultModuleName = 'vm:module';
 
 class Module {
   constructor(src, options = {}) {
@@ -82,13 +83,13 @@ class Module {
       }
       url = new URL(url).href;
     } else if (context === undefined) {
-      url = `vm:module(${globalModuleId++})`;
+      url = `${defaultModuleName}(${globalModuleId++})`;
     } else if (perContextModuleId.has(context)) {
       const curId = perContextModuleId.get(context);
-      url = `vm:module(${curId})`;
+      url = `${defaultModuleName}(${curId})`;
       perContextModuleId.set(context, curId + 1);
     } else {
-      url = 'vm:module(0)';
+      url = `${defaultModuleName}(0)`;
       perContextModuleId.set(context, 1);
     }
 


### PR DESCRIPTION
This commit adds a constant named defaultModuleName to avoid duplicating
it in the Module constructor function.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
