### PR TITLE
dns: default to verbatim=true in dns.lookup()

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -147,10 +147,7 @@ changes:
     an array. Otherwise, returns a single address. **Default:** `false`.
   - `verbatim` {boolean} When `true`, the callback receives IPv4 and IPv6
     addresses in the order the DNS resolver returned them. When `false`,
-    IPv4 addresses are placed before IPv6 addresses.
-    **Default:** currently `false` (addresses are reordered) but this is
-    expected to change in the not too distant future.
-    New code should use `{ verbatim: true }`.
+    IPv4 addresses are placed before IPv6 addresses. **Default:** `true`
 * `callback` {Function}
   - `err` {Error}
   - `address` {string} A string representation of an IPv4 or IPv6 address.

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -89,7 +89,7 @@ function lookup(hostname, options, callback) {
   var hints = 0;
   var family = -1;
   var all = false;
-  var verbatim = false;
+  var verbatim = true;
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
@@ -103,7 +103,7 @@ function lookup(hostname, options, callback) {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
     all = options.all === true;
-    verbatim = options.verbatim === true;
+    verbatim = options.verbatim !== false;
 
     validateHints(hints);
   } else {

--- a/test/addons/openssl-client-cert-engine/test.js
+++ b/test/addons/openssl-client-cert-engine/test.js
@@ -32,10 +32,10 @@ const serverOptions = {
 const server = https.createServer(serverOptions, (req, res) => {
   res.writeHead(200);
   res.end('hello world');
-}).listen(0, common.localhostIPv4, () => {
+}).listen(0, '127.0.0.1', () => {
   const clientOptions = {
     method: 'GET',
-    host: common.localhostIPv4,
+    host: '127.0.0.1',
     port: server.address().port,
     path: '/test',
     clientCertEngine: engine,  // engine will provide key+cert

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -214,11 +214,6 @@ Platform check for SunOS.
 
 Platform check for Windows.
 
-### localhostIPv4
-* [&lt;string>]
-
-IP of `localhost`.
-
 ### localIPv6Hosts
 * [&lt;Array>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -119,7 +119,6 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
 
 let opensslCli = null;
 let inFreeBSDJail = null;
-let localhostIPv4 = null;
 
 const localIPv6Hosts =
   isLinux ? [
@@ -757,27 +756,6 @@ module.exports = {
       inFreeBSDJail = false;
     }
     return inFreeBSDJail;
-  },
-
-  get localhostIPv4() {
-    if (localhostIPv4 !== null) return localhostIPv4;
-
-    if (this.inFreeBSDJail) {
-      // Jailed network interfaces are a bit special - since we need to jump
-      // through loops, as well as this being an exception case, assume the
-      // user will provide this instead.
-      if (process.env.LOCALHOST) {
-        localhostIPv4 = process.env.LOCALHOST;
-      } else {
-        console.error('Looks like we\'re in a FreeBSD Jail. ' +
-                      'Please provide your default interface address ' +
-                      'as LOCALHOST or expect some tests to fail.');
-      }
-    }
-
-    if (localhostIPv4 === null) localhostIPv4 = '127.0.0.1';
-
-    return localhostIPv4;
   },
 
   // opensslCli defined lazily to reduce overhead of spawnSync

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -375,6 +375,9 @@ class NodeInstance extends EventEmitter {
 
   httpGet(host, path, hostHeaderValue) {
     console.log('[test]', `Testing ${path}`);
+    // 'localhost' can either resolve to 127.0.0.1 or ::1 but
+    // the inspector only listens on 127.0.0.1 so be explicit.
+    if (!host) host = '127.0.0.1';
     const headers = hostHeaderValue ? { 'Host': hostHeaderValue } : null;
     return this.portPromise.then((port) => new Promise((resolve, reject) => {
       const req = http.get({ host, port, path, headers }, (res) => {

--- a/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
+++ b/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 // This test should fail because at present `cluster` does not know how to share
 // a socket when `worker1` binds with `port: 0`, and others try to bind to the
@@ -50,7 +50,7 @@ if (cluster.isMaster) {
   const socket1 = dgram.createSocket('udp4', () => {});
   socket1.on('error', PRT1 === 0 ? () => {} : assert.fail);
   socket1.bind(
-    { address: common.localhostIPv4, port: PRT1, exclusive: false },
+    { address: '127.0.0.1', port: PRT1, exclusive: false },
     () => process.send({ message: 'success', port1: socket1.address().port })
   );
 }

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -52,7 +52,7 @@ if (cluster.isMaster) {
 
   // block one of the ports with a listening socket
   const server = net.createServer();
-  server.listen(clashPort, common.localhostIPv4, common.mustCall(() => {
+  server.listen(clashPort, '127.0.0.1', common.mustCall(() => {
     // try to fork 3 workers No.2 should fail
     Promise.all([serialFork(), serialFork(), serialFork()])
       .then(common.mustNotCall())

--- a/test/parallel/test-child-process-send-keep-open.js
+++ b/test/parallel/test-child-process-send-keep-open.js
@@ -38,7 +38,7 @@ if (process.argv[2] !== 'child') {
   });
 
   server.listen(0, () => {
-    const socket = net.connect(server.address().port, common.localhostIPv4);
+    const socket = net.connect(server.address().port, '127.0.0.1');
     socket.setEncoding('utf8');
     socket.on('data', (data) => result += data);
   });

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -60,7 +60,7 @@ if (cluster.isWorker) {
     maybeReply();
   });
 
-  server.listen(0, '127.0.0.1');
+  server.listen();
 } else if (cluster.isMaster) {
 
   const checks = {

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -12,7 +12,7 @@ if (cluster.isWorker) {
     // Wait for any data, then close connection
     socket.write('.');
     socket.on('data', () => {});
-  }).listen(0, common.localhostIPv4);
+  }).listen(0, '127.0.0.1');
 
   server.once('close', function() {
     serverClosed = true;
@@ -34,7 +34,7 @@ if (cluster.isWorker) {
 
   // Disconnect worker when it is ready
   worker.once('listening', function(address) {
-    const socket = net.createConnection(address.port, common.localhostIPv4);
+    const socket = net.createConnection(address.port, '127.0.0.1');
 
     socket.on('connect', function() {
       socket.on('data', function() {

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -31,7 +31,7 @@ const dgram = require('dgram');
   socket.on('listening', common.mustCall(() => {
     const address = socket.address();
 
-    assert.strictEqual(address.address, common.localhostIPv4);
+    assert.strictEqual(address.address, '127.0.0.1');
     assert.strictEqual(typeof address.port, 'number');
     assert.ok(isFinite(address.port));
     assert.ok(address.port > 0);
@@ -44,7 +44,7 @@ const dgram = require('dgram');
     assert.fail(`Unexpected error on udp4 socket. ${err.toString()}`);
   });
 
-  socket.bind(0, common.localhostIPv4);
+  socket.bind(0, '127.0.0.1');
 }
 
 if (common.hasIPv6) {

--- a/test/parallel/test-dgram-create-socket-handle.js
+++ b/test/parallel/test-dgram-create-socket-handle.js
@@ -17,7 +17,7 @@ const UDP = internalBinding('udp_wrap').UDP;
 
 {
   // Create a bound handle.
-  const handle = _createSocketHandle(common.localhostIPv4, 0, 'udp4');
+  const handle = _createSocketHandle('127.0.0.1', 0, 'udp4');
 
   assert(handle instanceof UDP);
   assert.strictEqual(typeof handle.fd, 'number');

--- a/test/parallel/test-dgram-send-callback-buffer.js
+++ b/test/parallel/test-dgram-send-callback-buffer.js
@@ -16,5 +16,5 @@ const onMessage = common.mustCall(function(err, bytes) {
 
 client.bind(0, () => client.send(buf,
                                  client.address().port,
-                                 common.localhostIPv4,
+                                 '127.0.0.1',
                                  onMessage));

--- a/test/parallel/test-dgram-send-callback-multi-buffer.js
+++ b/test/parallel/test-dgram-send-callback-multi-buffer.js
@@ -15,7 +15,7 @@ const buf2 = Buffer.alloc(256, 'y');
 
 client.on('listening', () => {
   const port = client.address().port;
-  client.send([buf1, buf2], port, common.localhostIPv4, messageSent);
+  client.send([buf1, buf2], port, '127.0.0.1', messageSent);
 });
 
 client.on('message', common.mustCall((buf, info) => {

--- a/test/parallel/test-dgram-send-callback-recursive.js
+++ b/test/parallel/test-dgram-send-callback-recursive.js
@@ -13,7 +13,7 @@ let port;
 
 function onsend() {
   if (sent++ < limit) {
-    client.send(chunk, 0, chunk.length, port, common.localhostIPv4, onsend);
+    client.send(chunk, 0, chunk.length, port, '127.0.0.1', onsend);
   } else {
     assert.strictEqual(async, true);
   }

--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -18,7 +18,7 @@ client.on('message', common.mustCall(function onMessage(buf, info) {
 
 client.on('listening', common.mustCall(function() {
   interval = setInterval(function() {
-    client.send([], client.address().port, common.localhostIPv4);
+    client.send([], client.address().port, '127.0.0.1');
   }, 10);
 }));
 

--- a/test/parallel/test-dgram-send-error.js
+++ b/test/parallel/test-dgram-send-error.js
@@ -52,7 +52,7 @@ getSocket((socket) => {
       assert.strictEqual(err.code, 'UNKNOWN');
       assert.strictEqual(err.errno, 'UNKNOWN');
       assert.strictEqual(err.syscall, 'send');
-      assert.strictEqual(err.address, common.localhostIPv4);
+      assert.strictEqual(err.address, '127.0.0.1');
       assert.strictEqual(err.port, port);
       assert.strictEqual(
         err.message,
@@ -64,6 +64,6 @@ getSocket((socket) => {
       return UV_UNKNOWN;
     };
 
-    socket.send('foo', port, common.localhostIPv4, callback);
+    socket.send('foo', port, '127.0.0.1', callback);
   }));
 }

--- a/test/parallel/test-dgram-send-multi-buffer-copy.js
+++ b/test/parallel/test-dgram-send-multi-buffer-copy.js
@@ -15,7 +15,7 @@ const buf2 = Buffer.alloc(256, 'y');
 
 client.on('listening', function() {
   const toSend = [buf1, buf2];
-  client.send(toSend, this.address().port, common.localhostIPv4, onMessage);
+  client.send(toSend, this.address().port, '127.0.0.1', onMessage);
   toSend.splice(0, 2);
 });
 

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -27,7 +27,7 @@ const message_to_send = 'A message to send';
 
 const server = dgram.createSocket('udp4');
 server.on('message', common.mustCall((msg, rinfo) => {
-  assert.strictEqual(rinfo.address, common.localhostIPv4);
+  assert.strictEqual(rinfo.address, '127.0.0.1');
   assert.strictEqual(msg.toString(), message_to_send.toString());
   server.send(msg, 0, msg.length, rinfo.port, rinfo.address);
 }));
@@ -35,7 +35,7 @@ server.on('listening', common.mustCall(() => {
   const client = dgram.createSocket('udp4');
   const port = server.address().port;
   client.on('message', common.mustCall((msg, rinfo) => {
-    assert.strictEqual(rinfo.address, common.localhostIPv4);
+    assert.strictEqual(rinfo.address, '127.0.0.1');
     assert.strictEqual(rinfo.port, port);
     assert.strictEqual(msg.toString(), message_to_send.toString());
     client.close();

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -94,8 +94,8 @@ const tests = [
       const server = net.createServer(function(conn) {
         conn.pipe(conn);
       });
-      server.listen(0, common.localhostIPv4, function() {
-        const conn = net.connect(this.address().port, common.localhostIPv4);
+      server.listen(0, '127.0.0.1', function() {
+        const conn = net.connect(this.address().port, '127.0.0.1');
         conn.once('data', function() {
           throw new Error('ok');
         });

--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -35,8 +35,8 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end();
 }, 3));
 
-server.listen(0, common.localhostIPv4, common.mustCall(() => {
-  const u = `http://${common.localhostIPv4}:${server.address().port}${testPath}`;
+server.listen(0, '127.0.0.1', common.mustCall(() => {
+  const u = `http://127.0.0.1:${server.address().port}${testPath}`;
   http.get(u, common.mustCall(() => {
     http.get(url.parse(u), common.mustCall(() => {
       http.get(new URL(u), common.mustCall(() => {

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -6,7 +6,7 @@ const http = require('http');
 const baseOptions = {
   method: 'GET',
   port: undefined,
-  host: common.localhostIPv4,
+  host: '127.0.0.1',
 };
 
 const failingAgentOptions = [

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -11,9 +11,9 @@ const server = http.createServer((req, res) => {
   // This space is intentionally left blank.
 });
 
-server.listen(0, common.localhostIPv4, common.mustCall(() => {
+server.listen(0, '127.0.0.1', common.mustCall(() => {
   const port = server.address().port;
-  const req = http.get(`http://${common.localhostIPv4}:${port}`);
+  const req = http.get(`http://127.0.0.1:${port}`);
 
   req.setTimeout(1);
   req.on('socket', common.mustCall((socket) => {

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -16,7 +16,7 @@ const options = {
   agent,
   method: 'GET',
   port: undefined,
-  host: common.localhostIPv4,
+  host: '127.0.0.1',
   path: '/',
   timeout: timeout
 };

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -10,10 +10,10 @@ server.on('request', function(req, res) {
   res.flushHeaders();
   res.flushHeaders(); // Should be idempotent.
 });
-server.listen(0, common.localhostIPv4, function() {
+server.listen(0, '127.0.0.1', function() {
   const req = http.request({
     method: 'GET',
-    host: common.localhostIPv4,
+    host: '127.0.0.1',
     port: this.address().port,
   }, onResponse);
 

--- a/test/parallel/test-http-request-dont-override-options.js
+++ b/test/parallel/test-http-request-dont-override-options.js
@@ -19,7 +19,7 @@ server.listen(0, function() {
   // be mutable / modified
   const options = {
     host: undefined,
-    hostname: common.localhostIPv4,
+    hostname: '127.0.0.1',
     port: undefined,
     defaultPort: undefined,
     path: undefined,
@@ -31,7 +31,7 @@ server.listen(0, function() {
     res.resume();
     server.close();
     assert.strictEqual(options.host, undefined);
-    assert.strictEqual(options.hostname, common.localhostIPv4);
+    assert.strictEqual(options.hostname, '127.0.0.1');
     assert.strictEqual(options.port, undefined);
     assert.strictEqual(options.defaultPort, undefined);
     assert.strictEqual(options.path, undefined);

--- a/test/parallel/test-http-same-map.js
+++ b/test/parallel/test-http-same-map.js
@@ -1,12 +1,12 @@
 // Flags: --allow_natives_syntax
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
 const server =
-    http.createServer(onrequest).listen(0, common.localhostIPv4, () => next(0));
+    http.createServer(onrequest).listen(0, '127.0.0.1', () => next(0));
 
 function onrequest(req, res) {
   res.end('ok');

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -47,7 +47,7 @@ const srv = net.createServer(function(c) {
   });
 });
 
-srv.listen(0, '127.0.0.1', common.mustCall(function() {
+srv.listen(0, common.mustCall(function() {
   const port = this.address().port;
   const headers = [
     {

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -48,7 +48,7 @@ const server = https.createServer(options, common.mustCall((req, res) => {
 }, 3));
 
 server.listen(0, common.mustCall(() => {
-  const u = `https://${common.localhostIPv4}:${server.address().port}/foo?bar`;
+  const u = `https://127.0.0.1:${server.address().port}/foo?bar`;
   https.get(u, common.mustCall(() => {
     https.get(url.parse(u), common.mustCall(() => {
       https.get(new URL(u), common.mustCall(() => {

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -50,7 +50,6 @@ const server = https.createServer(options, function(req, res) {
 
 server.listen(0, '127.0.0.1', function() {
   const options = {
-    host: 'localhost',
     port: this.address().port,
     path: '/',
     method: 'GET',

--- a/test/parallel/test-net-client-bind-twice.js
+++ b/test/parallel/test-net-client-bind-twice.js
@@ -7,13 +7,13 @@ const assert = require('assert');
 const net = require('net');
 
 const server1 = net.createServer(common.mustNotCall());
-server1.listen(0, common.localhostIPv4, common.mustCall(() => {
+server1.listen(0, '127.0.0.1', common.mustCall(() => {
   const server2 = net.createServer(common.mustNotCall());
-  server2.listen(0, common.localhostIPv4, common.mustCall(() => {
+  server2.listen(0, '127.0.0.1', common.mustCall(() => {
     const client = net.connect({
-      host: common.localhostIPv4,
+      host: '127.0.0.1',
       port: server1.address().port,
-      localAddress: common.localhostIPv4,
+      localAddress: '127.0.0.1',
       localPort: server2.address().port
     }, common.mustNotCall());
 

--- a/test/parallel/test-net-connect-immediate-destroy.js
+++ b/test/parallel/test-net-connect-immediate-destroy.js
@@ -5,7 +5,7 @@ const net = require('net');
 const server = net.createServer();
 server.listen(0);
 const port = server.address().port;
-const socket = net.connect(port, common.localhostIPv4, common.mustNotCall());
+const socket = net.connect(port, '127.0.0.1', common.mustNotCall());
 socket.on('error', common.mustNotCall());
 server.close();
 socket.destroy();

--- a/test/parallel/test-net-connect-options-allowhalfopen.js
+++ b/test/parallel/test-net-connect-options-allowhalfopen.js
@@ -30,7 +30,7 @@ const net = require('net');
   let serverConnections = 0;
   let clientSentFIN = 0;
   let serverReceivedFIN = 0;
-  const host = common.localhostIPv4;
+  const host = '127.0.0.1';
 
   function serverOnConnection(socket) {
     console.log(`'connection' ${++serverConnections} emitted on server`);

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -10,7 +10,7 @@ function check(addressType, cb) {
     cb && cb();
   });
 
-  const address = addressType === 4 ? common.localhostIPv4 : '::1';
+  const address = addressType === 4 ? '127.0.0.1' : '::1';
   server.listen(0, address, common.mustCall(function() {
     net.connect({
       port: this.address().port,
@@ -28,7 +28,7 @@ function check(addressType, cb) {
     dnsopts.family = addressType;
     if (addressType === 4) {
       process.nextTick(function() {
-        cb(null, common.localhostIPv4, 4);
+        cb(null, '127.0.0.1', 4);
       });
     } else {
       process.nextTick(function() {

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -33,8 +33,8 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   net.connect(this.address().port, 'localhost')
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);
-      assert.strictEqual(ip, '127.0.0.1');
-      assert.strictEqual(type, 4);
+      assert(ip === '127.0.0.1' || ip === '::1', `ip === ${ip}`);
+      assert(type === 4 || type === 6, `type === ${type}`);
       assert.strictEqual(host, 'localhost');
     }));
 }));

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const net = require('net');
 
 const server = net.createServer(common.mustCall(function(socket) {
-  assert.strictEqual(socket.localAddress, common.localhostIPv4);
+  assert.strictEqual(socket.localAddress, '127.0.0.1');
   assert.strictEqual(socket.localPort, this.address().port);
   socket.on('end', function() {
     server.close();
@@ -33,9 +33,9 @@ const server = net.createServer(common.mustCall(function(socket) {
   socket.resume();
 }));
 
-server.listen(0, common.localhostIPv4, function() {
+server.listen(0, '127.0.0.1', function() {
   const client = net.createConnection(this.address()
-                    .port, common.localhostIPv4);
+                    .port, '127.0.0.1');
   client.on('connect', function() {
     client.end();
   });

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -28,7 +28,7 @@ const net = require('net');
 let conns_closed = 0;
 
 const remoteAddrCandidates = [ common.localhostIPv4 ];
-if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
+if (common.hasIPv6) remoteAddrCandidates.push('::1', '::ffff:127.0.0.1');
 
 const remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -27,7 +27,7 @@ const net = require('net');
 
 let conns_closed = 0;
 
-const remoteAddrCandidates = [ common.localhostIPv4 ];
+const remoteAddrCandidates = [ '127.0.0.1' ];
 if (common.hasIPv6) remoteAddrCandidates.push('::1', '::ffff:127.0.0.1');
 
 const remoteFamilyCandidates = ['IPv4'];

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -22,7 +22,7 @@ server.on('close', common.mustCall(() => {
   assert.strictEqual(conns, 2);
 }));
 
-server.listen(0, common.localhostIPv4, connect);
+server.listen(0, '127.0.0.1', connect);
 
 function connect() {
   if (conns === 2) {
@@ -34,7 +34,7 @@ function connect() {
   client.once('close', connect);
   assert.strictEqual(
     client,
-    client.connect(server.address().port, common.localhostIPv4, () => {
+    client.connect(server.address().port, '127.0.0.1', () => {
       clientLocalPorts.push(client.localPort);
     })
   );

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -18,7 +18,7 @@ const server = net.createServer((conn) => {
   });
 });
 
-const host = common.localhostIPv4;
+const host = '127.0.0.1';
 const port = 0;
 const options = { host, port };
 

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -14,7 +14,7 @@ const {
 
 const server = new TCP(TCPConstants.SOCKET);
 
-const r = server.bind('0.0.0.0', 0);
+const r = server.bind('127.0.0.1', 0);
 assert.strictEqual(r, 0);
 let port = {};
 server.getsockname(port);
@@ -84,7 +84,7 @@ server.onconnection = (err, client) => {
 
 const net = require('net');
 
-const c = net.createConnection(port);
+const c = net.createConnection(port, '127.0.0.1');
 
 c.on('connect', common.mustCall(() => { c.end('hello world'); }));
 

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -32,7 +32,7 @@ const server = net.createServer(function onClient(client) {
   }
 });
 
-server.listen(0, common.localhostIPv4, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   const countdown = new Countdown(2, () => server.close());
 
   {

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -12,7 +12,7 @@ function loadPEM(n) {
   return fixtures.readKey(`${n}.pem`);
 }
 
-const serverIP = common.localhostIPv4;
+const serverIP = '127.0.0.1';
 
 function checkResults(result, expected) {
   assert.strictEqual(result.server.ALPN, expected.server.ALPN);

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -48,6 +48,7 @@ function test(size, type, name, next) {
 
   server.listen(0, '127.0.0.1', common.mustCall(function() {
     const client = tls.connect({
+      host: '127.0.0.1',
       port: this.address().port,
       rejectUnauthorized: false
     }, function() {

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -40,6 +40,7 @@ function test(size, err, next) {
     // dhparams is 1024 bits
     const client = tls.connect({
       minDHSize: 2048,
+      host: '127.0.0.1',
       port: this.address().port,
       rejectUnauthorized: false
     }, function() {

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -24,11 +24,11 @@ const serverConfig = {
 
 const server = tls.createServer(serverConfig, common.mustCall(function() {
 
-}, clientConfigs.length)).listen(0, common.localhostIPv4, function() {
+}, clientConfigs.length)).listen(0, '127.0.0.1', function() {
   let connected = 0;
   clientConfigs.forEach(function(v) {
     tls.connect({
-      host: common.localhostIPv4,
+      host: '127.0.0.1',
       port: server.address().port,
       rejectUnauthorized: false,
       secureProtocol: v.secureProtocol

--- a/test/parallel/test-tls-multiple-cas-as-string.js
+++ b/test/parallel/test-tls-multiple-cas-as-string.js
@@ -23,7 +23,7 @@ function test(ca, next) {
 
   server.addContext('agent3', { ca, cert, key });
 
-  const host = common.localhostIPv4;
+  const host = '127.0.0.1';
   server.listen(0, host, function() {
     tls.connect({ servername: 'agent3', host, port: this.address().port, ca });
   });

--- a/test/parallel/test-tls-wrap-econnreset-localaddress.js
+++ b/test/parallel/test-tls-wrap-econnreset-localaddress.js
@@ -10,19 +10,18 @@ const tls = require('tls');
 
 const server = net.createServer((c) => {
   c.end();
-}).listen(common.mustCall(() => {
+}).listen(0, common.localhostIPv4, common.mustCall(() => {
   const port = server.address().port;
 
   tls.connect({
+    host: common.localhostIPv4,
     port: port,
     localAddress: common.localhostIPv4
-  }, common.localhostIPv4)
-    .once('error', common.mustCall((e) => {
-      assert.strictEqual(e.code, 'ECONNRESET');
-      assert.strictEqual(e.path, undefined);
-      assert.strictEqual(e.host, undefined);
-      assert.strictEqual(e.port, port);
-      assert.strictEqual(e.localAddress, common.localhostIPv4);
-      server.close();
-    }));
+  }).once('error', common.mustCall((e) => {
+    assert.strictEqual(e.code, 'ECONNRESET');
+    assert.strictEqual(e.path, undefined);
+    assert.strictEqual(e.port, port);
+    assert.strictEqual(e.localAddress, common.localhostIPv4);
+    server.close();
+  }));
 }));

--- a/test/parallel/test-tls-wrap-econnreset-localaddress.js
+++ b/test/parallel/test-tls-wrap-econnreset-localaddress.js
@@ -10,18 +10,18 @@ const tls = require('tls');
 
 const server = net.createServer((c) => {
   c.end();
-}).listen(0, common.localhostIPv4, common.mustCall(() => {
+}).listen(0, '127.0.0.1', common.mustCall(() => {
   const port = server.address().port;
 
   tls.connect({
-    host: common.localhostIPv4,
+    host: '127.0.0.1',
     port: port,
-    localAddress: common.localhostIPv4
+    localAddress: '127.0.0.1'
   }).once('error', common.mustCall((e) => {
     assert.strictEqual(e.code, 'ECONNRESET');
     assert.strictEqual(e.path, undefined);
     assert.strictEqual(e.port, port);
-    assert.strictEqual(e.localAddress, common.localhostIPv4);
+    assert.strictEqual(e.localAddress, '127.0.0.1');
     server.close();
   }));
 }));

--- a/test/parallel/test-tls-wrap-econnreset.js
+++ b/test/parallel/test-tls-wrap-econnreset.js
@@ -13,11 +13,11 @@ const server = net.createServer((c) => {
 }).listen(common.mustCall(() => {
   const port = server.address().port;
 
-  tls.connect(port, common.localhostIPv4)
+  tls.connect(port, '127.0.0.1')
     .once('error', common.mustCall((e) => {
       assert.strictEqual(e.code, 'ECONNRESET');
       assert.strictEqual(e.path, undefined);
-      assert.strictEqual(e.host, common.localhostIPv4);
+      assert.strictEqual(e.host, '127.0.0.1');
       assert.strictEqual(e.port, port);
       assert.strictEqual(e.localAddress, undefined);
       server.close();

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -216,7 +216,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
       socket.destroy();
     });
     socket.resume();
-  })).listen(0, common.localhostIPv4, common.mustCall(() => {
+  })).listen(0, '127.0.0.1', common.mustCall(() => {
     const handle = new tcp_wrap.TCP(tcp_wrap.constants.SOCKET);
     const req = new tcp_wrap.TCPConnectWrap();
     const sreq = new stream_wrap.ShutdownWrap();
@@ -247,7 +247,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
       }
       testInitialized(wreq, 'WriteWrap');
     }
-    req.address = common.localhostIPv4;
+    req.address = '127.0.0.1';
     req.port = server.address().port;
     const err = handle.connect(req, req.address, req.port);
     assert.strictEqual(err, 0);

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -77,8 +77,8 @@ if (process.argv[2] !== 'child') {
     });
     socketConnected();
   }).unref();
-  server.listen(0, common.localhostIPv4, () => {
+  server.listen(0, '127.0.0.1', () => {
     const { port } = server.address();
-    socket = net.connect(port, common.localhostIPv4, socketConnected).unref();
+    socket = net.connect(port, '127.0.0.1', socketConnected).unref();
   });
 }

--- a/test/sequential/test-dgram-bind-shared-ports.js
+++ b/test/sequential/test-dgram-bind-shared-ports.js
@@ -96,7 +96,7 @@ if (cluster.isMaster) {
       common.mustCall((err) => {
         process.send(`socket3:${err.code}`);
       });
-  const address = common.localhostIPv4;
+  const address = '127.0.0.1';
   const opt1 = { address, port: 0, exclusive: false };
   const opt2 = { address, port: common.PORT, exclusive: false };
   const opt3 = { address, port: common.PORT + 1, exclusive: true };

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -16,7 +16,7 @@ function checkListResponse(response) {
   );
   assert.ok(response[0].devtoolsFrontendUrl);
   assert.ok(
-    /ws:\/\/localhost:\d+\/[0-9A-Fa-f]{8}-/
+    /ws:\/\/127\.0\.0\.1:\d+\/[0-9A-Fa-f]{8}-/
       .test(response[0].webSocketDebuggerUrl),
     response[0].webSocketDebuggerUrl);
 }

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -52,7 +52,7 @@ function server() {
       console.error('_socketEnd');
     });
     socket.write(content);
-  }).listen(common.PORT, common.localhostIPv4, function() {
+  }).listen(common.PORT, '127.0.0.1', function() {
     console.log('listening');
   });
 }
@@ -60,7 +60,7 @@ function server() {
 function client() {
   const net = require('net');
   const client = net.connect({
-    host: common.localhostIPv4,
+    host: '127.0.0.1',
     port: common.PORT
   }, function() {
     client.destroy();

--- a/test/sequential/test-net-better-error-messages-port.js
+++ b/test/sequential/test-net-better-error-messages-port.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const net = require('net');
 const assert = require('assert');
 
-const c = net.createConnection(common.PORT);
+const c = net.createConnection(common.PORT, '127.0.0.1');
 
 c.on('connect', common.mustNotCall());
 

--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -10,7 +10,7 @@ const expectedErrorCodes = ['ECONNREFUSED', 'EADDRINUSE'];
 const optionsIPv4 = {
   port: common.PORT,
   localPort: common.PORT + 1,
-  localAddress: common.localhostIPv4
+  localAddress: '127.0.0.1'
 };
 
 const optionsIPv6 = {
@@ -21,7 +21,7 @@ const optionsIPv6 = {
 };
 
 function onError(err, options) {
-  assert.ok(expectedErrorCodes.includes(err.code));
+  assert.ok(expectedErrorCodes.includes(err.code), `err.code === ${err.code}`);
   assert.strictEqual(err.syscall, 'connect');
   assert.strictEqual(err.localPort, options.localPort);
   assert.strictEqual(err.localAddress, options.localAddress);

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -31,9 +31,9 @@ const server_ipv4 = net.createServer();
 server_ipv4.on('error', common.mustNotCall());
 
 server_ipv4
-  .listen(common.PORT + 1, common.localhostIPv4, common.mustCall(() => {
+  .listen(common.PORT + 1, '127.0.0.1', common.mustCall(() => {
     const address_ipv4 = server_ipv4.address();
-    assert.strictEqual(address_ipv4.address, common.localhostIPv4);
+    assert.strictEqual(address_ipv4.address, '127.0.0.1');
     assert.strictEqual(address_ipv4.port, common.PORT + 1);
     assert.strictEqual(address_ipv4.family, family_ipv4);
     server_ipv4.close();


### PR DESCRIPTION
Switch the default from false (reorder the result so that IPv4 addresses
come before IPv6 addresses) to true (return them exactly as the resolver
sent them to us.)

This is intended to be released in Node.js 11.