### PR TITLE
build: export openssl TLSv1 methods again

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -602,7 +602,7 @@
               # Categories to export.
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
               'PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,STDIO,TLSEXT,'
-              'FP_API',
+              'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.


### PR DESCRIPTION
Upstream deprecated them and moved them into categories of their own.
Add those categories to the export list.  Node.js doesn't use them but
some add-ons do.

Fixes: https://github.com/nodejs/node/issues/20369
CI: https://ci.nodejs.org/job/node-test-commit/18469/