### PR TITLE
tools: add bash completion for node

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -52,6 +52,17 @@ If this flag is passed, the behavior can still be set to not abort through
 [`process.setUncaughtExceptionCaptureCallback()`][] (and through usage of the
 `domain` module that uses it).
 
+### `--completion-bash`
+<!-- YAML
+added: REPLACEME
+-->
+
+Print source-able bash completion script for Node.js.
+```console
+$ node --completion-bash > node_bash_completion
+$ source node_bash_completion
+```
+
 ### `--enable-fips`
 <!-- YAML
 added: v6.0.0

--- a/doc/node.1
+++ b/doc/node.1
@@ -75,6 +75,9 @@ the next argument will be used as a script filename.
 .It Fl -abort-on-uncaught-exception
 Aborting instead of exiting causes a core file to be generated for analysis.
 .
+.It Fl -completion-bash
+Print source-able bash completion script for Node.js.
+.
 .It Fl -enable-fips
 Enable FIPS-compliant crypto at startup.
 Requires Node.js to be built with

--- a/lib/internal/bash_completion.js
+++ b/lib/internal/bash_completion.js
@@ -1,0 +1,25 @@
+'use strict';
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { getOptions } = internalBinding('options');
+
+function print(stream) {
+  const { options, aliases } = getOptions();
+  const all_opts = [...options.keys(), ...aliases.keys()];
+
+  stream.write(`_node_complete() {
+  local cur_word options
+  cur_word="\${COMP_WORDS[COMP_CWORD]}"
+  if [[ "\${cur_word}" == -* ]] ; then
+    COMPREPLY=( $(compgen -W '${all_opts.join(' ')}' -- "\${cur_word}") )
+    return 0
+  else
+    COMPREPLY=( $(compgen -f "\${cur_word}") )
+    return 0
+  fi
+}
+complete -F _node_complete node node_g`);
+}
+
+module.exports = {
+  print
+};

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -111,8 +111,14 @@
       NativeModule.require('internal/inspector_async_hook').setup();
     }
 
-    if (internalBinding('options').getOptions('--help')) {
+    const options = internalBinding('options');
+    if (options.getOptions('--help')) {
       NativeModule.require('internal/print_help').print(process.stdout);
+      return;
+    }
+
+    if (options.getOptions('--completion-bash')) {
+      NativeModule.require('internal/bash_completion').print(process.stdout);
       return;
     }
 

--- a/node.gyp
+++ b/node.gyp
@@ -84,6 +84,7 @@
       'lib/zlib.js',
       'lib/internal/assert.js',
       'lib/internal/async_hooks.js',
+      'lib/internal/bash_completion.js',
       'lib/internal/buffer.js',
       'lib/internal/cli_table.js',
       'lib/internal/child_process.js',

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -221,6 +221,9 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             kAllowedInEnvironment);
 
   AddOption("--security-reverts", "", &PerProcessOptions::security_reverts);
+  AddOption("--completion-bash",
+            "print source-able bash completion script",
+            &PerProcessOptions::print_bash_completion);
   AddOption("--help",
             "print node command line options",
             &PerProcessOptions::print_help);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,6 +112,7 @@ class PerProcessOptions {
   bool zero_fill_all_buffers = false;
 
   std::vector<std::string> security_reverts;
+  bool print_bash_completion = false;
   bool print_help = false;
   bool print_v8_help = false;
   bool print_version = false;


### PR DESCRIPTION
This commit adds a --completion-bash option to node which can be sourced to
provide bash code completion for node options.

Usage:
```shell
$ node --completion-bash > node_bash_completion
$ source node_bash_completion
$ ./node --[tab]
--abort_on_uncaught_exception  --inspect-brk-node=            --require
--check                        --inspect-brk=                 --security-reverts
--completion-bash              --inspect-port                 --stack_trace_limit
--debug                        --inspect=                     --throw-deprecation
--debug-brk                    --interactive                  --title
--debug-brk=                   --loader                       --tls-cipher-list
--debug-port                   --max_old_space_size           --trace-deprecation
--debug=                       --napi-modules                 --trace-event-categories
--eval                         --no-deprecation               --trace-event-file-pattern
--experimental-modules         --no-force-async-hooks-checks  --trace-events-enabled
--experimental-repl-await      --no-warnings                  --trace-sync-io
--experimental-vm-modules      --openssl-config               --trace-warnings
--experimental-worker          --pending-deprecation          --track-heap-objects
--expose-internals             --perf_basic_prof              --use-bundled-ca
--expose_internals             --perf_prof                    --use-openssl-ca
--help                         --preserve-symlinks            --v8-options
--icu-data-dir                 --preserve-symlinks-main       --v8-pool-size
--inspect                      --print                        --version
--inspect-brk                  --prof-process                 --zero-fill-buffers
--inspect-brk-node             --redirect-warnings
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
