### PR TITLE
util: recover from maximum call stack size

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -360,6 +360,10 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Inspecting linked lists and similar objects is now possible
+                 up to the maximum call stack size.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/19259
     description: The `WeakMap` and `WeakSet` entries can now be inspected
@@ -388,8 +392,9 @@ changes:
     properties will be included in the formatted result as well as [`WeakMap`][]
     and [`WeakSet`][] entries. **Default:** `false`.
   * `depth` {number} Specifies the number of times to recurse while formatting
-    the `object`. This is useful for inspecting large complicated objects.
-    To make it recurse indefinitely pass `null`. **Default:** `2`.
+    the `object`. This is useful for inspecting large complicated objects. To
+    make it recurse up to the maximum call stack size pass `Infinity` or `null`.
+    **Default:** `2`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.

--- a/lib/util.js
+++ b/lib/util.js
@@ -711,11 +711,11 @@ function formatValue(ctx, value, recurseTimes) {
     } catch (err) {
       if (errors.isStackOverflowError(err)) {
         ctx.seen.pop();
-        process.emitWarning(
-          'Inspection reached the maximum call stack size. Incomplete ' +
-          'inspected object returned.'
+        return ctx.stylize(
+          `[${constructor || tag || 'Object'}: Inspection interrupted ` +
+            'prematurely. Maximum call stack size exceeded.]',
+          'special'
         );
-        return ctx.stylize(`[${constructor || tag || 'Object'}]`, 'special');
       }
       throw err;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -701,14 +701,32 @@ function formatValue(ctx, value, recurseTimes) {
   }
 
   ctx.seen.push(value);
-  const output = formatter(ctx, value, recurseTimes, keys);
-
+  let output;
+  // This corresponds to a depth of at least 333 and likely 500.
+  if (ctx.indentationLvl < 1000) {
+    output = formatter(ctx, value, recurseTimes, keys);
+  } else {
+    try {
+      output = formatter(ctx, value, recurseTimes, keys);
+    } catch (err) {
+      if (errors.isStackOverflowError(err)) {
+        ctx.seen.pop();
+        process.emitWarning(
+          'Inspection reached the maximum call stack size. Incomplete ' +
+          'inspected object returned.'
+        );
+        return ctx.stylize(`[${constructor || tag || 'Object'}]`, 'special');
+      }
+      throw err;
+    }
+  }
   if (extra !== undefined)
     output.unshift(extra);
 
   for (var i = 0; i < symbols.length; i++) {
     output.push(formatProperty(ctx, value, recurseTimes, symbols[i], 0));
   }
+
   ctx.seen.pop();
 
   return reduceToSingleString(ctx, output, base, braces);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1410,10 +1410,23 @@ util.inspect(process);
   // Test that a long linked list can be inspected without throwing an error.
   const list = {};
   let head = list;
-  // The real cutoff value is closer to 1400 stack frames as of May 2018,
-  // but let's be generous here – even a linked listed of length 100k should be
-  // inspectable in some way.
+  // A linked list of length 100k should be inspectable in some way, even though
+  // the real cutoff value is much lower than 100k.
   for (let i = 0; i < 100000; i++)
     head = head.next = {};
-  util.inspect(list);
+  assert.strictEqual(
+    util.inspect(list),
+    '{ next: { next: { next: [Object] } } }'
+  );
+  common.expectWarning({
+    Warning: [
+      'Inspection reached the maximum call stack size. ' +
+        'Incomplete inspected object returned.',
+      common.noWarnCode
+    ]
+  });
+  const longList = util.inspect(list, { depth: Infinity });
+  const match = longList.match(/next/g);
+  assert(match.length > 1000 && match.length < 10000);
+  assert(longList.includes('[Object]'));
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1418,15 +1418,9 @@ util.inspect(process);
     util.inspect(list),
     '{ next: { next: { next: [Object] } } }'
   );
-  common.expectWarning({
-    Warning: [
-      'Inspection reached the maximum call stack size. ' +
-        'Incomplete inspected object returned.',
-      common.noWarnCode
-    ]
-  });
   const longList = util.inspect(list, { depth: Infinity });
   const match = longList.match(/next/g);
   assert(match.length > 1000 && match.length < 10000);
-  assert(longList.includes('[Object]'));
+  assert(longList.includes('[Object: Inspection interrupted ' +
+    'prematurely. Maximum call stack size exceeded.]'));
 }


### PR DESCRIPTION
Using util.inspect should still return values in case the maximum
call stack size is reached. This is important to inspect linked
lists and similar.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
