### PR TITLE
doc: improve specificity in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,4 +84,4 @@ CONTRIBUTING.md @nodejs/tsc
 CPP_STYLE_GUIDE.md @nodejs/tsc
 GOVERNANCE.md @nodejs/tsc
 LICENSE @nodejs/tsc
-README.md @nodejs/tsc
+/README.md @nodejs/tsc


### PR DESCRIPTION
Update CODEOWNERS entry for README.md to only apply to the top level
README.md. For example, if test/common/README.md is updated, that should
not be assigned to TSC automatically.

Ref: https://github.com/nodejs/node/pull/20717#issuecomment-388909095

@richardlau 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
