### PR TITLE
tools, docs: fix stability index isssues

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -56,7 +56,7 @@ function toHTML({ input, filename, nodeVersion, analytics }, cb) {
   const section = firstHeading ? firstHeading.text : 'Index';
 
   preprocessText(lexed);
-  preprocessElements(lexed);
+  preprocessElements(lexed, filename);
 
   // Generate the table of contents. This mutates the lexed contents in-place.
   const toc = buildToc(lexed, filename);
@@ -171,7 +171,7 @@ function linkJsTypeDocs(text) {
 }
 
 // Preprocess stability blockquotes and YAML blocks.
-function preprocessElements(lexed) {
+function preprocessElements(lexed, filename) {
   const STABILITY_RE = /(.*:)\s*(\d)([\s\S]*)/;
   let state = null;
   let headingIndex = -1;
@@ -205,10 +205,16 @@ function preprocessElements(lexed) {
           headingIndex = -1;
           heading = null;
         }
+
+        // Do not link to the section we are already in.
+        const noLinking = filename === 'documentation' &&
+          heading !== null && heading.text === 'Stability Index';
         token.text = `<div class="api_stability api_stability_${number}">` +
-          '<a href="documentation.html#documentation_stability_index">' +
-          `${prefix} ${number}</a>${explication}</div>`
+          (noLinking ? '' :
+            '<a href="documentation.html#documentation_stability_index">') +
+          `${prefix} ${number}${noLinking ? '' : '</a>'}${explication}</div>`
           .replace(/\n/g, ' ');
+
         lexed[index] = { type: 'html', text: token.text };
       } else if (state === 'MAYBE_STABILITY_BQ') {
         state = null;
@@ -298,9 +304,12 @@ function buildToc(lexed, filename) {
     const realFilename = path.basename(realFilenames[0], '.md');
     const headingText = token.text.trim();
     const id = getId(`${realFilename}_${headingText}`, idCounters);
+
+    const hasStability = token.stability !== undefined;
     toc += ' '.repeat((depth - 1) * 2) +
-           `* <span class="stability_${token.stability}">` +
-           `<a href="#${id}">${token.text}</a></span>\n`;
+      (hasStability ? `* <span class="stability_${token.stability}">` : '* ') +
+      `<a href="#${id}">${token.text}</a>${hasStability ? '</span>' : ''}\n`;
+
     token.text += `<span><a class="mark" href="#${id}" id="${id}">#</a></span>`;
     if (realFilename === 'errors' && headingText.startsWith('ERR_')) {
       token.text += `<span><a class="mark" href="#${headingText}" ` +


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

### Change 1: do not autolink in doc stability section

Currently, [stability index descriptions in `documentation.html`](https://nodejs.org/api/documentation.html#documentation_stability_index) contain links to their very section which is redundant. This commit prevents `tools/doc/html.js` from adding this links.

<details>
<summary>Screenshots of "before" and "after" states:</summary>

<br>Before:

![st1](https://user-images.githubusercontent.com/10393198/40028736-33cd2f40-57e9-11e8-8e2c-31f8108338e0.png)

After:

![st2](https://user-images.githubusercontent.com/10393198/40028740-3a290a1c-57e9-11e8-9f66-1e9cc81cd669.png)

</details>

### Change 2: do not add void wrapping elements to docs

Currently, all the TOC links are wrapped in `span` elements with class according to stability index of their sections. However, most doc sections have not any stability index, so these spans have useless class `stability_undefined`. This commit prevents `tools/doc/html.js` from wrapping TOC links in useless spans.

<details>
<summary>Screenshots of "before" and "after" states (no visible difference):</summary>

<br>Before:

![cls1](https://user-images.githubusercontent.com/10393198/40028881-0d8817a4-57ea-11e8-8d01-43b1a63280fb.png)

After:

![cls2](https://user-images.githubusercontent.com/10393198/40028888-159765da-57ea-11e8-8fee-fff7b62d28ae.png)

</details><br>

This PR eliminates 4402 useless elements in docs and reduces doc size by ~ 176 KB.