### PR TITLE
doc: reorder CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,10 @@ android-configure @nodejs/build
 *s390* @nodejs/platform-s390
 *windows* @nodejs/platform-windows
 
+/src/node_postmortem_metadata.cc @nodejs/diagnostics @nodejs/post-mortem
+/src/*.d @nodejs/diagnostics @nodejs/platform-smartos @nodejs/platform-freebsd @nodejs/platform-macos @nodejs/dtrace-mdb
+/src/node.stp @nodejs/diagnostics
+
 CODE_OF_CONDUCT.md @nodejs/tsc
 COLLABORATOR_GUIDE.md @nodejs/tsc
 CONTRIBUTING.md @nodejs/tsc
@@ -80,7 +84,3 @@ CPP_STYLE_GUIDE.md @nodejs/tsc
 GOVERNANCE.md @nodejs/tsc
 LICENSE @nodejs/tsc
 README.md @nodejs/tsc
-
-/src/node_postmortem_metadata.cc @nodejs/diagnostics @nodejs/post-mortem
-/src/*.d @nodejs/diagnostics @nodejs/platform-smartos @nodejs/platform-freebsd @nodejs/platform-macos @nodejs/dtrace-mdb
-/src/node.stp @nodejs/diagnostics


### PR DESCRIPTION
Later rules take precedence over earlier rules, so move all rules that
assign ownership to TSC to the end of the file. There are likely other
reorderings that we will want to consider.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

@vsemozhetbyt 