### PR TITLE
lib: lazy loading and cleanup

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -35,7 +35,6 @@ const {
   ERR_SOCKET_DGRAM_NOT_RUNNING
 } = errors.codes;
 const { Buffer } = require('buffer');
-const dns = require('dns');
 const util = require('util');
 const { isUint8Array } = require('internal/util/types');
 const EventEmitter = require('events');
@@ -56,6 +55,7 @@ const SEND_BUFFER = false;
 
 // Lazily loaded
 var cluster = null;
+var dns = null;
 
 const errnoException = errors.errnoException;
 const exceptionWithHostPort = errors.exceptionWithHostPort;
@@ -72,10 +72,13 @@ function lookup6(lookup, address, callback) {
 
 
 function newHandle(type, lookup) {
-  if (lookup === undefined)
+  if (lookup === undefined) {
+    if (!dns)
+      dns = require('dns');
     lookup = dns.lookup;
-  else if (typeof lookup !== 'function')
+  } else if (typeof lookup !== 'function') {
     throw new ERR_INVALID_ARG_TYPE('lookup', 'Function', lookup);
+  }
 
   if (type === 'udp4') {
     const handle = new UDP();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -48,7 +48,11 @@ const { FSEvent } = process.binding('fs_event_wrap');
 const promises = require('internal/fs/promises');
 const internalFS = require('internal/fs/utils');
 const { getPathFromURL } = require('internal/url');
-const internalUtil = require('internal/util');
+const {
+  customPromisifyArgs,
+  deprecate,
+  promisify
+} = require('internal/util');
 const {
   copyObject,
   getOptions,
@@ -230,7 +234,7 @@ fs.exists = function(path, callback) {
   }
 };
 
-Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
+Object.defineProperty(fs.exists, promisify.custom, {
   value: (path) => {
     const promise = createPromise();
     fs.exists(path, (exists) => promiseResolve(promise, exists));
@@ -591,7 +595,7 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
   binding.read(fd, buffer, offset, length, position, req);
 };
 
-Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
+Object.defineProperty(fs.read, customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
 
 fs.readSync = function(fd, buffer, offset, length, position) {
@@ -659,7 +663,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
   return binding.writeString(fd, buffer, offset, length, req);
 };
 
-Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
+Object.defineProperty(fs.write, customPromisifyArgs,
                       { value: ['bytesWritten', 'buffer'], enumerable: false });
 
 // usage:
@@ -2367,8 +2371,8 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 var SyncWriteStream = internalFS.SyncWriteStream;
 Object.defineProperty(fs, 'SyncWriteStream', {
   configurable: true,
-  get: internalUtil.deprecate(() => SyncWriteStream,
-                              'fs.SyncWriteStream is deprecated.', 'DEP0061'),
-  set: internalUtil.deprecate((val) => { SyncWriteStream = val; },
-                              'fs.SyncWriteStream is deprecated.', 'DEP0061')
+  get: deprecate(() => SyncWriteStream,
+                 'fs.SyncWriteStream is deprecated.', 'DEP0061'),
+  set: deprecate((val) => { SyncWriteStream = val; },
+                 'fs.SyncWriteStream is deprecated.', 'DEP0061')
 });

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -2,9 +2,6 @@
 
 const { Interface } = require('readline');
 const REPL = require('repl');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
 const util = require('util');
 const debug = util.debuglog('repl');
 module.exports = Object.create(REPL);
@@ -69,6 +66,11 @@ function createRepl(env, opts, cb) {
 }
 
 function setupHistory(repl, historyPath, ready) {
+  // Lazy load
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+
   // Empty string disables persistent history
   if (typeof historyPath === 'string')
     historyPath = historyPath.trim();

--- a/lib/net.js
+++ b/lib/net.js
@@ -75,7 +75,9 @@ const {
   ERR_SOCKET_BAD_PORT,
   ERR_SOCKET_CLOSED
 } = errors.codes;
-const dns = require('dns');
+
+// Lazy loaded
+var dns = null;
 
 const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 
@@ -1034,6 +1036,9 @@ function lookupAndConnect(self, options) {
     throw new ERR_INVALID_ARG_TYPE('options.lookup',
                                    'Function', options.lookup);
 
+  if (!dns)
+    dns = require('dns');
+
   var dnsopts = {
     family: options.family,
     hints: options.hints || 0
@@ -1482,6 +1487,8 @@ Server.prototype.listen = function(...args) {
 };
 
 function lookupAndListen(self, port, address, backlog, exclusive) {
+  if (!dns)
+    dns = require('dns');
   dns.lookup(address, function doListen(err, ip, addressType) {
     if (err) {
       self.emit('error', err);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -47,15 +47,16 @@ const {
   makeRequireFunction,
   addBuiltinLibsToObject
 } = require('internal/modules/cjs/helpers');
-const internalUtil = require('internal/util');
 const { isTypedArray } = require('internal/util/types');
 const util = require('util');
-const utilBinding = process.binding('util');
+const {
+  startSigintWatchdog,
+  stopSigintWatchdog
+} = process.binding('util');
 const { inherits } = util;
 const Stream = require('stream');
 const vm = require('vm');
 const path = require('path');
-const fs = require('fs');
 const { Interface } = require('readline');
 const { Console } = require('console');
 const CJSModule = require('internal/modules/cjs/loader');
@@ -72,6 +73,13 @@ const { experimentalREPLAwait } = process.binding('config');
 
 // Lazy-loaded.
 let processTopLevelAwait;
+let fs;
+
+function lazyFs() {
+  if (!fs)
+    fs = require('fs');
+  return fs;
+}
 
 const parentModule = module;
 const replMap = new WeakMap();
@@ -301,7 +309,7 @@ function REPLServer(prompt,
       if (self.breakEvalOnSigint) {
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn't lead to aborting the process completely.
-        if (!utilBinding.startSigintWatchdog())
+        if (!startSigintWatchdog())
           throw new ERR_CANNOT_WATCH_SIGINT();
         previouslyInRawMode = self._setRawMode(false);
       }
@@ -325,7 +333,7 @@ function REPLServer(prompt,
 
             // Returns true if there were pending SIGINTs *after* the script
             // has terminated without being interrupted itself.
-            if (utilBinding.stopSigintWatchdog()) {
+            if (stopSigintWatchdog()) {
               self.emit('SIGINT');
             }
           }
@@ -397,14 +405,15 @@ function REPLServer(prompt,
   self.eval = self._domain.bind(eval_);
 
   self._domain.on('error', function debugDomainError(e) {
+    const { decorateErrorStack, isError: _isError } = require('internal/util');
     debug('domain error');
     const top = replMap.get(self);
     const pstrace = Error.prepareStackTrace;
     Error.prepareStackTrace = prepareStackTrace(pstrace);
     if (typeof e === 'object')
-      internalUtil.decorateErrorStack(e);
+      decorateErrorStack(e);
     Error.prepareStackTrace = pstrace;
-    const isError = internalUtil.isError(e);
+    const isError = _isError(e);
     if (!self.underscoreErrAssigned)
       self.lastError = e;
     if (e instanceof SyntaxError && e.stack) {
@@ -1020,6 +1029,7 @@ function complete(line, callback) {
     }
 
     for (i = 0; i < paths.length; i++) {
+      const fs = lazyFs();
       dir = path.resolve(paths[i], subdir);
       try {
         files = fs.readdirSync(dir);
@@ -1428,7 +1438,7 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
-        fs.writeFileSync(file, this.lines.join('\n') + '\n');
+        lazyFs().writeFileSync(file, this.lines.join('\n') + '\n');
         this.outputStream.write('Session saved to: ' + file + '\n');
       } catch (e) {
         this.outputStream.write('Failed to save: ' + file + '\n');
@@ -1441,6 +1451,7 @@ function defineDefaultCommands(repl) {
     help: 'Load JS from a file into the REPL session',
     action: function(file) {
       try {
+        const fs = lazyFs();
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {
           _turnOnEditorMode(this);


### PR DESCRIPTION
This is a start towards an *very* incremental refactoring of core module loading the occurs at startup. Every core module that is loaded automatically adds to the overall cold start time of the node.js process. While this specific PR is not likely to have much impact, the goal is to start moving towards lazy-loading where it is practical. Fixed a bug or two and cleaned up a few other bits along the way.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
