### PR TITLE
fs: move SyncWriteStream to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -528,10 +528,11 @@ The [`util._extend()`][] API has been deprecated.
 <a id="DEP0061"></a>
 ### DEP0061: fs.SyncWriteStream
 
-Type: Runtime
+Type: End-of-Life
 
 The `fs.SyncWriteStream` class was never intended to be a publicly accessible
-API. No alternative API is available. Please use a userland alternative.
+API and has been removed. No alternative API is available. Please use a userland
+alternative.
 
 <a id="DEP0062"></a>
 ### DEP0062: node --debug

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2361,14 +2361,3 @@ WriteStream.prototype.close = function(cb) {
 
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
-
-// SyncWriteStream is internal. DO NOT USE.
-// This undocumented API was never intended to be made public.
-var SyncWriteStream = internalFS.SyncWriteStream;
-Object.defineProperty(fs, 'SyncWriteStream', {
-  configurable: true,
-  get: internalUtil.deprecate(() => SyncWriteStream,
-                              'fs.SyncWriteStream is deprecated.', 'DEP0061'),
-  set: internalUtil.deprecate((val) => { SyncWriteStream = val; },
-                              'fs.SyncWriteStream is deprecated.', 'DEP0061')
-});


### PR DESCRIPTION
This was deprecated in 8.x or 9.x. It was never intended for
public use.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
