### PR TITLE
tls: move convertNPNProtocols to End-of-Life

### DIFF
--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -12,11 +12,11 @@ function main({ n }) {
   var m = {};
   // First call dominates results
   if (n > 1) {
-    tls.convertNPNProtocols(input, m);
+    tls.convertALPNProtocols(input, m);
     m = {};
   }
   bench.start();
   for (var i = 0; i < n; i++)
-    tls.convertNPNProtocols(input, m);
+    tls.convertALPNProtocols(input, m);
   bench.end(n);
 }

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -977,7 +977,7 @@ objects respectively.
 <a id="DEP0107"></a>
 ### DEP0107: tls.convertNPNProtocols()
 
-Type: Runtime
+Type: End-of-Life
 
 This was an undocumented helper function not intended for use outside Node.js
 core and obsoleted by the removal of NPN (Next Protocol Negotiation) support.

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -76,16 +76,6 @@ function convertProtocols(protocols) {
   return buff;
 }
 
-exports.convertNPNProtocols = internalUtil.deprecate(function(protocols, out) {
-  // If protocols is Array - translate it into buffer
-  if (Array.isArray(protocols)) {
-    out.NPNProtocols = convertProtocols(protocols);
-  } else if (isUint8Array(protocols)) {
-    // Copy new buffer not to be modified by user.
-    out.NPNProtocols = Buffer.from(protocols);
-  }
-}, 'tls.convertNPNProtocols() is deprecated.', 'DEP0107');
-
 exports.convertALPNProtocols = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -94,24 +94,8 @@ common.expectsError(
 }
 
 {
-  const buffer = Buffer.from('abcd');
-  const out = {};
-  tls.convertNPNProtocols(buffer, out);
-  out.NPNProtocols.write('efgh');
-  assert(buffer.equals(Buffer.from('abcd')));
-  assert(out.NPNProtocols.equals(Buffer.from('efgh')));
-}
-
-{
   const buffer = new Uint8Array(Buffer.from('abcd'));
   const out = {};
   tls.convertALPNProtocols(buffer, out);
   assert(out.ALPNProtocols.equals(Buffer.from('abcd')));
-}
-
-{
-  const buffer = new Uint8Array(Buffer.from('abcd'));
-  const out = {};
-  tls.convertNPNProtocols(buffer, out);
-  assert(out.NPNProtocols.equals(Buffer.from('abcd')));
 }


### PR DESCRIPTION
This was deprecated in 10.0.0 because NPN support was removed.
It does not make sense to keep this around longer than 10.x

/cc @bnoordhuis 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
