### PR TITLE
doc: fix linter warnings and typos in manpage

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -39,7 +39,7 @@
 .Op Ar options
 .Op Ar v8-options
 .Op Fl e Ar string | Ar script.js | Fl
-.Op Fl \-
+.Op Fl -
 .Op Ar arguments ...
 .
 .Nm node
@@ -61,11 +61,11 @@ without arguments to start a REPL.
 .
 .Sh OPTIONS
 .Bl -tag -width 6n
-.It Sy \-
+.It Sy -
 Alias for stdin, analogous to the use of - in other command-line utilities.
 The executed script is read from stdin, and remaining arguments are passed to the script.
 .
-.It Fl \-
+.It Fl -
 Indicate the end of node options.
 Pass the rest of the arguments to the script.
 .Pp
@@ -80,15 +80,15 @@ Enable FIPS-compliant crypto at startup.
 Requires Node.js to be built with
 .Sy ./configure --openssl-fips .
 .
-.It Fl \-experimental-modules
+.It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
 .
-.It Fl \-experimental-repl-await
+.It Fl -experimental-repl-await
 Enable experimental top-level
 .Sy await
 keyword support in REPL.
 .
-.It Fl \-experimental-vm-modules
+.It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.
 .
 .It Fl -force-fips
@@ -122,7 +122,8 @@ V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js in
 It uses the Chrome DevTools Protocol.
 .
 .It Fl -napi-modules
-This option is a no-op. It is kept for compatibility.
+This option is a no-op.
+It is kept for compatibility.
 .
 .It Fl -no-deprecation
 Silence deprecation warnings.
@@ -145,7 +146,7 @@ Emit pending deprecation warnings.
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.
 .
-.It F1 -preserve-symlinks-main
+.It Fl -preserve-symlinks-main
 Instructs the module loader to preserve symbolic links when resolving and caching the main module.
 .
 .It Fl -prof-process
@@ -173,7 +174,10 @@ A comma-separated list of categories that should be traced when trace event trac
 .
 .It Fl -trace-event-file-pattern Ar pattern
 Template string specifying the filepath for the trace event data, it
-supports \fB${rotation}\fR and \fB${pid}\fR.
+supports
+.Sy ${rotation}
+and
+.Sy ${pid} .
 .
 .It Fl -trace-events-enabled
 Enable the collection of trace event tracing information.
@@ -187,7 +191,7 @@ Print stack traces for process warnings (including deprecations).
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.
 .
-.It Fl -use-bundled\-ca, Fl -use-openssl-ca
+.It Fl -use-bundled-ca , Fl -use-openssl-ca
 Use bundled Mozilla CA store as supplied by current Node.js version or use OpenSSL's default CA store.
 The default store is selectable at build-time.
 .Pp
@@ -206,7 +210,10 @@ and
 .It Fl -v8-options
 Print V8 command-line options.
 .Pp
-Note: V8 options allow words to be separated by both dashes (\fB-\fR) or underscores (\fB_\fR).
+Note: V8 options allow words to be separated by both dashes
+.Sy ( - )
+or underscores
+.Sy ( _ ) .
 .Pp
 For example,
 .Fl -stack-trace-limit


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [ ] ~~commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)~~ Uncertain how to detail this, as it combines a menial self-explanatory fix (\#1 below) and even more menial fixes which aren't self-explanatory (\#2 below).

##### Changes

### 1. This PR fixes a typo introduced in #19911 with the new `--preserve-symlinks-main` switch:

https://github.com/nodejs/node/blob/810af50ba2ab20e006a9e480b911c763f001ce8e/doc/node.1#L148

That `F1` (`U+0046 U+0031`) should really be `Fl` (`U+0046 U+006C`). The "Fl" is an abbreviation for "Flag"

In @dgoldstein0's defence, it was an easy mistake to make at a glance, because GitHub's code-font uses awkwardly-similar glyphs for `1` and `l`. However, thanks to my killer work on [Roff's syntax highlighting](https://github.com/Alhadis/language-roff) (used on GitHub), the discrepancy is easy to notice:

<img src="https://user-images.githubusercontent.com/2346707/40040056-0ea69792-585c-11e8-8171-4615ff440941.png" width="322" alt="Figure 1" />

Anyway, the formatted output currently looks like this:
~~~
--preserve-symlinks
     Instructs the module loader to …

F1 -preserve-symlinks-main
     Instructs the module loader to …

--prof-process
     Process V8 profiler output gene…
~~~

Now, that's actually legal markup, because the `mdoc` formatter has no way of knowing you *didn't* mean to insert the text `F1`. OTOH, `.F1` *would* have been caught by the linter, since a line starting with a dot always introduces a command/macro, so it couldn't be misconstrued as being a plain-text line.

### 2. I've removed the redundant use of `\-`, which I assume to be cargo-cult
__Short explanation:__  
`\-` is the same as writing `-`.

__Long explanation:__  
No, you don't want the long, painfully circuitous story behind `-` VS `\-`. Trust me, all you need to know now is that for terminal output, `\-` is always the same as `-`.

The *only* difference in manpage output is when using older versions of Groff with `-Tutf8` set (Groff defaults to `-Tascii` for terminal output, so even that's a non-issue. And even that difference is barely noticeable until you copy+paste it. Because in this lone scenario, `-` ([`hyphen-minus U+002D`](http://graphemica.com/-)) gets replaced by `-` ([`minus sign U+2212`](http://graphemica.com/%E2%88%92)).

### 3. I've replaced inline font sequences (`\fB…\fR`) with mdoc `.Sy` commands

Notice the spaces here?

~~~roff
.Sy ( - )
or underscores
.Sy ( _ ) .
~~~

That's much easier to follow than `(\fB-\fR)` and `(\fB_\fR)`, right? That's mdoc doing the hard work behind the scenes for you. When rendered, leading and trailing punctuation like this "closes in on" its contents, producing this:

~~~html
(<b>-</b>) or underscores (<b>_</b>).
~~~

More about delimiter syntax [here](https://man.openbsd.org/mdoc.7#Delimiters).
