### PR TITLE
socket: don't emit premature 'close'

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -407,10 +407,7 @@ endpoint, depending on what it [`connect()`][`socket.connect()`] to.
 added: v0.1.90
 -->
 
-* `hadError` {boolean} `true` if the socket had a transmission error.
-
-Emitted once the socket is fully closed. The argument `hadError` is a boolean
-which says if the socket was closed due to a transmission error.
+Emitted once the socket is fully closed.
 
 ### Event: 'connect'
 <!-- YAML

--- a/lib/net.js
+++ b/lib/net.js
@@ -249,8 +249,6 @@ function Socket(options) {
 
   // Prevent the "no-half-open enforcer" from being inherited from `Duplex`.
   options.allowHalfOpen = true;
-  // For backwards compat do not emit close on destroy.
-  options.emitClose = false;
   stream.Duplex.call(this, options);
 
   // Default to *not* allowing half open sockets.
@@ -583,33 +581,33 @@ Socket.prototype._destroy = function(exception, cb) {
     clearTimeout(s[kTimeout]);
   }
 
-  debug('close');
+  const onClosed = () => {
+    cb(exception);
+
+    if (this._server) {
+      COUNTER_NET_SERVER_CONNECTION_CLOSE(this);
+      debug('has server');
+      this._server._connections--;
+      if (this._server._emitCloseIfDrained) {
+        this._server._emitCloseIfDrained();
+      }
+    }
+  };
+
   if (this._handle) {
+    debug('close');
     if (this !== process.stderr)
       debug('close handle');
-    var isException = exception ? true : false;
     // `bytesRead` and `kBytesWritten` should be accessible after `.destroy()`
     this[kBytesRead] = this._handle.bytesRead;
     this[kBytesWritten] = this._handle.bytesWritten;
 
-    this._handle.close(() => {
-      debug('emit close');
-      this.emit('close', isException);
-    });
+    this._handle.close(onClosed);
     this._handle.onread = noop;
     this._handle = null;
     this._sockname = null;
-  }
-
-  cb(exception);
-
-  if (this._server) {
-    COUNTER_NET_SERVER_CONNECTION_CLOSE(this);
-    debug('has server');
-    this._server._connections--;
-    if (this._server._emitCloseIfDrained) {
-      this._server._emitCloseIfDrained();
-    }
+  } else {
+    onClosed();
   }
 };
 


### PR DESCRIPTION
I'm not sure how to get this to work properly nor how to create a test for it but I think there is an issue here to fix.

Looking at the current `net.Socket` implementation I see a few potential problems:

- ~~`'close'` can be emitted twice. Once from https://github.com/nodejs/node/blob/master/lib/net.js#L597 and once from https://github.com/nodejs/node/blob/master/lib/net.js#L604. Once with `hadError` argument and once without.~~

- EDIT: Doesn't emit `close` if `!_handle`.

- EDIT: `_server._emitCloseIfDrained` before socket is closed.

- ~~`'close'` can be prematurely emitted before the handle is actually closed.~~

- `'close'` has an argument which doesn't conform with the streams spec.

- ~~if the handle calls the callback synchronously then `'close'` is emitted while `destroyed !== false`.~~

- Some user land code expect `'close'` to have no arguments, e.g.

```js
function onComplete (err) {
  if (err) {
    ...
  } else {
    ...
  }
}

socket.on('error', onComplete)
socket.on('close', onComplete)
```

Also, I believe the spec for stream events says that `'close'` has no arguments?

##### Checklist 

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)