### PR TITLE
doc: fix doc for napi_get_typedarray_info

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1750,10 +1750,15 @@ napi_status napi_get_typedarray_info(napi_env env,
 properties to query.
 - `[out] type`: Scalar datatype of the elements within the `TypedArray`.
 - `[out] length`: The number of elements in the `TypedArray`.
-- `[out] data`: The data buffer underlying the `TypedArray`.
+- `[out] data`: The data buffer underlying the `TypedArray` adjusted by
+the byte_offset value so that it points to the first element in the
+`TypedArray`.
 - `[out] arraybuffer`: The `ArrayBuffer` underlying the `TypedArray`.
-- `[out] byte_offset`: The byte offset within the data buffer from which
-to start projecting the `TypedArray`.
+- `[out] byte_offset`: The byte offset within the underlying native array
+at which the first element of the arrays is located. The value for the data
+parameter has already been adjusted so that data points to the first element
+in the array. Therefore, the first byte of the native array would be at
+data - byte_offset.
 
 Returns `napi_ok` if the API succeeded.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1751,14 +1751,14 @@ properties to query.
 - `[out] type`: Scalar datatype of the elements within the `TypedArray`.
 - `[out] length`: The number of elements in the `TypedArray`.
 - `[out] data`: The data buffer underlying the `TypedArray` adjusted by
-the byte_offset value so that it points to the first element in the
+the `byte_offset` value so that it points to the first element in the
 `TypedArray`.
 - `[out] arraybuffer`: The `ArrayBuffer` underlying the `TypedArray`.
 - `[out] byte_offset`: The byte offset within the underlying native array
 at which the first element of the arrays is located. The value for the data
 parameter has already been adjusted so that data points to the first element
 in the array. Therefore, the first byte of the native array would be at
-data - byte_offset.
+data - `byte_offset`.
 
 Returns `napi_ok` if the API succeeded.
 


### PR DESCRIPTION
The data pointer returned for the typedarray has
already been adjusted by the offset so it does not
point to the start of the buffer, instead id points
to the start of the first element.

I think we probably would have liked it to point to the
start of the buffer, but we can't change as that would be
a breaking change.

Update the doc to match the implementation.

Fixes: https://github.com/nodejs/node-addon-api/issues/244

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
.- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
