### PR TITLE
doc: add note about autocrlf required for tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,9 @@ directory, see [the guide on writing tests](../doc/guides/writing-tests.md).
 On how to run tests in this directory, see
 [the contributing guide](../doc/guides/contributing/pull-requests.md#step-6-test).
 
+For the test to successfully run on Windows, Node.js has to be checked out from
+GitHub with the `autocrlf` git config flag set to true.
+
 ## Test Directories
 
 |Directory          |Runs on CI     |Purpose        |

--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@ directory, see [the guide on writing tests](../doc/guides/writing-tests.md).
 On how to run tests in this directory, see
 [the contributing guide](../doc/guides/contributing/pull-requests.md#step-6-test).
 
-For the test to successfully run on Windows, Node.js has to be checked out from
+For the tests to successfully run on Windows, Node.js has to be checked out from
 GitHub with the `autocrlf` git config flag set to true.
 
 ## Test Directories


### PR DESCRIPTION
Adds a note to `test/README.md` that setting `autocrlf` to true when checking out sources is required for the tests to run successfully.

See https://github.com/nodejs/node/issues/18967, which will fail if the `autocrlf` is set to false.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
