### PR TITLE
assert: fix EOL issue in messages on Windows

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -115,12 +115,12 @@ assert.fail = fail;
 assert.AssertionError = AssertionError;
 
 function getBuffer(fd, assertLine) {
-  var lines = 0;
+  let lines = 0;
   // Prevent blocking the event loop by limiting the maximum amount of
   // data that may be read.
-  var maxReads = 64; // bytesPerRead * maxReads = 512 kb
-  var bytesRead = 0;
-  var startBuffer = 0; // Start reading from that char on
+  let maxReads = 64; // bytesPerRead * maxReads = 512 kb
+  let bytesRead = 0;
+  let startBuffer = 0; // Start reading from that char on
   const bytesPerRead = 8192;
   const buffers = [];
   do {
@@ -163,7 +163,7 @@ function getErrMessage(call) {
     return;
   }
 
-  var fd;
+  let fd, message;
   try {
     fd = openSync(filename, 'r', 0o666);
     const buffers = getBuffer(fd, line);
@@ -182,11 +182,14 @@ function getErrMessage(call) {
     // not user defined function names.
       const ok = name === 'ok' ? '.ok' : '';
       const args = node.arguments;
-      var message = code
+      message = code
         .slice(args[0].start, args[args.length - 1].end)
         .replace(escapeSequencesRegExp, escapeFn);
+      if (EOL === '\r\n') {
+        message = message.replace(/\r\n/g, '\n');
+      }
       message = 'The expression evaluated to a falsy value:' +
-        `${EOL}${EOL}  assert${ok}(${message})${EOL}`;
+        `\n\n  assert${ok}(${message})\n`;
     }
     // Make sure to always set the cache! No matter if the message is
     // undefined or not

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -27,7 +27,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { EOL } = require('os');
 const EventEmitter = require('events');
 const { errorCache } = require('internal/assert');
 const { writeFileSync, unlinkSync } = require('fs');
@@ -462,8 +461,8 @@ assert.throws(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert.ok(typeof 123 === 'string')${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               "assert.ok(typeof 123 === 'string')\n"
     }
   );
   Error.stackTraceLimit = tmpLimit;
@@ -625,8 +624,8 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     generatedMessage: true,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert.ok(null)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert.ok(null)\n'
   }
 );
 common.expectsError(
@@ -635,8 +634,8 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     generatedMessage: true,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert(typeof 123 === 'string')${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             "assert(typeof 123 === 'string')\n"
   }
 );
 
@@ -666,8 +665,8 @@ common.expectsError(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert(Buffer.from('test') instanceof Error)${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               "assert(Buffer.from('test') instanceof Error)\n"
     }
   );
   common.expectsError(
@@ -675,8 +674,8 @@ common.expectsError(
     {
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
-      message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-               `assert(Buffer.from('test') instanceof Error)${EOL}`
+      message: 'The expression evaluated to a falsy value:\n\n  ' +
+               "assert(Buffer.from('test') instanceof Error)\n"
     }
   );
   fs.close = tmp;
@@ -695,12 +694,12 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert((() => 'string')()${EOL}` +
-             `      // eslint-disable-next-line${EOL}` +
-             `      ===${EOL}` +
-             `      123 instanceof${EOL}` +
-             `          Buffer)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             "assert((() => 'string')()\n" +
+             '      // eslint-disable-next-line\n' +
+             '      ===\n' +
+             '      123 instanceof\n' +
+             '          Buffer)\n'
   }
 );
 
@@ -709,8 +708,8 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: `The expression evaluated to a falsy value:${EOL}${EOL}  ` +
-             `assert(null, undefined)${EOL}`
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             'assert(null, undefined)\n'
   }
 );
 


### PR DESCRIPTION
My take of #19221. @joyeecheung please feel free to close this PR and just update yours.

I cite @joyeecheung:

```
On Windows if an error is thrown from a script that uses \n
to break lines - which is very common in the JavaScript ecosystem,
and is the case in our own code base -
then the error messages would contain mixed line feeds:
the part coming from the source code breaks with \n while the
message itself break with \r\n.

Since we do not use \r\n in util.inspect(), we should use \n
in error messages as well.
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
