### PR TITLE
test: tests for module not to use sync functions

### DIFF
--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -1,104 +1,126 @@
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
-const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
-const { COPYFILE_FICLONE } = fs.constants;
-const child_process = require('child_process');
 const pkgName = 'foo';
 const { addLibraryPath } = require('../common/shared-lib-util');
 
+common.crashOnUnhandledRejection();
+
 addLibraryPath(process.env);
-
-if (process.argv[2] === 'child') {
-  console.log(require(pkgName).string);
-} else {
-  const tmpdir = require('../common/tmpdir');
-  tmpdir.refresh();
-
-  // Copy node binary into a test $PREFIX directory.
-  const prefixPath = path.join(tmpdir.path, 'install');
-  fs.mkdirSync(prefixPath);
-  let testExecPath;
-  if (common.isWindows) {
-    testExecPath = path.join(prefixPath, path.basename(process.execPath));
+(async () => {
+  if (process.argv[2] === 'child') {
+    console.log(require(pkgName).string);
   } else {
-    const prefixBinPath = path.join(prefixPath, 'bin');
-    fs.mkdirSync(prefixBinPath);
-    testExecPath = path.join(prefixBinPath, path.basename(process.execPath));
+    const fixtures = require('../common/fixtures');
+    const assert = require('assert');
+    const path = require('path');
+    const fs = require('fs');
+    const { chmod, copyFile, mkdir, stat, writeFile } = fs.promises;
+    const { COPYFILE_FICLONE } = fs.constants;
+    const child_process = require('child_process');
+    const promisify = require('util').promisify;
+    const execFile = promisify(child_process.execFile);
+
+    const tmpdir = require('../common/tmpdir');
+    tmpdir.refresh();
+
+    // test directories
+    const noPkgHomeDir = path.join(tmpdir.path, 'home-no-pkg');
+    const prefixPath = path.join(tmpdir.path, 'install');
+    const prefixLibPath = path.join(prefixPath, 'lib');
+
+    // Copy node binary into a test $PREFIX directory.
+    await mkdir(prefixPath);
+    let testExecPath;
+    if (common.isWindows) {
+      testExecPath = path.join(prefixPath, path.basename(process.execPath));
+    } else {
+      const prefixBinPath = path.join(prefixPath, 'bin');
+      await mkdir(prefixBinPath);
+      testExecPath = path.join(prefixBinPath, path.basename(process.execPath));
+    }
+
+    // prepare test directories
+    const [{ mode }] = await Promise.all([
+      stat(process.execPath),
+      copyFile(process.execPath, testExecPath, COPYFILE_FICLONE),
+      mkdir(noPkgHomeDir),
+      mkdir(prefixLibPath)
+    ]);
+    const prefixLibNodePath = path.join(prefixLibPath, 'node');
+    await Promise.all([
+      mkdir(prefixLibNodePath),
+      chmod(testExecPath, mode)
+    ]);
+
+    const runTest = (expectedString, env) => {
+      child_process.execFile(
+        testExecPath,
+        [ __filename, 'child' ],
+        { encoding: 'utf8', env: env },
+        (err, stdout, stderr) => {
+          assert.strictEqual(stdout.trim(), expectedString);
+        }
+      );
+    };
+    const testFixturesDir = fixtures.path(path.basename(__filename, '.js'));
+
+    const env = Object.assign({}, process.env);
+    // Unset NODE_PATH.
+    delete env.NODE_PATH;
+
+    // Test empty global path.
+    env.HOME = env.USERPROFILE = noPkgHomeDir;
+    await assert.rejects(
+      async () => {
+        await execFile(
+          testExecPath,
+          [ __filename, 'child' ],
+          { encoding: 'utf8', env: env });
+      },
+      new RegExp(`Cannot find module '${pkgName}'`));
+
+    // Test module in $HOME/.node_modules.
+    const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');
+    env.HOME = env.USERPROFILE = modHomeDir;
+    runTest('$HOME/.node_modules', env);
+
+    // Test module in $HOME/.node_libraries.
+    const libHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_libraries');
+    env.HOME = env.USERPROFILE = libHomeDir;
+    runTest('$HOME/.node_libraries', env);
+
+    // Test module both $HOME/.node_modules and $HOME/.node_libraries.
+    const bothHomeDir = path.join(testFixturesDir, 'home-pkg-in-both');
+    env.HOME = env.USERPROFILE = bothHomeDir;
+    runTest('$HOME/.node_modules', env);
+
+    // Test module in $PREFIX/lib/node.
+    // Write module into $PREFIX/lib/node.
+    const expectedString = '$PREFIX/lib/node';
+    const pkgPath = path.join(prefixLibNodePath, `${pkgName}.js`);
+    await writeFile(pkgPath, `exports.string = '${expectedString}';`);
+
+    env.HOME = env.USERPROFILE = noPkgHomeDir;
+    runTest(expectedString, env);
+
+    // Test module in all global folders.
+    env.HOME = env.USERPROFILE = bothHomeDir;
+    runTest('$HOME/.node_modules', env);
+
+    // Test module in NODE_PATH is loaded ahead of global folders.
+    env.HOME = env.USERPROFILE = bothHomeDir;
+    env.NODE_PATH = path.join(testFixturesDir, 'node_path');
+    runTest('$NODE_PATH', env);
+
+    // Test module in local folder is loaded ahead of global folders.
+    const localDir = path.join(testFixturesDir, 'local-pkg');
+    env.HOME = env.USERPROFILE = bothHomeDir;
+    env.NODE_PATH = path.join(testFixturesDir, 'node_path');
+    const { stdout } = await execFile(
+      testExecPath,
+      [ path.join(localDir, 'test.js') ],
+      { encoding: 'utf8', env: env }
+    );
+    assert.strictEqual(stdout.trim(), 'local');
   }
-  const mode = fs.statSync(process.execPath).mode;
-  fs.copyFileSync(process.execPath, testExecPath, COPYFILE_FICLONE);
-  fs.chmodSync(testExecPath, mode);
-
-  const runTest = (expectedString, env) => {
-    const child = child_process.execFileSync(testExecPath,
-                                             [ __filename, 'child' ],
-                                             { encoding: 'utf8', env: env });
-    assert.strictEqual(child.trim(), expectedString);
-  };
-
-  const testFixturesDir = fixtures.path(path.basename(__filename, '.js'));
-
-  const env = Object.assign({}, process.env);
-  // Unset NODE_PATH.
-  delete env.NODE_PATH;
-
-  // Test empty global path.
-  const noPkgHomeDir = path.join(tmpdir.path, 'home-no-pkg');
-  fs.mkdirSync(noPkgHomeDir);
-  env.HOME = env.USERPROFILE = noPkgHomeDir;
-  assert.throws(
-    () => {
-      child_process.execFileSync(testExecPath, [ __filename, 'child' ],
-                                 { encoding: 'utf8', env: env });
-    },
-    new RegExp(`Cannot find module '${pkgName}'`));
-
-  // Test module in $HOME/.node_modules.
-  const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');
-  env.HOME = env.USERPROFILE = modHomeDir;
-  runTest('$HOME/.node_modules', env);
-
-  // Test module in $HOME/.node_libraries.
-  const libHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_libraries');
-  env.HOME = env.USERPROFILE = libHomeDir;
-  runTest('$HOME/.node_libraries', env);
-
-  // Test module both $HOME/.node_modules and $HOME/.node_libraries.
-  const bothHomeDir = path.join(testFixturesDir, 'home-pkg-in-both');
-  env.HOME = env.USERPROFILE = bothHomeDir;
-  runTest('$HOME/.node_modules', env);
-
-  // Test module in $PREFIX/lib/node.
-  // Write module into $PREFIX/lib/node.
-  const expectedString = '$PREFIX/lib/node';
-  const prefixLibPath = path.join(prefixPath, 'lib');
-  fs.mkdirSync(prefixLibPath);
-  const prefixLibNodePath = path.join(prefixLibPath, 'node');
-  fs.mkdirSync(prefixLibNodePath);
-  const pkgPath = path.join(prefixLibNodePath, `${pkgName}.js`);
-  fs.writeFileSync(pkgPath, `exports.string = '${expectedString}';`);
-
-  env.HOME = env.USERPROFILE = noPkgHomeDir;
-  runTest(expectedString, env);
-
-  // Test module in all global folders.
-  env.HOME = env.USERPROFILE = bothHomeDir;
-  runTest('$HOME/.node_modules', env);
-
-  // Test module in NODE_PATH is loaded ahead of global folders.
-  env.HOME = env.USERPROFILE = bothHomeDir;
-  env.NODE_PATH = path.join(testFixturesDir, 'node_path');
-  runTest('$NODE_PATH', env);
-
-  // Test module in local folder is loaded ahead of global folders.
-  const localDir = path.join(testFixturesDir, 'local-pkg');
-  env.HOME = env.USERPROFILE = bothHomeDir;
-  env.NODE_PATH = path.join(testFixturesDir, 'node_path');
-  const child = child_process.execFileSync(testExecPath,
-                                           [ path.join(localDir, 'test.js') ],
-                                           { encoding: 'utf8', env: env });
-  assert.strictEqual(child.trim(), 'local');
-}
+})();

--- a/test/parallel/test-module-main-fail.js
+++ b/test/parallel/test-module-main-fail.js
@@ -1,7 +1,8 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { execFileSync } = require('child_process');
+const { execFile } = require('child_process');
+const common = require('../common');
 
 const entryPoints = ['iDoNotExist', 'iDoNotExist.js', 'iDoNotExist.mjs'];
 const flags = [[], ['--experimental-modules']];
@@ -9,13 +10,16 @@ const node = process.argv[0];
 
 for (const args of flags) {
   for (const entryPoint of entryPoints) {
-    try {
-      execFileSync(node, args.concat(entryPoint), { stdio: 'pipe' });
-    } catch (e) {
-      assert(e.toString().match(/Error: Cannot find module/));
-      continue;
-    }
-    assert.fail('Executing node with inexistent entry point should ' +
-                `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+    execFile(
+      node,
+      args.concat(entryPoint),
+      common.mustCall((err, stdout, stderr) => {
+        if (!stderr) {
+          assert.fail('Executing node with inexistent entry point should ' +
+                  `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+        }
+        assert(stderr.toString().match(/Error: Cannot find module/));
+      })
+    );
   }
 }

--- a/test/parallel/test-module-main-preserve-symlinks-fail.js
+++ b/test/parallel/test-module-main-preserve-symlinks-fail.js
@@ -1,7 +1,8 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { execFileSync } = require('child_process');
+const { execFile } = require('child_process');
+const common = require('../common');
 
 const entryPoints = ['iDoNotExist', 'iDoNotExist.js', 'iDoNotExist.mjs'];
 const flags = [[], ['--experimental-modules', '--preserve-symlinks']];
@@ -9,13 +10,16 @@ const node = process.argv[0];
 
 for (const args of flags) {
   for (const entryPoint of entryPoints) {
-    try {
-      execFileSync(node, args.concat(entryPoint));
-    } catch (e) {
-      assert(e.toString().match(/Error: Cannot find module/));
-      continue;
-    }
-    assert.fail('Executing node with inexistent entry point should ' +
-                `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+    execFile(
+      node,
+      args.concat(entryPoint),
+      common.mustCall((err, stdout, stderr) => {
+        if (!stderr) {
+          assert.fail('Executing node with inexistent entry point should ' +
+                  `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+        }
+        assert(stderr.toString().match(/Error: Cannot find module/));
+      })
+    );
   }
 }


### PR DESCRIPTION
this refactors tests for module to reduce runtime

Refs: #20128

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
