### PR TITLE
src: trace_events: support for metadata events

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4545,6 +4545,9 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   Environment env(isolate_data, context, v8_platform.GetTracingAgent());
   env.Start(argc, argv, exec_argc, exec_argv, v8_is_profiling);
 
+  TRACE_EVENT_METADATA1("__metadata", "thread_name", "name",
+                        "JavaScriptMainThread");
+
   const char* path = argc > 1 ? argv[1] : nullptr;
   StartInspector(&env, path, debug_options);
 

--- a/test/parallel/test-trace-events-api.js
+++ b/test/parallel/test-trace-events-api.js
@@ -130,7 +130,8 @@ if (isChild) {
 
     assert(common.fileExists(file));
     fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents;
+      const traces = JSON.parse(data.toString()).traceEvents
+        .filter((trace) => trace.cat !== '__metadata');
       assert.strictEqual(traces.length,
                          expectedMarks.length +
                          expectedBegins.length +

--- a/test/parallel/test-trace-events-binding.js
+++ b/test/parallel/test-trace-events-binding.js
@@ -31,7 +31,8 @@ const proc = cp.spawn(process.execPath,
 proc.once('exit', common.mustCall(() => {
   assert(common.fileExists(FILE_NAME));
   fs.readFile(FILE_NAME, common.mustCall((err, data) => {
-    const traces = JSON.parse(data.toString()).traceEvents;
+    const traces = JSON.parse(data.toString()).traceEvents
+      .filter((trace) => trace.cat !== '__metadata');
     assert.strictEqual(traces.length, 3);
 
     assert.strictEqual(traces[0].pid, proc.pid);

--- a/test/parallel/test-trace-events-bootstrap.js
+++ b/test/parallel/test-trace-events-bootstrap.js
@@ -42,7 +42,8 @@ if (process.argv[2] === 'child') {
 
     assert(common.fileExists(file));
     fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents;
+      const traces = JSON.parse(data.toString()).traceEvents
+        .filter((trace) => trace.cat !== '__metadata');
       traces.forEach((trace) => {
         assert.strictEqual(trace.pid, proc.pid);
         assert(names.includes(trace.name));

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -12,16 +12,15 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 process.chdir(tmpdir.path);
 
-const proc_no_categories = cp.spawn(
-  process.execPath,
-  [ '--trace-event-categories', '""', '-e', CODE ]
-);
-
-proc_no_categories.once('exit', common.mustCall(() => {
+const proc = cp.spawn(process.execPath,
+                      [ '--trace-events-enabled', '-e', CODE ]);
+proc.once('exit', common.mustCall(() => {
   assert(common.fileExists(FILE_NAME));
-  // Only __metadata categories should have been emitted.
   fs.readFile(FILE_NAME, common.mustCall((err, data) => {
-    assert.ok(JSON.parse(data.toString()).traceEvents.every(
-      (trace) => trace.cat === '__metadata'));
+    const traces = JSON.parse(data.toString()).traceEvents;
+    assert(traces.length > 0);
+    assert(traces.some((trace) =>
+      trace.cat === '__metadata' && trace.name === 'thread_name' &&
+        trace.args.name === 'JavaScriptMainThread'));
   }));
 }));

--- a/test/parallel/test-trace-events-perf.js
+++ b/test/parallel/test-trace-events-perf.js
@@ -49,7 +49,8 @@ if (process.argv[2] === 'child') {
 
     assert(common.fileExists(file));
     fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents;
+      const traces = JSON.parse(data.toString()).traceEvents
+        .filter((trace) => trace.cat !== '__metadata');
       assert.strictEqual(traces.length,
                          expectedMarks.length +
                          expectedBegins.length +

--- a/test/parallel/test-trace-events-vm.js
+++ b/test/parallel/test-trace-events-vm.js
@@ -32,7 +32,8 @@ if (process.argv[2] === 'child') {
 
     assert(common.fileExists(file));
     fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents;
+      const traces = JSON.parse(data.toString()).traceEvents
+        .filter((trace) => trace.cat !== '__metadata');
       traces.forEach((trace) => {
         assert.strictEqual(trace.pid, proc.pid);
         assert(names.includes(trace.name));


### PR DESCRIPTION
Add support for metadata events. At this point they are added to the
main buffer. Emit a metadata event for the main thread.

Metadata events are implicitly enabled when tracing is enabled. They contain information pertaining not to the individual events as they occur but rather about the process and the environment. Trace viewers use this information, e.g. to render thread names.

Example:

Before
![image](https://user-images.githubusercontent.com/79017/40088067-35616b02-585a-11e8-8ffc-40690e5cb18e.png)

After:
![image](https://user-images.githubusercontent.com/79017/40088051-21196708-585a-11e8-98d0-26b24270028c.png)

/cc @nodejs/trace-events @nodejs/diagnostics 

CI: https://ci.nodejs.org/job/node-test-pull-request/14896/
