### PR TITLE
fs: fix and cleanup constants

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -48,7 +48,7 @@ const { createPromise, promiseResolve } = process.binding('util');
 
 const binding = process.binding('fs');
 const fs = exports;
-const { Buffer } = require('buffer');
+const { Buffer, kMaxLength } = require('buffer');
 const errors = require('internal/errors');
 const {
   ERR_FS_FILE_TOO_LARGE,
@@ -120,7 +120,6 @@ function lazyAssert() {
 }
 
 const kMinPoolSpace = 128;
-const { kMaxLength } = require('buffer');
 
 const isWindows = process.platform === 'win32';
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -24,8 +24,23 @@
 
 'use strict';
 
-const constants = process.binding('constants').fs;
-const { S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK } = constants;
+const { fs: constants } = process.binding('constants');
+const {
+  S_IFIFO,
+  S_IFLNK,
+  S_IFMT,
+  S_IFREG,
+  S_IFSOCK,
+  F_OK,
+  R_OK,
+  W_OK,
+  X_OK,
+  O_WRONLY,
+  O_SYMLINK,
+  UV_FS_COPYFILE_EXCL,
+  UV_FS_COPYFILE_FICLONE,
+  UV_FS_COPYFILE_FICLONE_FORCE
+} = constants;
 const util = require('util');
 const pathModule = require('path');
 const { isUint8Array } = require('internal/util/types');
@@ -181,10 +196,10 @@ function isFileType(stats, fileType) {
 
 // Don't allow mode to accidentally be overwritten.
 Object.defineProperties(fs, {
-  F_OK: { enumerable: true, value: constants.F_OK || 0 },
-  R_OK: { enumerable: true, value: constants.R_OK || 0 },
-  W_OK: { enumerable: true, value: constants.W_OK || 0 },
-  X_OK: { enumerable: true, value: constants.X_OK || 0 },
+  F_OK: { enumerable: true, value: F_OK || 0 },
+  R_OK: { enumerable: true, value: R_OK || 0 },
+  W_OK: { enumerable: true, value: W_OK || 0 },
+  X_OK: { enumerable: true, value: X_OK || 0 },
 });
 
 fs.access = function(path, mode, callback) {
@@ -1056,10 +1071,10 @@ fs.fchmodSync = function(fd, mode) {
   handleErrorFromBinding(ctx);
 };
 
-if (constants.O_SYMLINK !== undefined) {
+if (O_SYMLINK !== undefined) {
   fs.lchmod = function(path, mode, callback) {
     callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
+    fs.open(path, O_WRONLY | O_SYMLINK, function(err, fd) {
       if (err) {
         callback(err);
         return;
@@ -1075,7 +1090,7 @@ if (constants.O_SYMLINK !== undefined) {
   };
 
   fs.lchmodSync = function(path, mode) {
-    const fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
+    const fd = fs.openSync(path, O_WRONLY | O_SYMLINK);
 
     // Prefer to return the chmod error, if one occurs,
     // but still try to close, and report closing errors if they occur.
@@ -1112,10 +1127,10 @@ fs.chmodSync = function(path, mode) {
   handleErrorFromBinding(ctx);
 };
 
-if (constants.O_SYMLINK !== undefined) {
+if (O_SYMLINK !== undefined) {
   fs.lchown = function(path, uid, gid, callback) {
     callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
+    fs.open(path, O_WRONLY | O_SYMLINK, function(err, fd) {
       if (err) {
         callback(err);
         return;
@@ -1131,7 +1146,7 @@ if (constants.O_SYMLINK !== undefined) {
   };
 
   fs.lchownSync = function(path, uid, gid) {
-    const fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
+    const fd = fs.openSync(path, O_WRONLY | O_SYMLINK);
     let ret;
     try {
       ret = fs.fchownSync(fd, uid, gid);
@@ -1938,14 +1953,14 @@ fs.mkdtempSync = function(prefix, options) {
 
 // Define copyFile() flags.
 Object.defineProperties(fs.constants, {
-  COPYFILE_EXCL: { enumerable: true, value: constants.UV_FS_COPYFILE_EXCL },
+  COPYFILE_EXCL: { enumerable: true, value: UV_FS_COPYFILE_EXCL },
   COPYFILE_FICLONE: {
     enumerable: true,
-    value: constants.UV_FS_COPYFILE_FICLONE
+    value: UV_FS_COPYFILE_FICLONE
   },
   COPYFILE_FICLONE_FORCE: {
     enumerable: true,
-    value: constants.UV_FS_COPYFILE_FICLONE_FORCE
+    value: UV_FS_COPYFILE_FICLONE_FORCE
   }
 });
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -72,6 +72,7 @@ const {
   preprocessSymlinkDestination,
   Stats,
   getStatsFromBinding,
+  realpathCacheKey,
   stringToFlags,
   stringToSymlinkType,
   toUnixTimestamp,
@@ -204,7 +205,7 @@ Object.defineProperties(fs, {
 fs.access = function(path, mode, callback) {
   if (typeof mode === 'function') {
     callback = mode;
-    mode = fs.F_OK;
+    mode = F_OK;
   }
 
   path = getPathFromURL(path);
@@ -221,7 +222,7 @@ fs.accessSync = function(path, mode) {
   validatePath(path);
 
   if (mode === undefined)
-    mode = fs.F_OK;
+    mode = F_OK;
   else
     mode = mode | 0;
 
@@ -1647,7 +1648,7 @@ fs.realpathSync = function realpathSync(p, options) {
   validatePath(p);
   p = pathModule.resolve(p);
 
-  const cache = options[internalFS.realpathCacheKey];
+  const cache = options[realpathCacheKey];
   const maybeCachedResult = cache && cache.get(p);
   if (maybeCachedResult) {
     return maybeCachedResult;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -239,7 +239,7 @@ fs.exists = function(path, callback) {
   }
 
   try {
-    fs.access(path, fs.FS_OK, suppressedCallback);
+    fs.access(path, F_OK, suppressedCallback);
   } catch (err) {
     return callback(false);
   }
@@ -261,7 +261,7 @@ Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
 // TODO(joyeecheung): deprecate the never-throw-on-invalid-arguments behavior
 fs.existsSync = function(path) {
   try {
-    fs.accessSync(path, fs.FS_OK);
+    fs.accessSync(path, F_OK);
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
Subset of commits that were originally in https://github.com/nodejs/node/pull/20734

Cleans up some constants usage in `fs`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
