### PR TITLE
assert: lazy load fs

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -32,7 +32,6 @@ const { codes: {
   ERR_INVALID_RETURN_VALUE
 } } = require('internal/errors');
 const { AssertionError, errorCache } = require('internal/assert');
-const { openSync, closeSync, readSync } = require('fs');
 const { inspect, types: { isPromise, isRegExp } } = require('util');
 const { EOL } = require('os');
 const { NativeModule } = require('internal/bootstrap/loaders');
@@ -54,6 +53,11 @@ const meta = [
 const escapeFn = (str) => meta[str.charCodeAt(0)];
 
 let warned = false;
+
+// Lazy loaded
+let openSync;
+let closeSync;
+let readSync;
 
 // The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
@@ -114,37 +118,46 @@ assert.fail = fail;
 //                             expected: expected });
 assert.AssertionError = AssertionError;
 
-function getBuffer(fd, assertLine) {
-  var lines = 0;
-  // Prevent blocking the event loop by limiting the maximum amount of
-  // data that may be read.
-  var maxReads = 64; // bytesPerRead * maxReads = 512 kb
-  var bytesRead = 0;
-  var startBuffer = 0; // Start reading from that char on
-  const bytesPerRead = 8192;
-  const buffers = [];
-  do {
-    const buffer = Buffer.allocUnsafe(bytesPerRead);
-    bytesRead = readSync(fd, buffer, 0, bytesPerRead);
-    for (var i = 0; i < bytesRead; i++) {
-      if (buffer[i] === 10) {
-        lines++;
-        if (lines === assertLine) {
-          startBuffer = i + 1;
-        // Read up to 15 more lines to make sure all code gets matched
-        } else if (lines === assertLine + 16) {
-          buffers.push(buffer.slice(startBuffer, i));
-          return buffers;
+function getBuffer(filename, assertLine) {
+  if (!openSync)
+    ({ openSync, closeSync, readSync } = require('fs'));
+  var fd;
+  try {
+    fd = openSync(filename, 'r', 0o666);
+    var lines = 0;
+    // Prevent blocking the event loop by limiting the maximum amount of
+    // data that may be read.
+    var maxReads = 64; // bytesPerRead * maxReads = 512 kb
+    var bytesRead = 0;
+    var startBuffer = 0; // Start reading from that char on
+    const bytesPerRead = 8192;
+    const buffers = [];
+    do {
+      const buffer = Buffer.allocUnsafe(bytesPerRead);
+      bytesRead = readSync(fd, buffer, 0, bytesPerRead);
+      for (var i = 0; i < bytesRead; i++) {
+        if (buffer[i] === 10) {
+          lines++;
+          if (lines === assertLine) {
+            startBuffer = i + 1;
+          // Read up to 15 more lines to make sure all code gets matched
+          } else if (lines === assertLine + 16) {
+            buffers.push(buffer.slice(startBuffer, i));
+            return buffers;
+          }
         }
       }
-    }
-    if (lines >= assertLine) {
-      buffers.push(buffer.slice(startBuffer, bytesRead));
-      // Reset the startBuffer in case we need more than one chunk
-      startBuffer = 0;
-    }
-  } while (--maxReads !== 0 && bytesRead !== 0);
-  return buffers;
+      if (lines >= assertLine) {
+        buffers.push(buffer.slice(startBuffer, bytesRead));
+        // Reset the startBuffer in case we need more than one chunk
+        startBuffer = 0;
+      }
+    } while (--maxReads !== 0 && bytesRead !== 0);
+    return buffers;
+  } finally {
+    if (fd !== undefined)
+      closeSync(fd);
+  }
 }
 
 function getErrMessage(call) {
@@ -163,10 +176,8 @@ function getErrMessage(call) {
     return;
   }
 
-  var fd;
   try {
-    fd = openSync(filename, 'r', 0o666);
-    const buffers = getBuffer(fd, line);
+    const buffers = getBuffer(filename, line);
     const code = Buffer.concat(buffers).toString('utf8');
     // Lazy load acorn.
     const { parseExpressionAt } = require('internal/deps/acorn/dist/acorn');
@@ -197,9 +208,6 @@ function getErrMessage(call) {
   } catch (e) {
   // Invalidate cache to prevent trying to read this part again.
     errorCache.set(identifier, undefined);
-  } finally {
-    if (fd !== undefined)
-      closeSync(fd);
   }
 }
 


### PR DESCRIPTION
Originally part of https://github.com/nodejs/node/pull/20734 ...

Lazy load `fs` in `assert`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
