### PR TITLE
perf_hooks: always set bootstrapComplete

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -158,12 +158,12 @@
       // To allow people to extend Node in different ways, this hook allows
       // one to drop a file lib/_third_party_main.js into the build
       // directory which will be executed instead of Node's normal loading.
+      perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
       process.nextTick(function() {
         perf.markMilestone(NODE_PERFORMANCE_MILESTONE_THIRD_PARTY_MAIN_START);
         NativeModule.require('_third_party_main');
         perf.markMilestone(NODE_PERFORMANCE_MILESTONE_THIRD_PARTY_MAIN_END);
       });
-
     } else if (process.argv[1] === 'inspect' || process.argv[1] === 'debug') {
       if (process.argv[1] === 'debug') {
         process.emitWarning(
@@ -172,13 +172,14 @@
       }
 
       // Start the debugger agent.
+      perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
       process.nextTick(function() {
         NativeModule.require('internal/deps/node-inspect/lib/_inspect').start();
       });
 
     } else if (process.profProcess) {
+      perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
       NativeModule.require('internal/v8_prof_processor');
-
     } else {
       // There is user code to be run.
 
@@ -209,6 +210,7 @@
           addBuiltinLibsToObject
         } = NativeModule.require('internal/modules/cjs/helpers');
         addBuiltinLibsToObject(global);
+        perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
         evalScript('[eval]');
       } else if (process.argv[1] && process.argv[1] !== '-') {
         perf.markMilestone(NODE_PERFORMANCE_MILESTONE_MODULE_LOAD_START);
@@ -233,6 +235,7 @@
           checkScriptSyntax(source, filename);
           process.exit(0);
         }
+        perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
         CJSModule.runMain();
       } else {
         perf.markMilestone(NODE_PERFORMANCE_MILESTONE_MODULE_LOAD_START);
@@ -263,6 +266,7 @@
 
           if (process._eval != null) {
             // User passed '-e' or '--eval'
+            perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
             evalScript('[eval]');
           }
         } else {
@@ -279,6 +283,7 @@
               checkScriptSyntax(code, '[stdin]');
             } else {
               process._eval = code;
+              perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
               evalScript('[stdin]');
             }
           });

--- a/test/sequential/test-performance.js
+++ b/test/sequential/test-performance.js
@@ -74,7 +74,7 @@ checkNodeTiming({
   duration: { around: performance.now() },
   nodeStart: { around: 0 },
   v8Start: { around: 0 },
-  bootstrapComplete: -1,
+  bootstrapComplete: { around: inited },
   environment: { around: 0 },
   loopStart: -1,
   loopExit: -1,


### PR DESCRIPTION
The `performance.nodeTiming.bootstrapComplete` milestone was not always being set. It should be set immediately before the main user-code is run.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
