### PR TITLE
src: add override to ThreadPool methods in zlib

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -219,7 +219,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   // This function may be called multiple times on the uv_work pool
   // for a single write() call, until all of the input bytes have
   // been consumed.
-  void DoThreadPoolWork() {
+  void DoThreadPoolWork() override {
+
     const Bytef* next_expected_header_byte = nullptr;
 
     // If the avail_out is left at 0, then it means that it ran out
@@ -353,7 +354,7 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
 
   // v8 land!
-  void AfterThreadPoolWork(int status) {
+  void AfterThreadPoolWork(int status) override {
     write_in_progress_ = false;
 
     if (status == UV_ECANCELED) {

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -220,7 +220,6 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   // for a single write() call, until all of the input bytes have
   // been consumed.
   void DoThreadPoolWork() override {
-
     const Bytef* next_expected_header_byte = nullptr;
 
     // If the avail_out is left at 0, then it means that it ran out


### PR DESCRIPTION
Currently the following compiler warnings are generated:
```console
../src/node_zlib.cc:222:8:
warning: 'DoThreadPoolWork' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
  void DoThreadPoolWork() {
       ^
../src/node_internals.h:509:16: note: overridden virtual function is here
  virtual void DoThreadPoolWork() = 0;
               ^
../src/node_zlib.cc:357:8: warning:
'AfterThreadPoolWork' overrides a member function but is not marked
      'override' [-Winconsistent-missing-override]
  void AfterThreadPoolWork(int status) {
       ^
../src/node_internals.h:510:16:
note: overridden virtual function is here
  virtual void AfterThreadPoolWork(int status) = 0;
               ^
```
This commit adds the override specifier to the methods to silence the
warnings.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
