### PR TITLE
doc: describe using multiple link-module on win

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -423,8 +423,9 @@ $ ./configure --link-module '/root/myModule.js' --link-module './myModule2.js'
 
 ### Windows
 
-To make `./myCustomModule.js` available via `require('myCustomModule')`.
+To make `./myModule.js` available via `require('myModule')` and
+`./myModule2.js` available via `require('myModule2')`
 
 ```console
-> .\vcbuild link-module './myCustomModule.js'
+> .\vcbuild link-module './myModule.js' link-module './myModule2.js'
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -424,7 +424,7 @@ $ ./configure --link-module '/root/myModule.js' --link-module './myModule2.js'
 ### Windows
 
 To make `./myModule.js` available via `require('myModule')` and
-`./myModule2.js` available via `require('myModule2')`
+`./myModule2.js` available via `require('myModule2')`:
 
 ```console
 > .\vcbuild link-module './myModule.js' link-module './myModule2.js'


### PR DESCRIPTION
Current description seems to suggest that only one linked-module can be provided. This modifies the example to show that multiple inked-modules can be used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
