### PR TITLE
[v8.x backport] backport of tls-cnnic-whitelist fixes

### DIFF
--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -28,7 +28,7 @@ const testCases = [
       rejectUnauthorized: true,
       ca: [loadPEM('fake-cnnic-root-cert')]
     },
-    errorCode: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+    errorCode: 'CERT_HAS_EXPIRED'
   },
   // Test 1: for the fix of node#2061
   // agent6-cert.pem is signed by intermediate cert of ca3.
@@ -58,7 +58,7 @@ function runTest(tindex) {
   const server = tls.createServer(tcase.serverOpts, (s) => {
     s.resume();
   }).listen(0, common.mustCall(function() {
-    tcase.clientOpts = this.address().port;
+    tcase.clientOpts.port = this.address().port;
     const client = tls.connect(tcase.clientOpts);
     client.on('error', common.mustCall((e) => {
       assert.strictEqual(e.code, tcase.errorCode);

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -14,22 +14,6 @@ function loadPEM(n) {
 }
 
 const testCases = [
-  { // Test 0: for the check of a cert not existed in the whitelist.
-    // agent7-cert.pem is issued by the fake CNNIC root CA so that its
-    // hash is not listed in the whitelist.
-    // fake-cnnic-root-cert has the same subject name as the original
-    // rootCA.
-    serverOpts: {
-      key: loadPEM('agent7-key'),
-      cert: loadPEM('agent7-cert')
-    },
-    clientOpts: {
-      port: undefined,
-      rejectUnauthorized: true,
-      ca: [loadPEM('fake-cnnic-root-cert')]
-    },
-    errorCode: 'CERT_HAS_EXPIRED'
-  },
   // Test 1: for the fix of node#2061
   // agent6-cert.pem is signed by intermediate cert of ca3.
   // The server has a cert chain of agent6->ca3->ca1(root) but


### PR DESCRIPTION

This is a backport of https://github.com/nodejs/node/pull/19767 which includes two commits.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
