### PR TITLE
tools, doc: wrap manpage links in code elements

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -52,15 +52,15 @@ const testData = [
       '<tr><td>v4.2.0</td><td><p>The <code>error</code> parameter can now be' +
       'an arrow function.</p></td></tr></table></details></div> ' +
       '<p>Describe <code>Foobar II</code> in more detail here.' +
-      '<a href="http://man7.org/linux/man-pages/man1/fg.1.html">fg(1)</a></p>' +
-      '<h2>Deprecated thingy<span><a class="mark" ' +
+      '<a href="http://man7.org/linux/man-pages/man1/fg.1.html"><code>fg(1)' +
+      '</code></a></p><h2>Deprecated thingy<span><a class="mark" ' +
       'href="#foo_deprecated_thingy" id="foo_deprecated_thingy">#</a>' +
       '</span></h2><div class="api_metadata"><span>Added in: v1.0.0</span>' +
       '<span>Deprecated since: v2.0.0</span></div><p>Describe ' +
       '<code>Deprecated thingy</code> in more detail here.' +
-      '<a href="http://man7.org/linux/man-pages/man1/fg.1p.html">fg(1p)</a>' +
-      '</p><h2>Something<span><a class="mark" href="#foo_something" ' +
-      'id="foo_something">#</a></span></h2> ' +
+      '<a href="http://man7.org/linux/man-pages/man1/fg.1p.html"><code>fg(1p)' +
+      '</code></a></p><h2>Something<span><a class="mark" href="#foo_something' +
+      '" id="foo_something">#</a></span></h2> ' +
       '<!-- This is not a metadata comment --> ' +
       '<p>Describe <code>Something</code> in more detail here. </p>'
   },

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -141,7 +141,7 @@ function linkManPages(text) {
     MAN_PAGE, (match, beginning, name, number, optionalCharacter) => {
       // Name consists of lowercase letters,
       // number is a single digit with an optional lowercase letter.
-      const displayAs = `${name}(${number}${optionalCharacter})`;
+      const displayAs = `<code>${name}(${number}${optionalCharacter})</code>`;
 
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Before:

![mp1](https://user-images.githubusercontent.com/10393198/40137267-a70a7e44-5952-11e8-9201-e8954f903f8d.png)

After:

![mp2](https://user-images.githubusercontent.com/10393198/40137285-ad817142-5952-11e8-9d19-0599a8df336d.png)
