### PR TITLE
http: do not rely on the 'agentRemove' event

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -276,7 +276,6 @@ function installListeners(agent, s, options) {
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
     s.removeListener('agentRemove', onRemove);
-    s._httpMessage = null;
   }
   s.on('agentRemove', onRemove);
 }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -467,6 +467,7 @@ function socketOnData(d) {
       socket.removeListener('close', socketCloseListener);
       socket.removeListener('error', socketErrorListener);
 
+      socket._httpMessage = null;
       socket.readableFlowing = null;
 
       req.emit(eventName, res, socket, bodyHead);

--- a/test/parallel/test-http-agent-remove.js
+++ b/test/parallel/test-http-agent-remove.js
@@ -1,0 +1,21 @@
+'use strict';
+const { mustCall } = require('../common');
+
+const http = require('http');
+const { strictEqual } = require('assert');
+
+const server = http.createServer(mustCall((req, res) => {
+  res.flushHeaders();
+}));
+
+server.listen(0, mustCall(() => {
+  const req = http.get({
+    port: server.address().port
+  }, mustCall(() => {
+    const { socket } = req;
+    socket.emit('agentRemove');
+    strictEqual(socket._httpMessage, req);
+    socket.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Do not use the `'agentRemove'` event to null `socket._httpMessage` as
that event is public and can be used to not keep a request in the agent.

Fixes: https://github.com/nodejs/node/issues/20690

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
