### PR TITLE
doc: sort references in ASCII order

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -875,17 +875,17 @@ When things need extra attention, are controversial, or `semver-major`:
 
 If you cannot find who to cc for a file, `git shortlog -n -s <file>` may help.
 
+["Merge Pull Request"]: https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github
+[Enhancement Proposal]: https://github.com/nodejs/node-eps
+[Stability Index]: doc/api/documentation.md#stability-index
+[TSC]: https://github.com/nodejs/TSC
+[`--pending-deprecation`]: doc/api/cli.md#--pending-deprecation
+[`node-core-utils`]: https://github.com/nodejs/node-core-utils
 [backporting guide]: doc/guides/backporting-to-release-lines.md
 [contributing]: ./doc/guides/contributing/pull-requests.md#commit-message-guidelines
-[Stability Index]: doc/api/documentation.md#stability-index
-[Enhancement Proposal]: https://github.com/nodejs/node-eps
-[`--pending-deprecation`]: doc/api/cli.md#--pending-deprecation
-[git-node]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md
+[flaky tests]: https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22CI+%2F+flaky+test%22y
 [git-node-metadata]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md#git-node-metadata
+[git-node]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md
 [git-username]: https://help.github.com/articles/setting-your-username-in-git/
-[`node-core-utils`]: https://github.com/nodejs/node-core-utils
-[TSC]: https://github.com/nodejs/TSC
-[node-core-utils-issues]: https://github.com/nodejs/node-core-utils/issues
 [node-core-utils-credentials]: https://github.com/nodejs/node-core-utils#setting-up-credentials
-["Merge Pull Request"]: https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github
-[flaky tests]: https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22CI+%2F+flaky+test%22
+[node-core-utils-issues]: https://github.com/nodejs/node-core-utils/issues

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -884,8 +884,8 @@ If you cannot find who to cc for a file, `git shortlog -n -s <file>` may help.
 [backporting guide]: doc/guides/backporting-to-release-lines.md
 [contributing]: ./doc/guides/contributing/pull-requests.md#commit-message-guidelines
 [flaky tests]: https://github.com/nodejs/node/issues?q=is%3Aopen+is%3Aissue+label%3A%22CI+%2F+flaky+test%22y
-[git-node-metadata]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md#git-node-metadata
 [git-node]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md
+[git-node-metadata]: https://github.com/nodejs/node-core-utils/blob/master/docs/git-node.md#git-node-metadata
 [git-username]: https://help.github.com/articles/setting-your-username-in-git/
 [node-core-utils-credentials]: https://github.com/nodejs/node-core-utils#setting-up-credentials
 [node-core-utils-issues]: https://github.com/nodejs/node-core-utils/issues


### PR DESCRIPTION
The references in the COLLABORATOR_GUIDE appear to be in no particular
order. Sort in ASCII order.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
