### PR TITLE
assert: fix wrong message indentation

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -193,6 +193,19 @@ function getErrMessage(call) {
       if (EOL === '\r\n') {
         message = message.replace(/\r\n/g, '\n');
       }
+      // Always normalize indentation, otherwise the message could look weird.
+      if (message.indexOf('\n') !== -1) {
+        const tmp = message.split('\n');
+        message = tmp[0];
+        for (var i = 1; i < tmp.length; i++) {
+          let pos = 0;
+          while (pos < column &&
+              (tmp[i][pos] === ' ' || tmp[i][pos] === '\t')) {
+            pos++;
+          }
+          message += `\n  ${tmp[i].slice(pos)}`;
+        }
+      }
       message = 'The expression evaluated to a falsy value:' +
         `\n\n  assert${ok}(${message})\n`;
     }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -694,14 +694,55 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: 'The expression evaluated to a falsy value:\n\n  ' +
-             "assert((() => 'string')()\n" +
-             '      // eslint-disable-next-line\n' +
-             '      ===\n' +
-             '      123 instanceof\n' +
-             '          Buffer)\n'
+    message: 'The expression evaluated to a falsy value:\n\n' +
+             '  assert((() => \'string\')()\n' +
+             '    // eslint-disable-next-line\n' +
+             '    ===\n' +
+             '    123 instanceof\n' +
+             '        Buffer)\n'
   }
 );
+
+common.expectsError(
+  () => {
+    a(
+      (() => 'string')()
+      // eslint-disable-next-line
+      ===
+  123 instanceof
+          Buffer
+    );
+  },
+  {
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'The expression evaluated to a falsy value:\n\n' +
+             '  assert((() => \'string\')()\n' +
+             '    // eslint-disable-next-line\n' +
+             '    ===\n' +
+             '  123 instanceof\n' +
+             '        Buffer)\n'
+  }
+);
+
+/* eslint-disable indent */
+common.expectsError(() => {
+a((
+  () => 'string')() ===
+123 instanceof
+Buffer
+);
+}, {
+  code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
+  message: 'The expression evaluated to a falsy value:\n\n' +
+           '  assert((\n' +
+           '    () => \'string\')() ===\n' +
+           '  123 instanceof\n' +
+           '  Buffer)\n'
+  }
+);
+/* eslint-enable indent */
 
 common.expectsError(
   () => assert(null, undefined),


### PR DESCRIPTION
If code is read from a file and that code is indented, it would be
misaligned. This makes sure it has a natural indentation that is
relative to the starting point of the assertion.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
