### PR TITLE
test: fix tests that fail under coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -2,5 +2,6 @@
   "exclude": [
     "**/internal/process/write-coverage.js"
   ],
+  "compact": false,
   "reporter": ["html", "text"]
 }

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ v8:
 .PHONY: jstest
 jstest: build-addons build-addons-napi ## Runs addon tests and JS tests
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) \
+		--skip-tests=$(CI_SKIP_TESTS) \
 		$(CI_JS_SUITES) \
 		$(CI_NATIVE_SUITES)
 
@@ -265,7 +266,7 @@ test-cov: all
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
 	# $(MAKE) cctest
-	$(MAKE) jstest
+	CI_SKIP_TESTS=core_line_numbers.js $(MAKE) jstest
 
 test-parallel: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) parallel

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,6 @@ test-cov: all
 	$(MAKE) build-addons-napi
 	# $(MAKE) cctest
 	$(MAKE) jstest
-	$(MAKE) lint
 
 test-parallel: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) parallel

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -1,9 +1,9 @@
-punycode.js:*
+punycode.js:42
 	throw new RangeError(errors[type]);
 	^
 
 RangeError: Invalid input
-    at error (punycode.js:*:*)
+    at error (punycode.js:42:*)
     at Object.decode (punycode.js:*:*)
     at Object.<anonymous> (*test*message*core_line_numbers.js:*:*)
     at Module._compile (internal/modules/cjs/loader.js:*:*)

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -1,9 +1,9 @@
-punycode.js:42
+punycode.js:*
 	throw new RangeError(errors[type]);
 	^
 
 RangeError: Invalid input
-    at error (punycode.js:42:*)
+    at error (punycode.js:*:*)
     at Object.decode (punycode.js:*:*)
     at Object.<anonymous> (*test*message*core_line_numbers.js:*:*)
     at Module._compile (internal/modules/cjs/loader.js:*:*)

--- a/tools/test.py
+++ b/tools/test.py
@@ -1382,6 +1382,9 @@ def BuildOptions():
   result.add_option("--flaky-tests",
       help="Regard tests marked as flaky (run|skip|dontcare)",
       default="run")
+  result.add_option("--skip-tests",
+      help="Tests that should not be executed (comma-separated)",
+      default="")
   result.add_option("--warn-unused", help="Report unused rules",
       default=False, action="store_true")
   result.add_option("-j", help="The number of parallel tasks to run",
@@ -1424,6 +1427,7 @@ def ProcessOptions(options):
   options.arch = options.arch.split(',')
   options.mode = options.mode.split(',')
   options.run = options.run.split(',')
+  options.skip_tests = options.skip_tests.split(',')
   if options.run == [""]:
     options.run = None
   elif len(options.run) != 2:
@@ -1710,6 +1714,11 @@ def Main():
 
   result = None
   def DoSkip(case):
+    # A list of tests that should be skipped can be provided. This is
+    # useful for tests that fail in some environments, e.g., under coverage.
+    if options.skip_tests != [""]:
+        if [ st for st in options.skip_tests if st in case.case.file ]:
+            return True
     if SKIP in case.outcomes or SLOW in case.outcomes:
       return True
     return FLAKY in case.outcomes and options.flaky_tests == SKIP


### PR DESCRIPTION
A couple tests were failing when running `make coverage`, to fix this problem I:

* I made `core_line_numbers.js` no longer check line #s (coverage changes line #s, this was addressed in most other test files).
* I've made `nyc` no longer generate compact instrumentation (this was making significantly different code output, which lead to failing test assertions).

_Note: once unit tests all started passing, it became apparent that we probably shouldn't be running the linter when code is instrumented for coverage ... since the instrumentation results in 1000s of rules being broken._

CC: @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
