### PR TITLE
test: test about:blank against invalid WHATWG URL

### DIFF
--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -2,7 +2,7 @@
 
 /* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/ed4bb727ed/url/urltestdata.json
+   https://github.com/w3c/web-platform-tests/blob/88b75886e/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 module.exports =
@@ -6529,27 +6529,34 @@ module.exports =
     "search": "?a",
     "hash": "#%GH"
   },
-  "Bad bases",
+  "URLs that require a non-about:blank base. (Also serve as invalid base tests.)",
   {
-    "input": "test-a.html",
-    "base": "a",
+    "input": "a",
+    "base": "about:blank",
     "failure": true
   },
   {
-    "input": "test-a-slash.html",
-    "base": "a/",
+    "input": "a/",
+    "base": "about:blank",
     "failure": true
   },
   {
-    "input": "test-a-slash-slash.html",
-    "base": "a//",
+    "input": "a//",
+    "base": "about:blank",
     "failure": true
   },
+  "Bases that don't fail to parse but fail to be bases",
   {
     "input": "test-a-colon.html",
     "base": "a:",
     "failure": true
   },
+  {
+    "input": "test-a-colon-b.html",
+    "base": "a:b",
+    "failure": true
+  },
+  "Other base URL tests, that must succeed",
   {
     "input": "test-a-colon-slash.html",
     "base": "a:/",
@@ -6577,11 +6584,6 @@ module.exports =
     "pathname": "/test-a-colon-slash-slash.html",
     "search": "",
     "hash": ""
-  },
-  {
-    "input": "test-a-colon-b.html",
-    "base": "a:b",
-    "failure": true
   },
   {
     "input": "test-a-colon-slash-b.html",

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -40,8 +40,7 @@ const aboutBlankFailures = originalFailures
     input: 'about:blank',
     base: test.input,
     failure: true
-  })
-);
+  }));
 
 const failureTests = originalFailures
   .concat(typeFailures)

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -12,7 +12,10 @@ const fixtures = require('../common/fixtures');
 
 // Tests below are not from WPT.
 const tests = require(fixtures.path('url-tests'));
-const failureTests = tests.filter((test) => test.failure).concat([
+
+const originalFailures = tests.filter((test) => test.failure);
+
+const typeFailures = [
   { input: '' },
   { input: 'test' },
   { input: undefined },
@@ -25,7 +28,24 @@ const failureTests = tests.filter((test) => test.failure).concat([
   { input: 'test', base: null },
   { input: 'http://nodejs.org', base: null },
   { input: () => {} }
-]);
+];
+
+// See https://github.com/w3c/web-platform-tests/pull/10955
+// > If `failure` is true, parsing `about:blank` against `base`
+// > must give failure. This tests that the logic for converting
+// > base URLs into strings properly fails the whole parsing
+// > algorithm if the base URL cannot be parsed.
+const aboutBlankFailures = originalFailures
+  .map((test) => ({
+    input: 'about:blank',
+    base: test.input,
+    failure: true
+  })
+);
+
+const failureTests = originalFailures
+  .concat(typeFailures)
+  .concat(aboutBlankFailures);
 
 const expectedError = common.expectsError(
   { code: 'ERR_INVALID_URL', type: TypeError }, failureTests.length);


### PR DESCRIPTION
> If `failure` is true, parsing `about:blank` against `base`
> must give failure. This tests that the logic for converting
> base URLs into strings properly fails the whole parsing
> algorithm if the base URL cannot be parsed.

Fixes: https://github.com/nodejs/node/issues/20720

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
