### PR TITLE
repl: always show all error properties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -115,8 +115,7 @@ function hasOwnProperty(obj, prop) {
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options =
-    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
+writer.options = { ...util.inspect.defaultOptions, showProxy: true };
 
 exports._builtinLibs = builtinLibs;
 
@@ -417,9 +416,15 @@ function REPLServer(prompt,
                                 (_, pre, line) => pre + (line - 1));
     }
     if (isError && e.stack) {
-      top.outputStream.write(`${e.stack}\n`);
+      // Since this error is not exposed to the user otherwise, just remove this
+      // part to prevent it from being logged.
+      if (e.domainThrown === true) {
+        delete e.domain;
+        delete e.domainThrown;
+      }
+      top.outputStream.write(`${top.writer(e)}\n`);
     } else {
-      top.outputStream.write(`Thrown: ${String(e)}\n`);
+      top.outputStream.write(`Thrown: ${top.writer(e)}\n`);
     }
     top.clearBufferedCommand();
     top.lines.level = [];
@@ -485,7 +490,7 @@ function REPLServer(prompt,
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = Object.assign({}, writer.options, { colors: true });
+    self.writer.options = { ...writer.options, colors: true };
   }
 
   function filterInternalStackFrames(error, structuredStack) {

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -160,8 +160,8 @@ async function ctrlCTest() {
     { ctrl: true, name: 'c' }
   ]), [
     'await timeout(100000)\r',
-    'Thrown: Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
-      'Script execution was interrupted by `SIGINT`',
+    'Thrown: [Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
+      'Script execution was interrupted by `SIGINT`]',
     PROMPT
   ]);
 }

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -179,6 +179,10 @@ function testError() {
       // The sync error, with individual property echoes
       /Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
       /fs\.readdirSync/,
+      '  errno: -2,',
+      "  syscall: 'scandir',",
+      "  code: 'ENOENT',",
+      "  path: '/nonexistent?' }",
       "'ENOENT'",
       "'scandir'",
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -25,6 +25,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const net = require('net');
 const repl = require('repl');
+const { inspect } = require('util');
 
 common.globalCheck = false;
 common.crashOnUnhandledRejection();
@@ -62,7 +63,7 @@ async function runReplTests(socket, prompt, tests) {
         expectedLine = send;
 
       while (!lineBuffer.includes('\n')) {
-        lineBuffer += await event(socket, 'data');
+        lineBuffer += await event(socket, expect);
 
         // Cut away the initial prompt
         while (lineBuffer.startsWith(prompt))
@@ -523,11 +524,11 @@ const errorTests = [
   {
     send: 'require("internal/repl")',
     expect: [
-      /^Error: Cannot find module 'internal\/repl'/,
+      /^{ Error: Cannot find module 'internal\/repl'/,
       /^    at .*/,
       /^    at .*/,
       /^    at .*/,
-      /^    at .*/
+      /^    at .* code: 'MODULE_NOT_FOUND' }/
     ]
   },
   // REPL should handle quotes within regexp literal in multiline mode
@@ -836,8 +837,16 @@ function startUnixRepl() {
   ]);
 }
 
-function event(ee, eventName) {
-  return new Promise((resolve) => {
-    ee.once(eventName, common.mustCall(resolve));
+function event(ee, expected) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(`Repl did not reply as expected for:\n\n${inspect(expected)}`)
+      );
+    }, 500);
+    ee.once('data', common.mustCall((...args) => {
+      clearTimeout(timeout);
+      resolve(...args);
+    }));
   });
 }


### PR DESCRIPTION
Currently errors only show the error stack. This changes it to
inspect the full error instead of just using the stack.

Refs: #20253
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
