### PR TITLE
src: remove unused agent_ in node_trace_buffer

### DIFF
--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -88,7 +88,7 @@ void InternalTraceBuffer::ExtractHandle(
 
 NodeTraceBuffer::NodeTraceBuffer(size_t max_chunks,
     Agent* agent, uv_loop_t* tracing_loop)
-    : tracing_loop_(tracing_loop), agent_(agent),
+    : tracing_loop_(tracing_loop),
       buffer1_(max_chunks, 0, agent),
       buffer2_(max_chunks, 1, agent) {
   current_buf_.store(&buffer1_);

--- a/src/tracing/node_trace_buffer.h
+++ b/src/tracing/node_trace_buffer.h
@@ -72,7 +72,6 @@ class NodeTraceBuffer : public TraceBuffer {
   Mutex exit_mutex_;
   // Used to wait until async handles have been closed.
   ConditionVariable exit_cond_;
-  Agent* agent_;
   std::atomic<InternalTraceBuffer*> current_buf_;
   InternalTraceBuffer buffer1_;
   InternalTraceBuffer buffer2_;


### PR DESCRIPTION
Currently the following compiler warning is generated:
```console
In file included from ../src/tracing/node_trace_buffer.cc:1:
../src/tracing/node_trace_buffer.h:75:10:
warning: private field 'agent_' is not used [-Wunused-private-field]
  Agent* agent_;
         ^
1 warning generated.
```
This commit removes the private member from the header and also from
the constructors initializer list.

I was not sure if it should be removed completely from the constructor
or not, but hopefully someone can shed some light on whether it should.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
