### PR TITLE
crypto: add scrypt() and scryptSync() methods

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -739,6 +739,18 @@ An invalid [crypto digest algorithm][] was specified.
 A crypto method was used on an object that was in an invalid state. For
 instance, calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
 
+<a id="ERR_CRYPTO_SCRYPT_INVALID_PARAMETER"></a>
+### ERR_CRYPTO_SCRYPT_INVALID_PARAMETER
+
+One or more [`crypto.scrypt()`][] or [`crypto.scryptSync()`][] parameters are
+outside their legal range.
+
+<a id="ERR_CRYPTO_SCRYPT_NOT_SUPPORTED"></a>
+### ERR_CRYPTO_SCRYPT_NOT_SUPPORTED
+
+Node.js was compiled without `scrypt` support. Not possible with the official
+release binaries but can happen with custom builds, including distro builds.
+
 <a id="ERR_CRYPTO_SIGN_KEY_REQUIRED"></a>
 ### ERR_CRYPTO_SIGN_KEY_REQUIRED
 
@@ -1749,6 +1761,8 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 [`child_process`]: child_process.html
 [`cipher.getAuthTag()`]: crypto.html#crypto_cipher_getauthtag
 [`Class: assert.AssertionError`]: assert.html#assert_class_assert_assertionerror
+[`crypto.scrypt()`]: crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback
+[`crypto.scryptSync()`]: crypto.html#crypto_crypto_scryptSync_password_salt_keylen_options
 [`crypto.timingSafeEqual()`]: crypto.html#crypto_crypto_timingsafeequal_a_b
 [`dgram.createSocket()`]: dgram.html#dgram_dgram_createsocket_options_callback
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -739,6 +739,12 @@ An invalid [crypto digest algorithm][] was specified.
 A crypto method was used on an object that was in an invalid state. For
 instance, calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
 
+<a id="ERR_CRYPTO_PBKDF2_ERROR"></a>
+### ERR_CRYPTO_PBKDF2_ERROR
+
+The PBKDF2 algorithm failed for unspecified reasons. OpenSSL does not provide
+more details and therefore neither does Node.js.
+
 <a id="ERR_CRYPTO_SCRYPT_INVALID_PARAMETER"></a>
 ### ERR_CRYPTO_SCRYPT_INVALID_PARAMETER
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -53,6 +53,10 @@ const {
   pbkdf2Sync
 } = require('internal/crypto/pbkdf2');
 const {
+  scrypt,
+  scryptSync
+} = require('internal/crypto/scrypt');
+const {
   DiffieHellman,
   DiffieHellmanGroup,
   ECDH
@@ -163,6 +167,8 @@ module.exports = exports = {
   randomFill,
   randomFillSync,
   rng: randomBytes,
+  scrypt,
+  scryptSync,
   setEngine,
   timingSafeEqual,
   getFips: !fipsMode ? getFipsDisabled :

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -2,7 +2,8 @@
 
 const { AsyncWrap, Providers } = process.binding('async_wrap');
 const { Buffer } = require('buffer');
-const { pbkdf2: _pbkdf2 } = process.binding('crypto');
+const { INT_MAX, pbkdf2: _pbkdf2 } = process.binding('crypto');
+const { validateInt32 } = require('internal/validators');
 const {
   ERR_CRYPTO_INVALID_DIGEST,
   ERR_CRYPTO_PBKDF2_ERROR,
@@ -11,7 +12,6 @@ const {
 } = require('internal/errors').codes;
 const {
   checkIsArrayBufferView,
-  checkIsUint,
   getDefaultEncoding,
 } = require('internal/crypto/util');
 
@@ -59,10 +59,8 @@ function check(password, salt, iterations, keylen, digest, callback) {
 
   password = checkIsArrayBufferView('password', password);
   salt = checkIsArrayBufferView('salt', salt);
-  // FIXME(bnoordhuis) The error message is in fact wrong since |iterations|
-  // cannot be > INT_MAX.  Adjust in the next major release.
-  iterations = checkIsUint('iterations', iterations, 'a non-negative number');
-  keylen = checkIsUint('keylen', keylen);
+  iterations = validateInt32(iterations, 'iterations', 0, INT_MAX);
+  keylen = validateInt32(keylen, 'keylen', 0, INT_MAX);
 
   return { password, salt, iterations, keylen, digest };
 }

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -11,8 +11,8 @@ const {
   ERR_INVALID_CALLBACK,
 } = require('internal/errors').codes;
 const {
-  checkIsArrayBufferView,
   getDefaultEncoding,
+  validateArrayBufferView,
 } = require('internal/crypto/util');
 
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
@@ -57,8 +57,8 @@ function check(password, salt, iterations, keylen, digest, callback) {
     digest = 'sha1';
   }
 
-  password = checkIsArrayBufferView('password', password);
-  salt = checkIsArrayBufferView('salt', salt);
+  password = validateArrayBufferView(password, 'password');
+  salt = validateArrayBufferView(salt, 'salt');
   iterations = validateInt32(iterations, 'iterations', 0, INT_MAX);
   keylen = validateInt32(keylen, 'keylen', 0, INT_MAX);
 

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -1,18 +1,19 @@
 'use strict';
 
+const { AsyncWrap, Providers } = process.binding('async_wrap');
+const { Buffer } = require('buffer');
+const { pbkdf2: _pbkdf2 } = process.binding('crypto');
 const {
+  ERR_CRYPTO_INVALID_DIGEST,
+  ERR_CRYPTO_PBKDF2_ERROR,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,
-  ERR_CRYPTO_INVALID_DIGEST,
 } = require('internal/errors').codes;
 const {
   checkIsArrayBufferView,
   checkIsUint,
   getDefaultEncoding,
 } = require('internal/crypto/util');
-const {
-  PBKDF2
-} = process.binding('crypto');
 
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   if (typeof digest === 'function') {
@@ -20,20 +21,41 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
     digest = undefined;
   }
 
+  ({ password, salt, iterations, keylen, digest } =
+      check(password, salt, iterations, keylen, digest, callback));
+
   if (typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK();
 
-  return _pbkdf2(password, salt, iterations, keylen, digest, callback);
+  const encoding = getDefaultEncoding();
+  const keybuf = Buffer.alloc(keylen);
+
+  const wrap = new AsyncWrap(Providers.PBKDF2REQUEST);
+  wrap.ondone = (ok) => {  // Retains keybuf while request is in flight.
+    if (!ok) return callback.call(wrap, new ERR_CRYPTO_PBKDF2_ERROR());
+    if (encoding === 'buffer') return callback.call(wrap, null, keybuf);
+    callback.call(wrap, null, keybuf.toString(encoding));
+  };
+
+  handleError(keybuf, password, salt, iterations, digest, wrap);
 }
 
 function pbkdf2Sync(password, salt, iterations, keylen, digest) {
-  return _pbkdf2(password, salt, iterations, keylen, digest);
+  ({ password, salt, iterations, keylen, digest } =
+      check(password, salt, iterations, keylen, digest, pbkdf2Sync));
+  const keybuf = Buffer.alloc(keylen);
+  handleError(keybuf, password, salt, iterations, digest);
+  const encoding = getDefaultEncoding();
+  if (encoding === 'buffer') return keybuf;
+  return keybuf.toString(encoding);
 }
 
-function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
-
-  if (digest !== null && typeof digest !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);
+function check(password, salt, iterations, keylen, digest, callback) {
+  if (typeof digest !== 'string') {
+    if (digest !== null)
+      throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);
+    digest = 'sha1';
+  }
 
   password = checkIsArrayBufferView('password', password);
   salt = checkIsArrayBufferView('salt', salt);
@@ -42,30 +64,17 @@ function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
   iterations = checkIsUint('iterations', iterations, 'a non-negative number');
   keylen = checkIsUint('keylen', keylen);
 
-  const encoding = getDefaultEncoding();
+  return { password, salt, iterations, keylen, digest };
+}
 
-  if (encoding === 'buffer') {
-    const ret = PBKDF2(password, salt, iterations, keylen, digest, callback);
-    if (ret === -1)
-      throw new ERR_CRYPTO_INVALID_DIGEST(digest);
-    return ret;
-  }
+function handleError(keybuf, password, salt, iterations, digest, wrap) {
+  const rc = _pbkdf2(keybuf, password, salt, iterations, digest, wrap);
 
-  // at this point, we need to handle encodings.
-  if (callback) {
-    function next(er, ret) {
-      if (ret)
-        ret = ret.toString(encoding);
-      callback(er, ret);
-    }
-    if (PBKDF2(password, salt, iterations, keylen, digest, next) === -1)
-      throw new ERR_CRYPTO_INVALID_DIGEST(digest);
-  } else {
-    const ret = PBKDF2(password, salt, iterations, keylen, digest);
-    if (ret === -1)
-      throw new ERR_CRYPTO_INVALID_DIGEST(digest);
-    return ret.toString(encoding);
-  }
+  if (rc === -1)
+    throw new ERR_CRYPTO_INVALID_DIGEST(digest);
+
+  if (rc === false)
+    throw new ERR_CRYPTO_PBKDF2_ERROR();
 }
 
 module.exports = {

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -4,19 +4,15 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,
   ERR_CRYPTO_INVALID_DIGEST,
-  ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const {
   checkIsArrayBufferView,
+  checkIsUint,
   getDefaultEncoding,
-  toBuf
 } = require('internal/crypto/util');
 const {
   PBKDF2
 } = process.binding('crypto');
-const {
-  INT_MAX
-} = process.binding('constants').crypto;
 
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   if (typeof digest === 'function') {
@@ -39,22 +35,12 @@ function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
   if (digest !== null && typeof digest !== 'string')
     throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);
 
-  password = checkIsArrayBufferView('password', toBuf(password));
-  salt = checkIsArrayBufferView('salt', toBuf(salt));
-
-  if (typeof iterations !== 'number')
-    throw new ERR_INVALID_ARG_TYPE('iterations', 'number', iterations);
-
-  if (iterations < 0)
-    throw new ERR_OUT_OF_RANGE('iterations',
-                               'a non-negative number',
-                               iterations);
-
-  if (typeof keylen !== 'number')
-    throw new ERR_INVALID_ARG_TYPE('keylen', 'number', keylen);
-
-  if (keylen < 0 || !Number.isInteger(keylen) || keylen > INT_MAX)
-    throw new ERR_OUT_OF_RANGE('keylen', `>= 0 && <= ${INT_MAX}`, keylen);
+  password = checkIsArrayBufferView('password', password);
+  salt = checkIsArrayBufferView('salt', salt);
+  // FIXME(bnoordhuis) The error message is in fact wrong since |iterations|
+  // cannot be > INT_MAX.  Adjust in the next major release.
+  iterations = checkIsUint('iterations', iterations, 'a non-negative number');
+  keylen = checkIsUint('keylen', keylen);
 
   const encoding = getDefaultEncoding();
 

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -11,7 +11,7 @@ const {
 const { isArrayBufferView } = require('internal/util/types');
 
 const { kMaxLength } = require('buffer');
-const kMaxUint32 = Math.pow(2, 32) - 1;
+const kMaxUint32 = 2 ** 32 - 1;
 const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
 
 function assertOffset(offset, elementSize, length) {

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -1,15 +1,14 @@
 'use strict';
 
+const { AsyncWrap, Providers } = process.binding('async_wrap');
+const { Buffer } = require('buffer');
+const { randomBytes: _randomBytes } = process.binding('crypto');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { isArrayBufferView } = require('internal/util/types');
-const {
-  randomBytes: _randomBytes,
-  randomFill: _randomFill
-} = process.binding('crypto');
 
 const { kMaxLength } = require('buffer');
 const kMaxUint32 = Math.pow(2, 32) - 1;
@@ -27,7 +26,7 @@ function assertOffset(offset, elementSize, length) {
     throw new ERR_OUT_OF_RANGE('offset', `>= 0 && <= ${maxLength}`, offset);
   }
 
-  return offset;
+  return offset >>> 0;  // Convert to uint32.
 }
 
 function assertSize(size, elementSize, offset, length) {
@@ -46,14 +45,25 @@ function assertSize(size, elementSize, offset, length) {
     throw new ERR_OUT_OF_RANGE('size + offset', `<= ${length}`, size + offset);
   }
 
-  return size;
+  return size >>> 0;  // Convert to uint32.
 }
 
 function randomBytes(size, cb) {
-  assertSize(size, 1, 0, Infinity);
+  size = assertSize(size, 1, 0, Infinity);
   if (cb !== undefined && typeof cb !== 'function')
     throw new ERR_INVALID_CALLBACK();
-  return _randomBytes(size, cb);
+
+  const buf = Buffer.alloc(size);
+
+  if (!cb) return handleError(buf, 0, size);
+
+  const wrap = new AsyncWrap(Providers.RANDOMBYTESREQUEST);
+  wrap.ondone = (ex) => {  // Retains buf while request is in flight.
+    if (ex) return cb.call(wrap, ex);
+    cb.call(wrap, null, buf);
+  };
+
+  _randomBytes(buf, 0, size, wrap);
 }
 
 function randomFillSync(buf, offset = 0, size) {
@@ -71,7 +81,7 @@ function randomFillSync(buf, offset = 0, size) {
     size = assertSize(size, elementSize, offset, buf.byteLength);
   }
 
-  return _randomFill(buf, offset, size);
+  return handleError(buf, offset, size);
 }
 
 function randomFill(buf, offset, size, cb) {
@@ -100,7 +110,19 @@ function randomFill(buf, offset, size, cb) {
     size = assertSize(size, elementSize, offset, buf.byteLength);
   }
 
-  return _randomFill(buf, offset, size, cb);
+  const wrap = new AsyncWrap(Providers.RANDOMBYTESREQUEST);
+  wrap.ondone = (ex) => {  // Retains buf while request is in flight.
+    if (ex) return cb.call(wrap, ex);
+    cb.call(wrap, null, buf);
+  };
+
+  _randomBytes(buf, offset, size, wrap);
+}
+
+function handleError(buf, offset, size) {
+  const ex = _randomBytes(buf, offset, size);
+  if (ex) throw ex;
+  return buf;
 }
 
 module.exports = {

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { AsyncWrap, Providers } = process.binding('async_wrap');
+const { Buffer } = require('buffer');
+const { scrypt: _scrypt } = process.binding('crypto');
+const {
+  ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
+  ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
+  ERR_INVALID_CALLBACK,
+} = require('internal/errors').codes;
+const {
+  checkIsArrayBufferView,
+  checkIsUint,
+  getDefaultEncoding,
+} = require('internal/crypto/util');
+
+const defaults = {
+  N: 16384,
+  r: 8,
+  p: 1,
+  maxmem: 32 << 20,  // 32 MB, matches SCRYPT_MAX_MEM.
+};
+
+function scrypt(password, salt, keylen, options, callback = defaults) {
+  if (callback === defaults) {
+    callback = options;
+    options = defaults;
+  }
+
+  options = check(password, salt, keylen, options);
+  const { N, r, p, maxmem } = options;
+  ({ password, salt, keylen } = options);
+
+  if (typeof callback !== 'function')
+    throw new ERR_INVALID_CALLBACK();
+
+  const encoding = getDefaultEncoding();
+  const keybuf = Buffer.alloc(keylen);
+
+  const wrap = new AsyncWrap(Providers.SCRYPTREQUEST);
+  wrap.ondone = (ex) => {  // Retains keybuf while request is in flight.
+    if (ex) return callback.call(wrap, ex);
+    if (encoding === 'buffer') return callback.call(wrap, null, keybuf);
+    callback.call(wrap, null, keybuf.toString(encoding));
+  };
+
+  handleError(keybuf, password, salt, N, r, p, maxmem, wrap);
+}
+
+function scryptSync(password, salt, keylen, options = defaults) {
+  options = check(password, salt, keylen, options);
+  const { N, r, p, maxmem } = options;
+  ({ password, salt, keylen } = options);
+  const keybuf = Buffer.alloc(keylen);
+  handleError(keybuf, password, salt, N, r, p, maxmem);
+  const encoding = getDefaultEncoding();
+  if (encoding === 'buffer') return keybuf;
+  return keybuf.toString(encoding);
+}
+
+function handleError(keybuf, password, salt, N, r, p, maxmem, wrap) {
+  const ex = _scrypt(keybuf, password, salt, N, r, p, maxmem, wrap);
+
+  if (ex === undefined)
+    return;
+
+  if (ex === null)
+    throw new ERR_CRYPTO_SCRYPT_INVALID_PARAMETER();  // Bad N, r, p, or maxmem.
+
+  throw ex;  // Scrypt operation failed, exception object contains details.
+}
+
+function check(password, salt, keylen, options, callback) {
+  if (_scrypt === undefined)
+    throw new ERR_CRYPTO_SCRYPT_NOT_SUPPORTED();
+
+  password = checkIsArrayBufferView('password', password);
+  salt = checkIsArrayBufferView('salt', salt);
+  keylen = checkIsUint('keylen', keylen);
+
+  let { N, r, p, maxmem } = defaults;
+  if (options && options !== defaults) {
+    if (options.hasOwnProperty('N')) N = checkIsUint('N', options.N);
+    if (options.hasOwnProperty('r')) r = checkIsUint('r', options.r);
+    if (options.hasOwnProperty('p')) p = checkIsUint('p', options.p);
+    if (options.hasOwnProperty('maxmem'))
+      maxmem = checkIsUint('maxmem', options.maxmem);
+    if (N === 0) N = defaults.N;
+    if (r === 0) r = defaults.r;
+    if (p === 0) p = defaults.p;
+    if (maxmem === 0) maxmem = defaults.maxmem;
+  }
+
+  return { password, salt, keylen, N, r, p, maxmem };
+}
+
+module.exports = { scrypt, scryptSync };

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -10,8 +10,8 @@ const {
   ERR_INVALID_CALLBACK,
 } = require('internal/errors').codes;
 const {
-  checkIsArrayBufferView,
   getDefaultEncoding,
+  validateArrayBufferView,
 } = require('internal/crypto/util');
 
 const defaults = {
@@ -74,8 +74,8 @@ function check(password, salt, keylen, options, callback) {
   if (_scrypt === undefined)
     throw new ERR_CRYPTO_SCRYPT_NOT_SUPPORTED();
 
-  password = checkIsArrayBufferView('password', password);
-  salt = checkIsArrayBufferView(salt, 'salt');
+  password = validateArrayBufferView(password, 'password');
+  salt = validateArrayBufferView(salt, 'salt');
   keylen = validateInt32(keylen, 'keylen', 0, INT_MAX);
 
   let { N, r, p, maxmem } = defaults;

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -2,7 +2,8 @@
 
 const { AsyncWrap, Providers } = process.binding('async_wrap');
 const { Buffer } = require('buffer');
-const { scrypt: _scrypt } = process.binding('crypto');
+const { INT_MAX, scrypt: _scrypt } = process.binding('crypto');
+const { validateInt32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,
   ERR_CRYPTO_SCRYPT_NOT_SUPPORTED,
@@ -10,7 +11,6 @@ const {
 } = require('internal/errors').codes;
 const {
   checkIsArrayBufferView,
-  checkIsUint,
   getDefaultEncoding,
 } = require('internal/crypto/util');
 
@@ -75,16 +75,19 @@ function check(password, salt, keylen, options, callback) {
     throw new ERR_CRYPTO_SCRYPT_NOT_SUPPORTED();
 
   password = checkIsArrayBufferView('password', password);
-  salt = checkIsArrayBufferView('salt', salt);
-  keylen = checkIsUint('keylen', keylen);
+  salt = checkIsArrayBufferView(salt, 'salt');
+  keylen = validateInt32(keylen, 'keylen', 0, INT_MAX);
 
   let { N, r, p, maxmem } = defaults;
   if (options && options !== defaults) {
-    if (options.hasOwnProperty('N')) N = checkIsUint('N', options.N);
-    if (options.hasOwnProperty('r')) r = checkIsUint('r', options.r);
-    if (options.hasOwnProperty('p')) p = checkIsUint('p', options.p);
+    if (options.hasOwnProperty('N'))
+      N = validateInt32(options.N, 'N', 0, INT_MAX);
+    if (options.hasOwnProperty('r'))
+      r = validateInt32(options.r, 'r', 0, INT_MAX);
+    if (options.hasOwnProperty('p'))
+      p = validateInt32(options.p, 'p', 0, INT_MAX);
     if (options.hasOwnProperty('maxmem'))
-      maxmem = checkIsUint('maxmem', options.maxmem);
+      maxmem = validateInt32(options.maxmem, 'maxmem', 0, INT_MAX);
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;
     if (p === 0) p = defaults.p;

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -77,7 +77,7 @@ Sign.prototype.sign = function sign(options, encoding) {
 
   var pssSaltLength = getSaltLength(options);
 
-  key = checkIsArrayBufferView('key', toBuf(key));
+  key = checkIsArrayBufferView('key', key);
 
   var ret = this._handle.sign(key, passphrase, rsaPadding, pssSaltLength);
 
@@ -114,7 +114,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   var pssSaltLength = getSaltLength(options);
 
-  key = checkIsArrayBufferView('key', toBuf(key));
+  key = checkIsArrayBufferView('key', key);
 
   signature = checkIsArrayBufferView('signature',
                                      toBuf(signature, sigEncoding));

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -14,9 +14,9 @@ const {
   RSA_PKCS1_PADDING
 } = process.binding('constants').crypto;
 const {
-  checkIsArrayBufferView,
   getDefaultEncoding,
-  toBuf
+  toBuf,
+  validateArrayBufferView,
 } = require('internal/crypto/util');
 const { Writable } = require('stream');
 const { inherits } = require('util');
@@ -41,7 +41,8 @@ Sign.prototype._write = function _write(chunk, encoding, callback) {
 
 Sign.prototype.update = function update(data, encoding) {
   encoding = encoding || getDefaultEncoding();
-  data = checkIsArrayBufferView('data', toBuf(data, encoding));
+  data = validateArrayBufferView(toBuf(data, encoding),
+                                 'data');
   this._handle.update(data);
   return this;
 };
@@ -77,7 +78,7 @@ Sign.prototype.sign = function sign(options, encoding) {
 
   var pssSaltLength = getSaltLength(options);
 
-  key = checkIsArrayBufferView('key', key);
+  key = validateArrayBufferView(key, 'key');
 
   var ret = this._handle.sign(key, passphrase, rsaPadding, pssSaltLength);
 
@@ -114,10 +115,10 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   var pssSaltLength = getSaltLength(options);
 
-  key = checkIsArrayBufferView('key', key);
+  key = validateArrayBufferView(key, 'key');
 
-  signature = checkIsArrayBufferView('signature',
-                                     toBuf(signature, sigEncoding));
+  signature = validateArrayBufferView(toBuf(signature, sigEncoding),
+                                      'signature');
 
   return this._handle.verify(key, signature, rsaPadding, pssSaltLength);
 };

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -16,7 +16,6 @@ const {
   ERR_CRYPTO_ENGINE_UNKNOWN,
   ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH,
   ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE,
 } = require('internal/errors').codes;
 const { Buffer } = require('buffer');
 const {
@@ -26,9 +25,6 @@ const {
 const {
   isArrayBufferView
 } = require('internal/util/types');
-const {
-  INT_MAX
-} = process.binding('constants').crypto;
 
 var defaultEncoding = 'buffer';
 
@@ -99,19 +95,8 @@ function checkIsArrayBufferView(name, buffer) {
   return buffer;
 }
 
-function checkIsUint(name, value, errmsg = `>= 0 && <= ${INT_MAX}`) {
-  if (typeof value !== 'number')
-    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
-
-  if (value < 0 || !Number.isInteger(value) || value > INT_MAX)
-    throw new ERR_OUT_OF_RANGE(name, errmsg, value);
-
-  return value;
-}
-
 module.exports = {
   checkIsArrayBufferView,
-  checkIsUint,
   getCiphers,
   getCurves,
   getDefaultEncoding,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -15,7 +15,8 @@ const {
 const {
   ERR_CRYPTO_ENGINE_UNKNOWN,
   ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH,
-  ERR_INVALID_ARG_TYPE
+  ERR_INVALID_ARG_TYPE,
+  ERR_OUT_OF_RANGE,
 } = require('internal/errors').codes;
 const { Buffer } = require('buffer');
 const {
@@ -25,6 +26,9 @@ const {
 const {
   isArrayBufferView
 } = require('internal/util/types');
+const {
+  INT_MAX
+} = process.binding('constants').crypto;
 
 var defaultEncoding = 'buffer';
 
@@ -84,6 +88,7 @@ function timingSafeEqual(buf1, buf2) {
 }
 
 function checkIsArrayBufferView(name, buffer) {
+  buffer = toBuf(buffer);
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(
       name,
@@ -94,8 +99,19 @@ function checkIsArrayBufferView(name, buffer) {
   return buffer;
 }
 
+function checkIsUint(name, value, errmsg = `>= 0 && <= ${INT_MAX}`) {
+  if (typeof value !== 'number')
+    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+
+  if (value < 0 || !Number.isInteger(value) || value > INT_MAX)
+    throw new ERR_OUT_OF_RANGE(name, errmsg, value);
+
+  return value;
+}
+
 module.exports = {
   checkIsArrayBufferView,
+  checkIsUint,
   getCiphers,
   getCurves,
   getDefaultEncoding,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -83,7 +83,7 @@ function timingSafeEqual(buf1, buf2) {
   return _timingSafeEqual(buf1, buf2);
 }
 
-function checkIsArrayBufferView(name, buffer) {
+function validateArrayBufferView(buffer, name) {
   buffer = toBuf(buffer);
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(
@@ -96,7 +96,7 @@ function checkIsArrayBufferView(name, buffer) {
 }
 
 module.exports = {
-  checkIsArrayBufferView,
+  validateArrayBufferView,
   getCiphers,
   getCurves,
   getDefaultEncoding,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -500,6 +500,8 @@ E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called', Error);
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed', Error);
 E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s', TypeError);
 E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s', Error);
+// TODO(bnoordhuis) Decapitalize: s/PBKDF2 Error/PBKDF2 error/
+E('ERR_CRYPTO_PBKDF2_ERROR', 'PBKDF2 Error', Error);
 E('ERR_CRYPTO_SCRYPT_INVALID_PARAMETER', 'Invalid scrypt parameter', Error);
 E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -500,7 +500,8 @@ E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called', Error);
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed', Error);
 E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s', TypeError);
 E('ERR_CRYPTO_INVALID_STATE', 'Invalid state for operation %s', Error);
-
+E('ERR_CRYPTO_SCRYPT_INVALID_PARAMETER', 'Invalid scrypt parameter', Error);
+E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -71,6 +71,8 @@ function validateInteger(value, name) {
     Error.captureStackTrace(err, validateInteger);
     throw err;
   }
+
+  return value;
 }
 
 function validateInt32(value, name, min = -2147483648, max = 2147483647) {
@@ -91,6 +93,8 @@ function validateInt32(value, name, min = -2147483648, max = 2147483647) {
     Error.captureStackTrace(err, validateInt32);
     throw err;
   }
+
+  return value;
 }
 
 function validateUint32(value, name, positive) {
@@ -112,6 +116,8 @@ function validateUint32(value, name, positive) {
     Error.captureStackTrace(err, validateUint32);
     throw err;
   }
+
+  return value;
 }
 
 module.exports = {

--- a/node.gyp
+++ b/node.gyp
@@ -97,6 +97,7 @@
       'lib/internal/crypto/hash.js',
       'lib/internal/crypto/pbkdf2.js',
       'lib/internal/crypto/random.js',
+      'lib/internal/crypto/scrypt.js',
       'lib/internal/crypto/sig.js',
       'lib/internal/crypto/util.js',
       'lib/internal/constants.js',

--- a/node.gyp
+++ b/node.gyp
@@ -617,7 +617,7 @@
               # Categories to export.
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
               'PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,STDIO,TLSEXT,'
-              'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD',
+              'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD,SCRYPT',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -75,6 +75,7 @@ namespace node {
 #define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)                                   \
   V(PBKDF2REQUEST)                                                            \
   V(RANDOMBYTESREQUEST)                                                       \
+  V(SCRYPTREQUEST)                                                            \
   V(TLSWRAP)
 #else
 #define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)

--- a/src/env.h
+++ b/src/env.h
@@ -344,7 +344,6 @@ struct PackageConfig {
   V(promise_reject_unhandled_function, v8::Function)                          \
   V(promise_wrap_template, v8::ObjectTemplate)                                \
   V(push_values_to_array_function, v8::Function)                              \
-  V(randombytes_constructor_template, v8::ObjectTemplate)                     \
   V(sab_lifetimepartner_constructor_template, v8::FunctionTemplate)           \
   V(script_context_constructor_template, v8::FunctionTemplate)                \
   V(script_data_constructor_function, v8::Function)                           \

--- a/src/env.h
+++ b/src/env.h
@@ -244,7 +244,6 @@ struct PackageConfig {
   V(password_string, "password")                                              \
   V(path_string, "path")                                                      \
   V(pending_handle_string, "pendingHandle")                                   \
-  V(pbkdf2_error_string, "PBKDF2 Error")                                      \
   V(pid_string, "pid")                                                        \
   V(pipe_string, "pipe")                                                      \
   V(pipe_target_string, "pipeTarget")                                         \
@@ -337,7 +336,6 @@ struct PackageConfig {
   V(inspector_console_api_object, v8::Object)                                 \
   V(message_port, v8::Object)                                                 \
   V(message_port_constructor_template, v8::FunctionTemplate)                  \
-  V(pbkdf2_constructor_template, v8::ObjectTemplate)                          \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \
   V(performance_entry_callback, v8::Function)                                 \
   V(performance_entry_template, v8::Function)                                 \

--- a/src/env.h
+++ b/src/env.h
@@ -319,6 +319,7 @@ struct PackageConfig {
   V(async_hooks_destroy_function, v8::Function)                               \
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_promise_resolve_function, v8::Function)                       \
+  V(async_wrap_constructor_template, v8::FunctionTemplate)                    \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
   V(domain_callback, v8::Function)                                            \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -78,6 +78,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Null;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -204,57 +205,75 @@ static int NoPasswordCallback(char* buf, int size, int rwflag, void* u) {
 }
 
 
+struct CryptoErrorVector : public std::vector<std::string> {
+  inline void Capture() {
+    clear();
+    while (auto err = ERR_get_error()) {
+      char buf[256];
+      ERR_error_string_n(err, buf, sizeof(buf));
+      push_back(buf);
+    }
+    std::reverse(begin(), end());
+  }
+
+  inline Local<Value> ToException(
+      Environment* env,
+      Local<String> exception_string = Local<String>()) const {
+    if (exception_string.IsEmpty()) {
+      CryptoErrorVector copy(*this);
+      if (copy.empty()) copy.push_back("no error");  // But possibly a bug...
+      // Use last element as the error message, everything else goes
+      // into the .opensslErrorStack property on the exception object.
+      auto exception_string =
+          String::NewFromUtf8(env->isolate(), copy.back().data(),
+                              NewStringType::kNormal, copy.back().size())
+          .ToLocalChecked();
+      copy.pop_back();
+      return copy.ToException(env, exception_string);
+    }
+
+    Local<Value> exception_v = Exception::Error(exception_string);
+    CHECK(!exception_v.IsEmpty());
+
+    if (!empty()) {
+      Local<Array> array = Array::New(env->isolate(), size());
+      CHECK(!array.IsEmpty());
+
+      for (const std::string& string : *this) {
+        const size_t index = &string - &front();
+        Local<String> value =
+            String::NewFromUtf8(env->isolate(), string.data(),
+                                NewStringType::kNormal, string.size())
+            .ToLocalChecked();
+        array->Set(env->context(), index, value).FromJust();
+      }
+
+      CHECK(exception_v->IsObject());
+      Local<Object> exception = exception_v.As<Object>();
+      exception->Set(env->context(),
+                     env->openssl_error_stack(), array).FromJust();
+    }
+
+    return exception_v;
+  }
+};
+
+
 void ThrowCryptoError(Environment* env,
                       unsigned long err,  // NOLINT(runtime/int)
-                      const char* default_message = nullptr) {
+                      const char* message = nullptr) {
+  char message_buffer[128] = {0};
+  if (err != 0 || message == nullptr) {
+    ERR_error_string_n(err, message_buffer, sizeof(message_buffer));
+    message = message_buffer;
+  }
   HandleScope scope(env->isolate());
-  Local<String> message;
-
-  if (err != 0 || default_message == nullptr) {
-    char errmsg[128] = { 0 };
-    ERR_error_string_n(err, errmsg, sizeof(errmsg));
-    message = String::NewFromUtf8(env->isolate(), errmsg,
-                                  v8::NewStringType::kNormal)
-                                      .ToLocalChecked();
-  } else {
-    message = String::NewFromUtf8(env->isolate(), default_message,
-                                  v8::NewStringType::kNormal)
-                                      .ToLocalChecked();
-  }
-
-  Local<Value> exception_v = Exception::Error(message);
-  CHECK(!exception_v.IsEmpty());
-  Local<Object> exception = exception_v.As<Object>();
-
-  std::vector<Local<String>> errors;
-  for (;;) {
-    unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
-    if (err == 0) {
-      break;
-    }
-    char tmp_str[256];
-    ERR_error_string_n(err, tmp_str, sizeof(tmp_str));
-    errors.push_back(String::NewFromUtf8(env->isolate(), tmp_str,
-                                         v8::NewStringType::kNormal)
-                     .ToLocalChecked());
-  }
-
-  // ERR_get_error returns errors in order of most specific to least
-  // specific. We wish to have the reverse ordering:
-  // opensslErrorStack: [
-  // 'error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib',
-  // 'error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 err'
-  // ]
-  if (!errors.empty()) {
-    std::reverse(errors.begin(), errors.end());
-    Local<Array> errors_array = Array::New(env->isolate(), errors.size());
-    for (size_t i = 0; i < errors.size(); i++) {
-      errors_array->Set(env->context(), i, errors[i]).FromJust();
-    }
-    exception->Set(env->context(), env->openssl_error_stack(), errors_array)
-        .FromJust();
-  }
-
+  auto exception_string =
+      String::NewFromUtf8(env->isolate(), message, NewStringType::kNormal)
+      .ToLocalChecked();
+  CryptoErrorVector errors;
+  errors.Capture();
+  auto exception = errors.ToException(env, exception_string);
   env->isolate()->ThrowException(exception);
 }
 
@@ -4529,6 +4548,43 @@ bool ECDH::IsKeyPairValid() {
 }
 
 
+struct CryptoJob : public ThreadPoolWork {
+  Environment* const env;
+  std::unique_ptr<AsyncWrap> async_wrap;
+  inline explicit CryptoJob(Environment* env) : ThreadPoolWork(env), env(env) {}
+  inline void AfterThreadPoolWork(int status) final;
+  virtual void AfterThreadPoolWork() = 0;
+  static inline void Run(std::unique_ptr<CryptoJob> job, Local<Value> wrap);
+};
+
+
+void CryptoJob::AfterThreadPoolWork(int status) {
+  CHECK(status == 0 || status == UV_ECANCELED);
+  std::unique_ptr<CryptoJob> job(this);
+  if (status == UV_ECANCELED) return;
+  HandleScope handle_scope(env->isolate());
+  Context::Scope context_scope(env->context());
+  CHECK_EQ(false, async_wrap->persistent().IsWeak());
+  AfterThreadPoolWork();
+}
+
+
+void CryptoJob::Run(std::unique_ptr<CryptoJob> job, Local<Value> wrap) {
+  CHECK(wrap->IsObject());
+  CHECK_EQ(nullptr, job->async_wrap);
+  job->async_wrap.reset(Unwrap<AsyncWrap>(wrap.As<Object>()));
+  CHECK_EQ(false, job->async_wrap->persistent().IsWeak());
+  job->ScheduleWork();
+  job.release();  // Run free, little job!
+}
+
+
+inline void CopyBuffer(Local<Value> buf, std::vector<char>* vec) {
+  vec->clear();
+  if (auto p = Buffer::Data(buf)) vec->assign(p, p + Buffer::Length(buf));
+}
+
+
 class PBKDF2Request : public AsyncWrap, public ThreadPoolWork {
  public:
   PBKDF2Request(Environment* env,
@@ -4868,6 +4924,98 @@ void RandomBytesBuffer(const FunctionCallbackInfo<Value>& args) {
       args.GetReturnValue().Set(argv[1]);
   }
 }
+
+
+#ifndef OPENSSL_NO_SCRYPT
+struct ScryptJob : public CryptoJob {
+  unsigned char* keybuf_data;
+  size_t keybuf_size;
+  std::vector<char> pass;
+  std::vector<char> salt;
+  uint32_t N;
+  uint32_t r;
+  uint32_t p;
+  uint32_t maxmem;
+  CryptoErrorVector errors;
+
+  inline explicit ScryptJob(Environment* env) : CryptoJob(env) {}
+
+  inline ~ScryptJob() override {
+    Cleanse();
+  }
+
+  inline bool Validate() {
+    if (1 == EVP_PBE_scrypt(nullptr, 0, nullptr, 0, N, r, p, maxmem,
+                            nullptr, 0)) {
+      return true;
+    } else {
+      // Note: EVP_PBE_scrypt() does not always put errors on the error stack.
+      errors.Capture();
+      return false;
+    }
+  }
+
+  inline void DoThreadPoolWork() override {
+    auto salt_data = reinterpret_cast<const unsigned char*>(salt.data());
+    if (1 != EVP_PBE_scrypt(pass.data(), pass.size(), salt_data, salt.size(),
+                            N, r, p, maxmem, keybuf_data, keybuf_size)) {
+      errors.Capture();
+    }
+  }
+
+  inline void AfterThreadPoolWork() override {
+    Local<Value> arg = ToResult();
+    async_wrap->MakeCallback(env->ondone_string(), 1, &arg);
+  }
+
+  inline Local<Value> ToResult() const {
+    if (errors.empty()) return Undefined(env->isolate());
+    return errors.ToException(env);
+  }
+
+  inline void Cleanse() {
+    OPENSSL_cleanse(pass.data(), pass.size());
+    OPENSSL_cleanse(salt.data(), salt.size());
+    pass.clear();
+    salt.clear();
+  }
+};
+
+
+void Scrypt(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsArrayBufferView());  // keybuf; wrap object retains ref.
+  CHECK(args[1]->IsArrayBufferView());  // pass
+  CHECK(args[2]->IsArrayBufferView());  // salt
+  CHECK(args[3]->IsUint32());  // N
+  CHECK(args[4]->IsUint32());  // r
+  CHECK(args[5]->IsUint32());  // p
+  CHECK(args[6]->IsUint32());  // maxmem
+  CHECK(args[7]->IsObject() || args[7]->IsUndefined());  // wrap object
+  std::unique_ptr<ScryptJob> job(new ScryptJob(env));
+  job->keybuf_data = reinterpret_cast<unsigned char*>(Buffer::Data(args[0]));
+  job->keybuf_size = Buffer::Length(args[0]);
+  CopyBuffer(args[1], &job->pass);
+  CopyBuffer(args[2], &job->salt);
+  job->N = args[3].As<Uint32>()->Value();
+  job->r = args[4].As<Uint32>()->Value();
+  job->p = args[5].As<Uint32>()->Value();
+  job->maxmem = args[6].As<Uint32>()->Value();
+  if (!job->Validate()) {
+    // EVP_PBE_scrypt() does not always put errors on the error stack
+    // and therefore ToResult() may or may not return an exception
+    // object.  Return a sentinel value to inform JS land it should
+    // throw an ERR_CRYPTO_SCRYPT_PARAMETER_ERROR on our behalf.
+    auto result = job->ToResult();
+    if (result->IsUndefined()) result = Null(args.GetIsolate());
+    return args.GetReturnValue().Set(result);
+  }
+  if (args[7]->IsObject()) return ScryptJob::Run(std::move(job), args[7]);
+  env->PrintSyncTrace();
+  job->DoThreadPoolWork();
+  args.GetReturnValue().Set(job->ToResult());
+}
+#endif  // OPENSSL_NO_SCRYPT
 
 
 void GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
@@ -5293,6 +5441,9 @@ void Initialize(Local<Object> target,
                  PublicKeyCipher::Cipher<PublicKeyCipher::kPublic,
                                          EVP_PKEY_verify_recover_init,
                                          EVP_PKEY_verify_recover>);
+#ifndef OPENSSL_NO_SCRYPT
+  env->SetMethod(target, "scrypt", Scrypt);
+#endif  // OPENSSL_NO_SCRYPT
 
   Local<FunctionTemplate> pb = FunctionTemplate::New(env->isolate());
   pb->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "PBKDF2"));

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -523,6 +523,8 @@ class InternalCallbackScope {
 class ThreadPoolWork {
  public:
   explicit inline ThreadPoolWork(Environment* env) : env_(env) {}
+  inline virtual ~ThreadPoolWork() = default;
+
   inline void ScheduleWork();
   inline int CancelWork();
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -71,7 +71,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError [ERR_OUT_OF_RANGE]',
     message: 'The value of "iterations" is out of range. ' +
-             'It must be a non-negative number. Received -1'
+             'It must be >= 0 && <= 2147483647. Received -1'
   }
 );
 
@@ -87,7 +87,20 @@ assert.throws(
     });
 });
 
-[Infinity, -Infinity, NaN, -1, 4073741824, INT_MAX + 1].forEach((input) => {
+[Infinity, -Infinity, NaN].forEach((input) => {
+  assert.throws(
+    () => {
+      crypto.pbkdf2('password', 'salt', 1, input, 'sha256',
+                    common.mustNotCall());
+    }, {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError [ERR_OUT_OF_RANGE]',
+      message: 'The value of "keylen" is out of range. It ' +
+               `must be an integer. Received ${input}`
+    });
+});
+
+[-1, 4073741824, INT_MAX + 1].forEach((input) => {
   assert.throws(
     () => {
       crypto.pbkdf2('password', 'salt', 1, input, 'sha256',

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -1,0 +1,165 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+if (typeof process.binding('crypto').scrypt !== 'function')
+  common.skip('no scrypt support');
+
+const good = [
+  // Zero-length key is legal, functions as a parameter validation check.
+  {
+    pass: '',
+    salt: '',
+    keylen: 0,
+    N: 16,
+    p: 1,
+    r: 1,
+    expected: '',
+  },
+  // Test vectors from https://tools.ietf.org/html/rfc7914#page-13 that
+  // should pass.  Note that the test vector with N=1048576 is omitted
+  // because it takes too long to complete and uses over 1 GB of memory.
+  {
+    pass: '',
+    salt: '',
+    keylen: 64,
+    N: 16,
+    p: 1,
+    r: 1,
+    expected:
+        '77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442' +
+        'fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906',
+  },
+  {
+    pass: 'password',
+    salt: 'NaCl',
+    keylen: 64,
+    N: 1024,
+    p: 16,
+    r: 8,
+    expected:
+        'fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b373162' +
+        '2eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640',
+  },
+  {
+    pass: 'pleaseletmein',
+    salt: 'SodiumChloride',
+    keylen: 64,
+    N: 16384,
+    p: 1,
+    r: 8,
+    expected:
+        '7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2' +
+        'd5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887',
+  },
+];
+
+// Test vectors that should fail.
+const bad = [
+  { N: 1, p: 1, r: 1 },        // N < 2
+  { N: 3, p: 1, r: 1 },        // Not power of 2.
+  { N: 2 ** 16, p: 1, r: 1 },  // N >= 2**(r*16)
+  { N: 2, p: 2 ** 30, r: 1 },  // p > (2**30-1)/r
+];
+
+// Test vectors where 128*N*r exceeds maxmem.
+const toobig = [
+  { N: 2 ** 20, p: 1, r: 8 },
+  { N: 2 ** 10, p: 1, r: 8, maxmem: 2 ** 20 },
+];
+
+const badargs = [
+  {
+    args: [],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"password"/ },
+  },
+  {
+    args: [null],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"password"/ },
+  },
+  {
+    args: [''],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"salt"/ },
+  },
+  {
+    args: ['', null],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"salt"/ },
+  },
+  {
+    args: ['', ''],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"keylen"/ },
+  },
+  {
+    args: ['', '', null],
+    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"keylen"/ },
+  },
+  {
+    args: ['', '', .42],
+    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+  },
+  {
+    args: ['', '', -42],
+    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+  },
+];
+
+for (const options of good) {
+  const { pass, salt, keylen, expected } = options;
+  const actual = crypto.scryptSync(pass, salt, keylen, options);
+  assert.strictEqual(actual.toString('hex'), expected);
+  crypto.scrypt(pass, salt, keylen, options, common.mustCall((err, actual) => {
+    assert.ifError(err);
+    assert.strictEqual(actual.toString('hex'), expected);
+  }));
+}
+
+for (const options of bad) {
+  const expected = {
+    code: 'ERR_CRYPTO_SCRYPT_INVALID_PARAMETER',
+    message: 'Invalid scrypt parameter',
+    type: Error,
+  };
+  common.expectsError(() => crypto.scrypt('pass', 'salt', 1, options, () => {}),
+                      expected);
+  common.expectsError(() => crypto.scryptSync('pass', 'salt', 1, options),
+                      expected);
+}
+
+for (const options of toobig) {
+  const expected = {
+    message: /error:[^:]+:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded/,
+    type: Error,
+  };
+  common.expectsError(() => crypto.scrypt('pass', 'salt', 1, options, () => {}),
+                      expected);
+  common.expectsError(() => crypto.scryptSync('pass', 'salt', 1, options),
+                      expected);
+}
+
+{
+  const defaults = { N: 16384, p: 1, r: 8 };
+  const expected = crypto.scryptSync('pass', 'salt', 1, defaults);
+  const actual = crypto.scryptSync('pass', 'salt', 1);
+  assert.deepStrictEqual(actual.toString('hex'), expected.toString('hex'));
+  crypto.scrypt('pass', 'salt', 1, common.mustCall((err, actual) => {
+    assert.ifError(err);
+    assert.deepStrictEqual(actual.toString('hex'), expected.toString('hex'));
+  }));
+}
+
+for (const { args, expected } of badargs) {
+  common.expectsError(() => crypto.scrypt(...args), expected);
+  common.expectsError(() => crypto.scryptSync(...args), expected);
+}
+
+{
+  const expected = { code: 'ERR_INVALID_CALLBACK' };
+  common.expectsError(() => crypto.scrypt('', '', 42, null), expected);
+  common.expectsError(() => crypto.scrypt('', '', 42, {}, null), expected);
+  common.expectsError(() => crypto.scrypt('', '', 42, {}), expected);
+  common.expectsError(() => crypto.scrypt('', '', 42, {}, {}), expected);
+}

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -122,6 +122,12 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   crypto.randomBytes(1, common.mustCall(function rb() {
     testInitialized(this, 'RandomBytes');
   }));
+
+  if (typeof process.binding('crypto').scrypt === 'function') {
+    crypto.scrypt('password', 'salt', 8, common.mustCall(function() {
+      testInitialized(this, 'AsyncWrap');
+    }));
+  }
 }
 
 

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -120,7 +120,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   crypto.pbkdf2('password', 'salt', 1, 20, 'sha256', mc);
 
   crypto.randomBytes(1, common.mustCall(function rb() {
-    testInitialized(this, 'RandomBytes');
+    testInitialized(this, 'AsyncWrap');
   }));
 
   if (typeof process.binding('crypto').scrypt === 'function') {

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -115,7 +115,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   // so need to check it from the callback.
 
   const mc = common.mustCall(function pb() {
-    testInitialized(this, 'PBKDF2');
+    testInitialized(this, 'AsyncWrap');
   });
   crypto.pbkdf2('password', 'salt', 1, 20, 'sha256', mc);
 


### PR DESCRIPTION
Scrypt is a password-based key derivation function that is designed to
be expensive both computationally and memory-wise in order to make
brute-force attacks unrewarding.

OpenSSL has had support for the scrypt algorithm since v1.1.0.  Add a
Node.js API modeled after `crypto.pbkdf2()` and `crypto.pbkdf2Sync()`.

Changes:

* Introduce helpers for copying buffers, collecting openssl errors, etc.

* Add new infrastructure for offloading crypto to a worker thread.

* Add a `AsyncWrap` JS class to simplify pbkdf2(), randomBytes() and
  scrypt().

~~CI: https://ci.nodejs.org/job/node-test-pull-request/14953/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/14956/