### PR TITLE
src: introduce inspect-brk-node

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -40,7 +40,10 @@
 'use strict';
 
 (function bootstrapInternalLoaders(process, getBinding, getLinkedBinding,
-                                   getInternalBinding) {
+                                   getInternalBinding, debugBreak) {
+  if (debugBreak)
+    debugger; // eslint-disable-line no-debugger
+
   const {
     apply: ReflectApply,
     deleteProperty: ReflectDeleteProperty,

--- a/src/node.cc
+++ b/src/node.cc
@@ -3153,8 +3153,6 @@ static void PrintHelp() {
          "  --inspect-brk[=[host:]port]\n"
          "                             activate inspector on host:port\n"
          "                             and break at start of user script\n"
-         "  --inspect-brk-node         will break in node's bootstrap code\n"
-         "                             (default: false)\n"
          "  --inspect-port=[host:]port\n"
          "                             set host:port for inspector\n"
          "  --inspect[=[host:]port]    activate inspector on host:port\n"

--- a/src/node.cc
+++ b/src/node.cc
@@ -2843,6 +2843,11 @@ void SetupProcessObject(Environment* env,
                                 "_breakFirstLine", True(env->isolate()));
   }
 
+  if (debug_options.break_node_first_line()) {
+    READONLY_DONT_ENUM_PROPERTY(process,
+                                "_breakNodeFirstLine", True(env->isolate()));
+  }
+
   // --inspect --debug-brk
   if (debug_options.deprecated_invocation()) {
     READONLY_DONT_ENUM_PROPERTY(process,
@@ -3077,7 +3082,8 @@ void LoadEnvironment(Environment* env) {
     env->process_object(),
     get_binding_fn,
     get_linked_binding_fn,
-    get_internal_binding_fn
+    get_internal_binding_fn,
+    Boolean::New(env->isolate(), debug_options.break_node_first_line())
   };
 
   // Bootstrap internal loaders
@@ -3147,6 +3153,8 @@ static void PrintHelp() {
          "  --inspect-brk[=[host:]port]\n"
          "                             activate inspector on host:port\n"
          "                             and break at start of user script\n"
+         "  --inspect-brk-node         will break in node's bootstrap code\n"
+         "                             (default: false)\n"
          "  --inspect-port=[host:]port\n"
          "                             set host:port for inspector\n"
          "  --inspect[=[host:]port]    activate inspector on host:port\n"

--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -58,6 +58,7 @@ DebugOptions::DebugOptions() :
                                inspector_enabled_(false),
                                deprecated_debug_(false),
                                break_first_line_(false),
+                               break_node_first_line_(false),
                                host_name_("127.0.0.1"), port_(-1) { }
 
 bool DebugOptions::ParseOption(const char* argv0, const std::string& option) {
@@ -90,6 +91,9 @@ bool DebugOptions::ParseOption(const char* argv0, const std::string& option) {
   } else if (option_name == "--inspect-brk") {
     inspector_enabled_ = true;
     break_first_line_ = true;
+  } else if (option_name == "--inspect-brk-node") {
+    inspector_enabled_ = true;
+    break_node_first_line_ = true;
   } else if (option_name == "--debug-brk") {
     break_first_line_ = true;
     deprecated_debug_ = true;

--- a/src/node_debug_options.h
+++ b/src/node_debug_options.h
@@ -19,16 +19,20 @@ class DebugOptions {
   bool invalid_invocation() const {
     return deprecated_debug_ && !inspector_enabled_;
   }
-  bool wait_for_connect() const { return break_first_line_; }
+  bool wait_for_connect() const {
+    return break_first_line_ || break_node_first_line_;
+  }
   std::string host_name() const { return host_name_; }
   void set_host_name(std::string host_name) { host_name_ = host_name; }
   int port() const;
   void set_port(int port) { port_ = port; }
+  bool break_node_first_line() const { return break_node_first_line_; }
 
  private:
   bool inspector_enabled_;
   bool deprecated_debug_;
   bool break_first_line_;
+  bool break_node_first_line_;
   std::string host_name_;
   int port_;
 };


### PR DESCRIPTION
This commit is a suggestion to add a new option to the node executable
to allow for breaking in node's javascript bootstrapper code.

Previously I've been able to set breakpoints in node bootstrapper code
and then restart the debugging session and those breakpoints would be 
hit, but I don't seem to be able to do so anymore. Having this option
would allow me to use this option and then step through or add more 
break points as needed.

Currently test are missing as I wanted to see if this is worth
pursuing first.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
