### PR TITLE
trace_events: background thread metadata events

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -289,11 +289,11 @@ static struct {
 #if NODE_USE_V8_PLATFORM
   void Initialize(int thread_pool_size) {
     tracing_agent_.reset(new tracing::Agent(trace_file_pattern));
-    platform_ = new NodePlatform(thread_pool_size,
-        tracing_agent_->GetTracingController());
+    auto controller = tracing_agent_->GetTracingController();
+    tracing::TraceEventHelper::SetTracingController(controller);
+    StartTracingAgent();
+    platform_ = new NodePlatform(thread_pool_size, controller);
     V8::InitializePlatform(platform_);
-    tracing::TraceEventHelper::SetTracingController(
-        tracing_agent_->GetTracingController());
   }
 
   void Dispose() {
@@ -4406,8 +4406,6 @@ int Start(int argc, char** argv) {
 #endif  // HAVE_OPENSSL
 
   v8_platform.Initialize(v8_thread_pool_size);
-  // Enable tracing when argv has --trace-events-enabled.
-  v8_platform.StartTracingAgent();
   V8::Initialize();
   performance::performance_v8_start = PERFORMANCE_NOW();
   v8_initialized = true;

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -16,8 +16,10 @@ using v8::Platform;
 using v8::Task;
 using v8::TracingController;
 
-static void BackgroundRunner(void* data) {
-  TaskQueue<Task>* background_tasks = static_cast<TaskQueue<Task>*>(data);
+static void BackgroundRunner(void *data) {
+  TRACE_EVENT_METADATA1("__metadata", "thread_name", "name",
+                        "BackgroundTaskRunner");
+  TaskQueue<Task> *background_tasks = static_cast<TaskQueue<Task> *>(data);
   while (std::unique_ptr<Task> task = background_tasks->BlockingPop()) {
     task->Run();
     background_tasks->NotifyOfCompletion();

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -64,12 +64,12 @@ class NodeTestFixture : public ::testing::Test {
   v8::Isolate* isolate_;
 
   static void SetUpTestCase() {
-    platform.reset(new node::NodePlatform(4, nullptr));
     tracing_controller.reset(new v8::TracingController());
-    allocator.reset(v8::ArrayBuffer::Allocator::NewDefaultAllocator());
-    params.array_buffer_allocator = allocator.get();
     node::tracing::TraceEventHelper::SetTracingController(
         tracing_controller.get());
+    platform.reset(new node::NodePlatform(4, nullptr));
+    allocator.reset(v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+    params.array_buffer_allocator = allocator.get();
     CHECK_EQ(0, uv_loop_init(&current_loop));
     v8::V8::InitializePlatform(platform.get());
     v8::V8::Initialize();

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -22,5 +22,8 @@ proc.once('exit', common.mustCall(() => {
     assert(traces.some((trace) =>
       trace.cat === '__metadata' && trace.name === 'thread_name' &&
         trace.args.name === 'JavaScriptMainThread'));
+    assert(traces.some((trace) =>
+      trace.cat === '__metadata' && trace.name === 'thread_name' &&
+        trace.args.name === 'BackgroundTaskRunner'));
   }));
 }));


### PR DESCRIPTION
V8 uses a thread pool provided by the host to schedule background tasks
for concurrent GC and compiation. Emit trace events to identify the
background threads. Ensure that the tracing infrastructure is started
before the thread pool is initialized.

/cc @nodejs/trace-events @nodejs/diagnostics 

EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/15001/