### PR TITLE
Revert "doc: fix typo in COLLABORATOR_GUIDE.md"

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -843,7 +843,7 @@ LTS working group and the Release team.
 | `lib/domains`                            | @nodejs/domains                                                       |
 | `lib/fs`, `src/{fs,file}`                | @nodejs/fs                                                            |
 | `lib/{_}http{*}`                         | @nodejs/http                                                          |
-| `lib/inspector.js`, `src/inspector_*`    | @nodejs/v8-inspector                                                  |
+| `lib/inspector.js`, `src/inspector_*`    | @nodejs/V8-inspector                                                  |
 | `lib/internal/bootstrap/*`               | @nodejs/process                                                       |
 | `lib/internal/url`, `src/node_url`       | @nodejs/url                                                           |
 | `lib/net`                                | @bnoordhuis, @indutny, @nodejs/streams                                |


### PR DESCRIPTION
This reverts commit 59f71ea4ddf081b55f50334158c25ea19808b3d6.

Quick fix for the following linter error:

```
COLLABORATOR_GUIDE.md
  846:46-846:66  warning  Use "V8" instead of "v8"  prohibited-strings  remark-lint

⚠ 1 warning
```

(Despite being a warning, this breaks `make test`,
and I don’t know how else to address it.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
