### PR TITLE
test: revert changes to http2-client-upload-reject

### DIFF
--- a/test/parallel/test-http2-client-upload-reject.js
+++ b/test/parallel/test-http2-client-upload-reject.js
@@ -20,15 +20,14 @@ fs.readFile(loc, common.mustCall((err, data) => {
   const server = http2.createServer();
 
   server.on('stream', common.mustCall((stream) => {
-    // Wait for some data to come through.
-    setImmediate(() => {
-      stream.on('close', common.mustCall(() => {
-        assert.strictEqual(stream.rstCode, 0);
-      }));
+    // TODO(apapirovski): This should be wrapped in setImmediate to allow
+    // some data to come through so that it fully tests the desired condition.
+    stream.on('close', common.mustCall(() => {
+      assert.strictEqual(stream.rstCode, 0);
+    }));
 
-      stream.respond({ ':status': 400 });
-      stream.end();
-    });
+    stream.respond({ ':status': 400 });
+    stream.end();
   }));
 
   server.listen(0, common.mustCall(() => {


### PR DESCRIPTION
setImmediate makes this test flaky due to exposing a bug in http2. Temporarily revert until a fix can be found.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
