### PR TITLE
doc: discourage util.inspect.defaultOptions usage

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -638,6 +638,9 @@ The `defaultOptions` value allows customization of the default options used by
 object containing one or more valid [`util.inspect()`][] options. Setting
 option properties directly is also supported.
 
+It is strongly discouraged using this inside userland modules. Changing the
+default options should only ever be considered by end users.
+
 ```js
 const util = require('util');
 const arr = Array(101).fill(0);


### PR DESCRIPTION
Changing the default options is often a bad idea because it has
impact on the whole application and not only on a specific controlled
part.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
