### PR TITLE
doc: fix linting error

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -843,7 +843,7 @@ LTS working group and the Release team.
 | `lib/domains`                            | @nodejs/domains                                                       |
 | `lib/fs`, `src/{fs,file}`                | @nodejs/fs                                                            |
 | `lib/{_}http{*}`                         | @nodejs/http                                                          |
-| `lib/inspector.js`, `src/inspector_*`    | @nodejs/v8-inspector                                                  |
+| `lib/inspector.js`, `src/inspector_*`    | @nodejs/V8-inspector                                                  |
 | `lib/internal/bootstrap/*`               | @nodejs/process                                                       |
 | `lib/internal/url`, `src/node_url`       | @nodejs/url                                                           |
 | `lib/net`                                | @bnoordhuis, @indutny, @nodejs/streams                                |


### PR DESCRIPTION
Looks like a linting error crept in at some point

```
Running Markdown linter on misc docs...
COLLABORATOR_GUIDE.md
  846:46-846:66  warning  Use "V8" instead of "v8"  prohibited-strings  remark-lint

⚠ 1 warning
Makefile:1079: recipe for target 'tools/.miscmdlintstamp' failed
make[1]: *** [tools/.miscmdlintstamp] Error 1
Makefile:1178: recipe for target 'lint' failed
make: *** [lint] Error 2
```

Please :+1: to fast-track

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
