### PR TITLE
assert: handle undefined filename in getErrMessage

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -154,6 +154,10 @@ function getBuffer(fd, assertLine) {
 
 function getErrMessage(call) {
   const filename = call.getFileName();
+  if (!filename) {
+    return;
+  }
+
   const line = call.getLineNumber() - 1;
   const column = call.getColumnNumber() - 1;
   const identifier = `${filename}${line}${column}`;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -742,6 +742,16 @@ common.expectsError(
   }
 );
 
+// works in eval
+common.expectsError(
+  () => new Function('assert', 'assert(1 === 2);')(assert),
+  {
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'false == true'
+  }
+);
+
 // Do not try to check Node.js modules.
 {
   const e = new EventEmitter();


### PR DESCRIPTION
When generating an assertion error message,
`filename` might be undefined,
e.g. if `assert` is called in `eval`.

Handle this case gracefully instead of failing with
`Cannot read property 'endsWith' of undefined`.

Fixes: https://github.com/nodejs/node/issues/20847

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
