### PR TITLE
test: define SharedArrayBuffer as a known global

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -51,3 +51,4 @@ globals:
   WebAssembly: false
   BigInt64Array: false
   BigUint64Array: false
+  SharedArrayBuffer: false

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -1,4 +1,3 @@
-/* global SharedArrayBuffer */
 'use strict';
 
 require('../common');

--- a/test/parallel/test-util-format-shared-arraybuffer.js
+++ b/test/parallel/test-util-format-shared-arraybuffer.js
@@ -2,7 +2,5 @@
 require('../common');
 const assert = require('assert');
 const util = require('util');
-
-/* global SharedArrayBuffer */
 const sab = new SharedArrayBuffer(4);
 assert.strictEqual(util.format(sab), 'SharedArrayBuffer { byteLength: 4 }');

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,5 +1,4 @@
 // Flags: --harmony-bigint --experimental-vm-modules
-/* global SharedArrayBuffer */
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
This commit defines `SharedArrayBuffer` as a global for all tests, rather than adding comments to individual tests.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
