### PR TITLE
trace_events: add version metadata

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4231,6 +4231,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   Environment env(isolate_data, context, v8_platform.GetTracingAgent());
   env.Start(argc, argv, exec_argc, exec_argv, v8_is_profiling);
 
+  TRACE_EVENT_METADATA1("__metadata", "version", "node", NODE_VERSION_STRING);
   TRACE_EVENT_METADATA1("__metadata", "thread_name", "name",
                         "JavaScriptMainThread");
 

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -13,7 +13,8 @@ tmpdir.refresh();
 process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
-                      [ '--trace-events-enabled', '-e', CODE ]);
+                      [ '--trace-event-categories', 'node.perf.usertiming',
+                        '-e', CODE ]);
 proc.once('exit', common.mustCall(() => {
   assert(common.fileExists(FILE_NAME));
   fs.readFile(FILE_NAME, common.mustCall((err, data) => {
@@ -25,5 +26,8 @@ proc.once('exit', common.mustCall(() => {
     assert(traces.some((trace) =>
       trace.cat === '__metadata' && trace.name === 'thread_name' &&
         trace.args.name === 'BackgroundTaskRunner'));
+    assert(traces.some((trace) =>
+      trace.cat === '__metadata' && trace.name === 'version' &&
+        trace.args.node === process.versions.node));
   }));
 }));


### PR DESCRIPTION
Use `TRACE_EVENT_METADATA1` to include Node.js, v8, and libuv version
details in the trace log (helpful for log analysis when trace detail
may vary from one Node.js version to another).

/cc @ofrobots 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
