### PR TITLE
doc: fix some nits in hardcoded manpage links

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1703,6 +1703,7 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 [`--force-fips`]: cli.html#cli_force_fips
 [`child_process`]: child_process.html
 [`cipher.getAuthTag()`]: crypto.html#crypto_cipher_getauthtag
+[`Class: assert.AssertionError`]: assert.html#assert_class_assert_assertionerror
 [`crypto.timingSafeEqual()`]: crypto.html#crypto_crypto_timingsafeequal_a_b
 [`dgram.createSocket()`]: dgram.html#dgram_dgram_createsocket_options_callback
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
@@ -1735,7 +1736,7 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [`require('crypto').setEngine()`]: crypto.html#crypto_crypto_setengine_engine_flags
 [`server.listen()`]: net.html#net_server_listen
-[`Class: assert.AssertionError`]: assert.html#assert_class_assert_assertionerror
+[`zlib`]: zlib.html
 [ES6 module]: esm.html
 [Node.js Error Codes]: #nodejs-error-codes
 [V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
@@ -1747,8 +1748,7 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 [ICU]: intl.html#intl_internationalization_support
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
-[syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html
+[syscall]: http://man7.org/linux/man-pages/man2/syscalls.2.html
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 [vm]: vm.html
 [WHATWG Supported Encodings]: util.html#util_whatwg_supported_encodings
-[`zlib`]: zlib.html

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3046,9 +3046,9 @@ The recursive option is only supported on macOS and Windows.
 This feature depends on the underlying operating system providing a way
 to be notified of filesystem changes.
 
-* On Linux systems, this uses [`inotify`]
-* On BSD systems, this uses [`kqueue`]
-* On macOS, this uses [`kqueue`] for files and [`FSEvents`] for directories.
+* On Linux systems, this uses [`inotify(7)`].
+* On BSD systems, this uses [`kqueue(2)`].
+* On macOS, this uses [`kqueue(2)`] for files and [`FSEvents`] for directories.
 * On SunOS systems (including Solaris and SmartOS), this uses [`event ports`].
 * On Windows systems, this feature depends on [`ReadDirectoryChangesW`].
 * On Aix systems, this feature depends on [`AHAFS`], which must be enabled.
@@ -4506,8 +4506,8 @@ the file contents.
 [`fs.watch()`]: #fs_fs_watch_filename_options_listener
 [`fs.write()`]: #fs_fs_write_fd_buffer_offset_length_position_callback
 [`fs.writeFile()`]: #fs_fs_writefile_file_data_options_callback
-[`inotify`]: http://man7.org/linux/man-pages/man7/inotify.7.html
-[`kqueue`]: https://www.freebsd.org/cgi/man.cgi?kqueue
+[`inotify(7)`]: http://man7.org/linux/man-pages/man7/inotify.7.html
+[`kqueue(2)`]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 [`net.Socket`]: net.html#net_class_net_socket
 [`stat()`]: fs.html#fs_fs_stat_path_callback
 [`util.promisify()`]: util.html#util_util_promisify_original

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -204,7 +204,8 @@ length of the queue of pending connections. The actual length will be determined
 by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn`
 on Linux. The default value of this parameter is 511 (not 512).
 
-All [`net.Socket`][] are set to `SO_REUSEADDR` (See [socket(7)][] for details).
+All [`net.Socket`][] are set to `SO_REUSEADDR` (see [`socket(7)`][] for
+details).
 
 The `server.listen()` method can be called again if and only if there was an
 error during the first `server.listen()` call or `server.close()` has been
@@ -1135,6 +1136,7 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [`server.listen(handle)`]: #net_server_listen_handle_backlog_callback
 [`server.listen(options)`]: #net_server_listen_options_callback
 [`server.listen(path)`]: #net_server_listen_path_backlog_callback
+[`socket(7)`]: http://man7.org/linux/man-pages/man7/socket.7.html
 [`socket.connect()`]: #net_socket_connect
 [`socket.connect(options)`]: #net_socket_connect_options_connectlistener
 [`socket.connect(path)`]: #net_socket_connect_path_connectlistener
@@ -1152,7 +1154,6 @@ Returns `true` if input is a version 6 IP address, otherwise returns `false`.
 [Readable Stream]: stream.html#stream_class_stream_readable
 [duplex stream]: stream.html#stream_class_stream_duplex
 [half-closed]: https://tools.ietf.org/html/rfc1122
-[socket(7)]: http://man7.org/linux/man-pages/man7/socket.7.html
 [stream_writable_write]: stream.html#stream_writable_write_chunk_encoding_callback
 [unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0
 [unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

After https://github.com/nodejs/node/pull/20785, we wrap autogenerated manpage links in code elements. This PR unify some hardcoded manpage links with autogenerated ones: it adds backticks, parentheses, section numbers, and updates URLs.

Also, some typos are fixes in passing (missing periods, reference sorting).