### PR TITLE
test: isolate individual assert test to improve test hygiene

### DIFF
--- a/test/parallel/test-assert-builtins-not-read-from-filesystem.js
+++ b/test/parallel/test-assert-builtins-not-read-from-filesystem.js
@@ -1,0 +1,44 @@
+// Flags: --expose-internals
+
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const EventEmitter = require('events');
+const { errorCache } = require('internal/assert');
+const { writeFileSync, unlinkSync } = require('fs');
+
+// Do not read filesystem for error messages in builtin modules.
+{
+  const e = new EventEmitter();
+
+  e.on('hello', assert);
+
+  let threw = false;
+  try {
+    e.emit('hello', false);
+  } catch (err) {
+    const frames = err.stack.split('\n');
+    const [, filename, line, column] = frames[1].match(/\((.+):(\d+):(\d+)\)/);
+    // Reset the cache to check again
+    const size = errorCache.size;
+    errorCache.delete(`${filename}${line - 1}${column - 1}`);
+    assert.strictEqual(errorCache.size, size - 1);
+    const data = `${'\n'.repeat(line - 1)}${' '.repeat(column - 1)}` +
+                 'ok(failed(badly));';
+    try {
+      writeFileSync(filename, data);
+      assert.throws(
+        () => e.emit('hello', false),
+        {
+          message: 'false == true'
+        }
+      );
+      threw = true;
+    } finally {
+      unlinkSync(filename);
+    }
+  }
+  assert(threw);
+}

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -19,17 +19,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --expose-internals
-
 'use strict';
 
 /* eslint-disable node-core/prefer-common-expectserror */
 
 const common = require('../common');
 const assert = require('assert');
-const EventEmitter = require('events');
-const { errorCache } = require('internal/assert');
-const { writeFileSync, unlinkSync } = require('fs');
 const { inspect } = require('util');
 const a = assert;
 
@@ -792,40 +787,6 @@ common.expectsError(
     message: 'false == true'
   }
 );
-
-// Do not try to check Node.js modules.
-{
-  const e = new EventEmitter();
-
-  e.on('hello', assert);
-
-  let threw = false;
-  try {
-    e.emit('hello', false);
-  } catch (err) {
-    const frames = err.stack.split('\n');
-    const [, filename, line, column] = frames[1].match(/\((.+):(\d+):(\d+)\)/);
-    // Reset the cache to check again
-    const size = errorCache.size;
-    errorCache.delete(`${filename}${line - 1}${column - 1}`);
-    assert.strictEqual(errorCache.size, size - 1);
-    const data = `${'\n'.repeat(line - 1)}${' '.repeat(column - 1)}` +
-                 'ok(failed(badly));';
-    try {
-      writeFileSync(filename, data);
-      assert.throws(
-        () => e.emit('hello', false),
-        {
-          message: 'false == true'
-        }
-      );
-      threw = true;
-    } finally {
-      unlinkSync(filename);
-    }
-  }
-  assert(threw);
-}
 
 common.expectsError(
   // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
First commit:

    test: isolate unusual assert test in its own file
    
    test-assert.js contains a test that writes to the source tree, requires
    an internal module, and depends on modules not needed by the plethora of
    other test cases in the file. Move it to its own file so that there are
    not side effects in test-assert.js and so that it can be refactored to
    not write to the source tree.

Second commit:

    test: improve assert test hygiene
    
    Do not pollute the source tree for the test. Instead of writing to the
    source tree, spawn a process with the temp dir as cwd and write the file
    there.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
