### PR TITLE
lib,test: fix error message of ERR_INVALID_ARG_TYPE.

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -629,8 +629,8 @@ E('ERR_INVALID_ARG_TYPE',
       msg = `The "${name}" ${type} ${determiner} ${oneOf(expected, 'type')}`;
     }
 
-    // TODO(BridgeAR): Improve the output by showing `null` and similar.
-    msg += `. Received type ${typeof actual}`;
+    const actualType = (actual === null) ? 'null' : typeof actual;
+    msg += `. Received type ${actualType}`;
     return msg;
   }, TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -348,13 +348,14 @@ try {
 {
   // Verify that throws() and doesNotThrow() throw on non-function block.
   const testBlockTypeError = (method, block) => {
+    const blockType = block === null ? 'null' : typeof block;
     common.expectsError(
       () => method(block),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "block" argument must be of type Function. Received ' +
-                 `type ${typeof block}`
+                 `type ${blockType}`
       }
     );
   };
@@ -395,15 +396,16 @@ assert.throws(() => {
 
 {
   // Bad args to AssertionError constructor should throw TypeError.
-  const args = [1, true, false, '', null, Infinity, Symbol('test'), undefined];
+  const args = [1, true, false, '', null, Infinity, Symbol('test'), undefined]
   args.forEach((input) => {
+    const inputType = input === null ? 'null' : typeof input;
     assert.throws(
       () => new assert.AssertionError(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "options" argument must be of type Object. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       });
   });
 }

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -45,12 +45,13 @@ assert.strictEqual(flatLong.toString(), check);
 assert.strictEqual(flatLongLen.toString(), check);
 
 [undefined, null, Buffer.from('hello')].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   assert.throws(() => {
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "list" argument must be one of type Array, Buffer, ' +
-             `or Uint8Array. Received type ${typeof value}`
+             `or Uint8Array. Received type ${valueType}`
   });
 });
 

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -14,13 +14,14 @@ function typeName(value) {
   const child = new ChildProcess();
 
   [undefined, null, 'foo', 0, 1, NaN, true, false].forEach((options) => {
+    const optionsType = options === null ? 'null' : typeName(options);
     common.expectsError(() => {
       child.spawn(options);
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options" argument must be of type Object. ' +
-               `Received type ${typeName(options)}`
+               `Received type ${optionsType}`
     });
   });
 }
@@ -30,13 +31,14 @@ function typeName(value) {
   const child = new ChildProcess();
 
   [undefined, null, 0, 1, NaN, true, false, {}].forEach((file) => {
+    const fileType = file === null ? 'null' : typeName(file);
     common.expectsError(() => {
       child.spawn({ file });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options.file" property must be of type string. ' +
-               `Received type ${typeName(file)}`
+               `Received type ${fileType}`
     });
   });
 }
@@ -46,13 +48,14 @@ function typeName(value) {
   const child = new ChildProcess();
 
   [null, 0, 1, NaN, true, false, {}, 'foo'].forEach((envPairs) => {
+    const envPairsType = envPairs === null ? 'null' : typeName(envPairs);
     common.expectsError(() => {
       child.spawn({ envPairs, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options.envPairs" property must be of type Array. ' +
-               `Received type ${typeName(envPairs)}`
+               `Received type ${envPairsType}`
     });
   });
 }
@@ -62,13 +65,14 @@ function typeName(value) {
   const child = new ChildProcess();
 
   [null, 0, 1, NaN, true, false, {}, 'foo'].forEach((args) => {
+    const argsType = args === null ? 'null' : typeName(args);
     common.expectsError(() => {
       child.spawn({ file: 'foo', args });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options.args" property must be of type Array. ' +
-               `Received type ${typeName(args)}`
+               `Received type ${argsType}`
     });
   });
 }

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -69,23 +69,25 @@ function stripLineEndings(obj) {
 // Direct call Certificate() should return instance
 assert(Certificate() instanceof Certificate);
 
-[1, {}, [], Infinity, true, 'test', undefined, null].forEach((val) => {
+[1, {}, [], Infinity, true, 'test', undefined, null].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   assert.throws(
-    () => Certificate.verifySpkac(val),
+    () => Certificate.verifySpkac(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "spkac" argument must be one of type Buffer, TypedArray, ' +
-               `or DataView. Received type ${typeof val}`
+               `or DataView. Received type ${valueType}`
     }
   );
 });
 
-[1, {}, [], Infinity, true, undefined, null].forEach((val) => {
+[1, {}, [], Infinity, true, undefined, null].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "spkac" argument must be one of type string, Buffer,' +
-             ` TypedArray, or DataView. Received type ${typeof val}`
+             ` TypedArray, or DataView. Received type ${valueType}`
   };
-  assert.throws(() => Certificate.exportPublicKey(val), errObj);
-  assert.throws(() => Certificate.exportChallenge(val), errObj);
+  assert.throws(() => Certificate.exportPublicKey(value), errObj);
+  assert.throws(() => Certificate.exportChallenge(value), errObj);
 });

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -82,7 +82,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "cipher" argument must be of type string. ' +
-               'Received type object'
+               'Received type null'
     });
 
   common.expectsError(
@@ -91,7 +91,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "password" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 
   common.expectsError(
@@ -100,7 +100,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "data" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 
   common.expectsError(
@@ -109,7 +109,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "buffer" argument must be one of type Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 
   common.expectsError(
@@ -118,7 +118,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "buffer" argument must be one of type Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 }
 
@@ -134,7 +134,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "cipher" argument must be of type string. ' +
-               'Received type object'
+               'Received type null'
     });
 
   common.expectsError(
@@ -143,7 +143,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "password" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 }
 

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -93,7 +93,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "cipher" argument must be of type string. ' +
-               'Received type object'
+               'Received type null'
     });
 
   common.expectsError(
@@ -102,7 +102,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "key" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 
   common.expectsError(
@@ -130,7 +130,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "cipher" argument must be of type string. ' +
-               'Received type object'
+               'Received type null'
     });
 
   common.expectsError(
@@ -139,7 +139,7 @@ function testCipher3(key, iv) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "key" argument must be one of type string, Buffer, ' +
-               'TypedArray, or DataView. Received type object'
+               'TypedArray, or DataView. Received type null'
     });
 
   common.expectsError(

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -18,7 +18,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "hmac" argument must be of type string. Received type object'
+    message: 'The "hmac" argument must be of type string. Received type null'
   });
 
 common.expectsError(
@@ -27,7 +27,7 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "key" argument must be one of type string, TypedArray, or ' +
-             'DataView. Received type object'
+             'DataView. Received type null'
   });
 
 {

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -76,6 +76,7 @@ assert.throws(
 );
 
 ['str', null, undefined, [], {}].forEach((notNumber) => {
+  const notNumberType = notNumber === null ? 'null' : typeof notNumber;
   assert.throws(
     () => {
       crypto.pbkdf2Sync('password', 'salt', 1, notNumber, 'sha256');
@@ -83,7 +84,7 @@ assert.throws(
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
       message: 'The "keylen" argument must be of type number. ' +
-               `Received type ${typeof notNumber}`
+               `Received type ${notNumberType}`
     });
 });
 
@@ -123,8 +124,9 @@ assert.throws(
   });
 
 [1, {}, [], true, undefined, null].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const msgPart2 = 'Buffer, TypedArray, or DataView.' +
-                   ` Received type ${typeof input}`;
+                   ` Received type ${inputType}`;
   assert.throws(
     () => crypto.pbkdf2(input, 'salt', 8, 8, 'sha256', common.mustNotCall()),
     {
@@ -162,10 +164,11 @@ assert.throws(
   );
 });
 
-['test', {}, [], true, undefined, null].forEach((i) => {
-  const received = `Received type ${typeof i}`;
+['test', {}, [], true, undefined, null].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
+  const received = `Received type ${valueType}`;
   assert.throws(
-    () => crypto.pbkdf2('pass', 'salt', i, 8, 'sha256', common.mustNotCall()),
+    () => crypto.pbkdf2('pass', 'salt', value, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
@@ -174,7 +177,7 @@ assert.throws(
   );
 
   assert.throws(
-    () => crypto.pbkdf2Sync('pass', 'salt', i, 8, 'sha256'),
+    () => crypto.pbkdf2Sync('pass', 'salt', value, 8, 'sha256'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -38,11 +38,12 @@ process.setMaxListeners(256);
 {
   [crypto.randomBytes, crypto.pseudoRandomBytes].forEach((f) => {
     [undefined, null, false, true, {}, []].forEach((value) => {
+      const valueType = value === null ? 'null' : typeof value;
       const errObj = {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "size" argument must be of type number. ' +
-                `Received type ${typeof value}`
+                `Received type ${valueType}`
       };
       assert.throws(() => f(value), errObj);
       assert.throws(() => f(value, common.mustNotCall()), errObj);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -320,7 +320,7 @@ common.expectsError(
   const verify = crypto.createVerify('SHA1');
 
   [1, [], {}, undefined, null, true, Infinity].forEach((input) => {
-    const type = typeof input;
+    const type = input === null ? 'null' : typeof input;
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',

--- a/test/parallel/test-dgram-custom-lookup.js
+++ b/test/parallel/test-dgram-custom-lookup.js
@@ -35,13 +35,14 @@ const dns = require('dns');
 {
   // Verify that non-functions throw.
   [null, true, false, 0, 1, NaN, '', 'foo', {}, Symbol()].forEach((value) => {
+    const valueType = value === null ? 'null' : typeof value;
     common.expectsError(() => {
       dgram.createSocket({ type: 'udp4', lookup: value });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "lookup" argument must be of type Function. ' +
-               `Received type ${typeof value}`
+               `Received type ${valueType}`
     });
   });
 }

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -93,5 +93,5 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "listener" argument must be of type Function. ' +
-           'Received type object'
+           'Received type null'
 });

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -57,7 +57,7 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "listener" argument must be of type Function. ' +
-           'Received type object'
+           'Received type null'
 });
 
 {

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -26,7 +26,7 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "listener" argument must be of type Function. ' +
-           'Received type object'
+           'Received type null'
 });
 
 // Test fallback if prependListener is undefined.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -151,7 +151,7 @@ common.expectsError(() => {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "listener" argument must be of type Function. ' +
-           'Received type object'
+           'Received type null'
 });
 
 {

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -148,22 +148,24 @@ if (fs.lchmod) {
 }
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. ' +
-             `Received type ${typeof input}`
+             `Received type ${inputType}`
   };
   assert.throws(() => fs.fchmod(input, 0o000), errObj);
   assert.throws(() => fs.fchmodSync(input, 0o000), errObj);
 });
 
 [false, 1, {}, [], null, undefined].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "path" argument must be one of type string, Buffer, or URL.' +
-             ` Received type ${typeof input}`
+             ` Received type ${inputType}`
   };
   assert.throws(() => fs.chmod(input, 1, common.mustNotCall()), errObj);
   assert.throws(() => fs.chmodSync(input, 1), errObj);

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -8,11 +8,12 @@ const assert = require('assert');
 const fs = require('fs');
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. ' +
-             `Received type ${typeof input}`
+             `Received type ${inputType}`
   };
   assert.throws(() => fs.close(input), errObj);
   assert.throws(() => fs.closeSync(input), errObj);

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -9,11 +9,12 @@ const fs = require('fs');
 
 // Check input type
 [false, null, undefined, {}, [], ''].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. Received type ' +
-             typeof input
+             inputType
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
@@ -21,11 +22,12 @@ const fs = require('fs');
 
 
 [false, null, undefined, {}, [], '', '123x'].forEach((input) => {
+  const utilInspectType = input === null ? 'null' : util.inspect(input);
   const errObj = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError [ERR_INVALID_ARG_VALUE]',
     message: 'The argument \'mode\' must be a 32-bit unsigned integer or an ' +
-             `octal string. Received ${util.inspect(input)}`
+             `octal string. Received ${utilInspectType}`
   };
   assert.throws(() => fs.fchmod(1, input), errObj);
   assert.throws(() => fs.fchmodSync(1, input), errObj);

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -16,11 +16,12 @@ function test(input, errObj) {
 }
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. Received type ' +
-             typeof input
+             inputType
   };
   test(input, errObj);
 });

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -51,11 +51,12 @@ fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
 }));
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. Received type ' +
-             typeof input
+             inputType
   };
   assert.throws(() => fs.fdatasync(input), errObj);
   assert.throws(() => fs.fdatasyncSync(input), errObj);

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -21,6 +21,7 @@ assert.throws(
 );
 
 [true, null, undefined, () => {}, {}].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   assert.throws(() => {
     fs.read(value,
             Buffer.allocUnsafe(expected.length),
@@ -32,7 +33,7 @@ assert.throws(
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. ' +
-             `Received type ${typeof value}`
+             `Received type ${valueType}`
   });
 });
 
@@ -76,6 +77,7 @@ assert.throws(
 );
 
 [true, null, undefined, () => {}, {}].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   assert.throws(() => {
     fs.readSync(value,
                 Buffer.allocUnsafe(expected.length),
@@ -86,7 +88,7 @@ assert.throws(
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "fd" argument must be of type number. ' +
-             `Received type ${typeof value}`
+             `Received type ${valueType}`
   });
 });
 

--- a/test/parallel/test-fs-rename-type-check.js
+++ b/test/parallel/test-fs-rename-type-check.js
@@ -5,13 +5,14 @@ const assert = require('assert');
 const fs = require('fs');
 
 [false, 1, [], {}, null, undefined].forEach((input) => {
-  const type = `of type string, Buffer, or URL. Received type ${typeof input}`;
+  const inputType = input === null ? 'null' : typeof input;
+  const typeMessage = `of type string, Buffer, or URL. Received type ${inputType}`;
   assert.throws(
     () => fs.rename(input, 'does-not-exist', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-      message: `The "oldPath" argument must be one ${type}`
+      message: `The "oldPath" argument must be one ${typeMessage}`
     }
   );
   assert.throws(
@@ -19,7 +20,7 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-      message: `The "newPath" argument must be one ${type}`
+      message: `The "newPath" argument must be one ${typeMessage}`
     }
   );
   assert.throws(
@@ -27,7 +28,7 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-      message: `The "oldPath" argument must be one ${type}`
+      message: `The "oldPath" argument must be one ${typeMessage}`
     }
   );
   assert.throws(
@@ -35,7 +36,7 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-      message: `The "newPath" argument must be one ${type}`
+      message: `The "newPath" argument must be one ${typeMessage}`
     }
   );
 });

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -132,6 +132,7 @@ fs.stat(__filename, common.mustCall(function(err, s) {
 }));
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   ['fstat', 'fstatSync'].forEach((fnName) => {
     assert.throws(
       () => fs[fnName](input),
@@ -139,7 +140,7 @@ fs.stat(__filename, common.mustCall(function(err, s) {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "fd" argument must be of type number. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       }
     );
   });

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -59,11 +59,12 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
 }));
 
 [false, 1, {}, [], null, undefined].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "target" argument must be one of type string, Buffer, or ' +
-             `URL. Received type ${typeof input}`
+             `URL. Received type ${inputType}`
   };
   assert.throws(() => fs.symlink(input, '', common.mustNotCall()), errObj);
   assert.throws(() => fs.symlinkSync(input, ''), errObj);

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -179,13 +179,14 @@ function testFtruncate(cb) {
   process.on('exit', () => fs.closeSync(fd));
 
   ['', false, null, {}, []].forEach((input) => {
+    const inputType = input === null ? 'null' : typeof input;
     assert.throws(
       () => fs.ftruncate(fd, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "len" argument must be of type number. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       }
     );
   });
@@ -233,6 +234,7 @@ function testFtruncate(cb) {
 }
 
 ['', false, null, undefined, {}, []].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   ['ftruncate', 'ftruncateSync'].forEach((fnName) => {
     assert.throws(
       () => fs[fnName](input),
@@ -240,7 +242,7 @@ function testFtruncate(cb) {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
         message: 'The "fd" argument must be of type number. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       }
     );
   });

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -81,13 +81,14 @@ for (const testCase of cases) {
 }
 
 [false, 1, {}, [], null, undefined].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   common.expectsError(
     () => fs.watch(input, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "filename" argument must be one of type string, Buffer, ' +
-               `or URL. Received type ${typeof input}`
+               `or URL. Received type ${inputType}`
     }
   );
 });

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -118,14 +118,15 @@ const s = http.createServer(common.mustCall((req, res) => {
         {},
         { toString: () => 'X-TEST-HEADER2' },
         () => { }
-      ].forEach((val) => {
+      ].forEach((value) => {
+        const valueType = value === null ? 'null' : typeof value;
         common.expectsError(
-          () => res.hasHeader(val),
+          () => res.hasHeader(value),
           {
             code: 'ERR_INVALID_ARG_TYPE',
             type: TypeError,
             message: 'The "name" argument must be of type string. ' +
-                     `Received type ${typeof val}`
+                     `Received type ${valueType}`
           }
         );
       });

--- a/test/parallel/test-http2-client-setNextStreamID-errors.js
+++ b/test/parallel/test-http2-client-setNextStreamID-errors.js
@@ -43,13 +43,14 @@ server.listen(0, common.mustCall(() => {
         return;
       }
 
+      const valueType = value === null ? 'null' : typeof value;
       common.expectsError(
         () => client.setNextStreamID(value),
         {
           type: TypeError,
           code: 'ERR_INVALID_ARG_TYPE',
           message: 'The "id" argument must be of type number. Received type ' +
-                   typeof value
+                   valueType
         }
       );
     });

--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -10,13 +10,14 @@ const http2 = require('http2');
 // Error if options are not passed to createSecureServer
 const invalidOptions = [() => {}, 1, 'test', null];
 invalidOptions.forEach((invalidOption) => {
+  const invalidOptionType = invalidOption === null ? 'null' : typeof invalidOption;
   assert.throws(
     () => http2.createSecureServer(invalidOption),
     {
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options" argument must be of type Object. Received ' +
-               `type ${typeof invalidOption}`
+               `type ${invalidOptionType}`
     }
   );
 });

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -30,11 +30,12 @@ const server = http2.createServer();
 
 server.on('stream', common.mustCall((stream) => {
   // should throw if fd isn't a number
+  // TODOkakts
   Object.keys(types).forEach((type) => {
     if (type === 'number') {
       return;
     }
-
+    const valueType = types[type] === null ? 'null' : typeof types[type];
     common.expectsError(
       () => stream.respondWithFD(types[type], {
         'content-type': 'text/plain'
@@ -43,7 +44,7 @@ server.on('stream', common.mustCall((stream) => {
         type: TypeError,
         code: 'ERR_INVALID_ARG_TYPE',
         message: 'The "fd" argument must be of type number. Received type ' +
-                 typeof types[type]
+                 valueType
       }
     );
   });

--- a/test/parallel/test-http2-server-shutdown-options-errors.js
+++ b/test/parallel/test-http2-server-shutdown-options-errors.js
@@ -19,13 +19,14 @@ server.on('stream', common.mustCall((stream) => {
   const session = stream.session;
 
   types.forEach((input) => {
+    const inputType = input === null ? 'null' : typeof input;
     common.expectsError(
       () => session.goaway(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "code" argument must be of type number. Received type ' +
-                 typeof input
+        message: 'The "code" argument must be of type number. ' +
+                 `Received type ${inputType}`
       }
     );
     common.expectsError(
@@ -34,7 +35,7 @@ server.on('stream', common.mustCall((stream) => {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "lastStreamID" argument must be of type number. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       }
     );
     common.expectsError(
@@ -43,7 +44,7 @@ server.on('stream', common.mustCall((stream) => {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "opaqueData" argument must be one of type Buffer, ' +
-                 `TypedArray, or DataView. Received type ${typeof input}`
+                 `TypedArray, or DataView. Received type ${inputType}`
       }
     );
   });

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -47,7 +47,7 @@ common.expectsError(
     type: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "source" argument must be one of type Buffer ' +
-             'or Uint8Array. Received type object'
+             'or Uint8Array. Received type null'
   }
 );
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -221,13 +221,14 @@ function checkFormat(path, testCases) {
   });
 
   [null, undefined, 1, true, false, 'string'].forEach((pathObject) => {
+    const pathObjectType = pathObject === null ? 'null' : typeof pathObject;
     common.expectsError(() => {
       path.format(pathObject);
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "pathObject" argument must be of type Object. ' +
-               `Received type ${typeof pathObject}`
+               `Received type ${pathObjectType}`
     });
   });
 }

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -61,12 +61,13 @@ const {
 
 {
   [1, {}, [], null, undefined, Infinity].forEach((input) => {
+    const inputType = input === null ? 'null' : typeof input;
     common.expectsError(() => performance.timerify(input),
                         {
                           code: 'ERR_INVALID_ARG_TYPE',
                           type: TypeError,
                           message: 'The "fn" argument must be of type ' +
-                                   `Function. Received type ${typeof input}`
+                                   `Function. Received type ${inputType}`
                         });
   });
 }

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -38,13 +38,14 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
   const observer = new PerformanceObserver(common.mustNotCall());
 
   [1, null, undefined].forEach((input) => {
+    const inputType = input === null ? 'null' : typeof input;
     common.expectsError(
       () => observer.observe(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "options" argument must be of type Object. ' +
-                 `Received type ${typeof input}`
+                 `Received type ${inputType}`
       });
   });
 

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -49,13 +49,14 @@ assert.throws(
   { user: 'a' },
   { user: null, system: 'c' },
 ].forEach((value) => {
+  const userValueType = value.user === null ? 'null' : typeof value.user;
   assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
       message: 'The "prevValue.user" property must be of type number. ' +
-               `Received type ${typeof value.user}`
+               `Received type ${userValueType}`
     }
   );
 });
@@ -64,13 +65,14 @@ assert.throws(
   { user: 3, system: 'b' },
   { user: 3, system: null }
 ].forEach((value) => {
+  const systemType = value.system === null ? 'null' : typeof value.system;
   assert.throws(
     () => process.cpuUsage(value),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
       message: 'The "prevValue.system" property must be of type number. ' +
-               `Received type ${typeof value.system}`
+               `Received type ${systemType}`
     }
   );
 });

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -38,12 +38,13 @@ const assert = require('assert');
 //
 // process.pid, String(process.pid): ourself
 
-['SIGTERM', null, undefined, NaN, Infinity, -Infinity].forEach((val) => {
-  assert.throws(() => process.kill(val), {
+['SIGTERM', null, undefined, NaN, Infinity, -Infinity].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
+  assert.throws(() => process.kill(value), {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError [ERR_INVALID_ARG_TYPE]',
     message: 'The "pid" argument must be of type number. ' +
-             `Received type ${typeof val}`
+             `Received type ${valueType}`
   });
 });
 

--- a/test/parallel/test-tls-error-servername.js
+++ b/test/parallel/test-tls-error-servername.js
@@ -23,12 +23,13 @@ const client = connect({
 });
 
 [undefined, null, 1, true, {}].forEach((value) => {
+  const valueType = value === null ? 'null' : typeof value;
   common.expectsError(() => {
     client.setServername(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "name" argument must be of type string. ' +
-             `Received type ${typeof value}`
+             `Received type ${valueType}`
   });
 });
 

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -5,7 +5,7 @@ const url = require('url');
 
 const throwsObjsAndReportTypes = new Map([
   [undefined, 'undefined'],
-  [null, 'object'],
+  [null, 'null'],
   [true, 'boolean'],
   [false, 'boolean'],
   [0, 'number'],

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -6,7 +6,7 @@ const url = require('url');
 // https://github.com/joyent/node/issues/568
 [
   [undefined, 'undefined'],
-  [null, 'object'],
+  [null, 'null'],
   [true, 'boolean'],
   [false, 'boolean'],
   [0.0, 'number'],

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -231,13 +231,14 @@ const values = [
 {
   // Verify that non-function inputs throw.
   ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
+    const valueType = value === null ? 'null' : typeof value;
     common.expectsError(() => {
       callbackify(value);
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "original" argument must be of type Function. ' +
-               `Received type ${typeof value}`
+               `Received type ${valueType}`
     });
   });
 }
@@ -252,6 +253,7 @@ const values = [
 
   // Verify that the last argument to the callbackified function is a function.
   ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
+    const valueType = value === null ? 'null' : typeof value;
     args.push(value);
     common.expectsError(() => {
       cb(...args);
@@ -259,7 +261,7 @@ const values = [
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The last argument must be of type Function. ' +
-               `Received type ${typeof value}`
+               `Received type ${valueType}`
     });
   });
 }

--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -4,10 +4,11 @@ const common = require('../common');
 const util = require('util');
 
 [1, true, false, null, {}].forEach((notString) => {
+  const notStringType = notString === null ? 'null' : typeof notString;
   common.expectsError(() => util.deprecate(() => {}, 'message', notString), {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "code" argument must be of type string. ' +
-             `Received type ${typeof notString}`
+             `Received type ${notStringType}`
   });
 });

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -90,7 +90,7 @@ common.expectsError(function() {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "superCtor" argument must be of type Function. ' +
-           'Received type object'
+           'Received type null'
 });
 
 common.expectsError(function() {
@@ -98,5 +98,5 @@ common.expectsError(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "ctor" argument must be of type Function. Received type object'
+  message: 'The "ctor" argument must be of type Function. Received type null'
 });

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1089,7 +1089,7 @@ if (typeof Symbol !== 'undefined') {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "options" argument must be of type Object. ' +
-             'Received type object'
+             'Received type null'
   }
   );
 

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -186,12 +186,13 @@ const stat = promisify(fs.stat);
 }
 
 [undefined, null, true, 0, 'str', {}, [], Symbol()].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   common.expectsError(
     () => promisify(input),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "original" argument must be of type Function. ' +
-               `Received type ${typeof input}`
+               `Received type ${inputType}`
     });
 });

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -97,13 +97,14 @@ const vm = require('vm');
 
 // Invalid arguments
 [null, 'string'].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   common.expectsError(() => {
     vm.createContext({}, input);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "options" argument must be of type Object. ' +
-             `Received type ${typeof input}`
+             `Received type ${inputType}`
   });
 });
 
@@ -114,7 +115,7 @@ const vm = require('vm');
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: `The "options.${propertyName}" property must be of type string. ` +
-             'Received type object'
+             'Received type null'
   });
 });
 
@@ -125,6 +126,6 @@ const vm = require('vm');
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: `The "options.${propertyName}" property must be of type string. ` +
-             'Received type object'
+             'Received type null'
   });
 });

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -16,6 +16,7 @@ const zlib = require('zlib');
   [1, 2, 3],
   { foo: 'bar' }
 ].forEach((input) => {
+  const inputType = input === null ? 'null' : typeof input;
   common.expectsError(
     () => zlib.deflateSync(input),
     {
@@ -23,7 +24,7 @@ const zlib = require('zlib');
       type: TypeError,
       message: 'The "buffer" argument must be one of type string, Buffer, ' +
                'TypedArray, DataView, or ArrayBuffer. ' +
-               `Received type ${typeof input}`
+               `Received type ${inputType}`
     }
   );
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

## Summary
lib/internal/errors.js

Fixed "TODO" issue about the error message of ERR_INVALID_ARG_TYPE.
Before, when null value is passed to this error message, it shows "... Received type object".
It's better to print "Received type null" instead.

Example.
*Before*
```
TypeError [ERR_INVALID_ARG_TYPE]: The "list[2]" argument must be one of type Array, Buffer, or Uint8Array.   
Received type object
```
↓
*After*
```

TypeError [ERR_INVALID_ARG_TYPE]: The "list[2]" argument must be one of type Array, Buffer, or Uint8Array.   
Received type null
```

Also, I fixed some test codes relating to this error.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
