### PR TITLE
tls wild card check supports for port

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -121,8 +121,20 @@ function check(hostParts, pattern, wildcards) {
 
   // Check host parts from right to left first.
   for (var i = hostParts.length - 1; i > 0; i -= 1) {
-    if (hostParts[i] !== patternParts[i])
+    if (hostParts[i] !== patternParts[i]) {
+      if ((i === (hostParts.length - 1)) &&
+          (patternParts[i].indexOf(':') === -1) &&
+          (hostParts[i].indexOf(':') > -1)) {
+        // the last part can contain port from the host, and it is
+        // legit for the dn and san to not include port to indicate
+        // all ports for the server is allowed
+        const justHostPart = hostParts[i].split(':')[0];
+        if (justHostPart === patternParts[i]) {
+          continue;
+        }
+      }
       return false;
+    }
   }
 
   const hostSubdomain = hostParts[0];

--- a/test/parallel/test-tls-check-server-identity.js
+++ b/test/parallel/test-tls-check-server-identity.js
@@ -132,6 +132,43 @@ const tests = [
     }
   },
   {
+    host: 'a.co.uk:2443', cert: {
+      subject: { CN: '*.co.uk' }
+    }
+  },
+  {
+    host: 'a.co.uk:2443', cert: {
+      subject: { CN: '*.co.uk:2443' }
+    }
+  },
+  {
+    host: 'a.co.uk:2443', cert: {
+      subject: { CN: '*.co.uk:8443' }
+    },
+    error: 'Host: a.co.uk:2443. is not ' +
+           'cert\'s CN: *.co.uk:8443'
+  },
+  {
+    host: 'a.co.uk:2443', cert: {
+      subjectaltname: 'DNS:*.co.uk',
+      subject: { CN: 'b.com' }
+    }
+  },
+  {
+    host: 'a.co.uk:2443', cert: {
+      subjectaltname: 'DNS:*.co.uk:2443',
+      subject: { CN: 'b.com' }
+    }
+  },
+  {
+    host: 'a.co.uk:2443', cert: {
+      subjectaltname: 'DNS:*.co.uk:8443',
+      subject: { CN: 'b.com' }
+    },
+    error: 'Host: a.co.uk:2443. is not in the cert\'s ' +
+           'altnames: DNS:*.co.uk:8443'
+  },
+  {
     host: 'a.com', cert: {
       subjectaltname: 'DNS:*.a.com',
       subject: { CN: 'a.com' }


### PR DESCRIPTION
If wild card dns check (both CN, or SAN) does not
contain port, it applies to all ports on the server.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
```
  SOLINK_MODULE(target) Release/test_uv_loop.node
touch test/addons-napi/.buildstamp
/Applications/Xcode.app/Contents/Developer/usr/bin/make cctest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C out BUILDTYPE=Release V=1
  touch 14bc63f62e96cfbc513dcfa609a1cd109c24d103.intermediate
  LD_LIBRARY_PATH=/Users/spoon/sfp/node/out/Release/lib.host:/Users/spoon/sfp/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../.; mkdir -p /Users/spoon/sfp/node/out/Release/obj/gen/src/node/inspector/protocol; python deps/v8/third_party/inspector_protocol/CodeGenerator.py --jinja_dir deps/v8/third_party/inspector_protocol/.. --output_base "/Users/spoon/sfp/node/out/Release/obj/gen/src/" --config "/Users/spoon/sfp/node/out/Release/obj/gen/node_protocol_config.json"
  touch 3bc6331644efa748b7c8a3f9d879d754c4289033.intermediate
  LD_LIBRARY_PATH=/Users/spoon/sfp/node/out/Release/lib.host:/Users/spoon/sfp/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/v8/gypfiles; mkdir -p /Users/spoon/sfp/node/out/Release/obj/gen/src/inspector/protocol /Users/spoon/sfp/node/out/Release/obj/gen/include/inspector; python ../third_party/inspector_protocol/CodeGenerator.py --jinja_dir ../third_party --output_base "/Users/spoon/sfp/node/out/Release/obj/gen/src/inspector" --config ../src/inspector/inspector_protocol_config.json
rm 14bc63f62e96cfbc513dcfa609a1cd109c24d103.intermediate 3bc6331644efa748b7c8a3f9d879d754c4289033.intermediate
if [ ! -r node -o ! -L node ]; then ln -fs out/Release/node node; fi
[==========] Running 74 tests from 9 test cases.
[----------] Global test environment set-up.
[----------] 14 tests from AliasBufferTest
[ RUN      ] AliasBufferTest.Uint8Array
[       OK ] AliasBufferTest.Uint8Array (15 ms)
[ RUN      ] AliasBufferTest.Int8Array
[       OK ] AliasBufferTest.Int8Array (7 ms)
[ RUN      ] AliasBufferTest.Uint16Array
[       OK ] AliasBufferTest.Uint16Array (7 ms)
[ RUN      ] AliasBufferTest.Int16Array
[       OK ] AliasBufferTest.Int16Array (7 ms)
[ RUN      ] AliasBufferTest.Uint32Array
[       OK ] AliasBufferTest.Uint32Array (8 ms)
[ RUN      ] AliasBufferTest.Int32Array
[       OK ] AliasBufferTest.Int32Array (8 ms)
[ RUN      ] AliasBufferTest.Float32Array
[       OK ] AliasBufferTest.Float32Array (8 ms)
[ RUN      ] AliasBufferTest.Float64Array
[       OK ] AliasBufferTest.Float64Array (6 ms)
[ RUN      ] AliasBufferTest.SharedArrayBuffer1
[       OK ] AliasBufferTest.SharedArrayBuffer1 (8 ms)
[ RUN      ] AliasBufferTest.SharedArrayBuffer2
[       OK ] AliasBufferTest.SharedArrayBuffer2 (8 ms)
[ RUN      ] AliasBufferTest.SharedArrayBuffer3
[       OK ] AliasBufferTest.SharedArrayBuffer3 (8 ms)
[ RUN      ] AliasBufferTest.SharedArrayBuffer4
[       OK ] AliasBufferTest.SharedArrayBuffer4 (7 ms)
[ RUN      ] AliasBufferTest.OperatorOverloads
[       OK ] AliasBufferTest.OperatorOverloads (8 ms)
[ RUN      ] AliasBufferTest.OperatorOverloadsRefs
[       OK ] AliasBufferTest.OperatorOverloadsRefs (8 ms)
[----------] 14 tests from AliasBufferTest (113 ms total)

[----------] 2 tests from Base64Test
[ RUN      ] Base64Test.Encode
[       OK ] Base64Test.Encode (0 ms)
[ RUN      ] Base64Test.Decode
[       OK ] Base64Test.Decode (0 ms)
[----------] 2 tests from Base64Test (0 ms total)

[----------] 7 tests from DebugSymbolsTest
[ RUN      ] DebugSymbolsTest.ContextEmbedderEnvironmentIndex
[       OK ] DebugSymbolsTest.ContextEmbedderEnvironmentIndex (7 ms)
[ RUN      ] DebugSymbolsTest.ExternalStringDataOffset
[       OK ] DebugSymbolsTest.ExternalStringDataOffset (8 ms)
[ RUN      ] DebugSymbolsTest.BaseObjectPersistentHandle
[       OK ] DebugSymbolsTest.BaseObjectPersistentHandle (8 ms)
[ RUN      ] DebugSymbolsTest.EnvironmentHandleWrapQueue
[       OK ] DebugSymbolsTest.EnvironmentHandleWrapQueue (7 ms)
[ RUN      ] DebugSymbolsTest.EnvironmentReqWrapQueue
[       OK ] DebugSymbolsTest.EnvironmentReqWrapQueue (8 ms)
[ RUN      ] DebugSymbolsTest.HandleWrapList
[       OK ] DebugSymbolsTest.HandleWrapList (8 ms)
[ RUN      ] DebugSymbolsTest.ReqWrapList
[       OK ] DebugSymbolsTest.ReqWrapList (10 ms)
[----------] 7 tests from DebugSymbolsTest (57 ms total)

[----------] 4 tests from EnvironmentTest
[ RUN      ] EnvironmentTest.AtExitWithEnvironment
[       OK ] EnvironmentTest.AtExitWithEnvironment (8 ms)
[ RUN      ] EnvironmentTest.AtExitWithoutEnvironment
[       OK ] EnvironmentTest.AtExitWithoutEnvironment (8 ms)
[ RUN      ] EnvironmentTest.AtExitWithArgument
[       OK ] EnvironmentTest.AtExitWithArgument (7 ms)
[ RUN      ] EnvironmentTest.MultipleEnvironmentsPerIsolate
[       OK ] EnvironmentTest.MultipleEnvironmentsPerIsolate (8 ms)
[----------] 4 tests from EnvironmentTest (31 ms total)

[----------] 1 test from PlatformTest
[ RUN      ] PlatformTest.SkipNewTasksInFlushForegroundTasks
[       OK ] PlatformTest.SkipNewTasksInFlushForegroundTasks (8 ms)
[----------] 1 test from PlatformTest (8 ms total)

[----------] 9 tests from UtilTest
[ RUN      ] UtilTest.ListHead
[       OK ] UtilTest.ListHead (0 ms)
[ RUN      ] UtilTest.StringEqualNoCase
[       OK ] UtilTest.StringEqualNoCase (0 ms)
[ RUN      ] UtilTest.StringEqualNoCaseN
[       OK ] UtilTest.StringEqualNoCaseN (0 ms)
[ RUN      ] UtilTest.ToLower
[       OK ] UtilTest.ToLower (0 ms)
[ RUN      ] UtilTest.Malloc
[       OK ] UtilTest.Malloc (0 ms)
[ RUN      ] UtilTest.Calloc
[       OK ] UtilTest.Calloc (0 ms)
[ RUN      ] UtilTest.UncheckedMalloc
[       OK ] UtilTest.UncheckedMalloc (0 ms)
[ RUN      ] UtilTest.UncheckedCalloc
[       OK ] UtilTest.UncheckedCalloc (0 ms)
[ RUN      ] UtilTest.MaybeStackBuffer
[       OK ] UtilTest.MaybeStackBuffer (0 ms)
[----------] 9 tests from UtilTest (0 ms total)

[----------] 7 tests from URLTest
[ RUN      ] URLTest.Simple
[       OK ] URLTest.Simple (1 ms)
[ RUN      ] URLTest.Simple2
[       OK ] URLTest.Simple2 (0 ms)
[ RUN      ] URLTest.NoBase1
[       OK ] URLTest.NoBase1 (0 ms)
[ RUN      ] URLTest.Base1
[       OK ] URLTest.Base1 (0 ms)
[ RUN      ] URLTest.Base2
[       OK ] URLTest.Base2 (0 ms)
[ RUN      ] URLTest.Base3
[       OK ] URLTest.Base3 (0 ms)
[ RUN      ] URLTest.ToFilePath
[       OK ] URLTest.ToFilePath (0 ms)
[----------] 7 tests from URLTest (1 ms total)

[----------] 20 tests from InspectorSocketTest
[ RUN      ] InspectorSocketTest.ReadsAndWritesInspectorMessage
[       OK ] InspectorSocketTest.ReadsAndWritesInspectorMessage (0 ms)
[ RUN      ] InspectorSocketTest.BufferEdgeCases
[       OK ] InspectorSocketTest.BufferEdgeCases (1 ms)
[ RUN      ] InspectorSocketTest.AcceptsRequestInSeveralWrites
[       OK ] InspectorSocketTest.AcceptsRequestInSeveralWrites (0 ms)
[ RUN      ] InspectorSocketTest.ExtraTextBeforeRequest
[       OK ] InspectorSocketTest.ExtraTextBeforeRequest (0 ms)
[ RUN      ] InspectorSocketTest.RequestWithoutKey
[       OK ] InspectorSocketTest.RequestWithoutKey (1 ms)
[ RUN      ] InspectorSocketTest.KillsConnectionOnProtocolViolation
[       OK ] InspectorSocketTest.KillsConnectionOnProtocolViolation (0 ms)
[ RUN      ] InspectorSocketTest.CanStopReadingFromInspector
[       OK ] InspectorSocketTest.CanStopReadingFromInspector (0 ms)
[ RUN      ] InspectorSocketTest.CloseDoesNotNotifyReadCallback
[       OK ] InspectorSocketTest.CloseDoesNotNotifyReadCallback (1 ms)
[ RUN      ] InspectorSocketTest.CloseWorksWithoutReadEnabled
[       OK ] InspectorSocketTest.CloseWorksWithoutReadEnabled (0 ms)
[ RUN      ] InspectorSocketTest.ReportsHttpGet
[       OK ] InspectorSocketTest.ReportsHttpGet (11 ms)
[ RUN      ] InspectorSocketTest.HandshakeCanBeCanceled
[       OK ] InspectorSocketTest.HandshakeCanBeCanceled (0 ms)
[ RUN      ] InspectorSocketTest.GetThenHandshake
[       OK ] InspectorSocketTest.GetThenHandshake (1 ms)
[ RUN      ] InspectorSocketTest.WriteBeforeHandshake
[       OK ] InspectorSocketTest.WriteBeforeHandshake (0 ms)
[ RUN      ] InspectorSocketTest.CleanupSocketAfterEOF
[       OK ] InspectorSocketTest.CleanupSocketAfterEOF (10 ms)
[ RUN      ] InspectorSocketTest.EOFBeforeHandshake
[       OK ] InspectorSocketTest.EOFBeforeHandshake (0 ms)
[ RUN      ] InspectorSocketTest.Send1Mb
[       OK ] InspectorSocketTest.Send1Mb (25 ms)
[ RUN      ] InspectorSocketTest.ErrorCleansUpTheSocket
[       OK ] InspectorSocketTest.ErrorCleansUpTheSocket (0 ms)
[ RUN      ] InspectorSocketTest.NoCloseResponseFromClient
[       OK ] InspectorSocketTest.NoCloseResponseFromClient (0 ms)
[ RUN      ] InspectorSocketTest.HostCheckedForGET
[       OK ] InspectorSocketTest.HostCheckedForGET (1 ms)
[ RUN      ] InspectorSocketTest.HostCheckedForUPGRADE
[       OK ] InspectorSocketTest.HostCheckedForUPGRADE (0 ms)
[----------] 20 tests from InspectorSocketTest (51 ms total)

[----------] 10 tests from InspectorSocketServerTest
[ RUN      ] InspectorSocketServerTest.InspectorSessions
[       OK ] InspectorSocketServerTest.InspectorSessions (2 ms)
[ RUN      ] InspectorSocketServerTest.ServerDoesNothing
[       OK ] InspectorSocketServerTest.ServerDoesNothing (0 ms)
[ RUN      ] InspectorSocketServerTest.ServerWithoutTargets
[       OK ] InspectorSocketServerTest.ServerWithoutTargets (0 ms)
[ RUN      ] InspectorSocketServerTest.ServerCannotStart
[       OK ] InspectorSocketServerTest.ServerCannotStart (0 ms)
[ RUN      ] InspectorSocketServerTest.StoppingServerDoesNotKillConnections
[       OK ] InspectorSocketServerTest.StoppingServerDoesNotKillConnections (1 ms)
[ RUN      ] InspectorSocketServerTest.ClosingConnectionReportsDone
[       OK ] InspectorSocketServerTest.ClosingConnectionReportsDone (0 ms)
[ RUN      ] InspectorSocketServerTest.ClosingSocketReportsDone
[       OK ] InspectorSocketServerTest.ClosingSocketReportsDone (0 ms)
[ RUN      ] InspectorSocketServerTest.TerminatingSessionReportsDone
[       OK ] InspectorSocketServerTest.TerminatingSessionReportsDone (1 ms)
[ RUN      ] InspectorSocketServerTest.FailsToBindToNodejsHost
[       OK ] InspectorSocketServerTest.FailsToBindToNodejsHost (40 ms)
[ RUN      ] InspectorSocketServerTest.BindsToIpV6
[       OK ] InspectorSocketServerTest.BindsToIpV6 (0 ms)
[----------] 10 tests from InspectorSocketServerTest (44 ms total)

[----------] Global test environment tear-down
[==========] 74 tests from 9 test cases ran. (308 ms total)
[  PASSED  ] 74 tests.
/Applications/Xcode.app/Contents/Developer/usr/bin/make jstest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C out BUILDTYPE=Release V=1
  touch 14bc63f62e96cfbc513dcfa609a1cd109c24d103.intermediate
  LD_LIBRARY_PATH=/Users/spoon/sfp/node/out/Release/lib.host:/Users/spoon/sfp/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../.; mkdir -p /Users/spoon/sfp/node/out/Release/obj/gen/src/node/inspector/protocol; python deps/v8/third_party/inspector_protocol/CodeGenerator.py --jinja_dir deps/v8/third_party/inspector_protocol/.. --output_base "/Users/spoon/sfp/node/out/Release/obj/gen/src/" --config "/Users/spoon/sfp/node/out/Release/obj/gen/node_protocol_config.json"
  touch 3bc6331644efa748b7c8a3f9d879d754c4289033.intermediate
  LD_LIBRARY_PATH=/Users/spoon/sfp/node/out/Release/lib.host:/Users/spoon/sfp/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/v8/gypfiles; mkdir -p /Users/spoon/sfp/node/out/Release/obj/gen/src/inspector/protocol /Users/spoon/sfp/node/out/Release/obj/gen/include/inspector; python ../third_party/inspector_protocol/CodeGenerator.py --jinja_dir ../third_party --output_base "/Users/spoon/sfp/node/out/Release/obj/gen/src/inspector" --config ../src/inspector/inspector_protocol_config.json
rm 14bc63f62e96cfbc513dcfa609a1cd109c24d103.intermediate 3bc6331644efa748b7c8a3f9d879d754c4289033.intermediate
if [ ! -r node -o ! -L node ]; then ln -fs out/Release/node node; fi
/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python tools/test.py -J --mode=release \
		default \
		addons addons-napi
[03:09|% 100|+ 2269|-   0]: Done 
```
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
