### PR TITLE
src: fix MallocedBuffer move assignment operator

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -438,7 +438,7 @@ struct MallocedBuffer {
   }
   MallocedBuffer& operator=(MallocedBuffer&& other) {
     this->~MallocedBuffer();
-    return *new(this) MallocedBuffer(other);
+    return *new(this) MallocedBuffer(std::move(other));
   }
   ~MallocedBuffer() {
     free(data);


### PR DESCRIPTION
Split out from https://github.com/nodejs/node/pull/20876

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
