### PR TITLE
src: break out of timers loop if `!can_call_into_js()`

### DIFF
--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -134,7 +134,9 @@ class TimerWrap : public HandleWrap {
     do {
       ret = wrap->MakeCallback(env->timers_callback_function(), 1, args)
                 .ToLocalChecked();
-    } while (ret->IsUndefined() && !env->tick_info()->has_thrown());
+    } while (ret->IsUndefined() &&
+             !env->tick_info()->has_thrown() &&
+             env->can_call_into_js());
   }
 
   static void Now(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Split out from https://github.com/nodejs/node/pull/20876

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
