### PR TITLE
src: remove --expose-http2 option

### DIFF
--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   n: [1e3],
   nheaders: [0, 10, 100, 1000],
   benchmarker: ['h2load']
-}, { flags: ['--no-warnings', '--expose-http2'] });
+}, { flags: ['--no-warnings'] });
 
 function main({ n, nheaders }) {
   const http2 = require('http2');

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   clients: [1, 2],
   benchmarker: ['h2load']
-}, { flags: ['--no-warnings', '--expose-http2'] });
+}, { flags: ['--no-warnings'] });
 
 function main({ requests, streams, clients }) {
   fs.open(file, 'r', (err, fd) => {

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   clients: [1, 2],
   benchmarker: ['h2load']
-}, { flags: ['--no-warnings', '--expose-http2'] });
+}, { flags: ['--no-warnings'] });
 
 function main({ requests, streams, clients }) {
   const http2 = require('http2');

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   size: [100000],
   benchmarker: ['h2load']
-}, { flags: ['--no-warnings', '--expose-http2'] });
+}, { flags: ['--no-warnings'] });
 
 function main({ streams, length, size }) {
   const http2 = require('http2');

--- a/src/node.cc
+++ b/src/node.cc
@@ -3357,7 +3357,6 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--experimental-modules",
     "--experimental-repl-await",
     "--experimental-vm-modules",
-    "--expose-http2",   // keep as a non-op through v9.x
     "--force-fips",
     "--icu-data-dir",
     "--inspect",
@@ -3607,9 +3606,6 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       config_expose_internals = true;
-    } else if (strcmp(arg, "--expose-http2") == 0 ||
-               strcmp(arg, "--expose_http2") == 0) {
-      // Keep as a non-op through v9.x
     } else if (strcmp(arg, "-") == 0) {
       break;
     } else if (strcmp(arg, "--") == 0) {

--- a/test/parallel/test-http2-https-fallback-http-server-options.js
+++ b/test/parallel/test-http2-https-fallback-http-server-options.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
This commit removes the `--expose-http2` option. In the code comment it
states that this should should be noop through v9.x, and it sounds like
it can be removed for 10.x and above.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
