### PR TITLE
test: string to template literals, to include port

### DIFF
--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -9,11 +9,11 @@ if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
   worker1.on('message', function(port1) {
-    assert.strictEqual(port1, port1 | 0, 'first worker could not listen');
+    assert.strictEqual(port1, port1 | 0, `first worker could not listen on port ${port1}`);
     const worker2 = cluster.fork();
 
     worker2.on('message', function(port2) {
-      assert.strictEqual(port2, port2 | 0, 'second worker could not listen');
+      assert.strictEqual(port2, port2 | 0, `second worker could not listen on port ${port2}`);
       assert.notStrictEqual(port1, port2, 'ports should not be equal');
       worker1.kill();
       worker2.kill();
@@ -28,7 +28,7 @@ if (cluster.isMaster) {
 
   server.listen({
     port: 0,
-    exclusive: true
+    exclusive: true,
   }, function() {
     process.send(server.address().port);
   });

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -30,7 +30,7 @@ if (cluster.isMaster) {
 
   server.listen({
     port: 0,
-    exclusive: true,
+    exclusive: true
   }, function() {
     process.send(server.address().port);
   });

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -9,11 +9,13 @@ if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
   worker1.on('message', function(port1) {
-    assert.strictEqual(port1, port1 | 0, `first worker could not listen on port ${port1}`);
+    assert.strictEqual(port1, port1 | 0,
+                       `first worker could not listen on port ${port1}`);
     const worker2 = cluster.fork();
 
     worker2.on('message', function(port2) {
-      assert.strictEqual(port2, port2 | 0, `second worker could not listen on port ${port2}`);
+      assert.strictEqual(port2, port2 | 0,
+                         `second worker could not listen on port ${port2}`);
       assert.notStrictEqual(port1, port2, 'ports should not be equal');
       worker1.kill();
       worker2.kill();


### PR DESCRIPTION
test: string to template literals, to include port

Usage of template literals to include the port if strictEqual fails.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
