### PR TITLE
timers: add hasRef method to Timeout & Immediate

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -23,6 +23,16 @@ running as long as the immediate is active. The `Immediate` object returned by
 [`setImmediate()`][] exports both `immediate.ref()` and `immediate.unref()`
 functions that can be used to control this default behavior.
 
+### immediate.hasRef()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {boolean}
+
+Used to check whether the `Immediate` object will keep the Node.js event loop
+active.
+
 ### immediate.ref()
 <!-- YAML
 added: v9.7.0
@@ -60,6 +70,16 @@ By default, when a timer is scheduled using either [`setTimeout()`][] or
 timer is active. Each of the `Timeout` objects returned by these functions
 export both `timeout.ref()` and `timeout.unref()` functions that can be used to
 control this default behavior.
+
+### timeout.hasRef()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {boolean}
+
+Used to check whether the `Timeout` object will keep the Node.js event loop
+active.
 
 ### timeout.ref()
 <!-- YAML

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -30,8 +30,7 @@ added: REPLACEME
 
 * Returns: {boolean}
 
-Used to check whether the `Immediate` object will keep the Node.js event loop
-active.
+If true, the `Immediate` object will keep the Node.js event loop active.
 
 ### immediate.ref()
 <!-- YAML
@@ -78,8 +77,7 @@ added: REPLACEME
 
 * Returns: {boolean}
 
-Used to check whether the `Timeout` object will keep the Node.js event loop
-active.
+If true, the `Timeout` object will keep the Node.js event loop active.
 
 ### timeout.ref()
 <!-- YAML

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -547,6 +547,10 @@ Timeout.prototype.ref = function() {
   return this;
 };
 
+Timeout.prototype.hasRef = function() {
+  return !!this[kRefed];
+};
+
 Timeout.prototype.close = function() {
   clearTimeout(this);
   return this;
@@ -622,7 +626,7 @@ function processImmediate() {
     count++;
     if (immediate[kRefed])
       refCount++;
-    immediate[kRefed] = undefined;
+    immediate[kRefed] = null;
 
     tryOnImmediate(immediate, tail, count, refCount);
 
@@ -713,6 +717,10 @@ const Immediate = class Immediate {
     }
     return this;
   }
+
+  hasRef() {
+    return !!this[kRefed];
+  }
 };
 
 function setImmediate(callback, arg1, arg2, arg3) {
@@ -761,7 +769,7 @@ exports.clearImmediate = function clearImmediate(immediate) {
 
   if (immediate[kRefed] && --immediateInfo[kRefCount] === 0)
     toggleImmediateRef(false);
-  immediate[kRefed] = undefined;
+  immediate[kRefed] = null;
 
   if (destroyHooksExist()) {
     emitDestroy(immediate[async_id_symbol]);

--- a/test/parallel/test-timers-immediate-unref.js
+++ b/test/parallel/test-timers-immediate-unref.js
@@ -3,6 +3,14 @@
 const common = require('../common');
 const Countdown = require('../common/countdown');
 
+const assert = require('assert');
+
+const immediate = setImmediate(() => {});
+assert(immediate.hasRef());
+immediate.unref();
+assert(!immediate.hasRef());
+clearImmediate(immediate);
+
 // This immediate should execute as it was unrefed and refed again.
 // It also confirms that unref/ref are chainable.
 setImmediate(common.mustCall(firstStep)).ref().unref().unref().ref();

--- a/test/parallel/test-timers-immediate-unref.js
+++ b/test/parallel/test-timers-immediate-unref.js
@@ -6,9 +6,9 @@ const Countdown = require('../common/countdown');
 const assert = require('assert');
 
 const immediate = setImmediate(() => {});
-assert(immediate.hasRef());
+assert.strictEqual(immediate.hasRef(), true);
 immediate.unref();
-assert(!immediate.hasRef());
+assert.strictEqual(immediate.hasRef(), false);
 clearImmediate(immediate);
 
 // This immediate should execute as it was unrefed and refed again.

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -33,10 +33,10 @@ const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
 const timer = setTimeout(() => {}, 10);
-assert(timer.hasRef());
+assert.strictEqual(timer.hasRef(), true);
 // Should not throw.
 timer.unref().ref().unref();
-assert(!timer.hasRef());
+assert.strictEqual(timer.hasRef(), false);
 
 setInterval(() => {}, 10).unref().ref().unref();
 

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -23,6 +23,8 @@
 
 const common = require('../common');
 
+const assert = require('assert');
+
 let unref_interval = false;
 let unref_timer = false;
 let checks = 0;
@@ -30,8 +32,12 @@ let checks = 0;
 const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
+const timer = setTimeout(() => {}, 10);
+assert(timer.hasRef());
 // Should not throw.
-setTimeout(() => {}, 10).unref().ref().unref();
+timer.unref().ref().unref();
+assert(!timer.hasRef());
+
 setInterval(() => {}, 10).unref().ref().unref();
 
 setInterval(common.mustNotCall('Interval should not fire'), LONG_TIME).unref();


### PR DESCRIPTION
Provide a way to check whether the current timer or immediate is refed. This was done as per request from @Fishrock123 due to the removal of _handle from unrefed timers.

The method name was chosen to match what used to be available on the `_handle` — unlike a getter it should also make it clear that it's not possible to change it by trying to assign.

(Since it depends on a `semver-major` PR, I'm labeling this as such too.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
