### PR TITLE
doc: fix incorrect fs.readFileSync example output

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2377,7 +2377,7 @@ fs.readFileSync('<directory>');
 // => [Error: EISDIR: illegal operation on a directory, read <directory>]
 
 //  FreeBSD
-fs.readFileSync('<directory>'); // => null, <data>
+fs.readFileSync('<directory>'); // => <data>
 ```
 
 ## fs.readlink(path[, options], callback)


### PR DESCRIPTION
This fixes an incorrect example in the documentation for calling
`fs.readFileSync` on a directory. The example was presumably copied from
the documentation for `fs.readFile`, which has an error argument in its
callback.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)