### PR TITLE
doc: removed LTS label from v4 in doc version picker

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -345,7 +345,7 @@ function altDocs(filename, docCreated) {
     { num: '7.x' },
     { num: '6.x', lts: true },
     { num: '5.x' },
-    { num: '4.x', lts: true },
+    { num: '4.x' },
     { num: '0.12.x' },
     { num: '0.10.x' }
   ];


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20903

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
