### PR TITLE
events: support `once` with promise

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -419,14 +419,14 @@ myEE.emit('foo');
 //   a
 ```
 
-### emitter.once(eventName, listener)
+### emitter.once(eventName[, listener])
 <!-- YAML
 added: v0.3.0
 -->
 
 * `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
-* Returns: {EventEmitter}
+* Returns: {EventEmitter|Promise}
 
 Adds a **one-time** `listener` function for the event named `eventName`. The
 next time `eventName` is triggered, this listener is removed and then invoked.
@@ -438,6 +438,16 @@ server.once('connection', (stream) => {
 ```
 
 Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+If a listener function isn't passed - returns a `Promise` for the event happening:
+
+```js
+(async () => {
+  console.log('connecting');
+  const stream = await server.once('connection');
+  console.log('connected');
+})();
+```
 
 By default, event listeners are invoked in the order they are added. The
 `emitter.prependOnceListener()` method can be used as an alternative to add the

--- a/lib/events.js
+++ b/lib/events.js
@@ -284,8 +284,8 @@ function _onceWrap(target, type, listener) {
 
 EventEmitter.prototype.once = function once(type, listener) {
   if (typeof listener !== 'function') {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
+    return new Promise((resolve) =>
+      this.on(type, _onceWrap(this, type, resolve)));
   }
   this.on(type, _onceWrap(this, type, listener));
   return this;

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -26,6 +26,8 @@ const EventEmitter = require('events');
 
 const e = new EventEmitter();
 
+common.crashOnUnhandledRejection();
+
 e.once('hello', common.mustCall());
 
 e.emit('hello', 'a', 'b');
@@ -78,4 +80,15 @@ common.expectsError(() => {
 
     EventEmitter.prototype.emit.apply(ee, args);
   }
+}
+
+{
+  // verify the promise returning version of `once`
+  async function doTest() {
+    const ee = new EventEmitter();
+    setTimeout(() => ee.emit('hello'), 0);
+    await ee.once('hello');
+  }
+
+  doTest().then(common.mustCall());
 }


### PR DESCRIPTION
This commit introduces a `once` overload which returns a promise if a listener isn't passed to `once`.

This is a pretty common feature request and was constantly brought up when I asked users how we can improve our experience with event emitters for people using async/await.

I have decided to not add a new method but instead overload `.once` because it was safe to do so given the current behavior. Alternatives for this include adding a `oncePromise` method.

Ref: https://github.com/nodejs/node/issues/20893

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
