### PR TITLE
test: remove message argument from strictEqual()

### DIFF
--- a/test/parallel/test-require-process.js
+++ b/test/parallel/test-require-process.js
@@ -3,5 +3,5 @@ require('../common');
 const assert = require('assert');
 
 const nativeProcess = require('process');
-assert.strictEqual(nativeProcess, process,
-                   'require("process") should return global process reference');
+// require('process') should return global process reference
+assert.strictEqual(nativeProcess, process);


### PR DESCRIPTION
In `test/parallel/test-require-process.js`, the last thing in the test is
a call to `assert.strictEqual()`. It has a string literal as its third
argument. Unfortunately, that means that the diff between the two values
being compared will be suppressed if there is an `AssertionError`. That's
not helpful for debugging.

This is fixed by removing the third argument from the call. It is,
however, preserved in a comment above the call to `assert.strictEqual()`.

This issue was provided by @Trott of [nodetodo.org](https://www.nodetodo.org/getting-started). Gratitude! 🙏

Fixes: https://github.com/nodejs/node/issues/20911
Refs: https://www.nodetodo.org/getting-started

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
