### PR TITLE
src: add new CHECK macros

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -310,7 +310,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     }
   }
 
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   if (type == PromiseHookType::kBefore) {
     env->async_hooks()->push_async_ids(
       wrap->get_async_id(), wrap->get_trigger_async_id());

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -45,9 +45,7 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
     async_context_(asyncContext),
     object_(object),
     callback_scope_(env) {
-  if (expect == kRequireResource) {
-    CHECK(!object.IsEmpty());
-  }
+  CHECK_IMPLIES(expect == kRequireResource, !object.IsEmpty());
 
   if (!env->can_call_into_js()) {
     failed_ = true;

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -34,7 +34,7 @@ template <typename WrapType, typename UVType>
 void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
                                                     int status) {
   WrapType* wrap_data = static_cast<WrapType*>(handle->data);
-  CHECK_NE(wrap_data, nullptr);
+  CHECK_NOT_NULL(wrap_data);
   CHECK_EQ(&wrap_data->handle_, reinterpret_cast<UVType*>(handle));
 
   Environment* env = wrap_data->env();
@@ -78,7 +78,7 @@ template <typename WrapType, typename UVType>
 void ConnectionWrap<WrapType, UVType>::AfterConnect(uv_connect_t* req,
                                                     int status) {
   ConnectWrap* req_wrap = static_cast<ConnectWrap*>(req->data);
-  CHECK_NE(req_wrap, nullptr);
+  CHECK_NOT_NULL(req_wrap);
   WrapType* wrap = static_cast<WrapType*>(req->handle->data);
   CHECK_EQ(req_wrap->env(), wrap->env());
   Environment* env = wrap->env();

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -473,22 +473,22 @@ inline double Environment::get_default_trigger_async_id() {
 }
 
 inline double* Environment::heap_statistics_buffer() const {
-  CHECK_NE(heap_statistics_buffer_, nullptr);
+  CHECK_NOT_NULL(heap_statistics_buffer_);
   return heap_statistics_buffer_;
 }
 
 inline void Environment::set_heap_statistics_buffer(double* pointer) {
-  CHECK_EQ(heap_statistics_buffer_, nullptr);  // Should be set only once.
+  CHECK_NULL(heap_statistics_buffer_);  // Should be set only once.
   heap_statistics_buffer_ = pointer;
 }
 
 inline double* Environment::heap_space_statistics_buffer() const {
-  CHECK_NE(heap_space_statistics_buffer_, nullptr);
+  CHECK_NOT_NULL(heap_space_statistics_buffer_);
   return heap_space_statistics_buffer_;
 }
 
 inline void Environment::set_heap_space_statistics_buffer(double* pointer) {
-  CHECK_EQ(heap_space_statistics_buffer_, nullptr);  // Should be set only once.
+  CHECK_NULL(heap_space_statistics_buffer_);  // Should be set only once.
   heap_space_statistics_buffer_ = pointer;
 }
 
@@ -497,7 +497,7 @@ inline char* Environment::http_parser_buffer() const {
 }
 
 inline void Environment::set_http_parser_buffer(char* buffer) {
-  CHECK_EQ(http_parser_buffer_, nullptr);  // Should be set only once.
+  CHECK_NULL(http_parser_buffer_);  // Should be set only once.
   http_parser_buffer_ = buffer;
 }
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -80,7 +80,7 @@ IsolateData::~IsolateData() {
 v8::CpuProfiler* IsolateData::GetCpuProfiler() {
   if (cpu_profiler_ != nullptr) return cpu_profiler_;
   cpu_profiler_ = v8::CpuProfiler::New(isolate());
-  CHECK_NE(cpu_profiler_, nullptr);
+  CHECK_NOT_NULL(cpu_profiler_);
   return cpu_profiler_;
 }
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -88,7 +88,7 @@ FSEventWrap::~FSEventWrap() {
 
 void FSEventWrap::GetInitialized(const FunctionCallbackInfo<Value>& args) {
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
-  CHECK(wrap != nullptr);
+  CHECK_NOT_NULL(wrap);
   args.GetReturnValue().Set(wrap->initialized_);
 }
 
@@ -133,14 +133,14 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   CHECK(!wrap->initialized_);
 
   const int argc = args.Length();
   CHECK_GE(argc, 4);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   unsigned int flags = 0;
   if (args[2]->IsTrue())
@@ -233,7 +233,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 
 void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   CHECK(wrap->initialized_);
 
   wrap->initialized_ = false;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -317,7 +317,7 @@ class InspectorTimerHandle {
   InspectorTimerHandle(const InspectorTimerHandle&) = delete;
 
   ~InspectorTimerHandle() {
-    CHECK_NE(timer_, nullptr);
+    CHECK_NOT_NULL(timer_);
     timer_->Stop();
     timer_ = nullptr;
   }
@@ -562,7 +562,7 @@ bool Agent::StartIoThread(bool wait_for_connect) {
   if (io_ != nullptr)
     return true;
 
-  CHECK_NE(client_, nullptr);
+  CHECK_NOT_NULL(client_);
 
   io_ = std::unique_ptr<InspectorIo>(
       new InspectorIo(parent_env_, platform_, path_, debug_options_,
@@ -613,7 +613,7 @@ std::unique_ptr<InspectorSession> Agent::Connect(
 }
 
 void Agent::WaitForDisconnect() {
-  CHECK_NE(client_, nullptr);
+  CHECK_NOT_NULL(client_);
   // TODO(addaleax): Maybe this should use an at-exit hook for the Environment
   // or something similar?
   client_->contextDestroyed(parent_env_->context());

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -197,7 +197,7 @@ bool InspectorIo::Start() {
 }
 
 void InspectorIo::Stop() {
-  CHECK(state_ == State::kAccepting || !sessions_.empty());
+  CHECK_IMPLIES(sessions_.empty(), state_ == State::kAccepting);
   Write(TransportAction::kKill, 0, StringView());
   int err = uv_thread_join(&thread_);
   CHECK_EQ(err, 0);

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -34,7 +34,7 @@ std::string ScriptPath(uv_loop_t* loop, const std::string& script_name) {
     uv_fs_t req;
     req.ptr = nullptr;
     if (0 == uv_fs_realpath(loop, &req, script_name.c_str(), nullptr)) {
-      CHECK_NE(req.ptr, nullptr);
+      CHECK_NOT_NULL(req.ptr);
       script_path = std::string(static_cast<char*>(req.ptr));
     }
     uv_fs_req_cleanup(&req);

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -599,7 +599,7 @@ class HttpHandler : public ProtocolHandler {
 ProtocolHandler::ProtocolHandler(InspectorSocket* inspector,
                                  TcpHolder::Pointer tcp)
                                  : inspector_(inspector), tcp_(std::move(tcp)) {
-  CHECK_NE(nullptr, tcp_);
+  CHECK_NOT_NULL(tcp_);
   tcp_->SetHandler(this);
 }
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -104,7 +104,7 @@ int JSStream::DoWrite(WriteWrap* w,
                       uv_buf_t* bufs,
                       size_t count,
                       uv_stream_t* send_handle) {
-  CHECK_EQ(send_handle, nullptr);
+  CHECK_NULL(send_handle);
 
   HandleScope scope(env()->isolate());
   Context::Scope context_scope(env()->context());

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -106,7 +106,7 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
       ContextifyContext* sandbox =
           ContextifyContext::ContextFromContextifiedSandbox(
               env, args[2].As<Object>());
-      CHECK_NE(sandbox, nullptr);
+      CHECK_NOT_NULL(sandbox);
       context = sandbox->context();
     }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1964,7 +1964,7 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   auto context = env->context();
 
-  CHECK_EQ(modpending, nullptr);
+  CHECK_NULL(modpending);
 
   if (args.Length() < 2) {
     env->ThrowError("process.dlopen needs at least 2 arguments.");
@@ -2231,8 +2231,8 @@ static Local<Object> InitModule(Environment* env,
                                  Local<String> module) {
   Local<Object> exports = Object::New(env->isolate());
   // Internal bindings don't have a "module" object, only exports.
-  CHECK_EQ(mod->nm_register_func, nullptr);
-  CHECK_NE(mod->nm_context_register_func, nullptr);
+  CHECK_NULL(mod->nm_register_func);
+  CHECK_NOT_NULL(mod->nm_context_register_func);
   Local<Value> unused = Undefined(env->isolate());
   mod->nm_context_register_func(exports,
                                 unused,
@@ -4078,7 +4078,7 @@ void AtExit(void (*cb)(void* arg), void* arg) {
 
 
 void AtExit(Environment* env, void (*cb)(void* arg), void* arg) {
-  CHECK_NE(env, nullptr);
+  CHECK_NOT_NULL(env);
   env->AtExit(cb, arg);
 }
 
@@ -4339,7 +4339,7 @@ inline int Start(uv_loop_t* event_loop,
 
   {
     Mutex::ScopedLock scoped_lock(node_isolate_mutex);
-    CHECK_EQ(node_isolate, nullptr);
+    CHECK_NULL(node_isolate);
     node_isolate = isolate;
   }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -140,7 +140,7 @@ CallbackInfo::CallbackInfo(Isolate* isolate,
   ArrayBuffer::Contents obj_c = object->GetContents();
   CHECK_EQ(data_, static_cast<char*>(obj_c.Data()));
   if (object->ByteLength() != 0)
-    CHECK_NE(data_, nullptr);
+    CHECK_NOT_NULL(data_);
 
   persistent_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
   persistent_.SetWrapperClassId(BUFFER_ID);
@@ -329,7 +329,7 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
 
   void* new_data;
   if (length > 0) {
-    CHECK_NE(data, nullptr);
+    CHECK_NOT_NULL(data);
     new_data = node::UncheckedMalloc(length);
     if (new_data == nullptr)
       return Local<Object>();
@@ -408,7 +408,7 @@ MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
 
 MaybeLocal<Object> New(Environment* env, char* data, size_t length) {
   if (length > 0) {
-    CHECK_NE(data, nullptr);
+    CHECK_NOT_NULL(data);
     CHECK(length <= kMaxLength);
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -655,7 +655,7 @@ class ContextifyScript : public BaseObject {
         ContextifyContext* sandbox =
             ContextifyContext::ContextFromContextifiedSandbox(
                 env, args[6].As<Object>());
-        CHECK_NE(sandbox, nullptr);
+        CHECK_NOT_NULL(sandbox);
         parsing_context = sandbox->context();
       }
     } else {
@@ -785,7 +785,7 @@ class ContextifyScript : public BaseObject {
     // Get the context from the sandbox
     ContextifyContext* contextify_context =
         ContextifyContext::ContextFromContextifiedSandbox(env, sandbox);
-    CHECK_NE(contextify_context, nullptr);
+    CHECK_NOT_NULL(contextify_context);
 
     if (contextify_context->context().IsEmpty())
       return;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -731,7 +731,7 @@ static X509_STORE* NewRootCertStore() {
       BIO_free(bp);
 
       // Parse errors from the built-in roots are fatal.
-      CHECK_NE(x509, nullptr);
+      CHECK_NOT_NULL(x509);
 
       root_certs_vector.push_back(x509);
     }
@@ -1579,7 +1579,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     int rv;
 
     ext = X509_get_ext(cert, index);
-    CHECK_NE(ext, nullptr);
+    CHECK_NOT_NULL(ext);
 
     if (!SafeX509ExtPrint(bio.get(), ext)) {
       rv = X509V3_EXT_print(bio.get(), ext, 0, 0);
@@ -3382,7 +3382,7 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
 
 
 SignBase::Error SignBase::Init(const char* sign_type) {
-  CHECK_EQ(mdctx_, nullptr);
+  CHECK_NULL(mdctx_);
   // Historically, "dss1" and "DSS1" were DSA aliases for SHA-1
   // exposed through the public API.
   if (strcmp(sign_type, "dss1") == 0 ||
@@ -4237,7 +4237,7 @@ void DiffieHellman::SetKey(const v8::FunctionCallbackInfo<v8::Value>& args,
   BIGNUM* num =
       BN_bin2bn(reinterpret_cast<unsigned char*>(Buffer::Data(args[0])),
                 Buffer::Length(args[0]), nullptr);
-  CHECK_NE(num, nullptr);
+  CHECK_NOT_NULL(num);
   CHECK_EQ(1, set_field(dh->dh_.get(), num));
 }
 
@@ -4495,7 +4495,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   USE(&mark_pop_error_on_return);
 
   const BIGNUM* priv_key = EC_KEY_get0_private_key(ecdh->key_.get());
-  CHECK_NE(priv_key, nullptr);
+  CHECK_NOT_NULL(priv_key);
 
   ECPointPointer pub(EC_POINT_new(ecdh->group_));
   CHECK(pub);
@@ -5006,7 +5006,7 @@ void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(verify_result);
 
   char* data = Buffer::Data(args[0]);
-  CHECK_NE(data, nullptr);
+  CHECK_NOT_NULL(data);
 
   verify_result = VerifySpkac(data, length);
 
@@ -5051,7 +5051,7 @@ void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().SetEmptyString();
 
   char* data = Buffer::Data(args[0]);
-  CHECK_NE(data, nullptr);
+  CHECK_NOT_NULL(data);
 
   size_t pkey_size;
   char* pkey = ExportPublicKey(data, length, &pkey_size);
@@ -5083,7 +5083,7 @@ void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().SetEmptyString();
 
   char* data = Buffer::Data(args[0]);
-  CHECK_NE(data, nullptr);
+  CHECK_NOT_NULL(data);
 
   OpenSSLBuffer cert = ExportChallenge(data, len);
   if (!cert)

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -630,7 +630,7 @@ class ECDH : public BaseObject {
         key_(std::move(key)),
         group_(EC_KEY_get0_group(key_.get())) {
     MakeWeak();
-    CHECK_NE(group_, nullptr);
+    CHECK_NOT_NULL(group_);
   }
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -518,7 +518,7 @@ NodeBIO::~NodeBIO() {
 
 
 NodeBIO* NodeBIO::FromBIO(BIO* bio) {
-  CHECK_NE(BIO_get_data(bio), nullptr);
+  CHECK_NOT_NULL(BIO_get_data(bio));
   return static_cast<NodeBIO*>(BIO_get_data(bio));
 }
 

--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -65,7 +65,7 @@ inline void ClientHelloParser::Start(ClientHelloParser::OnHelloCb onhello_cb,
     return;
   Reset();
 
-  CHECK_NE(onhello_cb, nullptr);
+  CHECK_NOT_NULL(onhello_cb);
 
   state_ = kWaiting;
   onhello_cb_ = onhello_cb;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -223,7 +223,7 @@ inline MaybeLocal<Promise> FileHandle::ClosePromise() {
     CloseReq* req = new CloseReq(env(), promise, object());
     auto AfterClose = uv_fs_callback_t{[](uv_fs_t* req) {
       CloseReq* close = static_cast<CloseReq*>(req->data);
-      CHECK_NE(close, nullptr);
+      CHECK_NOT_NULL(close);
       close->file_handle()->AfterClose();
       Isolate* isolate = close->env()->isolate();
       if (req->result < 0) {
@@ -619,7 +619,7 @@ inline FSReqBase* AsyncDestCall(Environment* env,
     const FunctionCallbackInfo<Value>& args,
     const char* syscall, const char* dest, size_t len,
     enum encoding enc, uv_fs_cb after, Func fn, Args... fn_args) {
-  CHECK_NE(req_wrap, nullptr);
+  CHECK_NOT_NULL(req_wrap);
   req_wrap->Init(syscall, dest, len, enc);
   int err = req_wrap->Dispatch(fn, fn_args..., after);
   if (err < 0) {
@@ -690,7 +690,7 @@ void Access(const FunctionCallbackInfo<Value>& args) {
   int mode = args[1].As<Int32>()->Value();
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
   if (req_wrap_async != nullptr) {  // access(path, mode, req)
@@ -823,7 +823,7 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
   if (req_wrap_async != nullptr) {  // stat(path, req)
@@ -852,7 +852,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
   if (req_wrap_async != nullptr) {  // lstat(path, req)
@@ -911,9 +911,9 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 4);
 
   BufferValue target(env->isolate(), args[0]);
-  CHECK_NE(*target, nullptr);
+  CHECK_NOT_NULL(*target);
   BufferValue path(env->isolate(), args[1]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[2]->IsInt32());
   int flags = args[2].As<Int32>()->Value();
@@ -939,10 +939,10 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue src(env->isolate(), args[0]);
-  CHECK_NE(*src, nullptr);
+  CHECK_NOT_NULL(*src);
 
   BufferValue dest(env->isolate(), args[1]);
-  CHECK_NE(*dest, nullptr);
+  CHECK_NOT_NULL(*dest);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
   if (req_wrap_async != nullptr) {  // link(src, dest, req)
@@ -965,7 +965,7 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
@@ -1007,9 +1007,9 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue old_path(env->isolate(), args[0]);
-  CHECK_NE(*old_path, nullptr);
+  CHECK_NOT_NULL(*old_path);
   BufferValue new_path(env->isolate(), args[1]);
-  CHECK_NE(*new_path, nullptr);
+  CHECK_NOT_NULL(*new_path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[2]);
   if (req_wrap_async != nullptr) {
@@ -1103,7 +1103,7 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);
   if (req_wrap_async != nullptr) {
@@ -1125,7 +1125,7 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[1]);  // rmdir(path, req)
   if (req_wrap_async != nullptr) {
@@ -1148,7 +1148,7 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsInt32());
   const int mode = args[1].As<Int32>()->Value();
@@ -1174,7 +1174,7 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
@@ -1217,7 +1217,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
@@ -1299,7 +1299,7 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsInt32());
   const int flags = args[1].As<Int32>()->Value();
@@ -1329,7 +1329,7 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsInt32());
   const int flags = args[1].As<Int32>()->Value();
@@ -1364,10 +1364,10 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue src(env->isolate(), args[0]);
-  CHECK_NE(*src, nullptr);
+  CHECK_NOT_NULL(*src);
 
   BufferValue dest(env->isolate(), args[1]);
-  CHECK_NE(*dest, nullptr);
+  CHECK_NOT_NULL(*dest);
 
   CHECK(args[2]->IsInt32());
   const int flags = args[2].As<Int32>()->Value();
@@ -1536,7 +1536,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (is_async) {  // write(fd, string, pos, enc, req)
-    CHECK_NE(req_wrap_async, nullptr);
+    CHECK_NOT_NULL(req_wrap_async);
     len = StringBytes::StorageSize(env->isolate(), value, enc);
     FSReqBase::FSReqBuffer& stack_buffer =
         req_wrap_async->Init("write", len, enc);
@@ -1646,7 +1646,7 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsInt32());
   int mode = args[1].As<Int32>()->Value();
@@ -1706,7 +1706,7 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsUint32());
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Uint32>()->Value());
@@ -1769,7 +1769,7 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   BufferValue path(env->isolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsNumber());
   const double atime = args[1].As<Number>()->Value();
@@ -1827,7 +1827,7 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue tmpl(env->isolate(), args[0]);
-  CHECK_NE(*tmpl, nullptr);
+  CHECK_NOT_NULL(*tmpl);
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -36,7 +36,7 @@ inline Http2Stream* GetStream(Http2Session* session,
   Http2Stream* stream = static_cast<Http2Stream*>(source->ptr);
   if (stream == nullptr)
     stream = session->FindStream(id);
-  CHECK_NE(stream, nullptr);
+  CHECK_NOT_NULL(stream);
   CHECK_EQ(id, stream->id());
   return stream;
 }
@@ -778,7 +778,7 @@ int Http2Session::OnHeaderCallback(nghttp2_session* handle,
   Http2Session* session = static_cast<Http2Session*>(user_data);
   int32_t id = GetFrameID(frame);
   Http2Stream* stream = session->FindStream(id);
-  CHECK_NE(stream, nullptr);
+  CHECK_NOT_NULL(stream);
   // If the stream has already been destroyed, ignore.
   if (!stream->IsDestroyed() && !stream->AddHeader(name, value, flags)) {
     // This will only happen if the connected peer sends us more
@@ -1570,7 +1570,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   HandleScope handle_scope(env()->isolate());
   Context::Scope context_scope(env()->context());
   Http2Scope h2scope(this);
-  CHECK_NE(stream_, nullptr);
+  CHECK_NOT_NULL(stream_);
   DEBUG_HTTP2SESSION2(this, "receiving %d bytes", nread);
   IncrementCurrentSessionMemory(buf.len);
   CHECK(stream_buf_ab_.IsEmpty());
@@ -1584,7 +1584,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
     // Only pass data on if nread > 0
 
     // Makre sure that there was no read previously active.
-    CHECK_EQ(stream_buf_.base, nullptr);
+    CHECK_NULL(stream_buf_.base);
     CHECK_EQ(stream_buf_.len, 0);
 
     // Remember the current buffer, so that OnDataChunkReceived knows the
@@ -1932,7 +1932,7 @@ int Http2Stream::DoWrite(WriteWrap* req_wrap,
                          size_t nbufs,
                          uv_stream_t* send_handle) {
   CHECK(!this->IsDestroyed());
-  CHECK_EQ(send_handle, nullptr);
+  CHECK_NULL(send_handle);
   Http2Scope h2scope(this);
   if (!IsWritable()) {
     req_wrap->Done(UV_EOF);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -406,7 +406,7 @@ class Parser : public AsyncWrap, public StreamListener {
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
     CHECK(parser->current_buffer_.IsEmpty());
     CHECK_EQ(parser->current_buffer_len_, 0);
-    CHECK_EQ(parser->current_buffer_data_, nullptr);
+    CHECK_NULL(parser->current_buffer_data_);
     CHECK_EQ(Buffer::HasInstance(args[0]), true);
 
     Local<Object> buffer_obj = args[0].As<Object>();
@@ -487,7 +487,7 @@ class Parser : public AsyncWrap, public StreamListener {
     CHECK(args[0]->IsExternal());
     Local<External> stream_obj = args[0].As<External>();
     StreamBase* stream = static_cast<StreamBase*>(stream_obj->Value());
-    CHECK_NE(stream, nullptr);
+    CHECK_NOT_NULL(stream);
     stream->PushStreamListener(parser);
   }
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -127,7 +127,7 @@ struct Converter {
 
   explicit Converter(UConverter* converter,
                      const char* sub = nullptr) : conv(converter) {
-    CHECK_NE(conv, nullptr);
+    CHECK_NOT_NULL(conv);
     UErrorCode status = U_ZERO_ERROR;
     if (sub != nullptr) {
       ucnv_setSubstChars(conv, sub, strlen(sub), &status);

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -125,7 +125,7 @@ bool StatWatcher::IsActive() {
 
 void StatWatcher::IsActive(const v8::FunctionCallbackInfo<v8::Value>& args) {
   StatWatcher* wrap = Unwrap<StatWatcher>(args.This());
-  CHECK(wrap != nullptr);
+  CHECK_NOT_NULL(wrap);
   args.GetReturnValue().Set(wrap->IsActive());
 }
 
@@ -134,7 +134,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 3);
 
   StatWatcher* wrap = Unwrap<StatWatcher>(args.Holder());
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   if (wrap->IsActive()) {
     return;
   }
@@ -143,7 +143,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 3);
 
   node::Utf8Value path(args.GetIsolate(), args[0]);
-  CHECK_NE(*path, nullptr);
+  CHECK_NOT_NULL(*path);
 
   bool persistent = true;
   if (args[1]->IsFalse()) {
@@ -171,7 +171,7 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
 
 void StatWatcher::Stop(const FunctionCallbackInfo<Value>& args) {
   StatWatcher* wrap = Unwrap<StatWatcher>(args.Holder());
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   if (!wrap->IsActive()) {
     return;
   }

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -49,7 +49,7 @@ void NodeCategorySet::New(const FunctionCallbackInfo<Value>& args) {
     Utf8Value val(env->isolate(), category);
     categories.emplace(*val);
   }
-  CHECK_NE(env->tracing_agent(), nullptr);
+  CHECK_NOT_NULL(env->tracing_agent());
   new NodeCategorySet(env, args.This(), categories);
 }
 
@@ -57,7 +57,7 @@ void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   NodeCategorySet* category_set;
   ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
-  CHECK_NE(category_set, nullptr);
+  CHECK_NOT_NULL(category_set);
   const auto& categories = category_set->GetCategories();
   if (!category_set->enabled_ && !categories.empty()) {
     env->tracing_agent()->Enable(categories);
@@ -69,7 +69,7 @@ void NodeCategorySet::Disable(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   NodeCategorySet* category_set;
   ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
-  CHECK_NE(category_set, nullptr);
+  CHECK_NOT_NULL(category_set);
   const auto& categories = category_set->GetCategories();
   if (category_set->enabled_ && !categories.empty()) {
     env->tracing_agent()->Disable(categories);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -126,7 +126,7 @@ class ProcessWrap : public HandleWrap {
         Local<Object> handle =
             stdio->Get(context, handle_key).ToLocalChecked().As<Object>();
         uv_stream_t* stream = HandleToStream(env, handle);
-        CHECK_NE(stream, nullptr);
+        CHECK_NOT_NULL(stream);
 
         options->stdio[i].flags = UV_INHERIT_STREAM;
         options->stdio[i].data.stream = stream;
@@ -197,7 +197,7 @@ class ProcessWrap : public HandleWrap {
         node::Utf8Value arg(env->isolate(),
                             js_argv->Get(context, i).ToLocalChecked());
         options.args[i] = strdup(*arg);
-        CHECK_NE(options.args[i], nullptr);
+        CHECK_NOT_NULL(options.args[i]);
       }
       options.args[argc] = nullptr;
     }
@@ -223,7 +223,7 @@ class ProcessWrap : public HandleWrap {
         node::Utf8Value pair(env->isolate(),
                              env_opt->Get(context, i).ToLocalChecked());
         options.env[i] = strdup(*pair);
-        CHECK_NE(options.env[i], nullptr);
+        CHECK_NOT_NULL(options.env[i]);
       }
       options.env[envc] = nullptr;
     }
@@ -294,7 +294,7 @@ class ProcessWrap : public HandleWrap {
                      int64_t exit_status,
                      int term_signal) {
     ProcessWrap* wrap = static_cast<ProcessWrap*>(handle->data);
-    CHECK_NE(wrap, nullptr);
+    CHECK_NOT_NULL(wrap);
     CHECK_EQ(&wrap->process_, handle);
 
     Environment* env = wrap->env();

--- a/src/req_wrap-inl.h
+++ b/src/req_wrap-inl.h
@@ -123,7 +123,7 @@ struct MakeLibuvRequestCallback<ReqT, void(*)(ReqT*, Args...)> {
   }
 
   static F For(ReqWrap<ReqT>* req_wrap, F v) {
-    CHECK_EQ(req_wrap->original_callback_, nullptr);
+    CHECK_NULL(req_wrap->original_callback_);
     req_wrap->original_callback_ =
         reinterpret_cast<typename ReqWrap<ReqT>::callback_t>(v);
     return Wrapper;

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -149,7 +149,7 @@ int SyncProcessStdioPipe::Start() {
 
   if (readable()) {
     if (input_buffer_.len > 0) {
-      CHECK_NE(input_buffer_.base, nullptr);
+      CHECK_NOT_NULL(input_buffer_.base);
 
       int r = uv_write(&write_req_,
                        uv_stream(),
@@ -547,7 +547,7 @@ void SyncProcessRunner::CloseStdioPipes() {
 
   if (stdio_pipes_initialized_) {
     CHECK(stdio_pipes_);
-    CHECK_NE(uv_loop_, nullptr);
+    CHECK_NOT_NULL(uv_loop_);
 
     for (uint32_t i = 0; i < stdio_count_; i++) {
       if (stdio_pipes_[i])
@@ -564,7 +564,7 @@ void SyncProcessRunner::CloseKillTimer() {
 
   if (kill_timer_initialized_) {
     CHECK_GT(timeout_, 0);
-    CHECK_NE(uv_loop_, nullptr);
+    CHECK_NOT_NULL(uv_loop_);
 
     uv_handle_t* uv_timer_handle = reinterpret_cast<uv_handle_t*>(&uv_timer_);
     uv_ref(uv_timer_handle);

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -51,17 +51,17 @@ inline StreamListener::~StreamListener() {
 }
 
 inline void StreamListener::PassReadErrorToPreviousListener(ssize_t nread) {
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   previous_listener_->OnStreamRead(nread, uv_buf_init(nullptr, 0));
 }
 
 inline void StreamListener::OnStreamAfterShutdown(ShutdownWrap* w, int status) {
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   previous_listener_->OnStreamAfterShutdown(w, status);
 }
 
 inline void StreamListener::OnStreamAfterWrite(WriteWrap* w, int status) {
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   previous_listener_->OnStreamAfterWrite(w, status);
 }
 
@@ -79,8 +79,8 @@ inline StreamResource::~StreamResource() {
 }
 
 inline void StreamResource::PushStreamListener(StreamListener* listener) {
-  CHECK_NE(listener, nullptr);
-  CHECK_EQ(listener->stream_, nullptr);
+  CHECK_NOT_NULL(listener);
+  CHECK_NULL(listener->stream_);
 
   listener->previous_listener_ = listener_;
   listener->stream_ = this;
@@ -89,7 +89,7 @@ inline void StreamResource::PushStreamListener(StreamListener* listener) {
 }
 
 inline void StreamResource::RemoveStreamListener(StreamListener* listener) {
-  CHECK_NE(listener, nullptr);
+  CHECK_NOT_NULL(listener);
 
   StreamListener* previous;
   StreamListener* current;
@@ -98,7 +98,7 @@ inline void StreamResource::RemoveStreamListener(StreamListener* listener) {
   for (current = listener_, previous = nullptr;
        /* No loop condition because we want a crash if listener is not found */
        ; previous = current, current = current->previous_listener_) {
-    CHECK_NE(current, nullptr);
+    CHECK_NOT_NULL(current);
     if (current == listener) {
       if (previous != nullptr)
         previous->previous_listener_ = current->previous_listener_;
@@ -415,7 +415,7 @@ inline void ShutdownWrap::OnDone(int status) {
 }
 
 inline void WriteWrap::SetAllocatedStorage(char* data, size_t size) {
-  CHECK_EQ(storage_, nullptr);
+  CHECK_NULL(storage_);
   storage_ = data;
   storage_size_ = size;
 }

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -318,7 +318,7 @@ void StreamBase::CallJSOnreadMethod(ssize_t nread, Local<Object> buf) {
     argv[1] = Undefined(env->isolate());
 
   AsyncWrap* wrap = GetAsyncWrap();
-  CHECK_NE(wrap, nullptr);
+  CHECK_NOT_NULL(wrap);
   wrap->MakeCallback(env->onread_string(), arraysize(argv), argv);
 }
 
@@ -360,7 +360,7 @@ uv_buf_t StreamListener::OnStreamAlloc(size_t suggested_size) {
 
 
 void EmitToJSStreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
-  CHECK_NE(stream_, nullptr);
+  CHECK_NOT_NULL(stream_);
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
   HandleScope handle_scope(env->isolate());

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -19,8 +19,8 @@ StreamPipe::StreamPipe(StreamBase* source,
     : AsyncWrap(source->stream_env(), obj, AsyncWrap::PROVIDER_STREAMPIPE) {
   MakeWeak();
 
-  CHECK_NE(sink, nullptr);
-  CHECK_NE(source, nullptr);
+  CHECK_NOT_NULL(sink);
+  CHECK_NOT_NULL(source);
 
   source->PushStreamListener(&readable_listener_);
   sink->PushStreamListener(&writable_listener_);
@@ -120,7 +120,7 @@ void StreamPipe::ReadableListener::OnStreamRead(ssize_t nread,
     free(buf.base);
     pipe->is_eof_ = true;
     stream()->ReadStop();
-    CHECK_NE(previous_listener_, nullptr);
+    CHECK_NOT_NULL(previous_listener_);
     previous_listener_->OnStreamRead(nread, uv_buf_init(nullptr, 0));
     // If we’re not writing, close now. Otherwise, we’ll do that in
     // `OnStreamAfterWrite()`.
@@ -164,7 +164,7 @@ void StreamPipe::WritableListener::OnStreamAfterWrite(WriteWrap* w,
   }
 
   if (status != 0) {
-    CHECK_NE(previous_listener_, nullptr);
+    CHECK_NOT_NULL(previous_listener_);
     StreamListener* prev = previous_listener_;
     pipe->Unpipe();
     prev->OnStreamAfterWrite(w, status);
@@ -175,7 +175,7 @@ void StreamPipe::WritableListener::OnStreamAfterWrite(WriteWrap* w,
 void StreamPipe::WritableListener::OnStreamAfterShutdown(ShutdownWrap* w,
                                                          int status) {
   StreamPipe* pipe = ContainerOf(&StreamPipe::writable_listener_, this);
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   StreamListener* prev = previous_listener_;
   pipe->Unpipe();
   prev->OnStreamAfterShutdown(w, status);
@@ -205,13 +205,13 @@ void StreamPipe::WritableListener::OnStreamWantsWrite(size_t suggested_size) {
 }
 
 uv_buf_t StreamPipe::WritableListener::OnStreamAlloc(size_t suggested_size) {
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   return previous_listener_->OnStreamAlloc(suggested_size);
 }
 
 void StreamPipe::WritableListener::OnStreamRead(ssize_t nread,
                                                 const uv_buf_t& buf) {
-  CHECK_NE(previous_listener_, nullptr);
+  CHECK_NOT_NULL(previous_listener_);
   return previous_listener_->OnStreamRead(nread, buf);
 }
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -287,7 +287,7 @@ int LibuvStreamWrap::DoShutdown(ShutdownWrap* req_wrap_) {
 void LibuvStreamWrap::AfterUvShutdown(uv_shutdown_t* req, int status) {
   LibuvShutdownWrap* req_wrap = static_cast<LibuvShutdownWrap*>(
       LibuvShutdownWrap::from_req(req));
-  CHECK_NE(req_wrap, nullptr);
+  CHECK_NOT_NULL(req_wrap);
   HandleScope scope(req_wrap->env()->isolate());
   Context::Scope context_scope(req_wrap->env()->context());
   req_wrap->Done(status);
@@ -367,7 +367,7 @@ int LibuvStreamWrap::DoWrite(WriteWrap* req_wrap,
 void LibuvStreamWrap::AfterUvWrite(uv_write_t* req, int status) {
   LibuvWriteWrap* req_wrap = static_cast<LibuvWriteWrap*>(
       LibuvWriteWrap::from_req(req));
-  CHECK_NE(req_wrap, nullptr);
+  CHECK_NOT_NULL(req_wrap);
   HandleScope scope(req_wrap->env()->isolate());
   Context::Scope context_scope(req_wrap->env()->context());
   req_wrap->Done(status);

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -266,7 +266,7 @@ namespace {
 void DecodeData(const FunctionCallbackInfo<Value>& args) {
   StringDecoder* decoder =
       reinterpret_cast<StringDecoder*>(Buffer::Data(args[0]));
-  CHECK_NE(decoder, nullptr);
+  CHECK_NOT_NULL(decoder);
   size_t nread = Buffer::Length(args[1]);
   MaybeLocal<String> ret =
       decoder->DecodeData(args.GetIsolate(), Buffer::Data(args[1]), &nread);
@@ -277,7 +277,7 @@ void DecodeData(const FunctionCallbackInfo<Value>& args) {
 void FlushData(const FunctionCallbackInfo<Value>& args) {
   StringDecoder* decoder =
       reinterpret_cast<StringDecoder*>(Buffer::Data(args[0]));
-  CHECK_NE(decoder, nullptr);
+  CHECK_NOT_NULL(decoder);
   MaybeLocal<String> ret = decoder->FlushData(args.GetIsolate());
   if (!ret.IsEmpty())
     args.GetReturnValue().Set(ret.ToLocalChecked());

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -71,7 +71,7 @@ TLSWrap::TLSWrap(Environment* env,
   MakeWeak();
 
   // sc comes from an Unwrap. Make sure it was assigned.
-  CHECK_NE(sc, nullptr);
+  CHECK_NOT_NULL(sc);
 
   // We've our own session callbacks
   SSL_CTX_sess_set_get_cb(sc_->ctx_.get(),
@@ -169,7 +169,7 @@ void TLSWrap::Wrap(const FunctionCallbackInfo<Value>& args) {
                                   SSLWrap<TLSWrap>::kClient;
 
   StreamBase* stream = static_cast<StreamBase*>(stream_obj->Value());
-  CHECK_NE(stream, nullptr);
+  CHECK_NOT_NULL(stream);
 
   TLSWrap* res = new TLSWrap(env, kind, stream, Unwrap<SecureContext>(sc));
 
@@ -563,7 +563,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
                      uv_buf_t* bufs,
                      size_t count,
                      uv_stream_t* send_handle) {
-  CHECK_EQ(send_handle, nullptr);
+  CHECK_NULL(send_handle);
 
   if (ssl_ == nullptr) {
     ClearError();
@@ -585,7 +585,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
     // However, if there is any data that should be written to the socket,
     // the callback should not be invoked immediately
     if (BIO_pending(enc_out_) == 0) {
-      CHECK_EQ(current_empty_write_, nullptr);
+      CHECK_NULL(current_empty_write_);
       current_empty_write_ = w;
       StreamWriteResult res =
           underlying_stream()->Write(bufs, count, send_handle);
@@ -600,7 +600,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
   }
 
   // Store the current write wrap
-  CHECK_EQ(current_write_, nullptr);
+  CHECK_NULL(current_write_);
   current_write_ = w;
 
   // Write queued data
@@ -638,7 +638,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
 
 
 uv_buf_t TLSWrap::OnStreamAlloc(size_t suggested_size) {
-  CHECK_NE(ssl_, nullptr);
+  CHECK_NOT_NULL(ssl_);
 
   size_t size = suggested_size;
   char* base = crypto::NodeBIO::FromBIO(enc_in_)->PeekWritable(&size);
@@ -709,7 +709,7 @@ void TLSWrap::SetVerifyMode(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsBoolean());
   CHECK(args[1]->IsBoolean());
-  CHECK_NE(wrap->ssl_, nullptr);
+  CHECK_NOT_NULL(wrap->ssl_);
 
   int verify_mode;
   if (wrap->is_server()) {
@@ -737,7 +737,7 @@ void TLSWrap::EnableSessionCallbacks(
     const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-  CHECK_NE(wrap->ssl_, nullptr);
+  CHECK_NOT_NULL(wrap->ssl_);
   wrap->enable_session_callbacks();
   crypto::NodeBIO::FromBIO(wrap->enc_in_)->set_initial(kMaxHelloLength);
   wrap->hello_parser_.Start(SSLWrap<TLSWrap>::OnClientHello,
@@ -784,7 +784,7 @@ void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
-  CHECK_NE(wrap->ssl_, nullptr);
+  CHECK_NOT_NULL(wrap->ssl_);
 
   const char* servername = SSL_get_servername(wrap->ssl_.get(),
                                               TLSEXT_NAMETYPE_host_name);
@@ -807,7 +807,7 @@ void TLSWrap::SetServername(const FunctionCallbackInfo<Value>& args) {
   CHECK(!wrap->started_);
   CHECK(wrap->is_client());
 
-  CHECK_NE(wrap->ssl_, nullptr);
+  CHECK_NOT_NULL(wrap->ssl_);
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   node::Utf8Value servername(env->isolate(), args[0].As<String>());
@@ -847,7 +847,7 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   p->sni_context_.Reset(env->isolate(), ctx);
 
   SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
-  CHECK_NE(sc, nullptr);
+  CHECK_NOT_NULL(sc);
   p->SetSNIContext(sc);
   return SSL_TLSEXT_ERR_OK;
 }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -676,7 +676,7 @@ void TLSWrap::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   if (!hello_parser_.IsEnded()) {
     size_t avail = 0;
     uint8_t* data = reinterpret_cast<uint8_t*>(enc_in->Peek(&avail));
-    CHECK(avail == 0 || data != nullptr);
+    CHECK_IMPLIES(data == nullptr, avail == 0);
     return hello_parser_.Parse(data, avail);
   }
 

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -365,21 +365,21 @@ inline T* UncheckedCalloc(size_t n) {
 template <typename T>
 inline T* Realloc(T* pointer, size_t n) {
   T* ret = UncheckedRealloc(pointer, n);
-  if (n > 0) CHECK_NE(ret, nullptr);
+  CHECK_IMPLIES(n > 0, ret != nullptr);
   return ret;
 }
 
 template <typename T>
 inline T* Malloc(size_t n) {
   T* ret = UncheckedMalloc<T>(n);
-  if (n > 0) CHECK_NE(ret, nullptr);
+  CHECK_IMPLIES(n > 0, ret != nullptr);
   return ret;
 }
 
 template <typename T>
 inline T* Calloc(size_t n) {
   T* ret = UncheckedCalloc<T>(n);
-  if (n > 0) CHECK_NE(ret, nullptr);
+  CHECK_IMPLIES(n > 0, ret != nullptr);
   return ret;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -129,6 +129,8 @@ void DumpBacktrace(FILE* fp);
 #define CHECK_LE(a, b) CHECK((a) <= (b))
 #define CHECK_LT(a, b) CHECK((a) < (b))
 #define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_NULL(val) CHECK((val) == nullptr)
+#define CHECK_NOT_NULL(val) CHECK((val) != nullptr)
 #define CHECK_IMPLIES(a, b) CHECK(!(a) || (b))
 
 #define UNREACHABLE() ABORT()

--- a/src/util.h
+++ b/src/util.h
@@ -129,6 +129,7 @@ void DumpBacktrace(FILE* fp);
 #define CHECK_LE(a, b) CHECK((a) <= (b))
 #define CHECK_LT(a, b) CHECK((a) < (b))
 #define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_IMPLIES(a, b) CHECK(!(a) || (b))
 
 #define UNREACHABLE() ABORT()
 


### PR DESCRIPTION
This adds three more `CHECK` macros to `util.h`, similar to their definitions within v8. I personally like the added semantics very much, but I can also understand if people think of it as added complexity.

These macros are
- `CHECK_NULL(x)` - asserts that `x` is null
- `CHECK_NOT_NULL(x)` - asserts that `x` is not null
- `CHECK_IMPLIES(a, b)` - asserts that `b` is true if `a` is true

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)