### PR TITLE
crypto: add ticketKeys option in createSecureContext

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -223,6 +223,11 @@ exports.createSecureContext = function createSecureContext(options, context) {
                                    options.clientCertEngine);
   }
 
+  // Set ticketKeys right inside createSecureContext
+  if (options.ticketKeys) {
+    c.context.setTicketKeys(options.ticketKeys);
+  }
+
   return c;
 };
 

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -56,6 +56,15 @@ function SecureContext(secureProtocol, secureOptions, context) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
+SecureContext.prototype.getTicketKeys = function getTicketKeys(keys) {
+  return this.context.getTicketKeys(keys);
+};
+
+
+SecureContext.prototype.setTicketKeys = function setTicketKeys(keys) {
+  this.context.setTicketKeys(keys);
+};
+
 function validateKeyCert(name, value) {
   if (typeof value !== 'string' && !isArrayBufferView(value)) {
     throw new ERR_INVALID_ARG_TYPE(
@@ -223,9 +232,12 @@ exports.createSecureContext = function createSecureContext(options, context) {
                                    options.clientCertEngine);
   }
 
-  // Set ticketKeys right inside createSecureContext
   if (options.ticketKeys) {
     c.context.setTicketKeys(options.ticketKeys);
+  }
+
+  if (options.sessionTimeout) {
+    c.context.setSessionTimeout(options.sessionTimeout);
   }
 
   return c;

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -56,8 +56,8 @@ function SecureContext(secureProtocol, secureOptions, context) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
-SecureContext.prototype.getTicketKeys = function getTicketKeys(keys) {
-  return this.context.getTicketKeys(keys);
+SecureContext.prototype.getTicketKeys = function getTicketKeys() {
+  return this.context.getTicketKeys();
 };
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -886,7 +886,8 @@ function Server(options, listener) {
     honorCipherOrder: this.honorCipherOrder,
     crl: this.crl,
     sessionIdContext: this.sessionIdContext,
-    ticketKeys: this.ticketKeys
+    ticketKeys: this.ticketKeys,
+    sessionTimeout: this.sessionTimeout,
   });
 
   this[kHandshakeTimeout] = options.handshakeTimeout || (120 * 1000);
@@ -895,10 +896,6 @@ function Server(options, listener) {
   if (typeof this[kHandshakeTimeout] !== 'number') {
     throw new ERR_INVALID_ARG_TYPE(
       'options.handshakeTimeout', 'number', options.handshakeTimeout);
-  }
-
-  if (this.sessionTimeout) {
-    this._sharedCreds.context.setSessionTimeout(this.sessionTimeout);
   }
 
   // constructor call

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -885,7 +885,8 @@ function Server(options, listener) {
     secureOptions: this.secureOptions,
     honorCipherOrder: this.honorCipherOrder,
     crl: this.crl,
-    sessionIdContext: this.sessionIdContext
+    sessionIdContext: this.sessionIdContext,
+    ticketKeys: this.ticketKeys
   });
 
   this[kHandshakeTimeout] = options.handshakeTimeout || (120 * 1000);
@@ -898,10 +899,6 @@ function Server(options, listener) {
 
   if (this.sessionTimeout) {
     this._sharedCreds.context.setSessionTimeout(this.sessionTimeout);
-  }
-
-  if (this.ticketKeys) {
-    this._sharedCreds.context.setTicketKeys(this.ticketKeys);
   }
 
   // constructor call

--- a/test/parallel/test-tls-securecontext-ticketkeys.js
+++ b/test/parallel/test-tls-securecontext-ticketkeys.js
@@ -14,9 +14,11 @@ const otherKeys = crypto.randomBytes(48);
 const context = tls.createSecureContext({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
-  ticketKeys: keys
+  ticketKeys: keys,
+  sessionTimeout: 1,
 });
 
-assert.strictEqual(context.getTicketKeys(), keys);
+assert.deepStrictEqual(context.getTicketKeys(), keys);
 context.setTicketKeys(otherKeys);
-assert.strictEqual(context.getTicketKeys(), otherKeys);
+assert.deepStrictEqual(context.getTicketKeys(), otherKeys);
+setTimeout(() => assert.deepStrictEqual(context.getTicketKeys(), otherKeys), 5000);

--- a/test/parallel/test-tls-securecontext-ticketkeys.js
+++ b/test/parallel/test-tls-securecontext-ticketkeys.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const tls = require('tls');
+
+const keys = crypto.randomBytes(48);
+const otherKeys = crypto.randomBytes(48);
+
+const context = tls.createSecureContext({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ticketKeys: keys
+});
+
+assert.strictEqual(context.getTicketKeys(), keys);
+context.setTicketKeys(otherKeys);
+assert.strictEqual(context.getTicketKeys(), otherKeys);


### PR DESCRIPTION
There's a method to initialize a TLS Server using tls.createSever by
specifying a ticketKeys option, but none in the underlying constructor,
tls.createSecureContext.

This PR adds the ticketKeys option to tls.createSecureContext.

Fixes: https://github.com/nodejs/node/issues/20908

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/crypto @bnoordhuis @silverwind @DiegoTUI

I guess this qualifies as a `semver-minor`?