### PR TITLE
http2: fix missing 'timeout' event emit in request and response

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -705,11 +705,14 @@ class Http2ServerResponse extends Stream {
   }
 }
 
-function onServerStream(ServerRequest, ServerResponse,
+function onServerStream(ServerRequest, ServerResponse, kStreamEventsComposite,
                         stream, headers, flags, rawHeaders) {
   const server = this;
   const request = new ServerRequest(stream, headers, undefined, rawHeaders);
   const response = new ServerResponse(stream);
+
+  stream[kStreamEventsComposite].push(request);
+  stream[kStreamEventsComposite].push(response);
 
   // Check for the CONNECT method
   const method = headers[HTTP2_HEADER_METHOD];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -147,6 +147,7 @@ const kState = Symbol('state');
 const kType = Symbol('type');
 const kUpdateTimer = Symbol('update-timer');
 const kWriteGeneric = Symbol('write-generic');
+const kStreamEventsComposite = Symbol('streamEventsComposite');
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 
@@ -1551,6 +1552,8 @@ class Http2Stream extends Duplex {
       trailersReady: false
     };
 
+    this[kStreamEventsComposite] = [];
+
     this.on('pause', streamOnPause);
   }
 
@@ -1640,7 +1643,17 @@ class Http2Stream extends Duplex {
       }
     }
 
-    this.emit('timeout');
+    // if there is no timeout event listener, destroy session
+    let hasTimeoutCallback = this.emit('timeout');
+    for (const component of this[kStreamEventsComposite]) {
+      if (component.emit('timeout')) {
+        hasTimeoutCallback = true;
+      }
+    }
+
+    if (!hasTimeoutCallback) {
+      this.session.destroy();
+    }
   }
 
   // true if the HEADERS frame has been sent
@@ -2662,7 +2675,8 @@ function setupCompat(ev) {
     this.on('stream', onServerStream.bind(
       this,
       this[kOptions].Http2ServerRequest,
-      this[kOptions].Http2ServerResponse)
+      this[kOptions].Http2ServerResponse,
+      kStreamEventsComposite)
     );
   }
 }

--- a/test/parallel/test-http2-compat-serverrequest-settimeout.js
+++ b/test/parallel/test-http2-compat-serverrequest-settimeout.js
@@ -12,6 +12,10 @@ server.on('request', (req, res) => {
   req.setTimeout(msecs, common.mustCall(() => {
     res.end();
   }));
+
+  res.on('timeout', common.mustCall());
+  req.on('timeout', common.mustCall());
+
   res.on('finish', common.mustCall(() => {
     req.setTimeout(msecs, common.mustNotCall());
     process.nextTick(() => {


### PR DESCRIPTION
A timeout in a http2 stream should emit a 'timeout' event also on
request and response object. If there is no listener on stream,
request or response, stream should immediately be destroyed.

Fixes: https://github.com/nodejs/node/issues/20079

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
