### PR TITLE
test: remove third argument(string literal) from strictEqual()

### DIFF
--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -7,8 +7,7 @@ const writable = new stream.Writable({
   write: common.mustCall(function(chunk, encoding, cb) {
     assert.strictEqual(
       readable._readableState.awaitDrain,
-      0,
-      'State variable awaitDrain is not correct.'
+      0
     );
 
     if (chunk.length === 32 * 1024) { // first chunk
@@ -16,8 +15,7 @@ const writable = new stream.Writable({
       // We should check if awaitDrain counter is increased in the next
       // tick, because awaitDrain is incremented after this method finished
       process.nextTick(() => {
-        assert.strictEqual(readable._readableState.awaitDrain, 1,
-                           'Counter is not increased for awaitDrain');
+        assert.strictEqual(readable._readableState.awaitDrain, 1);
       });
     }
 


### PR DESCRIPTION
In `test/parallel/test-stream-pip-await-drain-push-while-write.js`, There are two
calls in it to `assert.strictEqual()`. Both calls are provided with three
arguments. The third argument in each case is a string literal. Unfortunately,
that will suppress the presentation of the values of the first two arguments in
the case of an `AssertionError`

This is fixed by removing the third argument from the call. The third argument
in the call is basically a string literal.

This particular issue is provided by @Trott,  Thank you so much for getting me started.

Refs: [https://www.nodetodo.org/getting-started](https://www.nodetodo.org/getting-started)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
