### PR TITLE
WIP: tools: add core files to @nodejs namespace

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -278,6 +278,7 @@ def JS2C(source, target):
   initializers = []
 
   for name in modules:
+    is_js = name.endswith('.js')
     lines = ReadFile(str(name))
     lines = ExpandConstants(lines, consts)
     lines = ExpandMacros(lines, macros)
@@ -309,6 +310,14 @@ def JS2C(source, target):
     definitions.append(Render(key, name))
     definitions.append(Render(value, lines))
     initializers.append(INITIALIZER.format(key=key, value=value))
+
+    if (is_js == True and not name.startswith('_') and
+       not name.startswith('internal')):
+      print(name)
+      key = 'nodejs_%s' % key
+      name = '@nodejs/%s' % name
+      definitions.append(Render(key, name))
+      initializers.append(INITIALIZER.format(key=key, value=value))
 
     if deprecated_deps is not None:
       name = '/'.join(deprecated_deps)


### PR DESCRIPTION
This is probably not the ideal solution, but I wanted to at least get the ball moving after the little bit of `'worker'` module naming drama.

This commit allows all of Node core's public modules to be accessed via the `@nodejs` namespace. The non-namespaced modules are not affected.

CJS:
```js
'use strict';
const fs = require('@nodejs/fs');

console.log(fs.readFileSync(__filename, 'utf8'));
```

ESM:
```
'use strict';
import fs from '@nodejs/fs';

console.log(fs.readFileSync('/path/to/file.mjs', 'utf8'));
```

I haven't added tests or docs because I expect pushback. Open to other suggestions.

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
