### PR TITLE
tools: add new headers to tarball

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -162,6 +162,9 @@ def headers(action):
   action([
     'common.gypi',
     'config.gypi',
+    'src/core.h',
+    'src/callback_scope.h',
+    'src/exceptions.h',
     'src/node.h',
     'src/node_api.h',
     'src/node_api_types.h',


### PR DESCRIPTION
Missed in https://github.com/nodejs/node/pull/20789 (I had mistakenly assumed the headers were picked up from the listing in node.gyp... and regular CI doesn't cover this).

Fixes: https://github.com/nodejs/node/issues/20921

This needs to be fast tracked and a new 10.2.1 release spun up as soon as it lands.

/cc @richardlau @MylesBorins 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
