### PR TITLE
Revert "test: reduce runtime"

### DIFF
--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -7,17 +7,15 @@ if (process.argv[2] === 'async') {
     fn();
     throw new Error();
   }
-  return (async function() { await fn(); })();
+  (async function() { await fn(); })();
+  // While the above should error, just in case it doesn't the script shouldn't
+  // fork itself indefinitely so return early.
+  return;
 }
 
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 
-const ret = spawnSync(
-  process.execPath,
-  ['--stack_size=50', __filename, 'async']
-);
+const ret = spawnSync(process.execPath, [__filename, 'async']);
 assert.strictEqual(ret.status, 0);
-const stderr = ret.stderr.toString('utf8', 0, 2048);
-assert.ok(!/async.*hook/i.test(stderr));
-assert.ok(stderr.includes('UnhandledPromiseRejectionWarning: Error'), stderr);
+assert.ok(!/async.*hook/i.test(ret.stderr.toString('utf8', 0, 1024)));

--- a/test/parallel/test-child-process-exec-encoding.js
+++ b/test/parallel/test-child-process-exec-encoding.js
@@ -1,17 +1,17 @@
 'use strict';
 const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
 const stdoutData = 'foo';
 const stderrData = 'bar';
+const expectedStdout = `${stdoutData}\n`;
+const expectedStderr = `${stderrData}\n`;
 
 if (process.argv[2] === 'child') {
   // The following console calls are part of the test.
   console.log(stdoutData);
   console.error(stderrData);
 } else {
-  const assert = require('assert');
-  const cp = require('child_process');
-  const expectedStdout = `${stdoutData}\n`;
-  const expectedStderr = `${stderrData}\n`;
   function run(options, callback) {
     const cmd = `"${process.execPath}" "${__filename}" child`;
 


### PR DESCRIPTION
This reverts commit 352ae2397434ddde058c14cd357e3bdd1d029cb6.

The commit appears to have introduced unreliability in one of the two refactored tests in AIX in CI (see https://github.com/nodejs/node/pull/20688#issuecomment-391496800)  and macOS (see https://github.com/nodejs/node/issues/20888).

Not looking to fast track this or anything (unless this becomes more of a problem for people). Just want it opened in case this is still an issue in 48 hours. The benefits of the change are small (and might be offset by unintentional slow-down on some platforms, see https://github.com/nodejs/node/pull/20688#issuecomment-391584196).

/cc @danbev @MylesBorins @BridgeAR  @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
