### PR TITLE
assert: reverse diff direction

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -57,7 +57,7 @@ function createErrDiff(actual, expected, operator) {
   const actualLines = inspectValue(actual);
   const expectedLines = inspectValue(expected);
   const msg = READABLE_OPERATOR[operator] +
-        `:\n${green}+ expected${white} ${red}- actual${white}`;
+        `:\n${green}- expected${white} ${red}+ actual${white}`;
   const skippedMsg = ` ${blue}...${white} Lines skipped`;
 
   // Remove all ending lines that match (this optimizes the output for
@@ -106,7 +106,7 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      other += `\n${green}+${white} ${expectedLines[i]}`;
+      other += `\n${green}-${white} ${expectedLines[i]}`;
       printedLines++;
     // Only extra actual lines exist
     } else if (expectedLines.length < i + 1) {
@@ -122,7 +122,7 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      res += `\n${red}-${white} ${actualLines[i]}`;
+      res += `\n${red}+${white} ${actualLines[i]}`;
       printedLines++;
     // Lines diverge
     } else if (actualLines[i] !== expectedLines[i]) {
@@ -138,8 +138,8 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      res += `\n${red}-${white} ${actualLines[i]}`;
-      other += `\n${green}+${white} ${expectedLines[i]}`;
+      res += `\n${red}+${white} ${actualLines[i]}`;
+      other += `\n${green}-${white} ${expectedLines[i]}`;
       printedLines += 2;
     // Lines are identical
     } else {


### PR DESCRIPTION
The current direction for the assert diffs is rather peculiar.
While it’s not the “wrong” way to do it per-se, it’s definitely
inconsistent with the ecosystem and is rather unintuitive.

This PR aims to fix that by reversing the direction.

Fixes: https://github.com/nodejs/node/issues/20897

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @BridgeAR @addaleax @targos 