### PR TITLE
doc: fix inconsistent documentation (host vs hostname)

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -358,7 +358,7 @@ added: v0.5.3
   `cert`, `ca`, etc).
 
 The `server.addContext()` method adds a secure context that will be used if
-the client request's SNI hostname matches the supplied `hostname` (or wildcard).
+the client request's SNI name matches the supplied `hostname` (or wildcard).
 
 ### server.address()
 <!-- YAML
@@ -796,17 +796,17 @@ and their processing can be delayed due to packet loss or reordering. However,
 smaller fragments add extra TLS framing bytes and CPU overhead, which may
 decrease overall server throughput.
 
-## tls.checkServerIdentity(host, cert)
+## tls.checkServerIdentity(hostname, cert)
 <!-- YAML
 added: v0.8.4
 -->
 
-* `host` {string} The hostname to verify the certificate against
+* `hostname` {string} The hostname to verify the certificate against
 * `cert` {Object} An object representing the peer's certificate. The returned
   object has some properties corresponding to the fields of the certificate.
 * Returns: {Error|undefined}
 
-Verifies the certificate `cert` is issued to host `host`.
+Verifies the certificate `cert` is issued to `hostname`.
 
 Returns {Error} object, populating it with the reason, host, and cert on
 failure. On success, returns {undefined}.

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -161,14 +161,14 @@ function check(hostParts, pattern, wildcards) {
 }
 
 let urlWarningEmitted = false;
-exports.checkServerIdentity = function checkServerIdentity(host, cert) {
+exports.checkServerIdentity = function checkServerIdentity(hostname, cert) {
   const subject = cert.subject;
   const altNames = cert.subjectaltname;
   const dnsNames = [];
   const uriNames = [];
   const ips = [];
 
-  host = '' + host;
+  hostname = '' + hostname;
 
   if (altNames) {
     for (const name of altNames.split(', ')) {
@@ -200,14 +200,14 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   let valid = false;
   let reason = 'Unknown reason';
 
-  if (net.isIP(host)) {
-    valid = ips.includes(canonicalizeIP(host));
+  if (net.isIP(hostname)) {
+    valid = ips.includes(canonicalizeIP(hostname));
     if (!valid)
-      reason = `IP: ${host} is not in the cert's list: ${ips.join(', ')}`;
+      reason = `IP: ${hostname} is not in the cert's list: ${ips.join(', ')}`;
     // TODO(bnoordhuis) Also check URI SANs that are IP addresses.
   } else if (subject) {
-    host = unfqdn(host);  // Remove trailing dot for error messages.
-    const hostParts = splitHost(host);
+    hostname = unfqdn(hostname);  // Remove trailing dot for error messages.
+    const hostParts = splitHost(hostname);
     const wildcard = (pattern) => check(hostParts, pattern, true);
     const noWildcard = (pattern) => check(hostParts, pattern, false);
 
@@ -221,11 +221,12 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
         valid = wildcard(cn);
 
       if (!valid)
-        reason = `Host: ${host}. is not cert's CN: ${cn}`;
+        reason = `Host: ${hostname}. is not cert's CN: ${cn}`;
     } else {
       valid = dnsNames.some(wildcard) || uriNames.some(noWildcard);
       if (!valid)
-        reason = `Host: ${host}. is not in the cert's altnames: ${altNames}`;
+        reason =
+          `Host: ${hostname}. is not in the cert's altnames: ${altNames}`;
     }
   } else {
     reason = 'Cert is empty';
@@ -234,7 +235,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   if (!valid) {
     const err = new ERR_TLS_CERT_ALTNAME_INVALID(reason);
     err.reason = reason;
-    err.host = host;
+    err.host = hostname;
     err.cert = cert;
     return err;
   }


### PR DESCRIPTION
Update docs for tls.checkServerIdentity(host, cert) to clear ambiguity between `host` and `hostname`.
Fixes https://github.com/nodejs/node/issues/20892 partially

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
