### PR TITLE
fs: allow file: URL strings as paths

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1393,7 +1393,11 @@ function getPathFromURLPosix(url) {
 }
 
 function getPathFromURL(path) {
-  if (path == null || !path[searchParams] ||
+  if (typeof path === 'string') {
+    if (!path.startsWith('file://'))
+      return path;
+    path = new URL(path);
+  } else if (path == null || !path[searchParams] ||
       !path[searchParams][searchParams]) {
     return path;
   }

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -145,6 +145,69 @@ check(null, fs.watch, fileUrl2, assert.fail);
 check(null, fs.watchFile, fileUrl2, assert.fail);
 check(fs.writeFile, fs.writeFileSync, fileUrl2, 'abc');
 
+const fileUrlString = new URL('file:///C:/foo\u0000bar').href;
+const fileUrl2String = new URL('file:///C:/foo%00bar').href;
+
+check(fs.access, fs.accessSync, fileUrlString);
+check(fs.access, fs.accessSync, fileUrlString, fs.F_OK);
+check(fs.appendFile, fs.appendFileSync, fileUrlString, 'abc');
+check(fs.chmod, fs.chmodSync, fileUrlString, '0644');
+check(fs.chown, fs.chownSync, fileUrlString, 12, 34);
+check(fs.copyFile, fs.copyFileSync, fileUrlString, 'abc');
+check(fs.copyFile, fs.copyFileSync, 'abc', fileUrlString);
+check(fs.link, fs.linkSync, fileUrlString, 'foobar');
+check(fs.link, fs.linkSync, 'foobar', fileUrlString);
+check(fs.lstat, fs.lstatSync, fileUrlString);
+check(fs.mkdir, fs.mkdirSync, fileUrlString, '0755');
+check(fs.open, fs.openSync, fileUrlString, 'r');
+check(fs.readFile, fs.readFileSync, fileUrlString);
+check(fs.readdir, fs.readdirSync, fileUrlString);
+check(fs.readlink, fs.readlinkSync, fileUrlString);
+check(fs.realpath, fs.realpathSync, fileUrlString);
+check(fs.rename, fs.renameSync, fileUrlString, 'foobar');
+check(fs.rename, fs.renameSync, 'foobar', fileUrlString);
+check(fs.rmdir, fs.rmdirSync, fileUrlString);
+check(fs.stat, fs.statSync, fileUrlString);
+check(fs.symlink, fs.symlinkSync, fileUrlString, 'foobar');
+check(fs.symlink, fs.symlinkSync, 'foobar', fileUrlString);
+check(fs.truncate, fs.truncateSync, fileUrlString);
+check(fs.unlink, fs.unlinkSync, fileUrlString);
+check(null, fs.unwatchFile, fileUrlString, assert.fail);
+check(fs.utimes, fs.utimesSync, fileUrlString, 0, 0);
+check(null, fs.watch, fileUrlString, assert.fail);
+check(null, fs.watchFile, fileUrlString, assert.fail);
+check(fs.writeFile, fs.writeFileSync, fileUrlString, 'abc');
+
+check(fs.access, fs.accessSync, fileUrl2String);
+check(fs.access, fs.accessSync, fileUrl2String, fs.F_OK);
+check(fs.appendFile, fs.appendFileSync, fileUrl2String, 'abc');
+check(fs.chmod, fs.chmodSync, fileUrl2String, '0644');
+check(fs.chown, fs.chownSync, fileUrl2String, 12, 34);
+check(fs.copyFile, fs.copyFileSync, fileUrl2String, 'abc');
+check(fs.copyFile, fs.copyFileSync, 'abc', fileUrl2String);
+check(fs.link, fs.linkSync, fileUrl2String, 'foobar');
+check(fs.link, fs.linkSync, 'foobar', fileUrl2String);
+check(fs.lstat, fs.lstatSync, fileUrl2String);
+check(fs.mkdir, fs.mkdirSync, fileUrl2String, '0755');
+check(fs.open, fs.openSync, fileUrl2String, 'r');
+check(fs.readFile, fs.readFileSync, fileUrl2String);
+check(fs.readdir, fs.readdirSync, fileUrl2String);
+check(fs.readlink, fs.readlinkSync, fileUrl2String);
+check(fs.realpath, fs.realpathSync, fileUrl2String);
+check(fs.rename, fs.renameSync, fileUrl2String, 'foobar');
+check(fs.rename, fs.renameSync, 'foobar', fileUrl2String);
+check(fs.rmdir, fs.rmdirSync, fileUrl2String);
+check(fs.stat, fs.statSync, fileUrl2String);
+check(fs.symlink, fs.symlinkSync, fileUrl2String, 'foobar');
+check(fs.symlink, fs.symlinkSync, 'foobar', fileUrl2String);
+check(fs.truncate, fs.truncateSync, fileUrl2String);
+check(fs.unlink, fs.unlinkSync, fileUrl2String);
+check(null, fs.unwatchFile, fileUrl2String, assert.fail);
+check(fs.utimes, fs.utimesSync, fileUrl2String, 0, 0);
+check(null, fs.watch, fileUrl2String, assert.fail);
+check(null, fs.watchFile, fileUrl2String, assert.fail);
+check(fs.writeFile, fs.writeFileSync, fileUrl2String, 'abc');
+
 // an 'error' for exists means that it doesn't exist.
 // one of many reasons why this file is the absolute worst.
 fs.exists('foo\u0000bar', common.mustCall((exists) => {


### PR DESCRIPTION
This extends support for WhatWG URL objects in fs APIs to also include file: URL strings beginning with `file://`.

The URL standard actually suggests using strings over the object where possible in https://url.spec.whatwg.org/#url-apis-elsewhere, so it would be good to be able to enable such a best-practice.

This will also enable use cases like `fs.readFile(import.meta.url)` for modules, where the URL is provided as a string.

While it is possible for files or directories to exist with names like 'file:' or 'file:/', by restricting only to the 'file://' we can reliably distinguish file URLs from unique file paths.

Performance is largely unaffected as there is a fast opt-out of this code path through the string prefix check.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
