### PR TITLE
test: improve error message in async-wrap test

### DIFF
--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -17,7 +17,8 @@ const ret = spawnSync(
   process.execPath,
   ['--stack_size=50', __filename, 'async']
 );
-assert.strictEqual(ret.status, 0);
+assert.strictEqual(ret.status, 0,
+                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
 const stderr = ret.stderr.toString('utf8', 0, 2048);
 assert.ok(!/async.*hook/i.test(stderr));
 assert.ok(stderr.includes('UnhandledPromiseRejectionWarning: Error'), stderr);


### PR DESCRIPTION
Improve AssertionError message in
test/parallel/test-async-wrap-pop-id-during-load.js to include the
contents of stderr when the spawned process fails.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
