### PR TITLE
fs: allow file: URL strings as paths for fs.promises

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3381,6 +3381,9 @@ The `fs.promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
 API is accessible via `require('fs').promises`.
 
+In addition to returning a promise, `file:///` URL strings are also permitted
+as paths in this API.
+
 ### class: FileHandle
 <!-- YAML
 added: v10.0.0

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -14,7 +14,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_METHOD_NOT_IMPLEMENTED
 } = require('internal/errors').codes;
-const { getPathFromURL } = require('internal/url');
+const { getPathFromURLString } = require('internal/url');
 const { isUint8Array } = require('internal/util/types');
 const {
   copyObject,
@@ -168,7 +168,7 @@ async function readFileHandle(filehandle, options) {
 // All of the functions are defined as async in order to ensure that errors
 // thrown cause promise rejections rather than being thrown synchronously.
 async function access(path, mode = F_OK) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
 
   mode = mode | 0;
@@ -177,8 +177,8 @@ async function access(path, mode = F_OK) {
 }
 
 async function copyFile(src, dest, flags) {
-  src = getPathFromURL(src);
-  dest = getPathFromURL(dest);
+  src = getPathFromURLString(src);
+  dest = getPathFromURLString(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
   flags = flags | 0;
@@ -190,7 +190,7 @@ async function copyFile(src, dest, flags) {
 // Note that unlike fs.open() which uses numeric file descriptors,
 // fsPromises.open() uses the fs.FileHandle class.
 async function open(path, flags, mode) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   mode = validateAndMaskMode(mode, 'mode', 0o666);
   return new FileHandle(
@@ -248,8 +248,8 @@ async function write(handle, buffer, offset, length, position) {
 }
 
 async function rename(oldPath, newPath) {
-  oldPath = getPathFromURL(oldPath);
-  newPath = getPathFromURL(newPath);
+  oldPath = getPathFromURLString(oldPath);
+  newPath = getPathFromURLString(newPath);
   validatePath(oldPath, 'oldPath');
   validatePath(newPath, 'newPath');
   return binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -269,7 +269,7 @@ async function ftruncate(handle, len = 0) {
 }
 
 async function rmdir(path) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   return binding.rmdir(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -285,7 +285,7 @@ async function fsync(handle) {
 }
 
 async function mkdir(path, mode) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   mode = validateAndMaskMode(mode, 'mode', 0o777);
   return binding.mkdir(pathModule.toNamespacedPath(path), mode, kUsePromises);
@@ -293,7 +293,7 @@ async function mkdir(path, mode) {
 
 async function readdir(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   return binding.readdir(pathModule.toNamespacedPath(path),
                          options.encoding, kUsePromises);
@@ -301,7 +301,7 @@ async function readdir(path, options) {
 
 async function readlink(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path),
                           options.encoding, kUsePromises);
@@ -309,8 +309,8 @@ async function readlink(path, options) {
 
 async function symlink(target, path, type_) {
   const type = (typeof type_ === 'string' ? type_ : null);
-  target = getPathFromURL(target);
-  path = getPathFromURL(path);
+  target = getPathFromURLString(target);
+  path = getPathFromURLString(path);
   validatePath(target, 'target');
   validatePath(path);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
@@ -326,7 +326,7 @@ async function fstat(handle) {
 }
 
 async function lstat(path) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   const result = await binding.lstat(pathModule.toNamespacedPath(path),
                                      kUsePromises);
@@ -334,7 +334,7 @@ async function lstat(path) {
 }
 
 async function stat(path) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   const result = await binding.stat(pathModule.toNamespacedPath(path),
                                     kUsePromises);
@@ -342,8 +342,8 @@ async function stat(path) {
 }
 
 async function link(existingPath, newPath) {
-  existingPath = getPathFromURL(existingPath);
-  newPath = getPathFromURL(newPath);
+  existingPath = getPathFromURLString(existingPath);
+  newPath = getPathFromURLString(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
   return binding.link(pathModule.toNamespacedPath(existingPath),
@@ -352,7 +352,7 @@ async function link(existingPath, newPath) {
 }
 
 async function unlink(path) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -364,7 +364,7 @@ async function fchmod(handle, mode) {
 }
 
 async function chmod(path, mode) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   mode = validateAndMaskMode(mode, 'mode');
   return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises);
@@ -394,7 +394,7 @@ async function fchown(handle, uid, gid) {
 }
 
 async function chown(path, uid, gid) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -403,7 +403,7 @@ async function chown(path, uid, gid) {
 }
 
 async function utimes(path, atime, mtime) {
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   return binding.utimes(pathModule.toNamespacedPath(path),
                         toUnixTimestamp(atime),
@@ -420,7 +420,7 @@ async function futimes(handle, atime, mtime) {
 
 async function realpath(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = getPathFromURLString(path);
   validatePath(path);
   return binding.realpath(path, options.encoding, kUsePromises);
 }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1392,6 +1392,20 @@ function getPathFromURLPosix(url) {
   return decodeURIComponent(pathname);
 }
 
+function getPathFromURLString(path) {
+  if (typeof path === 'string') {
+    if (!path.startsWith('file://'))
+      return path;
+    path = new URL(path);
+  } else if (path == null || !path[searchParams] ||
+      !path[searchParams][searchParams]) {
+    return path;
+  }
+  if (path.protocol !== 'file:')
+    throw new ERR_INVALID_URL_SCHEME('file');
+  return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
+}
+
 function getPathFromURL(path) {
   if (path == null || !path[searchParams] ||
       !path[searchParams][searchParams]) {
@@ -1442,6 +1456,7 @@ setURLConstructor(constructUrl);
 module.exports = {
   toUSVString,
   getPathFromURL,
+  getPathFromURLString,
   getURLFromFilePath,
   URL,
   URLSearchParams,

--- a/test/parallel/test-fs-promises-whatwg-url.js
+++ b/test/parallel/test-fs-promises-whatwg-url.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs').promises;
+const os = require('os');
+const URL = require('url').URL;
+
+function pathToFileURL(p) {
+  if (!path.isAbsolute(p))
+    throw new Error('Path must be absolute');
+  if (common.isWindows && p.startsWith('\\\\'))
+    p = p.slice(2);
+  return new URL(`file://${p}`);
+}
+
+const p = path.resolve(fixtures.fixturesDir, 'a.js');
+const url = pathToFileURL(p);
+
+assert(url instanceof URL);
+
+(async () => {
+  // Check that we can pass in a URL object successfully
+  const data = await fs.readFile(url.href);
+  assert(Buffer.isBuffer(data));
+
+  try {
+    // Check that using a non file:// URL reports an error
+    await fs.readFile('http://example.org', common.mustNotCall());
+  } catch (err) {
+    common.expectsError({
+      code: 'ENOENT',
+      type: Error,
+      message: 'ENOENT: no such file or directory, open \'http://example.org\''
+    })(err);
+  }
+
+  // pct-encoded characters in the path will be decoded and checked
+  if (common.isWindows) {
+    // encoded back and forward slashes are not permitted on windows
+    await Promise.all(['%2f', '%2F', '%5c', '%5C'].map(async (i) => {
+      try {
+        await fs.readFile(`file:///c:/tmp/${i}`);
+      } catch (err) {
+        common.expectsError({
+          code: 'ERR_INVALID_FILE_URL_PATH',
+          type: TypeError,
+          message: 'File URL path must not include encoded \\ or / characters'
+        })(err);
+      }
+    }));
+
+    try {
+      await fs.readFile('file:///c:/tmp%00test');
+    } catch (err) {
+      common.expectsError({
+        code: 'ERR_INVALID_ARG_VALUE',
+        type: TypeError,
+        message: 'The argument \'path\' must be a string or Uint8Array ' +
+                 'without null bytes. Received \'c:/tmp/\\u0000test\''
+      })(err);
+    }
+  } else {
+    // encoded forward slashes are not permitted on other platforms
+    await Promise.all(['%2f', '%2F'].map(async (i) => {
+      try {
+        await fs.readFile(`file:///c:/tmp/${i}`);
+      } catch (err) {
+        common.expectsError({
+          code: 'ERR_INVALID_FILE_URL_PATH',
+          type: TypeError,
+          message: 'File URL path must not include encoded / characters'
+        })(err);
+      }
+    }));
+
+    try {
+      await fs.readFile('file://hostname/a/b/c');
+    } catch (err) {
+      common.expectsError({
+        code: 'ERR_INVALID_FILE_URL_HOST',
+        type: TypeError,
+        message: `File URL host must be "localhost" or empty on ${
+          os.platform()
+        }`
+      })(err);
+    }
+
+    try {
+      fs.readFile('file:///tmp/%00test');
+    } catch (err) {
+      common.expectsError({
+        code: 'ERR_INVALID_ARG_VALUE',
+        type: TypeError,
+        message: 'The argument \'path\' must be a string or Uint8Array ' +
+                 'without null bytes. Received \'/tmp/\\u0000test\''
+      })(err);
+    }
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
As a follow-on to the security issue raised in #20944, this allows support for `file://` URL strings in the `fs.promises` API only.

In #17658 it was noted that files or directories can exist with the name `file:` leading to worries over ambiguity here. For this reason, this implementation only supports the exact prefix `"file://"` in File URLs so that a rare file or directory called 'file:/', can still be reliable and uniquely distinguished from file URLs.

The URL standard actually suggests using strings over the object where possible in https://url.spec.whatwg.org/#url-apis-elsewhere, so it would be good to be able to enable such a best-practice.

This will also enable use cases like `fs.readFile(import.meta.url)` for modules, where the URL is provided as a string.

Performance is largely unaffected as there is a fast opt-out of this code path through the string prefix check.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
