### PR TITLE
test: fix fs realpath.native test

### DIFF
--- a/test/parallel/test-fs-realpath-native.js
+++ b/test/parallel/test-fs-realpath-native.js
@@ -3,11 +3,17 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-if (!common.isOSX) common.skip('MacOS-only test.');
+const filename = __filename.toLowerCase();
 
-assert.strictEqual(fs.realpathSync.native('/users'), '/Users');
-fs.realpath.native('/users', common.mustCall(function(err, res) {
-  assert.ifError(err);
-  assert.strictEqual(res, '/Users');
-  assert.strictEqual(this, undefined);
-}));
+assert.strictEqual(
+  fs.realpathSync.native('./test/parallel/test-fs-realpath-native.js')
+    .toLowerCase(),
+  filename);
+
+fs.realpath.native(
+  './test/parallel/test-fs-realpath-native.js',
+  common.mustCall(function(err, res) {
+    assert.ifError(err);
+    assert.strictEqual(res.toLowerCase(), filename);
+    assert.strictEqual(this, undefined);
+  }));


### PR DESCRIPTION
If you're on a mac with a case sensitive filesystem this test fails.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
