### PR TITLE
test: show actual assertion error message with value

### DIFF
--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 
 process.on('exit', () => {
-  // process._exiting was not set!
   assert.strictEqual(process._exiting, true);
 
   process.nextTick(common.mustNotCall());

--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -6,7 +6,9 @@ const assert = require('assert');
 process.on('exit', () => {
   assert.strictEqual(process._exiting, true);
 
-  process.nextTick(common.mustNotCall());
+  process.nextTick(
+    common.mustNotCall('process is exiting, should not be called')
+  );
 });
 
 process.exit();

--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -1,14 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 process.on('exit', () => {
-  assert.strictEqual(process._exiting, true, 'process._exiting was not set!');
+  // process._exiting was not set!
+  assert.strictEqual(process._exiting, true);
 
-  process.nextTick(() => {
-    assert.fail('process is exiting, should not be called.');
-  });
+  process.nextTick(common.mustNotCall());
 });
 
 process.exit();


### PR DESCRIPTION
on process exit if some assertion error occurs value of `process._exiting`
was hidden, this fix will show the actual error message with value

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
