### PR TITLE
build,win: disable DLL-interface warnings

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -236,10 +236,18 @@
         'BufferSecurityCheck': 'true',
         'ExceptionHandling': 0, # /EHsc
         'SuppressStartupBanner': 'true',
-        # Disable "warning C4267: conversion from 'size_t' to 'int',
-        # possible loss of data".  Many originate from our dependencies
-        # and their sheer number drowns out other, more legitimate warnings.
-        'DisableSpecificWarnings': ['4267'],
+        # Disable warnings:
+        # - "C4251: class needs to have dll-interface"
+        # - "C4275: non-DLL-interface used as base for DLL-interface"
+        #   Over 10k of these warnings are generated when compiling node,
+        #   originating from v8.h. Most of them are false positives.
+        #   See also: https://github.com/nodejs/node/pull/15570
+        #   TODO: re-enable when Visual Studio fixes these upstream.
+        #
+        # - "C4267: conversion from 'size_t' to 'int'"
+        #   Many any originate from our dependencies, and their sheer number
+        #   drowns out other, more legitimate warnings.
+        'DisableSpecificWarnings': ['4251', '4275', '4267'],
         'WarnAsError': 'false',
       },
       'VCLinkerTool': {


### PR DESCRIPTION
Compiling node with vcbuild generates 10,000s of these warnings,
originating from v8.h. This makes it impossible to read any other
diagnostic messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
