### PR TITLE
util: fix inspection of module namespaces

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -478,7 +478,23 @@ function formatValue(ctx, value, recurseTimes) {
   if (ctx.showHidden) {
     keys = Object.getOwnPropertyNames(value);
   } else {
-    keys = Object.keys(value);
+    // This might throw if `value` is a Module Namespace Object from an
+    // unevaluated module, but we don't want to perform the actual type
+    // check because it's expensive.
+    // TODO(devsnek): track https://github.com/tc39/ecma262/issues/1209
+    // and modify this logic as needed.
+    try {
+      keys = Object.keys(value);
+    } catch (err) {
+      if (types.isNativeError(err) &&
+          err.name === 'ReferenceError' &&
+          types.isModuleNamespaceObject(value)) {
+        keys = Object.getOwnPropertyNames(value);
+      } else {
+        throw err;
+      }
+    }
+
     if (symbols.length !== 0)
       symbols = symbols.filter((key) => propertyIsEnumerable.call(value, key));
   }
@@ -772,7 +788,7 @@ function formatNamespaceObject(ctx, value, recurseTimes, keys) {
     try {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i], 0);
     } catch (err) {
-      if (!(err instanceof ReferenceError)) {
+      if (!(types.isNativeError(err) && err.name === 'ReferenceError')) {
         throw err;
       }
       // Use the existing functionality. This makes sure the indentation and


### PR DESCRIPTION
unbreaks 6.7 upgrade

/cc @targos i don't have 6.7 checked out or the room to do so, can you confirm this patch fixes it?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
