### PR TITLE
test: improve path tests

### DIFF
--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -68,6 +68,6 @@ assert.strictEqual(path.win32.delimiter, ';');
 assert.strictEqual(path.posix.delimiter, ':');
 
 if (common.isWindows)
-  assert.deepStrictEqual(path, path.win32, 'should be win32 path module');
+  assert.strictEqual(path, path.win32);
 else
-  assert.deepStrictEqual(path, path.posix, 'should be posix path module');
+  assert.strictEqual(path, path.posix);


### PR DESCRIPTION
Replaced deepStrictEqual with strictEqual when asserting that the
path is equal to the win32 or posix equivalent, since it is a more
strict check than deepStrictCheck. Also removed third argument
in the check so that if there is an assertion error the properties
that are different will be displayed.

Note: Credits to Rich Trott from nodetodo.org helping me find this first contribution to work on.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)

Note: One of the tests is crashing right when I clone and run `make -j4 test` before making any changes. I believe this is specific to my machine and unrelated to this PR:

`=== release test-zlib.zlib-binding.deflate ===                                 
Path: async-hooks/test-zlib.zlib-binding.deflate
Command: out/Release/node /home/shivang/oss/node/test/async-hooks/test-zlib.zlib-binding.deflate.js
--- CRASHED (Signal: 11) ---
`

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
