### PR TITLE
tls: throw if SNICallback is not a function

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -896,6 +896,11 @@ function Server(options, listener) {
       'options.handshakeTimeout', 'number', options.handshakeTimeout);
   }
 
+  if (this[kSNICallback] && typeof this[kSNICallback] !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.SNICallback', 'function', options.SNICallback);
+  }
+
   if (this.sessionTimeout) {
     this._sharedCreds.context.setSessionTimeout(this.sessionTimeout);
   }

--- a/test/parallel/test-tls-snicallback-error.js
+++ b/test/parallel/test-tls-snicallback-error.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+if (!process.features.tls_sni)
+  common.skip('compiled without OpenSSL or with old OpenSSL version');
+
+const assert = require('assert');
+const tls = require('tls');
+
+['fhqwhgads', 42, {}, []].forEach((testValue) => {
+  assert.throws(
+    () => { tls.createServer({ SNICallback: testValue }); },
+    { code: 'ERR_INVALID_ARG_TYPE', message: /\boptions\.SNICallback\b/ }
+  );
+});


### PR DESCRIPTION
If a value is passed for SNICallback and it is not a function,
createServer() will now throw.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
