### PR TITLE
src: do not cache `NumberOfHeapSpaces()` globally

### DIFF
--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -71,9 +71,6 @@ static const size_t kHeapSpaceStatisticsPropertiesCount =
     HEAP_SPACE_STATISTICS_PROPERTIES(V);
 #undef V
 
-// Will be populated in InitializeV8Bindings.
-static size_t number_of_heap_spaces = 0;
-
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -101,7 +98,7 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   Isolate* const isolate = env->isolate();
   double* buffer = env->heap_space_statistics_buffer();
 
-  for (size_t i = 0; i < number_of_heap_spaces; i++) {
+  for (size_t i = 0; i < isolate->NumberOfHeapSpaces(); i++) {
     isolate->GetHeapSpaceStatistics(&s, i);
     size_t const property_offset = i * kHeapSpaceStatisticsPropertiesCount;
 #define V(index, name, _) buffer[property_offset + index] = \
@@ -153,7 +150,7 @@ void Initialize(Local<Object> target,
               Uint32::NewFromUnsigned(env->isolate(),
                                       kHeapSpaceStatisticsPropertiesCount));
 
-  number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
+  size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
 
   // Heap space names are extracted once and exposed to JavaScript to
   // avoid excessive creation of heap space name Strings.


### PR DESCRIPTION
While `NumberOfHeapSpaces()` currently returns a constant value,
that is not strictly guaranteed by the V8 API as far as I can tell.
Therefore, caching it globally does not seem appropriate.

(The motivation here is that this squelches warnings which are
produced by concurrency debugging tooling due to the apparent
race conditions when accessing the global variable.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (presumably)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
