### PR TITLE
Revert "repl: add friendly tips about how to exit repl"

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -215,15 +215,9 @@ function REPLServer(prompt,
 
   function defaultEval(code, context, file, cb) {
     var err, result, script, wrappedErr;
-    var isExitCommand = false;
     var wrappedCmd = false;
     var awaitPromise = false;
     var input = code;
-    var trimmedCommand = code.trim();
-
-    if (trimmedCommand === 'exit' || trimmedCommand === 'quit') {
-      isExitCommand = true;
-    }
 
     if (/^\s*\{/.test(code) && /\}\s*$/.test(code)) {
       // It's confusing for `{ a : 1 }` to be interpreted as a block
@@ -319,16 +313,10 @@ function REPLServer(prompt,
             breakOnSigint: self.breakEvalOnSigint
           };
 
-          const localContext = self.useGlobal ? global : self.context;
-          if (isExitCommand && !localContext.hasOwnProperty(trimmedCommand)) {
-            self.outputStream.write('(To exit, press ^D or type .exit)\n');
-            return self.displayPrompt();
-          }
-
           if (self.useGlobal) {
             result = script.runInThisContext(scriptOptions);
           } else {
-            result = script.runInContext(localContext, scriptOptions);
+            result = script.runInContext(context, scriptOptions);
           }
         } finally {
           if (self.breakEvalOnSigint) {
@@ -344,10 +332,12 @@ function REPLServer(prompt,
         }
       } catch (e) {
         err = e;
+
         if (err && err.code === 'ERR_SCRIPT_EXECUTION_INTERRUPTED') {
-        // The stack trace for this case is not very useful anyway.
+          // The stack trace for this case is not very useful anyway.
           Object.defineProperty(err, 'stack', { value: '' });
         }
+
         if (process.domain) {
           debug('not recoverable, send to domain');
           process.domain.emit('error', err);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -130,29 +130,6 @@ const strictModeTests = [
   }
 ];
 
-const friendlyExitTests = [
-  {
-    send: 'exit',
-    expect: '(To exit, press ^D or type .exit)'
-  },
-  {
-    send: 'quit',
-    expect: '(To exit, press ^D or type .exit)'
-  },
-  {
-    send: 'quit = 1',
-    expect: '1'
-  },
-  {
-    send: 'quit',
-    expect: '1'
-  },
-  {
-    send: 'exit',
-    expect: '(To exit, press ^D or type .exit)'
-  },
-];
-
 const errorTests = [
   // Uncaught error throws and prints out
   {
@@ -763,7 +740,6 @@ const tcpTests = [
     const [ socket, replServer ] = await startUnixRepl();
 
     await runReplTests(socket, prompt_unix, unixTests);
-    await runReplTests(socket, prompt_unix, friendlyExitTests);
     await runReplTests(socket, prompt_unix, errorTests);
     replServer.replMode = repl.REPL_MODE_STRICT;
     await runReplTests(socket, prompt_unix, strictModeTests);


### PR DESCRIPTION
This reverts commit 9aa4ec43fce7fd9166459c98f347760cf450a350.

This commit in question introduced a regression in `repl.eval()`,
as the context argument is no longer passed to `runInContext()`.

Fixes: https://github.com/nodejs/node/issues/20965