### PR TITLE
tools: fix sorting in doc/type-parser.js

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -83,11 +83,11 @@ const customTypesMap = {
   'Http2Stream': 'http2.html#http2_class_http2stream',
   'ServerHttp2Stream': 'http2.html#http2_class_serverhttp2stream',
 
+  'module': 'modules.html#modules_the_module_object',
+
   'Handle': 'net.html#net_server_listen_handle_backlog_callback',
   'net.Server': 'net.html#net_class_net_server',
   'net.Socket': 'net.html#net_class_net_socket',
-
-  'module': 'modules.html#modules_the_module_object',
 
   'os.constants.dlopen': 'os.html#os_dlopen_constants',
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This section groups type links by their home modules and sort these groups alphabetically, so `modules` types should go before the `net` types.