### PR TITLE
test: removed message from strictEqual

### DIFF
--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -8,7 +8,8 @@ const a = require(fixtures.path('module-require', 'relative', 'dot.js'));
 const b = require(fixtures.path('module-require', 'relative', 'dot-slash.js'));
 
 assert.strictEqual(a.value, 42);
-assert.strictEqual(a, b, 'require(".") should resolve like require("./")');
+// require(".") should resolve like require("./")
+assert.strictEqual(a, b);
 
 process.env.NODE_PATH = fixtures.path('module-require', 'relative');
 m._initPaths();


### PR DESCRIPTION
By removing the message from strictEqual, it will now print out the
actual values of a and b, which will be more helpful in debugging. The
old message has been added as a comment above the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
