### PR TITLE
src: remove unused req_wrap-inl.h

### DIFF
--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -25,7 +25,6 @@
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_wrap.h"
-#include "req_wrap-inl.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 #include "util-inl.h"

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -27,7 +27,6 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "handle_wrap.h"
-#include "req_wrap-inl.h"
 #include "uv.h"
 #include "v8.h"
 


### PR DESCRIPTION
This commit removes the inclusion of `req_wrap-inl.h` from
`udp_wrap.h`, and `tty_wrap.cc` as they are not used.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
