### PR TITLE
http2: delay closing stream

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1906,7 +1906,10 @@ class Http2Stream extends Duplex {
           !(state.flags & STREAM_FLAGS_HAS_TRAILERS) &&
           !state.didRead &&
           this.readableFlowing === null) {
-        this.close();
+        // By using setImmediate we allow pushStreams to make it through
+        // before the stream is officially closed. This prevents a bug
+        // in most browsers where those pushStreams would be rejected.
+        setImmediate(this.close.bind(this));
       }
     }
   }
@@ -2178,7 +2181,7 @@ class ServerHttp2Stream extends Http2Stream {
     let headRequest = false;
     if (headers[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD)
       headRequest = options.endStream = true;
-    options.readable = !options.endStream;
+    options.readable = false;
 
     const headersList = mapToHeaders(headers);
     if (!Array.isArray(headersList))


### PR DESCRIPTION
Delay automatically closing the stream with setImmediate in order to allow any pushStreams to be sent first. Also disable the `readable` side of the `pushStream` since there should never be any data incoming.

I'm not able to make a test since technically what we were doing was fine (and works with our own client) but the browsers seem a bit too strict.

Fixes: https://github.com/nodejs/node/issues/20992

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
