### PR TITLE
events: prevent undefined as an event name

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -138,6 +138,8 @@ function enhanceStackTrace(err, own) {
 }
 
 EventEmitter.prototype.emit = function emit(type, ...args) {
+  validateEventName(type, 'eventName');
+
   let doError = (type === 'error');
 
   const events = this._events;
@@ -200,6 +202,7 @@ function _addListener(target, type, listener, prepend) {
     throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
   }
 
+  validateEventName(type, 'eventName');
   events = target._events;
   if (events === undefined) {
     events = target._events = Object.create(null);
@@ -311,6 +314,7 @@ EventEmitter.prototype.removeListener =
         throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
       }
 
+      validateEventName(type, 'eventName');
       events = this._events;
       if (events === undefined)
         return this;
@@ -479,4 +483,14 @@ function unwrapListeners(arr) {
     ret[i] = arr[i].listener || arr[i];
   }
   return ret;
+}
+
+function validateEventName(name, paramName) {
+  if (name === undefined) {
+    const { ERR_INVALID_ARG_TYPE } = lazyErrors();
+    const err = new ERR_INVALID_ARG_TYPE(paramName, ['string', 'symbol'], name);
+
+    Error.captureStackTrace(err, validateEventName);
+    throw err;
+  }
 }

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -95,3 +95,14 @@ common.expectsError(() => {
   message: 'The "listener" argument must be of type Function. ' +
            'Received type object'
 });
+
+// Verify that the event type cannot be undefined.
+common.expectsError(() => {
+  const ee = new EventEmitter();
+  ee.on(undefined, () => {});
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "eventName" argument must be one of type string or symbol. ' +
+           'Received type undefined'
+});

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -21,3 +21,13 @@ common.expectsError(
     message: 'Unhandled error. ([object Object])'
   }
 );
+
+// Verify that the event type cannot be undefined.
+common.expectsError(() => {
+  EE.emit(undefined, new Error());
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "eventName" argument must be one of type string or symbol. ' +
+           'Received type undefined'
+});

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -154,6 +154,17 @@ common.expectsError(() => {
            'Received type object'
 });
 
+// Verify that the event type cannot be undefined.
+common.expectsError(() => {
+  const ee = new EventEmitter();
+  ee.removeListener(undefined, () => {});
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "eventName" argument must be one of type string or symbol. ' +
+           'Received type undefined'
+});
+
 {
   const ee = new EventEmitter();
   const listener = () => {};


### PR DESCRIPTION
This commit prevents undefined as an event name in `addListener()`, `removeListener()`, and `emit()`.

Refs: https://github.com/nodejs/node/issues/20923

A few things to note:

- The motivation here is that `undefined` as an event name is almost certainly a mistake. I considered giving `null` the same treatment, but decided not to as a first draft.
- The validation message claims that the `'eventName'` input must be a string or symbol. Our documentation calls the parameter `'eventName'`, even though the code doesn't. The docs also call for a string or symbol, which simply isn't true.
- I tried to make this a minimally breaking change. If we require the input to be strictly a string or symbol, it will probably break a lot of perfectly good code that uses things like numbers. This kind of breakage seems unnecessary.
- I'm currently validating the addition and removal of listeners, as well as `emit()`. I considered adding validation to the methods that retrieve listeners, but I'm not sure that's necessary since they are only querying state, not modifying it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
