### PR TITLE
test: fix flaky test-child-process-fork-net

### DIFF
--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -175,7 +175,10 @@ if (process.argv[2] === 'child') {
       connect.on('close', function() {
         console.log('CLIENT: closed');
         assert.strictEqual(store, 'echo');
-        server.close();
+        server.close((err) => {
+          if (err && err.code !== 'EPIPE')
+            throw err;
+        });
       });
     });
   }

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -158,6 +158,11 @@ if (process.argv[2] === 'child') {
       console.log('PARENT: server closed');
       callback();
     });
+    server.on('error', (err) => {
+      if (err && err.code !== 'EPIPE') {
+        throw err;
+      }
+    });
     // Don't listen on the same port, because SmartOS sometimes says
     // that the server's fd is closed, but it still cannot listen
     // on the same port again.
@@ -176,8 +181,9 @@ if (process.argv[2] === 'child') {
         console.log('CLIENT: closed');
         assert.strictEqual(store, 'echo');
         server.close((err) => {
-          if (err && err.code !== 'EPIPE')
+          if (err && err.code !== 'EPIPE') {
             throw err;
+          }
         });
       });
     });


### PR DESCRIPTION
Patch inspired on 397eceb6d8eae723c0edc5a9050c72b6ce98d71c to fix
flakyness on test-child-process-fork-net.

Ref: https://github.com/nodejs/node/pull/20973

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
