### PR TITLE
tools: ensure doc-only doesn't update package-lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ available-node = \
 		exit 1; \
 	fi;
 
-run-npm-install = $(PWD)/$(NPM) install --production
+run-npm-install = $(PWD)/$(NPM) install --production --no-package-lock
 
 tools/doc/node_modules/js-yaml/package.json:
 	cd tools/doc && $(call available-node,$(run-npm-install))


### PR DESCRIPTION
Currently `make doc-only` is updating the package-lock.json
which is breaking our release build.

This adds the flags `--no-package-lock` and `--no-audit` when
running `npm install` as part of the `make doc-only` job.

This is blocking to 10.3.0 so I would appreciate a fast track
