### PR TITLE
test: fix flaky test-domain-timers

### DIFF
--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -28,7 +28,6 @@ const timeoutd = domain.create();
 
 timeoutd.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.message, 'Timeout UNREFd');
-  clearTimeout(timeout);
 }, 2));
 
 let t;
@@ -38,6 +37,7 @@ timeoutd.run(function() {
   }, 0).unref();
 
   t = setTimeout(function() {
+    clearTimeout(timeout);
     throw new Error('Timeout UNREFd');
   }, 0);
 });


### PR DESCRIPTION
It's possible for this test to be (extremely infrequently) flaky if 1ms (which due to rounding in libuv could be far less, actually) or more elapses between setting the two timeouts. In that case, the second timer will not fire and the test will fail.

This failed recently in https://ci.nodejs.org/job/node-test-commit-linuxone/1701/nodes=rhel72-s390x/testReport/junit/(root)/test/parallel_test_domain_timers/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
