### PR TITLE
deps: V8: cherry-pick a440efb27f from upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.7',
+    'v8_embedder_string': '-node.8',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1578,6 +1578,9 @@ class V8_EXPORT ScriptCompiler {
    * This will return nullptr if the script cannot be serialized. The
    * CachedData returned by this function should be owned by the caller.
    */
+  static CachedData* CreateCodeCache(Local<UnboundScript> unbound_script);
+
+  // Deprecated.
   static CachedData* CreateCodeCache(Local<UnboundScript> unbound_script,
                                      Local<String> source);
 
@@ -1587,6 +1590,9 @@ class V8_EXPORT ScriptCompiler {
    * This will return nullptr if the script cannot be serialized. The
    * CachedData returned by this function should be owned by the caller.
    */
+  static CachedData* CreateCodeCacheForFunction(Local<Function> function);
+
+  // Deprecated.
   static CachedData* CreateCodeCacheForFunction(Local<Function> function,
                                                 Local<String> source);
 

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -2626,21 +2626,31 @@ uint32_t ScriptCompiler::CachedDataVersionTag() {
 
 ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCache(
     Local<UnboundScript> unbound_script, Local<String> source) {
+  return CreateCodeCache(unbound_script);
+}
+
+ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCache(
+    Local<UnboundScript> unbound_script) {
   i::Handle<i::SharedFunctionInfo> shared =
       i::Handle<i::SharedFunctionInfo>::cast(
           Utils::OpenHandle(*unbound_script));
   i::Handle<i::String> source_str = Utils::OpenHandle(*source);
   DCHECK(shared->is_toplevel());
-  return i::CodeSerializer::Serialize(shared, source_str);
+  return i::CodeSerializer::Serialize(shared);
 }
 
 ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCacheForFunction(
     Local<Function> function, Local<String> source) {
+  return CreateCodeCacheForFunction(function);
+}
+
+ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCacheForFunction(
+    Local<Function> function) {
   i::Handle<i::SharedFunctionInfo> shared(
       i::Handle<i::JSFunction>::cast(Utils::OpenHandle(*function))->shared());
   i::Handle<i::String> source_str = Utils::OpenHandle(*source);
   CHECK(shared->is_wrapped());
-  return i::CodeSerializer::Serialize(shared, source_str);
+  return i::CodeSerializer::Serialize(shared);
 }
 
 MaybeLocal<Script> Script::Compile(Local<Context> context, Local<String> source,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -2634,7 +2634,6 @@ ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCache(
   i::Handle<i::SharedFunctionInfo> shared =
       i::Handle<i::SharedFunctionInfo>::cast(
           Utils::OpenHandle(*unbound_script));
-  i::Handle<i::String> source_str = Utils::OpenHandle(*source);
   DCHECK(shared->is_toplevel());
   return i::CodeSerializer::Serialize(shared);
 }
@@ -2648,7 +2647,6 @@ ScriptCompiler::CachedData* ScriptCompiler::CreateCodeCacheForFunction(
     Local<Function> function) {
   i::Handle<i::SharedFunctionInfo> shared(
       i::Handle<i::JSFunction>::cast(Utils::OpenHandle(*function))->shared());
-  i::Handle<i::String> source_str = Utils::OpenHandle(*source);
   CHECK(shared->is_wrapped());
   return i::CodeSerializer::Serialize(shared);
 }

--- a/deps/v8/src/d8.cc
+++ b/deps/v8/src/d8.cc
@@ -636,7 +636,7 @@ bool Shell::ExecuteString(Isolate* isolate, Local<String> source,
         ShellOptions::CodeCacheOptions::kProduceCache) {
       // Serialize and store it in memory for the next execution.
       ScriptCompiler::CachedData* cached_data =
-          ScriptCompiler::CreateCodeCache(script->GetUnboundScript(), source);
+          ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
       StoreInCodeCache(isolate, source, cached_data);
       delete cached_data;
     }
@@ -645,7 +645,7 @@ bool Shell::ExecuteString(Isolate* isolate, Local<String> source,
         ShellOptions::CodeCacheOptions::kProduceCacheAfterExecute) {
       // Serialize and store it in memory for the next execution.
       ScriptCompiler::CachedData* cached_data =
-          ScriptCompiler::CreateCodeCache(script->GetUnboundScript(), source);
+          ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
       StoreInCodeCache(isolate, source, cached_data);
       delete cached_data;
     }

--- a/deps/v8/src/snapshot/code-serializer.cc
+++ b/deps/v8/src/snapshot/code-serializer.cc
@@ -30,7 +30,6 @@ ScriptData::ScriptData(const byte* data, int length)
   }
 }
 
-<<<<<<< HEAD
 // static
 ScriptCompiler::CachedData* CodeSerializer::Serialize(
     Handle<SharedFunctionInfo> info) {

--- a/deps/v8/src/snapshot/code-serializer.cc
+++ b/deps/v8/src/snapshot/code-serializer.cc
@@ -30,9 +30,10 @@ ScriptData::ScriptData(const byte* data, int length)
   }
 }
 
+<<<<<<< HEAD
 // static
 ScriptCompiler::CachedData* CodeSerializer::Serialize(
-    Handle<SharedFunctionInfo> info, Handle<String> source) {
+    Handle<SharedFunctionInfo> info) {
   Isolate* isolate = info->GetIsolate();
   TRACE_EVENT_CALL_STATS_SCOPED(isolate, "v8", "V8.Execute");
   HistogramTimerScope histogram_timer(isolate->counters()->compile_serialize());
@@ -45,8 +46,7 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
   Handle<Script> script(Script::cast(info->script()), isolate);
   if (FLAG_trace_serializer) {
     PrintF("[Serializing from");
-    Object* script = info->script();
-    Script::cast(script)->name()->ShortPrint();
+    script->name()->ShortPrint();
     PrintF("]\n");
   }
   // TODO(7110): Enable serialization of Asm modules once the AsmWasmData is
@@ -55,10 +55,11 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
   if (isolate->debug()->is_loaded()) return nullptr;
 
   // Serialize code object.
+  Handle<String> source(String::cast(script->source()), isolate);
   CodeSerializer cs(isolate, SerializedCodeData::SourceHash(source));
   DisallowHeapAllocation no_gc;
   cs.reference_map()->AddAttachedReference(*source);
-  ScriptData* script_data = cs.Serialize(info);
+  ScriptData* script_data = cs.SerializeSharedFunctionInfo(info);
 
   if (FLAG_profile_deserialization) {
     double ms = timer.Elapsed().InMillisecondsF();
@@ -75,11 +76,12 @@ ScriptCompiler::CachedData* CodeSerializer::Serialize(
   return result;
 }
 
-ScriptData* CodeSerializer::Serialize(Handle<HeapObject> obj) {
+ScriptData* CodeSerializer::SerializeSharedFunctionInfo(
+    Handle<SharedFunctionInfo> info) {
   DisallowHeapAllocation no_gc;
 
   VisitRootPointer(Root::kHandleScope, nullptr,
-                   Handle<Object>::cast(obj).location());
+                   Handle<Object>::cast(info).location());
   SerializeDeferredObjects();
   Pad();
 

--- a/deps/v8/src/snapshot/code-serializer.h
+++ b/deps/v8/src/snapshot/code-serializer.h
@@ -45,9 +45,8 @@ class ScriptData {
 
 class CodeSerializer : public Serializer<> {
  public:
-  static ScriptCompiler::CachedData* Serialize(Handle<SharedFunctionInfo> info,
-                                               Handle<String> source);
-
+  static ScriptCompiler::CachedData* Serialize(Handle<SharedFunctionInfo> info);
+  static ScriptData* SerializeSharedFunctionInfo(Handle<SharedFunctionInfo> info);
   ScriptData* Serialize(Handle<HeapObject> obj);
 
   V8_WARN_UNUSED_RESULT static MaybeHandle<SharedFunctionInfo> Deserialize(

--- a/deps/v8/src/snapshot/code-serializer.h
+++ b/deps/v8/src/snapshot/code-serializer.h
@@ -46,8 +46,8 @@ class ScriptData {
 class CodeSerializer : public Serializer<> {
  public:
   static ScriptCompiler::CachedData* Serialize(Handle<SharedFunctionInfo> info);
-  static ScriptData* SerializeSharedFunctionInfo(Handle<SharedFunctionInfo> info);
-  ScriptData* Serialize(Handle<HeapObject> obj);
+
+  ScriptData* SerializeSharedFunctionInfo(Handle<SharedFunctionInfo> info);
 
   V8_WARN_UNUSED_RESULT static MaybeHandle<SharedFunctionInfo> Deserialize(
       Isolate* isolate, ScriptData* cached_data, Handle<String> source);

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -25485,8 +25485,7 @@ TEST(CodeCache) {
         v8::ScriptCompiler::kNoCompileOptions;
     v8::Local<v8::Script> script =
         v8::ScriptCompiler::Compile(context, &source, option).ToLocalChecked();
-    cache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript(),
-                                                source_string);
+    cache = v8::ScriptCompiler::CreateCodeCache(script->GetUnboundScript());
   }
   isolate1->Dispose();
 

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -1240,8 +1240,7 @@ static Handle<SharedFunctionInfo> CompileScriptAndProduceCache(
           NOT_NATIVES_CODE)
           .ToHandleChecked();
   std::unique_ptr<ScriptCompiler::CachedData> cached_data(
-      ScriptCompiler::CreateCodeCache(ToApiHandle<UnboundScript>(sfi),
-                                      Utils::ToLocal(source)));
+      ScriptCompiler::CreateCodeCache(ToApiHandle<UnboundScript>(sfi)));
   uint8_t* buffer = NewArray<uint8_t>(cached_data->length);
   MemCopy(buffer, cached_data->data, cached_data->length);
   *script_data = new i::ScriptData(buffer, cached_data->length);
@@ -1895,7 +1894,7 @@ v8::ScriptCompiler::CachedData* CompileRunAndProduceCache(
             .ToLocalChecked();
 
     if (cacheType != CodeCacheType::kAfterExecute) {
-      cache = ScriptCompiler::CreateCodeCache(script, source_str);
+      cache = ScriptCompiler::CreateCodeCache(script);
     }
 
     v8::Local<v8::Value> result = script->BindToCurrentContext()
@@ -1907,7 +1906,7 @@ v8::ScriptCompiler::CachedData* CompileRunAndProduceCache(
               .FromJust());
 
     if (cacheType == CodeCacheType::kAfterExecute) {
-      cache = ScriptCompiler::CreateCodeCache(script, source_str);
+      cache = ScriptCompiler::CreateCodeCache(script);
     }
     CHECK(cache);
   }
@@ -2153,7 +2152,7 @@ TEST(CodeSerializerWithHarmonyScoping) {
         v8::ScriptCompiler::CompileUnboundScript(
             isolate1, &source, v8::ScriptCompiler::kNoCompileOptions)
             .ToLocalChecked();
-    cache = v8::ScriptCompiler::CreateCodeCache(script, source_str);
+    cache = v8::ScriptCompiler::CreateCodeCache(script);
     CHECK(cache);
 
     v8::Local<v8::Value> result = script->BindToCurrentContext()
@@ -2218,7 +2217,7 @@ TEST(Regress503552) {
   heap::SimulateIncrementalMarking(isolate->heap());
 
   v8::ScriptCompiler::CachedData* cache_data =
-      CodeSerializer::Serialize(shared, source);
+      CodeSerializer::Serialize(shared);
   delete cache_data;
 }
 


### PR DESCRIPTION
Original commit message:

      [api] do not require source string for producing code cache.
    
      The embedder should not need to keep track of the source string.
    
      R=jgruber@chromium.org
    
      Cq-Include-Trybots: luci.chromium.try:linux_chromium_rel_ng
      Change-Id: Ie27df755a22fbcae7b6e87a435419d2d8f545558
      Reviewed-on: https://chromium-review.googlesource.com/1013482
      Reviewed-by: Jakob Gruber <jgruber@chromium.org>
      Commit-Queue: Yang Guo <yangguo@chromium.org>
      Cr-Commit-Position: refs/heads/master@{#52614}

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
