### PR TITLE
doc: remove vestigial onboarding section

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -93,7 +93,3 @@ to update from nodejs/node:
 * `git checkout master`
 * `git remote update -p` OR `git fetch --all`
 * `git merge --ff-only upstream/master` (or `REMOTENAME/BRANCH`)
-
-## Best practices
-
-* When making PRs, spend time writing a thorough description.


### PR DESCRIPTION
The onboarding-extras doc includes a section with a single bullet point
instructing the new Collaborator to write good pull request
descriptions. This material is likely superfluous and is in the wrong
document if it is not. (It more properly belongs in pull-requests.md as
it is information that is not specific to new Collaborators.) I am not
putting it in pullrequests.md because that document is already plenty
long and detailed, and includes advice on writing good commit messages,
which tend to become the pull request descriptions anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
