### PR TITLE
doc: move upstream information to onboarding doc

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -83,13 +83,3 @@ need to be attached anymore, as only important bugfixes will be included.
 * Architecture labels
   * `arm`, `mips`, `s390`, `ppc`
   * No x86{_64}, since that is the implied default
-
-## Updating Node.js from Upstream
-
-* `git remote add upstream git://github.com/nodejs/node.git`
-
-to update from nodejs/node:
-
-* `git checkout master`
-* `git remote update -p` OR `git fetch --all`
-* `git merge --ff-only upstream/master` (or `REMOTENAME/BRANCH`)

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -38,7 +38,12 @@ onboarding session.
     apply.whitespace fix`
   * Always continue to PR from your own GitHub fork
     * Branches in the `nodejs/node` repository are only for release lines
-  * See [Updating Node.js from Upstream][]
+  * Add the canonical nodejs repository as `upstream` remote:
+    * `git remote add upstream git://github.com/nodejs/node.git`
+  * To update from `upstream`:
+    * `git checkout master`
+    * `git remote update -p` OR `git fetch --all`
+    * `git merge --ff-only upstream/master` (or `REMOTENAME/BRANCH`)
   * Make a new branch for each PR you submit.
   * Membership: Consider making your membership in the Node.js GitHub
     organization public. This makes it easier to identify Collaborators.
@@ -251,6 +256,5 @@ needs to be pointed out separately during the onboarding.
 [Publicizing or hiding organization membership]: https://help.github.com/articles/publicizing-or-hiding-organization-membership/
 [set up the credentials]: https://github.com/nodejs/node-core-utils#setting-up-credentials
 [two-factor authentication]: https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
-[Updating Node.js from Upstream]: ./onboarding-extras.md#updating-nodejs-from-upstream
 [using a TOTP mobile app]: https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/
 [who-to-cc]: ../COLLABORATOR_GUIDE.md#who-to-cc-in-the-issue-tracker


### PR DESCRIPTION
Move information about setting `upstream` remote and updating from
`upstream` out of `onboarding-extras` and into `onboarding`. Previously,
a link was provided in `onboarding` to the section. This puts all the
git setup information for Collaborator onboardings in one place.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
