### PR TITLE
doc: remove link prediction from STYLE_GUIDE.md

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -26,8 +26,7 @@
     fragment of a clause.
 * Place end-of-sentence punctuation inside wrapping elements — periods go
   inside parentheses and quotes, not after.
-* Documents must start with a level-one heading. An example document will be
-  linked here eventually.
+* Documents must start with a level-one heading.
 * Prefer affixing links to inlining links — prefer `[a link][]` to
   `[a link](http://example.com)`.
 * When documenting APIs, note the version the API was introduced in at


### PR DESCRIPTION
Remove promise to eventually link an example document to show level-one
heading. The style guide has been fine without the example doc for a
long time. The statement is already clear. And the style guide itself is
an example. We don't link to examples of wrapping at 80 characters, for
example. There's no need to link just to show what a level-one heading
is. (And if level-one heading is unclear, then it may be preferable to
improve the terminology rather than to link to an example.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
