### PR TITLE
doc: add OS X to instead of only macOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ platforms in production.
 |--------------|--------------|----------------------------------|----------------------|------------------|
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
-| macOS / OS X | Tier 1       | >= 10.10                         | x64                  |                  |
+| macOS/OS X | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
@@ -115,7 +115,7 @@ using the `--openssl-no-asm` flag.
 *Note:* All prerequisites can be easily installed by following
 [this bootstrapping guide](https://github.com/nodejs/node/blob/master/tools/bootstrap/README.md).
 
-### Unix / macOS
+### Unix/macOS
 
 #### Prerequisites
 
@@ -330,7 +330,7 @@ With the `--download=all`, this may download ICU if you don't have an
 ICU in `deps/icu`. (The embedded `small-icu` included in the default
 Node.js source does not include all locales.)
 
-##### Unix / macOS:
+##### Unix/macOS:
 
 ```console
 $ ./configure --with-intl=full-icu --download=all
@@ -347,7 +347,7 @@ $ ./configure --with-intl=full-icu --download=all
 The `Intl` object will not be available, nor some other APIs such as
 `String.normalize`.
 
-##### Unix / macOS:
+##### Unix/macOS:
 
 ```console
 $ ./configure --without-intl
@@ -359,7 +359,7 @@ $ ./configure --without-intl
 > .\vcbuild without-intl
 ```
 
-#### Use existing installed ICU (Unix / macOS only):
+#### Use existing installed ICU (Unix/macOS only):
 
 ```console
 $ pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
@@ -375,7 +375,7 @@ You can find other ICU releases at
 Download the file named something like `icu4c-**##.#**-src.tgz` (or
 `.zip`).
 
-##### Unix / macOS
+##### Unix/macOS
 
 From an already-unpacked ICU:
 ```console
@@ -411,7 +411,7 @@ This version of Node.js does not support FIPS.
 It is possible to specify one or more JavaScript text files to be bundled in
 the binary as builtin modules when building Node.js.
 
-### Unix / macOS
+### Unix/macOS
 
 This command will make `/root/myModule.js` available via
 `require('/root/myModule')` and `./myModule2.js` available via

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ platforms in production.
 |--------------|--------------|----------------------------------|----------------------|------------------|
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
-| macOS/OS X | Tier 1       | >= 10.10                         | x64                  |                  |
+| macOS/OS X   | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,14 +41,14 @@ platforms in production.
 |--------------|--------------|----------------------------------|----------------------|------------------|
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
-| macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
+| macOS / OS X | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
 | AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be >=power7     |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |
-| macOS        | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
+| OS X         | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
 | GNU/Linux    | Experimental | kernel >= 2.6.32, glibc >= 2.12  | x86                  | limited CI       |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |
 
@@ -115,7 +115,7 @@ using the `--openssl-no-asm` flag.
 *Note:* All prerequisites can be easily installed by following
 [this bootstrapping guide](https://github.com/nodejs/node/blob/master/tools/bootstrap/README.md).
 
-### Unix/macOS
+### Unix / macOS
 
 #### Prerequisites
 
@@ -330,7 +330,7 @@ With the `--download=all`, this may download ICU if you don't have an
 ICU in `deps/icu`. (The embedded `small-icu` included in the default
 Node.js source does not include all locales.)
 
-##### Unix/macOS:
+##### Unix / macOS:
 
 ```console
 $ ./configure --with-intl=full-icu --download=all
@@ -347,7 +347,7 @@ $ ./configure --with-intl=full-icu --download=all
 The `Intl` object will not be available, nor some other APIs such as
 `String.normalize`.
 
-##### Unix/macOS:
+##### Unix / macOS:
 
 ```console
 $ ./configure --without-intl
@@ -359,7 +359,7 @@ $ ./configure --without-intl
 > .\vcbuild without-intl
 ```
 
-#### Use existing installed ICU (Unix/macOS only):
+#### Use existing installed ICU (Unix / macOS only):
 
 ```console
 $ pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
@@ -375,7 +375,7 @@ You can find other ICU releases at
 Download the file named something like `icu4c-**##.#**-src.tgz` (or
 `.zip`).
 
-##### Unix/macOS
+##### Unix / macOS
 
 From an already-unpacked ICU:
 ```console


### PR DESCRIPTION
The last OS X version is 10.11 El Captian, and the first macOS version
is 10.12 Sierra. So >= 10.8 < 10.10 is called OS X and >= 10.10 is
called OS X or macOS.

Refs: https://en.wikipedia.org/wiki/MacOS#Release_history

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
