### PR TITLE
doc: better font stack for monospace in docs

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -35,7 +35,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 pre, tt, code, .pre, span.type, a.type {
-  font-family: Monaco, Consolas, "Lucida Console", monospace;
+  font-family: SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: .9em;
 }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

There appear to be rendering issues with inconsistent glyph width when using the Monaco font on non-macOS machines. This change updates the native CSS font stack to use the same font stack as Boostrap does, minus the Monaco font.

Before:
![before](https://user-images.githubusercontent.com/115237/40729702-4249e8c4-642d-11e8-98e6-579ce9528b18.png)

After:
![after](https://user-images.githubusercontent.com/115237/40729701-4222e670-642d-11e8-9268-708156e5594e.png)


