### PR TITLE
test: mark test-trace-events-fs-sync as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -20,5 +20,7 @@ test-child-process-fork-net: PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
+# https://github.com/nodejs/node/issues/21038
+test-trace-events-fs-sync: PASS,FLAKY
 
 [$system==aix]


### PR DESCRIPTION
test-trace-events-fs-sync has been failing ocasinally on FreeBSD. While
we don't have a fix, it should be marked as flaky.

Ref: https://github.com/nodejs/node/issues/21038

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
