### PR TITLE
lib: use focused ESLint disabling in util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -87,10 +87,11 @@ const errorToString = Error.prototype.toString;
 let CIRCULAR_ERROR_MESSAGE;
 let internalDeepEqual;
 
-/* eslint-disable */
+/* eslint-disable no-control-regex */
 const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c]/;
 const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c]/g;
-/* eslint-enable */
+/* eslint-enable no-control-regex */
+
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;
 


### PR DESCRIPTION
Instead of disabling all ESLint rules for two lines that require a
violation of no-control-regex, disable only the no-control-regex rule.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
