### PR TITLE
doc: remove POST_STATUS_TO_PR from onboarding.md

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -180,9 +180,7 @@ onboarding session.
       request containing the code you wish to test. For example, if the URL for
       the pull request is `https://github.com/nodejs/node/issues/7006`, then put
       `7006` in the `PR_ID`.
-    * The remaining elements on the form are typically unchanged with the
-      exception of `POST_STATUS_TO_PR`. Check that if you want a CI status
-      indicator to be automatically inserted into the PR.
+    * The remaining elements on the form are typically unchanged.
   * If you need help with something CI-related:
     * Use #node-dev (IRC) to talk to other Collaborators.
     * Use #node-build (IRC) to talk to the Build WG members who maintain the CI


### PR DESCRIPTION
POST_STATUS_TO_PR is checked/enabled by default so there is no longer a
need to mention that it should be checked in onboarding.md. There is
almost never a situation when it should be unchecked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
