### PR TITLE
remove empty-directory fixture

### DIFF
--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -22,13 +22,17 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
+
+tmpdir.refresh();
+
 const nonexistentFile = fixtures.path('non-existent');
 const nonexistentDir = fixtures.path('non-existent', 'foo', 'bar');
 const existingFile = fixtures.path('exit.js');
 const existingFile2 = fixtures.path('create-file.js');
-const existingDir = fixtures.path('empty');
+const existingDir = tmpdir.path;
 const existingDir2 = fixtures.path('keys');
 const { COPYFILE_EXCL } = fs.constants;
 const uv = process.binding('uv');

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -21,9 +21,11 @@
 
 'use strict';
 const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
 const backslash = /\\/g;
 
@@ -168,9 +170,10 @@ assert.strictEqual(require('../fixtures/foo').foo, 'ok',
 
 // Should not attempt to load a directory
 try {
-  require('../fixtures/empty');
+  tmpdir.refresh();
+  require(tmpdir.path);
 } catch (err) {
-  assert.strictEqual(err.message, 'Cannot find module \'../fixtures/empty\'');
+  assert.strictEqual(err.message, `Cannot find module '${tmpdir.path}'`);
 }
 
 {
@@ -284,7 +287,6 @@ try {
     'fixtures/registerExt.test': {},
     'fixtures/registerExt.hello.world': {},
     'fixtures/registerExt2.test': {},
-    'fixtures/empty.js': {},
     'fixtures/module-load-order/file1': {},
     'fixtures/module-load-order/file2.js': {},
     'fixtures/module-load-order/file3.node': {},


### PR DESCRIPTION
Instead of having an empty directory fixture (that isn't actually empty because `git` can't track an empty directory), use `tmpdir.path` after running `tmpdir.refresh()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
