### PR TITLE
http: changed some var keywords to const and let keywords

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -61,7 +61,7 @@ function Agent(options) {
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
 
   this.on('free', (socket, options) => {
-    var name = this.getName(options);
+    const name = this.getName(options);
     debug('agent.on(free)', name);
 
     if (socket.writable &&
@@ -74,14 +74,14 @@ function Agent(options) {
     } else {
       // If there are no pending requests, then put it in
       // the freeSockets pool, but only if we're allowed to do so.
-      var req = socket._httpMessage;
+      const req = socket._httpMessage;
       if (req &&
           req.shouldKeepAlive &&
           socket.writable &&
           this.keepAlive) {
-        var freeSockets = this.freeSockets[name];
-        var freeLen = freeSockets ? freeSockets.length : 0;
-        var count = freeLen;
+        let freeSockets = this.freeSockets[name];
+        const freeLen = freeSockets ? freeSockets.length : 0;
+        let count = freeLen;
         if (this.sockets[name])
           count += this.sockets[name].length;
 
@@ -113,7 +113,7 @@ Agent.prototype.createConnection = net.createConnection;
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function getName(options) {
-  var name = options.host || 'localhost';
+  let name = options.host || 'localhost';
 
   name += ':';
   if (options.port)
@@ -153,17 +153,17 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
   if (!options.servername)
     options.servername = calculateServerName(options, req);
 
-  var name = this.getName(options);
+  const name = this.getName(options);
   if (!this.sockets[name]) {
     this.sockets[name] = [];
   }
 
-  var freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
-  var sockLen = freeLen + this.sockets[name].length;
+  const freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
+  const sockLen = freeLen + this.sockets[name].length;
 
   if (freeLen) {
     // we have a free socket, so use that.
-    var socket = this.freeSockets[name].shift();
+    const socket = this.freeSockets[name].shift();
     // Guard against an uninitialized or user supplied Socket.
     if (socket._handle && typeof socket._handle.asyncReset === 'function') {
       // Assign the handle a new asyncId and run any init() hooks.
@@ -201,12 +201,12 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   if (!options.servername)
     options.servername = calculateServerName(options, req);
 
-  var name = this.getName(options);
+  const name = this.getName(options);
   options._agentKey = name;
 
   debug('createConnection', name, options);
   options.encoding = null;
-  var called = false;
+  let called = false;
 
   const oncreate = (err, s) => {
     if (called)
@@ -281,19 +281,19 @@ function installListeners(agent, s, options) {
 }
 
 Agent.prototype.removeSocket = function removeSocket(s, options) {
-  var name = this.getName(options);
+  const name = this.getName(options);
   debug('removeSocket', name, 'writable:', s.writable);
-  var sets = [this.sockets];
+  const sets = [this.sockets];
 
   // If the socket was destroyed, remove it from the free buffers too.
   if (!s.writable)
     sets.push(this.freeSockets);
 
   for (var sk = 0; sk < sets.length; sk++) {
-    var sockets = sets[sk];
+    const sockets = sets[sk];
 
     if (sockets[name]) {
-      var index = sockets[name].indexOf(s);
+      const index = sockets[name].indexOf(s);
       if (index !== -1) {
         sockets[name].splice(index, 1);
         // Don't leak
@@ -305,7 +305,7 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
 
   if (this.requests[name] && this.requests[name].length) {
     debug('removeSocket, have a request, make a socket');
-    var req = this.requests[name][0];
+    const req = this.requests[name][0];
     // If we have pending requests and a socket gets closed make a new one
     this.createSocket(req, options, handleSocketCreation(req, false));
   }
@@ -324,12 +324,12 @@ Agent.prototype.reuseSocket = function reuseSocket(socket, req) {
 };
 
 Agent.prototype.destroy = function destroy() {
-  var sets = [this.freeSockets, this.sockets];
+  const sets = [this.freeSockets, this.sockets];
   for (var s = 0; s < sets.length; s++) {
-    var set = sets[s];
-    var keys = Object.keys(set);
+    const set = sets[s];
+    const keys = Object.keys(set);
     for (var v = 0; v < keys.length; v++) {
-      var setName = set[keys[v]];
+      const setName = set[keys[v]];
       for (var n = 0; n < setName.length; n++) {
         setName[n].destroy();
       }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -88,8 +88,8 @@ function ClientRequest(options, cb) {
     options = util._extend({}, options);
   }
 
-  var agent = options.agent;
-  var defaultAgent = options._defaultAgent || Agent.globalAgent;
+  let agent = options.agent;
+  const defaultAgent = options._defaultAgent || Agent.globalAgent;
   if (agent === false) {
     agent = new defaultAgent.constructor();
   } else if (agent === null || agent === undefined) {
@@ -105,12 +105,12 @@ function ClientRequest(options, cb) {
   }
   this.agent = agent;
 
-  var protocol = options.protocol || defaultAgent.protocol;
-  var expectedProtocol = defaultAgent.protocol;
+  const protocol = options.protocol || defaultAgent.protocol;
+  let expectedProtocol = defaultAgent.protocol;
   if (this.agent && this.agent.protocol)
     expectedProtocol = this.agent.protocol;
 
-  var path;
+  let path;
   if (options.path) {
     path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
@@ -121,20 +121,20 @@ function ClientRequest(options, cb) {
     throw new ERR_INVALID_PROTOCOL(protocol, expectedProtocol);
   }
 
-  var defaultPort = options.defaultPort ||
+  const defaultPort = options.defaultPort ||
                     this.agent && this.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = validateHost(options.hostname, 'hostname') ||
+  const port = options.port = options.port || defaultPort || 80;
+  const host = options.host = validateHost(options.hostname, 'hostname') ||
                             validateHost(options.host, 'host') || 'localhost';
 
-  var setHost = (options.setHost === undefined || Boolean(options.setHost));
+  const setHost = (options.setHost === undefined || Boolean(options.setHost));
 
   this.socketPath = options.socketPath;
   this.timeout = options.timeout;
 
-  var method = options.method;
-  var methodIsString = (typeof method === 'string');
+  let method = options.method;
+  const methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {
     throw new ERR_INVALID_ARG_TYPE('method', 'string', method);
   }
@@ -171,7 +171,7 @@ function ClientRequest(options, cb) {
   this.parser = null;
   this.maxHeadersCount = null;
 
-  var called = false;
+  let called = false;
 
   if (this.agent) {
     // If there is an agent we should default to Connection:keep-alive,
@@ -187,23 +187,23 @@ function ClientRequest(options, cb) {
     }
   }
 
-  var headersArray = Array.isArray(options.headers);
+  const headersArray = Array.isArray(options.headers);
   if (!headersArray) {
     if (options.headers) {
-      var keys = Object.keys(options.headers);
+      const keys = Object.keys(options.headers);
       for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
+        const key = keys[i];
         this.setHeader(key, options.headers[key]);
       }
     }
 
     if (host && !this.getHeader('host') && setHost) {
-      var hostHeader = host;
+      let hostHeader = host;
 
       // For the Host header, ensure that IPv6 addresses are enclosed
       // in square brackets, as defined by URI formatting
       // https://tools.ietf.org/html/rfc3986#section-3.2.2
-      var posColon = hostHeader.indexOf(':');
+      const posColon = hostHeader.indexOf(':');
       if (posColon !== -1 &&
           hostHeader.indexOf(':', posColon + 1) !== -1 &&
           hostHeader.charCodeAt(0) !== 91/* '[' */) {
@@ -234,7 +234,7 @@ function ClientRequest(options, cb) {
                       options.headers);
   }
 
-  var oncreate = (err, socket) => {
+  const oncreate = (err, socket) => {
     if (called)
       return;
     called = true;
@@ -318,15 +318,15 @@ function emitAbortNT() {
 
 function createHangUpError() {
   // eslint-disable-next-line no-restricted-syntax
-  var error = new Error('socket hang up');
+  const error = new Error('socket hang up');
   error.code = 'ECONNRESET';
   return error;
 }
 
 
 function socketCloseListener() {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('HTTP socket close');
 
   // Pull through final chunk, if anything is buffered.
@@ -379,8 +379,8 @@ function socketCloseListener() {
 }
 
 function socketErrorListener(err) {
-  var socket = this;
-  var req = socket._httpMessage;
+  const socket = this;
+  const req = socket._httpMessage;
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
@@ -393,7 +393,7 @@ function socketErrorListener(err) {
   // Handle any pending data
   socket.read();
 
-  var parser = socket.parser;
+  const parser = socket.parser;
   if (parser) {
     parser.finish();
     freeParser(parser, req, socket);
@@ -406,16 +406,16 @@ function socketErrorListener(err) {
 }
 
 function freeSocketErrorListener(err) {
-  var socket = this;
+  const socket = this;
   debug('SOCKET ERROR on FREE socket:', err.message, err.stack);
   socket.destroy();
   socket.emit('agentRemove');
 }
 
 function socketOnEnd() {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
@@ -431,13 +431,13 @@ function socketOnEnd() {
 }
 
 function socketOnData(d) {
-  var socket = this;
-  var req = this._httpMessage;
-  var parser = this.parser;
+  const socket = this;
+  const req = this._httpMessage;
+  const parser = this.parser;
 
   assert(parser && parser.socket === socket);
 
-  var ret = parser.execute(d);
+  const ret = parser.execute(d);
   if (ret instanceof Error) {
     debug('parse error', ret);
     freeParser(parser, req, socket);
@@ -446,8 +446,8 @@ function socketOnData(d) {
     req.emit('error', ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade (if status code 101) or CONNECT
-    var bytesParsed = ret;
-    var res = parser.incoming;
+    const bytesParsed = ret;
+    const res = parser.incoming;
     req.res = res;
 
     socket.removeListener('data', socketOnData);
@@ -456,9 +456,9 @@ function socketOnData(d) {
     parser.finish();
     freeParser(parser, req, socket);
 
-    var bodyHead = d.slice(bytesParsed, d.length);
+    const bodyHead = d.slice(bytesParsed, d.length);
 
-    var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+    const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
     if (req.listenerCount(eventName) > 0) {
       req.upgradeOrConnect = true;
 
@@ -499,8 +499,8 @@ function statusIsInformational(status) {
 
 // client
 function parserOnIncomingClient(res, shouldKeepAlive) {
-  var socket = this.socket;
-  var req = socket._httpMessage;
+  const socket = this.socket;
+  const req = socket._httpMessage;
 
   debug('AGENT incoming response!');
 
@@ -551,7 +551,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   // add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
   req.on('prefinish', requestOnPrefinish);
-  var handled = req.emit('response', res);
+  const handled = req.emit('response', res);
 
   // If the user did not listen for the 'response' event, then they
   // can't possibly read the data, so we ._dump() it into the void
@@ -567,7 +567,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
 // client
 function responseKeepAlive(res, req) {
-  var socket = req.socket;
+  const socket = req.socket;
 
   if (!req.shouldKeepAlive) {
     if (socket.writable) {
@@ -621,7 +621,7 @@ function emitFreeNT(socket) {
 }
 
 function tickOnSocket(req, socket) {
-  var parser = parsers.alloc();
+  const parser = parsers.alloc();
   req.socket = socket;
   req.connection = socket;
   parser.reinitialize(HTTPParser.RESPONSE);
@@ -724,7 +724,7 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   // Set timeoutCb so that it'll get cleaned up on request end
   this.timeoutCb = emitTimeout;
   if (this.socket) {
-    var sock = this.socket;
+    const sock = this.socket;
     this.socket.once('connect', function() {
       sock.setTimeout(msecs, emitTimeout);
     });


### PR DESCRIPTION
_http_agent.js: var keywords changed to const and let keywords.
_http_client.js: var keywords changed to const and let keywords.

Changed some var keywords to be const or let keywords to adjust to the ES6 standard ( i did not change var on the loops blocks cause the linter remarks those)

##### Checklist
- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
