### PR TITLE
http2: fix premature destroy

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1891,7 +1891,7 @@ class Http2Stream extends Duplex {
     }
 
     // TODO(mcollina): remove usage of _*State properties
-    if (!this.writable) {
+    if (this._writableState.finished) {
       if (!this.readable && this.closed) {
         this.destroy();
         return;


### PR DESCRIPTION
Check `stream._writableState.finished` instead of `stream.writable` as the latter can lead to premature calls to destroy and dropped writes on busy processes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
