### PR TITLE
deps: Upgrade node-inspect to 1.11.5

### DIFF
--- a/deps/node-inspect/.eslintrc
+++ b/deps/node-inspect/.eslintrc
@@ -5,7 +5,7 @@ env:
   es6: true
 
 parserOptions:
-  ecmaVersion: 2016
+  ecmaVersion: 2017
 
 rules:
   # Possible Errors
@@ -139,3 +139,9 @@ globals:
   DTRACE_HTTP_SERVER_RESPONSE: false
   DTRACE_NET_SERVER_CONNECTION: false
   DTRACE_NET_STREAM_END: false
+  LTTNG_HTTP_CLIENT_REQUEST: false
+  LTTNG_HTTP_CLIENT_RESPONSE: false
+  LTTNG_HTTP_SERVER_REQUEST: false
+  LTTNG_HTTP_SERVER_RESPONSE: false
+  LTTNG_NET_SERVER_CONNECTION: false
+  LTTNG_NET_STREAM_END: false

--- a/deps/node-inspect/.npmrc
+++ b/deps/node-inspect/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org
+package-lock=false

--- a/deps/node-inspect/CHANGELOG.md
+++ b/deps/node-inspect/CHANGELOG.md
@@ -1,3 +1,17 @@
+### 1.11.5
+
+* Fix eslint issues - **[@jkrems](https://github.com/jkrems)** [#63](https://github.com/nodejs/node-inspect/pull/63)
+  - [`2adadbc`](https://github.com/nodejs/node-inspect/commit/2adadbc1086d2e374c425acbf96260a122705db2) **style:** Fix eslint issues
+  - [`a6d2f88`](https://github.com/nodejs/node-inspect/commit/a6d2f882c026409696a1b063ff40ceba7e1ddb86) **doc:** Remove redundant newline at the end
+
+
+### 1.11.4
+
+* Handle blocked port - **[@jkrems](https://github.com/jkrems)** [#62](https://github.com/nodejs/node-inspect/pull/62)
+  - [`3388969`](https://github.com/nodejs/node-inspect/commit/3388969d0032a78ff0cdb8146f170b978ec13b7b) **chore:** Disable package-lock
+  - [`d278b23`](https://github.com/nodejs/node-inspect/commit/d278b233ae5e11a2b62d01ccbaae594f39b32a96) **fix:** Stop asking to report a blocked port - see: [#60](https://github.com/nodejs/node-inspect/issues/60)
+
+
 ### 1.11.3
 
 * [`93caa0f`](https://github.com/nodejs/node-inspect/commit/93caa0f5267c7ab452b258d3b03329a0bb5ac7f7) **docs:** Add missing oc in protocol

--- a/deps/node-inspect/package.json
+++ b/deps/node-inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-inspect",
-  "version": "1.11.3",
+  "version": "1.11.5",
   "description": "Node Inspect",
   "license": "MIT",
   "main": "lib/_inspect.js",

--- a/deps/node-inspect/test/cli/invalid-args.test.js
+++ b/deps/node-inspect/test/cli/invalid-args.test.js
@@ -1,4 +1,7 @@
 'use strict';
+const Path = require('path');
+const { createServer } = require('net');
+
 const { test } = require('tap');
 
 const startCLI = require('./start-cli');
@@ -22,4 +25,30 @@ test('launch w/ invalid host:port', (t) => {
         'Tells the user that the connection failed');
       t.equal(code, 1, 'exits with non-zero exit code');
     });
+});
+
+test('launch w/ unavailable port', async (t) => {
+  const blocker = createServer((socket) => socket.end());
+  const port = await new Promise((resolve, reject) => {
+    blocker.on('error', reject);
+    blocker.listen(0, '127.0.0.1', () => resolve(blocker.address().port));
+  });
+
+  try {
+    const script = Path.join('examples', 'three-lines.js');
+    const cli = startCLI([`--port=${port}`, script]);
+    const code = await cli.quit();
+
+    t.notMatch(
+      cli.output,
+      'report this bug',
+      'Omits message about reporting this as a bug');
+    t.match(
+      cli.output,
+      `waiting for 127.0.0.1:${port} to be free`,
+      'Tells the user that the port wasn\'t available');
+    t.equal(code, 1, 'exits with non-zero exit code');
+  } finally {
+    blocker.close();
+  }
 });


### PR DESCRIPTION
Removes the prompt to report a bug when trying to launch the
debugger using a port that is already in use.

Changeset generated via:

```
rm -rf deps/node-inspect node-inspect-* && \
  curl -sSL "https://github.com/nodejs/node-inspect/archive/v1.11.5.tar.gz" | \
  tar -xzvf - && mv node-inspect-* deps/node-inspect
```

Compare: https://github.com/nodejs/node-inspect/compare/v1.11.3...v1.11.5

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
