### PR TITLE
timers: check can_call_into_js in Immediates

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -457,7 +457,7 @@ void Environment::RunAndClearNativeImmediates() {
 void Environment::CheckImmediate(uv_check_t* handle) {
   Environment* env = Environment::from_immediate_check_handle(handle);
 
-  if (env->immediate_info()->count() == 0)
+  if (env->immediate_info()->count() == 0 || !env->can_call_into_js())
     return;
 
   HandleScope scope(env->isolate());
@@ -472,7 +472,7 @@ void Environment::CheckImmediate(uv_check_t* handle) {
                  0,
                  nullptr,
                  {0, 0}).ToLocalChecked();
-  } while (env->immediate_info()->has_outstanding());
+  } while (env->immediate_info()->has_outstanding() && env->can_call_into_js());
 
   if (env->immediate_info()->ref_count() == 0)
     env->ToggleImmediateRef(false);

--- a/src/env.cc
+++ b/src/env.cc
@@ -457,13 +457,16 @@ void Environment::RunAndClearNativeImmediates() {
 void Environment::CheckImmediate(uv_check_t* handle) {
   Environment* env = Environment::from_immediate_check_handle(handle);
 
-  if (env->immediate_info()->count() == 0 || !env->can_call_into_js())
+  if (env->immediate_info()->count() == 0)
     return;
 
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());
 
   env->RunAndClearNativeImmediates();
+
+  if (!env->can_call_into_js())
+    return;
 
   do {
     MakeCallback(env->isolate(),


### PR DESCRIPTION
Do not call into JS if it's not safe in Immediates and prevent a future infinite loop.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
