### PR TITLE
stream,doc: require finished callback and add options docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1301,14 +1301,14 @@ added: v10.0.0
 
 * `stream` {Stream} A readable and/or writable stream.
 * `options` {Object}
-  * `error` {boolean} If set to `false` a call to emit('error', err) is not
-    treated finished. **Default**: `true`.
-  * `readable` {boolean} When set to `false` the callback will be called after
-    the stream ended but the stream might still be readable. **Default**:
-    `true`.
-  * `writable` {boolean} When set to `false` the callback will be called after
-    the stream ended but the stream might still be writable. **Default**:
-    `true`.
+  * `error` {boolean} If set to `false`, then a call to `emit('error', err)` is
+    not treated as finished. **Default**: `true`.
+  * `readable` {boolean} When set to `false`, the callback will be called when
+    the stream ends even though the stream might still be readable.
+    **Default**: `true`.
+  * `writable` {boolean} When set to `false`, the callback will be called when
+    the stream ends even though the stream might still be writable.
+    **Default**: `true`.
 * `callback` {Function} A callback function that takes an optional error
   argument.
 
@@ -2447,7 +2447,7 @@ contain multi-byte characters.
 [zlib]: zlib.html
 [hwm-gotcha]: #stream_highwatermark_discrepancy_after_calling_readable_setencoding
 [pipeline]: #stream_stream_pipeline_streams_callback
-[finished]: #stream_stream_finished_stream_callback
+[finished]: #stream_stream_finished_stream_options_callback
 [stream-_flush]: #stream_transform_flush_callback
 [stream-_read]: #stream_readable_read_size_1
 [stream-_transform]: #stream_transform_transform_chunk_encoding_callback

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1294,12 +1294,21 @@ implementors should not override this method, but instead implement
 [`readable._destroy()`][readable-_destroy].
 The default implementation of `_destroy()` for `Transform` also emit `'close'`.
 
-### stream.finished(stream, callback)
+### stream.finished(stream[, options], callback)
 <!-- YAML
 added: v10.0.0
 -->
 
 * `stream` {Stream} A readable and/or writable stream.
+* `options` {Object}
+  * `error` {boolean} If set to `false` a call to emit('error', err) is not
+    treated finished. **Default**: `true`.
+  * `readable` {boolean} When set to `false` the callback will be called after
+    the stream ended but the stream might still be readable. **Default**:
+    `true`.
+  * `writable` {boolean} When set to `false` the callback will be called after
+    the stream ended but the stream might still be writable. **Default**:
+    `true`.
 * `callback` {Function} A callback function that takes an optional error
   argument.
 

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -25,8 +25,7 @@ function eos(stream, opts, callback) {
   if (arguments.length === 2) {
     callback = opts;
     opts = {};
-  }
-  if (opts == null) {
+  } else if (opts == null) {
     opts = {};
   } else if (typeof opts !== 'object') {
     throw new ERR_INVALID_ARG_TYPE('opts', 'object', opts);

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -4,10 +4,9 @@
 'use strict';
 
 const {
+  ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = require('internal/errors').codes;
-
-function noop() {}
 
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
@@ -23,10 +22,20 @@ function once(callback) {
 }
 
 function eos(stream, opts, callback) {
-  if (typeof opts === 'function') return eos(stream, null, opts);
-  if (!opts) opts = {};
+  if (arguments.length === 2) {
+    callback = opts;
+    opts = {};
+  }
+  if (opts == null) {
+    opts = {};
+  } else if (typeof opts !== 'object') {
+    throw new ERR_INVALID_ARG_TYPE('opts', 'object', opts);
+  }
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('callback', 'function', callback);
+  }
 
-  callback = once(callback || noop);
+  callback = once(callback);
 
   const ws = stream._writableState;
   const rs = stream._readableState;

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -91,8 +91,8 @@ const { promisify } = require('util');
 {
   const rs = fs.createReadStream('file-does-not-exist');
 
-  finished(rs, common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ENOENT');
+  finished(rs, common.expectsError({
+    code: 'ENOENT'
   }));
 }
 
@@ -116,6 +116,40 @@ const { promisify } = require('util');
   }));
 
   rs.emit('close'); // should trigger error
+  rs.push(null);
+  rs.resume();
+}
+
+// Test faulty input values and options.
+{
+  const rs = new Readable({
+    read() {}
+  });
+
+  assert.throws(
+    () => finished(rs, 'foo'),
+    {
+      name: /ERR_INVALID_ARG_TYPE/,
+      message: /callback/
+    }
+  );
+  assert.throws(
+    () => finished(rs, 'foo', () => {}),
+    {
+      name: /ERR_INVALID_ARG_TYPE/,
+      message: /opts/
+    }
+  );
+  assert.throws(
+    () => finished(rs, {}, 'foo'),
+    {
+      name: /ERR_INVALID_ARG_TYPE/,
+      message: /callback/
+    }
+  );
+
+  finished(rs, null, common.mustCall());
+
   rs.push(null);
   rs.resume();
 }


### PR DESCRIPTION
I just stumbled upon missing documentation about the `Stream.finished()` options. We should also make the callback mandatory as already documented. Right now there would be a no op added in case a falsy value is provided for the callback.

<s>Test cases are missing and I'll add some later on (if someone wants to add them, I am also more than happy about that ;-) please feel free to just directly pushing on this branch).</s>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
