### PR TITLE
test: improve internal/buffer.js test coverage

### DIFF
--- a/test/parallel/test-buffer-readint.js
+++ b/test/parallel/test-buffer-readint.js
@@ -160,7 +160,7 @@ const assert = require('assert');
   });
 
   // Test 1 to 6 bytes.
-  for (let i = 1; i < 6; i++) {
+  for (let i = 1; i <= 6; i++) {
     ['readIntBE', 'readIntLE'].forEach((fn) => {
       ['', '0', null, {}, [], () => {}, true, false, undefined].forEach((o) => {
         assert.throws(

--- a/test/parallel/test-buffer-readuint.js
+++ b/test/parallel/test-buffer-readuint.js
@@ -128,7 +128,7 @@ const assert = require('assert');
   });
 
   // Test 1 to 6 bytes.
-  for (let i = 1; i < 6; i++) {
+  for (let i = 1; i <= 6; i++) {
     ['readUIntBE', 'readUIntLE'].forEach((fn) => {
       ['', '0', null, {}, [], () => {}, true, false, undefined].forEach((o) => {
         assert.throws(

--- a/test/parallel/test-buffer-writeint.js
+++ b/test/parallel/test-buffer-writeint.js
@@ -162,6 +162,21 @@ const errorOutOfBounds = common.expectsError({
   });
 }
 
+// Test 48 bit
+{
+  const value = 0x1234567890ab;
+  const buffer = Buffer.allocUnsafe(6);
+  buffer.writeIntBE(value, 0, 6);
+  assert.ok(buffer.equals(new Uint8Array([
+    0x12, 0x34, 0x56, 0x78, 0x90, 0xab
+  ])));
+
+  buffer.writeIntLE(value, 0, 6);
+  assert.ok(buffer.equals(new Uint8Array([
+    0xab, 0x90, 0x78, 0x56, 0x34, 0x12
+  ])));
+}
+
 // Test Int
 {
   const data = Buffer.alloc(8);

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -110,6 +110,17 @@ const assert = require('assert');
   assert.ok(data.equals(new Uint8Array([0x6d, 0x6d, 0x6d, 0x0a, 0xf9, 0xe7])));
 }
 
+// Test 48 bit
+{
+  const value = 0x1234567890ab;
+  const data = Buffer.allocUnsafe(6);
+  data.writeUIntBE(value, 0, 6);
+  assert.ok(data.equals(new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab])));
+
+  data.writeUIntLE(value, 0, 6);
+  assert.ok(data.equals(new Uint8Array([0xab, 0x90, 0x78, 0x56, 0x34, 0x12])));
+}
+
 // Test UInt
 {
   const data = Buffer.alloc(8);


### PR DESCRIPTION
Added tests buffer.js methods to write 48 bit value to
improve test coverage.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
