### PR TITLE
Naming Initialize as Initialize like docs says

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -72,11 +72,11 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Local<Object> exports) {
+void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(NODE_GYP_MODULE_NAME, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 
 }  // namespace demo
 ```
@@ -95,7 +95,7 @@ There is no semi-colon after `NODE_MODULE` as it's not a function (see
 The `module_name` must match the filename of the final binary (excluding
 the `.node` suffix).
 
-In the `hello.cc` example, then, the initialization function is `init` and the
+In the `hello.cc` example, then, the initialization function is `Initialize` and the
 Addon module name is `addon`.
 
 ### Building


### PR DESCRIPTION
Hi!
in the first example of the addons (https://nodejs.org/docs/v8.11.2/api/addons.html#addons_hello_world), the documentation suggests to use `Initialize`.

##### Checklist
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
