### PR TITLE
build: fail on instrumentation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,8 @@ coverage-build: all
 		"$(CURDIR)/build/jenkins/scripts/coverage/gcovr-patches-3.4.diff"); fi
 	if [ -d lib_ ]; then $(RM) -r lib; mv lib_ lib; fi
 	mv lib lib_
-	$(NODE) ./node_modules/.bin/nyc instrument --extension .js --extension .mjs lib_/ lib/
+	NODE_DEBUG=nyc $(NODE) ./node_modules/.bin/nyc instrument --extension .js \
+		--extension .mjs --exit-on-error lib_/ lib/
 	$(MAKE)
 
 .PHONY: coverage-test


### PR DESCRIPTION
nyc was silently failing to instrument new language features, resulting in a failure to instrument console.js.

the actual underlying issues are discussed and addressed here:

https://github.com/babel/babel/issues/8075,
https://github.com/istanbuljs/istanbuljs/pull/174,
https://github.com/istanbuljs/istanbuljs/pull/175

In this pull request we enable nyc's logging and new "exit on failure" feature to ensure that we catch behavior like this immediately in the future.

see #20952

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CC: @BridgeAR, @maclover7