### PR TITLE
test: make handling of noWarnCode stricter

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -589,7 +589,7 @@ exports.isAlive = function isAlive(pid) {
   }
 };
 
-exports.noWarnCode = 'no_expected_warning_code';
+exports.noWarnCode = undefined;
 
 function expectWarning(name, expected) {
   const map = new Map(expected);
@@ -598,14 +598,7 @@ function expectWarning(name, expected) {
     assert.ok(map.has(warning.message),
               `unexpected error message: "${warning.message}"`);
     const code = map.get(warning.message);
-    if (code === undefined) {
-      throw new Error('An error code must be specified or use ' +
-      'common.noWarnCode if there is no error code. The error  ' +
-      `code for this warning was ${warning.code}`);
-    }
-    if (code !== exports.noWarnCode) {
-      assert.strictEqual(warning.code, code);
-    }
+    assert.strictEqual(warning.code, code);
     // Remove a warning message after it is seen so that we guarantee that we
     // get each message only once.
     map.delete(expected);

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -6,7 +6,7 @@ const expectedDeprecationWarning = ['Unhandled promise rejections are ' +
                                    'deprecated. In the future, promise ' +
                                    'rejections that are not handled will ' +
                                    'terminate the Node.js process with a ' +
-                                   'non-zero exit code.', common.noWarnCode];
+                                   'non-zero exit code.', 'DEP0018'];
 const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -142,10 +142,10 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
-  ['util.print is deprecated. Use console.log instead.', common.noWarnCode],
-  ['util.puts is deprecated. Use console.log instead.', common.noWarnCode],
-  ['util.debug is deprecated. Use console.error instead.', common.noWarnCode],
-  ['util.error is deprecated. Use console.error instead.', common.noWarnCode]
+  ['util.print is deprecated. Use console.log instead.', 'DEP0026'],
+  ['util.puts is deprecated. Use console.log instead.', 'DEP0027'],
+  ['util.debug is deprecated. Use console.error instead.', 'DEP0028'],
+  ['util.error is deprecated. Use console.error instead.', 'DEP0029']
 ]);
 
 util.print('test');


### PR DESCRIPTION
This change requires all expected warnings to be specified along with their respective code and will raise an error if the code does not match. This also kind of fixes the behavior when the expected warning
code was `noWarnCode` and there is an actual warning code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
