### PR TITLE
process,tls: stop relying on process.features

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -39,6 +39,10 @@ const {
   SecureContext: NativeSecureContext
 } = process.binding('crypto');
 const {
+  tlsALPN,
+  tlsSNI
+} = process.binding('config');
+const {
   ERR_INVALID_ARG_TYPE,
   ERR_MULTIPLE_CALLBACK,
   ERR_SOCKET_CLOSED,
@@ -512,7 +516,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
   // If custom SNICallback was given, or if
   // there're SNI contexts to perform match against -
   // set `.onsniselect` callback.
-  if (process.features.tls_sni &&
+  if (tlsSNI &&
       options.isServer &&
       options.SNICallback &&
       (options.SNICallback !== SNICallback ||
@@ -522,7 +526,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.enableCertCb();
   }
 
-  if (process.features.tls_alpn && options.ALPNProtocols) {
+  if (tlsALPN && options.ALPNProtocols) {
     // keep reference in secureContext not to be GC-ed
     ssl._secureContext.alpnBuffer = options.ALPNProtocols;
     ssl.setALPNProtocols(ssl._secureContext.alpnBuffer);
@@ -620,11 +624,11 @@ TLSSocket.prototype._releaseControl = function() {
 };
 
 TLSSocket.prototype._finishInit = function() {
-  if (process.features.tls_alpn) {
+  if (tlsALPN) {
     this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
   }
 
-  if (process.features.tls_sni) {
+  if (tlsSNI) {
     this.servername = this._handle.getServername();
   }
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -31,6 +31,7 @@ const {
   Server: HttpServer,
   _connectionListener
 } = require('_http_server');
+const { tlsALPN } = process.binding('config');
 const { ClientRequest } = require('_http_client');
 const { inherits } = util;
 const debug = util.debuglog('https');
@@ -48,7 +49,7 @@ function Server(opts, requestListener) {
   }
   opts = util._extend({}, opts);
 
-  if (process.features.tls_alpn && !opts.ALPNProtocols) {
+  if (tlsALPN && !opts.ALPNProtocols) {
     // http/1.0 is not defined as Protocol IDs in IANA
     // http://www.iana.org/assignments/tls-extensiontype-values
     //       /tls-extensiontype-values.xhtml#alpn-protocol-ids

--- a/src/node.cc
+++ b/src/node.cc
@@ -2458,39 +2458,39 @@ static void GetParentProcessId(Local<Name> property,
 static Local<Object> GetFeatures(Environment* env) {
   Isolate* isolate = env->isolate();
   EscapableHandleScope scope(isolate);
-  Local<Boolean> trueValue = True(isolate);
-  Local<Boolean> falseValue = False(isolate);
+  Local<Boolean> true_value = True(isolate);
+  Local<Boolean> false_value = False(isolate);
 
   Local<Object> obj = Object::New(isolate);
 #if defined(DEBUG) && DEBUG
-  Local<Boolean> debug = trueValue;
+  Local<Boolean> debug = true_value;
 #else
-  Local<Boolean> debug = falseValue;
+  Local<Boolean> debug = false_value;
 #endif  // defined(DEBUG) && DEBUG
   obj->Set(FIXED_ONE_BYTE_STRING(isolate, "debug"), debug);
 
-  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "uv"), trueValue);
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "uv"), true_value);
   // TODO(bnoordhuis) ping libuv
-  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "ipv6"), trueValue);
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "ipv6"), true_value);
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-  Local<Boolean> tls_alpn = trueValue;
+  Local<Boolean> tls_alpn = true_value;
 #else
-  Local<Boolean> tls_alpn = falseValue;
+  Local<Boolean> tls_alpn = false_value;
 #endif
   obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_alpn"), tls_alpn);
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-  Local<Boolean> tls_sni = trueValue;
+  Local<Boolean> tls_sni = true_value;
 #else
-  Local<Boolean> tls_sni = falseValue;
+  Local<Boolean> tls_sni = false_value;
 #endif
   obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_sni"), tls_sni);
 
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-  Local<Boolean> tls_ocsp = trueValue;
+  Local<Boolean> tls_ocsp = true_value;
 #else
-  Local<Boolean> tls_ocsp = falseValue;
+  Local<Boolean> tls_ocsp = false_value;
 #endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
   obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_ocsp"), tls_ocsp);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2456,44 +2456,46 @@ static void GetParentProcessId(Local<Name> property,
 
 
 static Local<Object> GetFeatures(Environment* env) {
-  EscapableHandleScope scope(env->isolate());
+  Isolate* isolate = env->isolate();
+  EscapableHandleScope scope(isolate);
+  Local<Boolean> trueValue = True(isolate);
+  Local<Boolean> falseValue = False(isolate);
 
-  Local<Object> obj = Object::New(env->isolate());
+  Local<Object> obj = Object::New(isolate);
 #if defined(DEBUG) && DEBUG
-  Local<Value> debug = True(env->isolate());
+  Local<Boolean> debug = trueValue;
 #else
-  Local<Value> debug = False(env->isolate());
+  Local<Boolean> debug = falseValue;
 #endif  // defined(DEBUG) && DEBUG
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "debug"), debug);
 
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "debug"), debug);
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "uv"), True(env->isolate()));
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "uv"), trueValue);
   // TODO(bnoordhuis) ping libuv
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ipv6"), True(env->isolate()));
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "ipv6"), trueValue);
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-  Local<Boolean> tls_alpn = True(env->isolate());
+  Local<Boolean> tls_alpn = trueValue;
 #else
-  Local<Boolean> tls_alpn = False(env->isolate());
+  Local<Boolean> tls_alpn = falseValue;
 #endif
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_alpn"), tls_alpn);
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_alpn"), tls_alpn);
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-  Local<Boolean> tls_sni = True(env->isolate());
+  Local<Boolean> tls_sni = trueValue;
 #else
-  Local<Boolean> tls_sni = False(env->isolate());
+  Local<Boolean> tls_sni = falseValue;
 #endif
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_sni"), tls_sni);
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_sni"), tls_sni);
 
 #if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-  Local<Boolean> tls_ocsp = True(env->isolate());
+  Local<Boolean> tls_ocsp = trueValue;
 #else
-  Local<Boolean> tls_ocsp = False(env->isolate());
+  Local<Boolean> tls_ocsp = falseValue;
 #endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_ocsp"), tls_ocsp);
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls_ocsp"), tls_ocsp);
 
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls"),
-           Boolean::New(env->isolate(),
-                        get_builtin_module("crypto") != nullptr));
+  obj->Set(FIXED_ONE_BYTE_STRING(isolate, "tls"),
+           Boolean::New(isolate, get_builtin_module("crypto") != nullptr));
 
   return scope.Escape(obj);
 }

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -4,6 +4,10 @@
 #include "util-inl.h"
 #include "node_debug_options.h"
 
+#if HAVE_OPENSSL
+#include "node_crypto.h"
+#endif
+
 namespace node {
 
 using v8::Boolean;
@@ -46,6 +50,14 @@ static void Initialize(Local<Object> target,
   READONLY_BOOLEAN_PROPERTY("fipsMode");
   if (force_fips_crypto)
     READONLY_BOOLEAN_PROPERTY("fipsForced");
+#endif
+
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+  READONLY_BOOLEAN_PROPERTY("tlsALPN");
+#endif
+
+#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+  READONLY_BOOLEAN_PROPERTY("tlsSNI");
 #endif
 
 #ifdef NODE_HAVE_I18N_SUPPORT


### PR DESCRIPTION
The `process.features` property is mutable by userland such that
`delete process.features` will cause SNI and ALPN support for fail.
Add the necessary properties to `process.config('binding')` so that
we are not relying on a user-modifiable object.

Also clean up the `GetFeatures` funciton just a bit.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
