### PR TITLE
stream: fix end not being called when reading some base64 files

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -530,7 +530,7 @@ function maybeReadMore(stream, state) {
 
 function maybeReadMore_(stream, state) {
   var len = state.length;
-  while (!state.reading && !state.flowing && !state.ended &&
+  while (!state.reading && !state.ended &&
          state.length < state.highWaterMark) {
     debug('maybeReadMore read 0');
     stream.read(0);

--- a/test/parallel/test-fs-read-stream-events.js
+++ b/test/parallel/test-fs-read-stream-events.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+
+const encodings = ['utf8', 'base64', 'ascii', 'binary', 'hex', 'utf16le'];
+
+function test(encoding) {
+
+  const file = path.join(tmpdir.path, `read-stream-events-${encoding}.txt`);
+
+  const data = '1234';
+  fs.writeFileSync(file, data);
+
+  const rs = fs.createReadStream(file, {
+    encoding,
+    highWaterMark: data.length - 1
+  });
+
+  let chunks = '';
+
+  rs.on('data', common.mustCall(function(data) {
+    chunks += Buffer.from(data, encoding);
+  }, 2));
+
+  rs.on('end', common.mustCall(function() {
+    assert.strictEqual(chunks, data);
+  }));
+}
+
+for (const encoding of encodings)
+  test(encoding);


### PR DESCRIPTION
This fixes `'end'` not being called when reading base64 files
with `highWaterMark` equal to: `file length - 1`,
and fixes `'data'` not being called on some edge cases
when `highWaterMark` was lower than file length.

Fixes: https://github.com/nodejs/node/issues/19862

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
