### PR TITLE
test: remove postmortem test from flaky list

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,8 +5,6 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# Postmortem debugging data is prone to accidental removal during V8 updates.
-test-postmortem-metadata: PASS,FLAKY
 
 [$system==win32]
 test-child-process-fork-net: PASS,FLAKY


### PR DESCRIPTION
test-postmortem-metadata does not ever seem to fail on master. According
to Michaël Zasso, when it fails locally for him during a V8 upgrade, he
pings Colin Ihrig who fixes it almost immediately. 

There was some discussion about marking it flaky when it first landed
but it's not clear to me that it is necessary. (We can always mark it
flaky again if it turns out that it is necessary.)

The reason I want this test removed from the status file for flaky tests
is that I believe that file can and should be used as a list of tests to
fix. But this test doesn't need any fixing.

Refs: https://github.com/nodejs/node/pull/17685

@bnoordhuis @cjihrig @targos @nodejs/v8-update 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
