### PR TITLE
src: manage handles more explicitly in cares_wrap, node_stat_watcher

### DIFF
--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -84,7 +84,8 @@ StatWatcher::StatWatcher(Environment* env, Local<Object> wrap, bool use_bigint)
 
 
 StatWatcher::~StatWatcher() {
-  CHECK_EQ(watcher_, nullptr);
+  if (IsActive())
+    Stop();
 }
 
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -152,10 +152,10 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   const uint32_t interval = args[2].As<Uint32>()->Value();
 
-  // Safe, uv_ref/uv_unref are idempotent.
   wrap->watcher_ = new uv_fs_poll_t();
-  uv_fs_poll_init(wrap->env()->event_loop(), wrap->watcher_);
+  CHECK_EQ(0, uv_fs_poll_init(wrap->env()->event_loop(), wrap->watcher_));
   wrap->watcher_->data = static_cast<void*>(wrap);
+  // Safe, uv_ref/uv_unref are idempotent.
   if (persistent)
     uv_ref(reinterpret_cast<uv_handle_t*>(wrap->watcher_));
   else

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-gc
 
 const common = require('../common');
 const assert = require('assert');
@@ -22,6 +23,11 @@ common.crashOnUnhandledRejection();
     },
   }).enable();
   process.on('beforeExit', common.mustCall(() => {
+    // This garbage collection call verifies that the wraps being garbage
+    // collected doesn't resurrect the process again due to weirdly timed
+    // uv_close calls and other similar instruments in destructors.
+    global.gc();
+
     process.removeAllListeners('uncaughtException');
     hooks.disable();
     delete providers.NONE;  // Should never be used.


### PR DESCRIPTION
When garbage collecting ChannelWrap & StatWatcher directly call uv_close which can wake up the event loop when it's already going for a shutdown. Instead be more explicit about managing these handles throughout the lifetime of these two classes.

Refs: https://github.com/nodejs/node/pull/18307
Fixes: https://github.com/nodejs/node/issues/18190

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
