### PR TITLE
lib,src: remove openssl feature conditionals

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -512,8 +512,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
   // If custom SNICallback was given, or if
   // there're SNI contexts to perform match against -
   // set `.onsniselect` callback.
-  if (process.features.tls_sni &&
-      options.isServer &&
+  if (options.isServer &&
       options.SNICallback &&
       (options.SNICallback !== SNICallback ||
        (options.server && options.server._contexts.length))) {
@@ -522,7 +521,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.enableCertCb();
   }
 
-  if (process.features.tls_alpn && options.ALPNProtocols) {
+  if (options.ALPNProtocols) {
     // keep reference in secureContext not to be GC-ed
     ssl._secureContext.alpnBuffer = options.ALPNProtocols;
     ssl.setALPNProtocols(ssl._secureContext.alpnBuffer);
@@ -620,15 +619,9 @@ TLSSocket.prototype._releaseControl = function() {
 };
 
 TLSSocket.prototype._finishInit = function() {
-  if (process.features.tls_alpn) {
-    this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
-  }
-
-  if (process.features.tls_sni) {
-    this.servername = this._handle.getServername();
-  }
-
   debug('secure established');
+  this.alpnProtocol = this._handle.getALPNNegotiatedProtocol();
+  this.servername = this._handle.getServername();
   this._secureEstablished = true;
   if (this._tlsOptions.handshakeTimeout > 0)
     this.setTimeout(0, this._handleTimeout);

--- a/lib/https.js
+++ b/lib/https.js
@@ -48,7 +48,7 @@ function Server(opts, requestListener) {
   }
   opts = util._extend({}, opts);
 
-  if (process.features.tls_alpn && !opts.ALPNProtocols) {
+  if (!opts.ALPNProtocols) {
     // http/1.0 is not defined as Protocol IDs in IANA
     // http://www.iana.org/assignments/tls-extensiontype-values
     //       /tls-extensiontype-values.xhtml#alpn-protocol-ids

--- a/src/node.cc
+++ b/src/node.cc
@@ -2470,30 +2470,16 @@ static Local<Object> GetFeatures(Environment* env) {
   // TODO(bnoordhuis) ping libuv
   obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ipv6"), True(env->isolate()));
 
-#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
-  Local<Boolean> tls_alpn = True(env->isolate());
+#ifdef HAVE_OPENSSL
+  Local<Boolean> have_openssl = True(env->isolate());
 #else
-  Local<Boolean> tls_alpn = False(env->isolate());
+  Local<Boolean> have_openssl = False(env->isolate());
 #endif
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_alpn"), tls_alpn);
 
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
-  Local<Boolean> tls_sni = True(env->isolate());
-#else
-  Local<Boolean> tls_sni = False(env->isolate());
-#endif
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_sni"), tls_sni);
-
-#if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-  Local<Boolean> tls_ocsp = True(env->isolate());
-#else
-  Local<Boolean> tls_ocsp = False(env->isolate());
-#endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_ocsp"), tls_ocsp);
-
-  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls"),
-           Boolean::New(env->isolate(),
-                        get_builtin_module("crypto") != nullptr));
+  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_alpn"), have_openssl);
+  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_sni"), have_openssl);
+  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls_ocsp"), have_openssl);
+  obj->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "tls"), have_openssl);
 
   return scope.Escape(obj);
 }

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -53,10 +53,6 @@
 #include <openssl/rand.h>
 #include <openssl/pkcs12.h>
 
-#if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-# define NODE__HAVE_TLSEXT_STATUS_CB
-#endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-
 namespace node {
 namespace crypto {
 
@@ -331,13 +327,8 @@ class SSLWrap {
 
   ClientHelloParser hello_parser_;
 
-#ifdef NODE__HAVE_TLSEXT_STATUS_CB
   Persistent<v8::Object> ocsp_response_;
-#endif  // NODE__HAVE_TLSEXT_STATUS_CB
-
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   Persistent<v8::Value> sni_context_;
-#endif
 
   friend class SecureContext;
 };

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -131,12 +131,10 @@ void TLSWrap::InitSSL() {
   SSL_set_app_data(ssl_.get(), this);
   SSL_set_info_callback(ssl_.get(), SSLInfoCallback);
 
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   if (is_server()) {
     SSL_CTX_set_tlsext_servername_callback(sc_->ctx_.get(),
                                            SelectSNIContextCallback);
   }
-#endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
   ConfigureSecureContext(sc_);
 
@@ -777,7 +775,6 @@ void TLSWrap::OnClientHelloParseEnd(void* arg) {
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -809,10 +806,8 @@ void TLSWrap::SetServername(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_NOT_NULL(wrap->ssl_);
 
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   node::Utf8Value servername(env->isolate(), args[0].As<String>());
   SSL_set_tlsext_host_name(wrap->ssl_.get(), *servername);
-#endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 }
 
 
@@ -851,7 +846,6 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   p->SetSNIContext(sc);
   return SSL_TLSEXT_ERR_OK;
 }
-#endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
 
 void TLSWrap::GetWriteQueueSize(const FunctionCallbackInfo<Value>& info) {
@@ -902,10 +896,8 @@ void TLSWrap::Initialize(Local<Object> target,
   StreamBase::AddMethods<TLSWrap>(env, t, StreamBase::kFlagHasWritev);
   SSLWrap<TLSWrap>::AddMethods(env, t);
 
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   env->SetProtoMethod(t, "getServername", GetServername);
   env->SetProtoMethod(t, "setServername", SetServername);
-#endif  // SSL_CRT_SET_TLSEXT_SERVERNAME_CB
 
   env->set_tls_wrap_constructor_function(t->GetFunction());
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -138,12 +138,9 @@ class TLSWrap : public AsyncWrap,
   static void EnableCertCb(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DestroySSL(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-#ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   static void GetServername(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetServername(const v8::FunctionCallbackInfo<v8::Value>& args);
   static int SelectSNIContextCallback(SSL* s, int* ad, void* arg);
-#endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
   crypto::SecureContext* sc_;
   BIO* enc_in_;

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -4,11 +4,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-if (!process.features.tls_alpn) {
-  common.skip(
-    'Skipping because node compiled without ALPN feature of OpenSSL.');
-}
-
 const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -4,9 +4,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-if (!process.features.tls_sni)
-  common.skip('node compiled without OpenSSL or with old OpenSSL version.');
-
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -22,9 +22,6 @@
 'use strict';
 const common = require('../common');
 
-if (!process.features.tls_ocsp)
-  common.skip('node compiled without OpenSSL or with old OpenSSL version.');
-
 if (!common.opensslCli)
   common.skip('node compiled without OpenSSL CLI.');
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -24,9 +24,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-if (!process.features.tls_sni)
-  common.skip('node compiled without OpenSSL or with old OpenSSL version.');
-
 const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -24,9 +24,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-if (!process.features.tls_sni)
-  common.skip('node compiled without OpenSSL or with old OpenSSL version.');
-
 const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-tls-snicallback-error.js
+++ b/test/parallel/test-tls-snicallback-error.js
@@ -3,9 +3,6 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-if (!process.features.tls_sni)
-  common.skip('compiled without OpenSSL or with old OpenSSL version');
-
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-socket-constructor-alpn-options-parsing.js
+++ b/test/parallel/test-tls-socket-constructor-alpn-options-parsing.js
@@ -13,9 +13,6 @@ new tls.TLSSocket(null, {
   ALPNProtocols: ['http/1.1'],
 });
 
-if (!process.features.tls_alpn)
-  common.skip('node compiled without ALPN feature of OpenSSL');
-
 const assert = require('assert');
 const net = require('net');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
Remove compile-time and run-time conditionals for features that
OpenSSL 1.0.0 and 1.0.1 didn't support: ALPN, OCSP and/or SNI.
They are no longer necessary since our baseline is OpenSSL 1.0.2.

Alternative to https://github.com/nodejs/node/pull/21087.

CI: https://ci.nodejs.org/job/node-test-pull-request/15223/