### PR TITLE
src: store pointer to Environment on DestroyParam

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -426,7 +426,7 @@ static void RegisterDestroyHook(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   DestroyParam* p = new DestroyParam();
   p->asyncId = args[1].As<Number>()->Value();
-  p->env = Environment::GetCurrent(isolate);
+  p->env = Environment::GetCurrent(args);
   p->target.Reset(isolate, args[0].As<Object>());
   p->propBag.Reset(isolate, args[2].As<Object>());
   p->target.SetWeak(


### PR DESCRIPTION
To avoid a potential segfault when inside `WeakCallback`, store a reference to `Environment` inside `DestroyParam`.  (Talk to @hashseed for more info.)

Without this patch, `node` will fail on one of our tests when run as `node --stress-compaction test/parallel/test-async-hooks-recursive-stack.js`.

Co-authored-by: Yang Guo <yangguo@chromium.org>
Co-authored-by: Michaël Zasso <targos@protonmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
