### PR TITLE
process: make getActive{Handles,Requests} official

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1005,6 +1005,15 @@ accepted by the legacy `url.parse()` API. The mentioned APIs now use the WHATWG
 URL parser that requires strictly valid URLs. Passing an invalid URL is
 deprecated and support will be removed in the future.
 
+<a id="DEP0110"></a>
+### DEP0110: _getActiveHandles and _getActiveRequests
+
+Type: Runtime
+
+As `process.getActiveHandles()` and `process.getActiveRequests()` are
+officially supported and documented, their previous names are now deprecated,
+and will be removed in the future.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1053,6 +1053,35 @@ a code.
 Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
 previous setting of `process.exitCode`.
 
+## process.getActiveHandles()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array}
+
+Returns an array containing all handles that are preventing the Node.js process
+from exiting. Be aware that the returned handles may not always correspond to
+the user-created handles, but instead to an internal one.
+
+```js
+console.log(`Active handles: ${util.inspect(process.getActiveHandles())}`);
+```
+
+## process.getActiveRequests()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array}
+
+Returns an array containing all requests that are preventing the Node.js process
+from exiting.
+
+```js
+console.log(`Active requests: ${util.inspect(process.getActiveRequests())}`);
+```
+
 ## process.getegid()
 <!-- YAML
 added: v2.0.0

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -289,6 +289,20 @@
   function setupProcessObject() {
     _setupProcessObject(pushValueToArray);
 
+    const util = NativeModule.require('util');
+    process._getActiveHandles = util.deprecate(
+      process.getActiveHandles,
+      "'process._getActiveHandles' is deprecated, " +
+      "use 'process.getActiveHandles' instead",
+      'DEP0110'
+    );
+    process._getActiveRequests = util.deprecate(
+      process.getActiveRequests,
+      "'process._getActiveRequests' is deprecated, " +
+      "use 'process.getActiveRequests' instead",
+      'DEP0110'
+    );
+
     function pushValueToArray() {
       for (var i = 0; i < arguments.length; i++)
         this.push(arguments[i]);

--- a/src/node.cc
+++ b/src/node.cc
@@ -2248,8 +2248,8 @@ void SetupProcessObject(Environment* env,
     env->SetMethod(process, "chdir", Chdir);
     env->SetMethod(process, "umask", Umask);
   }
-  env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
-  env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
+  env->SetMethod(process, "getActiveRequests", GetActiveRequests);
+  env->SetMethod(process, "getActiveHandles", GetActiveHandles);
   env->SetMethod(process, "_kill", Kill);
 
   env->SetMethod(process, "cwd", Cwd);

--- a/test/parallel/test-process-getactivehandles.js
+++ b/test/parallel/test-process-getactivehandles.js
@@ -30,7 +30,7 @@ function clientConnected(client) {
 
 
 function checkAll() {
-  const handles = process._getActiveHandles();
+  const handles = process.getActiveHandles();
 
   clients.forEach(function(item) {
     assert.ok(handles.includes(item));

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -12,7 +12,7 @@ handle.readStart();
 handle.onread = () => {};
 
 function isHandleActive(handle) {
-  return process._getActiveHandles().some((active) => active === handle);
+  return process.getActiveHandles().some((active) => active === handle);
 }
 
 strictEqual(isHandleActive(handle), true, 'TTY handle not initially active');

--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -51,8 +51,8 @@ function pummel() {
 
 function check() {
   setTimeout(function() {
-    assert.strictEqual(process._getActiveRequests().length, 0);
-    assert.strictEqual(process._getActiveHandles().length, 1); // the timer
+    assert.strictEqual(process.getActiveRequests().length, 0);
+    assert.strictEqual(process.getActiveHandles().length, 1); // the timer
     check_called = true;
   }, 0);
 }


### PR DESCRIPTION
Rebased version of https://github.com/nodejs/node/pull/18844

[Original message]

process._getActiveHandles() and process._getActiveRequests() have been around for a long time, and are utilized to a large enough degree that it makes sense to make them official
APIs.

Fixes: #1128

**Checklist :**
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

**Affected core subsystem(s)**
- process