### PR TITLE
child_process: swallow errors in internal communication

### DIFF
--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -13,7 +13,7 @@ class SocketListSend extends EventEmitter {
     child.once('exit', () => this.emit('exit', this));
   }
 
-  _request(msg, cmd, callback, swallowErrors = false) {
+  _request(msg, cmd, swallowErrors, callback) {
     var self = this;
 
     if (!this.child.connected) return onclose();
@@ -40,14 +40,14 @@ class SocketListSend extends EventEmitter {
     this._request({
       cmd: 'NODE_SOCKET_NOTIFY_CLOSE',
       key: this.key
-    }, 'NODE_SOCKET_ALL_CLOSED', callback, true);
+    }, 'NODE_SOCKET_ALL_CLOSED', true, callback);
   }
 
   getConnections(callback) {
     this._request({
       cmd: 'NODE_SOCKET_GET_COUNT',
       key: this.key
-    }, 'NODE_SOCKET_COUNT', function(err, msg) {
+    }, 'NODE_SOCKET_COUNT', false, function(err, msg) {
       if (err) return callback(err);
       callback(null, msg.count);
     });

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -13,11 +13,11 @@ class SocketListSend extends EventEmitter {
     child.once('exit', () => this.emit('exit', this));
   }
 
-  _request(msg, cmd, callback) {
+  _request(msg, cmd, callback, swallowErrors = false) {
     var self = this;
 
     if (!this.child.connected) return onclose();
-    this.child.send(msg);
+    this.child._send(msg, undefined, swallowErrors);
 
     function onclose() {
       self.child.removeListener('internalMessage', onreply);
@@ -40,7 +40,7 @@ class SocketListSend extends EventEmitter {
     this._request({
       cmd: 'NODE_SOCKET_NOTIFY_CLOSE',
       key: this.key
-    }, 'NODE_SOCKET_ALL_CLOSED', callback);
+    }, 'NODE_SOCKET_ALL_CLOSED', callback, true);
   }
 
   getConnections(callback) {
@@ -67,10 +67,10 @@ class SocketListReceive extends EventEmitter {
     function onempty(self) {
       if (!self.child.connected) return;
 
-      self.child.send({
+      self.child._send({
         cmd: 'NODE_SOCKET_ALL_CLOSED',
         key: self.key
-      });
+      }, undefined, true);
     }
 
     this.child.on('internalMessage', (msg) => {
@@ -84,7 +84,7 @@ class SocketListReceive extends EventEmitter {
         this.once('empty', onempty);
       } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
         if (!this.child.connected) return;
-        this.child.send({
+        this.child._send({
           cmd: 'NODE_SOCKET_COUNT',
           key: this.key,
           count: this.connections

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,7 +9,6 @@ prefix parallel
 test-postmortem-metadata: PASS,FLAKY
 
 [$system==win32]
-test-child-process-fork-net-socket: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/parallel/test-internal-socket-list-receive.js
+++ b/test/parallel/test-internal-socket-list-receive.js
@@ -12,7 +12,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: false,
-    send: common.mustNotCall()
+    _send: common.mustNotCall()
   });
 
   const list = new SocketListReceive(child, key);
@@ -24,7 +24,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: common.mustCall((msg) => {
+    _send: common.mustCall((msg) => {
       assert.strictEqual(msg.cmd, 'NODE_SOCKET_ALL_CLOSED');
       assert.strictEqual(msg.key, key);
     })
@@ -38,7 +38,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: common.mustCall((msg) => {
+    _send: common.mustCall((msg) => {
       assert.strictEqual(msg.cmd, 'NODE_SOCKET_COUNT');
       assert.strictEqual(msg.key, key);
       assert.strictEqual(msg.count, 0);

--- a/test/parallel/test-internal-socket-list-send.js
+++ b/test/parallel/test-internal-socket-list-send.js
@@ -16,7 +16,7 @@ const key = 'test-key';
 
   const list = new SocketListSend(child, 'test');
 
-  list._request('msg', 'cmd', common.mustCall((err) => {
+  list._request('msg', 'cmd', false, common.mustCall((err) => {
     common.expectsError({
       code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
       type: Error,
@@ -39,7 +39,7 @@ const key = 'test-key';
 
   const list = new SocketListSend(child, key);
 
-  list._request('msg', 'cmd', common.mustCall((err, msg) => {
+  list._request('msg', 'cmd', false, common.mustCall((err, msg) => {
     assert.strictEqual(err, null);
     assert.strictEqual(msg.cmd, 'cmd');
     assert.strictEqual(msg.key, key);
@@ -58,7 +58,7 @@ const key = 'test-key';
 
   const list = new SocketListSend(child, key);
 
-  list._request('msg', 'cmd', common.mustCall((err) => {
+  list._request('msg', 'cmd', false, common.mustCall((err) => {
     common.expectsError({
       code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
       type: Error,

--- a/test/parallel/test-internal-socket-list-send.js
+++ b/test/parallel/test-internal-socket-list-send.js
@@ -30,7 +30,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function(msg) {
+    _send: function(msg) {
       process.nextTick(() =>
         this.emit('internalMessage', { key, cmd: 'cmd' })
       );
@@ -53,7 +53,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function(msg) { process.nextTick(() => this.emit('disconnect')); }
+    _send: function(msg) { process.nextTick(() => this.emit('disconnect')); }
   });
 
   const list = new SocketListSend(child, key);
@@ -73,7 +73,7 @@ const key = 'test-key';
 {
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function(msg) {
+    _send: function(msg) {
       assert.strictEqual(msg.cmd, 'NODE_SOCKET_NOTIFY_CLOSE');
       assert.strictEqual(msg.key, key);
       process.nextTick(() =>
@@ -98,7 +98,7 @@ const key = 'test-key';
   const count = 1;
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function(msg) {
+    _send: function(msg) {
       assert.strictEqual(msg.cmd, 'NODE_SOCKET_GET_COUNT');
       assert.strictEqual(msg.key, key);
       process.nextTick(() =>
@@ -127,7 +127,7 @@ const key = 'test-key';
   const count = 1;
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function() {
+    _send: function() {
       process.nextTick(() => {
         this.emit('disconnect');
         this.emit('internalMessage', { key, count, cmd: 'NODE_SOCKET_COUNT' });


### PR DESCRIPTION
Much like with `NODE_HANDLE_ACK`, the internal protocol for communication about the sent socket should not expose its errors to the users when those async calls are not initiated by them. This also switches to use the internal `_send` api instead of the public one which performs a bunch of args validation which is not necessary in core code.

This will fix the currently reasonably frequent flakes on Windows in relation to child_process. It might also make it possible to remove some of our special case handling of Windows in our tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
