### PR TITLE
test: unmark test as flaky

### DIFF
--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -9,7 +9,6 @@ prefix async-hooks
 [$system==win32]
 
 [$system==linux]
-test-zlib.zlib-binding.deflate: PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
This test is no longer flaky as of https://github.com/nodejs/node/pull/21077.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
