### PR TITLE
test: update test-dns error message

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -70,7 +70,7 @@ function checkWrap(req) {
 TEST(function test_reverse_bogus(done) {
   assert.throws(() => {
     dns.reverse('bogus ip', common.mustNotCall());
-  }, /^Error: getHostByAddr EINVAL$/);
+  }, /^Error: getHostByAddr EINVAL bogus ip$/);
   done();
 });
 


### PR DESCRIPTION
test-dns is in the internet suite and therefore is rarely run. (That
will change soon. We will run internet tests nightly in CI.) Because it
is infrequently run, it was not noticed that it no longer passes. (An
error message has changed to provide more information.) This change
fixes the test so it passes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
