### PR TITLE
test: improve debug output in trace-events test

### DIFF
--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -3,6 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
+const util = require('util');
 
 const tests = new Array();
 const traceFile = 'node_trace.1.log';
@@ -118,7 +119,8 @@ for (const tr in tests) {
   const proc = cp.spawnSync(process.execPath,
                             [ '--trace-events-enabled',
                               '--trace-event-categories', 'node.fs.sync',
-                              '-e', tests[tr] ]);
+                              '-e', tests[tr] ],
+                            { encoding: 'utf8' });
   // Some AIX versions don't support futimes or utimes, so skip.
   if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.futimes') {
     continue;
@@ -128,7 +130,7 @@ for (const tr in tests) {
   }
 
   // Make sure the operation is successful.
-  assert.strictEqual(proc.status, 0, tr + ': ' + proc.stderr);
+  assert.strictEqual(proc.status, 0, `${tr}:\n${util.inspect(proc)}`);
 
   // Confirm that trace log file is created.
   assert(common.fileExists(traceFile));


### PR DESCRIPTION
test-trace-events-fs-sync is swallowing useful information when it
fails. This change results in more information being displayed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
