### PR TITLE
n-api: remove unused napi_env member

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -23,7 +23,6 @@ struct napi_env__ {
         loop(_loop) {}
   v8::Isolate* isolate;
   node::Persistent<v8::Value> last_exception;
-  node::Persistent<v8::ObjectTemplate> wrap_template;
   node::Persistent<v8::ObjectTemplate> function_data_template;
   node::Persistent<v8::ObjectTemplate> accessor_data_template;
   napi_extended_error_info last_error;


### PR DESCRIPTION
`wrap_template` is no longer used since we've switched to v8::Private.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
