### PR TITLE
util: add MIME utilities

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1971,8 +1971,7 @@ An IP address is not valid.
 
 ### `ERR_INVALID_MIME_SYNTAX`
 
-The syntax of a MIME is not valid. See [WHATWG MIME parsing][] for details on
-how MIME syntax is parsed.
+The syntax of a MIME is not valid.
 
 <a id="ERR_INVALID_MODULE"></a>
 
@@ -3526,7 +3525,6 @@ The native call from `process.cpuUsage` could not be processed.
 [RFC 7230 Section 3]: https://tools.ietf.org/html/rfc7230#section-3
 [Subresource Integrity specification]: https://www.w3.org/TR/SRI/#the-integrity-attribute
 [V8's stack trace API]: https://v8.dev/docs/stack-trace-api
-[WHATWG MIME parsing]: url.md#url_the_whatwg_url_api
 [WHATWG Supported Encodings]: util.md#whatwg-supported-encodings
 [WHATWG URL API]: url.md#the-whatwg-url-api
 [`"exports"`]: packages.md#exports

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1967,6 +1967,13 @@ An invalid HTTP token was supplied.
 
 An IP address is not valid.
 
+<a id="ERR_INVALID_MIME_SYNTAX"></a>
+
+### `ERR_INVALID_MIME_SYNTAX`
+
+The syntax of a MIME is not valid. See [WHATWG MIME parsing][] for details on
+how MIME syntax is parsed.
+
 <a id="ERR_INVALID_MODULE"></a>
 
 ### `ERR_INVALID_MODULE`
@@ -3519,6 +3526,7 @@ The native call from `process.cpuUsage` could not be processed.
 [RFC 7230 Section 3]: https://tools.ietf.org/html/rfc7230#section-3
 [Subresource Integrity specification]: https://www.w3.org/TR/SRI/#the-integrity-attribute
 [V8's stack trace API]: https://v8.dev/docs/stack-trace-api
+[WHATWG MIME parsing]: url.md#url_the_whatwg_url_api
 [WHATWG Supported Encodings]: util.md#whatwg-supported-encodings
 [WHATWG URL API]: url.md#the-whatwg-url-api
 [`"exports"`]: packages.md#exports

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1093,6 +1093,8 @@ console.log(myMIME.type);
 myMIME.type = 'application';
 console.log(myMIME.type);
 // Prints: application
+console.log(String(myMIME));
+// Prints: application/javascript
 ```
 
 ```cjs
@@ -1104,6 +1106,8 @@ console.log(myMIME.type);
 myMIME.type = 'application';
 console.log(myMIME.type);
 // Prints: application
+console.log(String(myMIME));
+// Prints: application/javascript/javascript
 ```
 
 #### `mime.subtype`
@@ -1121,6 +1125,8 @@ console.log(myMIME.subtype);
 myMIME.subtype = 'javascript';
 console.log(myMIME.subtype);
 // Prints: javascript
+console.log(String(myMIME));
+// Prints: text/javascript
 ```
 
 ```cjs
@@ -1132,6 +1138,8 @@ console.log(myMIME.subtype);
 myMIME.subtype = 'javascript';
 console.log(myMIME.subtype);
 // Prints: javascript
+console.log(String(myMIME));
+// Prints: text/javascript
 ```
 
 #### `mime.essence`
@@ -1144,23 +1152,27 @@ Use `mime.type` or `mime.subtype` to alter the MIME.
 ```mjs
 import { MIMEType } from 'node:util';
 
-const myMIME = new MIMEType('text/javascript');
+const myMIME = new MIMEType('text/javascript;key=value');
 console.log(myMIME.essence);
 // Prints: text/javascript
 myMIME.type = 'application';
 console.log(myMIME.essence);
 // Prints: application/javascript
+console.log(String(myMIME));
+// Prints: application/javascript;key=value
 ```
 
 ```cjs
 const { MIMEType } = require('node:util');
 
-const myMIME = new MIMEType('text/javascript');
+const myMIME = new MIMEType('text/javascript;key=value');
 console.log(myMIME.essence);
 // Prints: text/javascript
 myMIME.type = 'application';
 console.log(myMIME.essence);
 // Prints: application/javascript
+console.log(String(myMIME));
+// Prints: application/javascript;key=value
 ```
 
 #### `mime.params`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1121,7 +1121,6 @@ parameters of the MIME. This property is read-only. See
 * Returns: {string}
 
 The `toString()` method on the `MIMEType` object returns the serialized MIME.
-The value returned is equivalent to that of [`mime.toJSON()`][].
 
 Because of the need for standard compliance, this method does not allow users
 to customize the serialization process of the MIME.
@@ -1130,8 +1129,7 @@ to customize the serialization process of the MIME.
 
 * Returns: {string}
 
-The `toJSON()` method on the `MIMEType` object returns the serialized MIME. The
-value returned is equivalent to that of [`mime.toString()`][].
+Alias for [`mime.toString()`][].
 
 This method is automatically called when an `MIMEType` object is serialized
 with [`JSON.stringify()`][].
@@ -1172,11 +1170,9 @@ Remove all name-value pairs whose name is `name`.
 
 * Returns: {Iterator}
 
-Returns an ES6 Iterator over each of the name-value pairs in the parameters.
-Each item of the iterator is a JavaScript Array. The first item of the Array
-is the `name`, the second item of the Array is the `value`.
-
-Alias for [`mimeParams[@@iterator]()`][`mimeParams@@iterator()`].
+Returns an iterator over each of the name-value pairs in the parameters.
+Each item of the iterator is a JavaScript `Array`. The first item of the array
+is the `name`, the second item of the array is the `value`.
 
 #### `mimeParams.get(name)`
 
@@ -1198,7 +1194,7 @@ Returns `true` if there is at least one name-value pair whose name is `name`.
 
 * Returns: {Iterator}
 
-Returns an ES6 Iterator over the names of each name-value pair.
+Returns an iterator over the names of each name-value pair.
 
 ```js
 const { params } = new MIMEType('text/plain;foo=0;bar=1');
@@ -1231,15 +1227,11 @@ console.log(params.toString());
 
 * Returns: {Iterator}
 
-Returns an ES6 Iterator over the values of each name-value pair.
+Returns an iterator over the values of each name-value pair.
 
-#### `mimeParams\[@@iterator\]()`
+#### `mimeParams[@@iterator]()`
 
 * Returns: {Iterator}
-
-Returns an ES6 Iterator over each of the name-value pairs in the query string.
-Each item of the iterator is a JavaScript Array. The first item of the Array
-is the `name`, the second item of the Array is the `value`.
 
 Alias for [`mimeParams.entries()`][].
 
@@ -3151,10 +3143,8 @@ util.log('Timestamped message.');
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.md#assertdeepstrictequalactual-expected-message
 [`console.error()`]: console.md#consoleerrordata-args
-[`mime.toJSON()`]: #mimetojson
 [`mime.toString()`]: #mimetostring
 [`mimeParams.entries()`]: #mimeparamsentries
-[`mimeParams@@iterator()`]: #mimeparamsiterator
 [`napi_create_external()`]: n-api.md#napi_create_external
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`tty.hasColors()`]: tty.md#writestreamhascolorscount-env

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1048,8 +1048,14 @@ properties for each of these components.
 
 Creates a new `MIMEType` object by parsing the `input`.
 
-```js
+```mjs
 import { MIMEType } from 'node:util';
+
+const myMIME = new MIMEType('text/plain');
+```
+
+```cjs
+const { MIMEType } = require('node:util');
 
 const myMIME = new MIMEType('text/plain');
 ```
@@ -1058,7 +1064,15 @@ A `TypeError` will be thrown if the `input` is not a valid MIME. Note
 that an effort will be made to coerce the given values into strings. For
 instance:
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+const myMIME = new MIMEType({ toString: () => 'text/plain' });
+console.log(String(myMIME));
+// Prints: text/plain
+```
+
+```cjs
+const { MIMEType } = require('node:util');
 const myMIME = new MIMEType({ toString: () => 'text/plain' });
 console.log(String(myMIME));
 // Prints: text/plain
@@ -1070,7 +1084,20 @@ console.log(String(myMIME));
 
 Gets and sets the type portion of the MIME.
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const myMIME = new MIMEType('text/javascript');
+console.log(myMIME.type);
+// Prints: text
+myMIME.type = 'application';
+console.log(myMIME.type);
+// Prints: application
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const myMIME = new MIMEType('text/javascript');
 console.log(myMIME.type);
 // Prints: text
@@ -1085,7 +1112,20 @@ console.log(myMIME.type);
 
 Gets and sets the subtype portion of the MIME.
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const myMIME = new MIMEType('text/ecmascript');
+console.log(myMIME.subtype);
+// Prints: ecmascript
+myMIME.subtype = 'javascript';
+console.log(myMIME.subtype);
+// Prints: javascript
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const myMIME = new MIMEType('text/ecmascript');
 console.log(myMIME.subtype);
 // Prints: ecmascript
@@ -1101,7 +1141,20 @@ console.log(myMIME.subtype);
 Gets the essence of the MIME. This property is read only.
 Use `mime.type` or `mime.subtype` to alter the MIME.
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const myMIME = new MIMEType('text/javascript');
+console.log(myMIME.essence);
+// Prints: text/javascript
+myMIME.type = 'application';
+console.log(myMIME.essence);
+// Prints: application/javascript
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const myMIME = new MIMEType('text/javascript');
 console.log(myMIME.essence);
 // Prints: text/javascript
@@ -1136,7 +1189,20 @@ Alias for [`mime.toString()`][].
 This method is automatically called when an `MIMEType` object is serialized
 with [`JSON.stringify()`][].
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const myMIMES = [
+  new MIMEType('image/png'),
+  new MIMEType('image/gif'),
+];
+console.log(JSON.stringify(myMIMES));
+// Prints: ["image/png", "image/gif"]
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const myMIMES = [
   new MIMEType('image/png'),
   new MIMEType('image/gif'),
@@ -1158,7 +1224,15 @@ The `MIMEParams` API provides read and write access to the parameters of a
 
 Creates a new `MIMEParams` object by with empty parameters
 
-```js
+```mjs
+import { MIMEParams } from 'node:util';
+
+const myParams = new MIMEParams();
+```
+
+```cjs
+const { MIMEParams } = require('node:util');
+
 const myParams = new MIMEParams();
 ```
 
@@ -1198,7 +1272,21 @@ Returns `true` if there is at least one name-value pair whose name is `name`.
 
 Returns an iterator over the names of each name-value pair.
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const { params } = new MIMEType('text/plain;foo=0;bar=1');
+for (const name of params.keys()) {
+  console.log(name);
+}
+// Prints:
+//   foo
+//   bar
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const { params } = new MIMEType('text/plain;foo=0;bar=1');
 for (const name of params.keys()) {
   console.log(name);
@@ -1217,7 +1305,19 @@ Sets the value in the `MIMEParams` object associated with `name` to
 `value`. If there are any pre-existing name-value pairs whose names are `name`,
 set the first such pair's value to `value`.
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const { params } = new MIMEType('text/plain;foo=0;bar=1');
+params.set('foo', 'def');
+params.set('baz', 'xyz');
+console.log(params.toString());
+// Prints: foo=def&bar=1&baz=xyz
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const { params } = new MIMEType('text/plain;foo=0;bar=1');
 params.set('foo', 'def');
 params.set('baz', 'xyz');
@@ -1237,7 +1337,21 @@ Returns an iterator over the values of each name-value pair.
 
 Alias for [`mimeParams.entries()`][].
 
-```js
+```mjs
+import { MIMEType } from 'node:util';
+
+const { params } = new MIMEType('text/plain;foo=bar;xyz=baz');
+for (const [name, value] of params) {
+  console.log(name, value);
+}
+// Prints:
+//   foo bar
+//   xyz baz
+```
+
+```cjs
+const { MIMEType } = require('node:util');
+
 const { params } = new MIMEType('text/plain;foo=bar;xyz=baz');
 for (const [name, value] of params) {
   console.log(name, value);

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1024,6 +1024,235 @@ Otherwise, returns `false`.
 See [`assert.deepStrictEqual()`][] for more information about deep strict
 equality.
 
+## Class: `util.MIMEType`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An implementation of [the MIMEType class](https://bmeck.github.io/node-proposal-mime-api/).
+
+In accordance with browser conventions, all properties of `MIMEType` objects
+are implemented as getters and setters on the class prototype, rather than as
+data properties on the object itself.
+
+A MIME string is a structured string containing multiple meaningful
+components. When parsed, a `MIMEType` object is returned containing
+properties for each of these components.
+
+### Constructor: `new MIMEType(input)`
+
+* `input` {string} The input MIME to parse
+
+Creates a new `MIMEType` object by parsing the `input`.
+
+```js
+const myMIME = new MIMEType('text/plain');
+```
+
+A `TypeError` will be thrown if the `input` is not a valid MIME. Note
+that an effort will be made to coerce the given values into strings. For
+instance:
+
+```js
+const myMIME = new MIMEType({ toString: () => 'text/plain' });
+console.log(String(myMIME));
+// Prints: text/plain
+```
+
+#### `mime.type`
+
+* {string}
+
+Gets and sets the type portion of the MIME.
+
+```js
+const myMIME = new MIMEType('text/javascript');
+console.log(myMIME.type);
+// Prints: text
+myMIME.type = 'application';
+console.log(myMIME.type);
+// Prints: application
+```
+
+#### `mime.subtype`
+
+* {string}
+
+Gets and sets the subtype portion of the MIME.
+
+```js
+const myMIME = new MIMEType('text/ecmascript');
+console.log(myMIME.subtype);
+// Prints: ecmascript
+myMIME.subtype = 'javascript';
+console.log(myMIME.subtype);
+// Prints: javascript
+```
+
+#### `mime.essence`
+
+* {string}
+
+Gets the essence of the MIME. This property is read only.
+Use `mime.type` or `mime.subtype` to alter the MIME.
+
+```js
+const myMIME = new MIMEType('text/javascript');
+console.log(myMIME.essence);
+// Prints: text/javascript
+myMIME.type = 'application';
+console.log(myMIME.essence);
+// Prints: application/javascript
+```
+
+#### `mime.params`
+
+* {MIMEParams}
+
+Gets the [`MIMEParams`][] object representing the
+parameters of the MIME. This property is read-only. See
+[`MIMEParams`][] documentation for details.
+
+#### `mime.toString()`
+
+* Returns: {string}
+
+The `toString()` method on the `MIMEType` object returns the serialized MIME.
+The value returned is equivalent to that of [`mime.toJSON()`][].
+
+Because of the need for standard compliance, this method does not allow users
+to customize the serialization process of the MIME.
+
+#### `mime.toJSON()`
+
+* Returns: {string}
+
+The `toJSON()` method on the `MIMEType` object returns the serialized MIME. The
+value returned is equivalent to that of [`mime.toString()`][].
+
+This method is automatically called when an `MIMEType` object is serialized
+with [`JSON.stringify()`][].
+
+```js
+const myMIMES = [
+  new MIMEType('img/png'),
+  new MIMEType('img/gif'),
+];
+console.log(JSON.stringify(myMIMES));
+// Prints: ["img/png", "img/gif"]
+```
+
+### Class: `util.MIMEParams`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `MIMEParams` API provides read and write access to the parameters of a
+`MIMEType`.
+
+#### Constructor: `new MIMEParams()`
+
+Creates a new `MIMEParams` object by with empty parameters
+
+```js
+const myParams = new MIMEParams();
+```
+
+#### `mimeParams.delete(name)`
+
+* `name` {string}
+
+Remove all name-value pairs whose name is `name`.
+
+#### `mimeParams.entries()`
+
+* Returns: {Iterator}
+
+Returns an ES6 Iterator over each of the name-value pairs in the parameters.
+Each item of the iterator is a JavaScript Array. The first item of the Array
+is the `name`, the second item of the Array is the `value`.
+
+Alias for [`mimeParams[@@iterator]()`][`mimeParams@@iterator()`].
+
+#### `mimeParams.get(name)`
+
+* `name` {string}
+* Returns: {string} or `null` if there is no name-value pair with the given
+  `name`.
+
+Returns the value of the first name-value pair whose name is `name`. If there
+are no such pairs, `null` is returned.
+
+#### `mimeParams.has(name)`
+
+* `name` {string}
+* Returns: {boolean}
+
+Returns `true` if there is at least one name-value pair whose name is `name`.
+
+#### `mimeParams.keys()`
+
+* Returns: {Iterator}
+
+Returns an ES6 Iterator over the names of each name-value pair.
+
+```js
+const { params } = new MIMEType('text/plain;foo=0;bar=1');
+for (const name of params.keys()) {
+  console.log(name);
+}
+// Prints:
+//   foo
+//   bar
+```
+
+#### `mimeParams.set(name, value)`
+
+* `name` {string}
+* `value` {string}
+
+Sets the value in the `MIMEParams` object associated with `name` to
+`value`. If there are any pre-existing name-value pairs whose names are `name`,
+set the first such pair's value to `value`.
+
+```js
+const { params } = new MIMEType('text/plain;foo=0;bar=1');
+params.set('foo', 'def');
+params.set('baz', 'xyz');
+console.log(params.toString());
+// Prints: foo=def&bar=1&baz=xyz
+```
+
+#### `mimeParams.values()`
+
+* Returns: {Iterator}
+
+Returns an ES6 Iterator over the values of each name-value pair.
+
+#### `mimeParams\[@@iterator\]()`
+
+* Returns: {Iterator}
+
+Returns an ES6 Iterator over each of the name-value pairs in the query string.
+Each item of the iterator is a JavaScript Array. The first item of the Array
+is the `name`, the second item of the Array is the `value`.
+
+Alias for [`mimeParams.entries()`][].
+
+```js
+const { params } = new MIMEType('text/plain;foo=bar;xyz=baz');
+for (const [name, value] of params) {
+  console.log(name, value);
+}
+// Prints:
+//   foo bar
+//   xyz baz
+```
+
 ## `util.parseArgs([config])`
 
 <!-- YAML
@@ -2903,6 +3132,8 @@ util.log('Timestamped message.');
 [`Int16Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
 [`Int32Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
 [`Int8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
+[`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[`MIMEparams`]: #util_class_util_mimeparams
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`Object.assign()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 [`Object.freeze()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
@@ -2920,6 +3151,10 @@ util.log('Timestamped message.');
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.md#assertdeepstrictequalactual-expected-message
 [`console.error()`]: console.md#consoleerrordata-args
+[`mime.toJSON()`]: #util_mime_tojson
+[`mime.toString()`]: #util_mime_tostring
+[`mimeParams.entries()`]: #util_mimeparams_entries
+[`mimeParams@@iterator()`]: #util_mimeparams_iterator
 [`napi_create_external()`]: n-api.md#napi_create_external
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`tty.hasColors()`]: tty.md#writestreamhascolorscount-env

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -3133,7 +3133,7 @@ util.log('Timestamped message.');
 [`Int32Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
 [`Int8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
 [`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-[`MIMEparams`]: #util_class_util_mimeparams
+[`MIMEparams`]: #class-utilmimeparams
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`Object.assign()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 [`Object.freeze()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
@@ -3151,10 +3151,10 @@ util.log('Timestamped message.');
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.md#assertdeepstrictequalactual-expected-message
 [`console.error()`]: console.md#consoleerrordata-args
-[`mime.toJSON()`]: #util_mime_tojson
-[`mime.toString()`]: #util_mime_tostring
-[`mimeParams.entries()`]: #util_mimeparams_entries
-[`mimeParams@@iterator()`]: #util_mimeparams_iterator
+[`mime.toJSON()`]: #mimetojson
+[`mime.toString()`]: #mimetostring
+[`mimeParams.entries()`]: #mimeparamsentries
+[`mimeParams@@iterator()`]: #mimeparamsiterator
 [`napi_create_external()`]: n-api.md#napi_create_external
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`tty.hasColors()`]: tty.md#writestreamhascolorscount-env

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1049,6 +1049,8 @@ properties for each of these components.
 Creates a new `MIMEType` object by parsing the `input`.
 
 ```js
+import { MIMEType } from 'node:util';
+
 const myMIME = new MIMEType('text/plain');
 ```
 
@@ -1136,11 +1138,11 @@ with [`JSON.stringify()`][].
 
 ```js
 const myMIMES = [
-  new MIMEType('img/png'),
-  new MIMEType('img/gif'),
+  new MIMEType('image/png'),
+  new MIMEType('image/gif'),
 ];
 console.log(JSON.stringify(myMIMES));
-// Prints: ["img/png", "img/gif"]
+// Prints: ["image/png", "image/gif"]
 ```
 
 ### Class: `util.MIMEParams`

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -639,6 +639,9 @@ RegExp.prototype.exec = () => null;
 // Core
 console.log(RegExpPrototypeTest(/o/, 'foo')); // false
 console.log(RegExpPrototypeExec(/o/, 'foo') !== null); // true
+
+console.log(RegExpPrototypeSymbolSearch(/o/, 'foo')); // -1
+console.log(SafeStringPrototypeSearch('foo', /o/)); // 1
 ```
 
 #### Don't trust `RegExp` flags
@@ -668,19 +671,7 @@ Object.defineProperty(RegExp.prototype, 'global', { value: false });
 
 // Core
 console.log(RegExpPrototypeSymbolReplace(/o/g, 'foo', 'a')); // 'fao'
-
-const regex = /o/g;
-ObjectDefineProperties(regex, {
-  dotAll: { value: false },
-  exec: { value: undefined },
-  flags: { value: 'g' },
-  global: { value: true },
-  ignoreCase: { value: false },
-  multiline: { value: false },
-  unicode: { value: false },
-  sticky: { value: false },
-});
-console.log(RegExpPrototypeSymbolReplace(regex, 'foo', 'a')); // 'faa'
+console.log(RegExpPrototypeSymbolReplace(hardenRegExp(/o/g), 'foo', 'a')); // 'faa'
 ```
 
 ### Defining object own properties

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1310,6 +1310,10 @@ E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError);
+E('ERR_INVALID_MIME_SYNTAX', (production, str, invalidIndex) => {
+  const msg = invalidIndex !== -1 ? ` at ${invalidIndex}` : '';
+  return `The MIME syntax for a ${production} in "${str}" is invalid` + msg;
+}, TypeError);
 E('ERR_INVALID_MODULE_SPECIFIER', (request, reason, base = undefined) => {
   return `Invalid module "${request}" ${reason}${base ?
     ` imported from ${base}` : ''}`;

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -2,14 +2,12 @@
 
 const {
   ObjectCreate,
-  MapIteratorPrototypeNext,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolMatch,
   RegExpPrototypeSymbolMatchAll,
   RegExpPrototypeSymbolReplace,
   RegExpPrototypeSymbolSearch,
   RegExpPrototypeSymbolSplit,
-  StringPrototypeReplace,
   StringPrototypeToLowerCase,
   StringPrototypeSlice,
   StringPrototypeCharAt,
@@ -27,6 +25,7 @@ const {
 } = require('internal/errors').codes;
 
 function SafeStringPrototypeSearch(str, regexp) {
+  regexp.lastIndex = 0;
   const match = RegExpPrototypeExec(regexp, str);
   return match ? match.index : -1;
 }
@@ -46,10 +45,16 @@ const NotHTTPQuotedStringCodePoint = hardenRegExp(/[^\t\u0020-~\u0080-\u00FF]/g)
 const END_BEGINNING_WHITESPACE = hardenRegExp(/[^\r\n\t ]|$/);
 const START_ENDING_WHITESPACE = hardenRegExp(/[\r\n\t ]*$/);
 
-const ASCII_LOWER = hardenRegExp(/[A-Z]/g);
 function toASCIILower(str) {
-  return StringPrototypeReplace(str, ASCII_LOWER,
-                                (c) => StringPrototypeToLowerCase(c));
+  let ret = '';
+  for (const c of str) {
+    if (c >= 'A' && c <= 'Z') {
+      ret += StringPrototypeToLowerCase(c);
+    } else {
+      ret += c;
+    }
+  }
+  return ret;
 }
 
 const SOLIDUS = '/';
@@ -100,7 +105,27 @@ function parseTypeAndSubtype(str) {
 
 const EQUALS_SEMICOLON_OR_END = hardenRegExp(/[;=]|$/);
 const QUOTED_VALUE_PATTERN = hardenRegExp(/^(?:([\\]$)|[\\][\s\S]|[^"])*(?:(")|$)/u);
-const QUOTED_CHARACTER = hardenRegExp(/[\\]([\s\S])/ug);
+
+function removeBackslashes(str) {
+  let ret = '';
+  // We stop at str.length - 1 because we want to look ahead one character.
+  let i;
+  for (i = 0; i < str.length - 1; i++) {
+    const c = str[i];
+    if (c === '\\') {
+      i++;
+      ret += str[i];
+    } else {
+      ret += c;
+    }
+  }
+  // We add the last character if we didn't skip to it.
+  if (i === str.length - 1) {
+    ret += str[i];
+  }
+  return ret;
+}
+
 function parseParametersString(str, position, paramsMap = new Map()) {
   const endOfSource = SafeStringPrototypeSearch(
     StringPrototypeSlice(str, position),
@@ -155,7 +180,7 @@ function parseParametersString(str, position, paramsMap = new Map()) {
         StringPrototypeSlice(insideMatch[0], 0, -1) :
         insideMatch[0];
       // Unescape '\' quoted characters
-      parameterValue = StringPrototypeReplace(inside, QUOTED_CHARACTER, '$1');
+      parameterValue = removeBackslashes(inside);
       // If we did have an unmatched '\' add it back to the end
       if (insideMatch[1]) parameterValue += '\\';
     } else {
@@ -186,13 +211,24 @@ function parseParametersString(str, position, paramsMap = new Map()) {
   return paramsMap;
 }
 
-const QUOTE_OR_SOLIDUS = hardenRegExp(/["\\]/g);
+function escapeQuoteOrSolidus(str) {
+  let ret = '';
+  for (const c of str) {
+    if (c === '"' || c === '\\') {
+      ret += `\\${c}`;
+    } else {
+      ret += c;
+    }
+  }
+  return ret;
+}
+
 const encode = (value) => {
   if (value.length === 0) return '""';
   NotHTTPTokenCodePoint.lastIndex = 0;
   const encode = SafeStringPrototypeSearch(value, NotHTTPTokenCodePoint) !== -1;
   if (!encode) return value;
-  const escaped = StringPrototypeReplace(value, QUOTE_OR_SOLIDUS, '\\$&');
+  const escaped = escapeQuoteOrSolidus(value);
   return `"${escaped}"`;
 };
 
@@ -209,7 +245,7 @@ const MIMEParamsStringify = (parameters) => {
   let keyValuePair, done;
   // Using this to avoid prototype pollution on Map iterators
   // eslint-disable-next-line no-cond-assign
-  while ({ value: keyValuePair, done } = MapIteratorPrototypeNext(entries)) {
+  while ({ value: keyValuePair, done } = entries.next()) {
     if (done) break;
     const { 0: key, 1: value } = keyValuePair;
     const encoded = encode(value);

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -13,17 +13,16 @@ const {
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   SymbolIterator,
-  hardenRegExp,
 } = primordials;
 const {
   ERR_INVALID_MIME_SYNTAX,
 } = require('internal/errors').codes;
 
-const NotHTTPTokenCodePoint = hardenRegExp(/[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g);
-const NotHTTPQuotedStringCodePoint = hardenRegExp(/[^\t\u0020-~\u0080-\u00FF]/g);
+const NotHTTPTokenCodePoint = /[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g;
+const NotHTTPQuotedStringCodePoint = /[^\t\u0020-~\u0080-\u00FF]/g;
 
-const END_BEGINNING_WHITESPACE = hardenRegExp(/[^\r\n\t ]|$/);
-const START_ENDING_WHITESPACE = hardenRegExp(/[\r\n\t ]*$/);
+const END_BEGINNING_WHITESPACE = /[^\r\n\t ]|$/;
+const START_ENDING_WHITESPACE = /[\r\n\t ]*$/;
 
 function toASCIILower(str) {
   let result = '';
@@ -83,8 +82,8 @@ function parseTypeAndSubtype(str) {
   };
 }
 
-const EQUALS_SEMICOLON_OR_END = hardenRegExp(/[;=]|$/);
-const QUOTED_VALUE_PATTERN = hardenRegExp(/^(?:([\\]$)|[\\][\s\S]|[^"])*(?:(")|$)/u);
+const EQUALS_SEMICOLON_OR_END = /[;=]|$/;
+const QUOTED_VALUE_PATTERN = /^(?:([\\]$)|[\\][\s\S]|[^"])*(?:(")|$)/u;
 
 function removeBackslashes(str) {
   let ret = '';
@@ -205,7 +204,6 @@ function escapeQuoteOrSolidus(str) {
 
 const encode = (value) => {
   if (value.length === 0) return '""';
-  NotHTTPTokenCodePoint.lastIndex = 0;
   const encode = SafeStringPrototypeSearch(value, NotHTTPTokenCodePoint) !== -1;
   if (!encode) return value;
   const escaped = escapeQuoteOrSolidus(value);
@@ -251,7 +249,6 @@ class MIMEParams {
 
   set(name, value) {
     const data = this.#data;
-    NotHTTPTokenCodePoint.lastIndex = 0;
     name = `${name}`;
     value = `${value}`;
     const invalidNameIndex = SafeStringPrototypeSearch(name, NotHTTPTokenCodePoint);
@@ -262,7 +259,6 @@ class MIMEParams {
         invalidNameIndex,
       );
     }
-    NotHTTPQuotedStringCodePoint.lastIndex = 0;
     const invalidValueIndex = SafeStringPrototypeSearch(
       value,
       NotHTTPQuotedStringCodePoint);
@@ -335,9 +331,6 @@ class MIMEType {
 
   set type(v) {
     v = `${v}`;
-    // TODO: Is this next line necessary? If so, add comment explaining why. If not, remove it.
-    // eslint-disable-next-line no-unused-expressions
-    NotHTTPTokenCodePoint;
     const invalidTypeIndex = SafeStringPrototypeSearch(v, NotHTTPTokenCodePoint);
     if (v.length === 0 || invalidTypeIndex !== -1) {
       throw new ERR_INVALID_MIME_SYNTAX('type', v, invalidTypeIndex);

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const {
-  MapPrototypeEntries,
-  MapPrototypeKeys,
-  MapPrototypeValues,
+  FunctionPrototypeCall,
   ObjectDefineProperty,
   RegExpPrototypeExec,
   SafeMap,
@@ -210,24 +208,6 @@ const encode = (value) => {
   return `"${escaped}"`;
 };
 
-const MIMEStringify = (type, subtype, parameters) => {
-  let ret = `${type}/${subtype}`;
-  const paramStr = MIMEParamsStringify(parameters);
-  if (paramStr.length) ret += `;${paramStr}`;
-  return ret;
-};
-
-const MIMEParamsStringify = (parameters) => {
-  let ret = '';
-  for (const { 0: key, 1: value } of MIMEParamsData(parameters)) {
-    const encoded = encode(value);
-    // Ensure they are separated
-    if (ret.length) ret += ';';
-    ret += `${key}=${encoded}`;
-  }
-  return ret;
-};
-
 class MIMEParams {
   #data = new SafeMap();
 
@@ -272,24 +252,27 @@ class MIMEParams {
     data.set(name, value);
   }
 
-  entries() {
-    return MapPrototypeEntries(this.#data);
+  *entries() {
+    yield* this.#data.entries();
   }
 
-  keys() {
-    return MapPrototypeKeys(this.#data);
+  *keys() {
+    yield* this.#data.keys();
   }
 
-  values() {
-    return MapPrototypeValues(this.#data);
-  }
-
-  toJSON() {
-    return MIMEParamsStringify(this);
+  *values() {
+    yield* this.#data.values();
   }
 
   toString() {
-    return MIMEParamsStringify(this);
+    let ret = '';
+    for (const { 0: key, 1: value } of this.#data) {
+      const encoded = encode(value);
+      // Ensure they are separated
+      if (ret.length) ret += ';';
+      ret += `${key}=${encoded}`;
+    }
+    return ret;
   }
 
   // Used to act as a friendly class to stringifying stuff
@@ -298,14 +281,21 @@ class MIMEParams {
     return o.#data;
   }
 }
+const MIMEParamsStringify = MIMEParams.prototype.toString;
 ObjectDefineProperty(MIMEParams.prototype, SymbolIterator, {
   __proto__: null,
   configurable: true,
   value: MIMEParams.prototype.entries,
   writable: true,
 });
+ObjectDefineProperty(MIMEParams.prototype, 'toJSON', {
+  __proto__: null,
+  configurable: true,
+  value: MIMEParamsStringify,
+  writable: true,
+});
 
-const MIMEParamsData = MIMEParams._data;
+const getMIMEParamsData = MIMEParams._data;
 delete MIMEParams._data;
 
 class MIMEType {
@@ -321,7 +311,7 @@ class MIMEType {
     parseParametersString(
       string,
       data.parametersStringIndex,
-      MIMEParamsData(this.#parameters)
+      getMIMEParamsData(this.#parameters)
     );
   }
 
@@ -359,14 +349,20 @@ class MIMEType {
     return this.#parameters;
   }
 
-  toJSON() {
-    return MIMEStringify(this.#type, this.#subtype, this.#parameters);
-  }
-
   toString() {
-    return MIMEStringify(this.#type, this.#subtype, this.#parameters);
+    let ret = `${this.#type}/${this.#subtype}`;
+    const paramStr = FunctionPrototypeCall(MIMEParamsStringify, this.#parameters);
+    if (paramStr.length) ret += `;${paramStr}`;
+    return ret;
   }
 }
+ObjectDefineProperty(MIMEType.prototype, 'toJSON', {
+  __proto__: null,
+  configurable: true,
+  value: MIMEType.prototype.toString,
+  writable: true,
+});
+
 module.exports = {
   MIMEParams,
   MIMEType,

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -298,7 +298,12 @@ class MIMEParams {
     return o.#data;
   }
 }
-MIMEParams.prototype[SymbolIterator] = MIMEParams.prototype.entries;
+ObjectDefineProperty(MIMEParams.prototype, SymbolIterator, {
+  __proto__: null,
+  configurable: true,
+  value: MIMEParams.prototype.entries,
+  writable: true,
+});
 
 const MIMEParamsData = MIMEParams._data;
 delete MIMEParams._data;

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -1,14 +1,18 @@
 'use strict';
 
 const {
+  MapPrototypeEntries,
+  MapPrototypeKeys,
+  MapPrototypeValues,
+  ObjectDefineProperty,
   RegExpPrototypeExec,
-  StringPrototypeToLowerCase,
-  StringPrototypeSlice,
-  StringPrototypeCharAt,
-  StringPrototypeIndexOf,
-  SymbolIterator,
   SafeMap,
   SafeStringPrototypeSearch,
+  StringPrototypeCharAt,
+  StringPrototypeIndexOf,
+  StringPrototypeSlice,
+  StringPrototypeToLowerCase,
+  SymbolIterator,
   hardenRegExp,
 } = primordials;
 const {
@@ -273,15 +277,15 @@ class MIMEParams {
   }
 
   entries() {
-    return this.#data.entries();
+    return MapPrototypeEntries(this.#data);
   }
 
   keys() {
-    return this.#data.keys();
+    return MapPrototypeKeys(this.#data);
   }
 
   values() {
-    return this.#data.values();
+    return MapPrototypeValues(this.#data);
   }
 
   toJSON() {

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -103,93 +103,6 @@ function removeBackslashes(str) {
   return ret;
 }
 
-function parseParametersString(str, position, paramsMap = new SafeMap()) {
-  const endOfSource = SafeStringPrototypeSearch(
-    StringPrototypeSlice(str, position),
-    START_ENDING_WHITESPACE
-  ) + position;
-  while (position < endOfSource) {
-    // Skip any whitespace before parameter
-    position += SafeStringPrototypeSearch(
-      StringPrototypeSlice(str, position),
-      END_BEGINNING_WHITESPACE
-    );
-    // Read until ';' or '='
-    const afterParameterName = SafeStringPrototypeSearch(
-      StringPrototypeSlice(str, position),
-      EQUALS_SEMICOLON_OR_END
-    ) + position;
-    const parameterString = toASCIILower(
-      StringPrototypeSlice(str, position, afterParameterName)
-    );
-    position = afterParameterName;
-    // If we found a terminating character
-    if (position < endOfSource) {
-      // Safe to use because we never do special actions for surrogate pairs
-      const char = StringPrototypeCharAt(str, position);
-      // Skip the terminating character
-      position += 1;
-      // Ignore parameters without values
-      if (char === ';') {
-        continue;
-      }
-    }
-    // If we are at end of the string, it cannot have a value
-    if (position >= endOfSource) break;
-    // Safe to use because we never do special actions for surrogate pairs
-    const char = StringPrototypeCharAt(str, position);
-    let parameterValue = null;
-    if (char === '"') {
-      // Handle quoted-string form of values
-      // skip '"'
-      position += 1;
-      // Find matching closing '"' or end of string
-      //   use $1 to see if we terminated on unmatched '\'
-      //   use $2 to see if we terminated on a matching '"'
-      //   so we can skip the last char in either case
-      const insideMatch = RegExpPrototypeExec(
-        QUOTED_VALUE_PATTERN,
-        StringPrototypeSlice(str, position));
-      position += insideMatch[0].length;
-      // Skip including last character if an unmatched '\' or '"' during
-      // unescape
-      const inside = insideMatch[1] || insideMatch[2] ?
-        StringPrototypeSlice(insideMatch[0], 0, -1) :
-        insideMatch[0];
-      // Unescape '\' quoted characters
-      parameterValue = removeBackslashes(inside);
-      // If we did have an unmatched '\' add it back to the end
-      if (insideMatch[1]) parameterValue += '\\';
-    } else {
-      // Handle the normal parameter value form
-      const valueEnd = StringPrototypeIndexOf(str, SEMICOLON, position);
-      const rawValue = valueEnd === -1 ?
-        StringPrototypeSlice(str, position) :
-        StringPrototypeSlice(str, position, valueEnd);
-      position += rawValue.length;
-      const trimmedValue = StringPrototypeSlice(
-        rawValue,
-        0,
-        SafeStringPrototypeSearch(rawValue, START_ENDING_WHITESPACE)
-      );
-      // Ignore parameters without values
-      if (trimmedValue === '') continue;
-      parameterValue = trimmedValue;
-    }
-    if (
-      parameterString !== '' &&
-      SafeStringPrototypeSearch(parameterString,
-                                NotHTTPTokenCodePoint) === -1 &&
-      SafeStringPrototypeSearch(parameterValue,
-                                NotHTTPQuotedStringCodePoint) === -1 &&
-      paramsMap.has(parameterString) === false
-    ) {
-      paramsMap.set(parameterString, parameterValue);
-    }
-    position++;
-  }
-  return paramsMap;
-}
 
 function escapeQuoteOrSolidus(str) {
   let result = '';
@@ -277,8 +190,93 @@ class MIMEParams {
 
   // Used to act as a friendly class to stringifying stuff
   // not meant to be exposed to users, could inject invalid values
-  static _data(o) {
-    return o.#data;
+  static parseParametersString(str, position, params) {
+    const paramsMap = params.#data;
+    const endOfSource = SafeStringPrototypeSearch(
+      StringPrototypeSlice(str, position),
+      START_ENDING_WHITESPACE
+    ) + position;
+    while (position < endOfSource) {
+      // Skip any whitespace before parameter
+      position += SafeStringPrototypeSearch(
+        StringPrototypeSlice(str, position),
+        END_BEGINNING_WHITESPACE
+      );
+      // Read until ';' or '='
+      const afterParameterName = SafeStringPrototypeSearch(
+        StringPrototypeSlice(str, position),
+        EQUALS_SEMICOLON_OR_END
+      ) + position;
+      const parameterString = toASCIILower(
+        StringPrototypeSlice(str, position, afterParameterName)
+      );
+      position = afterParameterName;
+      // If we found a terminating character
+      if (position < endOfSource) {
+        // Safe to use because we never do special actions for surrogate pairs
+        const char = StringPrototypeCharAt(str, position);
+        // Skip the terminating character
+        position += 1;
+        // Ignore parameters without values
+        if (char === ';') {
+          continue;
+        }
+      }
+      // If we are at end of the string, it cannot have a value
+      if (position >= endOfSource) break;
+      // Safe to use because we never do special actions for surrogate pairs
+      const char = StringPrototypeCharAt(str, position);
+      let parameterValue = null;
+      if (char === '"') {
+        // Handle quoted-string form of values
+        // skip '"'
+        position += 1;
+        // Find matching closing '"' or end of string
+        //   use $1 to see if we terminated on unmatched '\'
+        //   use $2 to see if we terminated on a matching '"'
+        //   so we can skip the last char in either case
+        const insideMatch = RegExpPrototypeExec(
+          QUOTED_VALUE_PATTERN,
+          StringPrototypeSlice(str, position));
+        position += insideMatch[0].length;
+        // Skip including last character if an unmatched '\' or '"' during
+        // unescape
+        const inside = insideMatch[1] || insideMatch[2] ?
+          StringPrototypeSlice(insideMatch[0], 0, -1) :
+          insideMatch[0];
+        // Unescape '\' quoted characters
+        parameterValue = removeBackslashes(inside);
+        // If we did have an unmatched '\' add it back to the end
+        if (insideMatch[1]) parameterValue += '\\';
+      } else {
+        // Handle the normal parameter value form
+        const valueEnd = StringPrototypeIndexOf(str, SEMICOLON, position);
+        const rawValue = valueEnd === -1 ?
+          StringPrototypeSlice(str, position) :
+          StringPrototypeSlice(str, position, valueEnd);
+        position += rawValue.length;
+        const trimmedValue = StringPrototypeSlice(
+          rawValue,
+          0,
+          SafeStringPrototypeSearch(rawValue, START_ENDING_WHITESPACE)
+        );
+        // Ignore parameters without values
+        if (trimmedValue === '') continue;
+        parameterValue = trimmedValue;
+      }
+      if (
+        parameterString !== '' &&
+        SafeStringPrototypeSearch(parameterString,
+                                  NotHTTPTokenCodePoint) === -1 &&
+        SafeStringPrototypeSearch(parameterValue,
+                                  NotHTTPQuotedStringCodePoint) === -1 &&
+        params.has(parameterString) === false
+      ) {
+        paramsMap.set(parameterString, parameterValue);
+      }
+      position++;
+    }
+    return paramsMap;
   }
 }
 const MIMEParamsStringify = MIMEParams.prototype.toString;
@@ -295,8 +293,8 @@ ObjectDefineProperty(MIMEParams.prototype, 'toJSON', {
   writable: true,
 });
 
-const getMIMEParamsData = MIMEParams._data;
-delete MIMEParams._data;
+const { parseParametersString } = MIMEParams;
+delete MIMEParams.parseParametersString;
 
 class MIMEType {
   #type;
@@ -311,7 +309,7 @@ class MIMEType {
     parseParametersString(
       string,
       data.parametersStringIndex,
-      getMIMEParamsData(this.#parameters)
+      this.#parameters,
     );
   }
 

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -16,8 +16,8 @@ const {
   ERR_INVALID_MIME_SYNTAX,
 } = require('internal/errors').codes;
 
-const NotHTTPTokenCodePoint = /[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g;
-const NotHTTPQuotedStringCodePoint = /[^\t\u0020-~\u0080-\u00FF]/g;
+const NOT_HTTP_TOKEN_CODE_POINT = /[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g;
+const NOT_HTTP_QUOTED_STRING_CODE_POINT = /[^\t\u0020-~\u0080-\u00FF]/g;
 
 const END_BEGINNING_WHITESPACE = /[^\r\n\t ]|$/;
 const START_ENDING_WHITESPACE = /[\r\n\t ]*$/;

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -21,7 +21,7 @@ const {
   SafeMap: Map,
 } = primordials;
 const {
-  ERR_INVALID_MIME_SYNTAX
+  ERR_INVALID_MIME_SYNTAX,
 } = require('internal/errors').codes;
 
 function SafeStringPrototypeSearch(str, regexp) {
@@ -30,12 +30,20 @@ function SafeStringPrototypeSearch(str, regexp) {
   return match ? match.index : -1;
 }
 
+const {
+  [SymbolMatch]: OriginalRegExpPrototypeSymbolMatch,
+  [SymbolMatchAll]: OriginalRegExpPrototypeSymbolMatchAll,
+  [SymbolReplace]: OriginalRegExpPrototypeSymbolReplace,
+  [SymbolSearch]: OriginalRegExpPrototypeSymbolSearch,
+  [SymbolSplit]: OriginalRegExpPrototypeSymbolSplit,
+} = RegExpPrototype;
+
 function hardenRegExp(pattern) {
-  pattern[SymbolMatch] = RegExpPrototypeSymbolMatch;
-  pattern[SymbolMatchAll] = RegExpPrototypeSymbolMatchAll;
-  pattern[SymbolReplace] = RegExpPrototypeSymbolReplace;
-  pattern[SymbolSearch] = RegExpPrototypeSymbolSearch;
-  pattern[SymbolSplit] = RegExpPrototypeSymbolSplit;
+  pattern[SymbolMatch] = OriginalRegExpPrototypeSymbolMatch;
+  pattern[SymbolMatchAll] = OriginalRegExpPrototypeSymbolMatchAll;
+  pattern[SymbolReplace] = OriginalRegExpPrototypeSymbolReplace;
+  pattern[SymbolSearch] = OriginalRegExpPrototypeSymbolSearch;
+  pattern[SymbolSplit] = OriginalRegExpPrototypeSymbolSplit;
   return pattern;
 }
 
@@ -46,15 +54,15 @@ const END_BEGINNING_WHITESPACE = hardenRegExp(/[^\r\n\t ]|$/);
 const START_ENDING_WHITESPACE = hardenRegExp(/[\r\n\t ]*$/);
 
 function toASCIILower(str) {
-  let ret = '';
-  for (const c of str) {
-    if (c >= 'A' && c <= 'Z') {
-      ret += StringPrototypeToLowerCase(c);
-    } else {
-      ret += c;
-    }
+  let result = '';
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    result += char >= 'A' && char <= 'Z' ?
+      StringPrototypeToLowerCase(char) :
+      char;
   }
-  return ret;
+  return result;
 }
 
 const SOLIDUS = '/';
@@ -91,16 +99,16 @@ function parseTypeAndSubtype(str) {
     SafeStringPrototypeSearch(rawSubtype, START_ENDING_WHITESPACE));
   const invalidSubtypeIndex = SafeStringPrototypeSearch(trimmedSubtype,
                                                         NotHTTPTokenCodePoint);
-  if (trimmedSubtype === '' ||
-    invalidSubtypeIndex !== -1) {
+  if (trimmedSubtype === '' || invalidSubtypeIndex !== -1) {
     throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
   }
   const subtype = toASCIILower(trimmedSubtype);
-  const target = ObjectCreate(null);
-  target.type = type;
-  target.subtype = subtype;
-  target.parametersStringIndex = position;
-  return target;
+  return {
+    __proto__: null,
+    type,
+    subtype,
+    parametersStringIndex: position,
+  };
 }
 
 const EQUALS_SEMICOLON_OR_END = hardenRegExp(/[;=]|$/);
@@ -193,17 +201,20 @@ function parseParametersString(str, position, paramsMap = new Map()) {
       const trimmedValue = StringPrototypeSlice(
         rawValue,
         0,
-        SafeStringPrototypeSearch(rawValue, START_ENDING_WHITESPACE));
+        SafeStringPrototypeSearch(rawValue, START_ENDING_WHITESPACE)
+      );
       // Ignore parameters without values
       if (trimmedValue === '') continue;
       parameterValue = trimmedValue;
     }
-    if (parameterString !== '' &&
+    if (
+      parameterString !== '' &&
       SafeStringPrototypeSearch(parameterString,
                                 NotHTTPTokenCodePoint) === -1 &&
       SafeStringPrototypeSearch(parameterValue,
                                 NotHTTPQuotedStringCodePoint) === -1 &&
-      paramsMap.has(parameterString) === false) {
+      paramsMap.has(parameterString) === false
+    ) {
       paramsMap.set(parameterString, parameterValue);
     }
     position++;
@@ -212,15 +223,12 @@ function parseParametersString(str, position, paramsMap = new Map()) {
 }
 
 function escapeQuoteOrSolidus(str) {
-  let ret = '';
-  for (const c of str) {
-    if (c === '"' || c === '\\') {
-      ret += `\\${c}`;
-    } else {
-      ret += c;
-    }
+  let result = '';
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    result += (char === '"' || char === '\\') ? `\\${char}` : char;
   }
-  return ret;
+  return result;
 }
 
 const encode = (value) => {
@@ -257,10 +265,7 @@ const MIMEParamsStringify = (parameters) => {
 };
 
 class MIMEParams {
-  #data;
-  constructor() {
-    this.#data = new Map();
-  }
+  #data = new SafeMap();
 
   delete(name) {
     this.#data.delete(name);
@@ -285,18 +290,22 @@ class MIMEParams {
     value = `${value}`;
     const invalidNameIndex = SafeStringPrototypeSearch(name, NotHTTPTokenCodePoint);
     if (name.length === 0 || invalidNameIndex !== -1) {
-      throw new ERR_INVALID_MIME_SYNTAX('parameter name',
-                                        name,
-                                        invalidNameIndex);
+      throw new ERR_INVALID_MIME_SYNTAX(
+        'parameter name',
+        name,
+        invalidNameIndex,
+      );
     }
     NotHTTPQuotedStringCodePoint.lastIndex = 0;
     const invalidValueIndex = SafeStringPrototypeSearch(
       value,
       NotHTTPQuotedStringCodePoint);
     if (invalidValueIndex !== -1) {
-      throw new ERR_INVALID_MIME_SYNTAX('parameter value',
-                                        value,
-                                        invalidValueIndex);
+      throw new ERR_INVALID_MIME_SYNTAX(
+        'parameter value',
+        value,
+        invalidValueIndex,
+      );
     }
     data.set(name, value);
   }
@@ -398,6 +407,6 @@ class MIMEType {
   }
 }
 module.exports = {
+  MIMEParams,
   MIMEType,
-  MIMEParams
 };

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -45,7 +45,7 @@ function parseTypeAndSubtype(str) {
     StringPrototypeSlice(str, position) :
     StringPrototypeSlice(str, position, typeEnd);
   const invalidTypeIndex = SafeStringPrototypeSearch(trimmedType,
-                                                     NotHTTPTokenCodePoint);
+                                                     NOT_HTTP_TOKEN_CODE_POINT);
   if (trimmedType === '' || invalidTypeIndex !== -1 || typeEnd === -1) {
     throw new ERR_INVALID_MIME_SYNTAX('type', str, invalidTypeIndex);
   }
@@ -67,7 +67,7 @@ function parseTypeAndSubtype(str) {
     0,
     SafeStringPrototypeSearch(rawSubtype, START_ENDING_WHITESPACE));
   const invalidSubtypeIndex = SafeStringPrototypeSearch(trimmedSubtype,
-                                                        NotHTTPTokenCodePoint);
+                                                        NOT_HTTP_TOKEN_CODE_POINT);
   if (trimmedSubtype === '' || invalidSubtypeIndex !== -1) {
     throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
   }
@@ -115,7 +115,7 @@ function escapeQuoteOrSolidus(str) {
 
 const encode = (value) => {
   if (value.length === 0) return '""';
-  const encode = SafeStringPrototypeSearch(value, NotHTTPTokenCodePoint) !== -1;
+  const encode = SafeStringPrototypeSearch(value, NOT_HTTP_TOKEN_CODE_POINT) !== -1;
   if (!encode) return value;
   const escaped = escapeQuoteOrSolidus(value);
   return `"${escaped}"`;
@@ -144,7 +144,7 @@ class MIMEParams {
     const data = this.#data;
     name = `${name}`;
     value = `${value}`;
-    const invalidNameIndex = SafeStringPrototypeSearch(name, NotHTTPTokenCodePoint);
+    const invalidNameIndex = SafeStringPrototypeSearch(name, NOT_HTTP_TOKEN_CODE_POINT);
     if (name.length === 0 || invalidNameIndex !== -1) {
       throw new ERR_INVALID_MIME_SYNTAX(
         'parameter name',
@@ -154,7 +154,7 @@ class MIMEParams {
     }
     const invalidValueIndex = SafeStringPrototypeSearch(
       value,
-      NotHTTPQuotedStringCodePoint);
+      NOT_HTTP_QUOTED_STRING_CODE_POINT);
     if (invalidValueIndex !== -1) {
       throw new ERR_INVALID_MIME_SYNTAX(
         'parameter value',
@@ -267,9 +267,9 @@ class MIMEParams {
       if (
         parameterString !== '' &&
         SafeStringPrototypeSearch(parameterString,
-                                  NotHTTPTokenCodePoint) === -1 &&
+                                  NOT_HTTP_TOKEN_CODE_POINT) === -1 &&
         SafeStringPrototypeSearch(parameterValue,
-                                  NotHTTPQuotedStringCodePoint) === -1 &&
+                                  NOT_HTTP_QUOTED_STRING_CODE_POINT) === -1 &&
         params.has(parameterString) === false
       ) {
         paramsMap.set(parameterString, parameterValue);
@@ -319,7 +319,7 @@ class MIMEType {
 
   set type(v) {
     v = `${v}`;
-    const invalidTypeIndex = SafeStringPrototypeSearch(v, NotHTTPTokenCodePoint);
+    const invalidTypeIndex = SafeStringPrototypeSearch(v, NOT_HTTP_TOKEN_CODE_POINT);
     if (v.length === 0 || invalidTypeIndex !== -1) {
       throw new ERR_INVALID_MIME_SYNTAX('type', v, invalidTypeIndex);
     }
@@ -332,7 +332,7 @@ class MIMEType {
 
   set subtype(v) {
     v = `${v}`;
-    const invalidSubtypeIndex = SafeStringPrototypeSearch(v, NotHTTPTokenCodePoint);
+    const invalidSubtypeIndex = SafeStringPrototypeSearch(v, NOT_HTTP_TOKEN_CODE_POINT);
     if (v.length === 0 || invalidSubtypeIndex !== -1) {
       throw new ERR_INVALID_MIME_SYNTAX('subtype', v, invalidSubtypeIndex);
     }

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -1,51 +1,19 @@
 'use strict';
 
 const {
-  ObjectCreate,
   RegExpPrototypeExec,
-  RegExpPrototypeSymbolMatch,
-  RegExpPrototypeSymbolMatchAll,
-  RegExpPrototypeSymbolReplace,
-  RegExpPrototypeSymbolSearch,
-  RegExpPrototypeSymbolSplit,
   StringPrototypeToLowerCase,
   StringPrototypeSlice,
   StringPrototypeCharAt,
   StringPrototypeIndexOf,
   SymbolIterator,
-  SymbolMatch,
-  SymbolMatchAll,
-  SymbolReplace,
-  SymbolSearch,
-  SymbolSplit,
-  SafeMap: Map,
+  SafeMap,
+  SafeStringPrototypeSearch,
+  hardenRegExp,
 } = primordials;
 const {
   ERR_INVALID_MIME_SYNTAX,
 } = require('internal/errors').codes;
-
-function SafeStringPrototypeSearch(str, regexp) {
-  regexp.lastIndex = 0;
-  const match = RegExpPrototypeExec(regexp, str);
-  return match ? match.index : -1;
-}
-
-const {
-  [SymbolMatch]: OriginalRegExpPrototypeSymbolMatch,
-  [SymbolMatchAll]: OriginalRegExpPrototypeSymbolMatchAll,
-  [SymbolReplace]: OriginalRegExpPrototypeSymbolReplace,
-  [SymbolSearch]: OriginalRegExpPrototypeSymbolSearch,
-  [SymbolSplit]: OriginalRegExpPrototypeSymbolSplit,
-} = RegExpPrototype;
-
-function hardenRegExp(pattern) {
-  pattern[SymbolMatch] = OriginalRegExpPrototypeSymbolMatch;
-  pattern[SymbolMatchAll] = OriginalRegExpPrototypeSymbolMatchAll;
-  pattern[SymbolReplace] = OriginalRegExpPrototypeSymbolReplace;
-  pattern[SymbolSearch] = OriginalRegExpPrototypeSymbolSearch;
-  pattern[SymbolSplit] = OriginalRegExpPrototypeSymbolSplit;
-  return pattern;
-}
 
 const NotHTTPTokenCodePoint = hardenRegExp(/[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g);
 const NotHTTPQuotedStringCodePoint = hardenRegExp(/[^\t\u0020-~\u0080-\u00FF]/g);
@@ -134,7 +102,7 @@ function removeBackslashes(str) {
   return ret;
 }
 
-function parseParametersString(str, position, paramsMap = new Map()) {
+function parseParametersString(str, position, paramsMap = new SafeMap()) {
   const endOfSource = SafeStringPrototypeSearch(
     StringPrototypeSlice(str, position),
     START_ENDING_WHITESPACE
@@ -249,13 +217,7 @@ const MIMEStringify = (type, subtype, parameters) => {
 
 const MIMEParamsStringify = (parameters) => {
   let ret = '';
-  const entries = MIMEParamsData(parameters).entries();
-  let keyValuePair, done;
-  // Using this to avoid prototype pollution on Map iterators
-  // eslint-disable-next-line no-cond-assign
-  while ({ value: keyValuePair, done } = entries.next()) {
-    if (done) break;
-    const { 0: key, 1: value } = keyValuePair;
+  for (const { 0: key, 1: value } of MIMEParamsData(parameters)) {
     const encoded = encode(value);
     // Ensure they are separated
     if (ret.length) ret += ';';
@@ -310,20 +272,16 @@ class MIMEParams {
     data.set(name, value);
   }
 
-  *entries() {
-    return yield* this.#data.entries();
+  entries() {
+    return this.#data.entries();
   }
 
-  *keys() {
-    return yield* this.#data.keys();
+  keys() {
+    return this.#data.keys();
   }
 
-  *values() {
-    return yield* this.#data.values();
-  }
-
-  *[SymbolIterator]() {
-    return yield* this.#data.entries();
+  values() {
+    return this.#data.values();
   }
 
   toJSON() {
@@ -340,6 +298,7 @@ class MIMEParams {
     return o.#data;
   }
 }
+MIMEParams.prototype[SymbolIterator] = MIMEParams.prototype.entries;
 
 const MIMEParamsData = MIMEParams._data;
 delete MIMEParams._data;

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -1,0 +1,367 @@
+'use strict';
+
+const {
+  ObjectCreate,
+  MapIteratorPrototypeNext,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolMatch,
+  RegExpPrototypeSymbolMatchAll,
+  RegExpPrototypeSymbolReplace,
+  RegExpPrototypeSymbolSearch,
+  RegExpPrototypeSymbolSplit,
+  StringPrototypeReplace,
+  StringPrototypeToLowerCase,
+  StringPrototypeSlice,
+  StringPrototypeCharAt,
+  StringPrototypeIndexOf,
+  SymbolIterator,
+  SymbolMatch,
+  SymbolMatchAll,
+  SymbolReplace,
+  SymbolSearch,
+  SymbolSplit,
+  SafeMap: Map,
+} = primordials;
+const {
+  ERR_INVALID_MIME_SYNTAX
+} = require('internal/errors').codes;
+
+function SafeStringPrototypeSearch(str, regexp) {
+  const match = RegExpPrototypeExec(regexp, str);
+  return match ? match.index : -1;
+}
+
+function hardenRegExp(pattern) {
+  pattern[SymbolMatch] = RegExpPrototypeSymbolMatch;
+  pattern[SymbolMatchAll] = RegExpPrototypeSymbolMatchAll;
+  pattern[SymbolReplace] = RegExpPrototypeSymbolReplace;
+  pattern[SymbolSearch] = RegExpPrototypeSymbolSearch;
+  pattern[SymbolSplit] = RegExpPrototypeSymbolSplit;
+  return pattern;
+}
+
+const NotHTTPTokenCodePoint = hardenRegExp(/[^!#$%&'*+\-.^_`|~A-Za-z0-9]/g);
+const NotHTTPQuotedStringCodePoint = hardenRegExp(/[^\t\u0020-~\u0080-\u00FF]/g);
+
+const END_BEGINNING_WHITESPACE = hardenRegExp(/[^\r\n\t ]|$/);
+const START_ENDING_WHITESPACE = hardenRegExp(/[\r\n\t ]*$/);
+
+const ASCII_LOWER = hardenRegExp(/[A-Z]/g);
+function toASCIILower(str) {
+  return StringPrototypeReplace(str, ASCII_LOWER,
+                                (c) => StringPrototypeToLowerCase(c));
+}
+
+const SOLIDUS = '/';
+const SEMICOLON = ';';
+function parseTypeAndSubtype(str) {
+  // Skip only HTTP whitespace from start
+  let position = SafeStringPrototypeSearch(str, END_BEGINNING_WHITESPACE);
+  // read until '/'
+  const typeEnd = StringPrototypeIndexOf(str, SOLIDUS, position);
+  const trimmedType = typeEnd === -1 ?
+    StringPrototypeSlice(str, position) :
+    StringPrototypeSlice(str, position, typeEnd);
+  const invalidTypeIndex = SafeStringPrototypeSearch(trimmedType,
+                                                     NotHTTPTokenCodePoint);
+  if (trimmedType === '' || invalidTypeIndex !== -1 || typeEnd === -1) {
+    throw new ERR_INVALID_MIME_SYNTAX('type', str, invalidTypeIndex);
+  }
+  // skip type and '/'
+  position = typeEnd + 1;
+  const type = toASCIILower(trimmedType);
+  // read until ';'
+  const subtypeEnd = StringPrototypeIndexOf(str, SEMICOLON, position);
+  const rawSubtype = subtypeEnd === -1 ?
+    StringPrototypeSlice(str, position) :
+    StringPrototypeSlice(str, position, subtypeEnd);
+  position += rawSubtype.length;
+  if (subtypeEnd !== -1) {
+    // skip ';'
+    position += 1;
+  }
+  const trimmedSubtype = StringPrototypeSlice(
+    rawSubtype,
+    0,
+    SafeStringPrototypeSearch(rawSubtype, START_ENDING_WHITESPACE));
+  const invalidSubtypeIndex = SafeStringPrototypeSearch(trimmedSubtype,
+                                                        NotHTTPTokenCodePoint);
+  if (trimmedSubtype === '' ||
+    invalidSubtypeIndex !== -1) {
+    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
+  }
+  const subtype = toASCIILower(trimmedSubtype);
+  const target = ObjectCreate(null);
+  target.type = type;
+  target.subtype = subtype;
+  target.parametersStringIndex = position;
+  return target;
+}
+
+const EQUALS_SEMICOLON_OR_END = hardenRegExp(/[;=]|$/);
+const QUOTED_VALUE_PATTERN = hardenRegExp(/^(?:([\\]$)|[\\][\s\S]|[^"])*(?:(")|$)/u);
+const QUOTED_CHARACTER = hardenRegExp(/[\\]([\s\S])/ug);
+function parseParametersString(str, position, paramsMap = new Map()) {
+  const endOfSource = SafeStringPrototypeSearch(
+    StringPrototypeSlice(str, position),
+    START_ENDING_WHITESPACE
+  ) + position;
+  while (position < endOfSource) {
+    // Skip any whitespace before parameter
+    position += SafeStringPrototypeSearch(
+      StringPrototypeSlice(str, position),
+      END_BEGINNING_WHITESPACE
+    );
+    // Read until ';' or '='
+    const afterParameterName = SafeStringPrototypeSearch(
+      StringPrototypeSlice(str, position),
+      EQUALS_SEMICOLON_OR_END
+    ) + position;
+    const parameterString = toASCIILower(
+      StringPrototypeSlice(str, position, afterParameterName)
+    );
+    position = afterParameterName;
+    // If we found a terminating character
+    if (position < endOfSource) {
+      // Safe to use because we never do special actions for surrogate pairs
+      const char = StringPrototypeCharAt(str, position);
+      // Skip the terminating character
+      position += 1;
+      // Ignore parameters without values
+      if (char === ';') {
+        continue;
+      }
+    }
+    // If we are at end of the string, it cannot have a value
+    if (position >= endOfSource) break;
+    // Safe to use because we never do special actions for surrogate pairs
+    const char = StringPrototypeCharAt(str, position);
+    let parameterValue = null;
+    if (char === '"') {
+      // Handle quoted-string form of values
+      // skip '"'
+      position += 1;
+      // Find matching closing '"' or end of string
+      //   use $1 to see if we terminated on unmatched '\'
+      //   use $2 to see if we terminated on a matching '"'
+      //   so we can skip the last char in either case
+      const insideMatch = RegExpPrototypeExec(
+        QUOTED_VALUE_PATTERN,
+        StringPrototypeSlice(str, position));
+      position += insideMatch[0].length;
+      // Skip including last character if an unmatched '\' or '"' during
+      // unescape
+      const inside = insideMatch[1] || insideMatch[2] ?
+        StringPrototypeSlice(insideMatch[0], 0, -1) :
+        insideMatch[0];
+      // Unescape '\' quoted characters
+      parameterValue = StringPrototypeReplace(inside, QUOTED_CHARACTER, '$1');
+      // If we did have an unmatched '\' add it back to the end
+      if (insideMatch[1]) parameterValue += '\\';
+    } else {
+      // Handle the normal parameter value form
+      const valueEnd = StringPrototypeIndexOf(str, SEMICOLON, position);
+      const rawValue = valueEnd === -1 ?
+        StringPrototypeSlice(str, position) :
+        StringPrototypeSlice(str, position, valueEnd);
+      position += rawValue.length;
+      const trimmedValue = StringPrototypeSlice(
+        rawValue,
+        0,
+        SafeStringPrototypeSearch(rawValue, START_ENDING_WHITESPACE));
+      // Ignore parameters without values
+      if (trimmedValue === '') continue;
+      parameterValue = trimmedValue;
+    }
+    if (parameterString !== '' &&
+      SafeStringPrototypeSearch(parameterString,
+                                NotHTTPTokenCodePoint) === -1 &&
+      SafeStringPrototypeSearch(parameterValue,
+                                NotHTTPQuotedStringCodePoint) === -1 &&
+      paramsMap.has(parameterString) === false) {
+      paramsMap.set(parameterString, parameterValue);
+    }
+    position++;
+  }
+  return paramsMap;
+}
+
+const QUOTE_OR_SOLIDUS = hardenRegExp(/["\\]/g);
+const encode = (value) => {
+  if (value.length === 0) return '""';
+  NotHTTPTokenCodePoint.lastIndex = 0;
+  const encode = SafeStringPrototypeSearch(value, NotHTTPTokenCodePoint) !== -1;
+  if (!encode) return value;
+  const escaped = StringPrototypeReplace(value, QUOTE_OR_SOLIDUS, '\\$&');
+  return `"${escaped}"`;
+};
+
+const MIMEStringify = (type, subtype, parameters) => {
+  let ret = `${type}/${subtype}`;
+  const paramStr = MIMEParamsStringify(parameters);
+  if (paramStr.length) ret += `;${paramStr}`;
+  return ret;
+};
+
+const MIMEParamsStringify = (parameters) => {
+  let ret = '';
+  const entries = MIMEParamsData(parameters).entries();
+  let keyValuePair, done;
+  // Using this to avoid prototype pollution on Map iterators
+  // eslint-disable-next-line no-cond-assign
+  while ({ value: keyValuePair, done } = MapIteratorPrototypeNext(entries)) {
+    if (done) break;
+    const { 0: key, 1: value } = keyValuePair;
+    const encoded = encode(value);
+    // Ensure they are separated
+    if (ret.length) ret += ';';
+    ret += `${key}=${encoded}`;
+  }
+  return ret;
+};
+
+class MIMEParams {
+  #data;
+  constructor() {
+    this.#data = new Map();
+  }
+
+  delete(name) {
+    this.#data.delete(name);
+  }
+
+  get(name) {
+    const data = this.#data;
+    if (data.has(name)) {
+      return data.get(name);
+    }
+    return null;
+  }
+
+  has(name) {
+    return this.#data.has(name);
+  }
+
+  set(name, value) {
+    const data = this.#data;
+    NotHTTPTokenCodePoint.lastIndex = 0;
+    name = `${name}`;
+    value = `${value}`;
+    const invalidNameIndex = SafeStringPrototypeSearch(name, NotHTTPTokenCodePoint);
+    if (name.length === 0 || invalidNameIndex !== -1) {
+      throw new ERR_INVALID_MIME_SYNTAX('parameter name',
+                                        name,
+                                        invalidNameIndex);
+    }
+    NotHTTPQuotedStringCodePoint.lastIndex = 0;
+    const invalidValueIndex = SafeStringPrototypeSearch(
+      value,
+      NotHTTPQuotedStringCodePoint);
+    if (invalidValueIndex !== -1) {
+      throw new ERR_INVALID_MIME_SYNTAX('parameter value',
+                                        value,
+                                        invalidValueIndex);
+    }
+    data.set(name, value);
+  }
+
+  *entries() {
+    return yield* this.#data.entries();
+  }
+
+  *keys() {
+    return yield* this.#data.keys();
+  }
+
+  *values() {
+    return yield* this.#data.values();
+  }
+
+  *[SymbolIterator]() {
+    return yield* this.#data.entries();
+  }
+
+  toJSON() {
+    return MIMEParamsStringify(this);
+  }
+
+  toString() {
+    return MIMEParamsStringify(this);
+  }
+
+  // Used to act as a friendly class to stringifying stuff
+  // not meant to be exposed to users, could inject invalid values
+  static _data(o) {
+    return o.#data;
+  }
+}
+
+const MIMEParamsData = MIMEParams._data;
+delete MIMEParams._data;
+
+class MIMEType {
+  #type;
+  #subtype;
+  #parameters;
+  constructor(string) {
+    string = `${string}`;
+    const data = parseTypeAndSubtype(string);
+    this.#type = data.type;
+    this.#subtype = data.subtype;
+    this.#parameters = new MIMEParams();
+    parseParametersString(
+      string,
+      data.parametersStringIndex,
+      MIMEParamsData(this.#parameters)
+    );
+  }
+
+  get type() {
+    return this.#type;
+  }
+
+  set type(v) {
+    v = `${v}`;
+    // TODO: Is this next line necessary? If so, add comment explaining why. If not, remove it.
+    // eslint-disable-next-line no-unused-expressions
+    NotHTTPTokenCodePoint;
+    const invalidTypeIndex = SafeStringPrototypeSearch(v, NotHTTPTokenCodePoint);
+    if (v.length === 0 || invalidTypeIndex !== -1) {
+      throw new ERR_INVALID_MIME_SYNTAX('type', v, invalidTypeIndex);
+    }
+    this.#type = toASCIILower(v);
+  }
+
+  get subtype() {
+    return this.#subtype;
+  }
+
+  set subtype(v) {
+    v = `${v}`;
+    const invalidSubtypeIndex = SafeStringPrototypeSearch(v, NotHTTPTokenCodePoint);
+    if (v.length === 0 || invalidSubtypeIndex !== -1) {
+      throw new ERR_INVALID_MIME_SYNTAX('subtype', v, invalidSubtypeIndex);
+    }
+    this.#subtype = toASCIILower(v);
+  }
+
+  get essence() {
+    return `${this.#type}/${this.#subtype}`;
+  }
+
+  get params() {
+    return this.#parameters;
+  }
+
+  toJSON() {
+    return MIMEStringify(this.#type, this.#subtype, this.#parameters);
+  }
+
+  toString() {
+    return MIMEStringify(this.#type, this.#subtype, this.#parameters);
+  }
+}
+module.exports = {
+  MIMEType,
+  MIMEParams
+};

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -272,6 +272,11 @@ const {
   ObjectSetPrototypeOf,
   Promise,
   PromisePrototypeThen,
+  ReflectApply,
+  ReflectConstruct,
+  ReflectSet,
+  ReflectGet,
+  RegExp,
   RegExpPrototype,
   RegExpPrototypeExec,
   RegExpPrototypeGetDotAll,
@@ -289,6 +294,7 @@ const {
   SymbolMatchAll,
   SymbolReplace,
   SymbolSearch,
+  SymbolSpecies,
   SymbolSplit,
   WeakMap,
   WeakRef,
@@ -517,8 +523,27 @@ const {
   [SymbolSplit]: OriginalRegExpPrototypeSymbolSplit,
 } = RegExpPrototype;
 
+class RegExpLikeForStringSplitting {
+  #regex;
+  constructor() {
+    this.#regex = ReflectConstruct(RegExp, arguments);
+  }
+
+  get lastIndex() {
+    return ReflectGet(this.#regex, 'lastIndex');
+  }
+  set lastIndex(value) {
+    ReflectSet(this.#regex, 'lastIndex', value);
+  }
+
+  exec() {
+    return ReflectApply(OriginalRegExpPrototypeExec, this.#regex, arguments);
+  }
+}
+ObjectSetPrototypeOf(RegExpLikeForStringSplitting.prototype, null);
+
 primordials.hardenRegExp = function hardenRegExp(pattern) {
-  ObjectDefineProperties(RegExpPrototype, {
+  ObjectDefineProperties(pattern, {
     [SymbolMatch]: {
       __proto__: null,
       configurable: true,
@@ -543,6 +568,13 @@ primordials.hardenRegExp = function hardenRegExp(pattern) {
       __proto__: null,
       configurable: true,
       value: OriginalRegExpPrototypeSymbolSplit,
+    },
+    constructor: {
+      __proto__: null,
+      configurable: true,
+      value: {
+        [SymbolSpecies]: RegExpLikeForStringSplitting,
+      }
     },
     dotAll: {
       __proto__: null,
@@ -590,7 +622,7 @@ primordials.hardenRegExp = function hardenRegExp(pattern) {
       value: RegExpPrototypeGetUnicode(pattern),
     },
   });
-  ObjectDefineProperty(RegExpPrototype, 'flags', {
+  ObjectDefineProperty(pattern, 'flags', {
     __proto__: null,
     configurable: true,
     value: RegExpPrototypeGetFlags(pattern),

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -266,12 +266,30 @@ const {
   FinalizationRegistry,
   FunctionPrototypeCall,
   Map,
+  ObjectDefineProperties,
+  ObjectDefineProperty,
   ObjectFreeze,
   ObjectSetPrototypeOf,
   Promise,
   PromisePrototypeThen,
+  RegExpPrototype,
+  RegExpPrototypeExec,
+  RegExpPrototypeGetDotAll,
+  RegExpPrototypeGetFlags,
+  RegExpPrototypeGetGlobal,
+  RegExpPrototypeGetHasIndices,
+  RegExpPrototypeGetIgnoreCase,
+  RegExpPrototypeGetMultiline,
+  RegExpPrototypeGetSource,
+  RegExpPrototypeGetSticky,
+  RegExpPrototypeGetUnicode,
   Set,
   SymbolIterator,
+  SymbolMatch,
+  SymbolMatchAll,
+  SymbolReplace,
+  SymbolSearch,
+  SymbolSplit,
   WeakMap,
   WeakRef,
   WeakSet,
@@ -305,12 +323,6 @@ primordials.SafeArrayIterator = createSafeIterator(
 primordials.SafeStringIterator = createSafeIterator(
   primordials.StringPrototypeSymbolIterator,
   primordials.StringIteratorPrototypeNext
-);
-
-// TODO: Does this make using .entries() safe?
-primordials.SafeMapIterator = createSafeIterator(
-  primordials.MapPrototypeSymbolIterator,
-  primordials.MapIteratorPrototypeNext
 );
 
 const copyProps = (src, dest) => {
@@ -495,6 +507,79 @@ primordials.SafePromiseRace = (promises, mapFn) =>
     SafePromise.race(arrayToSafePromiseIterable(promises, mapFn)).then(a, b)
   );
 
+
+const {
+  exec: OriginalRegExpPrototypeExec,
+  [SymbolMatch]: OriginalRegExpPrototypeSymbolMatch,
+  [SymbolMatchAll]: OriginalRegExpPrototypeSymbolMatchAll,
+  [SymbolReplace]: OriginalRegExpPrototypeSymbolReplace,
+  [SymbolSearch]: OriginalRegExpPrototypeSymbolSearch,
+  [SymbolSplit]: OriginalRegExpPrototypeSymbolSplit,
+} = RegExpPrototype;
+
+primordials.hardenRegExp = function hardenRegExp(pattern) {
+  pattern[SymbolMatch] = OriginalRegExpPrototypeSymbolMatch;
+  pattern[SymbolMatchAll] = OriginalRegExpPrototypeSymbolMatchAll;
+  pattern[SymbolReplace] = OriginalRegExpPrototypeSymbolReplace;
+  pattern[SymbolSearch] = OriginalRegExpPrototypeSymbolSearch;
+  pattern[SymbolSplit] = OriginalRegExpPrototypeSymbolSplit;
+  pattern.exec = OriginalRegExpPrototypeExec;
+  ObjectDefineProperties(RegExpPrototype, {
+    dotAll: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetDotAll(pattern),
+    },
+    global: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetGlobal(pattern),
+    },
+    hasIndices: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetHasIndices(pattern),
+    },
+    ignoreCase: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetIgnoreCase(pattern),
+    },
+    multiline: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetMultiline(pattern),
+    },
+    source: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetSource(pattern),
+    },
+    sticky: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetSticky(pattern),
+    },
+    unicode: {
+      __proto__: null,
+      configurable: true,
+      value: RegExpPrototypeGetUnicode(pattern),
+    },
+  });
+  ObjectDefineProperty(RegExpPrototype, 'flags', {
+    __proto__: null,
+    configurable: true,
+    value: RegExpPrototypeGetFlags(pattern),
+  });
+  return pattern;
+};
+
+
+primordials.SafeStringPrototypeSearch = (str, regexp) => {
+  regexp.lastIndex = 0;
+  const match = RegExpPrototypeExec(regexp, str);
+  return match ? match.index : -1;
+};
 
 ObjectSetPrototypeOf(primordials, null);
 ObjectFreeze(primordials);

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -307,6 +307,12 @@ primordials.SafeStringIterator = createSafeIterator(
   primordials.StringIteratorPrototypeNext
 );
 
+// TODO: Does this make using .entries() safe?
+primordials.SafeMapIterator = createSafeIterator(
+  primordials.MapPrototypeSymbolIterator,
+  primordials.MapIteratorPrototypeNext
+);
+
 const copyProps = (src, dest) => {
   ArrayPrototypeForEach(ReflectOwnKeys(src), (key) => {
     if (!ReflectGetOwnPropertyDescriptor(dest, key)) {

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -518,17 +518,41 @@ const {
 } = RegExpPrototype;
 
 primordials.hardenRegExp = function hardenRegExp(pattern) {
-  pattern[SymbolMatch] = OriginalRegExpPrototypeSymbolMatch;
-  pattern[SymbolMatchAll] = OriginalRegExpPrototypeSymbolMatchAll;
-  pattern[SymbolReplace] = OriginalRegExpPrototypeSymbolReplace;
-  pattern[SymbolSearch] = OriginalRegExpPrototypeSymbolSearch;
-  pattern[SymbolSplit] = OriginalRegExpPrototypeSymbolSplit;
-  pattern.exec = OriginalRegExpPrototypeExec;
   ObjectDefineProperties(RegExpPrototype, {
+    [SymbolMatch]: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeSymbolMatch,
+    },
+    [SymbolMatchAll]: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeSymbolMatchAll,
+    },
+    [SymbolReplace]: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeSymbolReplace,
+    },
+    [SymbolSearch]: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeSymbolSearch,
+    },
+    [SymbolSplit]: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeSymbolSplit,
+    },
     dotAll: {
       __proto__: null,
       configurable: true,
       value: RegExpPrototypeGetDotAll(pattern),
+    },
+    exec: {
+      __proto__: null,
+      configurable: true,
+      value: OriginalRegExpPrototypeExec,
     },
     global: {
       __proto__: null,

--- a/lib/util.js
+++ b/lib/util.js
@@ -68,6 +68,7 @@ const {
   validateNumber,
 } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
+const { MIMEType, MIMEParams } = require('internal/mime');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
 
@@ -385,6 +386,8 @@ module.exports = {
   isFunction,
   isPrimitive,
   log,
+  MIMEType,
+  MIMEParams,
   parseArgs,
   promisify,
   stripVTControlCharacters,

--- a/test/fixtures/mime-whatwg-generated.js
+++ b/test/fixtures/mime-whatwg-generated.js
@@ -1,0 +1,3533 @@
+'use strict';
+
+/* The following tests are copied from WPT. Modifications to them should be
+   upstreamed first. Refs:
+   https://github.com/w3c/web-platform-tests/blob/88b75886e/url/urltestdata.json
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+module.exports = [
+  {
+    "input": "\u0000/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0000",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0000=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0000;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0000\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0001/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0001",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0001=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0001;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0001\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0002/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0002",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0002=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0002;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0002\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0003/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0003",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0003=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0003;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0003\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0004/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0004",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0004=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0004;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0004\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0005/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0005",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0005=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0005;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0005\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0006/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0006",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0006=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0006;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0006\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0007/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0007",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0007=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0007;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0007\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\b/x",
+    "output": null
+  },
+  {
+    "input": "x/\b",
+    "output": null
+  },
+  {
+    "input": "x/x;\b=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\b;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\b\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\t/x",
+    "output": null
+  },
+  {
+    "input": "x/\t",
+    "output": null
+  },
+  {
+    "input": "x/x;\t=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\n/x",
+    "output": null
+  },
+  {
+    "input": "x/\n",
+    "output": null
+  },
+  {
+    "input": "x/x;\n=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\n;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\n\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u000b/x",
+    "output": null
+  },
+  {
+    "input": "x/\u000b",
+    "output": null
+  },
+  {
+    "input": "x/x;\u000b=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u000b;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u000b\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\f/x",
+    "output": null
+  },
+  {
+    "input": "x/\f",
+    "output": null
+  },
+  {
+    "input": "x/x;\f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\f;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\f\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\r/x",
+    "output": null
+  },
+  {
+    "input": "x/\r",
+    "output": null
+  },
+  {
+    "input": "x/x;\r=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\r;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\r\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u000e/x",
+    "output": null
+  },
+  {
+    "input": "x/\u000e",
+    "output": null
+  },
+  {
+    "input": "x/x;\u000e=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u000e;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u000e\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u000f/x",
+    "output": null
+  },
+  {
+    "input": "x/\u000f",
+    "output": null
+  },
+  {
+    "input": "x/x;\u000f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u000f;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u000f\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0010/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0010",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0010=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0010;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0010\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0011/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0011",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0011=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0011;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0011\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0012/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0012",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0012=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0012;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0012\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0013/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0013",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0013=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0013;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0013\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0014/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0014",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0014=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0014;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0014\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0015/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0015",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0015=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0015;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0015\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0016/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0016",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0016=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0016;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0016\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0017/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0017",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0017=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0017;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0017\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0018/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0018",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0018=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0018;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0018\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0019/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0019",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0019=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0019;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0019\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001a/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001a",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001a=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001a;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001a\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001b/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001b",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001b=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001b;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001b\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001c/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001c",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001c=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001c;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001c\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001d/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001d",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001d=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001d;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001d\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001e/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001e",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001e=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001e;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001e\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u001f/x",
+    "output": null
+  },
+  {
+    "input": "x/\u001f",
+    "output": null
+  },
+  {
+    "input": "x/x;\u001f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u001f;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u001f\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": " /x",
+    "output": null
+  },
+  {
+    "input": "x/ ",
+    "output": null
+  },
+  {
+    "input": "x/x; =x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\"/x",
+    "output": null
+  },
+  {
+    "input": "x/\"",
+    "output": null
+  },
+  {
+    "input": "x/x;\"=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "(/x",
+    "output": null
+  },
+  {
+    "input": "x/(",
+    "output": null
+  },
+  {
+    "input": "x/x;(=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=(;bonus=x",
+    "output": "x/x;x=\"(\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"(\";bonus=x",
+    "output": "x/x;x=\"(\";bonus=x"
+  },
+  {
+    "input": ")/x",
+    "output": null
+  },
+  {
+    "input": "x/)",
+    "output": null
+  },
+  {
+    "input": "x/x;)=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=);bonus=x",
+    "output": "x/x;x=\")\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\")\";bonus=x",
+    "output": "x/x;x=\")\";bonus=x"
+  },
+  {
+    "input": ",/x",
+    "output": null
+  },
+  {
+    "input": "x/,",
+    "output": null
+  },
+  {
+    "input": "x/x;,=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=,;bonus=x",
+    "output": "x/x;x=\",\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\",\";bonus=x",
+    "output": "x/x;x=\",\";bonus=x"
+  },
+  {
+    "input": "x/x;/=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=/;bonus=x",
+    "output": "x/x;x=\"/\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"/\";bonus=x",
+    "output": "x/x;x=\"/\";bonus=x"
+  },
+  {
+    "input": ":/x",
+    "output": null
+  },
+  {
+    "input": "x/:",
+    "output": null
+  },
+  {
+    "input": "x/x;:=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=:;bonus=x",
+    "output": "x/x;x=\":\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\":\";bonus=x",
+    "output": "x/x;x=\":\";bonus=x"
+  },
+  {
+    "input": ";/x",
+    "output": null
+  },
+  {
+    "input": "x/;",
+    "output": null
+  },
+  {
+    "input": "</x",
+    "output": null
+  },
+  {
+    "input": "x/<",
+    "output": null
+  },
+  {
+    "input": "x/x;<=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=<;bonus=x",
+    "output": "x/x;x=\"<\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"<\";bonus=x",
+    "output": "x/x;x=\"<\";bonus=x"
+  },
+  {
+    "input": "=/x",
+    "output": null
+  },
+  {
+    "input": "x/=",
+    "output": null
+  },
+  {
+    "input": "x/x;x==;bonus=x",
+    "output": "x/x;x=\"=\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"=\";bonus=x",
+    "output": "x/x;x=\"=\";bonus=x"
+  },
+  {
+    "input": ">/x",
+    "output": null
+  },
+  {
+    "input": "x/>",
+    "output": null
+  },
+  {
+    "input": "x/x;>=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=>;bonus=x",
+    "output": "x/x;x=\">\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\">\";bonus=x",
+    "output": "x/x;x=\">\";bonus=x"
+  },
+  {
+    "input": "?/x",
+    "output": null
+  },
+  {
+    "input": "x/?",
+    "output": null
+  },
+  {
+    "input": "x/x;?=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=?;bonus=x",
+    "output": "x/x;x=\"?\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"?\";bonus=x",
+    "output": "x/x;x=\"?\";bonus=x"
+  },
+  {
+    "input": "@/x",
+    "output": null
+  },
+  {
+    "input": "x/@",
+    "output": null
+  },
+  {
+    "input": "x/x;@=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=@;bonus=x",
+    "output": "x/x;x=\"@\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"@\";bonus=x",
+    "output": "x/x;x=\"@\";bonus=x"
+  },
+  {
+    "input": "[/x",
+    "output": null
+  },
+  {
+    "input": "x/[",
+    "output": null
+  },
+  {
+    "input": "x/x;[=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=[;bonus=x",
+    "output": "x/x;x=\"[\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"[\";bonus=x",
+    "output": "x/x;x=\"[\";bonus=x"
+  },
+  {
+    "input": "\\/x",
+    "output": null
+  },
+  {
+    "input": "x/\\",
+    "output": null
+  },
+  {
+    "input": "x/x;\\=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "]/x",
+    "output": null
+  },
+  {
+    "input": "x/]",
+    "output": null
+  },
+  {
+    "input": "x/x;]=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=];bonus=x",
+    "output": "x/x;x=\"]\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"]\";bonus=x",
+    "output": "x/x;x=\"]\";bonus=x"
+  },
+  {
+    "input": "{/x",
+    "output": null
+  },
+  {
+    "input": "x/{",
+    "output": null
+  },
+  {
+    "input": "x/x;{=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x={;bonus=x",
+    "output": "x/x;x=\"{\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"{\";bonus=x",
+    "output": "x/x;x=\"{\";bonus=x"
+  },
+  {
+    "input": "}/x",
+    "output": null
+  },
+  {
+    "input": "x/}",
+    "output": null
+  },
+  {
+    "input": "x/x;}=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=};bonus=x",
+    "output": "x/x;x=\"}\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"}\";bonus=x",
+    "output": "x/x;x=\"}\";bonus=x"
+  },
+  {
+    "input": "\u007f/x",
+    "output": null
+  },
+  {
+    "input": "x/\u007f",
+    "output": null
+  },
+  {
+    "input": "x/x;\u007f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u007f;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u007f\";bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "\u0080/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0080",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0080=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0080;bonus=x",
+    "output": "x/x;x=\"\u0080\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0080\";bonus=x",
+    "output": "x/x;x=\"\u0080\";bonus=x"
+  },
+  {
+    "input": "\u0081/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0081",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0081=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0081;bonus=x",
+    "output": "x/x;x=\"\u0081\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0081\";bonus=x",
+    "output": "x/x;x=\"\u0081\";bonus=x"
+  },
+  {
+    "input": "\u0082/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0082",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0082=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0082;bonus=x",
+    "output": "x/x;x=\"\u0082\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0082\";bonus=x",
+    "output": "x/x;x=\"\u0082\";bonus=x"
+  },
+  {
+    "input": "\u0083/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0083",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0083=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0083;bonus=x",
+    "output": "x/x;x=\"\u0083\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0083\";bonus=x",
+    "output": "x/x;x=\"\u0083\";bonus=x"
+  },
+  {
+    "input": "\u0084/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0084",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0084=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0084;bonus=x",
+    "output": "x/x;x=\"\u0084\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0084\";bonus=x",
+    "output": "x/x;x=\"\u0084\";bonus=x"
+  },
+  {
+    "input": "\u0085/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0085",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0085=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0085;bonus=x",
+    "output": "x/x;x=\"\u0085\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0085\";bonus=x",
+    "output": "x/x;x=\"\u0085\";bonus=x"
+  },
+  {
+    "input": "\u0086/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0086",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0086=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0086;bonus=x",
+    "output": "x/x;x=\"\u0086\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0086\";bonus=x",
+    "output": "x/x;x=\"\u0086\";bonus=x"
+  },
+  {
+    "input": "\u0087/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0087",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0087=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0087;bonus=x",
+    "output": "x/x;x=\"\u0087\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0087\";bonus=x",
+    "output": "x/x;x=\"\u0087\";bonus=x"
+  },
+  {
+    "input": "\u0088/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0088",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0088=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0088;bonus=x",
+    "output": "x/x;x=\"\u0088\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0088\";bonus=x",
+    "output": "x/x;x=\"\u0088\";bonus=x"
+  },
+  {
+    "input": "\u0089/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0089",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0089=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0089;bonus=x",
+    "output": "x/x;x=\"\u0089\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0089\";bonus=x",
+    "output": "x/x;x=\"\u0089\";bonus=x"
+  },
+  {
+    "input": "\u008a/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008a",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008a=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008a;bonus=x",
+    "output": "x/x;x=\"\u008a\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008a\";bonus=x",
+    "output": "x/x;x=\"\u008a\";bonus=x"
+  },
+  {
+    "input": "\u008b/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008b",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008b=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008b;bonus=x",
+    "output": "x/x;x=\"\u008b\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008b\";bonus=x",
+    "output": "x/x;x=\"\u008b\";bonus=x"
+  },
+  {
+    "input": "\u008c/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008c",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008c=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008c;bonus=x",
+    "output": "x/x;x=\"\u008c\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008c\";bonus=x",
+    "output": "x/x;x=\"\u008c\";bonus=x"
+  },
+  {
+    "input": "\u008d/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008d",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008d=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008d;bonus=x",
+    "output": "x/x;x=\"\u008d\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008d\";bonus=x",
+    "output": "x/x;x=\"\u008d\";bonus=x"
+  },
+  {
+    "input": "\u008e/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008e",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008e=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008e;bonus=x",
+    "output": "x/x;x=\"\u008e\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008e\";bonus=x",
+    "output": "x/x;x=\"\u008e\";bonus=x"
+  },
+  {
+    "input": "\u008f/x",
+    "output": null
+  },
+  {
+    "input": "x/\u008f",
+    "output": null
+  },
+  {
+    "input": "x/x;\u008f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u008f;bonus=x",
+    "output": "x/x;x=\"\u008f\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u008f\";bonus=x",
+    "output": "x/x;x=\"\u008f\";bonus=x"
+  },
+  {
+    "input": "\u0090/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0090",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0090=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0090;bonus=x",
+    "output": "x/x;x=\"\u0090\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0090\";bonus=x",
+    "output": "x/x;x=\"\u0090\";bonus=x"
+  },
+  {
+    "input": "\u0091/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0091",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0091=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0091;bonus=x",
+    "output": "x/x;x=\"\u0091\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0091\";bonus=x",
+    "output": "x/x;x=\"\u0091\";bonus=x"
+  },
+  {
+    "input": "\u0092/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0092",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0092=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0092;bonus=x",
+    "output": "x/x;x=\"\u0092\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0092\";bonus=x",
+    "output": "x/x;x=\"\u0092\";bonus=x"
+  },
+  {
+    "input": "\u0093/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0093",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0093=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0093;bonus=x",
+    "output": "x/x;x=\"\u0093\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0093\";bonus=x",
+    "output": "x/x;x=\"\u0093\";bonus=x"
+  },
+  {
+    "input": "\u0094/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0094",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0094=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0094;bonus=x",
+    "output": "x/x;x=\"\u0094\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0094\";bonus=x",
+    "output": "x/x;x=\"\u0094\";bonus=x"
+  },
+  {
+    "input": "\u0095/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0095",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0095=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0095;bonus=x",
+    "output": "x/x;x=\"\u0095\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0095\";bonus=x",
+    "output": "x/x;x=\"\u0095\";bonus=x"
+  },
+  {
+    "input": "\u0096/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0096",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0096=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0096;bonus=x",
+    "output": "x/x;x=\"\u0096\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0096\";bonus=x",
+    "output": "x/x;x=\"\u0096\";bonus=x"
+  },
+  {
+    "input": "\u0097/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0097",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0097=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0097;bonus=x",
+    "output": "x/x;x=\"\u0097\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0097\";bonus=x",
+    "output": "x/x;x=\"\u0097\";bonus=x"
+  },
+  {
+    "input": "\u0098/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0098",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0098=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0098;bonus=x",
+    "output": "x/x;x=\"\u0098\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0098\";bonus=x",
+    "output": "x/x;x=\"\u0098\";bonus=x"
+  },
+  {
+    "input": "\u0099/x",
+    "output": null
+  },
+  {
+    "input": "x/\u0099",
+    "output": null
+  },
+  {
+    "input": "x/x;\u0099=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u0099;bonus=x",
+    "output": "x/x;x=\"\u0099\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u0099\";bonus=x",
+    "output": "x/x;x=\"\u0099\";bonus=x"
+  },
+  {
+    "input": "\u009a/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009a",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009a=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009a;bonus=x",
+    "output": "x/x;x=\"\u009a\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009a\";bonus=x",
+    "output": "x/x;x=\"\u009a\";bonus=x"
+  },
+  {
+    "input": "\u009b/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009b",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009b=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009b;bonus=x",
+    "output": "x/x;x=\"\u009b\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009b\";bonus=x",
+    "output": "x/x;x=\"\u009b\";bonus=x"
+  },
+  {
+    "input": "\u009c/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009c",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009c=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009c;bonus=x",
+    "output": "x/x;x=\"\u009c\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009c\";bonus=x",
+    "output": "x/x;x=\"\u009c\";bonus=x"
+  },
+  {
+    "input": "\u009d/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009d",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009d=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009d;bonus=x",
+    "output": "x/x;x=\"\u009d\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009d\";bonus=x",
+    "output": "x/x;x=\"\u009d\";bonus=x"
+  },
+  {
+    "input": "\u009e/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009e",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009e=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009e;bonus=x",
+    "output": "x/x;x=\"\u009e\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009e\";bonus=x",
+    "output": "x/x;x=\"\u009e\";bonus=x"
+  },
+  {
+    "input": "\u009f/x",
+    "output": null
+  },
+  {
+    "input": "x/\u009f",
+    "output": null
+  },
+  {
+    "input": "x/x;\u009f=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u009f;bonus=x",
+    "output": "x/x;x=\"\u009f\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u009f\";bonus=x",
+    "output": "x/x;x=\"\u009f\";bonus=x"
+  },
+  {
+    "input": "\u00a0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a0;bonus=x",
+    "output": "x/x;x=\"\u00a0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a0\";bonus=x",
+    "output": "x/x;x=\"\u00a0\";bonus=x"
+  },
+  {
+    "input": "\u00a1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a1;bonus=x",
+    "output": "x/x;x=\"\u00a1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a1\";bonus=x",
+    "output": "x/x;x=\"\u00a1\";bonus=x"
+  },
+  {
+    "input": "\u00a2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a2;bonus=x",
+    "output": "x/x;x=\"\u00a2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a2\";bonus=x",
+    "output": "x/x;x=\"\u00a2\";bonus=x"
+  },
+  {
+    "input": "\u00a3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a3;bonus=x",
+    "output": "x/x;x=\"\u00a3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a3\";bonus=x",
+    "output": "x/x;x=\"\u00a3\";bonus=x"
+  },
+  {
+    "input": "\u00a4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a4;bonus=x",
+    "output": "x/x;x=\"\u00a4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a4\";bonus=x",
+    "output": "x/x;x=\"\u00a4\";bonus=x"
+  },
+  {
+    "input": "\u00a5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a5;bonus=x",
+    "output": "x/x;x=\"\u00a5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a5\";bonus=x",
+    "output": "x/x;x=\"\u00a5\";bonus=x"
+  },
+  {
+    "input": "\u00a6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a6;bonus=x",
+    "output": "x/x;x=\"\u00a6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a6\";bonus=x",
+    "output": "x/x;x=\"\u00a6\";bonus=x"
+  },
+  {
+    "input": "\u00a7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a7;bonus=x",
+    "output": "x/x;x=\"\u00a7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a7\";bonus=x",
+    "output": "x/x;x=\"\u00a7\";bonus=x"
+  },
+  {
+    "input": "\u00a8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a8;bonus=x",
+    "output": "x/x;x=\"\u00a8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a8\";bonus=x",
+    "output": "x/x;x=\"\u00a8\";bonus=x"
+  },
+  {
+    "input": "\u00a9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00a9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00a9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00a9;bonus=x",
+    "output": "x/x;x=\"\u00a9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00a9\";bonus=x",
+    "output": "x/x;x=\"\u00a9\";bonus=x"
+  },
+  {
+    "input": "\u00aa/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00aa",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00aa=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00aa;bonus=x",
+    "output": "x/x;x=\"\u00aa\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00aa\";bonus=x",
+    "output": "x/x;x=\"\u00aa\";bonus=x"
+  },
+  {
+    "input": "\u00ab/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ab",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ab=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ab;bonus=x",
+    "output": "x/x;x=\"\u00ab\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ab\";bonus=x",
+    "output": "x/x;x=\"\u00ab\";bonus=x"
+  },
+  {
+    "input": "\u00ac/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ac",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ac=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ac;bonus=x",
+    "output": "x/x;x=\"\u00ac\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ac\";bonus=x",
+    "output": "x/x;x=\"\u00ac\";bonus=x"
+  },
+  {
+    "input": "\u00ad/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ad",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ad=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ad;bonus=x",
+    "output": "x/x;x=\"\u00ad\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ad\";bonus=x",
+    "output": "x/x;x=\"\u00ad\";bonus=x"
+  },
+  {
+    "input": "\u00ae/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ae",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ae=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ae;bonus=x",
+    "output": "x/x;x=\"\u00ae\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ae\";bonus=x",
+    "output": "x/x;x=\"\u00ae\";bonus=x"
+  },
+  {
+    "input": "\u00af/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00af",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00af=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00af;bonus=x",
+    "output": "x/x;x=\"\u00af\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00af\";bonus=x",
+    "output": "x/x;x=\"\u00af\";bonus=x"
+  },
+  {
+    "input": "\u00b0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b0;bonus=x",
+    "output": "x/x;x=\"\u00b0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b0\";bonus=x",
+    "output": "x/x;x=\"\u00b0\";bonus=x"
+  },
+  {
+    "input": "\u00b1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b1;bonus=x",
+    "output": "x/x;x=\"\u00b1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b1\";bonus=x",
+    "output": "x/x;x=\"\u00b1\";bonus=x"
+  },
+  {
+    "input": "\u00b2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b2;bonus=x",
+    "output": "x/x;x=\"\u00b2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b2\";bonus=x",
+    "output": "x/x;x=\"\u00b2\";bonus=x"
+  },
+  {
+    "input": "\u00b3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b3;bonus=x",
+    "output": "x/x;x=\"\u00b3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b3\";bonus=x",
+    "output": "x/x;x=\"\u00b3\";bonus=x"
+  },
+  {
+    "input": "\u00b4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b4;bonus=x",
+    "output": "x/x;x=\"\u00b4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b4\";bonus=x",
+    "output": "x/x;x=\"\u00b4\";bonus=x"
+  },
+  {
+    "input": "\u00b5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b5;bonus=x",
+    "output": "x/x;x=\"\u00b5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b5\";bonus=x",
+    "output": "x/x;x=\"\u00b5\";bonus=x"
+  },
+  {
+    "input": "\u00b6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b6;bonus=x",
+    "output": "x/x;x=\"\u00b6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b6\";bonus=x",
+    "output": "x/x;x=\"\u00b6\";bonus=x"
+  },
+  {
+    "input": "\u00b7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b7;bonus=x",
+    "output": "x/x;x=\"\u00b7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b7\";bonus=x",
+    "output": "x/x;x=\"\u00b7\";bonus=x"
+  },
+  {
+    "input": "\u00b8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b8;bonus=x",
+    "output": "x/x;x=\"\u00b8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b8\";bonus=x",
+    "output": "x/x;x=\"\u00b8\";bonus=x"
+  },
+  {
+    "input": "\u00b9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00b9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00b9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00b9;bonus=x",
+    "output": "x/x;x=\"\u00b9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00b9\";bonus=x",
+    "output": "x/x;x=\"\u00b9\";bonus=x"
+  },
+  {
+    "input": "\u00ba/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ba",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ba=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ba;bonus=x",
+    "output": "x/x;x=\"\u00ba\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ba\";bonus=x",
+    "output": "x/x;x=\"\u00ba\";bonus=x"
+  },
+  {
+    "input": "\u00bb/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00bb",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00bb=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00bb;bonus=x",
+    "output": "x/x;x=\"\u00bb\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00bb\";bonus=x",
+    "output": "x/x;x=\"\u00bb\";bonus=x"
+  },
+  {
+    "input": "\u00bc/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00bc",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00bc=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00bc;bonus=x",
+    "output": "x/x;x=\"\u00bc\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00bc\";bonus=x",
+    "output": "x/x;x=\"\u00bc\";bonus=x"
+  },
+  {
+    "input": "\u00bd/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00bd",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00bd=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00bd;bonus=x",
+    "output": "x/x;x=\"\u00bd\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00bd\";bonus=x",
+    "output": "x/x;x=\"\u00bd\";bonus=x"
+  },
+  {
+    "input": "\u00be/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00be",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00be=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00be;bonus=x",
+    "output": "x/x;x=\"\u00be\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00be\";bonus=x",
+    "output": "x/x;x=\"\u00be\";bonus=x"
+  },
+  {
+    "input": "\u00bf/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00bf",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00bf=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00bf;bonus=x",
+    "output": "x/x;x=\"\u00bf\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00bf\";bonus=x",
+    "output": "x/x;x=\"\u00bf\";bonus=x"
+  },
+  {
+    "input": "\u00c0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c0;bonus=x",
+    "output": "x/x;x=\"\u00c0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c0\";bonus=x",
+    "output": "x/x;x=\"\u00c0\";bonus=x"
+  },
+  {
+    "input": "\u00c1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c1;bonus=x",
+    "output": "x/x;x=\"\u00c1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c1\";bonus=x",
+    "output": "x/x;x=\"\u00c1\";bonus=x"
+  },
+  {
+    "input": "\u00c2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c2;bonus=x",
+    "output": "x/x;x=\"\u00c2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c2\";bonus=x",
+    "output": "x/x;x=\"\u00c2\";bonus=x"
+  },
+  {
+    "input": "\u00c3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c3;bonus=x",
+    "output": "x/x;x=\"\u00c3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c3\";bonus=x",
+    "output": "x/x;x=\"\u00c3\";bonus=x"
+  },
+  {
+    "input": "\u00c4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c4;bonus=x",
+    "output": "x/x;x=\"\u00c4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c4\";bonus=x",
+    "output": "x/x;x=\"\u00c4\";bonus=x"
+  },
+  {
+    "input": "\u00c5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c5;bonus=x",
+    "output": "x/x;x=\"\u00c5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c5\";bonus=x",
+    "output": "x/x;x=\"\u00c5\";bonus=x"
+  },
+  {
+    "input": "\u00c6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c6;bonus=x",
+    "output": "x/x;x=\"\u00c6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c6\";bonus=x",
+    "output": "x/x;x=\"\u00c6\";bonus=x"
+  },
+  {
+    "input": "\u00c7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c7;bonus=x",
+    "output": "x/x;x=\"\u00c7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c7\";bonus=x",
+    "output": "x/x;x=\"\u00c7\";bonus=x"
+  },
+  {
+    "input": "\u00c8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c8;bonus=x",
+    "output": "x/x;x=\"\u00c8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c8\";bonus=x",
+    "output": "x/x;x=\"\u00c8\";bonus=x"
+  },
+  {
+    "input": "\u00c9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00c9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00c9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00c9;bonus=x",
+    "output": "x/x;x=\"\u00c9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00c9\";bonus=x",
+    "output": "x/x;x=\"\u00c9\";bonus=x"
+  },
+  {
+    "input": "\u00ca/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ca",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ca=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ca;bonus=x",
+    "output": "x/x;x=\"\u00ca\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ca\";bonus=x",
+    "output": "x/x;x=\"\u00ca\";bonus=x"
+  },
+  {
+    "input": "\u00cb/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00cb",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00cb=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00cb;bonus=x",
+    "output": "x/x;x=\"\u00cb\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00cb\";bonus=x",
+    "output": "x/x;x=\"\u00cb\";bonus=x"
+  },
+  {
+    "input": "\u00cc/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00cc",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00cc=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00cc;bonus=x",
+    "output": "x/x;x=\"\u00cc\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00cc\";bonus=x",
+    "output": "x/x;x=\"\u00cc\";bonus=x"
+  },
+  {
+    "input": "\u00cd/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00cd",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00cd=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00cd;bonus=x",
+    "output": "x/x;x=\"\u00cd\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00cd\";bonus=x",
+    "output": "x/x;x=\"\u00cd\";bonus=x"
+  },
+  {
+    "input": "\u00ce/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ce",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ce=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ce;bonus=x",
+    "output": "x/x;x=\"\u00ce\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ce\";bonus=x",
+    "output": "x/x;x=\"\u00ce\";bonus=x"
+  },
+  {
+    "input": "\u00cf/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00cf",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00cf=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00cf;bonus=x",
+    "output": "x/x;x=\"\u00cf\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00cf\";bonus=x",
+    "output": "x/x;x=\"\u00cf\";bonus=x"
+  },
+  {
+    "input": "\u00d0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d0;bonus=x",
+    "output": "x/x;x=\"\u00d0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d0\";bonus=x",
+    "output": "x/x;x=\"\u00d0\";bonus=x"
+  },
+  {
+    "input": "\u00d1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d1;bonus=x",
+    "output": "x/x;x=\"\u00d1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d1\";bonus=x",
+    "output": "x/x;x=\"\u00d1\";bonus=x"
+  },
+  {
+    "input": "\u00d2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d2;bonus=x",
+    "output": "x/x;x=\"\u00d2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d2\";bonus=x",
+    "output": "x/x;x=\"\u00d2\";bonus=x"
+  },
+  {
+    "input": "\u00d3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d3;bonus=x",
+    "output": "x/x;x=\"\u00d3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d3\";bonus=x",
+    "output": "x/x;x=\"\u00d3\";bonus=x"
+  },
+  {
+    "input": "\u00d4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d4;bonus=x",
+    "output": "x/x;x=\"\u00d4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d4\";bonus=x",
+    "output": "x/x;x=\"\u00d4\";bonus=x"
+  },
+  {
+    "input": "\u00d5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d5;bonus=x",
+    "output": "x/x;x=\"\u00d5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d5\";bonus=x",
+    "output": "x/x;x=\"\u00d5\";bonus=x"
+  },
+  {
+    "input": "\u00d6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d6;bonus=x",
+    "output": "x/x;x=\"\u00d6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d6\";bonus=x",
+    "output": "x/x;x=\"\u00d6\";bonus=x"
+  },
+  {
+    "input": "\u00d7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d7;bonus=x",
+    "output": "x/x;x=\"\u00d7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d7\";bonus=x",
+    "output": "x/x;x=\"\u00d7\";bonus=x"
+  },
+  {
+    "input": "\u00d8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d8;bonus=x",
+    "output": "x/x;x=\"\u00d8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d8\";bonus=x",
+    "output": "x/x;x=\"\u00d8\";bonus=x"
+  },
+  {
+    "input": "\u00d9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00d9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00d9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00d9;bonus=x",
+    "output": "x/x;x=\"\u00d9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00d9\";bonus=x",
+    "output": "x/x;x=\"\u00d9\";bonus=x"
+  },
+  {
+    "input": "\u00da/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00da",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00da=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00da;bonus=x",
+    "output": "x/x;x=\"\u00da\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00da\";bonus=x",
+    "output": "x/x;x=\"\u00da\";bonus=x"
+  },
+  {
+    "input": "\u00db/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00db",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00db=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00db;bonus=x",
+    "output": "x/x;x=\"\u00db\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00db\";bonus=x",
+    "output": "x/x;x=\"\u00db\";bonus=x"
+  },
+  {
+    "input": "\u00dc/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00dc",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00dc=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00dc;bonus=x",
+    "output": "x/x;x=\"\u00dc\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00dc\";bonus=x",
+    "output": "x/x;x=\"\u00dc\";bonus=x"
+  },
+  {
+    "input": "\u00dd/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00dd",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00dd=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00dd;bonus=x",
+    "output": "x/x;x=\"\u00dd\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00dd\";bonus=x",
+    "output": "x/x;x=\"\u00dd\";bonus=x"
+  },
+  {
+    "input": "\u00de/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00de",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00de=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00de;bonus=x",
+    "output": "x/x;x=\"\u00de\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00de\";bonus=x",
+    "output": "x/x;x=\"\u00de\";bonus=x"
+  },
+  {
+    "input": "\u00df/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00df",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00df=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00df;bonus=x",
+    "output": "x/x;x=\"\u00df\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00df\";bonus=x",
+    "output": "x/x;x=\"\u00df\";bonus=x"
+  },
+  {
+    "input": "\u00e0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e0;bonus=x",
+    "output": "x/x;x=\"\u00e0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e0\";bonus=x",
+    "output": "x/x;x=\"\u00e0\";bonus=x"
+  },
+  {
+    "input": "\u00e1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e1;bonus=x",
+    "output": "x/x;x=\"\u00e1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e1\";bonus=x",
+    "output": "x/x;x=\"\u00e1\";bonus=x"
+  },
+  {
+    "input": "\u00e2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e2;bonus=x",
+    "output": "x/x;x=\"\u00e2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e2\";bonus=x",
+    "output": "x/x;x=\"\u00e2\";bonus=x"
+  },
+  {
+    "input": "\u00e3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e3;bonus=x",
+    "output": "x/x;x=\"\u00e3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e3\";bonus=x",
+    "output": "x/x;x=\"\u00e3\";bonus=x"
+  },
+  {
+    "input": "\u00e4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e4;bonus=x",
+    "output": "x/x;x=\"\u00e4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e4\";bonus=x",
+    "output": "x/x;x=\"\u00e4\";bonus=x"
+  },
+  {
+    "input": "\u00e5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e5;bonus=x",
+    "output": "x/x;x=\"\u00e5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e5\";bonus=x",
+    "output": "x/x;x=\"\u00e5\";bonus=x"
+  },
+  {
+    "input": "\u00e6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e6;bonus=x",
+    "output": "x/x;x=\"\u00e6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e6\";bonus=x",
+    "output": "x/x;x=\"\u00e6\";bonus=x"
+  },
+  {
+    "input": "\u00e7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e7;bonus=x",
+    "output": "x/x;x=\"\u00e7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e7\";bonus=x",
+    "output": "x/x;x=\"\u00e7\";bonus=x"
+  },
+  {
+    "input": "\u00e8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e8;bonus=x",
+    "output": "x/x;x=\"\u00e8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e8\";bonus=x",
+    "output": "x/x;x=\"\u00e8\";bonus=x"
+  },
+  {
+    "input": "\u00e9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00e9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00e9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00e9;bonus=x",
+    "output": "x/x;x=\"\u00e9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00e9\";bonus=x",
+    "output": "x/x;x=\"\u00e9\";bonus=x"
+  },
+  {
+    "input": "\u00ea/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ea",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ea=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ea;bonus=x",
+    "output": "x/x;x=\"\u00ea\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ea\";bonus=x",
+    "output": "x/x;x=\"\u00ea\";bonus=x"
+  },
+  {
+    "input": "\u00eb/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00eb",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00eb=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00eb;bonus=x",
+    "output": "x/x;x=\"\u00eb\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00eb\";bonus=x",
+    "output": "x/x;x=\"\u00eb\";bonus=x"
+  },
+  {
+    "input": "\u00ec/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ec",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ec=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ec;bonus=x",
+    "output": "x/x;x=\"\u00ec\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ec\";bonus=x",
+    "output": "x/x;x=\"\u00ec\";bonus=x"
+  },
+  {
+    "input": "\u00ed/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ed",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ed=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ed;bonus=x",
+    "output": "x/x;x=\"\u00ed\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ed\";bonus=x",
+    "output": "x/x;x=\"\u00ed\";bonus=x"
+  },
+  {
+    "input": "\u00ee/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ee",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ee=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ee;bonus=x",
+    "output": "x/x;x=\"\u00ee\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ee\";bonus=x",
+    "output": "x/x;x=\"\u00ee\";bonus=x"
+  },
+  {
+    "input": "\u00ef/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ef",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ef=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ef;bonus=x",
+    "output": "x/x;x=\"\u00ef\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ef\";bonus=x",
+    "output": "x/x;x=\"\u00ef\";bonus=x"
+  },
+  {
+    "input": "\u00f0/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f0",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f0=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f0;bonus=x",
+    "output": "x/x;x=\"\u00f0\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f0\";bonus=x",
+    "output": "x/x;x=\"\u00f0\";bonus=x"
+  },
+  {
+    "input": "\u00f1/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f1",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f1=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f1;bonus=x",
+    "output": "x/x;x=\"\u00f1\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f1\";bonus=x",
+    "output": "x/x;x=\"\u00f1\";bonus=x"
+  },
+  {
+    "input": "\u00f2/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f2",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f2=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f2;bonus=x",
+    "output": "x/x;x=\"\u00f2\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f2\";bonus=x",
+    "output": "x/x;x=\"\u00f2\";bonus=x"
+  },
+  {
+    "input": "\u00f3/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f3",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f3=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f3;bonus=x",
+    "output": "x/x;x=\"\u00f3\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f3\";bonus=x",
+    "output": "x/x;x=\"\u00f3\";bonus=x"
+  },
+  {
+    "input": "\u00f4/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f4",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f4=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f4;bonus=x",
+    "output": "x/x;x=\"\u00f4\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f4\";bonus=x",
+    "output": "x/x;x=\"\u00f4\";bonus=x"
+  },
+  {
+    "input": "\u00f5/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f5",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f5=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f5;bonus=x",
+    "output": "x/x;x=\"\u00f5\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f5\";bonus=x",
+    "output": "x/x;x=\"\u00f5\";bonus=x"
+  },
+  {
+    "input": "\u00f6/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f6",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f6=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f6;bonus=x",
+    "output": "x/x;x=\"\u00f6\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f6\";bonus=x",
+    "output": "x/x;x=\"\u00f6\";bonus=x"
+  },
+  {
+    "input": "\u00f7/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f7",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f7=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f7;bonus=x",
+    "output": "x/x;x=\"\u00f7\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f7\";bonus=x",
+    "output": "x/x;x=\"\u00f7\";bonus=x"
+  },
+  {
+    "input": "\u00f8/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f8",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f8=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f8;bonus=x",
+    "output": "x/x;x=\"\u00f8\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f8\";bonus=x",
+    "output": "x/x;x=\"\u00f8\";bonus=x"
+  },
+  {
+    "input": "\u00f9/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00f9",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00f9=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00f9;bonus=x",
+    "output": "x/x;x=\"\u00f9\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00f9\";bonus=x",
+    "output": "x/x;x=\"\u00f9\";bonus=x"
+  },
+  {
+    "input": "\u00fa/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00fa",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00fa=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00fa;bonus=x",
+    "output": "x/x;x=\"\u00fa\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00fa\";bonus=x",
+    "output": "x/x;x=\"\u00fa\";bonus=x"
+  },
+  {
+    "input": "\u00fb/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00fb",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00fb=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00fb;bonus=x",
+    "output": "x/x;x=\"\u00fb\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00fb\";bonus=x",
+    "output": "x/x;x=\"\u00fb\";bonus=x"
+  },
+  {
+    "input": "\u00fc/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00fc",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00fc=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00fc;bonus=x",
+    "output": "x/x;x=\"\u00fc\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00fc\";bonus=x",
+    "output": "x/x;x=\"\u00fc\";bonus=x"
+  },
+  {
+    "input": "\u00fd/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00fd",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00fd=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00fd;bonus=x",
+    "output": "x/x;x=\"\u00fd\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00fd\";bonus=x",
+    "output": "x/x;x=\"\u00fd\";bonus=x"
+  },
+  {
+    "input": "\u00fe/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00fe",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00fe=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00fe;bonus=x",
+    "output": "x/x;x=\"\u00fe\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00fe\";bonus=x",
+    "output": "x/x;x=\"\u00fe\";bonus=x"
+  },
+  {
+    "input": "\u00ff/x",
+    "output": null
+  },
+  {
+    "input": "x/\u00ff",
+    "output": null
+  },
+  {
+    "input": "x/x;\u00ff=x;bonus=x",
+    "output": "x/x;bonus=x"
+  },
+  {
+    "input": "x/x;x=\u00ff;bonus=x",
+    "output": "x/x;x=\"\u00ff\";bonus=x"
+  },
+  {
+    "input": "x/x;x=\"\u00ff\";bonus=x",
+    "output": "x/x;x=\"\u00ff\";bonus=x"
+  }
+];

--- a/test/fixtures/mime-whatwg.js
+++ b/test/fixtures/mime-whatwg.js
@@ -1,0 +1,390 @@
+'use strict';
+
+/* The following tests are copied from WPT. Modifications to them should be
+   upstreamed first. Refs:
+   https://github.com/w3c/web-platform-tests/blob/88b75886e/url/urltestdata.json
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+module.exports = [
+  "Basics",
+  {
+    "input": "text/html;charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "TEXT/HTML;CHARSET=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  "Legacy comment syntax",
+  {
+    "input": "text/html;charset=gbk(",
+    "output": "text/html;charset=\"gbk(\"",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;x=(;charset=gbk",
+    "output": "text/html;x=\"(\";charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  "Duplicate parameter",
+  {
+    "input": "text/html;charset=gbk;charset=windows-1255",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=();charset=GBK",
+    "output": "text/html;charset=\"()\"",
+    "navigable": true,
+    "encoding": null
+  },
+  "Spaces",
+  {
+    "input": "text/html;charset =gbk",
+    "output": "text/html",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html ;charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html; charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset= gbk",
+    "output": "text/html;charset=\" gbk\"",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset= \"gbk\"",
+    "output": "text/html;charset=\" \\\"gbk\\\"\"",
+    "navigable": true,
+    "encoding": null
+  },
+  "0x0B and 0x0C",
+  {
+    "input": "text/html;charset=\u000Bgbk",
+    "output": "text/html",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=\u000Cgbk",
+    "output": "text/html",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;\u000Bcharset=gbk",
+    "output": "text/html",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;\u000Ccharset=gbk",
+    "output": "text/html",
+    "navigable": true,
+    "encoding": null
+  },
+  "Single quotes are a token, not a delimiter",
+  {
+    "input": "text/html;charset='gbk'",
+    "output": "text/html;charset='gbk'",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset='gbk",
+    "output": "text/html;charset='gbk",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=gbk'",
+    "output": "text/html;charset=gbk'",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=';charset=GBK",
+    "output": "text/html;charset='",
+    "navigable": true,
+    "encoding": null
+  },
+  "Invalid parameters",
+  {
+    "input": "text/html;test;charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;test=;charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;';charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;\";charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html ; ; charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;;;;charset=gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset= \"\u007F;charset=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\u007F;charset=foo\";charset=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  "Double quotes",
+  {
+    "input": "text/html;charset=\"gbk\"",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"gbk",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=gbk\"",
+    "output": "text/html;charset=\"gbk\\\"\"",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=\" gbk\"",
+    "output": "text/html;charset=\" gbk\"",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"gbk \"",
+    "output": "text/html;charset=\"gbk \"",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\\ gbk\"",
+    "output": "text/html;charset=\" gbk\"",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\\g\\b\\k\"",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"gbk\"x",
+    "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\";charset=GBK",
+    "output": "text/html;charset=\"\"",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=\";charset=GBK",
+    "output": "text/html;charset=\";charset=GBK\"",
+    "navigable": true,
+    "encoding": null
+  },
+  "Unexpected code points",
+  {
+    "input": "text/html;charset={gbk}",
+    "output": "text/html;charset=\"{gbk}\"",
+    "navigable": true,
+    "encoding": null
+  },
+  "Parameter name longer than 127",
+  {
+    "input": "text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk",
+    "output": "text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  "type/subtype longer than 127",
+  {
+    "input": "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+    "output": "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+  },
+  "Valid",
+  {
+    "input": "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+    "output": "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  },
+  {
+    "input": "x/x;x=\"\t !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\"",
+    "output": "x/x;x=\"\t !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\""
+  },
+  "End-of-file handling",
+  {
+    "input": "x/x;test",
+    "output": "x/x"
+  },
+  {
+    "input": "x/x;test=\"\\",
+    "output": "x/x;test=\"\\\\\""
+  },
+  "Whitespace (not handled by generated-mime-types.json or above)",
+  {
+    "input": "x/x;x= ",
+    "output": "x/x"
+  },
+  {
+    "input": "x/x;x=\t",
+    "output": "x/x"
+  },
+  {
+    "input": "x/x\n\r\t ;x=x",
+    "output": "x/x;x=x"
+  },
+  {
+    "input": "\n\r\t x/x;x=x\n\r\t ",
+    "output": "x/x;x=x"
+  },
+  {
+    "input": "x/x;\n\r\t x=x\n\r\t ;x=y",
+    "output": "x/x;x=x"
+  },
+  "Latin1",
+  {
+    "input": "text/html;test=\u00FF;charset=gbk",
+    "output": "text/html;test=\"\u00FF\";charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  ">Latin1",
+  {
+    "input": "x/x;test=\uFFFD;x=x",
+    "output": "x/x;x=x"
+  },
+  "Failure",
+  {
+    "input": "\u000Bx/x",
+    "output": null
+  },
+  {
+    "input": "\u000Cx/x",
+    "output": null
+  },
+  {
+    "input": "x/x\u000B",
+    "output": null
+  },
+  {
+    "input": "x/x\u000C",
+    "output": null
+  },
+  {
+    "input": "",
+    "output": null
+  },
+  {
+    "input": "\t",
+    "output": null
+  },
+  {
+    "input": "/",
+    "output": null
+  },
+  {
+    "input": "bogus",
+    "output": null
+  },
+  {
+    "input": "bogus/",
+    "output": null
+  },
+  {
+    "input": "bogus/ ",
+    "output": null
+  },
+  {
+    "input": "bogus/bogus/;",
+    "output": null
+  },
+  {
+    "input": "</>",
+    "output": null
+  },
+  {
+    "input": "(/)",
+    "output": null
+  },
+  {
+    "input": "ÿ/ÿ",
+    "output": null
+  },
+  {
+    "input": "text/html(;doesnot=matter",
+    "output": null
+  },
+  {
+    "input": "{/}",
+    "output": null
+  },
+  {
+    "input": "\u0100/\u0100",
+    "output": null
+  },
+  {
+    "input": "text /html",
+    "output": null
+  },
+  {
+    "input": "text/ html",
+    "output": null
+  },
+  {
+    "input": "\"text/html\"",
+    "output": null
+  }
+];

--- a/test/fixtures/mime-whatwg.js
+++ b/test/fixtures/mime-whatwg.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// TODO: Incorporate this with the other WPT tests if it makes sense to do that.
+
 /* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/88b75886e/url/urltestdata.json

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -72,6 +72,7 @@ const expectedModules = new Set([
   'NativeModule internal/histogram',
   'NativeModule internal/idna',
   'NativeModule internal/linkedlist',
+  'NativeModule internal/mime',
   'NativeModule internal/modules/cjs/helpers',
   'NativeModule internal/modules/cjs/loader',
   'NativeModule internal/modules/esm/assert',

--- a/test/parallel/test-eslint-avoid-prototype-pollution.js
+++ b/test/parallel/test-eslint-avoid-prototype-pollution.js
@@ -164,7 +164,7 @@ new RuleTester({
       },
       {
         code: 'RegExpPrototypeSymbolSearch(/some regex/, "some string")',
-        errors: [{ message: /looks up the "exec" property/ }],
+        errors: [{ message: /SafeStringPrototypeSearch/ }],
       },
       {
         code: 'StringPrototypeMatch("some string", /some regex/)',
@@ -204,7 +204,7 @@ new RuleTester({
       },
       {
         code: 'StringPrototypeSearch("some string", /some regex/)',
-        errors: [{ message: /looks up the Symbol\.search property/ }],
+        errors: [{ message: /SafeStringPrototypeSearch/ }],
       },
       {
         code: 'StringPrototypeSplit("some string", /some regex/)',

--- a/test/parallel/test-mime-api.js
+++ b/test/parallel/test-mime-api.js
@@ -1,0 +1,160 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { MIMEType, MIMEParams } = require('util');
+
+
+const WHITESPACES = '\t\n\f\r ';
+const NOT_HTTP_TOKEN_CODE_POINT = ',';
+const NOT_HTTP_QUOTED_STRING_CODE_POINT = '\n';
+
+const mime = new MIMEType('application/ecmascript; ');
+const mime_descriptors = Object.getOwnPropertyDescriptors(mime);
+const mime_proto = Object.getPrototypeOf(mime);
+const mime_impersonator = Object.create(mime_proto);
+for (const key of Object.keys(mime_descriptors)) {
+  const descriptor = mime_descriptors[key];
+  if (descriptor.get) {
+    assert.throws(descriptor.get.call(mime_impersonator), /Invalid receiver/i);
+  }
+  if (descriptor.set) {
+    assert.throws(descriptor.set.call(mime_impersonator, 'x'), /Invalid receiver/i);
+  }
+}
+
+
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('application/ecmascript'));
+assert.strictEqual(`${mime}`, 'application/ecmascript');
+assert.strictEqual(mime.essence, 'application/ecmascript');
+assert.strictEqual(mime.type, 'application');
+assert.strictEqual(mime.subtype, 'ecmascript');
+assert.ok(mime.params);
+assert.deepStrictEqual([], [...mime.params]);
+assert.strictEqual(mime.params.has('not found'), false);
+assert.strictEqual(mime.params.get('not found'), null);
+assert.strictEqual(mime.params.delete('not found'), undefined);
+
+
+mime.type = 'text';
+assert.strictEqual(mime.type, 'text');
+assert.strictEqual(JSON.stringify(mime), JSON.stringify('text/ecmascript'));
+assert.strictEqual(`${mime}`, 'text/ecmascript');
+assert.strictEqual(mime.essence, 'text/ecmascript');
+
+assert.throws(() => {
+  mime.type = `${WHITESPACES}text`;
+}, /ERR_INVALID_MIME_SYNTAX/);
+
+assert.throws(() => mime.type = '', /type/i);
+assert.throws(() => mime.type = '/', /type/i);
+assert.throws(() => mime.type = 'x/', /type/i);
+assert.throws(() => mime.type = '/x', /type/i);
+assert.throws(() => mime.type = NOT_HTTP_TOKEN_CODE_POINT, /type/i);
+assert.throws(() => mime.type = `${NOT_HTTP_TOKEN_CODE_POINT}/`, /type/i);
+assert.throws(() => mime.type = `/${NOT_HTTP_TOKEN_CODE_POINT}`, /type/i);
+
+
+mime.subtype = 'javascript';
+assert.strictEqual(mime.type, 'text');
+assert.strictEqual(JSON.stringify(mime), JSON.stringify('text/javascript'));
+assert.strictEqual(`${mime}`, 'text/javascript');
+assert.strictEqual(mime.essence, 'text/javascript');
+assert.strictEqual(`${mime.params}`, '');
+assert.strictEqual(`${new MIMEParams()}`, '');
+assert.strictEqual(`${new MIMEParams(mime.params)}`, '');
+assert.strictEqual(`${new MIMEParams(`${mime.params}`)}`, '');
+
+assert.throws(() => {
+  mime.subtype = `javascript${WHITESPACES}`;
+}, /ERR_INVALID_MIME_SYNTAX/);
+
+assert.throws(() => mime.subtype = '', /subtype/i);
+assert.throws(() => mime.subtype = ';', /subtype/i);
+assert.throws(() => mime.subtype = 'x;', /subtype/i);
+assert.throws(() => mime.subtype = ';x', /subtype/i);
+assert.throws(() => mime.subtype = NOT_HTTP_TOKEN_CODE_POINT, /subtype/i);
+assert.throws(
+  () => mime.subtype = `${NOT_HTTP_TOKEN_CODE_POINT};`,
+  /subtype/i);
+assert.throws(
+  () => mime.subtype = `;${NOT_HTTP_TOKEN_CODE_POINT}`,
+  /subtype/i);
+
+
+const params = mime.params;
+params.set('charset', 'utf-8');
+assert.strictEqual(params.has('charset'), true);
+assert.strictEqual(params.get('charset'), 'utf-8');
+assert.deepStrictEqual([...params], [['charset', 'utf-8']]);
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('text/javascript;charset=utf-8'));
+assert.strictEqual(`${mime}`, 'text/javascript;charset=utf-8');
+assert.strictEqual(mime.essence, 'text/javascript');
+assert.strictEqual(`${mime.params}`, 'charset=utf-8');
+assert.strictEqual(`${new MIMEParams(mime.params)}`, '');
+assert.strictEqual(`${new MIMEParams(`${mime.params}`)}`, '');
+
+params.set('goal', 'module');
+assert.strictEqual(params.has('goal'), true);
+assert.strictEqual(params.get('goal'), 'module');
+assert.deepStrictEqual([...params], [['charset', 'utf-8'], ['goal', 'module']]);
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('text/javascript;charset=utf-8;goal=module'));
+assert.strictEqual(`${mime}`, 'text/javascript;charset=utf-8;goal=module');
+assert.strictEqual(mime.essence, 'text/javascript');
+assert.strictEqual(`${mime.params}`, 'charset=utf-8;goal=module');
+assert.strictEqual(`${new MIMEParams(mime.params)}`, '');
+assert.strictEqual(`${new MIMEParams(`${mime.params}`)}`, '');
+
+assert.throws(() => {
+  params.set(`${WHITESPACES}goal`, 'module');
+}, /ERR_INVALID_MIME_SYNTAX/);
+
+params.set('charset', 'iso-8859-1');
+assert.strictEqual(params.has('charset'), true);
+assert.strictEqual(params.get('charset'), 'iso-8859-1');
+assert.deepStrictEqual(
+  [...params],
+  [['charset', 'iso-8859-1'], ['goal', 'module']]);
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('text/javascript;charset=iso-8859-1;goal=module'));
+assert.strictEqual(`${mime}`, 'text/javascript;charset=iso-8859-1;goal=module');
+assert.strictEqual(mime.essence, 'text/javascript');
+
+params.delete('charset');
+assert.strictEqual(params.has('charset'), false);
+assert.strictEqual(params.get('charset'), null);
+assert.deepStrictEqual([...params], [['goal', 'module']]);
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('text/javascript;goal=module'));
+assert.strictEqual(`${mime}`, 'text/javascript;goal=module');
+assert.strictEqual(mime.essence, 'text/javascript');
+
+params.set('x', '');
+assert.strictEqual(params.has('x'), true);
+assert.strictEqual(params.get('x'), '');
+assert.deepStrictEqual([...params], [['goal', 'module'], ['x', '']]);
+assert.strictEqual(
+  JSON.stringify(mime),
+  JSON.stringify('text/javascript;goal=module;x=""'));
+assert.strictEqual(`${mime}`, 'text/javascript;goal=module;x=""');
+assert.strictEqual(mime.essence, 'text/javascript');
+
+assert.throws(() => params.set('', 'x'), /parameter name/i);
+assert.throws(() => params.set('=', 'x'), /parameter name/i);
+assert.throws(() => params.set('x=', 'x'), /parameter name/i);
+assert.throws(() => params.set('=x', 'x'), /parameter name/i);
+assert.throws(() => params.set(`${NOT_HTTP_TOKEN_CODE_POINT}=`, 'x'), /parameter name/i);
+assert.throws(() => params.set(`${NOT_HTTP_TOKEN_CODE_POINT}x`, 'x'), /parameter name/i);
+assert.throws(() => params.set(`x${NOT_HTTP_TOKEN_CODE_POINT}`, 'x'), /parameter name/i);
+
+assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT};`), /parameter value/i);
+assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT}x`), /parameter value/i);
+assert.throws(() => params.set('x', `x${NOT_HTTP_QUOTED_STRING_CODE_POINT}`), /parameter value/i);

--- a/test/parallel/test-mime-whatwg.js
+++ b/test/parallel/test-mime-whatwg.js
@@ -1,0 +1,23 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { MIMEType } = require('util');
+const fixtures = require('../common/fixtures');
+
+function test(mimes) {
+  for (const entry of mimes) {
+    if (typeof entry === 'string') continue;
+    const { input, output } = entry;
+    if (output === null) {
+      assert.throws(() => new MIMEType(input), /ERR_INVALID_MIME_SYNTAX/i);
+    } else {
+      const str = `${new MIMEType(input)}`;
+      assert.strictEqual(str, output);
+    }
+  }
+}
+
+// These come from https://github.com/web-platform-tests/wpt/tree/master/mimesniff/mime-types/resources
+test(require(fixtures.path('./mime-whatwg.js')));
+test(require(fixtures.path('./mime-whatwg-generated.js')));

--- a/test/parallel/test-primordials-regexp.js
+++ b/test/parallel/test-primordials-regexp.js
@@ -12,41 +12,74 @@ const {
 } = require('internal/test/binding').primordials;
 
 
-RegExp.prototype.exec = mustNotCall('%RegExp.prototype%.exec');
-RegExp.prototype.test = mustNotCall('%RegExp.prototype%.test');
-RegExp.prototype.toString = mustNotCall('%RegExp.prototype%.toString');
-RegExp.prototype[Symbol.match] = mustNotCall('%RegExp.prototype%[@@match]');
-RegExp.prototype[Symbol.matchAll] = mustNotCall('%RegExp.prototype%[@@matchAll]');
-RegExp.prototype[Symbol.replace] = mustNotCall('%RegExp.prototype%[@@replace]');
-RegExp.prototype[Symbol.search] = mustNotCall('%RegExp.prototype%[@@search]');
-RegExp.prototype[Symbol.split] = mustNotCall('%RegExp.prototype%[@@split]');
 Object.defineProperties(RegExp.prototype, {
+  [Symbol.match]: {
+    get: mustNotCall('get %RegExp.prototype%[@@match]'),
+    set: mustNotCall('set %RegExp.prototype%[@@match]'),
+  },
+  [Symbol.matchAll]: {
+    get: mustNotCall('get %RegExp.prototype%[@@matchAll]'),
+    set: mustNotCall('set %RegExp.prototype%[@@matchAll]'),
+  },
+  [Symbol.replace]: {
+    get: mustNotCall('get %RegExp.prototype%[@@replace]'),
+    set: mustNotCall('set %RegExp.prototype%[@@replace]'),
+  },
+  [Symbol.search]: {
+    get: mustNotCall('get %RegExp.prototype%[@@search]'),
+    set: mustNotCall('set %RegExp.prototype%[@@search]'),
+  },
+  [Symbol.split]: {
+    get: mustNotCall('get %RegExp.prototype%[@@split]'),
+    set: mustNotCall('set %RegExp.prototype%[@@split]'),
+  },
   dotAll: {
     get: mustNotCall('get %RegExp.prototype%.dotAll'),
+    set: mustNotCall('set %RegExp.prototype%.dotAll'),
+  },
+  exec: {
+    get: mustNotCall('get %RegExp.prototype%.exec'),
+    set: mustNotCall('set %RegExp.prototype%.exec'),
   },
   flags: {
     get: mustNotCall('get %RegExp.prototype%.flags'),
+    set: mustNotCall('set %RegExp.prototype%.flags'),
   },
   global: {
     get: mustNotCall('get %RegExp.prototype%.global'),
+    set: mustNotCall('set %RegExp.prototype%.global'),
   },
   hasIndices: {
     get: mustNotCall('get %RegExp.prototype%.hasIndices'),
+    set: mustNotCall('set %RegExp.prototype%.hasIndices'),
   },
   ignoreCase: {
     get: mustNotCall('get %RegExp.prototype%.ignoreCase'),
+    set: mustNotCall('set %RegExp.prototype%.ignoreCase'),
   },
   multiline: {
     get: mustNotCall('get %RegExp.prototype%.multiline'),
+    set: mustNotCall('set %RegExp.prototype%.multiline'),
   },
   source: {
     get: mustNotCall('get %RegExp.prototype%.source'),
+    set: mustNotCall('set %RegExp.prototype%.source'),
   },
   sticky: {
     get: mustNotCall('get %RegExp.prototype%.sticky'),
+    set: mustNotCall('set %RegExp.prototype%.sticky'),
+  },
+  test: {
+    get: mustNotCall('get %RegExp.prototype%.test'),
+    set: mustNotCall('set %RegExp.prototype%.test'),
+  },
+  toString: {
+    get: mustNotCall('get %RegExp.prototype%.toString'),
+    set: mustNotCall('set %RegExp.prototype%.toString'),
   },
   unicode: {
     get: mustNotCall('get %RegExp.prototype%.unicode'),
+    set: mustNotCall('set %RegExp.prototype%.unicode'),
   },
 });
 

--- a/test/parallel/test-primordials-regexp.js
+++ b/test/parallel/test-primordials-regexp.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const {
   RegExpPrototypeSymbolReplace,
   RegExpPrototypeSymbolSearch,
+  RegExpPrototypeSymbolSplit,
   SafeStringPrototypeSearch,
   hardenRegExp,
 } = require('internal/test/binding').primordials;
@@ -104,10 +105,15 @@ hardenRegExp(hardenRegExp(/1/));
   const myRegex = /a/;
   assert.strictEqual(SafeStringPrototypeSearch('baar', myRegex), 1);
 }
-// RegExpPrototypeSymbolSplit creates a new RegExp instance, and therefore
-// does not benefit from `hardenRegExp` and remains unsafe.
-// The following test doesn't pass:
-// {
-//   const myRegex = hardenRegExp(/a/);
-//   assert.deepStrictEqual(RegExpPrototypeSymbolSplit(myRegex, 'baar'), ['b', '', 'r']);
-// }
+{
+  const myRegex = hardenRegExp(/a/);
+  assert.deepStrictEqual(RegExpPrototypeSymbolSplit(myRegex, 'baar', 0), []);
+}
+{
+  const myRegex = hardenRegExp(/a/);
+  assert.deepStrictEqual(RegExpPrototypeSymbolSplit(myRegex, 'baar', 1), ['b']);
+}
+{
+  const myRegex = hardenRegExp(/a/);
+  assert.deepStrictEqual(RegExpPrototypeSymbolSplit(myRegex, 'baar'), ['b', '', 'r']);
+}

--- a/test/parallel/test-primordials-regexp.js
+++ b/test/parallel/test-primordials-regexp.js
@@ -1,0 +1,80 @@
+// Flags: --expose-internals
+'use strict';
+
+const { mustNotCall } = require('../common');
+const assert = require('assert');
+
+const {
+  RegExpPrototypeSymbolReplace,
+  RegExpPrototypeSymbolSearch,
+  SafeStringPrototypeSearch,
+  hardenRegExp,
+} = require('internal/test/binding').primordials;
+
+
+RegExp.prototype.exec = mustNotCall('%RegExp.prototype%.exec');
+RegExp.prototype.test = mustNotCall('%RegExp.prototype%.test');
+RegExp.prototype.toString = mustNotCall('%RegExp.prototype%.toString');
+RegExp.prototype[Symbol.match] = mustNotCall('%RegExp.prototype%[@@match]');
+RegExp.prototype[Symbol.matchAll] = mustNotCall('%RegExp.prototype%[@@matchAll]');
+RegExp.prototype[Symbol.replace] = mustNotCall('%RegExp.prototype%[@@replace]');
+RegExp.prototype[Symbol.search] = mustNotCall('%RegExp.prototype%[@@search]');
+RegExp.prototype[Symbol.split] = mustNotCall('%RegExp.prototype%[@@split]');
+Object.defineProperties(RegExp.prototype, {
+  dotAll: {
+    get: mustNotCall('get %RegExp.prototype%.dotAll'),
+  },
+  flags: {
+    get: mustNotCall('get %RegExp.prototype%.flags'),
+  },
+  global: {
+    get: mustNotCall('get %RegExp.prototype%.global'),
+  },
+  hasIndices: {
+    get: mustNotCall('get %RegExp.prototype%.hasIndices'),
+  },
+  ignoreCase: {
+    get: mustNotCall('get %RegExp.prototype%.ignoreCase'),
+  },
+  multiline: {
+    get: mustNotCall('get %RegExp.prototype%.multiline'),
+  },
+  source: {
+    get: mustNotCall('get %RegExp.prototype%.source'),
+  },
+  sticky: {
+    get: mustNotCall('get %RegExp.prototype%.sticky'),
+  },
+  unicode: {
+    get: mustNotCall('get %RegExp.prototype%.unicode'),
+  },
+});
+
+hardenRegExp(hardenRegExp(/1/));
+
+// IMO there are no valid use cases in node core to use RegExpPrototypeSymbolMatch
+// or RegExpPrototypeSymbolMatchAll, they are inherently unsafe.
+
+{
+  const myRegex = hardenRegExp(/a/);
+  assert.strictEqual(RegExpPrototypeSymbolReplace(myRegex, 'baar', 'e'), 'bear');
+}
+{
+  const myRegex = hardenRegExp(/a/g);
+  assert.strictEqual(RegExpPrototypeSymbolReplace(myRegex, 'baar', 'e'), 'beer');
+}
+{
+  const myRegex = hardenRegExp(/a/);
+  assert.strictEqual(RegExpPrototypeSymbolSearch(myRegex, 'baar'), 1);
+}
+{
+  const myRegex = /a/;
+  assert.strictEqual(SafeStringPrototypeSearch('baar', myRegex), 1);
+}
+// RegExpPrototypeSymbolSplit creates a new RegExp instance, and therefore
+// does not benefit from `hardenRegExp` and remains unsafe.
+// The following test doesn't pass:
+// {
+//   const myRegex = hardenRegExp(/a/);
+//   assert.deepStrictEqual(RegExpPrototypeSymbolSplit(myRegex, 'baar'), ['b', '', 'r']);
+// }

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -217,8 +217,7 @@ const customTypesMap = {
   'URL': 'url.html#the-whatwg-url-api',
   'URLSearchParams': 'url.html#class-urlsearchparams',
 
-  'MIME': 'util.html#util_class_util_mime',
-  'MIMEParams': 'util.html#util_class_util_mimeparams',
+  'MIMEParams': 'util.html#class-utilmimeparams',
 
   'vm.Module': 'vm.html#class-vmmodule',
   'vm.Script': 'vm.html#class-vmscript',

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -217,6 +217,9 @@ const customTypesMap = {
   'URL': 'url.html#the-whatwg-url-api',
   'URLSearchParams': 'url.html#class-urlsearchparams',
 
+  'MIME': 'util.html#util_class_util_mime',
+  'MIMEParams': 'util.html#util_class_util_mimeparams',
+
   'vm.Module': 'vm.html#class-vmmodule',
   'vm.Script': 'vm.html#class-vmscript',
   'vm.SourceTextModule': 'vm.html#class-vmsourcetextmodule',

--- a/tools/eslint-rules/avoid-prototype-pollution.js
+++ b/tools/eslint-rules/avoid-prototype-pollution.js
@@ -135,17 +135,22 @@ module.exports = {
           }],
         });
       },
-      [CallExpression(/^RegExpPrototypeSymbol(Match|MatchAll|Search)$/)](node) {
+      [CallExpression(/^RegExpPrototypeSymbol(Match|MatchAll)$/)](node) {
         context.report({
           node,
           message: node.callee.name + ' looks up the "exec" property of `this` value',
+        });
+      },
+      [CallExpression(/^(RegExpPrototypeSymbol|StringPrototype)Search$/)](node) {
+        context.report({
+          node,
+          message: node.callee.name + ' is unsafe, use SafeStringPrototypeSearch instead',
         });
       },
       ...createUnsafeStringMethodReport(context, '%String.prototype.match%', 'Symbol.match'),
       ...createUnsafeStringMethodReport(context, '%String.prototype.matchAll%', 'Symbol.matchAll'),
       ...createUnsafeStringMethodOnRegexReport(context, '%String.prototype.replace%', 'Symbol.replace'),
       ...createUnsafeStringMethodOnRegexReport(context, '%String.prototype.replaceAll%', 'Symbol.replace'),
-      ...createUnsafeStringMethodReport(context, '%String.prototype.search%', 'Symbol.search'),
       ...createUnsafeStringMethodOnRegexReport(context, '%String.prototype.split%', 'Symbol.split'),
 
       'NewExpression[callee.name="Proxy"][arguments.1.type="ObjectExpression"]'(node) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This adds a new module for handling MIME types. It is standalone based upon [the WHATWG MIME standards](https://mimesniff.spec.whatwg.org/) , but is more intended to open up APIs that wish to use MIME for coordinating content types. I have left out the various sniffing for content bodies until a future date as I believe that is a longer discussion than just parsing and serializing. The API is based upon [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) and intentionally allows us to expand MIMEParams for dealing with multiple parameters with the same name (`.getAll` / `.append` etc.).

This PR does not introduce any MIME databases for file paths.

The `MIMEParams` are not exposed as a string getter / setter, unlike `url.search`. These manipulations can be done using the map interface provided, and accessors can be added in a follow on if seen as desirable.

Test cases were pulled from [web platform tests](https://github.com/web-platform-tests/wpt/tree/master/mimesniff/mime-types/resources) , but we don't have a well documented process for keeping such fixtures in sync so I have not done anything except vendor them for now, similar to https://github.com/nodejs/node/blob/master/test/fixtures/url-tests.js .