### PR TITLE
n-api: back up env before async work finalize

### DIFF
--- a/test/addons-napi/test_async/test-loop.js
+++ b/test/addons-napi/test_async/test-loop.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const test_async = require(`./build/${common.buildType}/test_async`);
+const iterations = 500;
+
+let x = 0;
+const workDone = common.mustCall((status) => {
+  assert.strictEqual(status, 0, 'Work completed successfully');
+  if (++x < iterations) {
+    setImmediate(() => test_async.DoRepeatedWork(workDone));
+  }
+}, iterations);
+test_async.DoRepeatedWork(workDone);


### PR DESCRIPTION
We must back up the value of `_env` before calling the async work
complete callback, because the complete callback may delete the
instance in which `_env` is stored by calling `napi_delete_async_work`,
and because we need to use it after the complete callback has
completed.

Fixes: https://github.com/nodejs/node/issues/20966

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
