### PR TITLE
test: make url-parse-invalid-input engine agnostic

### DIFF
--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -33,8 +33,5 @@ assert.throws(() => { url.parse('http://%E0%A4%A@fail'); },
 
                 // The error should be from the JS engine and not from Node.js.
                 // JS engine errors do not have the `code` property.
-                if (e.code !== undefined)
-                  return false;
-
-                return true;
+                return e.code === undefined;
               });

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -26,4 +26,15 @@ const url = require('url');
 });
 
 assert.throws(() => { url.parse('http://%E0%A4%A@fail'); },
-              /^URIError: URI malformed$/);
+              (e) => {
+                // The error should be a URIError.
+                if (!(e instanceof URIError))
+                  return false;
+
+                // The error should be from the JS engine and not from Node.js.
+                // JS engine errors do not have the `code` property.
+                if (e.code !== undefined)
+                  return false;
+
+                return true;
+              });


### PR DESCRIPTION
test-url-parse-invalid-input checks the message of an error that is
generated by the JavaScript engine. Error messages that change in the
underlying JavaScript engine should not be breaking changes in Node.js
and therefore should not cause tests to fail. Remove the message check
and replace it with a check of the type of the Error object along with
the absence of a `code` property. (If a `code` property were present, it
would indicate that the error was coming from Node.js rather than the
JavaScript engine.)

This also makes this test usable without modification in the ChakraCore
fork of Node.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
