### PR TITLE
benchmark: disable only the ESLint rule needing it

### DIFF
--- a/benchmark/es/spread-assign.js
+++ b/benchmark/es/spread-assign.js
@@ -15,7 +15,7 @@ function main({ n, context, count, rest, method }) {
   for (let n = 0; n < count; n++)
     src[`p${n}`] = n;
 
-  let obj;  // eslint-disable-line
+  let obj;  // eslint-disable-line no-unused-vars
   let i;
 
   switch (method) {


### PR DESCRIPTION
In the spread-assign.js benchmark file, all ESLint rules are disabled
for a line where only no-unused-vars needs to be disabled. This change
makes it so that the remaining rules are still applied to the line.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
