### PR TITLE
test,tools: refactor custom ESLint for readability

### DIFF
--- a/test/parallel/test-eslint-lowercase-name-for-primitive.js
+++ b/test/parallel/test-eslint-lowercase-name-for-primitive.js
@@ -7,45 +7,33 @@ common.skipIfEslintMissing();
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
 const rule = require('../../tools/eslint-rules/lowercase-name-for-primitive');
 
-const valid = [
-  'string',
-  'number',
-  'boolean',
-  'null',
-  'undefined'
-];
-
 new RuleTester().run('lowercase-name-for-primitive', rule, {
   valid: [
     'new errors.TypeError("ERR_INVALID_ARG_TYPE", "a", ["string", "number"])',
-    ...valid.map((name) =>
-      `new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "${name}")`
-    )
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "string")',
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "number")',
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "boolean")',
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "null")',
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "undefined")',
   ],
   invalid: [
     {
-      code: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-            '\'Number\')',
+      code: "new errors.TypeError('ERR_INVALID_ARG_TYPE', 'a', 'Number')",
       errors: [{ message: 'primitive should use lowercase: Number' }],
-      output: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-              '\'number\')'
+      output: "new errors.TypeError('ERR_INVALID_ARG_TYPE', 'a', 'number')",
     },
     {
-      code: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-            '\'STRING\')',
+      code: "new errors.TypeError('ERR_INVALID_ARG_TYPE', 'a', 'STRING')",
       errors: [{ message: 'primitive should use lowercase: STRING' }],
-      output: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-               '\'string\')'
+      output: "new errors.TypeError('ERR_INVALID_ARG_TYPE', 'a', 'string')",
     },
     {
-      code: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-            '[\'String\', \'Number\']) ',
+      code: "new e.TypeError('ERR_INVALID_ARG_TYPE', a, ['String','Number'])",
       errors: [
         { message: 'primitive should use lowercase: String' },
-        { message: 'primitive should use lowercase: Number' }
+        { message: 'primitive should use lowercase: Number' },
       ],
-      output: 'new errors.TypeError(\'ERR_INVALID_ARG_TYPE\', \'a\', ' +
-              '[\'string\', \'number\']) '
-    }
+      output: "new e.TypeError('ERR_INVALID_ARG_TYPE', a, ['string','number'])",
+    },
   ]
 });

--- a/tools/eslint-rules/lowercase-name-for-primitive.js
+++ b/tools/eslint-rules/lowercase-name-for-primitive.js
@@ -12,9 +12,7 @@
 const astSelector = 'NewExpression[callee.property.name="TypeError"]' +
                     '[arguments.0.value="ERR_INVALID_ARG_TYPE"]';
 
-const primitives = [
-  'number', 'string', 'boolean', 'null', 'undefined'
-];
+const primitives = [ 'number', 'string', 'boolean', 'null', 'undefined' ];
 
 module.exports = function(context) {
   function checkNamesArgument(node) {


### PR DESCRIPTION
Refactor the test and the source for the `lowercase-name-for-primitive`
custom ESLint rule for readability.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
