### PR TITLE
test: make url-util-format engine agnostic

### DIFF
--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -53,10 +53,7 @@ assert.throws(
 
     // The error should be from the JS engine and not from Node.js.
     // JS engine errors do not have the `code` property.
-    if (e.code !== undefined)
-      return false;
-
-    return true;
+    return e.code === undefined;
   }
 );
 

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -44,9 +44,21 @@ assert.strictEqual(util.format(symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('foo', symbol), 'foo Symbol(foo)');
 assert.strictEqual(util.format('%s', symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('%j', symbol), 'undefined');
-assert.throws(function() {
-  util.format('%d', symbol);
-}, /^TypeError: Cannot convert a Symbol value to a number$/);
+assert.throws(
+  () => { util.format('%d', symbol); },
+  (e) => {
+    // The error should be a TypeError.
+    if (!(e instanceof TypeError))
+      return false;
+
+    // The error should be from the JS engine and not from Node.js.
+    // JS engine errors do not have the `code` property.
+    if (e.code !== undefined)
+      return false;
+
+    return true;
+  }
+);
 
 // Number format specifier
 assert.strictEqual(util.format('%d'), '%d');


### PR DESCRIPTION
test-util-format checks the message of an error that is
generated by the JavaScript engine. Error messages that change in the
underlying JavaScript engine should not be breaking changes in Node.js
and therefore should not cause tests to fail. Remove the message check
and replace it with a check of the type of the Error object along with
the absence of a `code` property. (If a `code` property were present, it
would indicate that the error was coming from Node.js rather than the
JavaScript engine.)

This also makes this test usable without modification in the ChakraCore
fork of Node.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
