### PR TITLE
test: move benchmark-dgram to sequential

### DIFF
--- a/test/sequential/test-benchmark-dgram.js
+++ b/test/sequential/test-benchmark-dgram.js
@@ -4,6 +4,10 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
+// Because the dgram benchmarks use hardcoded ports, this should be in
+// sequential rather than parallel to make sure it does not conflict with
+// tests that choose random available ports.
+
 runBenchmark('dgram', ['address=true',
                        'chunks=2',
                        'dur=0.1',


### PR DESCRIPTION
This test uses hardcoded ports, it should not be located in parallel.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
