### PR TITLE
esm: ensure require.main for CJS top-level loads

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -110,12 +110,7 @@ class Loader {
       loaderInstance = translators.get(format);
     }
 
-    let inspectBrk = false;
-    if (process._breakFirstLine) {
-      delete process._breakFirstLine;
-      inspectBrk = true;
-    }
-    job = new ModuleJob(this, url, loaderInstance, inspectBrk);
+    job = new ModuleJob(this, url, loaderInstance, parentURL === undefined);
     this.moduleMap.set(url, job);
     return job;
   }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -12,15 +12,15 @@ const resolvedPromise = SafePromise.resolve();
 class ModuleJob {
   // `loader` is the Loader instance used for loading dependencies.
   // `moduleProvider` is a function
-  constructor(loader, url, moduleProvider, inspectBrk) {
+  constructor(loader, url, moduleProvider, isMain) {
     this.loader = loader;
     this.error = null;
     this.hadError = false;
-    this.inspectBrk = inspectBrk;
+    this.isMain = isMain;
 
     // This is a Promise<{ module, reflect }>, whose fields will be copied
     // onto `this` by `link()` below once it has been resolved.
-    this.modulePromise = moduleProvider(url);
+    this.modulePromise = moduleProvider(url, isMain);
     this.module = undefined;
     this.reflect = undefined;
 
@@ -82,7 +82,8 @@ class ModuleJob {
       throw e;
     }
     try {
-      if (this.inspectBrk) {
+      if (this.isMain && process._breakFirstLine) {
+        delete process._breakFirstLine;
         const initWrapper = process.binding('inspector').callAndPauseOnStart;
         initWrapper(this.module.instantiate, this.module);
       } else {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -36,7 +36,7 @@ translators.set('esm', async (url) => {
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
-translators.set('cjs', async (url) => {
+translators.set('cjs', async (url, isMain) => {
   debug(`Translating CJSModule ${url}`);
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const module = CJSModule._cache[
@@ -51,7 +51,7 @@ translators.set('cjs', async (url) => {
     // we don't care about the return val of _load here because Module#load
     // will handle it for us by checking the loader registry and filling the
     // exports like above
-    CJSModule._load(pathname);
+    CJSModule._load(pathname, undefined, isMain);
   });
 });
 

--- a/test/es-module/test-esm-cjs-main.js
+++ b/test/es-module/test-esm-cjs-main.js
@@ -1,0 +1,6 @@
+// Flags: --experimental-modules
+'use strict';
+require('../common');
+const assert = require('assert');
+exports.asdf = 'asdf';
+assert.strictEqual(require.main.exports.asdf, 'asdf');


### PR DESCRIPTION
This fixes #21143, ensuring `require.main` is set correctly when running `node --experimental-modules cjs.js`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
