### PR TITLE
[v9.x backport] assert: fix diff color output

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,9 +14,9 @@ const kCode = Symbol('code');
 const messages = new Map();
 const codes = {};
 
-var green = '';
-var red = '';
-var white = '';
+let green = '';
+let red = '';
+let white = '';
 
 const {
   UV_EAI_MEMORY,
@@ -27,13 +27,7 @@ const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
 
 // Lazily loaded
-var util_ = null;
-function lazyUtil() {
-  if (!util_) {
-    util_ = require('util');
-  }
-  return util_;
-}
+var util;
 
 var internalUtil = null;
 function lazyInternalUtil() {
@@ -41,6 +35,13 @@ function lazyInternalUtil() {
     internalUtil = require('internal/util');
   }
   return internalUtil;
+}
+
+function inspectValue(val) {
+  return util.inspect(
+    val,
+    { compact: false, customInspect: false }
+  ).split('\n');
 }
 
 function makeNodeError(Base) {
@@ -89,11 +90,9 @@ function createErrDiff(actual, expected, operator) {
   var lastPos = 0;
   var end = '';
   var skipped = false;
-  const util = lazyUtil();
-  const actualLines = util
-    .inspect(actual, { compact: false, customInspect: false }).split('\n');
-  const expectedLines = util
-    .inspect(expected, { compact: false, customInspect: false }).split('\n');
+  if (util === undefined) util = require('util');
+  const actualLines = inspectValue(actual);
+  const expectedLines = inspectValue(expected);
   const msg = `Input A expected to ${operator} input B:\n` +
         `${green}+ expected${white} ${red}- actual${white}`;
   const skippedMsg = ' ... Lines skipped';
@@ -260,14 +259,20 @@ class AssertionError extends Error {
     if (message != null) {
       super(message);
     } else {
-      if (util_ === null &&
-          process.stdout.isTTY &&
-          process.stdout.getColorDepth() !== 1) {
-        green = '\u001b[32m';
-        white = '\u001b[39m';
-        red = '\u001b[31m';
+      if (process.stdout.isTTY) {
+        // Reset on each call to make sure we handle dynamically set environment
+        // variables correct.
+        if (process.stdout.getColorDepth() !== 1) {
+          green = '\u001b[32m';
+          white = '\u001b[39m';
+          red = '\u001b[31m';
+        } else {
+          green = '';
+          white = '';
+          red = '';
+        }
       }
-      const util = lazyUtil();
+      if (util === undefined) util = require('util');
       if (typeof actual === 'object' && actual !== null &&
         'stack' in actual && actual instanceof Error) {
         actual = `${actual.name}: ${actual.message}`;
@@ -288,10 +293,7 @@ class AssertionError extends Error {
       } else if (errorDiff === 1) {
         // In case the objects are equal but the operator requires unequal, show
         // the first object and say A equals B
-        const res = util.inspect(
-          actual,
-          { compact: false, customInspect: false }
-        ).split('\n');
+        const res = inspectValue(actual);
 
         if (res.length > 20) {
           res[19] = '...';
@@ -333,10 +335,10 @@ function message(key, args) {
   const msg = messages.get(key);
   internalAssert(msg, `An invalid error message key was used: ${key}.`);
   let fmt;
+  if (util === undefined) util = require('util');
   if (typeof msg === 'function') {
     fmt = msg;
   } else {
-    const util = lazyUtil();
     fmt = util.format;
     if (args === undefined || args.length === 0)
       return msg;
@@ -358,7 +360,8 @@ function errnoException(err, syscall, original) {
   // getSystemErrorName(err) to guard against invalid arguments from users.
   // This can be replaced with [ code ] = errmap.get(err) when this method
   // is no longer exposed to user land.
-  const code = lazyUtil().getSystemErrorName(err);
+  if (util === undefined) util = require('util');
+  const code = util.getSystemErrorName(err);
   const message = original ?
     `${syscall} ${code} ${original}` : `${syscall} ${code}`;
 
@@ -386,7 +389,8 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
   // getSystemErrorName(err) to guard against invalid arguments from users.
   // This can be replaced with [ code ] = errmap.get(err) when this method
   // is no longer exposed to user land.
-  const code = lazyUtil().getSystemErrorName(err);
+  if (util === undefined) util = require('util');
+  const code = util.getSystemErrorName(err);
   let details = '';
   if (port && port > 0) {
     details = ` ${address}:${port}`;
@@ -625,10 +629,9 @@ E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available', Error);
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected', Error);
 E('ERR_INVALID_ARG_TYPE', invalidArgType, TypeError);
 E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
-  const util = lazyUtil();
   let inspected = util.inspect(value);
   if (inspected.length > 128) {
-    inspected = inspected.slice(0, 128) + '...';
+    inspected = `${inspected.slice(0, 128)}...`;
   }
   return `The argument '${name}' ${reason}. Received ${inspected}`;
 }, TypeError, RangeError); // Some are currently falsy implemented as "Error"

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -28,6 +28,9 @@ const assert = require('assert');
 const { inspect } = require('util');
 const a = assert;
 
+const start = 'Input A expected to deepStrictEqual input B:';
+const actExp = '+ expected - actual';
+
 assert.ok(a.AssertionError.prototype instanceof Error,
           'a.AssertionError instanceof Error');
 
@@ -419,14 +422,7 @@ common.expectsError(
     }
   );
 
-  // Test error diffs
-  const colors = process.stdout.isTTY && process.stdout.getColorDepth() > 1;
-  const start = 'Input A expected to deepStrictEqual input B:';
-  const actExp = colors ?
-    '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m' :
-    '+ expected - actual';
-  const plus = colors ? '\u001b[32m+\u001b[39m' : '+';
-  const minus = colors ? '\u001b[31m-\u001b[39m' : '-';
+  // Test error diffs.
   let message = [
     start,
     `${actExp} ... Lines skipped`,
@@ -435,8 +431,8 @@ common.expectsError(
     '    [',
     '...',
     '        2,',
-    `${minus}       3`,
-    `${plus}       '3'`,
+    '-       3',
+    "+       '3'",
     '      ]',
     '...',
     '    5',
@@ -453,7 +449,7 @@ common.expectsError(
     '    1,',
     '...',
     '    0,',
-    `${plus}   1,`,
+    '+   1,',
     '    1,',
     '...',
     '    1',
@@ -473,7 +469,7 @@ common.expectsError(
     '    1,',
     '...',
     '    0,',
-    `${minus}   1,`,
+    '-   1,',
     '    1,',
     '...',
     '    1',
@@ -491,12 +487,12 @@ common.expectsError(
     '',
     '  [',
     '    1,',
-    `${minus}   2,`,
-    `${plus}   1,`,
+    '-   2,',
+    '+   1,',
     '    1,',
     '    1,',
     '    0,',
-    `${minus}   1,`,
+    '-   1,',
     '    1',
     '  ]'
   ].join('\n');
@@ -510,12 +506,12 @@ common.expectsError(
     start,
     actExp,
     '',
-    `${minus} [`,
-    `${minus}   1,`,
-    `${minus}   2,`,
-    `${minus}   1`,
-    `${minus} ]`,
-    `${plus} undefined`,
+    '- [',
+    '-   1,',
+    '-   2,',
+    '-   1',
+    '- ]',
+    '+ undefined',
   ].join('\n');
   assert.throws(
     () => assert.deepEqual([1, 2, 1]),
@@ -526,7 +522,7 @@ common.expectsError(
     actExp,
     '',
     '  [',
-    `${minus}   1,`,
+    '-   1,',
     '    2,',
     '    1',
     '  ]'
@@ -539,9 +535,9 @@ common.expectsError(
     `${actExp} ... Lines skipped\n` +
     '\n' +
     '  [\n' +
-    `${minus}   1,\n`.repeat(10) +
+    '-   1,\n'.repeat(10) +
     '...\n' +
-    `${plus}   2,\n`.repeat(10) +
+    '+   2,\n'.repeat(10) +
     '...';
   assert.throws(
     () => assert.deepEqual(Array(12).fill(1), Array(12).fill(2)),
@@ -555,11 +551,11 @@ common.expectsError(
     message: `${start}\n` +
     `${actExp}\n` +
     '\n' +
-    `${minus} {}\n` +
-    `${plus} {\n` +
-    `${plus}   loop: 'forever',\n` +
-    `${plus}   [Symbol(util.inspect.custom)]: [Function]\n` +
-    `${plus} }`
+    '- {}\n' +
+    '+ {\n' +
+    "+   loop: 'forever',\n" +
+    '+   [Symbol(util.inspect.custom)]: [Function]\n' +
+    '+ }'
   });
 
   // notDeepEqual tests

--- a/test/pseudo-tty/test-assert-colors.js
+++ b/test/pseudo-tty/test-assert-colors.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert').strict;
+
+try {
+  // Activate colors even if the tty does not support colors.
+  process.env.COLORTERM = '1';
+  assert.deepStrictEqual([1, 2], [2, 2]);
+} catch (err) {
+  const expected = 'Input A expected to deepStrictEqual input B:\n' +
+    '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m\n\n' +
+    '  [\n' +
+    '\u001b[31m-\u001b[39m   1,\n' +
+    '\u001b[32m+\u001b[39m   2,\n' +
+    '    2\n' +
+    '  ]';
+  assert.strictEqual(err.message, expected);
+}


### PR DESCRIPTION
Original PR: [19464](https://github.com/nodejs/node/pull/19464)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
