### PR TITLE
src: add consistency check to node_platform.cc

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -131,6 +131,7 @@ void NodePlatform::RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
   std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
   if (existing) {
+    CHECK_EQ(loop, existing->event_loop());
     existing->ref();
   } else {
     per_isolate_[isolate] =

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -72,7 +72,7 @@ class PerIsolatePlatformData :
   bool FlushForegroundTasksInternal();
   void CancelPendingDelayedTasks();
 
-  uv_loop_t* event_loop() { return loop_; }
+  const uv_loop_t* event_loop() const { return loop_; }
 
  private:
   void DeleteFromScheduledTasks(DelayedTask* task);

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -72,6 +72,8 @@ class PerIsolatePlatformData :
   bool FlushForegroundTasksInternal();
   void CancelPendingDelayedTasks();
 
+  uv_loop_t* event_loop() { return loop_; }
+
  private:
   void DeleteFromScheduledTasks(DelayedTask* task);
 


### PR DESCRIPTION
We use the `Isolate*` pointer as the sole identifier
for a V8 Isolate. In some environments (e.g. multi-threaded),
Isolates may be destroyed and new ones created; then, it
may happen that the memory that was previously used for
one `Isolate` can be re-used for another `Isolate`
after the first one has been disposed of.

This check is a little guard against accidentally
re-using the same per-Isolate platform data structure
in such cases, i.e. making sure (to the degree to which
that is possible) that the old `Isolate*` has been properly
unregistered before one at the same memory address is added.

(It’s not 100 % foolproof because the `uv_loop_t*`
pointer value could theoretically be the same as well.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

(Also, in case you were wondering, this is inspired by a 3-day debugging adventure for #20876. :no_mouth: )