### PR TITLE
[v10.x] src: break out of timers loop if `!can_call_into_js()`

### DIFF
--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -148,6 +148,7 @@ class TimerWrap : public HandleWrap {
                 .ToLocalChecked();
     } while (ret->IsUndefined() &&
              !env->tick_info()->has_thrown() &&
+             env->can_call_into_js() &&
              wrap->object()->Get(env->context(),
                                  env->owner_string()).ToLocalChecked()
                                                      ->IsUndefined());


### PR DESCRIPTION
Simple backport of https://github.com/nodejs/node/pull/20884