### PR TITLE
tools: update tooling to work with new macOS CLI

### DIFF
--- a/configure
+++ b/configure
@@ -667,7 +667,7 @@ def get_llvm_version(cc):
 
 def get_xcode_version(cc):
   return get_version_helper(
-    cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
+    cc, r"(^Apple LLVM version) ([0-9]+\.[0-9]+)")
 
 def get_gas_version(cc):
   try:


### PR DESCRIPTION
Using High Sierra and `xcode-select --install` without installing full
Xcode, our build tooling breaks due to faulty regular expressions.

This fixes it for me...

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
