### PR TITLE
lib: refactor lib/internal/fs/streams.js

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -169,15 +169,15 @@ ReadStream.prototype._read = function(n) {
         this.destroy();
       }
       this.emit('error', er);
-    } else {
-      let b = null;
-      if (bytesRead > 0) {
-        this.bytesRead += bytesRead;
-        b = thisPool.slice(start, start + bytesRead);
-      }
-
-      this.push(b);
+      return;
     }
+
+    let b = null;
+    if (bytesRead > 0) {
+      this.bytesRead += bytesRead;
+      b = thisPool.slice(start, start + bytesRead);
+    }
+    this.push(b);
   });
 
   // move the pool positions, and internal position for reading.
@@ -254,12 +254,12 @@ function WriteStream(path, options) {
 }
 util.inherits(WriteStream, Writable);
 
-WriteStream.prototype._final = function(callback) {
+WriteStream.prototype._final = function(cb) {
   if (this.autoClose) {
     this.destroy();
   }
 
-  callback();
+  cb();
 };
 
 WriteStream.prototype.open = function() {
@@ -307,10 +307,10 @@ WriteStream.prototype._write = function(data, encoding, cb) {
 };
 
 
-function writev(fd, chunks, position, callback) {
+function writev(fd, chunks, position, cb) {
   function wrapper(err, written) {
     // Retain a reference to chunks so that they can't be GC'ed too soon.
-    callback(err, written || 0, chunks);
+    cb(err, written || 0, chunks);
   }
 
   const req = new FSReqWrap();

--- a/test/parallel/test-fs-stream-destroy-emit-error.js
+++ b/test/parallel/test-fs-stream-destroy-emit-error.js
@@ -1,13 +1,13 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fs = require('fs');
+const { createReadStream, createWriteStream } = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-test(fs.createReadStream(__filename));
-test(fs.createWriteStream(`${tmpdir.path}/dummy`));
+test(createReadStream(__filename));
+test(createWriteStream(`${tmpdir.path}/dummy`));
 
 function test(stream) {
   const err = new Error('DESTROYED');

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -21,18 +21,18 @@
 
 'use strict';
 const common = require('../common');
-const fs = require('fs');
+const { createReadStream, createWriteStream } = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-test1(fs.createReadStream(__filename));
-test2(fs.createReadStream(__filename));
-test3(fs.createReadStream(__filename));
+test1(createReadStream(__filename));
+test2(createReadStream(__filename));
+test3(createReadStream(__filename));
 
-test1(fs.createWriteStream(`${tmpdir.path}/dummy1`));
-test2(fs.createWriteStream(`${tmpdir.path}/dummy2`));
-test3(fs.createWriteStream(`${tmpdir.path}/dummy3`));
+test1(createWriteStream(`${tmpdir.path}/dummy1`));
+test2(createWriteStream(`${tmpdir.path}/dummy2`));
+test3(createWriteStream(`${tmpdir.path}/dummy3`));
 
 function test1(stream) {
   stream.destroy();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Summary
Refactored lib/internal/fs/streams.js
- fixed if/else logic in ReadStream.prototype._read
- fixed argument variable name "callback" to "cb".    
In this file, other methods use "cb" for it.
- refactored some test files related to fs-stream.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
