### PR TITLE
Test workerData with SharedArrayBuffer

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -312,7 +312,7 @@ if (isMainThread) {
 * `options` {Object}
   * `eval` {boolean} If true, interpret the first argument to the constructor
     as a script that is executed once the worker is online.
-  * `data` {any} Any JavaScript value that will be cloned and made
+  * `workerData` {any} Any JavaScript value that will be cloned and made
     available as [`require('worker_threads').workerData`][]. The cloning will
     occur as described in the [HTML structured clone algorithm][], and an error
     will be thrown if the object cannot be cloned (e.g. because it contains

--- a/test/parallel/test-worker-workerdata-sharedarraybuffer.js
+++ b/test/parallel/test-worker-workerdata-sharedarraybuffer.js
@@ -1,0 +1,32 @@
+// Flags: --expose-gc --experimental-worker
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+{
+  const sharedArrayBuffer = new SharedArrayBuffer(12);
+  const local = Buffer.from(sharedArrayBuffer);
+
+  const w = new Worker(`
+    const { parentPort, workerData } = require('worker_threads');
+    const local = Buffer.from(workerData.sharedArrayBuffer);
+
+    parentPort.on('message', () => {
+      local.write('world!', 6);
+      parentPort.postMessage('written!');
+    });
+  `, {
+    eval: true,
+    workerData: { sharedArrayBuffer }
+  });
+  w.on('message', common.mustCall(() => {
+    assert.strictEqual(local.toString(), 'Hello world!');
+    global.gc();
+    w.terminate();
+  }));
+  w.postMessage({});
+  // This would be a race condition if the memory regions were overlapping
+  local.write('Hello ');
+}


### PR DESCRIPTION
This adds a test to ensure that sharing `SharedArrayBuffer`s across worker threads by way of the `workerData` mechanism functions correctly.

Also fixes a documentation reference referring to `data` rather than the actual `workerData`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
