### PR TITLE
[WIP] tools: add option to use custom template with js2c.py

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -330,6 +330,10 @@ def JS2C(source, target):
 def main():
   natives = sys.argv[1]
   source_files = sys.argv[2:]
+  if source_files[-2] == '-t':
+    global TEMPLATE
+    TEMPLATE = source_files[-1]
+    source_files = source_files[:-2]
   JS2C(source_files, [natives])
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows for embedders to to use custom template with `js2c.py`, therefore allowing non-UTF-8 for js2c in compiled-in JS source files. The `-t` flag is chosen as it was the simplest unique flag name indicating `TEMPLATE`, but if there is a preferred more descriptive scheme it can be changed!

Example usage by [Electron](https://github.com/electron/electron/blob/master/tools/js2c.py#L34-L41).

I may also be missing documentation for this; I was unclear on if this change merited docs updates, and if so, to where they might be added. 

##### Checklist
- [x] `make -j4 test` passes
- [ ] documentation is changed or added (<= need clarification on whether this is needed)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
