### PR TITLE
src: do proper error checking in `AsyncWrap::MakeCallback`

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -27,7 +27,6 @@
 #include "async_wrap.h"
 #include "base_object-inl.h"
 #include "node_internals.h"
-#include "node_errors.h"
 
 namespace node {
 

--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -86,11 +86,8 @@ inline v8::MaybeLocal<v8::Value> AsyncWrap::MakeCallback(
   if (!object()->Get(env()->context(), symbol).ToLocal(&cb_v))
     return v8::MaybeLocal<v8::Value>();
   if (!cb_v->IsFunction()) {
-    // Due to V8’s error handling mechanisms, this will not show up as an error
-    // in the common case, which is that this is outside of any JS frame.
-    // So, the exception here is mostly just there to fulfill the
+    // TODO(addaleax): We should throw an error here to fulfill the
     // `MaybeLocal<>` API contract.
-    THROW_ERR_MISSING_METHOD(env()->isolate(), symbol);
     return v8::MaybeLocal<v8::Value>();
   }
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -172,9 +172,6 @@ class AsyncWrap : public BaseObject {
       const v8::Local<v8::Name> symbol,
       int argc,
       v8::Local<v8::Value>* argv);
-  inline v8::MaybeLocal<v8::Value> MakeCallback(uint32_t index,
-                                                int argc,
-                                                v8::Local<v8::Value>* argv);
 
   virtual size_t self_size() const = 0;
   virtual std::string diagnostic_name() const;

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -83,6 +83,10 @@ class HandleWrap : public AsyncWrap {
   void MarkAsInitialized();
   void MarkAsUninitialized();
 
+  inline bool IsHandleClosing() const {
+    return state_ == kClosing || state_ == kClosed;
+  }
+
  private:
   friend class Environment;
   friend void GetActiveHandles(const v8::FunctionCallbackInfo<v8::Value>&);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -33,7 +33,6 @@ namespace node {
   V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                     \
   V(ERR_MISSING_ARGS, TypeError)                                             \
   V(ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST, TypeError)                    \
-  V(ERR_MISSING_METHOD, TypeError)                                           \
   V(ERR_MISSING_MODULE, Error)                                               \
   V(ERR_MISSING_PLATFORM_FOR_WORKER, Error)                                  \
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
@@ -53,11 +52,8 @@ namespace node {
            js_code).FromJust();                                               \
     return e;                                                                 \
   }                                                                           \
-  inline void THROW_ ## code(v8::Isolate* isolate, const char* message) {     \
-    isolate->ThrowException(code(isolate, message));                          \
-  }                                                                           \
   inline void THROW_ ## code(Environment* env, const char* message) {         \
-    THROW_ ## code (env->isolate(), message);                                 \
+    env->isolate()->ThrowException(code(env->isolate(), message));            \
   }
   ERRORS_WITH_CODE(V)
 #undef V
@@ -114,14 +110,6 @@ inline v8::Local<v8::Value> ERR_STRING_TOO_LONG(v8::Isolate* isolate) {
       "Cannot create a string longer than 0x%x characters",
       v8::String::kMaxLength);
   return ERR_STRING_TOO_LONG(isolate, message);
-}
-
-inline void THROW_ERR_MISSING_METHOD(v8::Isolate* isolate,
-                                     v8::Local<v8::Name> name) {
-  Utf8Value name_str(isolate, name);
-  std::string message("Missing method: ");
-  message += *name_str;
-  THROW_ERR_MISSING_METHOD(isolate, message.c_str());
 }
 
 #define THROW_AND_RETURN_IF_NOT_BUFFER(env, val, prefix)                     \

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -476,7 +476,6 @@ void MessagePort::OnMessage() {
       };
 
       if (args[0].IsEmpty() ||
-          !object()->Has(context, env()->onmessage_string()).FromMaybe(false) ||
           MakeCallback(env()->onmessage_string(), 1, args).IsEmpty()) {
         // Re-schedule OnMessage() execution in case of failure.
         if (data_)

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -391,7 +391,19 @@ uv_async_t* MessagePort::async() {
 }
 
 void MessagePort::TriggerAsync() {
+  if (IsHandleClosing()) return;
   CHECK_EQ(uv_async_send(async()), 0);
+}
+
+void MessagePort::Close(v8::Local<v8::Value> close_callback) {
+  if (data_) {
+    // Wrap this call with accessing the mutex, so that TriggerAsync()
+    // can check IsHandleClosing() without race conditions.
+    Mutex::ScopedLock sibling_lock(data_->mutex_);
+    HandleWrap::Close(close_callback);
+  } else {
+    HandleWrap::Close(close_callback);
+  }
 }
 
 void MessagePort::New(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -154,6 +154,8 @@ class MessagePort : public HandleWrap {
   std::unique_ptr<MessagePortData> Detach();
 
   bool IsSiblingClosed() const;
+  void Close(
+      v8::Local<v8::Value> close_callback = v8::Local<v8::Value>()) override;
 
   size_t self_size() const override;
 

--- a/test/parallel/test-async-wrap-missing-method.js
+++ b/test/parallel/test-async-wrap-missing-method.js
@@ -1,0 +1,32 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { MessageChannel, MessagePort } = require('worker_threads');
+
+{
+  const { port1, port2 } = new MessageChannel();
+
+  // Throwing in the getter should not crash.
+  Object.defineProperty(port1, 'onmessage', {
+    get() {
+      throw new Error('eyecatcher');
+    }
+  });
+
+  port2.postMessage({ foo: 'bar' });
+}
+
+{
+  const { port1, port2 } = new MessageChannel();
+
+  // Returning a non-function in the getter should not crash.
+  Object.defineProperty(port1, 'onmessage', {
+    get() {
+      return 42;
+    }
+  });
+
+  port2.postMessage({ foo: 'bar' });
+}

--- a/test/parallel/test-async-wrap-missing-method.js
+++ b/test/parallel/test-async-wrap-missing-method.js
@@ -1,21 +1,9 @@
 // Flags: --experimental-worker
 'use strict';
-require('../common');
+const common = require('../common');
+const assert = require('assert');
 
 const { MessageChannel } = require('worker_threads');
-
-{
-  const { port1, port2 } = new MessageChannel();
-
-  // Throwing in the getter should not crash.
-  Object.defineProperty(port1, 'onmessage', {
-    get() {
-      throw new Error('eyecatcher');
-    }
-  });
-
-  port2.postMessage({ foo: 'bar' });
-}
 
 {
   const { port1, port2 } = new MessageChannel();
@@ -23,9 +11,39 @@ const { MessageChannel } = require('worker_threads');
   // Returning a non-function in the getter should not crash.
   Object.defineProperty(port1, 'onmessage', {
     get() {
+      port1.unref();
       return 42;
     }
   });
 
   port2.postMessage({ foo: 'bar' });
+
+  // We need to start the port manually because .onmessage assignment tracking
+  // has been overridden.
+  port1.start();
+  port1.ref();
+}
+
+{
+  const err = new Error('eyecatcher');
+  process.on('uncaughtException', common.mustCall((exception) => {
+    port1.unref();
+    assert.strictEqual(exception, err);
+  }));
+
+  const { port1, port2 } = new MessageChannel();
+
+  // Throwing in the getter should not crash.
+  Object.defineProperty(port1, 'onmessage', {
+    get() {
+      throw err;
+    }
+  });
+
+  port2.postMessage({ foo: 'bar' });
+
+  // We need to start the port manually because .onmessage assignment tracking
+  // has been overridden.
+  port1.start();
+  port1.ref();
 }

--- a/test/parallel/test-async-wrap-missing-method.js
+++ b/test/parallel/test-async-wrap-missing-method.js
@@ -1,9 +1,8 @@
 // Flags: --experimental-worker
 'use strict';
-const common = require('../common');
-const assert = require('assert');
+require('../common');
 
-const { MessageChannel, MessagePort } = require('worker_threads');
+const { MessageChannel } = require('worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();


### PR DESCRIPTION
At least one method on a native object is added as a getter,
namely `MessagePort.prototype.onmessage`. When a MessagePort
attempts to call this method from C++ in response to receiving
data, it will first invoke that getter and then call the function.

Since `worker.terminate()` interrupts execution, this means
that the getter may fail (without being faulty code on its own).
This means that at least one test exercising these methods in
combination has been flaky and could have crashed, because
we did not actually check that the getter returns a value
so far, resulting in dereferencing an empty `Local`.

The proper fix for this is to use the non-deprecated overload
of `Get()` and check the result like we should be doing.
Also, as a (related) fix, don’t crash if the method
is not a function but rather something else, like a getter
could provide.

Example test failure: https://ci.nodejs.org/job/node-test-commit-linux-containered/4976/nodes=ubuntu1604_sharedlibs_zlib_x64/console

    17:56:56 not ok 1955 parallel/test-worker-dns-terminate
    17:56:56   ---
    17:56:56   duration_ms: 1.237
    17:56:56   severity: crashed
    17:56:56   exitcode: -11
    17:56:56   stack: |-

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
