### PR TITLE
http2: fix GC issue & typos

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -521,7 +521,7 @@ void Http2Stream::EmitStatistics() {
   Http2StreamPerformanceEntry* entry =
     new Http2StreamPerformanceEntry(env(), id_, statistics_);
   env()->SetImmediate([](Environment* env, void* data) {
-    // This takes ownership, the entr is destroyed at the end of this scope.
+    // This takes ownership, the entry is destroyed at the end of this scope.
     std::unique_ptr<Http2StreamPerformanceEntry> entry {
         static_cast<Http2StreamPerformanceEntry*>(data) };
     if (!HasHttp2Observer(env))
@@ -998,7 +998,7 @@ int Http2Session::OnDataChunkReceived(nghttp2_session* handle,
       // `buf.base == nullptr` is the default Http2StreamListener's way
       // of saying that it wants a pointer to the raw original.
       // Since it has access to the original socket buffer from which the data
-      // was read in the first place, it can use that to minizime ArrayBuffer
+      // was read in the first place, it can use that to minimize ArrayBuffer
       // allocations.
       if (LIKELY(buf.base == nullptr))
         buf.base = reinterpret_cast<char*>(const_cast<uint8_t*>(data));
@@ -1338,7 +1338,7 @@ void Http2Session::OnStreamAfterWrite(WriteWrap* w, int status) {
 }
 
 // If the underlying nghttp2_session struct has data pending in its outbound
-// queue, MaybeScheduleWrite will schedule a SendPendingData() call to occcur
+// queue, MaybeScheduleWrite will schedule a SendPendingData() call to occur
 // on the next iteration of the Node.js event loop (using the SetImmediate
 // queue), but only if a write has not already been scheduled.
 void Http2Session::MaybeScheduleWrite() {
@@ -2179,7 +2179,7 @@ void Http2Session::RefreshSettings(const FunctionCallbackInfo<Value>& args) {
 
 // A TypedArray instance is shared between C++ and JS land to contain state
 // information of the current Http2Session. This updates the values in the
-// TypedRray so those can be read in JS land.
+// TypedArray so those can be read in JS land.
 void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
@@ -2512,7 +2512,7 @@ void Http2Session::AltSvc(int32_t id,
                                  origin, origin_len, value, value_len), 0);
 }
 
-// Submits an AltSvc frame to the sent to the connected peer.
+// Submits an AltSvc frame to be sent to the connected peer.
 void Http2Session::AltSvc(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Http2Session* session;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -499,7 +499,7 @@ Http2Session::Http2Session(Environment* env,
 Http2Session::~Http2Session() {
   CHECK_EQ(flags_ & SESSION_STATE_HAS_SCOPE, 0);
   Debug(this, "freeing nghttp2 session");
-  for (auto stream : streams_)
+  for (const auto& stream : streams_)
     stream.second->session_ = nullptr;
   nghttp2_session_del(session_);
 }

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1787,7 +1787,8 @@ void Http2Stream::Destroy() {
     // We can destroy the stream now if there are no writes for it
     // already on the socket. Otherwise, we'll wait for the garbage collector
     // to take care of cleaning up.
-    if (!stream->session()->HasWritesOnSocketForStream(stream))
+    if (stream->session() == nullptr ||
+        !stream->session()->HasWritesOnSocketForStream(stream))
       delete stream;
   }, this, this->object());
 


### PR DESCRIPTION
There are two commits here:

1. It's hypothetically (and with certain V8 flags) possible for the session
to be garbage collected before all the streams are. In that case, trying
to remove the stream from the session will lead to a SEGFAULT due to
attempting to access no longer valid memory. Fix this by unsetting the
session on any streams still around when destroying.

2. fix node_http2.cc comment typos

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
