### PR TITLE
v8: replace Buffer with FastBuffer in deserialize

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -143,7 +143,7 @@ const arrayBufferViewTypeToIndex = new Map();
   }
 }
 
-const bufferConstructorIndex = arrayBufferViewTypes.push(Buffer) - 1;
+const bufferConstructorIndex = arrayBufferViewTypes.push(FastBuffer) - 1;
 
 class DefaultSerializer extends Serializer {
   constructor() {

--- a/test/parallel/test-v8-deserialize-buffer.js
+++ b/test/parallel/test-v8-deserialize-buffer.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+process.on('warning', common.mustNotCall());
+v8.deserialize(v8.serialize(Buffer.alloc(0)));

--- a/test/parallel/test-v8-deserialize-buffer.js
+++ b/test/parallel/test-v8-deserialize-buffer.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const v8 = require('v8');
 
 process.on('warning', common.mustNotCall());

--- a/test/parallel/test-v8-deserialize-buffer.js
+++ b/test/parallel/test-v8-deserialize-buffer.js
@@ -1,3 +1,4 @@
+// Flags: --pending-deprecation --no-warnings
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
Replace the Buffer constructor with a FastBuffer in v8.deserialize in
order to avoid calling the Buffer constructor and thus triggering a
deprecation warning from code inside the core.

Fixes: https://github.com/nodejs/node/issues/21181

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/buffer @addaleax 