### PR TITLE
Fix configure script to work with Apple Clang 10

### DIFF
--- a/configure
+++ b/configure
@@ -612,10 +612,8 @@ def try_check_compiler(cc, lang):
 
   values = (proc.communicate()[0].split() + ['0'] * 7)[0:7]
   is_clang = values[0] == '1'
-  gcc_version = '%s.%s.%s' % tuple(values[1:1+3])
-  clang_version = '%s.%s.%s' % tuple(values[4:4+3])
 
-  return (True, is_clang, clang_version, gcc_version)
+  return (True, is_clang, tuple(values[4:4+3]), tuple(values[1:1+3]))
 
 
 #
@@ -667,7 +665,7 @@ def get_llvm_version(cc):
 
 def get_xcode_version(cc):
   return get_version_helper(
-    cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
+    cc, r"(^Apple LLVM version) ([0-9]+\.[0-9]+)")
 
 def get_gas_version(cc):
   try:
@@ -707,13 +705,13 @@ def check_compiler(o):
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
-  elif clang_version < '3.4.2' if is_clang else gcc_version < '4.9.4':
+  elif clang_version < (3, 4, 2) if is_clang else gcc_version < (4, 9, 4):
     warn('C++ compiler too old, need g++ 4.9.4 or clang++ 3.4.2 (CXX=%s)' % CXX)
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:
     warn('failed to autodetect C compiler version (CC=%s)' % CC)
-  elif not is_clang and gcc_version < '4.2.0':
+  elif not is_clang and gcc_version < (4, 2, 0):
     # clang 3.2 is a little white lie because any clang version will probably
     # do for the C bits.  However, we might as well encourage people to upgrade
     # to a version that is not completely ancient.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is a simple fix to the configure script so it doesn't spuriously drop out for newer versions of Apple's Clang:

```
$ clang --version
Apple LLVM version 10.0.0 (clang-1000.10.25.5)
Target: x86_64-apple-darwin18.0.0
Thread model: posix
InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Please do let me know if there's something wrong with my implementation; I haven't tested this on systems other than macOS so it might have silently broke something there.