### PR TITLE
test: add crypto check to test-http2-debug

### DIFF
--- a/test/parallel/test-http2-debug.js
+++ b/test/parallel/test-http2-debug.js
@@ -1,5 +1,7 @@
 'use strict';
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const child_process = require('child_process');
 const path = require('path');


### PR DESCRIPTION
This commit adds a crypto check to test-http2-debug.js as it currently
will error if configured `--without-ssl`.

The issue here is that the while the test spawns a child process that
runs `test-http2-ping.js`, which does have a crypto check, it will just
print `1..0 # Skipped: missing crypto` to stdout, and nothing to stderr
which is what this test is trying to assert and hence failing.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
