### PR TITLE
test: remove string literals from assert.strictEqual() calls

### DIFF
--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -105,14 +105,14 @@ if (!common.hasIntl) {
   const collOpts = { sensitivity: 'base', ignorePunctuation: true };
   const coll = new Intl.Collator(['en'], collOpts);
 
-  assert.strictEqual(coll.compare('blackbird', 'black-bird'), 0,
-                     'ignore punctuation failed');
-  assert.strictEqual(coll.compare('blackbird', 'red-bird'), -1,
-                     'compare less failed');
-  assert.strictEqual(coll.compare('bluebird', 'blackbird'), 1,
-                     'compare greater failed');
-  assert.strictEqual(coll.compare('Bluebird', 'bluebird'), 0,
-                     'ignore case failed');
-  assert.strictEqual(coll.compare('\ufb03', 'ffi'), 0,
-                     'ffi ligature (contraction) failed');
+  // ignore punctuation failed
+  assert.strictEqual(coll.compare('blackbird', 'black-bird'), 0);
+  // compare less failed
+  assert.strictEqual(coll.compare('blackbird', 'red-bird'), -1);
+  // compare greater failed
+  assert.strictEqual(coll.compare('bluebird', 'blackbird'), 1);
+  // ignore case failed
+  assert.strictEqual(coll.compare('Bluebird', 'bluebird'), 0);
+  // ffi ligature (contraction) failed
+  assert.strictEqual(coll.compare('\ufb03', 'ffi'), 0);
 }


### PR DESCRIPTION
In test/parallel/test-intl.js, five calls to assert.strictEqual() use a
third, string-literal parameter, which specifies a message to display
when the assertion fails. The problem is that if the assertion fails,
the error message will show the string literal but not the values that
caused the assertion to fail.

This commit removes the third parameter from the five calls and makes
them comments above the assertions instead. The default error message
produced by assert.strictEqual() shows the values that caused the
assertion to fail, which should be somewhat more helpful.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
