### PR TITLE
build: install markdown linter for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - os: linux
       node_js: "latest"
+      install:
+        - NODE=$(which node) make lint-md-build
       script:
         - NODE=$(which node) make lint-ci
     - os: linux


### PR DESCRIPTION
Looking at the Travis logs, e.g. https://travis-ci.com/nodejs/node/jobs/126938119 from https://github.com/nodejs/node/pull/21059:

```
...
$ NODE=$(which node) make lint-ci
Running JS linter...
Running C++ linter...
Total errors found: 0
The markdown linter is not installed.
To install (requires internet access) run: make lint-md-build
...
```

Run `make lint-md-build` to install the markdown linter.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
