### PR TITLE
doc: clarify async execute callback usage

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -181,7 +181,7 @@ typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 
 Implementations of this type of function should avoid making any N-API calls
 that could result in the execution of JavaScript or interaction with
-JavaScript objects. Most often any code that needs to make N-API
+JavaScript objects. Most often, any code that needs to make N-API
 calls should be made in `napi_async_complete_callback` instead.
 
 #### napi_async_complete_callback
@@ -3331,7 +3331,7 @@ task respectively.
 
 The `execute` function should avoid making any N-API calls
 that could result in the execution of JavaScript or interaction with
-JavaScript objects. Most often any code that needs to make N-API
+JavaScript objects. Most often, any code that needs to make N-API
 calls should be made in `complete` callback instead.
 
 These functions implement the following interfaces:

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -179,6 +179,11 @@ operations. Callback functions must statisfy the following signature:
 typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 ```
 
+Implementations of this type of function should avoid making any N-API calls
+that could result in the execution of JavaScript or interaction with
+JavaScript objects. Most often any code that needs to make N-API
+calls should be made in `napi_async_complete_callback` instead.
+
 #### napi_async_complete_callback
 Function pointer used with functions that support asynchronous
 operations. Callback functions must statisfy the following signature:
@@ -3322,7 +3327,14 @@ asynchronous workers. Instances are created/deleted with
 
 The `execute` and `complete` callbacks are functions that will be
 invoked when the executor is ready to execute and when it completes its
-task respectively. These functions implement the following interfaces:
+task respectively.
+
+The `execute` function should avoid making any N-API calls
+that could result in the execution of JavaScript or interaction with
+JavaScript objects. Most often any code that needs to make N-API
+calls should be made in `complete` callback instead.
+
+These functions implement the following interfaces:
 
 ```C
 typedef void (*napi_async_execute_callback)(napi_env env,


### PR DESCRIPTION
Clarify that calls to N-API should be avoided in
the 'execute' callback.

Refs: https://github.com/nodejs/help/issues/1318

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
