### PR TITLE
build: use LC_ALL=en_US.UTF-8 in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -672,7 +672,7 @@ def get_xcode_version(cc):
 def get_gas_version(cc):
   try:
     custom_env = os.environ.copy()
-    custom_env["LC_ALL"] = "en_US"
+    custom_env["LC_ALL"] = "en_US.UTF-8"
     proc = subprocess.Popen(shlex.split(cc) + ['-Wa,-v', '-c', '-o',
                                                '/dev/null', '-x',
                                                'assembler',  '/dev/null'],


### PR DESCRIPTION
:+1: to approve fast-tracking. This will (hopefully) unbreak CI.

On SmartOS 16, at least in our CI environment, LC_ALL cannot be set to
en_US, so the configuration script fails. Use en_US.UTF-8 instead.

Simpler alternative to https://github.com/nodejs/node/pull/21220, but will have to run CI to see if it works everywhere.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
