### PR TITLE
build: use LC_ALL of C for maximum compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -672,10 +672,7 @@ def get_xcode_version(cc):
 def get_gas_version(cc):
   try:
     custom_env = os.environ.copy()
-    # smartos (a.k.a. sunos5) does not have the en_US locale, and will give:
-    # `setlocale: LC_ALL: cannot change locale (en_US): Invalid argument`
-    if 'sunos' not in sys.platform:
-      custom_env["LC_ALL"] = "en_US"
+    custom_env["LC_ALL"] = "C"
     proc = subprocess.Popen(shlex.split(cc) + ['-Wa,-v', '-c', '-o',
                                                '/dev/null', '-x',
                                                'assembler',  '/dev/null'],


### PR DESCRIPTION
LC_ALL=en_US breaks on some systems (notably the SmartOS 16
configuration in our CI). Use LC_ALL=C instead.

Yet another alternative to https://github.com/nodejs/node/pull/21221 and https://github.com/nodejs/node/pull/21220.

:+1: here for fast-tracking, although hopefully #21220 is the answer and we can close all of these. :-D

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
