### PR TITLE
[WIP] esm: Import modules by https

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -59,6 +59,13 @@ function resolve(specifier, parentURL) {
     };
   }
 
+  if (specifier.match(/http?s:/g)) {
+    return {
+      url: specifier,
+      format: 'http'
+    };
+  }
+
   let url;
   try {
     url = search(specifier,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -64,7 +64,11 @@ class Loader {
     if (format === 'builtin')
       return { url: `node:${url}`, format };
 
-    if (format !== 'dynamic' && !url.startsWith('file:'))
+    if (
+      format !== 'dynamic' &&
+      !url.startsWith('file:') &&
+      !url.startsWith('https:')
+    )
       throw new ERR_INVALID_PROTOCOL(url, 'file:');
 
     return { url, format };

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -65,6 +65,12 @@ class ModuleJob {
             dest = dest.slice(0, dest.length - 1);
           }
 
+          dest += '/node_http_modules';
+
+          if (!fs.existsSync(dest)) {
+            fs.mkdirSync(dest);
+          }
+
           const scriptPath = `${dest}/${url2hash(specifier)}.mjs`;
 
           if (!fs.existsSync(scriptPath)) {

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -7,30 +7,6 @@ const { decorateErrorStack } = require('internal/util');
 const assert = require('assert');
 const resolvedPromise = SafePromise.resolve();
 
-const req = require('https');
-const fs = require('fs');
-const crypto = require('crypto');
-
-const fetchModule = (url) => new Promise((resolve, reject) => {
-  req.get(url, (res) => {
-    let data = '';
-
-    res.on('data', (chunk) => {
-      data += chunk;
-    });
-
-    res.on('end', () => {
-      resolve(data);
-    });
-  });
-});
-
-function url2hash(url) {
-  const hash = crypto.createHash('sha256');
-  hash.update(url);
-  return hash.digest('hex');
-}
-
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
 class ModuleJob {
@@ -56,29 +32,6 @@ class ModuleJob {
 
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
-        if (specifier.match(/http?s:/g)) {
-          let dest = process.env.NODE_HTTP_MODULES || '/tmp';
-
-          if (dest[dest.length - 1] === '/') {
-            dest = dest.slice(0, dest.length - 1);
-          }
-
-          dest += '/node_http_modules';
-
-          if (!fs.existsSync(dest)) {
-            fs.mkdirSync(dest);
-          }
-
-          const scriptPath = `${dest}/${url2hash(specifier)}.mjs`;
-
-          if (!fs.existsSync(scriptPath)) {
-            const scriptContent = await fetchModule(specifier);
-            fs.writeFileSync(scriptPath, scriptContent);
-          }
-
-          specifier = scriptPath;
-        }
-
         const jobPromise = this.loader.getModuleJob(specifier, url);
         dependencyJobs.push(jobPromise);
         return (await (await jobPromise).modulePromise).module;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -9,6 +9,7 @@ const resolvedPromise = SafePromise.resolve();
 
 const req = require('https');
 const fs = require('fs');
+const crypto = require('crypto');
 
 const fetchModule = (url) => new Promise((resolve, reject) => {
   req.get(url, (res) => {
@@ -24,11 +25,11 @@ const fetchModule = (url) => new Promise((resolve, reject) => {
   });
 });
 
-const writeModule = (filename, content) => new Promise((resolve, reject) => {
-  const filePath = `/tmp/react-hash1234.mjs`;
-  fs.writeFileSync(filePath, content);
-  resolve(filePath);
-});
+function url2hash(url) {
+  const hash = crypto.createHash('sha256');
+  hash.update(url);
+  return hash.digest('hex');
+}
 
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
@@ -55,14 +56,16 @@ class ModuleJob {
 
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
-        console.log(`Specifier ${specifier}`);
-
         if (specifier.match(/http?s:/g)) {
-          // get content
-          // save as a .mjs file
-          // continue with path to this file
+          // TODO: check if file already exists
+          // TODO: if --reload arg is given then reload http modules even
+
+          // TODO: specify download destination with env variable
+          const scriptPath = `/tmp/${url2hash(specifier)}.mjs`;
+
           const scriptContent = await fetchModule(specifier);
-          const scriptPath = await writeModule(specifier.slice(8), scriptContent);
+
+          fs.writeFileSync(scriptPath, scriptContent);
 
           specifier = scriptPath;
         }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -7,6 +7,29 @@ const { decorateErrorStack } = require('internal/util');
 const assert = require('assert');
 const resolvedPromise = SafePromise.resolve();
 
+const req = require('https');
+const fs = require('fs');
+
+const fetchModule = (url) => new Promise((resolve, reject) => {
+  req.get(url, (res) => {
+    let data = '';
+
+    res.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    res.on('end', () => {
+      resolve(data);
+    });
+  });
+});
+
+const writeModule = (filename, content) => new Promise((resolve, reject) => {
+  const filePath = `/tmp/react-hash1234.mjs`;
+  fs.writeFileSync(filePath, content);
+  resolve(filePath);
+});
+
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
 class ModuleJob {
@@ -32,6 +55,18 @@ class ModuleJob {
 
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
+        console.log(`Specifier ${specifier}`);
+
+        if (specifier.match(/http?s:/g)) {
+          // get content
+          // save as a .mjs file
+          // continue with path to this file
+          const scriptContent = await fetchModule(specifier);
+          const scriptPath = await writeModule(specifier.slice(8), scriptContent);
+
+          specifier = scriptPath;
+        }
+
         const jobPromise = this.loader.getModuleJob(specifier, url);
         dependencyJobs.push(jobPromise);
         return (await (await jobPromise).modulePromise).module;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -57,15 +57,16 @@ class ModuleJob {
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
         if (specifier.match(/http?s:/g)) {
-          // TODO: check if file already exists
+          // TODO: Create http_node_modules and keep things inside it
           // TODO: if --reload arg is given then reload http modules even
 
           // TODO: specify download destination with env variable
           const scriptPath = `/tmp/${url2hash(specifier)}.mjs`;
 
-          const scriptContent = await fetchModule(specifier);
-
-          fs.writeFileSync(scriptPath, scriptContent);
+          if (!fs.existsSync(scriptPath)) {
+            const scriptContent = await fetchModule(specifier);
+            fs.writeFileSync(scriptPath, scriptContent);
+          }
 
           specifier = scriptPath;
         }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -57,8 +57,6 @@ class ModuleJob {
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier) => {
         if (specifier.match(/http?s:/g)) {
-          // TODO: Create http_node_modules and keep things inside it
-
           let dest = process.env.NODE_HTTP_MODULES || '/tmp';
 
           if (dest[dest.length - 1] === '/') {

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -58,10 +58,14 @@ class ModuleJob {
       const promises = this.module.link(async (specifier) => {
         if (specifier.match(/http?s:/g)) {
           // TODO: Create http_node_modules and keep things inside it
-          // TODO: if --reload arg is given then reload http modules even
 
-          // TODO: specify download destination with env variable
-          const scriptPath = `/tmp/${url2hash(specifier)}.mjs`;
+          let dest = process.env.NODE_HTTP_MODULES || '/tmp';
+
+          if (dest[dest.length - 1] === '/') {
+            dest = dest.slice(0, dest.length - 1);
+          }
+
+          const scriptPath = `${dest}/${url2hash(specifier)}.mjs`;
 
           if (!fs.existsSync(scriptPath)) {
             const scriptContent = await fetchModule(specifier);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -122,32 +122,33 @@ translators.set('http', async (url) => {
     });
   });
 
-  function url2hash(url) {
+  function createHash(url) {
     const hash = crypto.createHash('sha256');
     hash.update(url);
     return hash.digest('hex');
   }
 
-  let dest = process.env.NODE_HTTP_MODULES || '/tmp';
+  // (?) Maybe path.resolve? But then wouldn't it be overhead?
+  const norm = (url) => `/${url.split(/\//).filter((x) => x).join('/')}`;
 
-  if (dest[dest.length - 1] === '/') {
-    dest = dest.slice(0, dest.length - 1);
-  }
-
-  dest += '/node_http_modules';
+  const dest = norm(process.env.NODE_HTTP_MODULES || '/tmp') +
+    '/node_http_modules';
 
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest);
   }
 
-  const scriptPath = `${dest}/${url2hash(url)}.mjs`;
+  // TODO: Create directory for each "package" and leave original filenames
+  const scriptPath = `${dest}/${createHash(url)}.mjs`;
 
-  if (!fs.existsSync(scriptPath)) {
-    const scriptContent = await fetchModule(url);
-    fs.writeFileSync(scriptPath, scriptContent);
+  let source;
+
+  if (fs.existsSync(scriptPath)) {
+    source = readFileSync(new URL(`file://${scriptPath}`), 'utf8');
+  } else {
+    source = await fetchModule(url);
+    fs.writeFileSync(scriptPath, source);
   }
-
-  const source = `${await readFileAsync(new URL(scriptPath))}`;
 
   return {
     module: new ModuleWrap(stripShebang(source), scriptPath),

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -11,6 +11,8 @@ const internalURLModule = require('internal/url');
 const createDynamicModule = require(
   'internal/modules/esm/create_dynamic_module');
 const fs = require('fs');
+const https = require('https');
+const crypto = require('crypto');
 const { _makeLong } = require('path');
 const { SafeMap } = require('internal/safe_globals');
 const { URL } = require('url');
@@ -100,4 +102,55 @@ translators.set('json', async (url) => {
       throw err;
     }
   });
+});
+
+// Strategy for loading from HTTP(s)
+translators.set('http', async (url) => {
+  debug(`Translating Remote Http Module ${url}`);
+
+  const fetchModule = (url) => new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        resolve(data);
+      });
+    });
+  });
+
+  function url2hash(url) {
+    const hash = crypto.createHash('sha256');
+    hash.update(url);
+    return hash.digest('hex');
+  }
+
+  let dest = process.env.NODE_HTTP_MODULES || '/tmp';
+
+  if (dest[dest.length - 1] === '/') {
+    dest = dest.slice(0, dest.length - 1);
+  }
+
+  dest += '/node_http_modules';
+
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest);
+  }
+
+  const scriptPath = `${dest}/${url2hash(url)}.mjs`;
+
+  if (!fs.existsSync(scriptPath)) {
+    const scriptContent = await fetchModule(url);
+    fs.writeFileSync(scriptPath, scriptContent);
+  }
+
+  const source = `${await readFileAsync(new URL(scriptPath))}`;
+
+  return {
+    module: new ModuleWrap(stripShebang(source), scriptPath),
+    reflect: undefined
+  };
 });

--- a/test/es-module/test-esm-http-lookup.mjs
+++ b/test/es-module/test-esm-http-lookup.mjs
@@ -1,3 +1,5 @@
+// Flags: --experimental-modules
+
 import '../common';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-http-lookup.mjs
+++ b/test/es-module/test-esm-http-lookup.mjs
@@ -1,6 +1,8 @@
 import '../common';
 import assert from 'assert';
 
-import esm from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/main.mjs';
+import { a } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/a.js';
+import { b } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/b.js';
 
-console.log(esm);
+assert.strictEqual(a, 'a');
+assert.strictEqual(b(), 'b');

--- a/test/es-module/test-esm-http-lookup.mjs
+++ b/test/es-module/test-esm-http-lookup.mjs
@@ -1,0 +1,6 @@
+import '../common';
+import assert from 'assert';
+
+import esm from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/main.mjs';
+
+console.log(esm);

--- a/test/es-module/test-esm-http-lookup.mjs
+++ b/test/es-module/test-esm-http-lookup.mjs
@@ -1,6 +1,7 @@
 import '../common';
 import assert from 'assert';
 
+// TODO: Need to find another source to test remote modules
 import { a } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/a.js';
 import { b } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/b.js';
 


### PR DESCRIPTION
Hi everyone,

I implemented basic version of *esm over the internet* idea. Example below is working.

I'd like to know from the community: what do you think?

Personally I am dying to see Node.js doing something like this. I just feel like `node_modules` managed by `npm` sometimes just gets overhead. It's how we got used to it - yeah. But it doesn't mean we can't experiment with other ideas, right?

```js
import assert from 'assert';

import { a } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/a.js';
import { b } from 'https://raw.githubusercontent.com/kuroljov/esm-test/master/b.js';

assert.strictEqual(a, 'a');
assert.strictEqual(b(), 'b');
```

### How

I basically added new `translator` called `http` where I am fetching (or if it's already there then reading from the disk) something

### Next

I am able to invest more time to it but I'd like to know if it will make sense. That is why *WIP* basically :smile: 

If yes then I'd like to see in this PR

- Remote dependency resolving (right now you can't fetch script that has `import` statements (it's like in the browser right now - you get one script that has to `export default`)
- Community fixes and suggestions

### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
