### PR TITLE
build: fix cctest build failure in Windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -989,6 +989,10 @@
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
+        # Skip cctest while building shared lib node for Windows
+        [ 'OS=="win" and node_shared=="true"', {
+          'type': 'none',
+        }],
       ],
     }
   ], # end targets

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -542,6 +542,7 @@ if "%test_args%"=="" goto test-v8
 if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 if defined no_cctest echo Skipping cctest because no-cctest was specified && goto run-test-py
+if not exist %config%\cctest.exe goto run-test-py
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
 :run-test-py


### PR DESCRIPTION
cctest needs to access some internal APIs in node core. Putting
node_lib_target_name as dependency would causes linking error when
node_lib is built as shared lib in Windows. The reason being is
those internal APIs don't have `__declspec(dllexport)`. For cctest
we still need to specify individual obj files and link them instead
of node_lib. In Windows, changes of the dependencies in `libraries`
trigger the cctest to rebuild. However, in Linux platforms, it
doesn't work. Instead, need to put obj dependencies into `sources`.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
