### PR TITLE
doc: note synchronous part of child_process.spawn

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -39,6 +39,11 @@ without blocking the Node.js event loop. The [`child_process.spawnSync()`][]
 function provides equivalent functionality in a synchronous manner that blocks
 the event loop until the spawned process either exits or is terminated.
 
+*Note*: On some operating systems, the [`child_process.spawn()`][] method
+performs memory operations synchronously before decoupling the event loop
+from the child. Applications with a large memory footprint may find frequent
+[`child_process.spawn()`][] calls to be a bottleneck.
+
 For convenience, the `child_process` module provides a handful of synchronous
 and asynchronous alternatives to [`child_process.spawn()`][] and
 [`child_process.spawnSync()`][]. *Note that each of these alternatives are


### PR DESCRIPTION
If an application has a large RSS (MB-GB), @jorangreef observed that child_process.spawn will block the event loop for milliseconds to seconds.

This is surprising behavior and merits documentation.

See discussion on #14917.

##### Checklist

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
