### PR TITLE
tools: add BigInt to globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -243,6 +243,7 @@ module.exports = {
     'node-core/no-unescaped-regexp-dot': 'error',
   },
   globals: {
+    BigInt: false,
     COUNTER_HTTP_CLIENT_REQUEST: false,
     COUNTER_HTTP_CLIENT_RESPONSE: false,
     COUNTER_HTTP_SERVER_REQUEST: false,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -160,7 +160,6 @@ Stats.prototype._checkModeProperty = function(property) {
     return false;  // Some types are not available on Windows
   }
   if (typeof this.mode === 'bigint') {  // eslint-disable-line valid-typeof
-    // eslint-disable-next-line no-undef
     return (this.mode & BigInt(S_IFMT)) === BigInt(property);
   }
   return (this.mode & S_IFMT) === property;

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -31,7 +31,6 @@ function verifyStats(bigintStats, numStats) {
         `difference of ${key}.getTime() should < 2.\n` +
         `Number version ${time}, BigInt version ${time2}n`);
     } else if (key === 'mode') {
-      // eslint-disable-next-line no-undef
       assert.strictEqual(bigintStats[key], BigInt(val));
       assert.strictEqual(
         bigintStats.isBlockDevice(),
@@ -65,7 +64,6 @@ function verifyStats(bigintStats, numStats) {
       assert.strictEqual(bigintStats[key], undefined);
       assert.strictEqual(numStats[key], undefined);
     } else if (Number.isSafeInteger(val)) {
-      // eslint-disable-next-line no-undef
       assert.strictEqual(bigintStats[key], BigInt(val));
     } else {
       assert(


### PR DESCRIPTION
I was going to do it in https://github.com/nodejs/node/pull/19691, but then I noticed that https://github.com/nodejs/node/pull/20220 added several `// eslint-disable-next-line no-undef` lines. I talked about it with @ljharb and we agreed that a separate PR makes more sense.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
