### PR TITLE
doc: documentation of sync methods links now to async methods

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1140,7 +1140,8 @@ changes:
 Synchronously changes the permissions of a file. Returns `undefined`.
 This is the synchronous version of [`fs.chmod()`][].
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.chmod()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.chmod()`][].
 
 See also: chmod(2).
 
@@ -1572,7 +1573,8 @@ changes:
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the path exists, `false` otherwise.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.exists()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.exists()`][].
 
 `fs.exists()` is deprecated, but `fs.existsSync()` is not. The `callback`
 parameter to `fs.exists()` accepts parameters that are inconsistent with other
@@ -1827,7 +1829,8 @@ added: v0.8.6
 
 Synchronous ftruncate(2). Returns `undefined`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.ftruncate()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.ftruncate()`][].
 
 ## fs.futimes(fd, atime, mtime, callback)
 <!-- YAML
@@ -2180,7 +2183,8 @@ added: v5.10.0
 The synchronous version of [`fs.mkdtemp()`][]. Returns the created
 folder path.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.mkdtemp()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.mkdtemp()`][].
 
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
@@ -2239,7 +2243,8 @@ changes:
 Synchronous version of [`fs.open()`][]. Returns an integer representing the file
 descriptor.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.open()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.open()`][].
 
 ## fs.read(fd, buffer, offset, length, position, callback)
 <!-- YAML
@@ -2439,7 +2444,8 @@ changes:
 
 Synchronous version of [`fs.readFile()`][]. Returns the contents of the `path`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.readFile()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.readFile()`][].
 
 If the `encoding` option is specified then this function returns a
 string. Otherwise it returns a buffer.
@@ -2529,7 +2535,8 @@ changes:
 
 Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.read()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.read()`][].
 
 ## fs.realpath(path[, options], callback)
 <!-- YAML
@@ -2646,7 +2653,8 @@ changes:
 
 Synchronous version of [`fs.realpath()`][]. Returns the resolved pathname.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.realpath()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.realpath()`][].
 
 ## fs.realpathSync.native(path[, options])
 <!-- YAML
@@ -2884,7 +2892,8 @@ changes:
 
 Synchronous symlink(2). Returns `undefined`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.symlink()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.symlink()`][].
 
 ## fs.truncate(path[, len], callback)
 <!-- YAML
@@ -3062,7 +3071,8 @@ changes:
 
 Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.utimes()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.utimes()`][].
 
 ## fs.watch(filename[, options][, listener])
 <!-- YAML
@@ -3415,7 +3425,8 @@ changes:
 
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.writeFile()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.writeFile()`][].
 
 ## fs.writeSync(fd, buffer[, offset[, length[, position]]])
 <!-- YAML
@@ -3453,7 +3464,8 @@ changes:
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 
-For detailed information, see the documentation of the asynchronous version of this API: [`fs.write()`][].
+For detailed information, see the documentation of the asynchronous version of
+this API: [`fs.write()`][].
 
 ## fs Promises API
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4617,6 +4617,7 @@ the file contents.
 [`fs.chown()`]: #fs_fs_chown_path_uid_gid_callback
 [`fs.copyFile()`]: #fs_fs_copyfile_src_dest_flags_callback
 [`fs.exists()`]: fs.html#fs_fs_exists_path_callback
+[`fs.ftruncate()`]: #fs_fs_ftruncate_fd_len_callback
 [`fs.fstat()`]: #fs_fs_fstat_fd_options_callback
 [`fs.futimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
 [`fs.lstat()`]: #fs_fs_lstat_path_options_callback
@@ -4629,6 +4630,7 @@ the file contents.
 [`fs.realpath()`]: #fs_fs_realpath_path_options_callback
 [`fs.rmdir()`]: #fs_fs_rmdir_path_callback
 [`fs.stat()`]: #fs_fs_stat_path_options_callback
+[`fs.symlink()`]: #fs_fs_symlink_target_path_type_callback
 [`fs.utimes()`]: #fs_fs_utimes_path_atime_mtime_callback
 [`fs.watch()`]: #fs_fs_watch_filename_options_listener
 [`fs.write()`]: #fs_fs_write_fd_buffer_offset_length_position_callback

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1140,7 +1140,7 @@ changes:
 Synchronously changes the permissions of a file. Returns `undefined`.
 This is the synchronous version of [`fs.chmod()`][].
 
-For detailed information, see the documentation of [`fs.chmod()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.chmod()`][].
 
 See also: chmod(2).
 
@@ -1572,7 +1572,7 @@ changes:
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the path exists, `false` otherwise.
 
-For detailed information, see the documentation of [`fs.exists()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.exists()`][].
 
 `fs.exists()` is deprecated, but `fs.existsSync()` is not. The `callback`
 parameter to `fs.exists()` accepts parameters that are inconsistent with other
@@ -1827,7 +1827,7 @@ added: v0.8.6
 
 Synchronous ftruncate(2). Returns `undefined`.
 
-For detailed information, see the documentation of [`fs.ftruncate()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.ftruncate()`][].
 
 ## fs.futimes(fd, atime, mtime, callback)
 <!-- YAML
@@ -2180,7 +2180,7 @@ added: v5.10.0
 The synchronous version of [`fs.mkdtemp()`][]. Returns the created
 folder path.
 
-For detailed information, see the documentation of [`fs.mkdtemp()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.mkdtemp()`][].
 
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
@@ -2239,7 +2239,7 @@ changes:
 Synchronous version of [`fs.open()`][]. Returns an integer representing the file
 descriptor.
 
-For detailed information, see the documentation of [`fs.open()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.open()`][].
 
 ## fs.read(fd, buffer, offset, length, position, callback)
 <!-- YAML
@@ -2439,7 +2439,7 @@ changes:
 
 Synchronous version of [`fs.readFile()`][]. Returns the contents of the `path`.
 
-For detailed information, see the documentation of [`fs.readFile()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.readFile()`][].
 
 If the `encoding` option is specified then this function returns a
 string. Otherwise it returns a buffer.
@@ -2529,7 +2529,7 @@ changes:
 
 Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 
-For detailed information, see the documentation of [`fs.read()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.read()`][].
 
 ## fs.realpath(path[, options], callback)
 <!-- YAML
@@ -2646,7 +2646,7 @@ changes:
 
 Synchronous version of [`fs.realpath()`][]. Returns the resolved pathname.
 
-For detailed information, see the documentation of [`fs.realpath()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.realpath()`][].
 
 ## fs.realpathSync.native(path[, options])
 <!-- YAML
@@ -2884,7 +2884,7 @@ changes:
 
 Synchronous symlink(2). Returns `undefined`.
 
-For detailed information, see the documentation of [`fs.symlink()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.symlink()`][].
 
 ## fs.truncate(path[, len], callback)
 <!-- YAML
@@ -3062,7 +3062,7 @@ changes:
 
 Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
 
-For detailed information, see the documentation of [`fs.utimes()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.utimes()`][].
 
 ## fs.watch(filename[, options][, listener])
 <!-- YAML
@@ -3415,7 +3415,7 @@ changes:
 
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
-For detailed information, see the documentation of [`fs.writeFile()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.writeFile()`][].
 
 ## fs.writeSync(fd, buffer[, offset[, length[, position]]])
 <!-- YAML
@@ -3453,7 +3453,7 @@ changes:
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 
-For detailed information, see the documentation of [`fs.write()`][].
+For detailed information, see the documentation of the asynchronous version of this API: [`fs.write()`][].
 
 ## fs Promises API
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1137,7 +1137,7 @@ changes:
 * `path` {string|Buffer|URL}
 * `mode` {integer}
 
-Synchronously changes the permissions of a file. Returns `undefined`.
+Returns `undefined`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.chmod()`][].

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1140,6 +1140,8 @@ changes:
 Synchronously changes the permissions of a file. Returns `undefined`.
 This is the synchronous version of [`fs.chmod()`][].
 
+For detailed information, see the documentation of [`fs.chmod()`][].
+
 See also: chmod(2).
 
 ## fs.chown(path, uid, gid, callback)
@@ -1570,9 +1572,12 @@ changes:
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the path exists, `false` otherwise.
 
+For detailed information, see the documentation of [`fs.exists()`][].
+
 `fs.exists()` is deprecated, but `fs.existsSync()` is not. The `callback`
 parameter to `fs.exists()` accepts parameters that are inconsistent with other
 Node.js callbacks. `fs.existsSync()` does not use a callback.
+
 
 ## fs.fchmod(fd, mode, callback)
 <!-- YAML
@@ -1821,6 +1826,8 @@ added: v0.8.6
 * `len` {integer} **Default:** `0`
 
 Synchronous ftruncate(2). Returns `undefined`.
+
+For detailed information, see the documentation of [`fs.ftruncate()`][].
 
 ## fs.futimes(fd, atime, mtime, callback)
 <!-- YAML
@@ -2173,6 +2180,8 @@ added: v5.10.0
 The synchronous version of [`fs.mkdtemp()`][]. Returns the created
 folder path.
 
+For detailed information, see the documentation of [`fs.mkdtemp()`][].
+
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
 
@@ -2229,6 +2238,8 @@ changes:
 
 Synchronous version of [`fs.open()`][]. Returns an integer representing the file
 descriptor.
+
+For detailed information, see the documentation of [`fs.open()`][].
 
 ## fs.read(fd, buffer, offset, length, position, callback)
 <!-- YAML
@@ -2428,6 +2439,8 @@ changes:
 
 Synchronous version of [`fs.readFile()`][]. Returns the contents of the `path`.
 
+For detailed information, see the documentation of [`fs.readFile()`][].
+
 If the `encoding` option is specified then this function returns a
 string. Otherwise it returns a buffer.
 
@@ -2515,6 +2528,8 @@ changes:
 * Returns: {number}
 
 Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
+
+For detailed information, see the documentation of [`fs.read()`][].
 
 ## fs.realpath(path[, options], callback)
 <!-- YAML
@@ -2630,6 +2645,8 @@ changes:
 * Returns: {string|Buffer}
 
 Synchronous version of [`fs.realpath()`][]. Returns the resolved pathname.
+
+For detailed information, see the documentation of [`fs.realpath()`][].
 
 ## fs.realpathSync.native(path[, options])
 <!-- YAML
@@ -2867,6 +2884,8 @@ changes:
 
 Synchronous symlink(2). Returns `undefined`.
 
+For detailed information, see the documentation of [`fs.symlink()`][].
+
 ## fs.truncate(path[, len], callback)
 <!-- YAML
 added: v0.8.6
@@ -3042,6 +3061,8 @@ changes:
 * `mtime` {integer}
 
 Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
+
+For detailed information, see the documentation of [`fs.utimes()`][].
 
 ## fs.watch(filename[, options][, listener])
 <!-- YAML
@@ -3394,6 +3415,8 @@ changes:
 
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
+For detailed information, see the documentation of [`fs.writeFile()`][].
+
 ## fs.writeSync(fd, buffer[, offset[, length[, position]]])
 <!-- YAML
 added: v0.1.21
@@ -3429,6 +3452,8 @@ changes:
 * Returns: {number}
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
+
+For detailed information, see the documentation of [`fs.write()`][].
 
 ## fs Promises API
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1138,7 +1138,6 @@ changes:
 * `mode` {integer}
 
 Synchronously changes the permissions of a file. Returns `undefined`.
-This is the synchronous version of [`fs.chmod()`][].
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.chmod()`][].
@@ -1570,7 +1569,6 @@ changes:
 * `path` {string|Buffer|URL}
 * Returns: {boolean}
 
-Synchronous version of [`fs.exists()`][].
 Returns `true` if the path exists, `false` otherwise.
 
 For detailed information, see the documentation of the asynchronous version of
@@ -1827,7 +1825,7 @@ added: v0.8.6
 * `fd` {integer}
 * `len` {integer} **Default:** `0`
 
-Synchronous ftruncate(2). Returns `undefined`.
+Returns `undefined`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.ftruncate()`][].
@@ -2180,8 +2178,7 @@ added: v5.10.0
   * `encoding` {string} **Default:** `'utf8'`
 * Returns: {string}
 
-The synchronous version of [`fs.mkdtemp()`][]. Returns the created
-folder path.
+Returns the created folder path.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.mkdtemp()`][].
@@ -2240,8 +2237,7 @@ changes:
 * `mode` {integer} **Default:** `0o666`
 * Returns: {number}
 
-Synchronous version of [`fs.open()`][]. Returns an integer representing the file
-descriptor.
+Returns an integer representing the file descriptor.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.open()`][].
@@ -2442,7 +2438,7 @@ changes:
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'r'`.
 * Returns: {string|Buffer}
 
-Synchronous version of [`fs.readFile()`][]. Returns the contents of the `path`.
+Returns the contents of the `path`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.readFile()`][].
@@ -2533,7 +2529,7 @@ changes:
 * `position` {integer}
 * Returns: {number}
 
-Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
+Returns the number of `bytesRead`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.read()`][].
@@ -2651,7 +2647,7 @@ changes:
   * `encoding` {string} **Default:** `'utf8'`
 * Returns: {string|Buffer}
 
-Synchronous version of [`fs.realpath()`][]. Returns the resolved pathname.
+Returns the resolved pathname.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.realpath()`][].
@@ -2890,7 +2886,7 @@ changes:
 * `path` {string|Buffer|URL}
 * `type` {string} **Default:** `'file'`
 
-Synchronous symlink(2). Returns `undefined`.
+Returns `undefined`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.symlink()`][].
@@ -3069,7 +3065,7 @@ changes:
 * `atime` {integer}
 * `mtime` {integer}
 
-Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
+Returns `undefined`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.utimes()`][].
@@ -3423,7 +3419,7 @@ changes:
   * `mode` {integer} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
 
-The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
+Returns `undefined`.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.writeFile()`][].
@@ -3462,7 +3458,7 @@ changes:
 * `encoding` {string}
 * Returns: {number}
 
-Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
+Returns the number of bytes written.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.write()`][].

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1137,8 +1137,6 @@ changes:
 * `path` {string|Buffer|URL}
 * `mode` {integer}
 
-Returns `undefined`.
-
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.chmod()`][].
 
@@ -4625,8 +4623,8 @@ the file contents.
 [`fs.chown()`]: #fs_fs_chown_path_uid_gid_callback
 [`fs.copyFile()`]: #fs_fs_copyfile_src_dest_flags_callback
 [`fs.exists()`]: fs.html#fs_fs_exists_path_callback
-[`fs.ftruncate()`]: #fs_fs_ftruncate_fd_len_callback
 [`fs.fstat()`]: #fs_fs_fstat_fd_options_callback
+[`fs.ftruncate()`]: #fs_fs_ftruncate_fd_len_callback
 [`fs.futimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
 [`fs.lstat()`]: #fs_fs_lstat_path_options_callback
 [`fs.mkdir()`]: #fs_fs_mkdir_path_mode_callback


### PR DESCRIPTION
Documentation of sync methods links now to async methods if it made sense
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Refs: #21197 