### PR TITLE
lib,src: make `StatWatcher` a `HandleWrap`

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -11,9 +11,7 @@ const {
   getStatsFromBinding,
   validatePath
 } = require('internal/fs/utils');
-const {
-  defaultTriggerAsyncIdScope
-} = require('internal/async_hooks');
+const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
 const { getPathFromURL } = require('internal/url');

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -11,11 +11,18 @@ const {
   getStatsFromBinding,
   validatePath
 } = require('internal/fs/utils');
+const {
+  defaultTriggerAsyncIdScope
+} = require('internal/async_hooks');
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
 const { getPathFromURL } = require('internal/url');
 const util = require('util');
 const assert = require('assert');
+
+const kOldStatus = Symbol('kOldStatus');
+const kUseBigint = Symbol('kUseBigint');
+const kOwner = Symbol('kOwner');
 
 function emitStop(self) {
   self.emit('stop');
@@ -24,28 +31,24 @@ function emitStop(self) {
 function StatWatcher(bigint) {
   EventEmitter.call(this);
 
-  this._handle = new _StatWatcher(bigint);
-
-  // uv_fs_poll is a little more powerful than ev_stat but we curb it for
-  // the sake of backwards compatibility
-  let oldStatus = -1;
-
-  this._handle.onchange = (newStatus, stats) => {
-    if (oldStatus === -1 &&
-        newStatus === -1 &&
-        stats[2/* new nlink */] === stats[16/* old nlink */]) return;
-
-    oldStatus = newStatus;
-    this.emit('change', getStatsFromBinding(stats),
-              getStatsFromBinding(stats, kFsStatsFieldsLength));
-  };
-
-  this._handle.onstop = () => {
-    process.nextTick(emitStop, this);
-  };
+  this._handle = null;
+  this[kOldStatus] = -1;
+  this[kUseBigint] = bigint;
 }
 util.inherits(StatWatcher, EventEmitter);
 
+function onchange(newStatus, stats) {
+  const self = this[kOwner];
+  if (self[kOldStatus] === -1 &&
+      newStatus === -1 &&
+      stats[2/* new nlink */] === stats[16/* old nlink */]) {
+    return;
+  }
+
+  self[kOldStatus] = newStatus;
+  self.emit('change', getStatsFromBinding(stats),
+            getStatsFromBinding(stats, kFsStatsFieldsLength));
+}
 
 // FIXME(joyeecheung): this method is not documented.
 // At the moment if filename is undefined, we
@@ -54,16 +57,23 @@ util.inherits(StatWatcher, EventEmitter);
 //    on a valid filename and the wrap has been initialized
 // This method is a noop if the watcher has already been started.
 StatWatcher.prototype.start = function(filename, persistent, interval) {
-  assert(this._handle instanceof _StatWatcher, 'handle must be a StatWatcher');
-  if (this._handle.isActive) {
+  if (this._handle !== null)
     return;
-  }
+
+  this._handle = new _StatWatcher(this[kUseBigint]);
+  this._handle[kOwner] = this;
+  this._handle.onchange = onchange;
+  if (!persistent)
+    this._handle.unref();
+
+  // uv_fs_poll is a little more powerful than ev_stat but we curb it for
+  // the sake of backwards compatibility
+  this[kOldStatus] = -1;
 
   filename = getPathFromURL(filename);
   validatePath(filename, 'filename');
   validateUint32(interval, 'interval');
-  const err = this._handle.start(toNamespacedPath(filename),
-                                 persistent, interval);
+  const err = this._handle.start(toNamespacedPath(filename), interval);
   if (err) {
     const error = errors.uvException({
       errno: err,
@@ -80,11 +90,15 @@ StatWatcher.prototype.start = function(filename, persistent, interval) {
 // FSWatcher is .close()
 // This method is a noop if the watcher has not been started.
 StatWatcher.prototype.stop = function() {
-  assert(this._handle instanceof _StatWatcher, 'handle must be a StatWatcher');
-  if (!this._handle.isActive) {
+  if (this._handle === null)
     return;
-  }
-  this._handle.stop();
+
+  defaultTriggerAsyncIdScope(this._handle.getAsyncId(),
+                             process.nextTick,
+                             emitStop,
+                             this);
+  this._handle.close();
+  this._handle = null;
 };
 
 

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -25,26 +25,24 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "async_wrap.h"
+#include "handle_wrap.h"
 #include "env.h"
 #include "uv.h"
 #include "v8.h"
 
 namespace node {
 
-class StatWatcher : public AsyncWrap {
+class StatWatcher : public HandleWrap {
  public:
-  ~StatWatcher() override;
-
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
-  StatWatcher(Environment* env, v8::Local<v8::Object> wrap, bool use_bigint);
+  StatWatcher(Environment* env,
+              v8::Local<v8::Object> wrap,
+              bool use_bigint);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void IsActive(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   size_t self_size() const override { return sizeof(*this); }
 
@@ -53,10 +51,8 @@ class StatWatcher : public AsyncWrap {
                        int status,
                        const uv_stat_t* prev,
                        const uv_stat_t* curr);
-  void Stop();
-  bool IsActive();
 
-  uv_fs_poll_t* watcher_;
+  uv_fs_poll_t watcher_;
   const bool use_bigint_;
 };
 

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -1,21 +1,29 @@
 'use strict';
 
 const common = require('../common');
-const commonPath = require.resolve('../common');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
 const fs = require('fs');
+const path = require('path');
 
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
+
+tmpdir.refresh();
+
+const file1 = path.join(tmpdir.path, 'file1');
+const file2 = path.join(tmpdir.path, 'file2');
+fs.writeFileSync(file1, 'foo');
+fs.writeFileSync(file2, 'bar');
 
 const hooks = initHooks();
 hooks.enable();
 
 function onchange() {}
 // install first file watcher
-const w1 = fs.watchFile(__filename, { interval: 10 }, onchange);
+const w1 = fs.watchFile(file1, { interval: 10 }, onchange);
 
 let as = hooks.activitiesOfTypes('STATWATCHER');
 assert.strictEqual(as.length, 1);
@@ -28,7 +36,7 @@ checkInvocations(statwatcher1, { init: 1 },
                  'watcher1: when started to watch file');
 
 // install second file watcher
-const w2 = fs.watchFile(commonPath, { interval: 10 }, onchange);
+const w2 = fs.watchFile(file2, { interval: 10 }, onchange);
 as = hooks.activitiesOfTypes('STATWATCHER');
 assert.strictEqual(as.length, 2);
 
@@ -41,9 +49,7 @@ checkInvocations(statwatcher1, { init: 1 },
 checkInvocations(statwatcher2, { init: 1 },
                  'watcher2: when started to watch second file');
 
-// Touch the first file by modifying its access time.
-const origStat = fs.statSync(__filename);
-fs.utimesSync(__filename, Date.now() + 10, origStat.mtime);
+fs.writeFileSync(file1, 'foo++');
 w1.once('change', common.mustCall(() => {
   setImmediate(() => {
     checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
@@ -52,16 +58,15 @@ w1.once('change', common.mustCall(() => {
                      'watcher2: when unwatched first file');
 
     // Touch the second file by modifying its access time.
-    const origStat = fs.statSync(commonPath);
-    fs.utimesSync(commonPath, Date.now() + 10, origStat.mtime);
+    fs.writeFileSync(file2, 'bar++');
     w2.once('change', common.mustCall(() => {
       setImmediate(() => {
         checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
                          'watcher1: when unwatched second file');
         checkInvocations(statwatcher2, { init: 1, before: 1, after: 1 },
                          'watcher2: when unwatched second file');
-        w1.stop();
-        w2.stop();
+        fs.unwatchFile(file1);
+        fs.unwatchFile(file2);
       });
     }));
   });

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -49,7 +49,7 @@ checkInvocations(statwatcher1, { init: 1 },
 checkInvocations(statwatcher2, { init: 1 },
                  'watcher2: when started to watch second file');
 
-fs.writeFileSync(file1, 'foo++');
+setTimeout(() => fs.writeFileSync(file1, 'foo++'), 10);
 w1.once('change', common.mustCall(() => {
   setImmediate(() => {
     checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
@@ -57,8 +57,7 @@ w1.once('change', common.mustCall(() => {
     checkInvocations(statwatcher2, { init: 1 },
                      'watcher2: when unwatched first file');
 
-    // Touch the second file by modifying its access time.
-    fs.writeFileSync(file2, 'bar++');
+    setTimeout(() => fs.writeFileSync(file2, 'bar++'), 10);
     w2.once('change', common.mustCall(() => {
       setImmediate(() => {
         checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -49,7 +49,8 @@ checkInvocations(statwatcher1, { init: 1 },
 checkInvocations(statwatcher2, { init: 1 },
                  'watcher2: when started to watch second file');
 
-setTimeout(() => fs.writeFileSync(file1, 'foo++'), 10);
+setTimeout(() => fs.writeFileSync(file1, 'foo++'),
+           common.platformTimeout(100));
 w1.once('change', common.mustCall(() => {
   setImmediate(() => {
     checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
@@ -57,7 +58,8 @@ w1.once('change', common.mustCall(() => {
     checkInvocations(statwatcher2, { init: 1 },
                      'watcher2: when unwatched first file');
 
-    setTimeout(() => fs.writeFileSync(file2, 'bar++'), 10);
+    setTimeout(() => fs.writeFileSync(file2, 'bar++'),
+               common.platformTimeout(100));
     w2.once('change', common.mustCall(() => {
       setImmediate(() => {
         checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -126,19 +126,3 @@ tmpdir.refresh();
   });
   oldhandle.close(); // clean up
 }
-
-{
-  let oldhandle;
-  assert.throws(() => {
-    const w = fs.watchFile(__filename,
-                           { persistent: false },
-                           common.mustNotCall());
-    oldhandle = w._handle;
-    w._handle = { stop: w._handle.stop };
-    w.stop();
-  }, {
-    message: 'handle must be a StatWatcher',
-    code: 'ERR_ASSERTION'
-  });
-  oldhandle.stop(); // clean up
-}


### PR DESCRIPTION
Wrapping libuv handles is what `HandleWrap` is there for.
This allows a decent reduction of state tracking machinery
by moving active-ness tracking to JS, and removing all
interaction with garbage collection.

Refs: https://github.com/nodejs/node/pull/21093

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
