### PR TITLE
trace_events: set thread name for workers

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -598,11 +598,11 @@ inline bool Environment::is_main_thread() const {
   return thread_id_ == 0;
 }
 
-inline double Environment::thread_id() const {
+inline uint64_t Environment::thread_id() const {
   return thread_id_;
 }
 
-inline void Environment::set_thread_id(double id) {
+inline void Environment::set_thread_id(uint64_t id) {
   thread_id_ = id;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -726,8 +726,8 @@ class Environment {
   bool is_stopping_worker() const;
 
   inline bool is_main_thread() const;
-  inline double thread_id() const;
-  inline void set_thread_id(double id);
+  inline uint64_t thread_id() const;
+  inline void set_thread_id(uint64_t id);
   inline worker::Worker* worker_context() const;
   inline void set_worker_context(worker::Worker* context);
   inline void add_sub_worker_context(worker::Worker* context);
@@ -881,7 +881,7 @@ class Environment {
   std::unordered_map<std::string, uint64_t> performance_marks_;
 
   bool can_call_into_js_ = true;
-  double thread_id_ = 0;
+  uint64_t thread_id_ = 0;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
 
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -62,7 +62,7 @@ class Worker : public AsyncWrap {
 
   bool thread_joined_ = true;
   int exit_code_ = 0;
-  double thread_id_ = -1;
+  uint64_t thread_id_ = -1;
 
   std::unique_ptr<MessagePortData> child_port_data_;
 

--- a/test/parallel/test-trace-events-worker-metadata.js
+++ b/test/parallel/test-trace-events-worker-metadata.js
@@ -1,0 +1,33 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const { isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const CODE = 'const { Worker } = require(\'worker_threads\'); ' +
+               `new Worker('${__filename.replace(/\\/g,'/')}')`;
+  const FILE_NAME = 'node_trace.1.log';
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
+
+  const proc = cp.spawn(process.execPath,
+                        [ '--experimental-worker',
+                          '--trace-event-categories', 'node',
+                          '-e', CODE ]);
+  proc.once('exit', common.mustCall(() => {
+    assert(common.fileExists(FILE_NAME));
+    fs.readFile(FILE_NAME, common.mustCall((err, data) => {
+      const traces = JSON.parse(data.toString()).traceEvents;
+      assert(traces.length > 0);
+      assert(traces.some((trace) =>
+        trace.cat === '__metadata' && trace.name === 'thread_name' &&
+          trace.args.name === 'WorkerThread 1'));
+    }));
+  }));
+} else {
+  // Do nothing here.
+}

--- a/test/parallel/test-trace-events-worker-metadata.js
+++ b/test/parallel/test-trace-events-worker-metadata.js
@@ -8,7 +8,7 @@ const { isMainThread } = require('worker_threads');
 
 if (isMainThread) {
   const CODE = 'const { Worker } = require(\'worker_threads\'); ' +
-               `new Worker('${__filename.replace(/\\/g,'/')}')`;
+               `new Worker('${__filename.replace(/\\/g, '/')}')`;
   const FILE_NAME = 'node_trace.1.log';
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();


### PR DESCRIPTION
names the `Worker` thread in the trace event log. All workers would have the same name... may want to allow differentiation somehow.

/cc @addaleax @ofrobots 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
