### PR TITLE
test: add test to check colorMode type of Console

### DIFF
--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -48,7 +48,7 @@ check(false, false, false);
 // check invalid colorMode type
 {
   const stream = new Writable({
-    write: common.mustNotCall
+    write: common.mustNotCall()
   });
 
   [0, 'true', null, {}, [], () => {}].forEach((colorMode) => {

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -44,3 +44,27 @@ check(true, true, true);
 check(false, true, true);
 check(true, false, false);
 check(false, false, false);
+
+// check invalid colorMode type
+{
+  const stream = new Writable({
+    write: common.mustNotCall
+  });
+
+  [0, 'true', null, {}, [], () => {}].forEach((colorMode) => {
+    const received = util.inspect(colorMode);
+    assert.throws(
+      () => {
+        new Console({
+          stdout: stream,
+          ignoreErrors: false,
+          colorMode: colorMode
+        });
+      },
+      {
+        message: `The argument 'colorMode' is invalid. Received ${received}`,
+        code: 'ERR_INVALID_ARG_VALUE'
+      }
+    );
+  });
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
