### PR TITLE
test: add primitive handler in expectsError

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -685,6 +685,10 @@ exports.expectsError = function expectsError(fn, settings, exact) {
       // always being called.
       assert.fail(`Expected one argument, got ${util.inspect(arguments)}`);
     }
+    if (typeof error !== 'object') {
+      assert.strictEqual(error, settings);
+      return;
+    }
     const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
     assert.strictEqual(descriptor.enumerable,
                        false, 'The error message should be non-enumerable');

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -52,6 +52,12 @@ common.expectsError(
     message: /^fhqwhgads$/
   });
 
+common.expectsError(
+  // eslint-disable-next-line no-throw-literal
+  () => { throw 5; },
+  5
+);
+
 const fnOnce = common.mustCall(() => {});
 fnOnce();
 const fnTwice = common.mustCall(() => {}, 2);


### PR DESCRIPTION
The common.expectsError function is now able to expect a primitive
as error to properly verify that a primitive was thrown.

This just came as a handy thing for me when I worked on something else and I thought it would be a good addition.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
