### PR TITLE
test: mark test-inspector-port-zero-cluster flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -10,12 +10,13 @@ prefix sequential
 test-fs-readfile-tostring-fail: PASS, FLAKY
 
 [$system==win32]
-test-inspector-async-call-stack       : PASS, FLAKY
-test-inspector-bindings               : PASS, FLAKY
-test-inspector-debug-end              : PASS, FLAKY
+test-inspector-async-call-stack          : PASS, FLAKY
 test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
+test-inspector-bindings                  : PASS, FLAKY
+test-inspector-debug-end                 : PASS, FLAKY
 
 [$system==linux]
+test-inspector-port-zero-cluster         :  PASS, FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
Mark test-inspector-port-zero-cluster flaky on Linux. Also,
alphabetize win32 entries in status file.

Please :+1: for fast-tracking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
