### PR TITLE
tools: add BigInt64Array and BigUint64Array to globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -244,6 +244,8 @@ module.exports = {
   },
   globals: {
     BigInt: false,
+    BigInt64Array: false,
+    BigUint64Array: false,
     COUNTER_HTTP_CLIENT_REQUEST: false,
     COUNTER_HTTP_CLIENT_RESPONSE: false,
     COUNTER_HTTP_SERVER_REQUEST: false,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/21237

https://github.com/nodejs/node/pull/21237 only added the BigInt primitive to .eslintrc.js, this patch adds the type arrays to globals as well.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
