### PR TITLE
test: fix deprecation warning due to util.print

### DIFF
--- a/test/parallel/test-child-process-double-pipe.js
+++ b/test/parallel/test-child-process-double-pipe.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const os = require('os');
-const util = require('util');
 const spawn = require('child_process').spawn;
 
 // We're trying to reproduce:
@@ -108,7 +107,7 @@ let result = '';
 // print sed's output
 sed.stdout.on('data', function(data) {
   result += data.toString('utf8', 0, data.length);
-  util.print(data);
+  console.log(data);
 });
 
 sed.stdout.on('end', function(code) {


### PR DESCRIPTION
There should not be a reason to keep using the deprecated API here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)