### PR TITLE
doc: add build wg info to releases.md

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -81,6 +81,19 @@ Notes:
 - Version strings are listed below as _"vx.y.z"_. Substitute for the release
   version.
 
+### 0. Pre-release steps
+
+Before preparing a Node.js release, you must notify the Build Working Group at
+least twenty-four hours in advance of the expected release. Coordinating with
+Build is essential to make sure that the CI works, release files are published,
+and the release blog post is available on the project website.
+
+When preparing a security release, contact Build at least forty-eight hours in
+advance of the expected release. To ensure that the security patch(es) can be
+properly tested, run a `node-test-pull-request` job against the `master` branch
+of the `nodejs-private/node-private` repository a day or so before the
+[CI lockdown procedure][] begins.
+
 ### 1. Cherry-picking from `master` and other branches
 
 Create a new branch named _"vx.y.z-proposal"_, or something similar. Using `git
@@ -517,4 +530,5 @@ Close your release proposal PR and remove the proposal branch.
 
 _In whatever form you do this..._
 
+[CI lockdown procedure]: https://github.com/nodejs/build/blob/master/doc/jenkins-guide.md#restricting-access-for-security-releases
 [nodejs.org release-post.js script]: https://github.com/nodejs/nodejs.org/blob/master/scripts/release-post.js

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -83,19 +83,20 @@ Notes:
 
 ### 0. Pre-release steps
 
-Before preparing a Node.js release, you must notify the Build Working Group at
-least twenty-four hours in advance of the expected release. Coordinating with
+Before preparing a Node.js release, the Build Working Group must be notified at
+least one business day in advance of the expected release. Coordinating with
 Build is essential to make sure that the CI works, release files are published,
 and the release blog post is available on the project website.
 
-Build can be contacted best by opening up an issue on the [issue tracker][],
+Build can be contacted best by opening up an issue on the [Build issue tracker][],
 and by posting in `#node-build` on [webchat.freenode.net][].
 
-When preparing a security release, contact Build at least forty-eight hours in
+When preparing a security release, contact Build at least two weekdays in
 advance of the expected release. To ensure that the security patch(es) can be
 properly tested, run a `node-test-pull-request` job against the `master` branch
 of the `nodejs-private/node-private` repository a day or so before the
-[CI lockdown procedure][] begins.
+[CI lockdown procedure][] begins. This is to confirm that Jenkins can properly
+access the private repository.
 
 ### 1. Cherry-picking from `master` and other branches
 
@@ -534,6 +535,6 @@ Close your release proposal PR and remove the proposal branch.
 _In whatever form you do this..._
 
 [CI lockdown procedure]: https://github.com/nodejs/build/blob/master/doc/jenkins-guide.md#restricting-access-for-security-releases
-[issue tracker]: https://github.com/nodejs/build/issues/new
+[Build issue tracker]: https://github.com/nodejs/build/issues/new
 [nodejs.org release-post.js script]: https://github.com/nodejs/nodejs.org/blob/master/scripts/release-post.js
 [webchat.freenode.net]: https://webchat.freenode.net/

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -88,6 +88,9 @@ least twenty-four hours in advance of the expected release. Coordinating with
 Build is essential to make sure that the CI works, release files are published,
 and the release blog post is available on the project website.
 
+Build can be contacted best by opening up an issue on the [issue tracker][],
+and by posting in `#node-build` on [webchat.freenode.net][].
+
 When preparing a security release, contact Build at least forty-eight hours in
 advance of the expected release. To ensure that the security patch(es) can be
 properly tested, run a `node-test-pull-request` job against the `master` branch
@@ -531,4 +534,6 @@ Close your release proposal PR and remove the proposal branch.
 _In whatever form you do this..._
 
 [CI lockdown procedure]: https://github.com/nodejs/build/blob/master/doc/jenkins-guide.md#restricting-access-for-security-releases
+[issue tracker]: https://github.com/nodejs/build/issues/new
 [nodejs.org release-post.js script]: https://github.com/nodejs/nodejs.org/blob/master/scripts/release-post.js
+[webchat.freenode.net]: https://webchat.freenode.net/


### PR DESCRIPTION
Given the issues faced when preparing the security release tonight, I think it is necessary to document the expectations and reality faced from the Build Working Group. I am hopeful that defining the relationship between the releasers and the all-volunteer WG will help to try and avert last-minute-dashes in the future.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
