### PR TITLE
Float patch for OpenSSL low-severity TLS handshake using a DH(E) DoS (?)

### DIFF
--- a/deps/openssl/openssl/crypto/dh/dh_key.c
+++ b/deps/openssl/openssl/crypto/dh/dh_key.c
@@ -78,9 +78,14 @@ static int generate_key(DH *dh)
     int ok = 0;
     int generate_new_key = 0;
     unsigned l;
-    BN_CTX *ctx;
+    BN_CTX *ctx = NULL;
     BN_MONT_CTX *mont = NULL;
     BIGNUM *pub_key = NULL, *priv_key = NULL;
+
+    if (BN_num_bits(dh->p) > OPENSSL_DH_MAX_MODULUS_BITS) {
+        DHerr(DH_F_GENERATE_KEY, DH_R_MODULUS_TOO_LARGE);
+        return 0;
+    }
 
     ctx = BN_CTX_new();
     if (ctx == NULL)


### PR DESCRIPTION
As per https://mta.openssl.org/pipermail/openssl-announce/2018-June/000127.html:

```
OpenSSL Security Advisory [12 June 2018]
========================================

Client DoS due to large DH parameter (CVE-2018-0732)
====================================================

Severity: Low

During key agreement in a TLS handshake using a DH(E) based ciphersuite a
malicious server can send a very large prime value to the client. This will
cause the client to spend an unreasonably long period of time generating a key
for this prime resulting in a hang until the client has finished. This could be
exploited in a Denial Of Service attack.

Due to the low severity of this issue we are not issuing a new release of
OpenSSL 1.1.0 or 1.0.2 at this time. The fix will be included in OpenSSL 1.1.0i
and OpenSSL 1.0.2p when they become available. The fix is also available in
commit ea7abeeab (for 1.1.0) and commit 3984ef0b7 (for 1.0.2) in the OpenSSL git
repository.
```

This PR is [ea7abeeab](https://github.com/openssl/openssl/commit/ea7abeeab) and would apply to `master` and `v10.x`. [3984ef0b7](https://github.com/openssl/openssl/commit/3984ef0b7) is basically identical and would apply to `v6.x` and `v8.x`.

So the question is whether we want to bother backporting this. I don't have a strong opinion either way but if we do include it I don't think it needs to go out in any special security releases, just along with other releases (if they happen before the next OpenSSLs are released). I don't know why this is labelled "low" and why it's not embargoed (suggesting something more like "very low")—maybe simply because it's the server disrupting clients and that's more difficult to cause widespread problems than the other way around?

/cc @nodejs/security, @nodejs/tsc, @nodejs/release, @nodejs/crypto - sorry for the broad pings but opinions are needed!

---------------------------

Pending OpenSSL 1.1.0i release.

Original message:

    Reject excessively large primes in DH key generation.

    CVE-2018-0732

    Signed-off-by: Guido Vranken <guidovranken@gmail.com>

    (cherry picked from commit 91f7361f47b082ae61ffe1a7b17bb2adf213c7fe)

    Reviewed-by: Tim Hudson <tjh@openssl.org>
    Reviewed-by: Matt Caswell <matt@openssl.org>
    (Merged from https://github.com/openssl/openssl/pull/6457)
