### PR TITLE
test: add tests for process.setgroups()

### DIFF
--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -1,6 +1,11 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+if (common.isWindows || !common.isMainThread) {
+  assert.strictEqual(process.setgroups, undefined);
+  return;
+}
 
 assert.throws(
   () => {

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -1,0 +1,42 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(
+  () => {
+    process.setgroups();
+  },
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+    message: 'The "groups" argument must be of type Array. ' +
+             'Received type undefined'
+  }
+);
+
+assert.throws(
+  () => {
+    process.setgroups([1, -1]);
+  },
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "groups[1]" is out of range. ' +
+              'It must be >= 0 && < 4294967296. Received -1'
+  }
+);
+
+[undefined, null, true, {}, [], () => {}].forEach((val) => {
+  assert.throws(
+    () => {
+      process.setgroups([val]);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "groups[0]" argument must be ' +
+               'one of type number or string. ' +
+               `Received type ${typeof val}`
+    }
+  );
+});


### PR DESCRIPTION
Added tests to validate process.setgroups() arguments

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
