### PR TITLE
crypto: fix behavior of createCipher in wrap mode

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2593,7 +2593,7 @@ void CipherBase::Init(const char* cipher_type,
 
   ctx_.reset(EVP_CIPHER_CTX_new());
 
-  int mode = EVP_CIPHER_mode(cipher);
+  const int mode = EVP_CIPHER_mode(cipher);
   if (mode == EVP_CIPH_WRAP_MODE)
     EVP_CIPHER_CTX_set_flags(ctx_.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2592,10 +2592,14 @@ void CipherBase::Init(const char* cipher_type,
                                iv);
 
   ctx_.reset(EVP_CIPHER_CTX_new());
+
+  int mode = EVP_CIPHER_mode(cipher);
+  if (mode == EVP_CIPH_WRAP_MODE)
+    EVP_CIPHER_CTX_set_flags(ctx_.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
   const bool encrypt = (kind_ == kCipher);
   EVP_CipherInit_ex(ctx_.get(), cipher, nullptr, nullptr, nullptr, encrypt);
 
-  int mode = EVP_CIPHER_CTX_mode(ctx_.get());
   if (encrypt && (mode == EVP_CIPH_CTR_MODE || mode == EVP_CIPH_GCM_MODE ||
       mode == EVP_CIPH_CCM_MODE)) {
     // Ignore the return value (i.e. possible exception) because we are
@@ -2604,9 +2608,6 @@ void CipherBase::Init(const char* cipher_type,
                        "Use Cipheriv for counter mode of %s",
                        cipher_type);
   }
-
-  if (mode == EVP_CIPH_WRAP_MODE)
-    EVP_CIPHER_CTX_set_flags(ctx_.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 
   if (IsAuthenticatedMode()) {
     if (!InitAuthenticated(cipher_type, EVP_CIPHER_iv_length(cipher),


### PR DESCRIPTION
The old implementation silently failed in `EVP_CipherInit_ex` in `EVP_CIPH_WRAP_MODE` with `EVP_R_WRAP_MODE_NOT_ALLOWED`, this commit should fix that by moving the flag to the earliest possible moment.

I am pinging @shigeki who originally authored this in https://github.com/nodejs/node/pull/15037 just in case I missed something and this behavior was intentional.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
