### PR TITLE
crypto: handle OpenSSL error queue in CipherBase

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2566,6 +2566,7 @@ void CipherBase::Init(const char* cipher_type,
                       int key_buf_len,
                       unsigned int auth_tag_len) {
   HandleScope scope(env()->isolate());
+  MarkPopErrorOnReturn mark_pop_error_on_return;
 
 #ifdef NODE_FIPS_MODE
   if (FIPS_mode()) {
@@ -2658,6 +2659,7 @@ void CipherBase::InitIv(const char* cipher_type,
                         int iv_len,
                         unsigned int auth_tag_len) {
   HandleScope scope(env()->isolate());
+  MarkPopErrorOnReturn mark_pop_error_on_return;
 
   const EVP_CIPHER* const cipher = EVP_get_cipherbyname(cipher_type);
   if (cipher == nullptr) {
@@ -2697,7 +2699,6 @@ void CipherBase::InitIv(const char* cipher_type,
       return;
   }
 
-  ClearErrorOnReturn clear_error_on_return;
   if (!EVP_CIPHER_CTX_set_key_length(ctx_.get(), key_len)) {
     ctx_.reset();
     return env()->ThrowError("Invalid key length");
@@ -2898,7 +2899,7 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
 bool CipherBase::SetAAD(const char* data, unsigned int len, int plaintext_len) {
   if (!ctx_ || !IsAuthenticatedMode())
     return false;
-  ClearErrorOnReturn clear_error_on_return;
+  MarkPopErrorOnReturn mark_pop_error_on_return;
 
   int outlen;
   const int mode = EVP_CIPHER_CTX_mode(ctx_.get());
@@ -2958,7 +2959,7 @@ CipherBase::UpdateResult CipherBase::Update(const char* data,
                                             int* out_len) {
   if (!ctx_)
     return kErrorState;
-  ClearErrorOnReturn clear_error_on_return;
+  MarkPopErrorOnReturn mark_pop_error_on_return;
 
   const int mode = EVP_CIPHER_CTX_mode(ctx_.get());
 
@@ -3051,7 +3052,7 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
 bool CipherBase::SetAutoPadding(bool auto_padding) {
   if (!ctx_)
     return false;
-  ClearErrorOnReturn clear_error_on_return;
+  MarkPopErrorOnReturn mark_pop_error_on_return;
   return EVP_CIPHER_CTX_set_padding(ctx_.get(), auto_padding);
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2595,8 +2595,11 @@ void CipherBase::Init(const char* cipher_type,
 
   ctx_.reset(EVP_CIPHER_CTX_new());
   const bool encrypt = (kind_ == kCipher);
-  CHECK(EVP_CipherInit_ex(ctx_.get(), cipher, nullptr,
-                          nullptr, nullptr, encrypt));
+  if (1 != EVP_CipherInit_ex(ctx_.get(), cipher, nullptr,
+                             nullptr, nullptr, encrypt)) {
+    return ThrowCryptoError(env(), ERR_get_error(),
+                            "Failed to initialize cipher");
+  }
 
   int mode = EVP_CIPHER_CTX_mode(ctx_.get());
   if (encrypt && (mode == EVP_CIPH_CTR_MODE || mode == EVP_CIPH_GCM_MODE ||
@@ -2619,12 +2622,15 @@ void CipherBase::Init(const char* cipher_type,
 
   CHECK_EQ(1, EVP_CIPHER_CTX_set_key_length(ctx_.get(), key_len));
 
-  CHECK(EVP_CipherInit_ex(ctx_.get(),
-                          nullptr,
-                          nullptr,
-                          reinterpret_cast<unsigned char*>(key),
-                          reinterpret_cast<unsigned char*>(iv),
-                          encrypt));
+  if (1 != EVP_CipherInit_ex(ctx_.get(),
+                             nullptr,
+                             nullptr,
+                             reinterpret_cast<unsigned char*>(key),
+                             reinterpret_cast<unsigned char*>(iv),
+                             encrypt)) {
+    return ThrowCryptoError(env(), ERR_get_error(),
+                            "Failed to initialize cipher");
+  }
 }
 
 
@@ -2690,8 +2696,11 @@ void CipherBase::InitIv(const char* cipher_type,
     EVP_CIPHER_CTX_set_flags(ctx_.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 
   const bool encrypt = (kind_ == kCipher);
-  CHECK(EVP_CipherInit_ex(ctx_.get(), cipher, nullptr,
-                          nullptr, nullptr, encrypt));
+  if (1 != EVP_CipherInit_ex(ctx_.get(), cipher, nullptr,
+                             nullptr, nullptr, encrypt)) {
+    return ThrowCryptoError(env(), ERR_get_error(),
+                            "Failed to initialize cipher");
+  }
 
   if (IsAuthenticatedMode()) {
     CHECK(has_iv);
@@ -2704,12 +2713,15 @@ void CipherBase::InitIv(const char* cipher_type,
     return env()->ThrowError("Invalid key length");
   }
 
-  CHECK(EVP_CipherInit_ex(ctx_.get(),
-                          nullptr,
-                          nullptr,
-                          reinterpret_cast<const unsigned char*>(key),
-                          reinterpret_cast<const unsigned char*>(iv),
-                          encrypt));
+  if (1 != EVP_CipherInit_ex(ctx_.get(),
+                             nullptr,
+                             nullptr,
+                             reinterpret_cast<const unsigned char*>(key),
+                             reinterpret_cast<const unsigned char*>(iv),
+                             encrypt)) {
+    return ThrowCryptoError(env(), ERR_get_error(),
+                            "Failed to initialize cipher");
+  }
 }
 
 


### PR DESCRIPTION
This handles all errors produced by OpenSSL within the `CipherBase` class. API functions clear the error queue on return, utility functions such as `InitAuthenticated()` ensure that they do not add any new errors to the queue. Previously ignored return values are now being `CHECK`'d.

`::Final` does not clear the error queue as there is a custom error handler in place.

Note that https://github.com/nodejs/node/pull/21287 is required for this to work, otherwise the `CHECK` in line 2597 will fail.

Fixes: https://github.com/nodejs/node/issues/21281

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)