### PR TITLE
net: emit 'close' when socket ends before connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1138,7 +1138,8 @@ function afterConnect(status, handle, req, readable, writable) {
 
   if (status === 0) {
     self.readable = readable;
-    self.writable = writable;
+    if (!self._writableState.ended)
+      self.writable = writable;
     self._unrefTimer();
 
     self.emit('connect');

--- a/test/parallel/test-net-socket-end-before-connect.js
+++ b/test/parallel/test-net-socket-end-before-connect.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const common = require('../common');
+
+const net = require('net');
+
+const server = net.createServer();
+
+server.listen(common.mustCall(() => {
+  const socket = net.createConnection(server.address().port);
+  socket.on('close', common.mustCall(() => server.close()));
+  socket.end();
+}));


### PR DESCRIPTION
Don't set `writable` to true when a socket connects if the socket is
already in an ending state.

In the existing code, afterConnect always set `writable` to true.  This
has been the case for a long time, but previous to commit
9b7a6914a7f0bd754e78b42b48c75851cfd6b3c4, the socket would still be
destroyed by `destroySoon` and emit a `'close'` event. Since that
commit removed this masking behavior, we have relied on maybeDestroy to
destroy the socket when the readble state is ended, and that won't
happen if `writable` is set to true.

Fixes: https://github.com/nodejs/node/issues/21268

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
