### PR TITLE
Test stream writable state

### DIFF
--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -7,7 +7,7 @@ const stream = require('stream');
 const writable = new stream.Writable();
 
 writable._writev = common.mustCall((chunks, cb) => {
-  //two chunks to write
+  //error: two chunks to write
   assert.strictEqual(chunks.length, 2);
   cb();
 }, 1);

--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -7,7 +7,6 @@ const stream = require('stream');
 const writable = new stream.Writable();
 
 writable._writev = common.mustCall((chunks, cb) => {
-  //error: two chunks to write
   assert.strictEqual(chunks.length, 2);
   cb();
 }, 1);

--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -7,7 +7,8 @@ const stream = require('stream');
 const writable = new stream.Writable();
 
 writable._writev = common.mustCall((chunks, cb) => {
-  assert.strictEqual(chunks.length, 2, 'two chunks to write');
+  //two chunks to write
+  assert.strictEqual(chunks.length, 2);
   cb();
 }, 1);
 


### PR DESCRIPTION
First contribution here, this one cleans up one of the test cases to improve the error message thrown when the test fails.
It used to be in the form of:

`AssertionError [ERR_ASSERTION]: two chunks to write`

Now, with this change, error message is in the form of:
```

AssertionError [ERR_ASSERTION]: Input A expected to strictly equal input B:
+ expected - actual

- 2
+ 3
```


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
