### PR TITLE
tests,aix: avoid running fsync on directory

### DIFF
--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -35,7 +35,11 @@ function stat_resource(resource) {
   if (typeof resource === 'string') {
     return fs.statSync(resource);
   } else {
+    const stats = fs.fstatSync(resource);
     // ensure mtime has been written to disk
+    // except for directories on AIX where it cannot be synced
+    if (common.isAIX && stats.isDirectory())
+      return stats;
     fs.fsyncSync(resource);
     return fs.fstatSync(resource);
   }


### PR DESCRIPTION
The underlying fsync system call returns EBADF on a file descriptor
for an open directory. So avoid running fsync on it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
