### PR TITLE
Remove unnecessary parameter in assert call in test-stream2-basic.js

### DIFF
--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -212,10 +212,10 @@ class TestWriter extends EE {
                    'xxxxx' ];
 
   w[0].on('end', common.mustCall(function(received) {
-    assert.deepStrictEqual(received, expect, 'first');
+    assert.deepStrictEqual(received, expect);
   }));
   w[1].on('end', common.mustCall(function(received) {
-    assert.deepStrictEqual(received, expect, 'second');
+    assert.deepStrictEqual(received, expect);
   }));
 
   r.pipe(w[0]);


### PR DESCRIPTION
Removed unnecessary string literals from the assert calls
in parallel/test-stream2-basic.js.

Fixes #21305

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
