### PR TITLE
async_hooks: add currentResource

### DIFF
--- a/benchmark/async_hooks/current-resource-vs-destroy.js
+++ b/benchmark/async_hooks/current-resource-vs-destroy.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const { promisify } = require('util');
+const { readFile } = require('fs');
+const sleep = promisify(setTimeout);
+const read = promisify(readFile);
+const common = require('../common.js');
+const {
+  createHook,
+  currentResource,
+  executionAsyncId
+} = require('async_hooks');
+const { createServer } = require('http');
+
+// configuration for the http server
+// there is no need for parameters in this test
+const connections = 500;
+const path = '/';
+
+const bench = common.createBenchmark(main, {
+  type: ['current-resource', 'destroy'],
+  method: ['callbacks', 'async'],
+  n: [1e6]
+});
+
+function buildCurrentResource(getServe) {
+  const server = createServer(getServe(getCLS, setCLS));
+  const hook = createHook({ init });
+  const cls = Symbol('cls');
+  let closed = false;
+  hook.enable();
+
+  return {
+    server,
+    close
+  };
+
+  function getCLS() {
+    // we need to protect this, as once the hook is
+    // disabled currentResource will return null
+    if (closed) {
+      return;
+    }
+
+    const resource = currentResource();
+    if (!resource[cls]) {
+      return null;
+    }
+    return resource[cls].state;
+  }
+
+  function setCLS(state) {
+    // we need to protect this, as once the hook is
+    // disabled currentResource will return null
+    if (closed) {
+      return;
+    }
+    const resource = currentResource();
+    if (!resource[cls]) {
+      resource[cls] = { state };
+    } else {
+      resource[cls].state = state;
+    }
+  }
+
+  function init(asyncId, type, triggerAsyncId, resource) {
+    if (type === 'TIMERWRAP') return;
+
+    var cr = currentResource();
+    if (cr) {
+      resource[cls] = cr[cls];
+    }
+  }
+
+  function close() {
+    closed = true;
+    hook.disable();
+    server.close();
+  }
+}
+
+function buildDestroy(getServe) {
+  const transactions = new Map();
+  const server = createServer(getServe(getCLS, setCLS));
+  const hook = createHook({ init, destroy });
+  hook.enable();
+
+  return {
+    server,
+    close
+  };
+
+  function getCLS() {
+    const asyncId = executionAsyncId();
+    return transactions.has(asyncId) ? transactions.get(asyncId) : null;
+  }
+
+  function setCLS(value) {
+    const asyncId = executionAsyncId();
+    transactions.set(asyncId, value);
+  }
+
+  function init(asyncId, type, triggerAsyncId, resource) {
+    if (type === 'TIMERWRAP') return;
+
+    transactions.set(asyncId, getCLS());
+  }
+
+  function destroy(asyncId) {
+    transactions.delete(asyncId);
+  }
+
+  function close() {
+    hook.disable();
+    server.close();
+  }
+}
+
+function getServeAwait(getCLS, setCLS) {
+  return async function serve(req, res) {
+    setCLS(Math.random());
+    await sleep(10);
+    await read(__filename);
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ cls: getCLS() }));
+  };
+}
+
+function getServeCallbacks(getCLS, setCLS) {
+  return function serve(req, res) {
+    setCLS(Math.random());
+    setTimeout(function() {
+      readFile(__filename, function() {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ cls: getCLS() }));
+      });
+    }, 10);
+  };
+}
+
+const types = {
+  'current-resource': buildCurrentResource,
+  'destroy': buildDestroy
+};
+
+const asyncMethod = {
+  'callbacks': getServeCallbacks,
+  'async': getServeAwait
+};
+
+function main({ type, method }) {
+  const { server, close } = types[type](asyncMethod[method]);
+
+  server
+    .listen(common.PORT)
+    .on('listening', function() {
+
+      bench.http({
+        path,
+        connections
+      }, function() {
+        close();
+      });
+    });
+}

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -25,6 +25,7 @@ const {
   emitBefore,
   emitAfter,
   emitDestroy,
+  currentResource
 } = internal_async_hooks;
 
 // Get symbols
@@ -216,6 +217,7 @@ module.exports = {
   createHook,
   executionAsyncId,
   triggerAsyncId,
+  currentResource,
   // Embedder API
   AsyncResource,
 };

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -67,6 +67,8 @@ const active_hooks = {
 
 const { registerDestroyHook } = async_wrap;
 
+const { currentResource, setCurrentResource } = async_wrap;
+
 // Each constant tracks how many callbacks there are for any given step of
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
@@ -337,13 +339,14 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
 }
 
 
-function emitBeforeScript(asyncId, triggerAsyncId) {
+function emitBeforeScript(asyncId, triggerAsyncId, resource) {
   // Validate the ids. An id of -1 means it was never set and is visible on the
   // call graph. An id < -1 should never happen in any circumstance. Throw
   // on user calls because async state should still be recoverable.
   validateAsyncId(asyncId, 'asyncId');
   validateAsyncId(triggerAsyncId, 'triggerAsyncId');
 
+  setCurrentResource(resource);
   pushAsyncIds(asyncId, triggerAsyncId);
 
   if (async_hook_fields[kBefore] > 0)
@@ -356,6 +359,8 @@ function emitAfterScript(asyncId) {
 
   if (async_hook_fields[kAfter] > 0)
     emitAfterNative(asyncId);
+
+  setCurrentResource(null);
 
   popAsyncIds(asyncId);
 }
@@ -444,6 +449,7 @@ module.exports = {
   clearDefaultTriggerAsyncId,
   clearAsyncIdStack,
   hasAsyncIdStack,
+  currentResource,
   // Internal Embedder API
   newAsyncId,
   getOrSetAsyncId,
@@ -457,4 +463,5 @@ module.exports = {
   emitAfter: emitAfterScript,
   emitDestroy: emitDestroyScript,
   registerDestroyHook,
+  setCurrentResource
 };

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -43,7 +43,7 @@ function setupNextTick(_setupNextTick, _setupPromises) {
     do {
       while (tock = queue.shift()) {
         const asyncId = tock[async_id_symbol];
-        emitBefore(asyncId, tock[trigger_async_id_symbol]);
+        emitBefore(asyncId, tock[trigger_async_id_symbol], tock);
         // emitDestroy() places the async_id_symbol into an asynchronous queue
         // that calls the destroy callback in the future. It's called before
         // calling tock.callback so destroy will be called even if the callback

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -45,7 +45,8 @@ const {
   // The needed emit*() functions.
   emitBefore,
   emitAfter,
-  emitDestroy
+  emitDestroy,
+  setCurrentResource
 } = require('internal/async_hooks');
 
 // *Must* match Environment::ImmediateInfo::Fields in src/env.h.
@@ -310,7 +311,7 @@ function listOnTimeout(list, now) {
       continue;
     }
 
-    emitBefore(asyncId, timer[trigger_async_id_symbol]);
+    emitBefore(asyncId, timer[trigger_async_id_symbol], timer);
 
     tryOnTimeout(timer);
 
@@ -340,6 +341,7 @@ function tryOnTimeout(timer, start) {
   try {
     ontimeout(timer);
   } finally {
+    setCurrentResource(null);
     if (timer._repeat) {
       rearm(timer, start);
     } else {
@@ -621,7 +623,7 @@ function processImmediate() {
     immediate._destroyed = true;
 
     const asyncId = immediate[async_id_symbol];
-    emitBefore(asyncId, immediate[trigger_async_id_symbol]);
+    emitBefore(asyncId, immediate[trigger_async_id_symbol], immediate);
 
     count++;
     if (immediate[kRefed])

--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -50,7 +50,7 @@ inline AsyncWrap::AsyncScope::AsyncScope(AsyncWrap* wrap)
   Environment* env = wrap->env();
   if (env->async_hooks()->fields()[Environment::AsyncHooks::kBefore] == 0)
     return;
-  EmitBefore(env, wrap->get_async_id());
+  EmitBefore(env, wrap->get_async_id(), wrap->object());
 }
 
 inline AsyncWrap::AsyncScope::~AsyncScope() {

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -139,7 +139,8 @@ class AsyncWrap : public BaseObject {
                             double trigger_async_id);
 
   static void EmitDestroy(Environment* env, double async_id);
-  static void EmitBefore(Environment* env, double async_id);
+  static void EmitBefore(Environment* env, double async_id,
+    v8::Local<v8::Object> resource);
   static void EmitAfter(Environment* env, double async_id);
   static void EmitPromiseResolve(Environment* env, double async_id);
 

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -58,7 +58,7 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
   if (asyncContext.async_id != 0) {
     // No need to check a return value because the application will exit if
     // an exception occurs.
-    AsyncWrap::EmitBefore(env, asyncContext.async_id);
+    AsyncWrap::EmitBefore(env, asyncContext.async_id, object);
   }
 
   if (!IsInnerMakeCallback()) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -177,7 +177,7 @@ void PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<Task> task) {
   Isolate* isolate = Isolate::GetCurrent();
   HandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  InternalCallbackScope cb_scope(env, Local<Object>(), { 0, 0 },
+  InternalCallbackScope cb_scope(env, Local<Object>(), {0, 0},
                                  InternalCallbackScope::kAllowEmptyResource);
   task->Run();
 }

--- a/test/parallel/test-async-hooks-current-resource-await.js
+++ b/test/parallel/test-async-hooks-current-resource-await.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const sleep = require('util').promisify(setTimeout);
+const assert = require('assert');
+const common = require('../common');
+const { currentResource, createHook } = require('async_hooks');
+const { createServer, get } = require('http');
+const sym = Symbol('cls');
+const id = Symbol('id');
+
+// tests continuation local storage with the currentResource API
+// through an async function
+
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    const cr = currentResource();
+    resource[id] = asyncId;
+    if (cr) {
+      resource[sym] = cr[sym];
+    }
+  }
+}).enable();
+
+async function handler(req, res) {
+  currentResource()[sym] = { state: req.url };
+  await sleep(10);
+  const { state } = currentResource()[sym];
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ state }));
+}
+
+const server = createServer(function(req, res) {
+  handler(req, res);
+});
+
+function test(n) {
+  get(`http://localhost:${server.address().port}/${n}`, common.mustCall(function(res) {
+    res.setEncoding('utf8');
+
+    let body = '';
+    res.on('data', function(chunk) {
+      body += chunk;
+    });
+
+    res.on('end', common.mustCall(function() {
+      assert.deepStrictEqual(JSON.parse(body), { state: `/${n}` });
+    }));
+  }));
+}
+
+server.listen(0, common.mustCall(function() {
+  server.unref();
+  for (let i = 0; i < 10; i++) {
+    test(i);
+  }
+}));

--- a/test/parallel/test-async-hooks-current-resource.js
+++ b/test/parallel/test-async-hooks-current-resource.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common');
+const { currentResource, createHook } = require('async_hooks');
+const { createServer, get } = require('http');
+const sym = Symbol('cls');
+const id = Symbol('id');
+
+// tests continuation local storage with the currentResource API
+
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    const cr = currentResource();
+    resource[id] = asyncId;
+    if (cr) {
+      resource[sym] = cr[sym];
+    }
+  }
+}).enable();
+
+const server = createServer(function(req, res) {
+  currentResource()[sym] = { state: req.url };
+  setTimeout(function() {
+    const { state } = currentResource()[sym];
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ state }));
+  }, 10);
+});
+
+function test(n) {
+  get(`http://localhost:${server.address().port}/${n}`, common.mustCall(function(res) {
+    res.setEncoding('utf8');
+
+    let body = '';
+    res.on('data', function(chunk) {
+      body += chunk;
+    });
+
+    res.on('end', common.mustCall(function() {
+      assert.deepStrictEqual(JSON.parse(body), { state: `/${n}` });
+    }));
+  }));
+}
+
+server.listen(0, common.mustCall(function() {
+  server.unref();
+  for (let i = 0; i < 10; i++) {
+    test(i);
+  }
+}));


### PR DESCRIPTION
Remove the need for the destroy hook in the basic APM case.
APM and continuation local storage users can use only the init hook.

This lead to a 5% improvement in throughput. in the attached benchmark:

```
async_hooks/current-resource-vs-destroy.js n=1000000 method="callbacks" type="current-resource" benchmarker="wrk": 7,428.04
async_hooks/current-resource-vs-destroy.js n=1000000 method="async" type="current-resource" benchmarker="wrk": 5,938.27
async_hooks/current-resource-vs-destroy.js n=1000000 method="callbacks" type="destroy" benchmarker="wrk": 7,142.18
async_hooks/current-resource-vs-destroy.js n=1000000 method="async" type="destroy" benchmarker="wrk": 5,297.4
```

I've also measured this against a simple Hapi v17 server and it leads to a 15% improvement.

cc @nodejs/diagnostics @bmeurer @MayaLekova

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
