### PR TITLE
child_process: add the --windows-hide flag

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -523,6 +523,11 @@ var spawn = exports.spawn = function spawn(/* file, args, options */) {
   var options = opts.options;
   var child = new ChildProcess();
 
+  // If run with the --windows-hide flag, hide spawned windows by default.
+  const windowsHideFlag = process.binding('config').windowsHide;
+  if (options.windowsHide === undefined && windowsHideFlag)
+    options.windowsHide = true;
+
   debug('spawn', opts.args, options);
 
   child.spawn({

--- a/src/node.cc
+++ b/src/node.cc
@@ -277,6 +277,11 @@ std::string config_warning_file;  // NOLINT(runtime/string)
 // that is used by lib/internal/bootstrap/node.js
 bool config_expose_internals = false;
 
+// Set in node.cc by ParseArgs when --windows-hide is used.
+// Used in node_config.cc to set a constant on process.binding('config') that
+// is used by lib/child_process.js
+bool config_windows_hide
+
 bool v8_initialized = false;
 
 bool linux_at_secure = false;
@@ -3184,6 +3189,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--v8-pool-size",
     "--zero-fill-buffers",
     "-r",
+    "--windows-hide",
 
     // V8 options (define with '_', which allows '-' or '_')
     "--abort_on_uncaught_exception",
@@ -3418,6 +3424,8 @@ static void ParseArgs(int* argc,
       // Also a V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;
       new_v8_argc += 1;
+    } else if (strcmp(arg, "--windows-hide") == 0) {
+      config_windows_hide = true;
     } else {
       // V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -103,6 +103,9 @@ static void Initialize(Local<Object> target,
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
 
+  if (config_windows_hide)
+    READONLY_BOOLEAN_PROPERTY("windowsHide")
+
   if (env->abort_on_uncaught_exception())
     READONLY_BOOLEAN_PROPERTY("shouldAbortOnUncaughtException");
 


### PR DESCRIPTION
Add a flag called --windows-hide that hides console windows for newly spawned
processes by default on Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/child_process @nodejs/delivery-channels @codebytere 

This *should* work, but I might be wrong. Thinking of adding tests for this, suggestions welcome.