### PR TITLE
Import.meta.require

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -45,6 +45,9 @@ The `import.meta` metaproperty is an `Object` that contains the following
 property:
 
 * `url` {string} The absolute `file:` URL of the module.
+* `require` {Function} To require CommonJS modules. This function enables
+  interoperability between CJS and ESM. See [`require()`]. None of the properties
+  generally exposed on require are available via `import.meta.require`.
 
 ### Unsupported
 
@@ -256,3 +259,4 @@ in the import tree.
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
 [addons]: addons.html
 [dynamic instantiate hook]: #esm_dynamic_instantiate_hook
+[`require()`]: modules.html#modules_require

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -46,8 +46,9 @@ property:
 
 * `url` {string} The absolute `file:` URL of the module.
 * `require` {Function} To require CommonJS modules. This function enables
-  interoperability between CJS and ESM. See [`require()`]. None of the properties
-  generally exposed on require are available via `import.meta.require`.
+  interoperability between CJS and ESM. See [`require()`]. None of the
+  properties generally exposed on require are available via
+  `import.meta.require`.
 
 ### Unsupported
 

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -1,12 +1,16 @@
 'use strict';
 
+const { makeRequireFunction } = require('internal/modules/cjs/helpers');
+const Module = require('module');
 const { internalBinding } = require('internal/bootstrap/loaders');
+
 const {
   setImportModuleDynamicallyCallback,
   setInitializeImportMetaObjectCallback
 } = internalBinding('module_wrap');
+const { defineProperty } = Object;
 
-const { getURLFromFilePath } = require('internal/url');
+const { getURLFromFilePath, getPathFromURL } = require('internal/url');
 const Loader = require('internal/modules/esm/loader');
 const path = require('path');
 const { URL } = require('url');
@@ -27,6 +31,27 @@ function initializeImportMetaObject(wrap, meta) {
   if (vmModule === undefined) {
     // This ModuleWrap belongs to the Loader.
     meta.url = wrap.url;
+    let req;
+    defineProperty(meta, 'require', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        if (req !== undefined)
+          return req;
+        const url = new URL(meta.url);
+        const path = getPathFromURL(url);
+        const mod = new Module(path, null);
+        mod.filename = path;
+        req = makeRequireFunction(mod).bind(null);
+
+        // remove properties that don't affect ESM loading
+        // delete req.cache;
+        // delete req.extensions;
+        // delete req.main;
+        // delete req.resolve.paths;
+        return req;
+      }
+    });
   } else {
     const initializeImportMeta = initImportMetaMap.get(vmModule);
     if (initializeImportMeta !== undefined) {

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -42,13 +42,8 @@ function initializeImportMetaObject(wrap, meta) {
         const path = getPathFromURL(url);
         const mod = new Module(path, null);
         mod.filename = path;
+        mod.paths = Module._nodeModulePaths(path);
         req = makeRequireFunction(mod).bind(null);
-
-        // remove properties that don't affect ESM loading
-        // delete req.cache;
-        // delete req.extensions;
-        // delete req.main;
-        // delete req.resolve.paths;
         return req;
       }
     });

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,20 +3,47 @@
 import '../common';
 import assert from 'assert';
 
+const fixtures = import.meta.require('../common/fixtures');
+
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['url'];
+const keys = ['url', 'require'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);
+
 for (const descriptor of Object.values(descriptors)) {
   delete descriptor.value; // Values are verified below.
-  assert.deepStrictEqual(descriptor, {
-    enumerable: true,
-    writable: true,
-    configurable: true
-  });
 }
+
+assert.deepStrictEqual(descriptors.url, {
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.deepStrictEqual(descriptors.require, {
+  get: descriptors.require.get,
+  set: undefined,
+  enumerable: true,
+  configurable: true
+});
+
+assert.strictEqual(import.meta.require.cache, undefined);
+assert.strictEqual(import.meta.require.extensions, undefined);
+assert.strictEqual(import.meta.require.main, undefined);
+assert.strictEqual(import.meta.require.paths, undefined);
 
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert(import.meta.url.match(urlReg));
+
+const a = import.meta.require(
+  fixtures.path('module-require', 'relative', 'dot.js')
+);
+const b = import.meta.require(
+  fixtures.path('module-require', 'relative', 'dot-slash.js')
+);
+
+assert.strictEqual(a.value, 42);
+// require(".") should resolve like require("./")
+assert.strictEqual(a, b);


### PR DESCRIPTION
Hey All,

This builds on top of @targos's earlier implementation of `import.meta.require`. It has been refactored to work with our current layout for the module system. I've also added some basic tests, let me know if you think we need something more robust.

@nodejs/modules I am not planning to land this without consensus from the group, but I think that this is a necessary base feature no matter what implementation we move forward with. I'll open a corresponding issue to discuss.