### PR TITLE
test: add tests for end event of stream.Duplex

### DIFF
--- a/test/parallel/test-stream-duplex-end.js
+++ b/test/parallel/test-stream-duplex-end.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const Duplex = require('stream').Duplex;
+{
+  const stream = new Duplex();
+  assert(stream.allowHalfOpen);
+  stream.on('finish', common.mustNotCall());
+  assert.strictEqual(stream.emit('end'), false);
+}
+
+{
+  const stream = new Duplex({
+    allowHalfOpen: false
+  });
+  assert.strictEqual(stream.allowHalfOpen, false);
+  stream.on('finish', common.mustCall());
+  assert(stream.emit('end'));
+}
+
+{
+  const stream = new Duplex({
+    allowHalfOpen: false
+  });
+  assert.strictEqual(stream.allowHalfOpen, false);
+  stream._writableState.ended = true;
+  stream.on('finish', common.mustNotCall());
+  assert(stream.emit('end'));
+}


### PR DESCRIPTION
Added tests to check the stream will automatically end the writable side
when readable side ends when allowHalfOpen option is false.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
