### PR TITLE
build: add crypto check to markdown lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1048,7 +1048,7 @@ LINT_MD_DOC_FILES = $(shell ls doc/**/*.md)
 run-lint-doc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_DOC_FILES)
 # Lint all changed markdown files under doc/
 tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
-ifeq ("$(HAS_CRYPTO)", "true")
+ifeq ("$(NODE_USE_OPENSSL)", "true")
 	@echo "Running Markdown linter on docs..."
 	@$(call available-node,$(run-lint-doc-md))
 	@touch $@
@@ -1063,7 +1063,7 @@ LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
 run-lint-misc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_MISC_FILES)
 # Lint other changed markdown files maintained by us
 tools/.miscmdlintstamp: $(LINT_MD_MISC_FILES)
-ifeq ("$(HAS_CRYPTO)", "true")
+ifeq ("$(NODE_USE_OPENSSL)", "true")
 	@echo "Running Markdown linter on misc docs..."
 	@$(call available-node,$(run-lint-misc-md))
 	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ GTEST_FILTER ?= "*"
 GNUMAKEFLAGS += --no-print-directory
 GCOV ?= gcov
 PWD = $(CURDIR)
-NODE_USE_OPENSSL ?= true
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ GTEST_FILTER ?= "*"
 GNUMAKEFLAGS += --no-print-directory
 GCOV ?= gcov
 PWD = $(CURDIR)
+NODE_USE_OPENSSL ?= true
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)

--- a/Makefile
+++ b/Makefile
@@ -1048,7 +1048,7 @@ LINT_MD_DOC_FILES = $(shell ls doc/**/*.md)
 run-lint-doc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_DOC_FILES)
 # Lint all changed markdown files under doc/
 tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
-ifeq ("$(NODE_USE_OPENSSL)", "true")
+ifeq ($(NODE_USE_OPENSSL),true)
 	@echo "Running Markdown linter on docs..."
 	@$(call available-node,$(run-lint-doc-md))
 	@touch $@
@@ -1063,7 +1063,7 @@ LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
 run-lint-misc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_MISC_FILES)
 # Lint other changed markdown files maintained by us
 tools/.miscmdlintstamp: $(LINT_MD_MISC_FILES)
-ifeq ("$(NODE_USE_OPENSSL)", "true")
+ifeq ($(NODE_USE_OPENSSL),true)
 	@echo "Running Markdown linter on misc docs..."
 	@$(call available-node,$(run-lint-misc-md))
 	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -1048,9 +1048,13 @@ LINT_MD_DOC_FILES = $(shell ls doc/**/*.md)
 run-lint-doc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_DOC_FILES)
 # Lint all changed markdown files under doc/
 tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
+ifeq ("$(HAS_CRYPTO)", "true")
 	@echo "Running Markdown linter on docs..."
 	@$(call available-node,$(run-lint-doc-md))
 	@touch $@
+else
+	@echo "Skipping Markdown linter on docs (no crypto)"
+endif
 
 LINT_MD_TARGETS = src lib benchmark tools/doc tools/icu
 LINT_MD_ROOT_DOCS := $(wildcard *.md)
@@ -1059,9 +1063,13 @@ LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
 run-lint-misc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_MISC_FILES)
 # Lint other changed markdown files maintained by us
 tools/.miscmdlintstamp: $(LINT_MD_MISC_FILES)
+ifeq ("$(HAS_CRYPTO)", "true")
 	@echo "Running Markdown linter on misc docs..."
 	@$(call available-node,$(run-lint-misc-md))
 	@touch $@
+else
+	@echo "Skipping Markdown linter on misc docs (no crypto)"
+endif
 
 tools/.mdlintstamp: tools/.miscmdlintstamp tools/.docmdlintstamp
 

--- a/Makefile
+++ b/Makefile
@@ -1046,9 +1046,11 @@ ifneq ("","$(wildcard tools/remark-cli/node_modules/)")
 
 LINT_MD_DOC_FILES = $(shell ls doc/**/*.md)
 run-lint-doc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_DOC_FILES)
+node_use_openssl = $(shell $(call available-node,"-p" \
+		   "process.versions.openssl != undefined"))
 # Lint all changed markdown files under doc/
 tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
-ifeq ($(NODE_USE_OPENSSL),true)
+ifeq ($(node_use_openssl),true)
 	@echo "Running Markdown linter on docs..."
 	@$(call available-node,$(run-lint-doc-md))
 	@touch $@
@@ -1063,7 +1065,7 @@ LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
 run-lint-misc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_MISC_FILES)
 # Lint other changed markdown files maintained by us
 tools/.miscmdlintstamp: $(LINT_MD_MISC_FILES)
-ifeq ($(NODE_USE_OPENSSL),true)
+ifeq ($(node_use_openssl),true)
 	@echo "Running Markdown linter on misc docs..."
 	@$(call available-node,$(run-lint-misc-md))
 	@touch $@

--- a/configure
+++ b/configure
@@ -1517,7 +1517,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'PYTHON': sys.executable,
   'NODE_TARGET_TYPE': variables['node_target_type'],
-  'HAS_CRYPTO': variables['node_use_openssl'],
+  'NODE_USE_OPENSSL': variables['node_use_openssl'],
 }
 
 if options.prefix:

--- a/configure
+++ b/configure
@@ -1517,6 +1517,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'PYTHON': sys.executable,
   'NODE_TARGET_TYPE': variables['node_target_type'],
+  'HAS_CRYPTO': variables['node_use_openssl'],
 }
 
 if options.prefix:

--- a/configure
+++ b/configure
@@ -1517,7 +1517,6 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'PYTHON': sys.executable,
   'NODE_TARGET_TYPE': variables['node_target_type'],
-  'NODE_USE_OPENSSL': variables['node_use_openssl'],
 }
 
 if options.prefix:


### PR DESCRIPTION
Currently, if configured `--without-ssl` the following error will be
repored by remark-cli:
```shell
Running Markdown linter on misc docs...
internal/util.js:100
    throw new ERR_NO_CRYPTO();
    ^

Error [ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto support
    at assertCrypto (internal/util.js:100:11)
    at crypto.js:31:1
    at NativeModule.compile (internal/bootstrap/loaders.js:235:7)
    at Function.NativeModule.require
      (internal/bootstrap/loaders.js:155:18)
    at Function.Module._load (internal/modules/cjs/loader.js:530:25)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous>
      (/node/tools/remark-cli/node_modules/math-random/node.js:1:76)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js
      (internal/modules/cjs/loader.js:713:10)
make[1]: *** [tools/.miscmdlintstamp] Error 1
make: *** [lint] Error 2
```
This commit adds a check for crypto to avoid this error when node has
been configured without crypto support. The alternative was to try to
fix this in randomatic but that lead to another dependency failing
(uuid) and felt like this might be simpler.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
