### PR TITLE
doc: switched the order of Writable and Readable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -37,10 +37,10 @@ the elements of the API that are required to *implement* new types of streams.
 
 There are four fundamental stream types within Node.js:
 
-* [`Readable`][] - streams from which data can be read (for example
-  [`fs.createReadStream()`][]).
 * [`Writable`][] - streams to which data can be written (for example
   [`fs.createWriteStream()`][]).
+* [`Readable`][] - streams from which data can be read (for example
+  [`fs.createReadStream()`][]).
 * [`Duplex`][] - streams that are both `Readable` and `Writable` (for example
   [`net.Socket`][]).
 * [`Transform`][] - `Duplex` streams that can modify or transform the data as it


### PR DESCRIPTION
This change places the links to Writable stream and Readble stream
in the order these sections appear when scrolling down the screen.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
