### PR TITLE
http2: fix memory leak for uncommon headers

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -1203,6 +1203,7 @@ class ExternalHeader :
     }
 
     if (may_internalize && vec.len < 64) {
+      nghttp2_rcbuf_decref(buf);
       // This is a short header name, so there is a good chance V8 already has
       // it internalized.
       return GetInternalizedString(env, vec);


### PR DESCRIPTION
Fix a memory leak that occurs with header names that are
short and not present in the static table of default headers.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
