### PR TITLE
src: remove unused argc var in node_stat_watcher

### DIFF
--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -110,8 +110,6 @@ void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   CHECK(!uv_is_active(wrap->GetHandle()));
 
-  const int argc = args.Length();
-
   node::Utf8Value path(args.GetIsolate(), args[0]);
   CHECK_NOT_NULL(*path);
 


### PR DESCRIPTION
Currently the following compiler warning is reported:
```console
../src/node_stat_watcher.cc:113:13: warning:
unused variable 'argc' [-Wunused-variable]
  const int argc = args.Length();
            ^
1 warning generated.
```
This commit removes the unused argc variable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
