### PR TITLE
tools: enable `quotes` rule in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,32 +147,32 @@ module.exports = {
         message: '__defineSetter__ is deprecated.',
       }
     ],
-    /* eslint-disable max-len, quotes */
+    /* eslint-disable max-len */
     // If this list is modified, please copy the change to lib/.eslintrc.yaml
     'no-restricted-syntax': [
       'error',
       {
         selector: "CallExpression[callee.object.name='assert'][callee.property.name='doesNotThrow']",
-        message: "Please replace `assert.doesNotThrow()` and add a comment next to the code instead."
+        message: 'Please replace `assert.doesNotThrow()` and add a comment next to the code instead.'
       },
       {
-        selector: `CallExpression[callee.object.name='assert'][callee.property.name='rejects'][arguments.length<2]`,
+        selector: "CallExpression[callee.object.name='assert'][callee.property.name='rejects'][arguments.length<2]",
         message: 'assert.rejects() must be invoked with at least two arguments.',
       },
       {
-        selector: `CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.1.type='Literal']:not([arguments.1.regex])`,
+        selector: "CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.1.type='Literal']:not([arguments.1.regex])",
         message: 'Use an object as second argument of assert.throws()',
       },
       {
-        selector: `CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.length<2]`,
+        selector: "CallExpression[callee.object.name='assert'][callee.property.name='throws'][arguments.length<2]",
         message: 'assert.throws() must be invoked with at least two arguments.',
       },
       {
-        selector: `CallExpression[callee.name='setTimeout'][arguments.length<2]`,
+        selector: "CallExpression[callee.name='setTimeout'][arguments.length<2]",
         message: 'setTimeout() must be invoked with at least two arguments.',
       },
       {
-        selector: `CallExpression[callee.name='setInterval'][arguments.length<2]`,
+        selector: "CallExpression[callee.name='setInterval'][arguments.length<2]",
         message: 'setInterval() must be invoked with at least 2 arguments.',
       },
       {


### PR DESCRIPTION
Re-enable `quotes` rule in .eslintrc.js and fix code to abide by the
rule. As a bonus, this makes the code (IMO, anyway) more readable. (It
certainly isn't *less* readable, at least not IMO.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
