### PR TITLE
doc: use imperative in COLLABORATOR_GUIDE

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -463,11 +463,11 @@ Runtime Deprecation cycle. However, there is no requirement that deprecated
 code must progress ultimately to *End-of-Life*. Documentation-only and runtime
 deprecations may remain indefinitely.
 
-A best effort will be made to communicate pending deprecations and associated
-mitigations with the ecosystem as soon as possible (preferably before the pull
-request adding the deprecation lands on the master branch). All deprecations
-included in a Node.js release should be listed prominently in the "Notable
-Changes" section of the release notes.
+Communicate pending deprecations and associated mitigations with the ecosystem
+as soon as possible (preferably before the pull request adding the deprecation
+lands on the master branch). Use the `notable-change` label on all pull requests
+that add a new deprecation or move an existing deprecation to a new deprecation
+level.
 
 ### Involving the TSC
 


### PR DESCRIPTION
Instead of wording the paragraph about communicating deprecations with
the ecosystem as if it were directed at the ecosystem, write it as in
imperative directed at the collaborator, since that is the audience for
the COLLABORATOR_GUIDE. Instead of assuring the reader that a best effort
will be made, instruct the reader to make the effort to communicate with
the ecosystem.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
