### PR TITLE
src: add options to control low-level hooks and disable exceptions

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -213,6 +213,9 @@ NODE_EXTERN void Init(int* argc,
                       const char** argv,
                       int* exec_argc,
                       const char*** exec_argv);
+NODE_EXTERN void InitGeneric(int* argc, const char** argv, int* exec_argc,
+                             const char*** exec_argv, bool standalone_mode,
+                             bool upstream_node_mode);
 
 class ArrayBufferAllocator;
 
@@ -271,6 +274,8 @@ NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
                                            const char* const* exec_argv);
 
 NODE_EXTERN void LoadEnvironment(Environment* env);
+NODE_EXTERN void LoadEnvironmentGeneric(Environment* env, bool standalone_mode,
+                                 bool upstream_node_mode);
 NODE_EXTERN void FreeEnvironment(Environment* env);
 
 // This returns the MultiIsolatePlatform used in the main thread of Node.js.


### PR DESCRIPTION
This PR adds two new exposed methods to `node.cc`, `InitGeneric` and `LoadEnvironmentGeneric` that allow for control of which mode Node should run, which i have called `standalone_mode` and `upstream_node_mode`. Current usage in Electron is [here](https://github.com/electron/electron/blob/master/atom/common/node_bindings.cc#L196-L197). Default behavior of `Init` and `LoadEnvironment` remain the same.

We have 3 modes when running Node in Electron:
1. In the main process, we want to have a full Node environment, but with signal handlers and other low level things disabled
2. In renderer process, we want Node to reuse the web page's context
3. In `ELECTRON_RUN_AS_NODE`, we want Node to run as it runs officially by default

For modes 1 and 3, we have Node create a new V8 context with a Node Environment on it. However, for mode 2, since the V8 context is created by blink for web frames and web workers we make Node create the Node Environment on the V8 context of blink, so no new V8 context is created.

As a result, a renderer process may have multiple Node Environments in it.

/cc @ryzokuken 

##### Checklist
- [x] `make -j4 test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
