### PR TITLE
deps: float 3984ef0 from openssl / CVE-2018-0732 (8.x backport)

### DIFF
--- a/deps/openssl/openssl/crypto/dh/dh_key.c
+++ b/deps/openssl/openssl/crypto/dh/dh_key.c
@@ -130,9 +130,14 @@ static int generate_key(DH *dh)
     int ok = 0;
     int generate_new_key = 0;
     unsigned l;
-    BN_CTX *ctx;
+    BN_CTX *ctx = NULL;
     BN_MONT_CTX *mont = NULL;
     BIGNUM *pub_key = NULL, *priv_key = NULL;
+
+    if (BN_num_bits(dh->p) > OPENSSL_DH_MAX_MODULUS_BITS) {
+        DHerr(DH_F_GENERATE_KEY, DH_R_MODULUS_TOO_LARGE);
+        return 0;
+    }
 
     ctx = BN_CTX_new();
     if (ctx == NULL)


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/21282 but for OpenSSL 1.0.2

I'm not sure what 8.x lts label this should get, if any, so help would be appreciated.

```
Pending OpenSSL 1.0.2p release.

Ref: https://github.com/nodejs/node/pull/21282
Reviewed-By: Shigeki Ohtsu <ohtsu@ohtsu.org>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Upstream: https://github.com/openssl/openssl/commit/3984ef0

Original commit message:
    Reject excessively large primes in DH key generation.

    CVE-2018-0732

    Signed-off-by: Guido Vranken <guidovranken@gmail.com>

    (cherry picked from commit 91f7361)

    Reviewed-by: Tim Hudson <tjh@openssl.org>
    Reviewed-by: Matt Caswell <matt@openssl.org>
    (Merged from #6457)
```