### PR TITLE
deps: float 949ff366 from openssl (ECDSA blinding) (6.x backport)

### DIFF
--- a/deps/openssl/openssl/crypto/ecdsa/ecdsatest.c
+++ b/deps/openssl/openssl/crypto/ecdsa/ecdsatest.c
@@ -137,7 +137,7 @@ int restore_rand(void)
         return 1;
 }
 
-static int fbytes_counter = 0;
+static int fbytes_counter = 0, use_fake = 0;
 static const char *numbers[8] = {
     "651056770906015076056810763456358567190100156695615665659",
     "6140507067065001063065065565667405560006161556565665656654",
@@ -157,6 +157,11 @@ int fbytes(unsigned char *buf, int num)
 {
     int ret;
     BIGNUM *tmp = NULL;
+
+    if (use_fake == 0)
+        return old_rand->bytes(buf, num);
+
+    use_fake = 0;
 
     if (fbytes_counter >= 8)
         return 0;
@@ -199,11 +204,13 @@ int x9_62_test_internal(BIO *out, int nid, const char *r_in, const char *s_in)
     /* create the key */
     if ((key = EC_KEY_new_by_curve_name(nid)) == NULL)
         goto x962_int_err;
+    use_fake = 1;
     if (!EC_KEY_generate_key(key))
         goto x962_int_err;
     BIO_printf(out, ".");
     (void)BIO_flush(out);
     /* create the signature */
+    use_fake = 1;
     signature = ECDSA_do_sign(digest, 20, key);
     if (signature == NULL)
         goto x962_int_err;


### PR DESCRIPTION
Same as https://github.com/nodejs/node/pull/21345 but for 1.0.2 on 8.x.

Pending OpenSSL 1.0.2p release.

Ref: https://www.nccgroup.trust/us/our-research/technical-advisory-return-of-the-hidden-number-problem/
Ref: https://github.com/nodejs/node/pull/21345
Upstream: https://github.com/openssl/openssl/commit/949ff366

Original commit message:

    Add blinding to an ECDSA signature

    Keegan Ryan (NCC Group) has demonstrated a side channel attack on an
    ECDSA signature operation. During signing the signer calculates:

    s:= k^-1 * (m + r * priv_key) mod order

    The addition operation above provides a sufficient signal for a
    flush+reload attack to derive the private key given sufficient signature
    operations.

    As a mitigation (based on a suggestion from Keegan) we add blinding to
    the operation so that:

    s := k^-1 * blind^-1 (blind * m + blind * r * priv_key) mod order

    Since this attack is a localhost side channel only no CVE is assigned.

    Reviewed-by: Rich Salz <rsalz@openssl.org>
