### PR TITLE
Refactor experimental-modules check into runMain

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -504,19 +504,6 @@ Module._load = function(request, parent, isMain) {
     debug('Module._load REQUEST %s parent: %s', request, parent.id);
   }
 
-  if (experimentalModules && isMain) {
-    if (asyncESM === undefined) lazyLoadESM();
-    asyncESM.loaderPromise.then((loader) => {
-      return loader.import(getURLFromFilePath(request).pathname);
-    })
-    .catch((e) => {
-      decorateErrorStack(e);
-      console.error(e);
-      process.exit(1);
-    });
-    return;
-  }
-
   var filename = Module._resolveFilename(request, parent, isMain);
 
   var cachedModule = Module._cache[filename];
@@ -741,7 +728,19 @@ if (experimentalModules) {
 // bootstrap main module.
 Module.runMain = function() {
   // Load the main module--the command line argument.
-  Module._load(process.argv[1], null, true);
+  if (experimentalModules) {
+    if (asyncESM === undefined) lazyLoadESM();
+    asyncESM.loaderPromise.then((loader) => {
+      return loader.import(getURLFromFilePath(process.argv[1]).pathname);
+    })
+    .catch((e) => {
+      decorateErrorStack(e);
+      console.error(e);
+      process.exit(1);
+    });
+  } else {
+    Module._load(process.argv[1], null, true);
+  }
   // Handle any nextTicks added in the first tick of the program
   process._tickCallback();
 };

--- a/test/es-module/test-esm-cjs-main.js
+++ b/test/es-module/test-esm-cjs-main.js
@@ -1,6 +1,27 @@
-// Flags: --experimental-modules
 'use strict';
+
 require('../common');
+const { spawn } = require('child_process');
 const assert = require('assert');
-exports.asdf = 'asdf';
-assert.strictEqual(require.main.exports.asdf, 'asdf');
+const path = require('path');
+
+const entry = path.resolve(__dirname, '../fixtures/es-modules/cjs.js');
+
+const child = spawn(process.execPath, ['--experimental-modules', entry]);
+let experimentalWarning = false;
+let validatedExecution = false;
+child.stderr.on('data', (data) => {
+  if (!experimentalWarning) {
+    experimentalWarning = true;
+    return;
+  }
+  throw new Error(data.toString());
+});
+child.stdout.on('data', (data) => {
+  assert.strictEqual(data.toString(), 'executed\n');
+  validatedExecution = true;
+});
+child.on('close', (code, stdout) => {
+  assert.strictEqual(validatedExecution, true);
+  assert.strictEqual(code, 0);
+});

--- a/test/es-module/test-esm-cjs-main.js
+++ b/test/es-module/test-esm-cjs-main.js
@@ -1,11 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const assert = require('assert');
-const path = require('path');
 
-const entry = path.resolve(__dirname, '../fixtures/es-modules/cjs.js');
+const entry = fixtures.path('/es-modules/cjs.js');
 
 const child = spawn(process.execPath, ['--experimental-modules', entry]);
 let experimentalWarning = false;
@@ -21,7 +21,7 @@ child.stdout.on('data', (data) => {
   assert.strictEqual(data.toString(), 'executed\n');
   validatedExecution = true;
 });
-child.on('close', (code, stdout) => {
+child.on('close', common.mustCall((code, stdout) => {
   assert.strictEqual(validatedExecution, true);
   assert.strictEqual(code, 0);
-});
+}));

--- a/test/es-module/test-esm-error-cache.js
+++ b/test/es-module/test-esm-error-cache.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 common.crashOnUnhandledRejection();
 
-const file = '../../fixtures/syntax/bad_syntax.js';
+const file = '../fixtures/syntax/bad_syntax.js';
 
 let error;
 (async () => {

--- a/test/fixtures/es-modules/cjs.js
+++ b/test/fixtures/es-modules/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// test we can use commonjs require
+require('path');
+console.log('executed');


### PR DESCRIPTION
This provides a slightly cleaner separation, moving the top-level ESM load to higher up in the bootstrap as it should be.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
