### PR TITLE
esm: Ensure custom loader resolved "url" is properly validated

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1207,18 +1207,20 @@ is not supported.
 <a id="ERR_INVALID_RETURN_PROPERTY"></a>
 ### ERR_INVALID_RETURN_PROPERTY
 
-Thrown in case a function option does not return an expected property type.
+Thrown in case a function option does not provide a valid value for one of its
+returned object properties on execution.
 
-<a id="ERR_INVALID_RETURN_PROPERTY_STRING"></a>
-### ERR_INVALID_RETURN_PROPERTY_STRING
+<a id="ERR_INVALID_RETURN_PROPERTY_VALUE"></a>
+### ERR_INVALID_RETURN_PROPERTY_VALUE
 
-Thrown in case a function option does not return an expected string property
-type.
+Thrown in case a function option does not provide an expected value
+type for one of its returned object properties on execution.
 
 <a id="ERR_INVALID_RETURN_VALUE"></a>
 ### ERR_INVALID_RETURN_VALUE
 
-Thrown in case a function option does not return an expected value on execution.
+Thrown in case a function option does not return an expected value
+type on execution.
 For example when a function is expected to return a promise.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1204,6 +1204,17 @@ An invalid `options.protocol` was passed.
 Both `breakEvalOnSigint` and `eval` options were set in the REPL config, which
 is not supported.
 
+<a id="ERR_INVALID_RETURN_PROPERTY"></a>
+### ERR_INVALID_RETURN_PROPERTY
+
+Thrown in case a function option does not return an expected property type.
+
+<a id="ERR_INVALID_RETURN_PROPERTY_STRING"></a>
+### ERR_INVALID_RETURN_PROPERTY_STRING
+
+Thrown in case a function option does not return an expected string property
+type.
+
 <a id="ERR_INVALID_RETURN_VALUE"></a>
 ### ERR_INVALID_RETURN_VALUE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -681,6 +681,20 @@ E('ERR_INVALID_PROTOCOL',
   TypeError);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', TypeError);
+E('ERR_INVALID_RETURN_PROPERTY', (input, name, prop, value) => {
+  let type;
+  if (value && value.constructor && value.constructor.name) {
+    type = `instance of ${value.constructor.name}`;
+  } else {
+    type = `type ${typeof value}`;
+  }
+  return `Expected ${input} to be returned for the ${prop} from the ` +
+         `"${name}" function but got ${type}.`;
+}, TypeError);
+E('ERR_INVALID_RETURN_PROPERTY_STRING', (input, name, prop, value) => {
+  return `Expected a valid ${input} to be returned for the ${prop} from the ` +
+         `"${name}" function but got ${value}.`;
+}, TypeError);
 E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   let type;
   if (value && value.constructor && value.constructor.name) {
@@ -688,8 +702,8 @@ E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   } else {
     type = `type ${typeof value}`;
   }
-  return `Expected ${input} to be returned from the "${name}"` +
-          ` function but got ${type}.`;
+  return `Expected ${input} to be returned from the ` +
+         `"${name}" function but got ${type}.`;
 }, TypeError);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support Buffer, Uint8Array or string input: %s',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -702,8 +702,8 @@ E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   } else {
     type = `type ${typeof value}`;
   }
-  return `Expected ${input} to be returned from the ` +
-         `"${name}" function but got ${type}.`;
+  return `Expected ${input} to be returned from the "${name}"` +
+         ` function but got ${type}.`;
 }, TypeError);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support Buffer, Uint8Array or string input: %s',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -682,18 +682,18 @@ E('ERR_INVALID_PROTOCOL',
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', TypeError);
 E('ERR_INVALID_RETURN_PROPERTY', (input, name, prop, value) => {
+  return `Expected a valid ${input} to be returned for the "${prop}" from the` +
+         ` "${name}" function but got ${value}.`;
+}, TypeError);
+E('ERR_INVALID_RETURN_PROPERTY_VALUE', (input, name, prop, value) => {
   let type;
   if (value && value.constructor && value.constructor.name) {
     type = `instance of ${value.constructor.name}`;
   } else {
     type = `type ${typeof value}`;
   }
-  return `Expected ${input} to be returned for the ${prop} from the ` +
-         `"${name}" function but got ${type}.`;
-}, TypeError);
-E('ERR_INVALID_RETURN_PROPERTY_STRING', (input, name, prop, value) => {
-  return `Expected a valid ${input} to be returned for the ${prop} from the ` +
-         `"${name}" function but got ${value}.`;
+  return `Expected ${input} to be returned for the "${prop}" from the` +
+         ` "${name}" function but got ${type}.`;
 }, TypeError);
 E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   let type;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -2,7 +2,8 @@
 
 const {
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_PROTOCOL,
+  ERR_INVALID_RETURN_PROPERTY,
+  ERR_INVALID_RETURN_PROPERTY_STRING,
   ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
@@ -57,21 +58,32 @@ class Loader {
       await this._resolve(specifier, parentURL, defaultResolve);
 
     if (typeof url !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('url', 'string', url);
+      throw new ERR_INVALID_RETURN_PROPERTY(
+        'string', 'loader resolve', 'url', url
+      );
 
     if (typeof format !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('format', 'string', format);
+      throw new ERR_INVALID_RETURN_PROPERTY_STRING(
+        'string', 'loader resolve', 'format', format
+      );
 
     if (format === 'builtin')
       return { url: `node:${url}`, format };
 
     if (this._resolve !== defaultResolve) {
-      // throws ERR_INVALID_URL for resolve if not valid
-      new URL(url);
+      try {
+        new URL(url);
+      } catch (e) {
+        throw new ERR_INVALID_RETURN_PROPERTY_STRING(
+          'url', 'loader resolve', 'url', url
+        );
+      }
     }
 
     if (format !== 'dynamic' && !url.startsWith('file:'))
-      throw new ERR_INVALID_PROTOCOL(url, 'file:');
+      throw new ERR_INVALID_RETURN_PROPERTY_STRING(
+        'file: url', 'loader resolve', 'url', url
+      );
 
     return { url, format };
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -70,8 +70,8 @@ class Loader {
       );
 
     if (typeof format !== 'string')
-      throw new ERR_INVALID_RETURN_PROPERTY(
-        'module format', 'loader resolve', 'format', format
+      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
+        'string', 'loader resolve', 'format', format
       );
 
     if (format === 'builtin')

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -3,7 +3,7 @@
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_RETURN_PROPERTY,
-  ERR_INVALID_RETURN_PROPERTY_STRING,
+  ERR_INVALID_RETURN_PROPERTY_VALUE,
   ERR_INVALID_RETURN_VALUE,
   ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
@@ -65,13 +65,13 @@ class Loader {
     const { url, format } = resolved;
 
     if (typeof url !== 'string')
-      throw new ERR_INVALID_RETURN_PROPERTY(
+      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
         'string', 'loader resolve', 'url', url
       );
 
     if (typeof format !== 'string')
-      throw new ERR_INVALID_RETURN_PROPERTY_STRING(
-        'string', 'loader resolve', 'format', format
+      throw new ERR_INVALID_RETURN_PROPERTY(
+        'module format', 'loader resolve', 'format', format
       );
 
     if (format === 'builtin')
@@ -81,14 +81,14 @@ class Loader {
       try {
         new URL(url);
       } catch (e) {
-        throw new ERR_INVALID_RETURN_PROPERTY_STRING(
+        throw new ERR_INVALID_RETURN_PROPERTY(
           'url', 'loader resolve', 'url', url
         );
       }
     }
 
     if (format !== 'dynamic' && !url.startsWith('file:'))
-      throw new ERR_INVALID_RETURN_PROPERTY_STRING(
+      throw new ERR_INVALID_RETURN_PROPERTY(
         'file: url', 'loader resolve', 'url', url
       );
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -4,6 +4,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_RETURN_PROPERTY,
   ERR_INVALID_RETURN_PROPERTY_STRING,
+  ERR_INVALID_RETURN_VALUE,
   ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
@@ -54,8 +55,14 @@ class Loader {
     if (!isMain && typeof parentURL !== 'string')
       throw new ERR_INVALID_ARG_TYPE('parentURL', 'string', parentURL);
 
-    const { url, format } =
-      await this._resolve(specifier, parentURL, defaultResolve);
+    const resolved = await this._resolve(specifier, parentURL, defaultResolve);
+
+    if (typeof resolved !== 'object')
+      throw new ERR_INVALID_RETURN_VALUE(
+        'object', 'loader resolve', resolved
+      );
+
+    const { url, format } = resolved;
 
     if (typeof url !== 'string')
       throw new ERR_INVALID_RETURN_PROPERTY(

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -3,7 +3,6 @@
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_PROTOCOL,
-  ERR_INVALID_URL,
   ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
@@ -67,11 +66,8 @@ class Loader {
       return { url: `node:${url}`, format };
 
     if (this._resolve !== defaultResolve) {
-      try {
-        new URL(url);
-      } catch (err) {
-        throw new ERR_INVALID_URL(url);
-      }
+      // throws ERR_INVALID_URL for resolve if not valid
+      new URL(url);
     }
 
     if (format !== 'dynamic' && !url.startsWith('file:'))

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -3,9 +3,11 @@
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_PROTOCOL,
+  ERR_INVALID_URL,
   ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
+const { URL } = require('url');
 const ModuleMap = require('internal/modules/esm/module_map');
 const ModuleJob = require('internal/modules/esm/module_job');
 const defaultResolve = require('internal/modules/esm/default_resolve');
@@ -63,6 +65,14 @@ class Loader {
 
     if (format === 'builtin')
       return { url: `node:${url}`, format };
+
+    if (this._resolve !== defaultResolve) {
+      try {
+        new URL(url);
+      } catch (err) {
+        throw new ERR_INVALID_URL(url);
+      }
+    }
 
     if (format !== 'dynamic' && !url.startsWith('file:'))
       throw new ERR_INVALID_PROTOCOL(url, 'file:');

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -1,71 +1,123 @@
 // Flags: --experimental-modules
 /* eslint-disable node-core/required-modules */
+import common from './index.js';
 
-import assert from 'assert';
+const {
+  PORT,
+  isMainThread,
+  isWindows,
+  isWOW64,
+  isAIX,
+  isLinuxPPCBE,
+  isSunOS,
+  isFreeBSD,
+  isOpenBSD,
+  isLinux,
+  isOSX,
+  isGlibc,
+  enoughTestMem,
+  enoughTestCpu,
+  rootDir,
+  buildType,
+  localIPv6Hosts,
+  opensslCli,
+  PIPE,
+  hasIPv6,
+  childShouldThrowAndAbort,
+  ddCommand,
+  spawnPwd,
+  spawnSyncPwd,
+  platformTimeout,
+  allowGlobals,
+  leakedGlobals,
+  mustCall,
+  mustCallAtLeast,
+  mustCallAsync,
+  hasMultiLocalhost,
+  fileExists,
+  skipIfEslintMissing,
+  canCreateSymLink,
+  getCallSite,
+  mustNotCall,
+  printSkipMessage,
+  skip,
+  ArrayStream,
+  nodeProcessAborted,
+  busyLoop,
+  isAlive,
+  noWarnCode,
+  expectWarning,
+  expectsError,
+  skipIfInspectorDisabled,
+  skipIf32Bits,
+  getArrayBufferViews,
+  getBufferSources,
+  crashOnUnhandledRejection,
+  getTTYfd,
+  runWithInvalidFD,
+  hijackStdout,
+  hijackStderr,
+  restoreStdout,
+  restoreStderr,
+  isCPPSymbolsNotMapped
+} = common;
 
-let knownGlobals = [
-  Buffer,
-  clearImmediate,
-  clearInterval,
-  clearTimeout,
-  global,
-  process,
-  setImmediate,
-  setInterval,
-  setTimeout
-];
-
-if (process.env.NODE_TEST_KNOWN_GLOBALS) {
-  const knownFromEnv = process.env.NODE_TEST_KNOWN_GLOBALS.split(',');
-  allowGlobals(...knownFromEnv);
-}
-
-export function allowGlobals(...whitelist) {
-  knownGlobals = knownGlobals.concat(whitelist);
-}
-
-export function leakedGlobals() {
-  // Add possible expected globals
-  if (global.gc) {
-    knownGlobals.push(global.gc);
-  }
-
-  if (global.DTRACE_HTTP_SERVER_RESPONSE) {
-    knownGlobals.push(DTRACE_HTTP_SERVER_RESPONSE);
-    knownGlobals.push(DTRACE_HTTP_SERVER_REQUEST);
-    knownGlobals.push(DTRACE_HTTP_CLIENT_RESPONSE);
-    knownGlobals.push(DTRACE_HTTP_CLIENT_REQUEST);
-    knownGlobals.push(DTRACE_NET_STREAM_END);
-    knownGlobals.push(DTRACE_NET_SERVER_CONNECTION);
-  }
-
-  if (global.COUNTER_NET_SERVER_CONNECTION) {
-    knownGlobals.push(COUNTER_NET_SERVER_CONNECTION);
-    knownGlobals.push(COUNTER_NET_SERVER_CONNECTION_CLOSE);
-    knownGlobals.push(COUNTER_HTTP_SERVER_REQUEST);
-    knownGlobals.push(COUNTER_HTTP_SERVER_RESPONSE);
-    knownGlobals.push(COUNTER_HTTP_CLIENT_REQUEST);
-    knownGlobals.push(COUNTER_HTTP_CLIENT_RESPONSE);
-  }
-
-  const leaked = [];
-
-  for (const val in global) {
-    if (!knownGlobals.includes(global[val])) {
-      leaked.push(val);
-    }
-  }
-
-  if (global.__coverage__) {
-    return leaked.filter((varname) => !/^(?:cov_|__cov)/.test(varname));
-  } else {
-    return leaked;
-  }
-}
-
-process.on('exit', function() {
-  const leaked = leakedGlobals();
-  if (leaked.length > 0) {
-    assert.fail(`Unexpected global(s) found: ${leaked.join(', ')}`);
-  }
-});
+export {
+  PORT,
+  isMainThread,
+  isWindows,
+  isWOW64,
+  isAIX,
+  isLinuxPPCBE,
+  isSunOS,
+  isFreeBSD,
+  isOpenBSD,
+  isLinux,
+  isOSX,
+  isGlibc,
+  enoughTestMem,
+  enoughTestCpu,
+  rootDir,
+  buildType,
+  localIPv6Hosts,
+  opensslCli,
+  PIPE,
+  hasIPv6,
+  childShouldThrowAndAbort,
+  ddCommand,
+  spawnPwd,
+  spawnSyncPwd,
+  platformTimeout,
+  allowGlobals,
+  leakedGlobals,
+  mustCall,
+  mustCallAtLeast,
+  mustCallAsync,
+  hasMultiLocalhost,
+  fileExists,
+  skipIfEslintMissing,
+  canCreateSymLink,
+  getCallSite,
+  mustNotCall,
+  printSkipMessage,
+  skip,
+  ArrayStream,
+  nodeProcessAborted,
+  busyLoop,
+  isAlive,
+  noWarnCode,
+  expectWarning,
+  expectsError,
+  skipIfInspectorDisabled,
+  skipIf32Bits,
+  getArrayBufferViews,
+  getBufferSources,
+  crashOnUnhandledRejection,
+  getTTYfd,
+  runWithInvalidFD,
+  hijackStdout,
+  hijackStderr,
+  restoreStdout,
+  restoreStderr,
+  isCPPSymbolsNotMapped
+};

--- a/test/es-module/test-esm-loader-invalid-format.mjs
+++ b/test/es-module/test-esm-loader-invalid-format.mjs
@@ -1,0 +1,11 @@
+// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-format.mjs
+import { expectsError, mustCall } from '../common';
+import assert from 'assert';
+
+import('../fixtures/es-modules/test-esm-ok.mjs')
+.then(assert.fail, expectsError({
+  code: 'ERR_INVALID_RETURN_PROPERTY_VALUE',
+  message: 'Expected string to be returned for the "format" from the ' +
+           '"loader resolve" function but got type undefined.'
+}))
+.then(mustCall());

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -1,10 +1,12 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
 /* eslint-disable node-core/required-modules */
 import assert from 'assert';
+import common from '../common';
 
 import('../fixtures/es-modules/test-esm-ok.mjs')
 .then(() => {
   assert.fail();
 }, (err) => {
-  assert.strictEqual(err.code, 'ERR_INVALID_URL');
-});
+  assert.strictEqual(err.code, 'ERR_INVALID_RETURN_PROPERTY_STRING');
+})
+.then(common.mustCall());

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -1,12 +1,11 @@
 // Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
-/* eslint-disable node-core/required-modules */
+import { expectsError, mustCall } from '../common';
 import assert from 'assert';
-import common from '../common';
 
 import('../fixtures/es-modules/test-esm-ok.mjs')
-.then(() => {
-  assert.fail();
-}, (err) => {
-  assert.strictEqual(err.code, 'ERR_INVALID_RETURN_PROPERTY_STRING');
-})
-.then(common.mustCall());
+.then(assert.fail, expectsError({
+  code: 'ERR_INVALID_RETURN_PROPERTY_STRING',
+  message: 'Expected a valid url to be returned for the url from the "loader ' +
+           'resolve" function but got ../fixtures/es-modules/test-esm-ok.mjs.'
+}))
+.then(mustCall());

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -4,8 +4,9 @@ import assert from 'assert';
 
 import('../fixtures/es-modules/test-esm-ok.mjs')
 .then(assert.fail, expectsError({
-  code: 'ERR_INVALID_RETURN_PROPERTY_STRING',
-  message: 'Expected a valid url to be returned for the url from the "loader ' +
-           'resolve" function but got ../fixtures/es-modules/test-esm-ok.mjs.'
+  code: 'ERR_INVALID_RETURN_PROPERTY',
+  message: 'Expected a valid url to be returned for the "url" from the ' +
+           '"loader resolve" function but got ' +
+           '../fixtures/es-modules/test-esm-ok.mjs.'
 }))
 .then(mustCall());

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -1,0 +1,10 @@
+// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-invalid-url.mjs
+/* eslint-disable node-core/required-modules */
+import assert from 'assert';
+
+import('../fixtures/es-modules/test-esm-ok.mjs')
+.then(() => {
+  assert.fail();
+}, (err) => {
+  assert.strictEqual(err.code, 'ERR_INVALID_URL');
+});

--- a/test/fixtures/es-module-loaders/loader-invalid-format.mjs
+++ b/test/fixtures/es-module-loaders/loader-invalid-format.mjs
@@ -1,0 +1,8 @@
+export async function resolve(specifier, parentModuleURL, defaultResolve) {
+  if (parentModuleURL && specifier === '../fixtures/es-modules/test-esm-ok.mjs') {
+    return {
+      url: 'file:///asdf'
+    };
+  }
+  return defaultResolve(specifier, parentModuleURL);
+}

--- a/test/fixtures/es-module-loaders/loader-invalid-url.mjs
+++ b/test/fixtures/es-module-loaders/loader-invalid-url.mjs
@@ -1,5 +1,5 @@
 export async function resolve(specifier, parentModuleURL, defaultResolve) {
-  if (parentModuleURL && specifier !== 'assert') {
+  if (parentModuleURL && specifier === '../fixtures/es-modules/test-esm-ok.mjs') {
     return {
       url: specifier,
       format: 'esm'

--- a/test/fixtures/es-module-loaders/loader-invalid-url.mjs
+++ b/test/fixtures/es-module-loaders/loader-invalid-url.mjs
@@ -1,0 +1,8 @@
+export async function resolve(specifier, parentModuleURL, defaultResolve) {
+  if (parentModuleURL && specifier !== 'assert')
+    return {
+      url: specifier,
+      format: 'esm'
+    };
+  return defaultResolve(specifier, parentModuleURL);
+}

--- a/test/fixtures/es-module-loaders/loader-invalid-url.mjs
+++ b/test/fixtures/es-module-loaders/loader-invalid-url.mjs
@@ -1,8 +1,9 @@
 export async function resolve(specifier, parentModuleURL, defaultResolve) {
-  if (parentModuleURL && specifier !== 'assert')
+  if (parentModuleURL && specifier !== 'assert') {
     return {
       url: specifier,
       format: 'esm'
     };
+  }
   return defaultResolve(specifier, parentModuleURL);
 }


### PR DESCRIPTION
This ensures that any loader returning a non-valid URL from the resolve hook will throw an error in the main resolution.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
