### PR TITLE
doc: use Class Method label consistently

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -672,7 +672,7 @@ assert.strictEqual(aliceSecret.toString('hex'), bobSecret.toString('hex'));
 // OK
 ```
 
-### ECDH.convertKey(key, curve[, inputEncoding[, outputEncoding[, format]]])
+### Class Method: ECDH.convertKey(key, curve[, inputEncoding[, outputEncoding[, format]]])
 <!-- YAML
 added: v10.0.0
 -->


### PR DESCRIPTION
The Buffer doc has a helpful "Class Method" label before static methods
on the Buffer class. The only other class in the docs that I can find
with static methods is ECDH in crypto. Add the label to the one static
method on the ECDH class.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
