### PR TITLE
build: minor improvement to coverage-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ coverage: coverage-test ## Run the tests and generate a coverage report.
 coverage-build: all
 	mkdir -p node_modules
 	if [ ! -d node_modules/nyc ]; then \
-		$(NODE) ./deps/npm install nyc --no-save --no-package-lock; fi
+		$(NODE) ./deps/npm install nyc --no-save --no-package-lock --production; fi
 	if [ ! -d gcovr ]; then git clone -b 3.4 --depth=1 \
 		--single-branch git://github.com/gcovr/gcovr.git; fi
 	if [ ! -d build ]; then git clone --depth=1 \


### PR DESCRIPTION
Do not install devDependencies when installing `nyc` for code coverage
reporting. (In other words, use the `--production` flag with `npm`.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
