### PR TITLE
http2: pass incoming set-cookie header as array

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2130,8 +2130,7 @@ For incoming headers:
 `proxy-authorization`, `range`, `referer`,`retry-after`, `tk`,
 `upgrade-insecure-requests`, `user-agent` or `x-content-type-options` are
 discarded.
-* `set-cookie` is a string if present once or an array in case duplicates
-are present.
+* `set-cookie` is always an array. Duplicates are added to the array.
 * `cookie`: the values are joined together with '; '.
 * For all other headers, the values are joined together with ', '.
 

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -509,7 +509,7 @@ function toHeaderObject(headers) {
       value |= 0;
     var existing = obj[name];
     if (existing === undefined) {
-      obj[name] = value;
+      obj[name] = name === HTTP2_HEADER_SET_COOKIE ? [value] : value;
     } else if (!kSingleValueHeaders.has(name)) {
       switch (name) {
         case HTTP2_HEADER_COOKIE:
@@ -528,10 +528,7 @@ function toHeaderObject(headers) {
           // fields with the same name.  Since it cannot be combined into a
           // single field-value, recipients ought to handle "Set-Cookie" as a
           // special case while processing header fields."
-          if (Array.isArray(existing))
-            existing.push(value);
-          else
-            obj[name] = [existing, value];
+          existing.push(value);
           break;
         default:
           // https://tools.ietf.org/html/rfc7230#section-3.2.2

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -1,14 +1,14 @@
 // Flags: --expose-internals
 'use strict';
 
-// Tests the internal utility function that is used to prepare headers
-// to pass to the internal binding layer.
+// Tests the internal utility functions that are used to prepare headers
+// to pass to the internal binding layer and to build a header object.
 
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
-const { mapToHeaders } = require('internal/http2/util');
+const { mapToHeaders, toHeaderObject } = require('internal/http2/util');
 
 const {
   HTTP2_HEADER_STATUS,
@@ -305,3 +305,41 @@ common.expectsError({
 
 assert(!(mapToHeaders({ te: 'trailers' }) instanceof Error));
 assert(!(mapToHeaders({ te: ['trailers'] }) instanceof Error));
+
+
+{
+  const rawHeaders = [
+    ':status', '200',
+    'cookie', 'foo',
+    'set-cookie', 'sc1',
+    'age', '10',
+    'x-multi', 'first'
+  ];
+  const headers = toHeaderObject(rawHeaders);
+  assert.strictEqual(headers[':status'], 200);
+  assert.strictEqual(headers.cookie, 'foo');
+  assert.deepStrictEqual(headers['set-cookie'], ['sc1']);
+  assert.strictEqual(headers.age, '10');
+  assert.strictEqual(headers['x-multi'], 'first');
+}
+
+{
+  const rawHeaders = [
+    ':status', '200',
+    ':status', '400',
+    'cookie', 'foo',
+    'cookie', 'bar',
+    'set-cookie', 'sc1',
+    'set-cookie', 'sc2',
+    'age', '10',
+    'age', '20',
+    'x-multi', 'first',
+    'x-multi', 'second'
+  ];
+  const headers = toHeaderObject(rawHeaders);
+  assert.strictEqual(headers[':status'], 200);
+  assert.strictEqual(headers.cookie, 'foo; bar');
+  assert.deepStrictEqual(headers['set-cookie'], ['sc1', 'sc2']);
+  assert.strictEqual(headers.age, '10');
+  assert.strictEqual(headers['x-multi'], 'first, second');
+}


### PR DESCRIPTION
Incoming set-cookie headers should be passed to user as array like in http module - even for single occurrence.

Besides improving compatibility between http and http2 it avoids the need to check if the type is an array or not in user code.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Regarding doc: If this PR is accepted #21296 should be updated accordingly - or doc needs to be adapted in this PR if #21296 landed meanwhile.
