### PR TITLE
doc: fix indentation in console.md

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -94,7 +94,7 @@ changes:
   * `stdout` {stream.Writable}
   * `stderr` {stream.Writable}
   * `ignoreErrors` {boolean} Ignore errors when writing to the underlying
-                             streams. **Default:** `true`.
+    streams. **Default:** `true`.
   * `colorMode` {boolean|string} Set color support for this `Console` instance.
     Setting to `true` enables coloring while inspecting values, setting to
     `'auto'` will make color support depend on the value of the `isTTY` property


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Currently, this indented fragment [is wrongly rendered as a code block](https://nodejs.org/download/nightly/v11.0.0-nightly20180616b505d2a1cf/docs/api/console.html#console_new_console_options).