### PR TITLE
build: remove requirement to re-run ./configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ ipch/
 
 /config.mk
 /config.gypi
+/config.status
 /config_fips.gypi
 *-nodegyp*
 /gyp-mac-tool

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,12 @@ out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
 	$(PYTHON) tools/gyp_node.py -f make
 
 config.gypi: configure
-	$(error Missing or stale $@, please run ./$<)
+	@if [ -x config.status ]; then \
+		./config.status; \
+	else \
+		echo Missing or stale $@, please run ./$<; \
+		exit 1; \
+	fi
 
 .PHONY: install
 install: all ## Installs node into $PREFIX (default=/usr/local).

--- a/configure
+++ b/configure
@@ -38,6 +38,8 @@ import string
 # If not run from node/, cd to node/.
 os.chdir(os.path.dirname(__file__) or '.')
 
+original_argv = sys.argv[1:]
+
 # gcc and g++ as defaults matches what GYP's Makefile generator does,
 # except on OS X.
 CC = os.environ.get('CC', 'cc' if sys.platform == 'darwin' else 'gcc')
@@ -1447,6 +1449,9 @@ def make_bin_override():
 
   return bin_override
 
+def shell_quote(arg):
+  return "'" + arg.replace("'", "'\\''") + "'"
+
 output = {
   'variables': {},
   'include_dirs': [],
@@ -1512,6 +1517,10 @@ pprint.pprint(output, indent=2)
 
 write('config.gypi', do_not_edit +
       pprint.pformat(output, indent=2) + '\n')
+
+write('config.status', '#!/bin/sh\nset -ex\n./configure ' +
+      ' '.join([shell_quote(arg) for arg in original_argv]) + '\n')
+os.chmod('config.status', 0775)
 
 config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',

--- a/configure
+++ b/configure
@@ -28,6 +28,7 @@ if sys.version_info[0] != 2 or sys.version_info[1] not in (6, 7):
 import errno
 import optparse
 import os
+import pipes
 import pprint
 import re
 import shlex
@@ -1449,9 +1450,6 @@ def make_bin_override():
 
   return bin_override
 
-def shell_quote(arg):
-  return "'" + arg.replace("'", "'\\''") + "'"
-
 output = {
   'variables': {},
   'include_dirs': [],
@@ -1518,8 +1516,8 @@ pprint.pprint(output, indent=2)
 write('config.gypi', do_not_edit +
       pprint.pformat(output, indent=2) + '\n')
 
-write('config.status', '#!/bin/sh\nset -ex\n./configure ' +
-      ' '.join([shell_quote(arg) for arg in original_argv]) + '\n')
+write('config.status', '#!/bin/sh\nset -x\nexec ./configure ' +
+      ' '.join([pipes.quote(arg) for arg in original_argv]) + '\n')
 os.chmod('config.status', 0775)
 
 config = {


### PR DESCRIPTION
Instead of requiring `./configure` to be run again after
the file changed, first try to re-run the configure script
with the arguments with which it was originally run.

Usually, those arguments will either contain no flags,
or all flags that were passed are still supported.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
