### PR TITLE
lib: ensure every unhandled promise reason is wrapped in an error

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -15,6 +15,9 @@ function setupPromises(_setupPromises) {
 }
 
 function unhandledRejection(promise, reason) {
+  if (process.traceProcessWarnings && !(reason instanceof Error)) {
+    reason = new Error(safeToString(reason));
+  }
   maybeUnhandledPromises.set(promise, {
     reason,
     uid: ++lastPromiseId,


### PR DESCRIPTION
This change adds more debugging context to any unhandled promise.
If the unhandled promise does not have a reason which is an error,
it is very difficult to determine where the error came from.  This
ensures every reason has an appropriate stack trace before the
"next_tick" when the stack is lost.

Refs: https://github.com/nodejs/node/pull/16768

If people like this change, I will happily add any tests/documentation as well.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
