### PR TITLE
http2: fix memory leak when headers are not emitted

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -592,16 +592,12 @@ class Http2Stream : public AsyncWrap,
 
   bool AddHeader(nghttp2_rcbuf* name, nghttp2_rcbuf* value, uint8_t flags);
 
-  inline nghttp2_header* headers() {
-    return current_headers_.data();
+  inline std::vector<nghttp2_header> move_headers() {
+    return std::move(current_headers_);
   }
 
   inline nghttp2_headers_category headers_category() const {
     return current_headers_category_;
-  }
-
-  inline size_t headers_count() const {
-    return current_headers_.size();
   }
 
   void StartHeaders(nghttp2_headers_category category);


### PR DESCRIPTION
When headers are not emitted to JS, e.g. because of an error
before that could happen, we currently still have the vector of
previously received headers lying around, each one holding
a reference count of 1.

To fix the resulting memory leak, release them in the `Http2Stream`
destructor.

Also, clear the vector of headers once they have been emitted –
there’s not need to keep it around, wasting memory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
