### PR TITLE
inspector: don't bind to 0.0.0.0 by default (v6.x)

### DIFF
--- a/configure
+++ b/configure
@@ -572,8 +572,8 @@ def try_check_compiler(cc, lang):
 
   values = (proc.communicate()[0].split() + ['0'] * 7)[0:7]
   is_clang = values[0] == '1'
-  gcc_version = '%s.%s.%s' % tuple(values[1:1+3])
-  clang_version = '%s.%s.%s' % tuple(values[4:4+3])
+  gcc_version = tuple(values[1:1+3])
+  clang_version = tuple(values[4:4+3])
 
   return (True, is_clang, clang_version, gcc_version)
 
@@ -647,13 +647,13 @@ def check_compiler(o):
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
-  elif clang_version < '3.4.2' if is_clang else gcc_version < '4.8.0':
+  elif clang_version < (3, 4, 2) if is_clang else gcc_version < (4, 8, 0):
     warn('C++ compiler too old, need g++ 4.8 or clang++ 3.4.2 (CXX=%s)' % CXX)
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:
     warn('failed to autodetect C compiler version (CC=%s)' % CC)
-  elif not is_clang and gcc_version < '4.2.0':
+  elif not is_clang and gcc_version < (4, 2, 0):
     # clang 3.2 is a little white lie because any clang version will probably
     # do for the C bits.  However, we might as well encourage people to upgrade
     # to a version that is not completely ancient.

--- a/configure
+++ b/configure
@@ -610,7 +610,7 @@ def get_llvm_version(cc):
 
 def get_xcode_version(cc):
   return get_version_helper(
-    cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
+    cc, r"(^Apple LLVM version) ([0-9]+\.[0-9]+)")
 
 def get_gas_version(cc):
   try:

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -29,7 +29,8 @@ class Agent {
   ~Agent();
 
   // Start the inspector agent thread
-  bool Start(v8::Platform* platform, const char* path, int port, bool wait);
+  bool Start(v8::Platform* platform, const char* path,
+             const char* address, int port, bool wait);
   // Stop the inspector agent
   void Stop();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -232,9 +232,10 @@ static struct {
   }
 
   bool StartInspector(Environment *env, const char* script_path,
-                      int port, bool wait) {
+                      const char* host, int port, bool wait) {
 #if HAVE_INSPECTOR
-    return env->inspector_agent()->Start(platform_, script_path, port, wait);
+    return env->inspector_agent()->Start(platform_, script_path,
+                                         host, port, wait);
 #else
     return true;
 #endif  // HAVE_INSPECTOR
@@ -246,7 +247,7 @@ static struct {
   void PumpMessageLoop(Isolate* isolate) {}
   void Dispose() {}
   bool StartInspector(Environment *env, const char* script_path,
-                      int port, bool wait) {
+                      const char* host, int port, bool wait) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
     return false;  // make compiler happy
   }
@@ -4092,8 +4093,9 @@ static void DispatchMessagesDebugAgentCallback(Environment* env) {
 static void StartDebug(Environment* env, const char* path, bool wait) {
   CHECK(!debugger_running);
   if (use_inspector) {
-    debugger_running = v8_platform.StartInspector(env, path, inspector_port,
-                                                  wait);
+    debugger_running = v8_platform.StartInspector(env, path,
+                                                  inspector_host.c_str(),
+                                                  inspector_port, wait);
   } else {
     env->debugger_agent()->set_dispatch_handler(
           DispatchMessagesDebugAgentCallback);

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -446,7 +446,7 @@ exports.startNodeForInspectorTest = function(callback) {
     clearTimeout(timeoutId);
     console.log('[err]', text);
     if (found) return;
-    const match = text.match(/Debugger listening on port (\d+)/);
+    const match = text.match(/Debugger listening on 127\.0\.0\.1:(\d+)\./);
     found = true;
     child.stderr.removeListener('data', dataCallback);
     assert.ok(match, text);

--- a/test/sequential/test-inspector-address.js
+++ b/test/sequential/test-inspector-address.js
@@ -1,0 +1,44 @@
+'use strict';
+const { PORT, mustCall, skipIfInspectorDisabled } = require('../common');
+
+skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+function test(arg, expected, done) {
+  const args = [arg, '-p', 'process.debugPort'];
+  const proc = spawn(process.execPath, args);
+  proc.stdout.setEncoding('utf8');
+  proc.stderr.setEncoding('utf8');
+  let stdout = '';
+  let stderr = '';
+  proc.stdout.on('data', (data) => stdout += data);
+  proc.stderr.on('data', (data) => stderr += data);
+  proc.stdout.on('close', (hadErr) => assert(!hadErr));
+  proc.stderr.on('close', (hadErr) => assert(!hadErr));
+  proc.stderr.on('data', () => {
+    if (!stderr.includes('\n')) return;
+    assert(/Debugger listening on (.+)\./.test(stderr));
+    assert.strictEqual(RegExp.$1, expected);
+  });
+  proc.on('exit', (exitCode, signalCode) => {
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(signalCode, null);
+    done();
+  });
+}
+
+function one() {
+  test(`--inspect=${PORT}`, `127.0.0.1:${PORT}`, mustCall(two));
+}
+
+function two() {
+  test(`--inspect=0.0.0.0:${PORT}`, `0.0.0.0:${PORT}`, mustCall(three));
+}
+
+function three() {
+  test(`--inspect=127.0.0.1:${PORT}`, `127.0.0.1:${PORT}`, mustCall());
+}
+
+one();

--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -1262,7 +1262,7 @@ def XcodeVersion():
   except:
     version = CLTVersion()
     if version:
-      version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
+      version = re.match(r'(\d+\.\d+\.?\d*)', version).groups()[0]
     else:
       raise GypError("No Xcode or CLT version detected!")
     # The CLT has no build information, so we return an empty string.


### PR DESCRIPTION
Change the bind address from 0.0.0.0 to 127.0.0.1 and start respecting
the address part of `--inspect=<address>:<port>` so that the bind
address can be overridden by the user.

Fixes: https://github.com/nodejs/node/issues/21349