### PR TITLE
src: remove .h if -inl.h is already included

### DIFF
--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -1,5 +1,4 @@
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 #include "node_internals.h"
 #include "v8.h"

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -1,7 +1,5 @@
 #include "node.h"
-#include "async_wrap.h"
 #include "async_wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "v8.h"
 

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -1,8 +1,6 @@
 #include "node.h"
 #include "node_internals.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 #include "uv.h"

--- a/src/node_encoding.cc
+++ b/src/node_encoding.cc
@@ -1,8 +1,6 @@
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 #include "string_bytes.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -1,7 +1,6 @@
 #include "node_platform.h"
 #include "node_internals.h"
 
-#include "env.h"
 #include "env-inl.h"
 #include "util.h"
 #include <algorithm>

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -1,8 +1,6 @@
 #include "node.h"
 #include "node_internals.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "uv.h"
 #include "v8.h"


### PR DESCRIPTION
This commit removes the normal header file include if an internal one
is specified as per the CPP_STYLE_GUIDE.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
