### PR TITLE
src: guard against nullptr returned by uv_err_name

### DIFF
--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -100,7 +100,17 @@ Local<Value> UVException(Isolate* isolate,
   if (!msg || !msg[0])
     msg = uv_strerror(errorno);
 
-  Local<String> js_code = OneByteString(isolate, uv_err_name(errorno));
+  const char* err_name = uv_err_name(errorno);
+
+  // prevent V8 crash on creating string from nullptr
+  if (err_name == nullptr) {
+    err_name = "UnknownSystemError";
+    // handle memory leak resultant of uv_err_name
+    // being called with unknown error code
+    free(const_cast<char*>(err_name));
+  }
+
+  Local<String> js_code = OneByteString(isolate, err_name);
   Local<String> js_syscall = OneByteString(isolate, syscall);
   Local<String> js_path;
   Local<String> js_dest;

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -45,8 +45,15 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int err = args[0]->Int32Value();
   CHECK_LT(err, 0);
-  const char* name = uv_err_name(err);
-  args.GetReturnValue().Set(OneByteString(env->isolate(), name));
+  const char* err_name = uv_err_name(err);
+  // prevent V8 crash on creating string from nullptr
+  if (err_name == nullptr) {
+    err_name = "UnknownSystemError";
+    // handle memory leak resultant of uv_err_name
+    // being called with unknown error code
+    free(const_cast<char*>(err_name));
+  }
+  args.GetReturnValue().Set(OneByteString(env->isolate(), err_name));
 }
 
 


### PR DESCRIPTION
In Electron, `uv_err_name` returns `nullptr` on unknown system errors, which V8 tries to create a string from and then crashes. 

This PR introduces a guard against `err_name` being set to null by setting it to `UnknownSystemError` if `nullptr` is returned by `uv_err_name` and thus preventing the V8 crash.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
