### PR TITLE
test: remove the third string literal argument from assert.strictEqual()

### DIFF
--- a/test/parallel/test-string-decoder-end.js
+++ b/test/parallel/test-string-decoder-end.js
@@ -103,8 +103,10 @@ function testBuf(encoding, buf) {
   // .toString() on the buffer
   const res3 = buf.toString(encoding);
 
-  assert.strictEqual(res1, res3, 'one byte at a time should match toString');
-  assert.strictEqual(res2, res3, 'all bytes at once should match toString');
+  // One byte at a time should match toString
+  assert.strictEqual(res1, res3);
+  // All bytes at once should match toString
+  assert.strictEqual(res2, res3);
 }
 
 function testEnd(encoding, incomplete, next, expected) {


### PR DESCRIPTION
Third string literal argument in assert.strictEqual() needs to be
removed. Otherwise, on AssertionError it would not display the
values that failed the check -- this hinders debugging.
The string literals are added as comments above the check.



##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
