### PR TITLE
worker: remove workerData option

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -255,7 +255,6 @@ class Worker extends EventEmitter {
       type: 'loadScript',
       filename,
       doEval: !!options.eval,
-      workerData: options.workerData,
       publicPort: port2,
       hasStdin: !!options.stdin
     }, [port2]);
@@ -391,10 +390,9 @@ function setupChild(evalScript) {
 
   port.on('message', (message) => {
     if (message.type === 'loadScript') {
-      const { filename, doEval, workerData, publicPort, hasStdin } = message;
+      const { filename, doEval, publicPort, hasStdin } = message;
       publicWorker.parentPort = publicPort;
       setupPortReferencing(publicPort, publicPort, 'message');
-      publicWorker.workerData = workerData;
 
       if (!hasStdin)
         workerStdio.stdin.push(null);


### PR DESCRIPTION
to start out my crawl of aligning node's workers with the web, this pr removes `workerData`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
