### PR TITLE
test: make cctest fixture use node::NewIsolate

### DIFF
--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -2,5 +2,5 @@
 
 ArrayBufferUniquePtr NodeTestFixture::allocator{nullptr, nullptr};
 uv_loop_t NodeTestFixture::current_loop;
-std::unique_ptr<node::NodePlatform> NodeTestFixture::platform;
-std::unique_ptr<v8::TracingController> NodeTestFixture::tracing_controller;
+NodePlatformUniquePtr NodeTestFixture::platform;
+TracingControllerUniquePtr NodeTestFixture::tracing_controller;

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -1,7 +1,6 @@
 #include "node_test_fixture.h"
 
+ArrayBufferUniquePtr NodeTestFixture::allocator{nullptr, nullptr};
 uv_loop_t NodeTestFixture::current_loop;
 std::unique_ptr<node::NodePlatform> NodeTestFixture::platform;
-std::unique_ptr<v8::ArrayBuffer::Allocator> NodeTestFixture::allocator;
 std::unique_ptr<v8::TracingController> NodeTestFixture::tracing_controller;
-v8::Isolate::CreateParams NodeTestFixture::params;

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -55,12 +55,14 @@ struct Argv {
 
 using ArrayBufferUniquePtr = std::unique_ptr<node::ArrayBufferAllocator,
       decltype(&node::FreeArrayBufferAllocator)>;
+using TracingControllerUniquePtr = std::unique_ptr<v8::TracingController>;
+using NodePlatformUniquePtr = std::unique_ptr<node::NodePlatform>;
 
 class NodeTestFixture : public ::testing::Test {
  protected:
   static ArrayBufferUniquePtr allocator;
-  static std::unique_ptr<v8::TracingController> tracing_controller;
-  static std::unique_ptr<node::NodePlatform> platform;
+  static TracingControllerUniquePtr tracing_controller;
+  static NodePlatformUniquePtr platform;
   static uv_loop_t current_loop;
   v8::Isolate* isolate_;
 


### PR DESCRIPTION
This commit updates the gtest fixture to use node::NewIsolate instead of
creating a new V8 Isolate using v8::Isolate::New.

The motivation for this is that without calling node::NewIsolate the
various callbacks set on the isolate, for example AddMessageListener,
SetFatalErrorHandler etc, would not get set. I don't think this is the
expected behaviour and I ran into this when writing a new cctest.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
