### PR TITLE
src: fix debugging for multiple categories

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -537,7 +537,7 @@ void Environment::set_debug_categories(const std::string& cats, bool enabled) {
     if (comma_pos == std::string::npos)
       break;
     // Use everything after the `,` as the list for the next iteration.
-    debug_categories = debug_categories.substr(comma_pos);
+    debug_categories = debug_categories.substr(comma_pos + 1);
   }
 }
 


### PR DESCRIPTION
Fix parsing of e.g. `NODE_DEBUG_NATIVE=worker,messaging`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
