### PR TITLE
[8.x] deps: V8: fix bug in InternalPerformPromiseThen

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 59
+#define V8_PATCH_LEVEL 60
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/builtins/builtins-promise-gen.cc
+++ b/deps/v8/src/builtins/builtins-promise-gen.cc
@@ -509,8 +509,8 @@ Node* PromiseBuiltinsAssembler::InternalPerformPromiseThen(
     BIND(&if_existingcallbacks);
     {
       Label if_singlecallback(this), if_multiplecallbacks(this);
-      BranchIfJSObject(existing_deferred_promise, &if_singlecallback,
-                       &if_multiplecallbacks);
+      Branch(HasInstanceType(existing_deferred_promise, FIXED_ARRAY_TYPE),
+             &if_multiplecallbacks, &if_singlecallback);
 
       BIND(&if_singlecallback);
       {

--- a/deps/v8/test/mjsunit/compiler/promise-proxy-callback.js
+++ b/deps/v8/test/mjsunit/compiler/promise-proxy-callback.js
@@ -1,0 +1,21 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class MyPromise extends Promise {
+    static get [Symbol.species]() {
+        return function(f) {
+            console.log("foo")
+            var a = new Promise(f);
+            return new Proxy(new Function(),{})
+        }
+    }
+}
+var p1 = new Promise(function(resolve, reject) {});
+p1.__proto__ = MyPromise.prototype;
+p1.then();
+p1.then();
+
+for (var i = 0; i < 0x20000; i++) {
+    new String()
+}


### PR DESCRIPTION
This fix never landed upstream as it was not longer relevant to active V8 branches for Chromium.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/v8 
@mhdawson this PR is also going to be blocked because of the infra issues with the V8-CI

CI: https://ci.nodejs.org/job/node-test-pull-request/15541/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1498/