### PR TITLE
net: report uv_tcp_open() errors

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -260,8 +260,14 @@ function Socket(options) {
     this[async_id_symbol] = getNewAsyncId(this._handle);
   } else if (options.fd !== undefined) {
     const { fd } = options;
+    let err;
+
     this._handle = createHandle(fd, false);
-    this._handle.open(fd);
+
+    err = this._handle.open(fd);
+    if (err)
+      throw errnoException(err, 'open');
+
     this[async_id_symbol] = this._handle.getAsyncId();
     // options.fd can be string (since it is user-defined),
     // so changing this to === would be semver-major
@@ -271,7 +277,7 @@ function Socket(options) {
         (this._handle instanceof Pipe) &&
         process.platform === 'win32') {
       // Make stdout and stderr blocking on Windows
-      var err = this._handle.setBlocking(true);
+      err = this._handle.setBlocking(true);
       if (err)
         throw errnoException(err, 'setBlocking');
 
@@ -1237,7 +1243,11 @@ function createServerHandle(address, port, addressType, fd) {
       debug('listen invalid fd=%d:', fd, e.message);
       return UV_EINVAL;
     }
-    handle.open(fd);
+
+    err = handle.open(fd);
+    if (err)
+      return err;
+
     handle.readable = true;
     handle.writable = true;
     assert(!address && !port);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -211,8 +211,12 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
   int fd = static_cast<int>(args[0]->IntegerValue());
-  uv_tcp_open(&wrap->handle_, fd);
-  wrap->set_fd(fd);
+  int err = uv_tcp_open(&wrap->handle_, fd);
+
+  if (err == 0)
+    wrap->set_fd(fd);
+
+  args.GetReturnValue().Set(err);
 }
 
 


### PR DESCRIPTION
`uv_tcp_open()` can fail. Prior to this commit, any error was being silently ignored. This commit raises the errors.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
