### PR TITLE
net: validate fds passed to Socket constructor

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -75,7 +75,7 @@ const {
   ERR_SOCKET_BAD_PORT,
   ERR_SOCKET_CLOSED
 } = errors.codes;
-
+const { validateInt32 } = require('internal/validators');
 const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 
 // Lazy loaded to improve startup performance.
@@ -93,6 +93,7 @@ const {
 function noop() {}
 
 function createHandle(fd, is_server) {
+  validateInt32(fd, 'fd', 0);
   const type = TTYWrap.guessHandleType(fd);
   if (type === 'PIPE') {
     return new Pipe(

--- a/test/parallel/test-net-socket-constructor.js
+++ b/test/parallel/test-net-socket-constructor.js
@@ -4,6 +4,14 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
+common.expectsError(() => {
+  new net.Socket({ fd: -1 });
+}, { code: 'ERR_OUT_OF_RANGE' });
+
+common.expectsError(() => {
+  new net.Socket({ fd: 'foo' });
+}, { code: 'ERR_INVALID_ARG_TYPE' });
+
 function test(sock, readable, writable) {
   let socket;
   if (sock instanceof net.Socket) {


### PR DESCRIPTION
This commit validates the file descriptor passed to the TTY wrap's `guessHandleType()` function. Prior to this commit, a bad file descriptor would trigger an abort in the binding layer.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
