### PR TITLE
fs: fix fsPromises.lchmod  errors on non-Mac

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -371,7 +371,7 @@ async function chmod(path, mode) {
 
 async function lchmod(path, mode) {
   if (O_SYMLINK === undefined)
-    throw new ERR_METHOD_NOT_IMPLEMENTED();
+    throw new ERR_METHOD_NOT_IMPLEMENTED('lchmod()');
 
   const fd = await open(path, O_WRONLY | O_SYMLINK);
   return fchmod(fd, mode).finally(fd.close.bind(fd));

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -140,14 +140,25 @@ function verifyStatObject(stat) {
                          (await realpath(newLink)).toLowerCase());
       assert.strictEqual(newPath.toLowerCase(),
                          (await readlink(newLink)).toLowerCase());
+
+      const newMode = 0o666;
       if (common.isOSX) {
         // lchmod is only available on macOS
-        const newMode = 0o666;
         await lchmod(newLink, newMode);
         stats = await lstat(newLink);
         assert.strictEqual(stats.mode & 0o777, newMode);
+      } else {
+        await Promise.all([
+          assert.rejects(
+            lchmod(newLink, newMode),
+            common.expectsError({
+              code: 'ERR_METHOD_NOT_IMPLEMENTED',
+              type: Error,
+              message: 'The lchmod() method is not implemented'
+            })
+          )
+        ]);
       }
-
 
       await unlink(newLink);
     }


### PR DESCRIPTION
On non-macOS, fsPromises.lchmod and lchown throws AssertionError.
Expected behavior is `Error [ERR_METHOD_NOT_IMPLEMENTED]`.
`ERR_METHOD_NOT_IMPLEMENTED()` requires argument, but it didn't set.
Fixes `ERR_METHOD_NOT_IMPLEMENTED()` to `ERR_METHOD_NOT_IMPLEMENTED('lchmod')`
or `ERR_METHOD_NOT_IMPLEMENTED('lchown')`.

Fixes: #21421
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
~~- [ ] documentation is changed or added~~
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
