### PR TITLE
util: fix comment typos

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -287,7 +287,7 @@ function setHasEqualElement(set, val1, strict, memo) {
   return false;
 }
 
-// Note: we val1ly run this multiple times for each loose key!
+// Note: we currently run this multiple times for each loose key!
 // This is done to prevent slowing down the average case.
 function setHasLoosePrim(a, b, val) {
   const altValues = findLooseMatchingPrimitives(val);
@@ -381,9 +381,9 @@ function findLooseMatchingPrimitives(prim) {
 }
 
 // This is a ugly but relatively fast way to determine if a loose equal entry
-// val1ly has a correspondent matching entry. Otherwise checking for such
+// currently has a correspondent matching entry. Otherwise checking for such
 // values would be way more expensive (O(n^2)).
-// Note: we val1ly run this multiple times for each loose key!
+// Note: we currently run this multiple times for each loose key!
 // This is done to prevent slowing down the average case.
 function mapHasLoosePrim(a, b, key1, memo, item1, item2) {
   const altKeys = findLooseMatchingPrimitives(key1);


### PR DESCRIPTION
When the deep(Strict)Equal comparison functions were moved to an
internal module, a variable named `current` was replaced with `val1`.
That accidentally also replaced a few "currently"s in comments.

Refs: https://github.com/nodejs/node/pull/16084

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
