### PR TITLE
doc: Windows building officially supported only on x64 hosts

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -42,8 +42,8 @@ platforms in production.
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x64, arm             |                  |
 | GNU/Linux    | Tier 1       | kernel >= 3.10, glibc >= 2.17    | arm64                |                  |
 | macOS/OS X   | Tier 1       | >= 10.11                         | x64                  |                  |
-| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | vs2017           |
-| SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
+| Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | [2](#fn2),[3](#fn3),[4](#fn4) |
+| SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | [1](#fn1) |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
 | AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be >=power7     |                  |
@@ -51,7 +51,7 @@ platforms in production.
 | GNU/Linux    | Experimental | kernel >= 2.6.32, glibc >= 2.12  | x86                  | limited CI       |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |
 
-note1 - The gcc4.8-libs package needs to be installed, because node
+<em id="fn1">1</em>: The gcc4.8-libs package needs to be installed, because node
   binaries have been built with GCC 4.8, for which runtime libraries are not
   installed by default. For these node versions, the recommended binaries
   are the ones available in pkgsrc, not the one available from nodejs.org.
@@ -60,19 +60,22 @@ note1 - The gcc4.8-libs package needs to be installed, because node
   by Joyent. SmartOS images >= 16.4 are not supported because
   GCC 4.8 runtime libraries are not available in their pkgsrc repository
 
-*Note*: On Windows, running Node.js in windows terminal emulators like `mintty`
-  requires the usage of [winpty](https://github.com/rprichard/winpty) for
-  Node's tty channels to work correctly (e.g. `winpty node.exe script.js`).
+<em id="fn2">2</em>: Tier 1 support for building on Windows is only on 64 bit
+  hosts. Support is experimental for 32 bit hosts.
+
+<em id="fn3">3</em>: On Windows, running Node.js in Windows terminal emulators
+  like `mintty` requires the usage of [winpty](https://github.com/rprichard/winpty)
+  for the tty channels to work correctly (e.g. `winpty node.exe script.js`).
   In "Git bash" if you call the node shell alias (`node` without the `.exe`
   extension), `winpty` is used automatically.
 
-The Windows Subsystem for Linux (WSL) is not directly supported, but the
-GNU/Linux build process and binaries should work. The community will only
-address issues that reproduce on native GNU/Linux systems. Issues that only
-reproduce on WSL should be reported in the
-[WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
-Windows binary (`node.exe`) in WSL is not recommended, and will not work
-without adjustment (such as stdio redirection).
+<em id="fn4">4</em>: The Windows Subsystem for Linux (WSL) is not directly
+  supported, but the GNU/Linux build process and binaries should work. The
+  community will only address issues that reproduce on native GNU/Linux
+  systems. Issues that only reproduce on WSL should be reported in the
+  [WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
+  Windows binary (`node.exe`) in WSL is not recommended, and will not work
+  without adjustment (such as stdio redirection).
 
 ### Supported toolchains
 
@@ -88,7 +91,7 @@ Depending on host platform, the selection of toolchains may vary.
 
 #### Windows
 
-* Visual Studio 2017 or the Build Tools thereof
+* Visual Studio 2017 with the Windows 10 SDK on a 64 bit host.
 
 #### OpenSSL asm support
 


### PR DESCRIPTION
Since we are CI testing on x64 hosts, we can only commit to x64 hosts.
We could add x86_x86 and x86_x64 as `Experimental`, to indicate willingness to accept community PRs.

Ref: https://github.com/nodejs/node/issues/21402
Ref: https://github.com/nodejs/node/pull/21437

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
