### PR TITLE
doc: update notes about GCM decryption

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -434,16 +434,8 @@ supported), the `decipher.setAuthTag()` method is used to pass in the
 received _authentication tag_. If no tag is provided, or if the cipher text
 has been tampered with, [`decipher.final()`][] will throw, indicating that the
 cipher text should be discarded due to failed authentication. If the tag length
-is invalid according to [NIST SP 800-38D][], `decipher.setAuthTag()` will throw
-an error.
-
-Note that this Node.js version does not verify the length of GCM authentication
-tags. Such a check *must* be implemented by applications and is crucial to the
-authenticity of the encrypted data, otherwise, an attacker can use an
-arbitrarily short authentication tag to increase the chances of successfully
-passing authentication (up to 0.39%). It is highly recommended to associate one
-of the values 16, 15, 14, 13, 12, 8 or 4 bytes with each key, and to only permit
-authentication tags of that length, see [NIST SP 800-38D][].
+is invalid according to [NIST SP 800-38D][] or does not match the value of the
+`authTagLength` option, `decipher.setAuthTag()` will throw an error.
 
 The `decipher.setAuthTag()` method must be called before
 [`decipher.final()`][].


### PR DESCRIPTION
Given that https://github.com/nodejs/node/pull/17825 and https://github.com/nodejs/node/pull/20039 have landed on master, this statement is no longer true.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
