### PR TITLE
tools: fix typo in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,7 @@ module.exports = {
       {
         object: 'assert',
         property: 'equal',
-        message: 'Use assert.astrictEqual() rather than assert.equal().',
+        message: 'Use assert.strictEqual() rather than assert.equal().',
       },
       {
         object: 'assert',


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/18566

`astrictEqual` is not a thing.

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
