### PR TITLE
async_hooks: add getActiveResources (prototype)

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -6,6 +6,7 @@ const {
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
 const internal_async_hooks = require('internal/async_hooks');
+const internalTimers = require('internal/timers');
 
 // Get functions
 // For userland AsyncResources, make sure to emit a destroy event when the
@@ -123,6 +124,35 @@ function createHook(fns) {
 }
 
 
+function getActiveResources() {
+  const handles = process._getActiveHandles();
+  const reqs = process._getActiveRequests();
+
+  const timers = {};
+  for (const list of Object.values(internalTimers.timerLists)) {
+    var timer = list._idlePrev === list ? null : list._idlePrev;
+
+    while (timer !== null) {
+      timers[timer[internalTimers.async_id_symbol]] = timer;
+
+      timer = timer._idlePrev === list ? null : list._idlePrev;
+    }
+  }
+
+  const immediates = {};
+  const queue = internalTimers.outstandingQueue.head !== null ?
+    internalTimers.outstandingQueue : internalTimers.immediateQueue;
+  var immediate = queue.head;
+  while (immediate !== null) {
+    immediates[immediate[internalTimers.async_id_symbol]] = immediate;
+
+    immediate = immediate._idleNext;
+  }
+
+  return Object.assign({}, handles, reqs, timers, immediates);
+}
+
+
 // Embedder API //
 
 const destroyedSymbol = Symbol('destroyed');
@@ -216,6 +246,7 @@ module.exports = {
   createHook,
   executionAsyncId,
   triggerAsyncId,
+  getActiveResources,
   // Embedder API
   AsyncResource,
 };

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -21,6 +21,59 @@ const TIMEOUT_MAX = 2 ** 31 - 1;
 
 const kRefed = Symbol('refed');
 
+// Object map containing linked lists of timers, keyed and sorted by their
+// duration in milliseconds.
+//
+// - key = time in milliseconds
+// - value = linked list
+const timerLists = Object.create(null);
+
+// A linked list for storing `setImmediate()` requests
+function ImmediateList() {
+  this.head = null;
+  this.tail = null;
+}
+
+// Appends an item to the end of the linked list, adjusting the current tail's
+// previous and next pointers where applicable
+ImmediateList.prototype.append = function(item) {
+  if (this.tail !== null) {
+    this.tail._idleNext = item;
+    item._idlePrev = this.tail;
+  } else {
+    this.head = item;
+  }
+  this.tail = item;
+};
+
+// Removes an item from the linked list, adjusting the pointers of adjacent
+// items and the linked list's head or tail pointers as necessary
+ImmediateList.prototype.remove = function(item) {
+  if (item._idleNext !== null) {
+    item._idleNext._idlePrev = item._idlePrev;
+  }
+
+  if (item._idlePrev !== null) {
+    item._idlePrev._idleNext = item._idleNext;
+  }
+
+  if (item === this.head)
+    this.head = item._idleNext;
+  if (item === this.tail)
+    this.tail = item._idlePrev;
+
+  item._idleNext = null;
+  item._idlePrev = null;
+};
+
+// Create a single linked list instance only once at startup
+const immediateQueue = new ImmediateList();
+
+// If an uncaught exception was thrown during execution of immediateQueue,
+// this queue will store all remaining Immediates that need to run upon
+// resolution of all error handling (if process is still alive).
+const outstandingQueue = new ImmediateList();
+
 module.exports = {
   TIMEOUT_MAX,
   kTimeout: Symbol('timeout'), // For hiding Timeouts on other internals.
@@ -30,7 +83,10 @@ module.exports = {
   kRefed,
   initAsyncResource,
   setUnrefTimeout,
-  validateTimerDuration
+  validateTimerDuration,
+  timerLists,
+  immediateQueue,
+  outstandingQueue
 };
 
 var timers;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -33,7 +33,10 @@ const {
   Timeout,
   kRefed,
   initAsyncResource,
-  validateTimerDuration
+  validateTimerDuration,
+  timerLists: lists,
+  immediateQueue,
+  outstandingQueue
 } = require('internal/timers');
 const internalUtil = require('internal/util');
 const { createPromise, promiseResolve } = process.binding('util');
@@ -127,14 +130,6 @@ const [immediateInfo, toggleImmediateRef] =
 // Timeout lists and the object map lookup of a specific list by the duration of
 // timers within (or creation of a new list). However, these operations combined
 // have shown to be trivial in comparison to other timers architectures.
-
-
-// Object map containing linked lists of timers, keyed and sorted by their
-// duration in milliseconds.
-//
-// - key = time in milliseconds
-// - value = linked list
-const lists = Object.create(null);
 
 // This is a priority queue with a custom sorting function that first compares
 // the expiry times of two lists and if they're the same then compares their
@@ -555,53 +550,6 @@ Timeout.prototype.close = function() {
   clearTimeout(this);
   return this;
 };
-
-
-// A linked list for storing `setImmediate()` requests
-function ImmediateList() {
-  this.head = null;
-  this.tail = null;
-}
-
-// Appends an item to the end of the linked list, adjusting the current tail's
-// previous and next pointers where applicable
-ImmediateList.prototype.append = function(item) {
-  if (this.tail !== null) {
-    this.tail._idleNext = item;
-    item._idlePrev = this.tail;
-  } else {
-    this.head = item;
-  }
-  this.tail = item;
-};
-
-// Removes an item from the linked list, adjusting the pointers of adjacent
-// items and the linked list's head or tail pointers as necessary
-ImmediateList.prototype.remove = function(item) {
-  if (item._idleNext !== null) {
-    item._idleNext._idlePrev = item._idlePrev;
-  }
-
-  if (item._idlePrev !== null) {
-    item._idlePrev._idleNext = item._idleNext;
-  }
-
-  if (item === this.head)
-    this.head = item._idleNext;
-  if (item === this.tail)
-    this.tail = item._idlePrev;
-
-  item._idleNext = null;
-  item._idlePrev = null;
-};
-
-// Create a single linked list instance only once at startup
-const immediateQueue = new ImmediateList();
-
-// If an uncaught exception was thrown during execution of immediateQueue,
-// this queue will store all remaining Immediates that need to run upon
-// resolution of all error handling (if process is still alive).
-const outstandingQueue = new ImmediateList();
 
 
 function processImmediate() {

--- a/test/parallel/test-async-hooks-getactiveresources-requests.js
+++ b/test/parallel/test-async-hooks-getactiveresources-requests.js
@@ -3,8 +3,9 @@
 require('../common');
 const assert = require('assert');
 const fs = require('fs');
+const { getActiveResources } = require('async_hooks');
 
 for (let i = 0; i < 12; i++)
   fs.open(__filename, 'r', () => {});
 
-assert.strictEqual(12, process._getActiveRequests().length);
+assert.strictEqual(12, Object.values(getActiveResources()).length);

--- a/test/parallel/test-async-hooks-getactiveresources.js
+++ b/test/parallel/test-async-hooks-getactiveresources.js
@@ -3,6 +3,8 @@
 require('../common');
 const assert = require('assert');
 const net = require('net');
+const { getActiveResources } = require('async_hooks');
+
 const NUM = 8;
 const connections = [];
 const clients = [];
@@ -30,18 +32,18 @@ function clientConnected(client) {
 
 
 function checkAll() {
-  const handles = process._getActiveHandles();
+  const handles = Object.values(getActiveResources());
 
   clients.forEach(function(item) {
-    assert.ok(handles.includes(item));
+    assert.ok(handles.includes(item._handle));
     item.destroy();
   });
 
   connections.forEach(function(item) {
-    assert.ok(handles.includes(item));
+    assert.ok(handles.includes(item._handle));
     item.end();
   });
 
-  assert.ok(handles.includes(server));
+  assert.ok(handles.includes(server._handle));
   server.close();
 }

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const strictEqual = require('assert').strictEqual;
+const { getActiveResources } = require('async_hooks');
 
 // child_process
 {
@@ -113,10 +114,10 @@ const dgram = require('dgram');
 // timers
 {
   const { Timer } = process.binding('timer_wrap');
-  strictEqual(process._getActiveHandles().filter(
+  strictEqual(Object.values(getActiveResources()).filter(
     (handle) => (handle instanceof Timer)).length, 0);
   const timer = setTimeout(() => {}, 500);
-  const handles = process._getActiveHandles().filter(
+  const handles = Object.values(getActiveResources()).filter(
     (handle) => (handle instanceof Timer));
   strictEqual(handles.length, 1);
   const handle = handles[0];

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -4,6 +4,7 @@ require('../common');
 
 const { TTY, isTTY } = process.binding('tty_wrap');
 const strictEqual = require('assert').strictEqual;
+const { getActiveResources } = require('async_hooks');
 
 strictEqual(isTTY(0), true, 'fd 0 is not a TTY');
 
@@ -12,7 +13,8 @@ handle.readStart();
 handle.onread = () => {};
 
 function isHandleActive(handle) {
-  return process._getActiveHandles().some((active) => active === handle);
+  return Object.values(getActiveResources())
+    .some((active) => active === handle);
 }
 
 strictEqual(isHandleActive(handle), true, 'TTY handle not initially active');


### PR DESCRIPTION
Prototype of a new `getActiveResources()` API for `async_hooks`.

Returns an object map of `{ <id>: <resource> }`, and differs slightly from `getActiveHandles()`. (The old API used to return the handle owner property for some reason.)

Currently, it works for all async_hooks resources except nextTick-s, which are probably not useful to expose in this way.

Reason being that nextTick-s almost always have no interesting information attached, and exist in async_hooks almost exclusively for continuation purposes. The same thing can pretty much be said for Immediate-s too, and I wouldn't be opposed to removing them from this.

As an alternative to not producing nextTicks, I think something along the lines of `getActiveResources(async_type_mask)` could be acceptable.

-----

There are two primary reasons for why this might be useful compared to `async_hooks`, and why `_getActiveHandles()` is still useful today.

1. Handle access. This bypasses the tricky problem of somehow storing a weak reference to handles so that you can access them up to `destroy()` but also not prevent GC.
2. Performance. It is unnecessary to do tracking on each resource allocation, which requires boundary crossing for C++ resources on each call and also dealing with the way-too-plentiful nextTicks.

The root _why_ of this is that some tools (such as N|Solid) like to have access to this kind of thing so we can inspect what kind of resources are active in a live application at any arbitrary point in time.

-----

@nodejs/diagnostics @mike-kaufman @gpotter2 

Supersedes https://github.com/nodejs/node/pull/21102 & probably also https://github.com/nodejs/node/pull/21313

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
