### PR TITLE
doc: clarify setServer method

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1010,7 +1010,12 @@ An error will be thrown if an invalid address is provided.
 The `dnsPromises.setServers()` method must not be called while a DNS query is in
 progress.
 
-Note that this method works much like [resolve.conf in Linux](http://man7.org/linux/man-pages/man5/resolv.conf.5.html). That is, if attempting to resolve with the first server provided results in a `NOTFOUND` error, the `resolve` method will *not* attempt to resolve with subsequent servers provided. Fallback DNS servers will only be used if the earlier ones time out or result in some other error.
+Note that this method works much like
+[resolve.conf](http://man7.org/linux/man-pages/man5/resolv.conf.5.html).
+That is, if attempting to resolve with the first server provided results in a
+`NOTFOUND` error, the `resolve` method will *not* attempt to resolve with
+subsequent servers provided. Fallback DNS servers will only be used if the
+earlier ones time out or result in some other error.
 
 ## Error codes
 

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1010,6 +1010,8 @@ An error will be thrown if an invalid address is provided.
 The `dnsPromises.setServers()` method must not be called while a DNS query is in
 progress.
 
+Note that this method works much like [resolve.conf in Linux](http://man7.org/linux/man-pages/man5/resolv.conf.5.html). That is, if attempting to resolve with the first server provided results in a `NOTFOUND` error, the `resolve` method will *not* attempt to resolve with subsequent servers provided. Fallback DNS servers will only be used if the earlier ones time out or result in some other error.
+
 ## Error codes
 
 Each DNS query can return one of the following error codes:

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -568,6 +568,13 @@ An error will be thrown if an invalid address is provided.
 The `dns.setServers()` method must not be called while a DNS query is in
 progress.
 
+Note that this method works much like
+[resolve.conf](http://man7.org/linux/man-pages/man5/resolv.conf.5.html).
+That is, if attempting to resolve with the first server provided results in a
+`NOTFOUND` error, the `resolve` method will *not* attempt to resolve with
+subsequent servers provided. Fallback DNS servers will only be used if the
+earlier ones time out or result in some other error.
+
 ## DNS Promises API
 
 > Stability: 1 - Experimental

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -571,7 +571,7 @@ progress.
 Note that this method works much like
 [resolve.conf](http://man7.org/linux/man-pages/man5/resolv.conf.5.html).
 That is, if attempting to resolve with the first server provided results in a
-`NOTFOUND` error, the `resolve` method will *not* attempt to resolve with
+`NOTFOUND` error, the `resolve()` method will *not* attempt to resolve with
 subsequent servers provided. Fallback DNS servers will only be used if the
 earlier ones time out or result in some other error.
 
@@ -1020,7 +1020,7 @@ progress.
 Note that this method works much like
 [resolve.conf](http://man7.org/linux/man-pages/man5/resolv.conf.5.html).
 That is, if attempting to resolve with the first server provided results in a
-`NOTFOUND` error, the `resolve` method will *not* attempt to resolve with
+`NOTFOUND` error, the `resolve()` method will *not* attempt to resolve with
 subsequent servers provided. Fallback DNS servers will only be used if the
 earlier ones time out or result in some other error.
 


### PR DESCRIPTION
Added a note that that clarifies the fact that setServer does not
check subsequent servers when the first one produces a NOTFOUND
error.


- [ x] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Refs: https://github.com/nodejs/node/issues/21391