### PR TITLE
inspector: add debugging for WebSocket messages

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -415,10 +415,10 @@ struct ContextInfo {
 };
 
 // Listing the AsyncWrap provider types first enables us to cast directly
-// from a provider type to a debug category. Currently no other debug
-// categories are available.
+// from a provider type to a debug category.
 #define DEBUG_CATEGORY_NAMES(V) \
-    NODE_ASYNC_PROVIDER_TYPES(V)
+    NODE_ASYNC_PROVIDER_TYPES(V) \
+    V(INSPECTOR_SERVER)
 
 enum class DebugCategory {
 #define V(name) name,

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -314,6 +314,8 @@ void InspectorIo::SwapBehindLock(MessageQueue<ActionType>* vector1,
 
 void InspectorIo::PostIncomingMessage(InspectorAction action, int session_id,
                                       const std::string& message) {
+  Debug(parent_env_, DebugCategory::INSPECTOR_SERVER,
+        ">>> %s\n", message.c_str());
   if (AppendMessage(&incoming_message_queue_, action, session_id,
                     Utf8ToStringView(message))) {
     Agent* agent = main_thread_req_->second;
@@ -395,6 +397,10 @@ void InspectorIo::MainThreadReqAsyncCb(uv_async_t* req) {
 
 void InspectorIo::Write(TransportAction action, int session_id,
                         const StringView& inspector_message) {
+  std::string message_str =
+      protocol::StringUtil::StringViewToUtf8(inspector_message);
+  Debug(parent_env_, DebugCategory::INSPECTOR_SERVER,
+        "<<< %s\n", message_str.c_str());
   AppendMessage(&outgoing_message_queue_, action, session_id,
                 StringBuffer::create(inspector_message));
   int err = uv_async_send(&thread_req_);


### PR DESCRIPTION
Useful for seeing how DevTools does something with Node.js.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
