### PR TITLE
src: add --title command line argument, trace event

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -271,6 +271,13 @@ added: v0.11.14
 
 Throw errors for deprecations.
 
+### `--title=title`
+<!-- YAML
+added: REPLACEME
+-->
+
+Set `process.title` on startup.
+
 ### `--tls-cipher-list=list`
 <!-- YAML
 added: v4.0.0
@@ -532,6 +539,7 @@ Node options that are allowed are:
 - `--redirect-warnings`
 - `--require`, `-r`
 - `--throw-deprecation`
+- `--title`
 - `--tls-cipher-list`
 - `--trace-deprecation`
 - `--trace-event-categories`

--- a/doc/node.1
+++ b/doc/node.1
@@ -164,6 +164,9 @@ instead of printing to stderr.
 .It Fl -throw-deprecation
 Throw errors for deprecations.
 .
+.It Fl -title Ns = Ns Ar title
+Specify process.title on startup.
+.
 .It Fl -tls-cipher-list Ns = Ns Ar list
 Specify an alternative default TLS cipher list.
 Requires Node.js to be built with crypto support. (Default)

--- a/src/node.cc
+++ b/src/node.cc
@@ -273,6 +273,8 @@ std::string config_warning_file;  // NOLINT(runtime/string)
 // that is used by lib/internal/bootstrap/node.js
 bool config_expose_internals = false;
 
+std::string config_process_title;  // NOLINT(runtime/string)
+
 bool v8_initialized = false;
 
 bool linux_at_secure = false;
@@ -2508,6 +2510,7 @@ static void PrintHelp() {
          "                             write warnings to file instead of\n"
          "                             stderr\n"
          "  --throw-deprecation        throw an exception on deprecations\n"
+         "  --title=title              the process title to use on start up\n"
 #if HAVE_OPENSSL
          "  --tls-cipher-list=val      use an alternative default TLS cipher "
          "list\n"
@@ -2645,6 +2648,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--redirect-warnings",
     "--require",
     "--throw-deprecation",
+    "--title",
     "--tls-cipher-list",
     "--trace-deprecation",
     "--trace-event-categories",
@@ -2815,6 +2819,8 @@ static void ParseArgs(int* argc,
     } else if (strncmp(arg, "--security-revert=", 18) == 0) {
       const char* cve = arg + 18;
       Revert(cve);
+    } else if (strncmp(arg, "--title=", 8) == 0) {
+      config_process_title = arg + 8;
     } else if (strcmp(arg, "--preserve-symlinks") == 0) {
       config_preserve_symlinks = true;
     } else if (strcmp(arg, "--preserve-symlinks-main") == 0) {
@@ -3305,6 +3311,10 @@ void Init(int* argc,
 #endif
 
   ProcessArgv(argc, argv, exec_argc, exec_argv);
+
+  // Set the process.title immediately after processing argv if --title is set.
+  if (!config_process_title.empty())
+    uv_set_process_title(config_process_title.c_str());
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
   // If the parameter isn't given, use the env variable.

--- a/test/parallel/test-process-title-cli.js
+++ b/test/parallel/test-process-title-cli.js
@@ -1,0 +1,13 @@
+// Flags: --title=foo
+'use strict';
+
+const common = require('../common');
+
+if (common.isSunOS)
+  common.skip(`Unsupported platform [${process.platform}]`);
+
+const assert = require('assert');
+
+// Verifies that the --title=foo command line flag set the process
+// title on startup.
+assert.strictEqual(process.title, 'foo');


### PR DESCRIPTION
Adds a simple utility `--title` command line argument to set the process title on startup. Also, emit the `process_name` metadata to the trace event log.

```
$ node --title=foo -pe "process.title"
foo
```

When emit trace events, the process name appears within the trace event viewer UI:
```
$ node --title=foo --trace-event-categories node -pe "process.title"
foo
```

![image](https://user-images.githubusercontent.com/439929/41802856-e2a1ccd4-7638-11e8-9e04-94936dd362d8.png)

Changes to `process.title` also appear within the trace_event log:

/cc @ofrobots @eugeneo 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
