### PR TITLE
doc: add a missing anchor to error codes

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1407,6 +1407,7 @@ An attempt was made to `require()` an [ES6 module][].
 Script execution was interrupted by `SIGINT` (For example, when Ctrl+C was
 pressed).
 
+<a id="ERR_SCRIPT_EXECUTION_TIMEOUT"></a>
 ### ERR_SCRIPT_EXECUTION_TIMEOUT
 
 Script execution timed out, possibly due to bugs in the script being executed.


### PR DESCRIPTION
Only one error code was missing an appropriate anchor, and it was `ERR_SCRIPT_EXECUTION_TIMEOUT`.
This commit adds that missing anchor.

This is a part of the fixes hinted by #21470, which includes some tests for error codes usage and documentation and enforces a stricter format.

I split this into a separate commit/PR as this should be easy to land (and backport if needed), and some of the other fixes are more heavy and/or controversial.

Refs: https://github.com/nodejs/node/pull/21470,  https://github.com/nodejs/node/issues/21440

Tests are not included — #21470 does that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
