### PR TITLE
doc: fix worker example to receive message

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -377,7 +377,7 @@ added: v10.5.0
 * `transferList` {Object[]}
 
 Send a message to the worker that will be received via
-[`require('worker_threads').on('message')`][].
+[`require('worker_threads').parentPort.on('message')`][].
 See [`port.postMessage()`][] for more details.
 
 ### worker.ref()
@@ -480,7 +480,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`process.stdout`]: process.html#process_process_stdout
 [`process.title`]: process.html#process_process_title
 [`require('worker_threads').workerData`]: #worker_threads_worker_workerdata
-[`require('worker_threads').on('message')`]: #worker_threads_event_message_1
+[`require('worker_threads').parentPort.on('message')`]: #worker_threads_event_message
 [`require('worker_threads').postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
 [`require('worker_threads').isMainThread`]: #worker_threads_worker_ismainthread
 [`require('worker_threads').parentPort`]: #worker_threads_worker_parentport


### PR DESCRIPTION
`require('worker_threads')` is not an instance of `EventEmitter`. So
`once` method would not be in it. The correct way to receive the message
would be to attach a listener to the `message` event on the
`parentPort`.

Also, there is no built-in event called `workerMessage`. This patch
fixes it by referencing `message` event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
