### PR TITLE
doc: fix http2stream.pushStream error doc

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3143,7 +3143,7 @@ added: v8.4.0
 Call [`http2stream.pushStream()`][] with the given headers, and wraps the
 given newly created [`Http2Stream`] on `Http2ServerResponse`.
 
-The callback will be called with an error with code `ERR_HTTP2_STREAM_CLOSED`
+The callback will be called with an error with code `ERR_HTTP2_INVALID_STREAM`
 if the stream is closed.
 
 ## Collecting HTTP/2 Performance Metrics


### PR DESCRIPTION
The old error code `ERR_HTTP2_STREAM_CLOSED` was removed in commit 0babd181a0c5d775e62a12b3b04fe4d7654fe80a (pull request #17406), and the testcase for `http2stream.pushStream` was changed accordingly, but the documentation change was overlooked.

This commit fixes it and aligns the documentation with the testcase.

This is a part of the fixes hinted by #21470, which includes some tests for error codes usage and documentation and enforces a stricter format.

Refs: https://github.com/nodejs/node/pull/21470, https://github.com/nodejs/node/pull/17406

Tests are not included — #21470 does that.

/cc @jasnell @addaleax 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
