### PR TITLE
doc: remove 2 unused error codes from errors.md

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1564,12 +1564,6 @@ or a pipeline ends non gracefully with no explicit error.
 An attempt was made to call [`stream.push()`][] after a `null`(EOF) had been
 pushed to the stream.
 
-<a id="ERR_STREAM_READ_NOT_IMPLEMENTED"></a>
-### ERR_STREAM_READ_NOT_IMPLEMENTED
-
-An attempt was made to use a readable stream that did not implement
-[`readable._read()`][].
-
 <a id="ERR_STREAM_UNSHIFT_AFTER_END_EVENT"></a>
 ### ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 
@@ -1777,11 +1771,6 @@ The V8 `BreakIterator` API was used but the full ICU data set is not installed.
 While using the Performance Timing API (`perf_hooks`), no valid performance
 entry types were found.
 
-<a id="ERR_VALUE_OUT_OF_RANGE"></a>
-### ERR_VALUE_OUT_OF_RANGE
-
-Superseded by `ERR_OUT_OF_RANGE`.
-
 <a id="ERR_VM_MODULE_ALREADY_LINKED"></a>
 ### ERR_VM_MODULE_ALREADY_LINKED
 
@@ -1874,7 +1863,6 @@ A module file could not be resolved while attempting a [`require()`][] or
 [`new URLSearchParams(iterable)`]: url.html#url_constructor_new_urlsearchparams_iterable
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
-[`readable._read()`]: stream.html#stream_readable_read_size_1
 [`require()`]: modules.html#modules_require
 [`require('crypto').setEngine()`]: crypto.html#crypto_crypto_setengine_engine_flags
 [`server.listen()`]: net.html#net_server_listen


### PR DESCRIPTION
This removes two unused error codes.

Those two are:
1. `ERR_STREAM_READ_NOT_IMPLEMENTED`, removed in c9794880e89dbbecbbd85e4ee0980ed9c7ac0971 (PR #18813).
2. `ERR_VALUE_OUT_OF_RANGE`, removed in d022cb1bdd20f10483cbe988a950548df2dfd48c (PR #17648).

There are concerns about removing error codes voiced by @jasnell and @joyeecheung here: https://github.com/nodejs/node/pull/21470#issuecomment-399550687, implying that the documentation for all removed error codes should stay forever in `doc/api/errors.md` _(hence I requested their review here)_.

As I said in that PR — we have a history of removing error codes from that document, and those two remainders look more like an accident than a result of an established process to keep error codes.

List of previous removals (might be or not be parital):
 * 186857f15c — removes `ERR_INVALID_ARRAY_LENGTH`
 * 564048dc29 — removes `ERR_INVALID_DOMAIN_NAME` 
 * 362694401f — renames `ERR_STRING_TOO_LARGE` (#19864, old name never ended up in a release)
 * 301f6cc553 — removes `ERR_FS_WATCHER_ALREADY_STARTED` and `ERR_FS_WATCHER_NOT_STARTED`
 * 5e3f51648e — removes/renames `ERR_ZLIB_BINDING_CLOSED`
 * 6e1c25c456 — removes `ERR_HTTP_INVALID_CHAR`, `ERR_HTTP2_ALREADY_SHUTDOWN`, `ERR_HTTP2_FRAME_ERROR`, `ERR_HTTP2_HEADER_REQUIRED`, `ERR_HTTP2_HEADERS_OBJECT`, `ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND`, `ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK`, `ERR_NAPI_CONS_PROTOTYPE_OBJECT`, `ERR_PARSE_HISTORY_DATA`, `ERR_TLS_RENEGOTIATION_FAILED`
 * a82b1b7b30 — removes `ERR_OUTOFMEMORY`
 * 0babd181a0 — removes/renames `ERR_HTTP2_STREAM_CLOSED`
 * 1cdb41f287 — removes `ERR_HTTP2_ERROR`, `ERR_UNKNOWN_BUILTIN_MODULE`
  _(`ERR_HTTP2_HEADER_SINGLE_VALUE` is just moved around)_
  _Revert in #21484._
 * e6b69b9418 — removes `ERR_INVALID_REPL_HISTORY`
 * 1b54371c50 — renames `ERR_STREAM_HAS_STRINGDECODER`

See e.g. the first one from that list: https://github.com/nodejs/node/pull/20484, which happened recently, is about an explicit error code removal, has been reviewed by @jasnell and @joyeecheung, and removed an error code that was present in released versions.

To my understanding, the current process is to remove obsolete error codes — this is what the list of commits above hints, and else there would have been more than two documented but unused error codes (in fact, there would have been a lot of those).

I propose to align the current documentation with that (i.e. to remove those two unused error codes from the doc), then, if/when we come to a conclusion to change that process and revert the removal — land them all back, perhaps to a separate page or whatever.

---

This is a part of the fixes hinted by #21470, which includes some tests for error codes usage and documentation and enforces a stricter format.

Tests are not included — #21470 does that.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
