### PR TITLE
errors: fix ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1312,6 +1312,14 @@ strict compliance with the API specification (which in some cases may accept
 `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
 
+<a id="ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK"></a>
+### ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK
+
+> Stability: 1 - Experimental
+
+An [ES6 module][] loader hook specified `format: 'dynamic` but did not provide a
+`dynamicInstantiate` hook.
+
 <a id="ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST"></a>
 ### ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -725,6 +725,9 @@ E('ERR_MISSING_ARGS',
     }
     return `${msg} must be specified`;
   }, TypeError);
+E('ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK',
+  'The ES Module loader may not return a format of \'dynamic\' when no ' +
+  'dynamicInstantiate function was provided');
 E('ERR_MISSING_MODULE', 'Cannot find module %s', Error);
 E('ERR_MODULE_RESOLUTION_LEGACY',
   '%s not found by import in %s.' +

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -93,7 +93,7 @@ class Loader {
     let loaderInstance;
     if (format === 'dynamic') {
       if (typeof this._dynamicInstantiate !== 'function')
-        throw new ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK();
+        throw new ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK();
 
       loaderInstance = async (url) => {
         debug(`Translating dynamic ${url}`);


### PR DESCRIPTION
This restores a broken and erroneously removed error, which was accidentially renamed to `ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK` (notice the `INTST` vs `INST`) in 921fb84687fb8135075c1f001383e9b0b863f4b5 (PR #16874) and then had documentation and implementation removed under the old name in 6e1c25c45672b70f4b6c6c8af56d9c0762bfae04 (PR #18857), as it appeared unused.

This error code never worked or was documented under the mistyped name
`ERR_MISSING_DYNAMIC_INTSTANTIATE_HOOK`, so renaming it back to
`ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK` is a semver-patch fix.

Refs: https://github.com/nodejs/node/issues/21440, https://github.com/nodejs/node/pull/21470, https://github.com/nodejs/node/pull/16874, https://github.com/nodejs/node/pull/18857.

---

This is a part of the fixes hinted by #21470, which includes some tests for error codes usage and documentation and enforces a stricter format.

This is mostly a revert, and specific tests for esm loader actually emitting that error are not included here.
Generic tests for error codes are included in a separate PR: #21470.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
