### PR TITLE
fs: support special files in promises.readFile

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -143,8 +143,9 @@ async function readFileHandle(filehandle, options) {
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
   const chunks = [];
-  const chunkSize = size === 0 ? kReadFileMaxChunkSize :
-                                 Math.min(size, kReadFileMaxChunkSize);
+  const chunkSize = size === 0 ?
+    kReadFileMaxChunkSize :
+    Math.min(size, kReadFileMaxChunkSize);
   let endOfFile = false;
   do {
     const buf = Buffer.alloc(chunkSize);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -135,21 +135,16 @@ async function readFileHandle(filehandle, options) {
     size = 0;
   }
 
-  if (size === 0)
-    return options.encoding ? '' : Buffer.alloc(0);
-
   if (size > kMaxLength)
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
   const chunks = [];
-  const chunkSize = Math.min(size, 16384);
-  let totalRead = 0;
+  const chunkSize = size === 0 ? 16384 : Math.min(size, 16384);
   let endOfFile = false;
   do {
     const buf = Buffer.alloc(chunkSize);
     const { bytesRead, buffer } =
-      await read(filehandle, buf, 0, chunkSize, totalRead);
-    totalRead += bytesRead;
+      await read(filehandle, buf, 0, chunkSize, -1);
     endOfFile = bytesRead !== chunkSize;
     if (bytesRead > 0)
       chunks.push(buffer.slice(0, bytesRead));

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -125,6 +125,10 @@ async function writeFileHandle(filehandle, data, options) {
   } while (remaining > 0);
 }
 
+// Note: This is different from kReadFileBufferLength used for non-promisified
+// fs.readFile.
+const kReadFileMaxChunkSize = 16384;
+
 async function readFileHandle(filehandle, options) {
   const statFields = await binding.fstat(filehandle.fd, false, kUsePromises);
 
@@ -139,13 +143,14 @@ async function readFileHandle(filehandle, options) {
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
   const chunks = [];
-  const chunkSize = size === 0 ? 16384 : Math.min(size, 16384);
+  const chunkSize = size === 0 ? kReadFileMaxChunkSize :
+                                 Math.min(size, kReadFileMaxChunkSize);
   let endOfFile = false;
   do {
     const buf = Buffer.alloc(chunkSize);
     const { bytesRead, buffer } =
       await read(filehandle, buf, 0, chunkSize, -1);
-    endOfFile = bytesRead !== chunkSize;
+    endOfFile = bytesRead === 0;
     if (bytesRead > 0)
       chunks.push(buffer.slice(0, bytesRead));
   } while (!endOfFile);

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -28,5 +28,22 @@ async function validateReadFile() {
   assert.deepStrictEqual(buffer, readFileData);
 }
 
+async function validateReadFileProc() {
+  // Test to make sure reading a file under the /proc directory works. Adapted
+  // from test-fs-read-file-sync-hostname.js.
+  // Refs:
+  // - https://groups.google.com/forum/#!topic/nodejs-dev/rxZ_RoH1Gn0
+  // - https://github.com/nodejs/node/issues/21331
+
+  // Test is Linux-specific.
+  if (!common.isLinux)
+    return;
+
+  const fileHandle = await open('/proc/sys/kernel/hostname', 'r');
+  const hostname = await fileHandle.readFile();
+  assert.ok(hostname.length > 0);
+}
+
 validateReadFile()
+  .then(() => validateReadFileProc())
   .then(common.mustCall());

--- a/test/parallel/test-fs-promises-readfile.js
+++ b/test/parallel/test-fs-promises-readfile.js
@@ -12,17 +12,35 @@ const fn = path.join(tmpdir.path, 'large-file');
 
 common.crashOnUnhandledRejection();
 
-// Creating large buffer with random content
-const buffer = Buffer.from(
-  Array.apply(null, { length: 16834 * 2 })
-    .map(Math.random)
-    .map((number) => (number * (1 << 8)))
-);
+async function validateReadFile() {
+  // Creating large buffer with random content
+  const buffer = Buffer.from(
+    Array.apply(null, { length: 16834 * 2 })
+      .map(Math.random)
+      .map((number) => (number * (1 << 8)))
+  );
 
-// Writing buffer to a file then try to read it
-writeFile(fn, buffer)
-  .then(() => readFile(fn))
-  .then((readBuffer) => {
-    assert.strictEqual(readBuffer.equals(buffer), true);
-  })
+  // Writing buffer to a file then try to read it
+  await writeFile(fn, buffer);
+  const readBuffer = await readFile(fn);
+  assert.strictEqual(readBuffer.equals(buffer), true);
+}
+
+async function validateReadFileProc() {
+  // Test to make sure reading a file under the /proc directory works. Adapted
+  // from test-fs-read-file-sync-hostname.js.
+  // Refs:
+  // - https://groups.google.com/forum/#!topic/nodejs-dev/rxZ_RoH1Gn0
+  // - https://github.com/nodejs/node/issues/21331
+
+  // Test is Linux-specific.
+  if (!common.isLinux)
+    return;
+
+  const hostname = await readFile('/proc/sys/kernel/hostname');
+  assert.ok(hostname.length > 0);
+}
+
+validateReadFile()
+  .then(() => validateReadFileProc())
   .then(common.mustCall());


### PR DESCRIPTION
A size of 0 may indicate that the file is a Linux special file, which may still have content when `read()`. Instead of returning early, use the same approach as `fs.readFile()`:

https://github.com/nodejs/node/blob/6ced651b6c3da64727bce260ecf55b8d86ec6cc3/lib/internal/fs/read_file_context.js#L74-L88

Additionally, only the return code of 0 indicates end of file, and we should not use `bytesRead !== chunkSize` as a indication of EOF. Per [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html): 

> The value returned may be less than *nbyte* if the number of bytes left in the file is less than *nbyte*, if the *read()* request was interrupted by a signal, or if the file is a pipe or FIFO or special file and has fewer than *nbyte* bytes immediately available for reading. For example, a *read()* from a file associated with a terminal may return one typed line of data.

Refs: http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
Refs: https://groups.google.com/forum/#!topic/nodejs-dev/rxZ_RoH1Gn0
Fixes: https://github.com/nodejs/node/issues/21331

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
