### PR TITLE
util: add inspect suffix to BigInt64Array elements

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -901,10 +901,9 @@ function formatTypedArray(ctx, value, recurseTimes, keys) {
   const maxLength = Math.min(Math.max(0, ctx.maxArrayLength), value.length);
   const remaining = value.length - maxLength;
   const output = new Array(maxLength + (remaining > 0 ? 1 : 0));
-  const elementFormatter =
-    types.isBigInt64Array(value) || types.isBigUint64Array(value) ?
-      formatBigInt :
-      formatNumber;
+  const elementFormatter = typeof value[0] === 'number' ?
+    formatNumber :
+    formatBigInt;
   for (var i = 0; i < maxLength; ++i)
     output[i] = elementFormatter(ctx.stylize, value[i]);
   if (remaining > 0)

--- a/lib/util.js
+++ b/lib/util.js
@@ -721,6 +721,10 @@ function formatNumber(fn, value) {
   return fn(`${value}`, 'number');
 }
 
+function formatBigInt(fn, value) {
+  return fn(`${value}n`, 'bigint');
+}
+
 function formatPrimitive(fn, value, ctx) {
   if (typeof value === 'string') {
     if (ctx.compact === false &&
@@ -761,7 +765,7 @@ function formatPrimitive(fn, value, ctx) {
     return formatNumber(fn, value);
   // eslint-disable-next-line valid-typeof
   if (typeof value === 'bigint')
-    return fn(`${value}n`, 'bigint');
+    return formatBigInt(fn, value);
   if (typeof value === 'boolean')
     return fn(`${value}`, 'boolean');
   if (typeof value === 'undefined')
@@ -897,8 +901,12 @@ function formatTypedArray(ctx, value, recurseTimes, keys) {
   const maxLength = Math.min(Math.max(0, ctx.maxArrayLength), value.length);
   const remaining = value.length - maxLength;
   const output = new Array(maxLength + (remaining > 0 ? 1 : 0));
+  const elementFormatter =
+    types.isBigInt64Array(value) || types.isBigUint64Array(value) ?
+      formatBigInt :
+      formatNumber;
   for (var i = 0; i < maxLength; ++i)
-    output[i] = formatNumber(ctx.stylize, value[i]);
+    output[i] = elementFormatter(ctx.stylize, value[i]);
   if (remaining > 0)
     output[i] = `... ${remaining} more item${remaining > 1 ? 's' : ''}`;
   if (ctx.showHidden) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -901,7 +901,7 @@ function formatTypedArray(ctx, value, recurseTimes, keys) {
   const maxLength = Math.min(Math.max(0, ctx.maxArrayLength), value.length);
   const remaining = value.length - maxLength;
   const output = new Array(maxLength + (remaining > 0 ? 1 : 0));
-  const elementFormatter = typeof value[0] === 'number' ?
+  const elementFormatter = value.length > 0 && typeof value[0] === 'number' ?
     formatNumber :
     formatBigInt;
   for (var i = 0; i < maxLength; ++i)

--- a/test/parallel/test-util-inspect-bigint.js
+++ b/test/parallel/test-util-inspect-bigint.js
@@ -10,3 +10,5 @@ const { inspect } = require('util');
 assert.strictEqual(inspect(1n), '1n');
 assert.strictEqual(inspect(Object(-1n)), '[BigInt: -1n]');
 assert.strictEqual(inspect(Object(13n)), '[BigInt: 13n]');
+assert.strictEqual(inspect(new BigInt64Array([0n])), 'BigInt64Array [ 0n ]');
+assert.strictEqual(inspect(new BigUint64Array([0n])), 'BigUint64Array [ 0n ]');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This commit updates `util.inspect` to add an `n` suffix to BigInts that
appear in BigInt64Arrays. BigInts are formatted with an `n` suffix in
most cases, but this did not occur in BigInt64Arrays due to an apparent
oversight where the implementation of `inspect` for typed arrays assumed
that all typed array elements are numbers.
