### PR TITLE
worker: add test for messagePort.onmessage

### DIFF
--- a/test/parallel/test-worker-onmessage.js
+++ b/test/parallel/test-worker-onmessage.js
@@ -1,0 +1,18 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+
+if (isMainThread) {
+  const w = new Worker(__filename);
+  w.on('message', common.mustCall((message) => {
+    assert.strictEqual(message, 4);
+    w.terminate();
+  }));
+  w.postMessage(2);
+} else {
+  parentPort.onmessage = common.mustCall((message) => {
+    parentPort.postMessage(message * 2);
+  });
+}


### PR DESCRIPTION
@nodejs/workers 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
