### PR TITLE
test: add a request-response test for MessageChannel

### DIFF
--- a/test/parallel/test-message-port.js
+++ b/test/parallel/test-message-port.js
@@ -21,6 +21,21 @@ const { MessageChannel, MessagePort } = require('worker_threads');
 {
   const { port1, port2 } = new MessageChannel();
 
+  port1.onmessage = common.mustCall((message) => {
+    assert.strictEqual(message, 4);
+    port2.close(common.mustCall());
+  });
+
+  port1.postMessage(2);
+
+  port2.onmessage = common.mustCall((message) => {
+    port2.postMessage(message * 2);
+  });
+}
+
+{
+  const { port1, port2 } = new MessageChannel();
+
   const input = { a: 1 };
   port1.postMessage(input);
   // Check that the message still gets delivered if `port2` has its


### PR DESCRIPTION
This commit adds a request-response test for MessageChannel.

Suggested by @benjamingr and @TimothyGu [here](https://github.com/nodejs/node/pull/21510#issuecomment-399780169)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
