### PR TITLE
Fix native module loading in multi-context (--experimental-workers)

### DIFF
--- a/test/addons/hello-world-from-worker/binding.cc
+++ b/test/addons/hello-world-from-worker/binding.cc
@@ -1,0 +1,13 @@
+#include <node.h>
+#include <v8.h>
+
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+}
+
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  NODE_SET_METHOD(module, "exports", Method);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/hello-world-from-worker/binding.gyp
+++ b/test/addons/hello-world-from-worker/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/hello-world-from-worker/test.js
+++ b/test/addons/hello-world-from-worker/test.js
@@ -1,0 +1,32 @@
+// Flags: --experimental-worker
+'use strict';
+const assert = require('assert');
+
+function testModule() {
+  const common = require('../../common');
+  const binding = require(`./build/${common.buildType}/binding`);
+  assert.strictEqual(binding(), 'world');
+  console.log('binding.hello() =', binding());
+}
+
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+if (isMainThread) {
+  testModule();
+  const worker = new Worker(__filename);
+  worker.on('message', (message) => {
+    assert.strictEqual(message, undefined);
+    worker.terminate();
+  });
+  worker.on('error', (error) => {
+    console.error(error);
+    worker.terminate();
+  });
+} else {
+  let response;
+  try {
+    testModule();
+  } catch (e) {
+    response = e + '';
+  }
+  parentPort.postMessage(response);
+}


### PR DESCRIPTION
Fixes native module loading from multiple contexts by saving the module metadata provided by native modules when they call `node_module_register`. Also fixes a race condition when multiple contexts happen to load a module at the same time.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
