### PR TITLE
move per-context changes from c++ to js

### DIFF
--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -25,6 +25,7 @@ module.exports = {
     // the code cache is also used when compiling these
     // two files.
     'internal/bootstrap/loaders',
-    'internal/bootstrap/node'
+    'internal/bootstrap/node',
+    'internal/per_context',
   ]
 };

--- a/lib/internal/per_context.js
+++ b/lib/internal/per_context.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// node::NewContext calls this script
+
+(function(global) {
+  // https://github.com/nodejs/node/issues/14909
+  delete global.Intl.v8BreakIterator;
+
+  // https://github.com/nodejs/node/issues/21219
+  Object.defineProperty(global.Atomics, 'notify', {
+    value: global.Atomics.wake,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}(this));

--- a/lib/internal/per_context.js
+++ b/lib/internal/per_context.js
@@ -7,10 +7,46 @@
   delete global.Intl.v8BreakIterator;
 
   // https://github.com/nodejs/node/issues/21219
-  Object.defineProperty(global.Atomics, 'notify', {
-    value: global.Atomics.wake,
-    writable: true,
-    enumerable: false,
-    configurable: true,
+  // Adds Atomics.notify and warns on first usage of Atomics.wake
+
+  const AtomicsWake = global.Atomics.wake;
+  const ReflectApply = global.Reflect.apply;
+
+  // wrap for function.name
+  function notify(...args) {
+    return ReflectApply(AtomicsWake, this, args);
+  }
+
+  const warning = 'Atomics.wake will be removed in a future version, ' +
+    'use Atomics.notify instead.';
+
+  let wakeWarned = false;
+  function wake(...args) {
+    if (!wakeWarned) {
+      wakeWarned = true;
+
+      if (global.process !== undefined) {
+        global.process.emitWarning(warning, 'Atomics');
+      } else {
+        global.console.error(`Atomics: ${warning}`);
+      }
+    }
+
+    return ReflectApply(AtomicsWake, this, args);
+  }
+
+  global.Object.defineProperties(global.Atomics, {
+    notify: {
+      value: notify,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
+    wake: {
+      value: wake,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
   });
 }(this));

--- a/node.gyp
+++ b/node.gyp
@@ -25,6 +25,7 @@
     'node_lib_target_name%': 'node_lib',
     'node_intermediate_lib_type%': 'static_library',
     'library_files': [
+      'lib/internal/per_context.js',
       'lib/internal/bootstrap/cache.js',
       'lib/internal/bootstrap/loaders.js',
       'lib/internal/bootstrap/node.js',

--- a/src/node.cc
+++ b/src/node.cc
@@ -3497,35 +3497,19 @@ Local<Context> NewContext(Isolate* isolate,
   auto context = Context::New(isolate, nullptr, object_template);
   if (context.IsEmpty()) return context;
   HandleScope handle_scope(isolate);
+
   context->SetEmbedderData(
       ContextEmbedderIndex::kAllowWasmCodeGeneration, True(isolate));
 
-  auto intl_key = FIXED_ONE_BYTE_STRING(isolate, "Intl");
-  auto break_iter_key = FIXED_ONE_BYTE_STRING(isolate, "v8BreakIterator");
-  Local<Value> intl_v;
-  if (context->Global()->Get(context, intl_key).ToLocal(&intl_v) &&
-      intl_v->IsObject()) {
-    Local<Object> intl = intl_v.As<Object>();
-    intl->Delete(context, break_iter_key).FromJust();
-  }
-
-  // https://github.com/nodejs/node/issues/21219
-  // TODO(devsnek): remove when v8 supports Atomics.notify
-  auto atomics_key = FIXED_ONE_BYTE_STRING(isolate, "Atomics");
-  Local<Value> atomics_v;
-  if (context->Global()->Get(context, atomics_key).ToLocal(&atomics_v) &&
-      atomics_v->IsObject()) {
-    Local<Object> atomics = atomics_v.As<Object>();
-    auto wake_key = FIXED_ONE_BYTE_STRING(isolate, "wake");
-
-    Local<Value> wake = atomics->Get(context, wake_key).ToLocalChecked();
-    auto notify_key = FIXED_ONE_BYTE_STRING(isolate, "notify");
-
-    v8::PropertyDescriptor desc(wake, true);
-    desc.set_enumerable(false);
-    desc.set_configurable(true);
-
-    atomics->DefineProperty(context, notify_key, desc).ToChecked();
+  {
+    // Run lib/internal/per_context.js
+    Context::Scope context_scope(context);
+    Local<String> per_context = NodePerContextSource(isolate);
+    v8::ScriptCompiler::Source per_context_src(per_context, nullptr);
+    Local<v8::Script> s = v8::ScriptCompiler::Compile(
+        context,
+        &per_context_src).ToLocalChecked();
+    s->Run(context).ToLocalChecked();
   }
 
   return context;

--- a/src/node.h
+++ b/src/node.h
@@ -241,9 +241,7 @@ class MultiIsolatePlatform : public v8::Platform {
 // Creates a new isolate with Node.js-specific settings.
 NODE_EXTERN v8::Isolate* NewIsolate(ArrayBufferAllocator* allocator);
 
-// Creates a new context with Node.js-specific tweaks.  Currently, it removes
-// the `v8BreakIterator` property from the global `Intl` object if present.
-// See https://github.com/nodejs/node/issues/14909 for more info.
+// Creates a new context with Node.js-specific tweaks.
 NODE_EXTERN v8::Local<v8::Context> NewContext(
     v8::Isolate* isolate,
     v8::Local<v8::ObjectTemplate> object_template =

--- a/src/node_javascript.h
+++ b/src/node_javascript.h
@@ -29,6 +29,7 @@
 namespace node {
 
 void DefineJavaScript(Environment* env, v8::Local<v8::Object> target);
+v8::Local<v8::String> NodePerContextSource(v8::Isolate* isolate);
 v8::Local<v8::String> LoadersBootstrapperSource(Environment* env);
 v8::Local<v8::String> NodeBootstrapperSource(Environment* env);
 

--- a/test/parallel/test-atomics-notify.js
+++ b/test/parallel/test-atomics-notify.js
@@ -1,10 +1,19 @@
 'use strict';
 
-require('../common');
+const { expectWarning, noWarnCode } = require('../common');
 
 const assert = require('assert');
 const { runInNewContext } = require('vm');
 
-assert.strictEqual(Atomics.wake, Atomics.notify);
+assert.strictEqual(typeof Atomics.wake, 'function');
+assert.strictEqual(typeof Atomics.notify, 'function');
 
-assert(runInNewContext('Atomics.wake === Atomics.notify'));
+assert.strictEqual(runInNewContext('typeof Atomics.wake'), 'function');
+assert.strictEqual(runInNewContext('typeof Atomics.notify'), 'function');
+
+expectWarning(
+  'Atomics',
+  'Atomics.wake will be removed in a future version, ' +
+  'use Atomics.notify instead.', noWarnCode);
+
+Atomics.wake(new Int32Array(new SharedArrayBuffer(4)), 0, 0);

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -189,6 +189,10 @@ namespace {{
 
 }}  // anonymous namespace
 
+v8::Local<v8::String> NodePerContextSource(v8::Isolate* isolate) {{
+  return internal_per_context_value.ToStringChecked(isolate);
+}}
+
 v8::Local<v8::String> LoadersBootstrapperSource(Environment* env) {{
   return internal_bootstrap_loaders_value.ToStringChecked(env->isolate());
 }}


### PR DESCRIPTION
move the changes made to new contexts from c++ to js.

second commit adds a warning when Atomics.wake is used and changes Atomics.notify.name to `notify`

/cc @rwaldron

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
