### PR TITLE
tools: update gyp to make xcode tools work

### DIFF
--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -645,9 +645,10 @@ class XcodeSettings(object):
 
     cflags += self._Settings().get('WARNING_CFLAGS', [])
 
-    platform_root = self._XcodePlatformPath(configname)
-    if platform_root and self._IsXCTest():
-      cflags.append('-F' + platform_root + '/Developer/Library/Frameworks/')
+    if self._IsXCTest():
+        platform_root = self._XcodePlatformPath(configname)
+        if platform_root:
+          cflags.append('-F' + platform_root + '/Developer/Library/Frameworks/')
 
     if sdk_root:
       framework_root = sdk_root
@@ -913,10 +914,11 @@ class XcodeSettings(object):
     for directory in framework_dirs:
       ldflags.append('-F' + directory.replace('$(SDKROOT)', sdk_root))
 
-    platform_root = self._XcodePlatformPath(configname)
-    if sdk_root and platform_root and self._IsXCTest():
-      ldflags.append('-F' + platform_root + '/Developer/Library/Frameworks/')
-      ldflags.append('-framework XCTest')
+    if self._IsXCTest():
+        platform_root = self._XcodePlatformPath(configname)
+        if sdk_root and platform_root:
+          ldflags.append('-F' + platform_root + '/Developer/Library/Frameworks/')
+          ldflags.append('-framework XCTest')
 
     is_extension = self._IsIosAppExtension() or self._IsIosWatchKitExtension()
     if sdk_root and is_extension:


### PR DESCRIPTION
A recent change must have started requiring a full XCode installation in
order to run "./configure" and pretty much everything related.
This patch ensures that a full installation isn't required and the tools
work just fine.

Credits: @bnoordhuis
Fixes: https://github.com/nodejs/node/issues/12531

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @bnoordhuis @refack @nodejs/gyp 