### PR TITLE
doc: fix setUncaughtExceptionCaptureCallback name in body text

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1720,18 +1720,19 @@ added: v9.3.0
 
 * `fn` {Function|null}
 
-The `process.setUncaughtExceptionCapture` function sets a function that will
-be invoked when an uncaught exception occurs, which will receive the exception
-value itself as its first argument.
+The `process.setUncaughtExceptionCaptureCallback` function sets a function that
+will be invoked when an uncaught exception occurs, which will receive the
+exception value itself as its first argument.
 
 If such a function is set, the [`'uncaughtException'`][] event will
 not be emitted. If `--abort-on-uncaught-exception` was passed from the
 command line or set through [`v8.setFlagsFromString()`][], the process will
 not abort.
 
-To unset the capture function, `process.setUncaughtExceptionCapture(null)`
-may be used. Calling this method with a non-`null` argument while another
-capture function is set will throw an error.
+To unset the capture function,
+`process.setUncaughtExceptionCaptureCallback(null)` may be used. Calling this
+method with a non-`null` argument while another capture function is set will
+throw an error.
 
 Using this function is mutually exclusive with using the deprecated
 [`domain`][] built-in module.


### PR DESCRIPTION
Name of this function was misspelled in [its Process docs](https://nodejs.org/api/process.html#process_process_setuncaughtexceptioncapturecallback_fn), so I changed `setUncaughtExceptionCapture` to `setUncaughtExceptionCaptureCallback`.

`process.setUncaughtExceptionCaptureCallback` and its docs were originally added in https://github.com/nodejs/node/pull/17159

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
