### PR TITLE
src: include cwd in chdir error message

### DIFF
--- a/test/parallel/test-process-chdir-errormessage.js
+++ b/test/parallel/test-process-chdir-errormessage.js
@@ -11,6 +11,9 @@ common.expectsError(
   {
     type: Error,
     code: 'ENOENT',
-    message: "ENOENT: no such file or directory, chdir 'does-not-exist'",
+    message: /ENOENT: no such file or directory, chdir .+ -> 'does-not-exist'/,
+    path: process.cwd(),
+    syscall: 'chdir',
+    dest: 'does-not-exist'
   }
 );


### PR DESCRIPTION
Include the current working directory in the error
message for a failing `process.chdir()` since that is
usually information relevant for debugging.

This is semver-major because it moves properties
of the error message object.

Inspired by https://github.com/nodejs/help/issues/1355.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
