### PR TITLE
src: remove extra `ReadStop()` call

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -373,11 +373,6 @@ void LibuvStreamWrap::AfterUvWrite(uv_write_t* req, int status) {
   req_wrap->Done(status);
 }
 
-void LibuvStreamWrap::Close(v8::Local<v8::Value> close_callback) {
-  ReadStop();
-  HandleWrap::Close(close_callback);
-}
-
 }  // namespace node
 
 NODE_BUILTIN_MODULE_CONTEXT_AWARE(stream_wrap,

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -76,8 +76,6 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   ShutdownWrap* CreateShutdownWrap(v8::Local<v8::Object> object) override;
   WriteWrap* CreateWriteWrap(v8::Local<v8::Object> object) override;
 
-  void Close(v8::Local<v8::Value> close_callback) override;
-
  protected:
   LibuvStreamWrap(Environment* env,
                   v8::Local<v8::Object> object,


### PR DESCRIPTION
This is no longer necessary since libuv 1.21.0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

CI: https://ci.nodejs.org/job/node-test-commit/19444/

(Only failure is https://github.com/nodejs/node/issues/21038 and the automatically started re-run is clear on LinuxOne)