### PR TITLE
build: make --shared-[...]-path work on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -1020,8 +1020,14 @@ def configure_library(lib, output):
 
     # libpath needs to be provided ahead libraries
     if options.__dict__[shared_lib + '_libpath']:
-      output['libraries'] += [
-          '-L%s' % options.__dict__[shared_lib + '_libpath']]
+      if flavor == 'win':
+        if 'msvs_settings' not in output:
+          output['msvs_settings'] = { 'VCLinkerTool': { 'AdditionalOptions': [] } }
+        output['msvs_settings']['VCLinkerTool']['AdditionalOptions'] += [
+          '/LIBPATH:%s' % options.__dict__[shared_lib + '_libpath']]
+      else:
+        output['libraries'] += [
+            '-L%s' % options.__dict__[shared_lib + '_libpath']]
     elif pkg_libpath:
       output['libraries'] += [pkg_libpath]
 


### PR DESCRIPTION
The `-L<path>` syntax isn't recognized by link.exe, and gyp doesn't
translate it properly. Without this, link.exe generates the following
warning and fails to link:

```
LINK : warning LNK4044: unrecognized option '/LC:/Users/nornagon/...'; ignored
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
