### PR TITLE
test: skip non-doc files in test-make-doc checks

### DIFF
--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -15,9 +15,12 @@ const apiPath = path.resolve(__dirname, '..', '..', 'out', 'doc', 'api');
 const allDocs = fs.readdirSync(apiPath);
 assert.ok(allDocs.includes('_toc.html'));
 
-const filter = ['assets', '_toc.html', '.md'];
 const actualDocs = allDocs.filter(
-  (name) => !filter.some((str) => name.includes(str))
+  (name) => {
+    const extension = path.extname(name);
+    return (extension === '.html' || extension === '.json') &&
+           name !== '_toc.html';
+  }
 );
 
 const toc = fs.readFileSync(path.resolve(apiPath, '_toc.html'), 'utf8');


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: https://github.com/nodejs/node/issues/21519
