### PR TITLE
src: slightly simplify `FSEventWrap`

### DIFF
--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -55,7 +55,6 @@ class FSEventWrap: public HandleWrap {
                          Local<Context> context);
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
-  static void Close(const FunctionCallbackInfo<Value>& args);
   static void GetInitialized(const FunctionCallbackInfo<Value>& args);
   size_t self_size() const override { return sizeof(*this); }
 
@@ -69,7 +68,6 @@ class FSEventWrap: public HandleWrap {
     int status);
 
   uv_fs_event_t handle_;
-  bool initialized_ = false;
   enum encoding encoding_ = kDefaultEncoding;
 };
 
@@ -89,7 +87,7 @@ FSEventWrap::~FSEventWrap() {
 void FSEventWrap::GetInitialized(const FunctionCallbackInfo<Value>& args) {
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
   CHECK_NOT_NULL(wrap);
-  args.GetReturnValue().Set(wrap->initialized_);
+  args.GetReturnValue().Set(!wrap->IsHandleClosing());
 }
 
 void FSEventWrap::Initialize(Local<Object> target,
@@ -104,7 +102,7 @@ void FSEventWrap::Initialize(Local<Object> target,
 
   AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "start", Start);
-  env->SetProtoMethod(t, "close", Close);
+  env->SetProtoMethod(t, "close", HandleWrap::Close);
 
   Local<FunctionTemplate> get_initialized_templ =
       FunctionTemplate::New(env->isolate(),
@@ -134,7 +132,7 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
 
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
   CHECK_NOT_NULL(wrap);
-  CHECK(!wrap->initialized_);
+  CHECK(wrap->IsHandleClosing());  // Check that Start() has not been called.
 
   const int argc = args.Length();
   CHECK_GE(argc, 4);
@@ -155,7 +153,6 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
 
   err = uv_fs_event_start(&wrap->handle_, OnEvent, *path, flags);
   wrap->MarkAsInitialized();
-  wrap->initialized_ = true;
 
   if (err != 0) {
     FSEventWrap::Close(args);
@@ -228,16 +225,6 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
   }
 
   wrap->MakeCallback(env->onchange_string(), arraysize(argv), argv);
-}
-
-
-void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
-  FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
-  CHECK_NOT_NULL(wrap);
-  CHECK(wrap->initialized_);
-
-  wrap->initialized_ = false;
-  HandleWrap::Close(args);
 }
 
 }  // anonymous namespace

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -102,7 +102,7 @@ void FSEventWrap::Initialize(Local<Object> target,
 
   AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "start", Start);
-  env->SetProtoMethod(t, "close", HandleWrap::Close);
+  env->SetProtoMethod(t, "close", Close);
 
   Local<FunctionTemplate> get_initialized_templ =
       FunctionTemplate::New(env->isolate(),


### PR DESCRIPTION
We don’t need to track `initialized_`, `HandleWrap` already does
that for us.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
