### PR TITLE
worker: replace message types string by constants

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -47,6 +47,15 @@ const kIncrementsPortRef = Symbol('kIncrementsPortRef');
 
 const debug = util.debuglog('worker');
 
+const messageTypes = {
+  UP_AND_RUNNING: 'upAndRunning',
+  COULD_NOT_SERIALIZE_ERROR: 'couldNotSerializeError',
+  ERROR_MESSAGE: 'errorMessage',
+  STDIO_PAYLOAD: 'stdioPayload',
+  STDIO_WANTS_MORE_DATA: 'stdioWantsMoreData',
+  LOAD_SCRIPT: 'loadScript'
+};
+
 // A communication channel consisting of a handle (that wraps around an
 // uv_async_t) which can receive information from other threads and emits
 // .onmessage events, and a function used for sending data to a MessagePort
@@ -158,7 +167,7 @@ class ReadableWorkerStdio extends Readable {
     }
 
     this[kPort].postMessage({
-      type: 'stdioWantsMoreData',
+      type: messageTypes.STDIO_WANTS_MORE_DATA,
       stream: this[kName]
     });
   }
@@ -174,7 +183,7 @@ class WritableWorkerStdio extends Writable {
 
   _write(chunk, encoding, cb) {
     this[kPort].postMessage({
-      type: 'stdioPayload',
+      type: messageTypes.STDIO_PAYLOAD,
       stream: this[kName],
       chunk,
       encoding
@@ -186,7 +195,7 @@ class WritableWorkerStdio extends Writable {
 
   _final(cb) {
     this[kPort].postMessage({
-      type: 'stdioPayload',
+      type: messageTypes.STDIO_PAYLOAD,
       stream: this[kName],
       chunk: null
     });
@@ -252,7 +261,7 @@ class Worker extends EventEmitter {
     this[kPublicPort].on('message', (message) => this.emit('message', message));
     setupPortReferencing(this[kPublicPort], this, 'message');
     this[kPort].postMessage({
-      type: 'loadScript',
+      type: messageTypes.LOAD_SCRIPT,
       filename,
       doEval: !!options.eval,
       workerData: options.workerData,
@@ -283,18 +292,18 @@ class Worker extends EventEmitter {
 
   [kOnMessage](message) {
     switch (message.type) {
-      case 'upAndRunning':
+      case messageTypes.UP_AND_RUNNING:
         return this.emit('online');
-      case 'couldNotSerializeError':
+      case messageTypes.COULD_NOT_SERIALIZE_ERROR:
         return this[kOnCouldNotSerializeErr]();
-      case 'errorMessage':
+      case messageTypes.ERROR_MESSAGE:
         return this[kOnErrorMessage](message.error);
-      case 'stdioPayload':
+      case messageTypes.STDIO_PAYLOAD:
       {
         const { stream, chunk, encoding } = message;
         return this[kParentSideStdio][stream].push(chunk, encoding);
       }
-      case 'stdioWantsMoreData':
+      case messageTypes.STDIO_WANTS_MORE_DATA:
       {
         const { stream } = message;
         return this[kParentSideStdio][stream][kStdioWantsMoreDataCallback]();
@@ -390,7 +399,7 @@ function setupChild(evalScript) {
   const publicWorker = require('worker_threads');
 
   port.on('message', (message) => {
-    if (message.type === 'loadScript') {
+    if (message.type === messageTypes.LOAD_SCRIPT) {
       const { filename, doEval, workerData, publicPort, hasStdin } = message;
       publicWorker.parentPort = publicPort;
       setupPortReferencing(publicPort, publicPort, 'message');
@@ -402,7 +411,7 @@ function setupChild(evalScript) {
       debug(`[${threadId}] starts worker script ${filename} ` +
             `(eval = ${eval}) at cwd = ${process.cwd()}`);
       port.unref();
-      port.postMessage({ type: 'upAndRunning' });
+      port.postMessage({ type: messageTypes.UP_AND_RUNNING });
       if (doEval) {
         evalScript('[worker eval]', filename);
       } else {
@@ -410,11 +419,11 @@ function setupChild(evalScript) {
         require('module').runMain();
       }
       return;
-    } else if (message.type === 'stdioPayload') {
+    } else if (message.type === messageTypes.STDIO_PAYLOAD) {
       const { stream, chunk, encoding } = message;
       workerStdio[stream].push(chunk, encoding);
       return;
-    } else if (message.type === 'stdioWantsMoreData') {
+    } else if (message.type === messageTypes.STDIO_WANTS_MORE_DATA) {
       const { stream } = message;
       workerStdio[stream][kStdioWantsMoreDataCallback]();
       return;
@@ -445,9 +454,12 @@ function setupChild(evalScript) {
       } catch {}
       debug(`[${threadId}] fatal exception serialized = ${!!serialized}`);
       if (serialized)
-        port.postMessage({ type: 'errorMessage', error: serialized });
+        port.postMessage({
+          type: messageTypes.ERROR_MESSAGE,
+          error: serialized
+        });
       else
-        port.postMessage({ type: 'couldNotSerializeError' });
+        port.postMessage({ type: messageTypes.COULD_NOT_SERIALIZE_ERROR });
       clearAsyncIdStack();
     }
   }


### PR DESCRIPTION
This change can prevent typos and redundant strings in code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
