### PR TITLE
[WIP] tools: s/npm install/npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ available-node = \
 		exit 1; \
 	fi;
 
-run-npm-install = $(PWD)/$(NPM) ci --production --no-package-lock
+run-npm-install = $(PWD)/$(NPM) ci --production
 
 tools/doc/node_modules/js-yaml/package.json:
 	cd tools/doc && $(call available-node,$(run-npm-install))

--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ available-node = \
 		exit 1; \
 	fi;
 
-run-npm-install = $(PWD)/$(NPM) install --production --no-package-lock
+run-npm-install = $(PWD)/$(NPM) ci --production --no-package-lock
 
 tools/doc/node_modules/js-yaml/package.json:
 	cd tools/doc && $(call available-node,$(run-npm-install))


### PR DESCRIPTION
`npm ci` is substantially faster than `npm install`.

Can't see why we wouldn't want to do this... only catch would be if we don't support package-lock... but we have those currently checked in afaik