### PR TITLE
src: add null check to GetCategoryGroupEnabled()

### DIFF
--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -95,9 +95,8 @@ static std::unordered_set<std::string> categoryGroups;
 // Gets a pointer to the category-enabled flags for a tracing category group,
 // if tracing is enabled for it.
 static const uint8_t* GetCategoryGroupEnabled(const char* category_group) {
-    if (category_group == nullptr) return nullptr;
-
-    return TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_group);
+  CHECK_NOT_NULL(category_group);
+  return TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_group);
 }
 
 static const char* GetCategoryGroup(Environment* env,


### PR DESCRIPTION
The input to this function shouldn't be null, and callers are not equipped to deal with a `nullptr` return value. Change the `nullptr` return to a `CHECK_NOT_NULL()`. Also fix the indentation of the function.

Fixes: https://github.com/nodejs/node/issues/19991

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
