### PR TITLE
doc: add DataView to crypto.scrypt() and scryptSync()

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1776,8 +1776,8 @@ changes:
     description: The default encoding for `password` if it is a string changed
                  from `binary` to `utf8`.
 -->
-- `password` {string|Buffer|TypedArray}
-- `salt` {string|Buffer|TypedArray}
+- `password` {string|Buffer|TypedArray|DataView}
+- `salt` {string|Buffer|TypedArray|DataView}
 - `iterations` {number}
 - `keylen` {number}
 - `digest` {string}
@@ -1846,8 +1846,8 @@ changes:
     description: The default encoding for `password` if it is a string changed
                  from `binary` to `utf8`.
 -->
-- `password` {string|Buffer|TypedArray}
-- `salt` {string|Buffer|TypedArray}
+- `password` {string|Buffer|TypedArray|DataView}
+- `salt` {string|Buffer|TypedArray|DataView}
 - `iterations` {number}
 - `keylen` {number}
 - `digest` {string}

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2144,8 +2144,8 @@ request.
 <!-- YAML
 added: v10.5.0
 -->
-- `password` {string|Buffer|TypedArray}
-- `salt` {string|Buffer|TypedArray}
+- `password` {string|Buffer|TypedArray|DataView}
+- `salt` {string|Buffer|TypedArray|DataView}
 - `keylen` {number}
 - `options` {Object}
   - `N` {number} CPU/memory cost parameter. Must be a power of two greater
@@ -2190,8 +2190,8 @@ crypto.scrypt('secret', 'salt', 64, { N: 1024 }, (err, derivedKey) => {
 <!-- YAML
 added: v10.5.0
 -->
-- `password` {string|Buffer|TypedArray}
-- `salt` {string|Buffer|TypedArray}
+- `password` {string|Buffer|TypedArray|DataView}
+- `salt` {string|Buffer|TypedArray|DataView}
 - `keylen` {number}
 - `options` {Object}
   - `N` {number} CPU/memory cost parameter. Must be a power of two greater


### PR DESCRIPTION
`crypto.scrypt()` and `crypto.scryptSync()` support also `DataView` like most other crypto Apis.

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
