### PR TITLE
doc: correct crypto.randomFill() and randomFillSync()

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2041,7 +2041,7 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView} Must be supplied.
 * `offset` {number} **Default:** `0`
 * `size` {number} **Default:** `buffer.length - offset`
-* Returns: {Buffer}
+* Returns: {Buffer|TypedArray|DataView} The object passed as `buffer` argument.
 
 Synchronous version of [`crypto.randomFill()`][].
 
@@ -2061,13 +2061,13 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 
 ```js
 const a = new Uint32Array(10);
-console.log(crypto.randomFillSync(a).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(a).buffer).toString('hex'));
 
 const b = new Float64Array(10);
-console.log(crypto.randomFillSync(b).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(b).buffer).toString('hex'));
 
 const c = new DataView(new ArrayBuffer(10));
-console.log(crypto.randomFillSync(c).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(c).buffer).toString('hex'));
 ```
 
 ### crypto.randomFill(buffer[, offset][, size], callback)
@@ -2115,19 +2115,19 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 const a = new Uint32Array(10);
 crypto.randomFill(a, (err, buf) => {
   if (err) throw err;
-  console.log(buf.toString('hex'));
+  console.log(Buffer.from(buf.buffer).toString('hex'));
 });
 
 const b = new Float64Array(10);
 crypto.randomFill(b, (err, buf) => {
   if (err) throw err;
-  console.log(buf.toString('hex'));
+  console.log(Buffer.from(buf.buffer).toString('hex'));
 });
 
 const c = new DataView(new ArrayBuffer(10));
 crypto.randomFill(c, (err, buf) => {
   if (err) throw err;
-  console.log(buf.toString('hex'));
+  console.log(Buffer.from(buf.buffer).toString('hex'));
 });
 ```
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2061,13 +2061,16 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 
 ```js
 const a = new Uint32Array(10);
-console.log(Buffer.from(crypto.randomFillSync(a).buffer, a.byteOffset, a.byteLength).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(a).buffer,
+                        a.byteOffset, a.byteLength).toString('hex'));
 
 const b = new Float64Array(10);
-console.log(Buffer.from(crypto.randomFillSync(b).buffer, b.byteOffset, b.byteLength).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(b).buffer,
+                        b.byteOffset, b.byteLength).toString('hex'));
 
 const c = new DataView(new ArrayBuffer(10));
-console.log(Buffer.from(crypto.randomFillSync(c).buffer, c.byteOffset, c.byteLength).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(c).buffer,
+                        c.byteOffset, c.byteLength).toString('hex'));
 ```
 
 ### crypto.randomFill(buffer[, offset][, size], callback)
@@ -2115,19 +2118,22 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 const a = new Uint32Array(10);
 crypto.randomFill(a, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
+    .toString('hex'));
 });
 
 const b = new Float64Array(10);
 crypto.randomFill(b, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
+    .toString('hex'));
 });
 
 const c = new DataView(new ArrayBuffer(10));
 crypto.randomFill(c, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
+    .toString('hex'));
 });
 ```
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2061,13 +2061,13 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 
 ```js
 const a = new Uint32Array(10);
-console.log(Buffer.from(crypto.randomFillSync(a).buffer).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(a).buffer, a.byteOffset, a.byteLength).toString('hex'));
 
 const b = new Float64Array(10);
-console.log(Buffer.from(crypto.randomFillSync(b).buffer).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(b).buffer, b.byteOffset, b.byteLength).toString('hex'));
 
 const c = new DataView(new ArrayBuffer(10));
-console.log(Buffer.from(crypto.randomFillSync(c).buffer).toString('hex'));
+console.log(Buffer.from(crypto.randomFillSync(c).buffer, c.byteOffset, c.byteLength).toString('hex'));
 ```
 
 ### crypto.randomFill(buffer[, offset][, size], callback)
@@ -2115,19 +2115,19 @@ Any `TypedArray` or `DataView` instance may be passed as `buffer`.
 const a = new Uint32Array(10);
 crypto.randomFill(a, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
 });
 
 const b = new Float64Array(10);
 crypto.randomFill(b, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
 });
 
 const c = new DataView(new ArrayBuffer(10));
 crypto.randomFill(c, (err, buf) => {
   if (err) throw err;
-  console.log(Buffer.from(buf.buffer).toString('hex'));
+  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString('hex'));
 });
 ```
 


### PR DESCRIPTION
Correct return type of `crypto.randomFillSync()` which is of same type as passed as `buffer` argument.

Correct samples for `randomFill()` and `randomFillSync()` using a `TypeArray` or `DataView` as these types don't support `.toString(encoding)`.

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
