### PR TITLE
new core modules go under a namespace

### DIFF
--- a/benchmark/fixtures/echo.worker.js
+++ b/benchmark/fixtures/echo.worker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { parentPort } = require('worker_threads');
+const { parentPort } = require('nodejs:worker_threads');
 
 parentPort.on('message', (msg) => {
   parentPort.postMessage(msg);

--- a/benchmark/fixtures/echo.worker.js
+++ b/benchmark/fixtures/echo.worker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { parentPort } = require('nodejs:worker_threads');
+const { parentPort } = require('@nodejs/worker_threads');
 
 parentPort.on('message', (msg) => {
   parentPort.postMessage(msg);

--- a/benchmark/fixtures/require-cachable.js
+++ b/benchmark/fixtures/require-cachable.js
@@ -3,7 +3,7 @@
 const list = require('internal/bootstrap/cache');
 const {
   isMainThread
-} = require('worker_threads');
+} = require('nodejs:worker_threads');
 
 for (const key of list.cachableBuiltins) {
   if (!isMainThread && key === 'trace_events') {

--- a/benchmark/fixtures/require-cachable.js
+++ b/benchmark/fixtures/require-cachable.js
@@ -3,7 +3,7 @@
 const list = require('internal/bootstrap/cache');
 const {
   isMainThread
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 
 for (const key of list.cachableBuiltins) {
   if (!isMainThread && key === 'trace_events') {

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -66,7 +66,7 @@ function main({ dur, script, mode }) {
 
   script = path.resolve(__dirname, '../../', `${script}.js`);
   if (mode === 'worker') {
-    Worker = require('worker_threads').Worker;
+    Worker = require('nodejs:worker_threads').Worker;
     bench.start();
     start(state, script, bench, spawnWorker);
   } else {

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -66,7 +66,7 @@ function main({ dur, script, mode }) {
 
   script = path.resolve(__dirname, '../../', `${script}.js`);
   if (mode === 'worker') {
-    Worker = require('nodejs:worker_threads').Worker;
+    Worker = require('@nodejs/worker_threads').Worker;
     bench.start();
     start(state, script, bench, spawnWorker);
   } else {

--- a/benchmark/worker/echo.js
+++ b/benchmark/worker/echo.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 const workerPath = path.resolve(__dirname, '..', 'fixtures', 'echo.worker.js');
 
 function main(conf) {
-  const { Worker } = require('worker_threads');
+  const { Worker } = require('nodejs:worker_threads');
 
   const n = +conf.n;
   const workers = +conf.workers;

--- a/benchmark/worker/echo.js
+++ b/benchmark/worker/echo.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 const workerPath = path.resolve(__dirname, '..', 'fixtures', 'echo.worker.js');
 
 function main(conf) {
-  const { Worker } = require('nodejs:worker_threads');
+  const { Worker } = require('@nodejs/worker_threads');
 
   const n = +conf.n;
   const workers = +conf.workers;

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1234,6 +1234,12 @@ An invalid HTTP token was supplied.
 
 An IP address is not valid.
 
+<a id="ERR_INVALID_NODE_BUILTIN"></a>
+### ERR_INVALID_NODE_BUILTIN
+
+An attempt was made to load a module from the Node.js namespace that doesn't
+exist. Only built in modules can be require from 'nodejs:'.
+
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### ERR_INVALID_OPT_VALUE
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1238,7 +1238,7 @@ An IP address is not valid.
 ### ERR_INVALID_NODE_BUILTIN
 
 An attempt was made to load a module from the Node.js namespace that doesn't
-exist. Only built in modules can be require from 'nodejs:'.
+exist. Only built in modules can be require from '@nodejs/'.
 
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### ERR_INVALID_OPT_VALUE

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -9,7 +9,7 @@ on independent threads, and to create message channels between them. It
 can be accessed using the `--experimental-worker` flag and:
 
 ```js
-const worker = require('worker_threads');
+const worker = require('nodejs:worker_threads');
 ```
 
 Workers are useful for performing CPU-intensive JavaScript operations; do not
@@ -23,7 +23,7 @@ share memory efficiently by transferring `ArrayBuffer` instances or sharing
 ```js
 const {
   Worker, isMainThread, parentPort, workerData
-} = require('worker_threads');
+} = require('nodejs:worker_threads');
 
 if (isMainThread) {
   module.exports = async function parseJSAsync(script) {
@@ -104,7 +104,7 @@ yields an object with `port1` and `port2` properties, which refer to linked
 [`MessagePort`][] instances.
 
 ```js
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 const { port1, port2 } = new MessageChannel();
 port1.on('message', (message) => console.log('received', message));
@@ -243,8 +243,10 @@ Notable differences inside a Worker environment are:
 
 - The [`process.stdin`][], [`process.stdout`][] and [`process.stderr`][]
   may be redirected by the parent thread.
-- The [`require('worker_threads').isMainThread`][] property is set to `false`.
-- The [`require('worker_threads').parentPort`][] message port is available,
+- The [`require('nodejs:worker_threads').isMainThread`][]
+  property is set to `false`.
+- The [`require('nodejs:worker_threads').parentPort`][] message port is
+  available,
 - [`process.exit()`][] does not stop the whole program, just the single thread,
   and [`process.abort()`][] is not available.
 - [`process.chdir()`][] and `process` methods that set group or user ids
@@ -286,7 +288,7 @@ the thread barrier.
 const assert = require('assert');
 const {
   Worker, MessageChannel, MessagePort, isMainThread, parentPort
-} = require('worker_threads');
+} = require('nodejs:worker_threads');
 if (isMainThread) {
   const worker = new Worker(__filename);
   const subChannel = new MessageChannel();
@@ -314,10 +316,10 @@ if (isMainThread) {
   * `eval` {boolean} If true, interpret the first argument to the constructor
     as a script that is executed once the worker is online.
   * `workerData` {any} Any JavaScript value that will be cloned and made
-    available as [`require('worker_threads').workerData`][]. The cloning will
-    occur as described in the [HTML structured clone algorithm][], and an error
-    will be thrown if the object cannot be cloned (e.g. because it contains
-    `function`s).
+    available as [`require('nodejs:worker_threads').workerData`][]. The
+    cloning will occur as described in the [HTML structured clone algorithm][],
+    and an error will be thrown if the object cannot be cloned (e.g. because it
+    contains `function`s).
   * stdin {boolean} If this is set to `true`, then `worker.stdin` will
     provide a writable stream whose contents will appear as `process.stdin`
     inside the Worker. By default, no data is provided.
@@ -356,7 +358,7 @@ added: v10.5.0
 * `value` {any} The transmitted value
 
 The `'message'` event is emitted when the worker thread has invoked
-[`require('worker_threads').postMessage()`][]. See the [`port.on('message')`][]
+[`require('nodejs:worker_threads').postMessage()`][]. See the [`port.on('message')`][]
 event for more details.
 
 ### Event: 'online'
@@ -376,7 +378,7 @@ added: v10.5.0
 * `transferList` {Object[]}
 
 Send a message to the worker that will be received via
-[`require('worker_threads').parentPort.on('message')`][].
+[`require('nodejs:worker_threads').parentPort.on('message')`][].
 See [`port.postMessage()`][] for more details.
 
 ### worker.ref()
@@ -451,7 +453,7 @@ added: v10.5.0
 * {integer}
 
 An integer identifier for the referenced thread. Inside the worker thread,
-it is available as [`require('worker_threads').threadId`][].
+it is available as [`require('nodejs:worker_threads').threadId`][].
 
 ### worker.unref()
 <!-- YAML
@@ -480,12 +482,12 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`process.stdin`]: process.html#process_process_stdin
 [`process.stdout`]: process.html#process_process_stdout
 [`process.title`]: process.html#process_process_title
-[`require('worker_threads').isMainThread`]: #worker_threads_worker_ismainthread
-[`require('worker_threads').parentPort.on('message')`]: #worker_threads_event_message
-[`require('worker_threads').parentPort`]: #worker_threads_worker_parentport
-[`require('worker_threads').postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
-[`require('worker_threads').threadId`]: #worker_threads_worker_threadid
-[`require('worker_threads').workerData`]: #worker_threads_worker_workerdata
+[`require('nodejs:worker_threads').isMainThread`]: #worker_threads_worker_ismainthread
+[`require('nodejs:worker_threads').parentPort.on('message')`]: #worker_threads_event_message
+[`require('nodejs:worker_threads').parentPort`]: #worker_threads_worker_parentport
+[`require('nodejs:worker_threads').postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
+[`require('nodejs:worker_threads').threadId`]: #worker_threads_worker_threadid
+[`require('nodejs:worker_threads').workerData`]: #worker_threads_worker_workerdata
 [`trace_events`]: tracing.html
 [`worker.on('message')`]: #worker_threads_event_message_1
 [`worker.postMessage()`]: #worker_threads_worker_postmessage_value_transferlist

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -9,7 +9,7 @@ on independent threads, and to create message channels between them. It
 can be accessed using the `--experimental-worker` flag and:
 
 ```js
-const worker = require('nodejs:worker_threads');
+const worker = require('@nodejs/worker_threads');
 ```
 
 Workers are useful for performing CPU-intensive JavaScript operations; do not
@@ -23,7 +23,7 @@ share memory efficiently by transferring `ArrayBuffer` instances or sharing
 ```js
 const {
   Worker, isMainThread, parentPort, workerData
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 
 if (isMainThread) {
   module.exports = async function parseJSAsync(script) {
@@ -104,7 +104,7 @@ yields an object with `port1` and `port2` properties, which refer to linked
 [`MessagePort`][] instances.
 
 ```js
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 const { port1, port2 } = new MessageChannel();
 port1.on('message', (message) => console.log('received', message));
@@ -243,9 +243,9 @@ Notable differences inside a Worker environment are:
 
 - The [`process.stdin`][], [`process.stdout`][] and [`process.stderr`][]
   may be redirected by the parent thread.
-- The [`require('nodejs:worker_threads').isMainThread`][]
+- The [`require('@nodejs/worker_threads').isMainThread`][]
   property is set to `false`.
-- The [`require('nodejs:worker_threads').parentPort`][] message port is
+- The [`require('@nodejs/worker_threads').parentPort`][] message port is
   available,
 - [`process.exit()`][] does not stop the whole program, just the single thread,
   and [`process.abort()`][] is not available.
@@ -288,7 +288,7 @@ the thread barrier.
 const assert = require('assert');
 const {
   Worker, MessageChannel, MessagePort, isMainThread, parentPort
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 if (isMainThread) {
   const worker = new Worker(__filename);
   const subChannel = new MessageChannel();
@@ -316,7 +316,7 @@ if (isMainThread) {
   * `eval` {boolean} If true, interpret the first argument to the constructor
     as a script that is executed once the worker is online.
   * `workerData` {any} Any JavaScript value that will be cloned and made
-    available as [`require('nodejs:worker_threads').workerData`][]. The
+    available as [`require('@nodejs/worker_threads').workerData`][]. The
     cloning will occur as described in the [HTML structured clone algorithm][],
     and an error will be thrown if the object cannot be cloned (e.g. because it
     contains `function`s).
@@ -358,7 +358,7 @@ added: v10.5.0
 * `value` {any} The transmitted value
 
 The `'message'` event is emitted when the worker thread has invoked
-[`require('nodejs:worker_threads').postMessage()`][]. See the [`port.on('message')`][]
+[`require('@nodejs/worker_threads').postMessage()`][]. See the [`port.on('message')`][]
 event for more details.
 
 ### Event: 'online'
@@ -378,7 +378,7 @@ added: v10.5.0
 * `transferList` {Object[]}
 
 Send a message to the worker that will be received via
-[`require('nodejs:worker_threads').parentPort.on('message')`][].
+[`require('@nodejs/worker_threads').parentPort.on('message')`][].
 See [`port.postMessage()`][] for more details.
 
 ### worker.ref()
@@ -453,7 +453,7 @@ added: v10.5.0
 * {integer}
 
 An integer identifier for the referenced thread. Inside the worker thread,
-it is available as [`require('nodejs:worker_threads').threadId`][].
+it is available as [`require('@nodejs/worker_threads').threadId`][].
 
 ### worker.unref()
 <!-- YAML
@@ -482,12 +482,12 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`process.stdin`]: process.html#process_process_stdin
 [`process.stdout`]: process.html#process_process_stdout
 [`process.title`]: process.html#process_process_title
-[`require('nodejs:worker_threads').isMainThread`]: #worker_threads_worker_ismainthread
-[`require('nodejs:worker_threads').parentPort.on('message')`]: #worker_threads_event_message
-[`require('nodejs:worker_threads').parentPort`]: #worker_threads_worker_parentport
-[`require('nodejs:worker_threads').postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
-[`require('nodejs:worker_threads').threadId`]: #worker_threads_worker_threadid
-[`require('nodejs:worker_threads').workerData`]: #worker_threads_worker_workerdata
+[`require('@nodejs/worker_threads').isMainThread`]: #worker_threads_worker_ismainthread
+[`require('@nodejs/worker_threads').parentPort.on('message')`]: #worker_threads_event_message
+[`require('@nodejs/worker_threads').parentPort`]: #worker_threads_worker_parentport
+[`require('@nodejs/worker_threads').postMessage()`]: #worker_threads_worker_postmessage_value_transferlist
+[`require('@nodejs/worker_threads').threadId`]: #worker_threads_worker_threadid
+[`require('@nodejs/worker_threads').workerData`]: #worker_threads_worker_workerdata
 [`trace_events`]: tracing.html
 [`worker.on('message')`]: #worker_threads_event_message_1
 [`worker.postMessage()`]: #worker_threads_worker_postmessage_value_transferlist

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -254,7 +254,8 @@ if (config.exposeInternals) {
 
   NativeModule.isInternal = function(id) {
     return id.startsWith('internal/') ||
-        (id === '@nodejs/worker_threads' && !config.experimentalWorker);
+        ((id === '@nodejs/worker_threads' || id === 'worker_threads')
+          && !config.experimentalWorker);
   };
 }
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -254,8 +254,8 @@ if (config.exposeInternals) {
 
   NativeModule.isInternal = function(id) {
     return id.startsWith('internal/') ||
-        ((id === '@nodejs/worker_threads' || id === 'worker_threads')
-          && !config.experimentalWorker);
+        ((id === '@nodejs/worker_threads' || id === 'worker_threads') &&
+          !config.experimentalWorker);
   };
 }
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -254,7 +254,7 @@ if (config.exposeInternals) {
 
   NativeModule.isInternal = function(id) {
     return id.startsWith('internal/') ||
-        (id === 'worker_threads' && !config.experimentalWorker);
+        (id === 'nodejs:worker_threads' && !config.experimentalWorker);
   };
 }
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -254,7 +254,7 @@ if (config.exposeInternals) {
 
   NativeModule.isInternal = function(id) {
     return id.startsWith('internal/') ||
-        (id === 'nodejs:worker_threads' && !config.experimentalWorker);
+        (id === '@nodejs/worker_threads' && !config.experimentalWorker);
   };
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -749,6 +749,7 @@ E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s', TypeError);
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent', TypeError);
 E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]', TypeError);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s', TypeError);
+E('ERR_INVALID_NODE_BUILTIN', '%s is not a builtin Node.js module', Error);
 E('ERR_INVALID_OPT_VALUE', (name, value) =>
   `The value "${String(value)}" is invalid for option "${name}"`,
   TypeError,

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -95,18 +95,22 @@ function stripShebang(content) {
   return content;
 }
 
+const namespaceBuiltinLibs = [];
+
+if (getOptionValue('--experimental-worker')) {
+  namespaceBuiltinLibs.push('worker_threads');
+  namespaceBuiltinLibs.sort();
+}
+
 const builtinLibs = [
   'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'crypto',
   'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'http2', 'https', 'net',
   'os', 'path', 'perf_hooks', 'punycode', 'querystring', 'readline', 'repl',
   'stream', 'string_decoder', 'tls', 'trace_events', 'tty', 'url', 'util',
-  'v8', 'vm', 'zlib'
+  'v8', 'vm', 'zlib', ...namespaceBuiltinLibs
 ];
 
-if (getOptionValue('--experimental-worker')) {
-  builtinLibs.push('worker_threads');
-  builtinLibs.sort();
-}
+builtinLibs.sort();
 
 if (typeof process.binding('inspector').open === 'function') {
   builtinLibs.push('inspector');
@@ -156,6 +160,7 @@ module.exports = exports = {
   addBuiltinLibsToObject,
   builtinLibs,
   makeRequireFunction,
+  namespaceBuiltinLibs,
   requireDepth: 0,
   stripBOM,
   stripShebang

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -99,7 +99,6 @@ const namespaceBuiltinLibs = [];
 
 if (getOptionValue('--experimental-worker')) {
   namespaceBuiltinLibs.push('worker_threads');
-  namespaceBuiltinLibs.sort();
 }
 
 const builtinLibs = [
@@ -110,12 +109,11 @@ const builtinLibs = [
   'v8', 'vm', 'zlib', ...namespaceBuiltinLibs
 ];
 
-builtinLibs.sort();
-
 if (typeof process.binding('inspector').open === 'function') {
   builtinLibs.push('inspector');
-  builtinLibs.sort();
 }
+
+builtinLibs.sort();
 
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -95,10 +95,10 @@ function stripShebang(content) {
   return content;
 }
 
-const namespaceBuiltinLibs = [];
+const namespaceBuiltinLibs = new Set();
 
 if (getOptionValue('--experimental-worker')) {
-  namespaceBuiltinLibs.push('worker_threads');
+  namespaceBuiltinLibs.add('worker_threads');
 }
 
 const builtinLibs = [

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -98,7 +98,7 @@ function stripShebang(content) {
 const nonNamespaceBlacklist = new Set();
 
 if (getOptionValue('--experimental-worker')) {
-  namespaceBuiltinLibs.add('worker_threads');
+  nonNamespaceBlacklist.add('worker_threads');
 }
 
 const builtinLibs = [

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -95,7 +95,7 @@ function stripShebang(content) {
   return content;
 }
 
-const namespaceBuiltinLibs = new Set();
+const nonNamespaceBlacklist = new Set();
 
 if (getOptionValue('--experimental-worker')) {
   namespaceBuiltinLibs.add('worker_threads');
@@ -106,7 +106,7 @@ const builtinLibs = [
   'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'http2', 'https', 'net',
   'os', 'path', 'perf_hooks', 'punycode', 'querystring', 'readline', 'repl',
   'stream', 'string_decoder', 'tls', 'trace_events', 'tty', 'url', 'util',
-  'v8', 'vm', 'zlib', ...namespaceBuiltinLibs
+  'v8', 'vm', 'zlib', ...nonNamespaceBlacklist
 ];
 
 if (typeof process.binding('inspector').open === 'function') {
@@ -114,6 +114,8 @@ if (typeof process.binding('inspector').open === 'function') {
 }
 
 builtinLibs.sort();
+
+const namespaceWhitelist = new Set(builtinLibs);
 
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).
@@ -158,7 +160,8 @@ module.exports = exports = {
   addBuiltinLibsToObject,
   builtinLibs,
   makeRequireFunction,
-  namespaceBuiltinLibs,
+  namespaceWhitelist,
+  nonNamespaceBlacklist,
   requireDepth: 0,
   stripBOM,
   stripShebang

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -37,6 +37,7 @@ const {
 const { safeGetenv } = internalBinding('util');
 const {
   makeRequireFunction,
+  namespaceBuiltinLibs,
   requireDepth,
   stripBOM,
   stripShebang
@@ -48,6 +49,7 @@ const experimentalModules = getOptionValue('--experimental-modules');
 
 const {
   ERR_INVALID_ARG_VALUE,
+  ERR_INVALID_NODE_BUILTIN,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -567,7 +569,17 @@ function tryModuleLoad(module, filename) {
 }
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-  if (NativeModule.nonInternalExists(request)) {
+
+  if (request.search('nodejs:') !== -1) {
+    request = request.slice(7);
+    if (!NativeModule.nonInternalExists(request)) {
+      throw new ERR_INVALID_NODE_BUILTIN(request);
+    }
+    return request;
+  }
+
+  if (!namespaceBuiltinLibs.includes(request) &&
+      NativeModule.nonInternalExists(request)) {
     return request;
   }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -37,7 +37,8 @@ const {
 const { safeGetenv } = internalBinding('util');
 const {
   makeRequireFunction,
-  namespaceBuiltinLibs,
+  namespaceWhitelist,
+  nonNamespaceBlacklist,
   requireDepth,
   stripBOM,
   stripShebang
@@ -571,13 +572,13 @@ function tryModuleLoad(module, filename) {
 Module._resolveFilename = function(request, parent, isMain, options) {
   if (request.startsWith('@nodejs/')) {
     request = request.slice(8);
-    if (!NativeModule.nonInternalExists(request)) {
+    if (!namespaceWhitelist.has(request)) {
       throw new ERR_INVALID_NODE_BUILTIN(request);
     }
     return request;
   }
 
-  if (!namespaceBuiltinLibs.has(request) &&
+  if (!nonNamespaceBlacklist.has(request) &&
       NativeModule.nonInternalExists(request)) {
     return request;
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -569,7 +569,7 @@ function tryModuleLoad(module, filename) {
 }
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-  if (request.startsWith('@nodejs/') === 0) {
+  if (request.startsWith('@nodejs/')) {
     request = request.slice(8);
     if (!NativeModule.nonInternalExists(request)) {
       throw new ERR_INVALID_NODE_BUILTIN(request);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -569,7 +569,6 @@ function tryModuleLoad(module, filename) {
 }
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-
   if (request.search('@nodejs/') === 0) {
     request = request.slice(8);
     if (!NativeModule.nonInternalExists(request)) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -577,7 +577,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     return request;
   }
 
-  if (!namespaceBuiltinLibs.includes(request) &&
+  if (!namespaceBuiltinLibs.has(request) &&
       NativeModule.nonInternalExists(request)) {
     return request;
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -570,8 +570,8 @@ function tryModuleLoad(module, filename) {
 
 Module._resolveFilename = function(request, parent, isMain, options) {
 
-  if (request.search('nodejs:') !== -1) {
-    request = request.slice(7);
+  if (request.search('@nodejs/') === 0) {
+    request = request.slice(8);
     if (!NativeModule.nonInternalExists(request)) {
       throw new ERR_INVALID_NODE_BUILTIN(request);
     }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -569,7 +569,7 @@ function tryModuleLoad(module, filename) {
 }
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-  if (request.search('@nodejs/') === 0) {
+  if (request.startsWith('@nodejs/') === 0) {
     request = request.slice(8);
     if (!NativeModule.nonInternalExists(request)) {
       throw new ERR_INVALID_NODE_BUILTIN(request);

--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 const { spawnSync } = require('child_process');
 
 // This is a sibling test to test/addons/uv-handle-leak.

--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 const { spawnSync } = require('child_process');
 
 // This is a sibling test to test/addons/uv-handle-leak.

--- a/test/addons/uv-handle-leak/test.js
+++ b/test/addons/uv-handle-leak/test.js
@@ -13,7 +13,7 @@ const binding = require(bindingPath);
 try {
   // We don’t want to run this in Workers because they do actually enforce
   // a clean-exit policy.
-  const { isMainThread } = require('worker_threads');
+  const { isMainThread } = require('nodejs:worker_threads');
   if (!isMainThread)
     common.skip('Cannot run test in environment with clean-exit policy');
 } catch {}

--- a/test/addons/uv-handle-leak/test.js
+++ b/test/addons/uv-handle-leak/test.js
@@ -13,7 +13,7 @@ const binding = require(bindingPath);
 try {
   // We don’t want to run this in Workers because they do actually enforce
   // a clean-exit policy.
-  const { isMainThread } = require('nodejs:worker_threads');
+  const { isMainThread } = require('@nodejs/worker_threads');
   if (!isMainThread)
     common.skip('Cannot run test in environment with clean-exit policy');
 } catch {}

--- a/test/code-cache/test-code-cache.js
+++ b/test/code-cache/test-code-cache.js
@@ -13,7 +13,7 @@ const {
 } = require('internal/bootstrap/cache');
 const {
   isMainThread
-} = require('worker_threads');
+} = require('nodejs:worker_threads');
 
 const {
   internalBinding

--- a/test/code-cache/test-code-cache.js
+++ b/test/code-cache/test-code-cache.js
@@ -13,7 +13,7 @@ const {
 } = require('internal/bootstrap/cache');
 const {
   isMainThread
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 
 const {
   internalBinding

--- a/test/code-cache/test-code-cache.js
+++ b/test/code-cache/test-code-cache.js
@@ -13,7 +13,7 @@ const {
 } = require('internal/bootstrap/cache');
 const {
   isMainThread
-} = require('@nodejs/worker_threads');
+} = require('worker_threads');
 
 const {
   internalBinding

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,7 +38,7 @@ const noop = () => {};
 
 const isMainThread = (() => {
   try {
-    return require('worker_threads').isMainThread;
+    return require('nodejs:worker_threads').isMainThread;
   } catch {
     // Worker module not enabled → only a single main thread exists.
     return true;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,7 +38,7 @@ const noop = () => {};
 
 const isMainThread = (() => {
   try {
-    return require('nodejs:worker_threads').isMainThread;
+    return require('@nodejs/worker_threads').isMainThread;
   } catch {
     // Worker module not enabled → only a single main thread exists.
     return true;

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -281,7 +281,7 @@ class WPTRunner {
     // TODO(joyeecheung): we are not a window - work with the upstream to
     // add a new scope for us.
 
-    const { Worker } = require('worker_threads');
+    const { Worker } = require('nodejs:worker_threads');
     sandbox.DedicatedWorker = Worker;  // Pretend we are a Worker
     return context;
   }

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -281,7 +281,7 @@ class WPTRunner {
     // TODO(joyeecheung): we are not a window - work with the upstream to
     // add a new scope for us.
 
-    const { Worker } = require('nodejs:worker_threads');
+    const { Worker } = require('@nodejs/worker_threads');
     sandbox.DedicatedWorker = Worker;  // Pretend we are a Worker
     return context;
   }

--- a/test/fixtures/v8-coverage/worker.js
+++ b/test/fixtures/v8-coverage/worker.js
@@ -1,5 +1,5 @@
 'use strict';
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 const path = require('path');
 
 new Worker(path.resolve(__dirname, 'subprocess.js'));

--- a/test/fixtures/v8-coverage/worker.js
+++ b/test/fixtures/v8-coverage/worker.js
@@ -1,5 +1,5 @@
 'use strict';
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 const path = require('path');
 
 new Worker(path.resolve(__dirname, 'subprocess.js'));

--- a/test/parallel/test-async-wrap-missing-method.js
+++ b/test/parallel/test-async-wrap-missing-method.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-async-wrap-missing-method.js
+++ b/test/parallel/test-async-wrap-missing-method.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-heapdump-worker.js
+++ b/test/parallel/test-heapdump-worker.js
@@ -2,7 +2,7 @@
 'use strict';
 require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 validateSnapshotNodes('Node / Worker', []);
 const worker = new Worker('setInterval(() => {}, 100);', { eval: true });

--- a/test/parallel/test-heapdump-worker.js
+++ b/test/parallel/test-heapdump-worker.js
@@ -2,7 +2,7 @@
 'use strict';
 require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 validateSnapshotNodes('Node / Worker', []);
 const worker = new Worker('setInterval(() => {}, 100);', { eval: true });

--- a/test/parallel/test-trace-events-api-worker-disabled.js
+++ b/test/parallel/test-trace-events-api-worker-disabled.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 new Worker("require('trace_events')", { eval: true })
   .on('error', common.expectsError({

--- a/test/parallel/test-trace-events-api-worker-disabled.js
+++ b/test/parallel/test-trace-events-api-worker-disabled.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 new Worker("require('trace_events')", { eval: true })
   .on('error', common.expectsError({

--- a/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
+++ b/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 common.skipIfInspectorDisabled();
 

--- a/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
+++ b/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 common.skipIfInspectorDisabled();
 

--- a/test/parallel/test-trace-events-worker-metadata.js
+++ b/test/parallel/test-trace-events-worker-metadata.js
@@ -4,10 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-const { isMainThread } = require('worker_threads');
+const { isMainThread } = require('nodejs:worker_threads');
 
 if (isMainThread) {
-  const CODE = 'const { Worker } = require(\'worker_threads\'); ' +
+  const CODE = 'const { Worker } = require(\'nodejs:worker_threads\'); ' +
                `new Worker('${__filename.replace(/\\/g, '/')}')`;
   const FILE_NAME = 'node_trace.1.log';
   const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-trace-events-worker-metadata.js
+++ b/test/parallel/test-trace-events-worker-metadata.js
@@ -4,10 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-const { isMainThread } = require('nodejs:worker_threads');
+const { isMainThread } = require('@nodejs/worker_threads');
 
 if (isMainThread) {
-  const CODE = 'const { Worker } = require(\'nodejs:worker_threads\'); ' +
+  const CODE = 'const { Worker } = require(\'@nodejs/worker_threads\'); ' +
                `new Worker('${__filename.replace(/\\/g, '/')}')`;
   const FILE_NAME = 'node_trace.1.log';
   const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-worker-cleanup-handles.js
+++ b/test/parallel/test-worker-cleanup-handles.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
 const { Server } = require('net');
 const fs = require('fs');
 

--- a/test/parallel/test-worker-cleanup-handles.js
+++ b/test/parallel/test-worker-cleanup-handles.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
+const { Worker, isMainThread, parentPort } = require('@nodejs/worker_threads');
 const { Server } = require('net');
 const fs = require('fs');
 

--- a/test/parallel/test-worker-debug.js
+++ b/test/parallel/test-worker-debug.js
@@ -10,7 +10,7 @@ const { Session } = require('inspector');
 const { pathToFileURL } = require('url');
 const {
   Worker, isMainThread, parentPort, workerData
-} = require('worker_threads');
+} = require('nodejs:worker_threads');
 
 
 const workerMessage = 'This is a message from a worker';

--- a/test/parallel/test-worker-debug.js
+++ b/test/parallel/test-worker-debug.js
@@ -10,7 +10,7 @@ const { Session } = require('inspector');
 const { pathToFileURL } = require('url');
 const {
   Worker, isMainThread, parentPort, workerData
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 
 
 const workerMessage = 'This is a message from a worker';

--- a/test/parallel/test-worker-dns-terminate.js
+++ b/test/parallel/test-worker-dns-terminate.js
@@ -1,12 +1,12 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 const w = new Worker(`
 const dns = require('dns');
 dns.lookup('nonexistent.org', () => {});
-require('worker_threads').parentPort.postMessage('0');
+require('nodejs:worker_threads').parentPort.postMessage('0');
 `, { eval: true });
 
 w.on('message', common.mustCall(() => {

--- a/test/parallel/test-worker-dns-terminate.js
+++ b/test/parallel/test-worker-dns-terminate.js
@@ -1,12 +1,12 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 const w = new Worker(`
 const dns = require('dns');
 dns.lookup('nonexistent.org', () => {});
-require('nodejs:worker_threads').parentPort.postMessage('0');
+require('@nodejs/worker_threads').parentPort.postMessage('0');
 `, { eval: true });
 
 w.on('message', common.mustCall(() => {

--- a/test/parallel/test-worker-esmodule.js
+++ b/test/parallel/test-worker-esmodule.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 const w = new Worker(fixtures.path('worker-script.mjs'));
 w.on('message', common.mustCall((message) => {

--- a/test/parallel/test-worker-esmodule.js
+++ b/test/parallel/test-worker-esmodule.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 const w = new Worker(fixtures.path('worker-script.mjs'));
 w.on('message', common.mustCall((message) => {

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -6,7 +6,7 @@ const common = require('../common');
 // in multiple situations.
 
 const assert = require('assert');
-const worker = require('worker_threads');
+const worker = require('nodejs:worker_threads');
 const { Worker, parentPort } = worker;
 
 const testCases = require('../fixtures/process-exit-code-cases');

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -6,7 +6,7 @@ const common = require('../common');
 // in multiple situations.
 
 const assert = require('assert');
-const worker = require('nodejs:worker_threads');
+const worker = require('@nodejs/worker_threads');
 const { Worker, parentPort } = worker;
 
 const testCases = require('../fixtures/process-exit-code-cases');

--- a/test/parallel/test-worker-invalid-workerdata.js
+++ b/test/parallel/test-worker-invalid-workerdata.js
@@ -2,7 +2,7 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // This tests verifies that failing to serialize workerData does not keep
 // the process alive.

--- a/test/parallel/test-worker-invalid-workerdata.js
+++ b/test/parallel/test-worker-invalid-workerdata.js
@@ -2,7 +2,7 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // This tests verifies that failing to serialize workerData does not keep
 // the process alive.

--- a/test/parallel/test-worker-memory.js
+++ b/test/parallel/test-worker-memory.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 const numWorkers = +process.env.JOBS || require('os').cpus().length;
 
@@ -14,7 +14,7 @@ function run(n, done) {
   if (n <= 0)
     return done();
   const worker = new Worker(
-    'require(\'worker_threads\').parentPort.postMessage(2 + 2)',
+    'require(\'nodejs:worker_threads\').parentPort.postMessage(2 + 2)',
     { eval: true });
   worker.on('message', common.mustCall((value) => {
     assert.strictEqual(value, 4);

--- a/test/parallel/test-worker-memory.js
+++ b/test/parallel/test-worker-memory.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 const numWorkers = +process.env.JOBS || require('os').cpus().length;
 
@@ -14,7 +14,7 @@ function run(n, done) {
   if (n <= 0)
     return done();
   const worker = new Worker(
-    'require(\'nodejs:worker_threads\').parentPort.postMessage(2 + 2)',
+    'require(\'@nodejs/worker_threads\').parentPort.postMessage(2 + 2)',
     { eval: true });
   worker.on('message', common.mustCall((value) => {
     assert.strictEqual(value, 4);

--- a/test/parallel/test-worker-message-channel-sharedarraybuffer.js
+++ b/test/parallel/test-worker-message-channel-sharedarraybuffer.js
@@ -3,14 +3,14 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 {
   const sharedArrayBuffer = new SharedArrayBuffer(12);
   const local = Buffer.from(sharedArrayBuffer);
 
   const w = new Worker(`
-    const { parentPort } = require('worker_threads');
+    const { parentPort } = require('nodejs:worker_threads');
     parentPort.on('message', ({ sharedArrayBuffer }) => {
       const local = Buffer.from(sharedArrayBuffer);
       local.write('world!', 6);

--- a/test/parallel/test-worker-message-channel-sharedarraybuffer.js
+++ b/test/parallel/test-worker-message-channel-sharedarraybuffer.js
@@ -3,14 +3,14 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 {
   const sharedArrayBuffer = new SharedArrayBuffer(12);
   const local = Buffer.from(sharedArrayBuffer);
 
   const w = new Worker(`
-    const { parentPort } = require('nodejs:worker_threads');
+    const { parentPort } = require('@nodejs/worker_threads');
     parentPort.on('message', ({ sharedArrayBuffer }) => {
       const local = Buffer.from(sharedArrayBuffer);
       local.write('world!', 6);

--- a/test/parallel/test-worker-message-channel.js
+++ b/test/parallel/test-worker-message-channel.js
@@ -2,7 +2,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { MessageChannel, MessagePort, Worker } = require('worker_threads');
+const {
+  MessageChannel,
+  MessagePort,
+  Worker
+} = require('nodejs:worker_threads');
 
 {
   const channel = new MessageChannel();
@@ -29,9 +33,9 @@ const { MessageChannel, MessagePort, Worker } = require('worker_threads');
   const channel = new MessageChannel();
 
   const w = new Worker(`
-    const { MessagePort } = require('worker_threads');
+    const { MessagePort } = require('nodejs:worker_threads');
     const assert = require('assert');
-    require('worker_threads').parentPort.on('message', ({ port }) => {
+    require('nodejs:worker_threads').parentPort.on('message', ({ port }) => {
       assert(port instanceof MessagePort);
       port.postMessage('works');
     });

--- a/test/parallel/test-worker-message-channel.js
+++ b/test/parallel/test-worker-message-channel.js
@@ -6,7 +6,7 @@ const {
   MessageChannel,
   MessagePort,
   Worker
-} = require('nodejs:worker_threads');
+} = require('@nodejs/worker_threads');
 
 {
   const channel = new MessageChannel();
@@ -33,9 +33,9 @@ const {
   const channel = new MessageChannel();
 
   const w = new Worker(`
-    const { MessagePort } = require('nodejs:worker_threads');
+    const { MessagePort } = require('@nodejs/worker_threads');
     const assert = require('assert');
-    require('nodejs:worker_threads').parentPort.on('message', ({ port }) => {
+    require('@nodejs/worker_threads').parentPort.on('message', ({ port }) => {
       assert(port instanceof MessagePort);
       port.postMessage('works');
     });

--- a/test/parallel/test-worker-message-port-arraybuffer.js
+++ b/test/parallel/test-worker-message-port-arraybuffer.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-arraybuffer.js
+++ b/test/parallel/test-worker-message-port-arraybuffer.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-message-port-transferring.js
+++ b/test/parallel/test-worker-message-port-message-port-transferring.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 {
   const { port1: basePort1, port2: basePort2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-message-port-transferring.js
+++ b/test/parallel/test-worker-message-port-message-port-transferring.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 {
   const { port1: basePort1, port2: basePort2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-transfer-closed.js
+++ b/test/parallel/test-worker-message-port-transfer-closed.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 // This tests various behaviors around transferring MessagePorts with closing
 // or closed handles.

--- a/test/parallel/test-worker-message-port-transfer-closed.js
+++ b/test/parallel/test-worker-message-port-transfer-closed.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 // This tests various behaviors around transferring MessagePorts with closing
 // or closed handles.

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 const tick = require('../common/tick');
 
 const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 const tick = require('../common/tick');
 
 const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port-transfer-target.js
+++ b/test/parallel/test-worker-message-port-transfer-target.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { MessageChannel } = require('worker_threads');
+const { MessageChannel } = require('nodejs:worker_threads');
 
 const { port1, port2 } = new MessageChannel();
 

--- a/test/parallel/test-worker-message-port-transfer-target.js
+++ b/test/parallel/test-worker-message-port-transfer-target.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { MessageChannel } = require('nodejs:worker_threads');
+const { MessageChannel } = require('@nodejs/worker_threads');
 
 const { port1, port2 } = new MessageChannel();
 

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel, MessagePort } = require('worker_threads');
+const { MessageChannel, MessagePort } = require('nodejs:worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const { MessageChannel, MessagePort } = require('nodejs:worker_threads');
+const { MessageChannel, MessagePort } = require('@nodejs/worker_threads');
 
 {
   const { port1, port2 } = new MessageChannel();

--- a/test/parallel/test-worker-nexttick-terminate.js
+++ b/test/parallel/test-worker-nexttick-terminate.js
@@ -1,13 +1,13 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // Checks that terminating in the middle of `process.nextTick()` does not
 // Crash the process.
 
 const w = new Worker(`
-require('worker_threads').parentPort.postMessage('0');
+require('nodejs:worker_threads').parentPort.postMessage('0');
 process.nextTick(() => {
   while(1);
 });

--- a/test/parallel/test-worker-nexttick-terminate.js
+++ b/test/parallel/test-worker-nexttick-terminate.js
@@ -1,13 +1,13 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // Checks that terminating in the middle of `process.nextTick()` does not
 // Crash the process.
 
 const w = new Worker(`
-require('nodejs:worker_threads').parentPort.postMessage('0');
+require('@nodejs/worker_threads').parentPort.postMessage('0');
 process.nextTick(() => {
   while(1);
 });

--- a/test/parallel/test-worker-onmessage-not-a-function.js
+++ b/test/parallel/test-worker-onmessage-not-a-function.js
@@ -6,7 +6,7 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker, parentPort } = require('worker_threads');
+const { Worker, parentPort } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-onmessage-not-a-function.js
+++ b/test/parallel/test-worker-onmessage-not-a-function.js
@@ -6,7 +6,7 @@
 // Flags: --experimental-worker
 'use strict';
 const common = require('../common');
-const { Worker, parentPort } = require('nodejs:worker_threads');
+const { Worker, parentPort } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-onmessage.js
+++ b/test/parallel/test-worker-onmessage.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, parentPort } = require('worker_threads');
+const { Worker, parentPort } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-onmessage.js
+++ b/test/parallel/test-worker-onmessage.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, parentPort } = require('nodejs:worker_threads');
+const { Worker, parentPort } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-parent-port-ref.js
+++ b/test/parallel/test-worker-parent-port-ref.js
@@ -2,7 +2,7 @@
 'use strict';
 const assert = require('assert');
 const common = require('../common');
-const { isMainThread, parentPort, Worker } = require('worker_threads');
+const { isMainThread, parentPort, Worker } = require('nodejs:worker_threads');
 
 // This test makes sure that we manipulate the references of
 // `parentPort` correctly so that any worker threads will

--- a/test/parallel/test-worker-parent-port-ref.js
+++ b/test/parallel/test-worker-parent-port-ref.js
@@ -2,7 +2,7 @@
 'use strict';
 const assert = require('assert');
 const common = require('../common');
-const { isMainThread, parentPort, Worker } = require('nodejs:worker_threads');
+const { isMainThread, parentPort, Worker } = require('@nodejs/worker_threads');
 
 // This test makes sure that we manipulate the references of
 // `parentPort` correctly so that any worker threads will

--- a/test/parallel/test-worker-relative-path-double-dot.js
+++ b/test/parallel/test-worker-relative-path-double-dot.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const assert = require('assert');
 const common = require('../common');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
 
 if (isMainThread) {
   const cwdName = path.relative('../', '.');

--- a/test/parallel/test-worker-relative-path-double-dot.js
+++ b/test/parallel/test-worker-relative-path-double-dot.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const assert = require('assert');
 const common = require('../common');
-const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
+const { Worker, isMainThread, parentPort } = require('@nodejs/worker_threads');
 
 if (isMainThread) {
   const cwdName = path.relative('../', '.');

--- a/test/parallel/test-worker-relative-path.js
+++ b/test/parallel/test-worker-relative-path.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const assert = require('assert');
 const common = require('../common');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
 
 if (isMainThread) {
   const w = new Worker('./' + path.relative('.', __filename));

--- a/test/parallel/test-worker-relative-path.js
+++ b/test/parallel/test-worker-relative-path.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const assert = require('assert');
 const common = require('../common');
-const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
+const { Worker, isMainThread, parentPort } = require('@nodejs/worker_threads');
 
 if (isMainThread) {
   const w = new Worker('./' + path.relative('.', __filename));

--- a/test/parallel/test-worker-stdio.js
+++ b/test/parallel/test-worker-stdio.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const util = require('util');
 const { Writable } = require('stream');
-const { Worker, isMainThread } = require('worker_threads');
+const { Worker, isMainThread } = require('nodejs:worker_threads');
 
 class BufferingWritable extends Writable {
   constructor() {

--- a/test/parallel/test-worker-stdio.js
+++ b/test/parallel/test-worker-stdio.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const util = require('util');
 const { Writable } = require('stream');
-const { Worker, isMainThread } = require('nodejs:worker_threads');
+const { Worker, isMainThread } = require('@nodejs/worker_threads');
 
 class BufferingWritable extends Writable {
   constructor() {

--- a/test/parallel/test-worker-syntax-error-file.js
+++ b/test/parallel/test-worker-syntax-error-file.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-syntax-error-file.js
+++ b/test/parallel/test-worker-syntax-error-file.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-syntax-error.js
+++ b/test/parallel/test-worker-syntax-error.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-syntax-error.js
+++ b/test/parallel/test-worker-syntax-error.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-type-check.js
+++ b/test/parallel/test-worker-type-check.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 {
   [

--- a/test/parallel/test-worker-type-check.js
+++ b/test/parallel/test-worker-type-check.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 {
   [

--- a/test/parallel/test-worker-uncaught-exception-async.js
+++ b/test/parallel/test-worker-uncaught-exception-async.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-uncaught-exception-async.js
+++ b/test/parallel/test-worker-uncaught-exception-async.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 {
   const expectedErr = common.expectsError({

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 {
   const expectedErr = common.expectsError({

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename);

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
+const { Worker, isMainThread, parentPort } = require('@nodejs/worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename);

--- a/test/parallel/test-worker-workerdata-sharedarraybuffer.js
+++ b/test/parallel/test-worker-workerdata-sharedarraybuffer.js
@@ -3,14 +3,14 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 {
   const sharedArrayBuffer = new SharedArrayBuffer(12);
   const local = Buffer.from(sharedArrayBuffer);
 
   const w = new Worker(`
-    const { parentPort, workerData } = require('worker_threads');
+    const { parentPort, workerData } = require('nodejs:worker_threads');
     const local = Buffer.from(workerData.sharedArrayBuffer);
 
     parentPort.on('message', () => {

--- a/test/parallel/test-worker-workerdata-sharedarraybuffer.js
+++ b/test/parallel/test-worker-workerdata-sharedarraybuffer.js
@@ -3,14 +3,14 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 {
   const sharedArrayBuffer = new SharedArrayBuffer(12);
   const local = Buffer.from(sharedArrayBuffer);
 
   const w = new Worker(`
-    const { parentPort, workerData } = require('nodejs:worker_threads');
+    const { parentPort, workerData } = require('@nodejs/worker_threads');
     const local = Buffer.from(workerData.sharedArrayBuffer);
 
     parentPort.on('message', () => {

--- a/test/parallel/test-worker.js
+++ b/test/parallel/test-worker.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename);

--- a/test/parallel/test-worker.js
+++ b/test/parallel/test-worker.js
@@ -2,7 +2,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('nodejs:worker_threads');
+const { Worker, isMainThread, parentPort } = require('@nodejs/worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename);

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -35,7 +35,7 @@ async function testContextCreatedAndDestroyed() {
     } else {
       let expects = `${process.argv0}[${process.pid}]`;
       if (!common.isMainThread) {
-        expects = `Worker[${require('worker_threads').threadId}]`;
+        expects = `Worker[${require('nodejs:worker_threads').threadId}]`;
       }
       strictEqual(expects, name);
     }

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -35,7 +35,7 @@ async function testContextCreatedAndDestroyed() {
     } else {
       let expects = `${process.argv0}[${process.pid}]`;
       if (!common.isMainThread) {
-        expects = `Worker[${require('nodejs:worker_threads').threadId}]`;
+        expects = `Worker[${require('@nodejs/worker_threads').threadId}]`;
       }
       strictEqual(expects, name);
     }

--- a/tools/run-worker.js
+++ b/tools/run-worker.js
@@ -5,7 +5,7 @@ if (typeof require === 'undefined') {
 }
 
 const path = require('path');
-const { Worker } = require('worker_threads');
+const { Worker } = require('nodejs:worker_threads');
 
 new Worker(path.resolve(process.cwd(), process.argv[2]))
   .on('exit', (code) => process.exitCode = code);

--- a/tools/run-worker.js
+++ b/tools/run-worker.js
@@ -5,7 +5,7 @@ if (typeof require === 'undefined') {
 }
 
 const path = require('path');
-const { Worker } = require('nodejs:worker_threads');
+const { Worker } = require('@nodejs/worker_threads');
 
 new Worker(path.resolve(process.cwd(), process.argv[2]))
   .on('exit', (code) => process.exitCode = code);


### PR DESCRIPTION
Per https://github.com/nodejs/TSC/issues/389#issuecomment-400300064

Do not merge this - this is solely a demonstration of how a namespaced module could exist.

Existing core modules would be aliased, either like this, using symlinks, or in the CJS/ESM loaders.

New modules would live inside `lib/@nodejs`, just like current ones live inside `lib/`.

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
