### PR TITLE
test: add support for NODE_TEST_DIR on a separate mount point

### DIFF
--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -64,7 +64,7 @@ try {
 } catch (err) {
   assert.strictEqual(err.syscall, 'copyfile');
   assert(err.code === 'ENOTSUP' || err.code === 'ENOTTY' ||
-    err.code === 'ENOSYS');
+    err.code === 'ENOSYS' || err.code === 'EXDEV');
   assert.strictEqual(err.path, src);
   assert.strictEqual(err.dest, dest);
 }

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -303,6 +303,11 @@ function re(literals, ...values) {
         `ENOTEMPTY: directory not empty, rename '${existingDir}' -> ` +
         `'${existingDir2}'`);
       assert.strictEqual(err.errno, uv.UV_ENOTEMPTY);
+    } else if (err.code === 'EXDEV') {  // not on the same mounted filesystem
+      assert.strictEqual(
+        err.message,
+        `EXDEV: cross-device link not permitted, rename '${existingDir}' -> ` +
+            `'${existingDir2}'`);
     } else if (err.code === 'EEXIST') {  // smartos and aix
       assert.strictEqual(
         err.message,


### PR DESCRIPTION
Linux permits a filesystem to be mounted at multiple points, but `fs.renameSync` does not work across different mount points, even if the same filesystem is mounted on both.
This fixes failing tests when NODE_TEST_DIR mount point is different from the one on which the tests are executed (E.G. on a separate partition).

On my configuration, I have the node source on a NTFS partition (dual-boot Windows), and I want to avoid the tests on the `chmod` to fail (the chmod is partition-wide and set when mounting). This PR allows to run the tests using a different tmpdir without having to move the node source to the same mount point.

```
NODE_TEST_DIR=/tmp/ make test -j4
```

Ref: http://man7.org/linux/man-pages/man2/rename.2.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
