### PR TITLE
test: add tests for dnsPromises.lookup

### DIFF
--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -97,21 +97,6 @@ common.expectsError(() => {
   });
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
 
-  res = await dnsPromises.lookup(addresses.INET4_HOST, {
-    hints: 0,
-    family: 4,
-    all: false
-  });
-  assert.strictEqual(res.family, 4);
-
-  res = await dnsPromises.lookup(addresses.INET4_HOST, {
-    hints: 0,
-    family: 4,
-    all: true
-  });
-  assert.ok(res.length > 0);
-  res.forEach((obj) => { assert.strictEqual(obj.family, 4); });
-
   assert.rejects(
     dnsPromises.lookup(addresses.INVALID_HOST, {
       hints: 0,

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 const assert = require('assert');
 const cares = process.binding('cares_wrap');
 const dns = require('dns');
@@ -95,6 +96,45 @@ common.expectsError(() => {
     all: false
   });
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
+
+  res = await dnsPromises.lookup(addresses.INET4_HOST, {
+    hints: 0,
+    family: 4,
+    all: false
+  });
+  assert.strictEqual(res.family, 4);
+
+  res = await dnsPromises.lookup(addresses.INET4_HOST, {
+    hints: 0,
+    family: 4,
+    all: true
+  });
+  assert.ok(res.length > 0);
+  res.forEach((obj) => { assert.strictEqual(obj.family, 4); });
+
+  assert.rejects(
+    dnsPromises.lookup(addresses.INVALID_HOST, {
+      hints: 0,
+      family: 0,
+      all: false
+    }),
+    {
+      code: 'ENOTFOUND',
+      message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+    }
+  );
+
+  assert.rejects(
+    dnsPromises.lookup(addresses.INVALID_HOST, {
+      hints: 0,
+      family: 0,
+      all: true
+    }),
+    {
+      code: 'ENOTFOUND',
+      message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+    }
+  );
 })();
 
 dns.lookup(false, {


### PR DESCRIPTION
Added tests for dnsPromises.lookup to increase coverage and test
`onlookup()` and `onlookupall()` methods.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
