### PR TITLE
doc: fix some typos in deprecations.md and vm.md

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -991,8 +991,8 @@ accepted by the legacy `url.parse()` API. The mentioned APIs now use the WHATWG
 URL parser that requires strictly valid URLs. Passing an invalid URL is
 deprecated and support will be removed in the future.
 
-<a id="DEP00XX"></a>
-### DEP00XX: vm.Script cached data
+<a id="DEP0110"></a>
+### DEP0110: vm.Script cached data
 
 Type: Documentation-only
 
@@ -1047,7 +1047,7 @@ The option `produceCachedData` has been deprecated. Use
 [`process.env`]: process.html#process_process_env
 [`punycode`]: punycode.html
 [`require.extensions`]: modules.html#modules_require_extensions
-[`script.createCachedData()`]: vm.html#vm_script_create_cached_data
+[`script.createCachedData()`]: vm.html#vm_script_createcacheddata
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
 [`tls.CryptoStream`]: tls.html#tls_class_cryptostream

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -435,7 +435,7 @@ changes:
     `cachedData` property of the returned `vm.Script` instance.
     The `cachedDataProduced` value will be set to either `true` or `false`
     depending on whether code cache data is produced successfully.
-    This option is deprecated in favor of `script.createCachedData`.
+    This option is deprecated in favor of `script.createCachedData()`.
 
 Creating a new `vm.Script` object compiles `code` but does not run it. The
 compiled `vm.Script` can be run later multiple times. The `code` is not bound to


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
