### PR TITLE
doc: fix typo in fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4026,7 +4026,7 @@ added: v10.0.0
 * Returns: {Promise}
 
 Reads the contents of a directory then resolves the `Promise` with an array
-of the names of the files in the directory excludiing `'.'` and `'..'`.
+of the names of the files in the directory excluding `'.'` and `'..'`.
 
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use for


### PR DESCRIPTION
Fixes simple typo of `excludiing` to `excluding`.

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
