### PR TITLE
test: fix args passed to strictEqual

### DIFF
--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -50,5 +50,5 @@ for (let i = 0; i < QUEUE; i++)
 
 process.on('exit', function() {
   console.log('hit', hit);
-  assert.strictEqual(hit, QUEUE, 'We ticked between the immediate queue');
+  assert.strictEqual(hit, QUEUE);
 });


### PR DESCRIPTION
The third argument passed to asert.strictEqual() displays the message
passed as third argument and does not report the difference between
actual and expected if the test is failing.
Hence, the third argument has been removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
