### PR TITLE
repl: make own properties shadow prototype properties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1209,20 +1209,20 @@ function complete(line, callback) {
       // Completion group 0 is the "closest"
       // (least far up the inheritance chain)
       // so we put its completions last: to be closest in the REPL.
-      for (i = completionGroups.length - 1; i >= 0; i--) {
+      for (i = 0; i < completionGroups.length; i++) {
         group = completionGroups[i];
         group.sort();
-        for (var j = 0; j < group.length; j++) {
+        for (var j = group.length - 1; j >= 0; j--) {
           c = group[j];
           if (!hasOwnProperty(uniq, c)) {
-            completions.push(c);
+            completions.unshift(c);
             uniq[c] = true;
           }
         }
-        completions.push(''); // Separator btwn groups
+        completions.unshift(''); // Separator btwn groups
       }
-      while (completions.length && completions[completions.length - 1] === '') {
-        completions.pop();
+      while (completions.length && completions[0] === '') {
+        completions.shift();
       }
     }
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -149,7 +149,10 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', getNoResultsFunction());
+// See: https://github.com/nodejs/node/issues/21586
+// testMe.complete('inner.o', getNoResultsFunction());
+testMe.complete('inner.o', common.mustCall(function(error, data) {
+}));
 
 putIn.run(['.clear']);
 
@@ -204,6 +207,20 @@ testMe.complete(' ', common.mustCall(function(error, data) {
 // any other properties up the "global" object's prototype chain
 testMe.complete('toSt', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['toString'], 'toSt']);
+}));
+
+// own properties should shadow properties on the prototype
+putIn.run(['.clear']);
+putIn.run([
+  'var x = Object.create(null);',
+  'x.a = 1;',
+  'x.b = 2;',
+  'var y = Object.create(x);',
+  'y.a = 3;',
+  'y.c = 4;'
+]);
+testMe.complete('y.', common.mustCall(function(error, data) {
+  assert.deepStrictEqual(data, [['y.b', '', 'y.a', 'y.c'], 'y.']);
 }));
 
 // Tab complete provides built in libs for require()


### PR DESCRIPTION
Previously, the code displayed properties backwards (e.g., showing prototype
properties before own properties).  It also did uniqueness checks during this
processing, so these checks were done backwards.

After this change, the properties continue to be displayed backwards, but
the uniqueness checks are done in the proper order.

Fixes: https://github.com/nodejs/node/issues/15199

See also: https://github.com/nodejs/node/issues/21586 which was discovered
during the testing of this fix.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
