### PR TITLE
doc: add policy for landing new npm releases

### DIFF
--- a/doc/guides/maintaining-npm.md
+++ b/doc/guides/maintaining-npm.md
@@ -1,5 +1,19 @@
 # Maintaining npm in Node.js
 
+New pull requests should be opened when a "next" version of npm has
+been released. Once the "next" version has been promoted to "latest"
+the PR should be updated as necessary.
+
+Two weeks after the "latest" release has been promoted it can land on master
+assuming no major regressions are found. There is no additional constraints
+for Semver-Major releases.
+
+The Node.js release streams the new version will land into are at the
+discretion of the release and LTS teams.
+
+This process only covers full updates to new versions of npm. Cherry-picked
+changes can be reviewed and landed via the normal consensus seeking process.
+
 ## Step 1: Clone npm
 
 ```console

--- a/doc/guides/maintaining-npm.md
+++ b/doc/guides/maintaining-npm.md
@@ -5,11 +5,11 @@ been released. Once the "next" version has been promoted to "latest"
 the PR should be updated as necessary.
 
 Two weeks after the "latest" release has been promoted it can land on master
-assuming no major regressions are found. There is no additional constraints
+assuming no major regressions are found. There are no additional constraints
 for Semver-Major releases.
 
-The Node.js release streams the new version will land into are at the
-discretion of the release and LTS teams.
+The specific Node.js release stream the new version will be able to land into
+are at the discretion of the release and LTS teams.
 
 This process only covers full updates to new versions of npm. Cherry-picked
 changes can be reviewed and landed via the normal consensus seeking process.


### PR DESCRIPTION
This change in policy sets clear terms for when / how npm releases
can be landed into master and how long they are expected to bake in the
ecosystem. This is to cover all release types of npm including semver-major
releases.

What Node.js release streams the new version of npm land into are at the discretion of the
release team and not specified by this policy.

I would like to ensure that we have consensus in landing this from @nodejs/collaborators @nodejs/tsc @nodejs/release and @nodejs/npm 

/cc @zkat @iarna @bcoe @ceejbot 