### PR TITLE
pgo: enabling pgo at configure

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -179,9 +179,19 @@
           }],
           ['OS=="linux"', {
             'variables': {
+              'pgo_generate': ' -fprofile-generate ',
+              'pgo_use': ' -fprofile-use -fprofile-correction ',
               'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ',
             },
             'conditions': [
+              ['enable_pgo_generate=="true"', {
+                'cflags': ['<(pgo_generate)'],
+                'ldflags': ['<(pgo_generate)'],
+              },],
+              ['enable_pgo_use=="true"', {
+                'cflags': ['<(pgo_use)'],
+                'ldflags': ['<(pgo_use)'],
+              },],
               ['enable_lto=="true"', {
                 'cflags': ['<(lto)'],
                 'ldflags': ['<(lto)'],

--- a/configure
+++ b/configure
@@ -157,11 +157,23 @@ parser.add_option("--enable-vtune-profiling",
          "JavaScript code executed in nodejs. This feature is only available "
          "for x32, x86, and x64 architectures.")
 
+parser.add_option("--enable-pgo-generate",
+    action="store_true",
+    dest="enable_pgo_generate",
+    help="Enable profiling with pgo of a binary. This feature is only available "
+         "on linux with gcc and g++ 5.4.1 or newer.")
+
+parser.add_option("--enable-pgo-use",
+    action="store_true",
+    dest="enable_pgo_use",
+    help="Enable use of the profile generated with --enable-pgo-generate. This "
+         "feature is only available on linux with gcc and g++ 5.4.1 or newer.")
+
 parser.add_option("--enable-lto",
     action="store_true",
     dest="enable_lto",
     help="Enable compiling with lto of a binary. This feature is only available "
-         "on linux with gcc and g++.")
+         "on linux with gcc and g++ 5.4.1 or newer.")
 
 parser.add_option("--link-module",
     action="append",
@@ -898,6 +910,16 @@ def configure_mips(o):
   o['variables']['mips_fpu_mode'] = options.mips_fpu_mode
 
 
+def gcc_version_ge(version_checked):
+  for compiler in [(CC, 'c'), (CXX, 'c++')]:
+    ok, is_clang, clang_version, compiler_version = \
+      try_check_compiler(compiler[0], compiler[1])
+    compiler_version_num = tuple(map(int, compiler_version))
+    if is_clang or compiler_version_num < version_checked:
+      return False
+  return True
+
+
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
@@ -942,6 +964,29 @@ def configure_node(o):
   else:
     o['variables']['node_enable_v8_vtunejit'] = 'false'
 
+  if flavor != 'linux' and (options.enable_pgo_generate or options.enable_pgo_use):
+    raise Exception(
+      'The pgo option is supported only on linux.')
+
+  if flavor == 'linux':
+    if options.enable_pgo_generate or options.enable_pgo_use:
+      version_checked = (5, 4, 1)
+      if not gcc_version_ge(version_checked):
+        version_checked_str = ".".join(map(str, version_checked))
+        raise Exception(
+          'The options --enable-pgo-generate and --enable-pgo-use '
+          'are supported for gcc and gxx %s or newer only.' % (version_checked_str))
+
+    if options.enable_pgo_generate and options.enable_pgo_use:
+      raise Exception(
+        'Only one of the --enable-pgo-generate or --enable-pgo-use options '
+        'can be specified at a time. You would like to use '
+        '--enable-pgo-generate first, profile node, and then recompile '
+        'with --enable-pgo-use')
+
+  o['variables']['enable_pgo_generate'] = b(options.enable_pgo_generate)
+  o['variables']['enable_pgo_use']      = b(options.enable_pgo_use)
+
   if flavor != 'linux' and (options.enable_lto):
     raise Exception(
       'The lto option is supported only on linux.')
@@ -949,15 +994,11 @@ def configure_node(o):
   if flavor == 'linux':
     if options.enable_lto:
       version_checked = (5, 4, 1)
-      for compiler in [(CC, 'c'), (CXX, 'c++')]:
-        ok, is_clang, clang_version, compiler_version = \
-          try_check_compiler(compiler[0], compiler[1])
-        compiler_version_num = tuple(map(int, compiler_version))
-        if is_clang or compiler_version_num < version_checked:
-          version_checked_str = ".".join(map(str, version_checked))
-          raise Exception(
-            'The option --enable-lto is supported for gcc and gxx %s'
-            ' or newer only.' % (version_checked_str))
+      if not gcc_version_ge(version_checked):
+        version_checked_str = ".".join(map(str, version_checked))
+        raise Exception(
+          'The option --enable-lto is supported for gcc and gxx %s'
+          ' or newer only.' % (version_checked_str))
 
   o['variables']['enable_lto'] = b(options.enable_lto)
 


### PR DESCRIPTION
This modification allows for compiling with profiled guided optimization (pgo) using the flags
--enable-pgo-generate and --enable-pgo-use.

Refs: https://github.com/nodejs/node/issues/21583
Refs: https://github.com/nodejs/node/issues/1409

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is a modification proposed towards enabling pgo compilation. From some preliminary results, I have the following data:

I have compared Node-DC-EIS and Ghost, and have obtained 3.7% and 3.8% improvements respectively. These numbers were validated with unpaired t-test. Moreover, I am collecting data regarding the Node.js benchmark suite and mentioned partial results in Refs: https://github.com/nodejs/node/issues/21583. In this context, I would like to mention that assert and async manifest 3.17% and 3.92% improvements respectively.

The experiments were done on Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz. Nevertheless, the solution passes the tests, and also compiles for 32 bits, see also issue Refs: https://github.com/nodejs/node/issues/1409.