### PR TITLE
n-api: fix compiler warning

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3883,7 +3883,6 @@ class TsFn: public node::AsyncResource {
   void* finalize_data;
   napi_finalize finalize_cb;
   bool idle_running;
-  napi_async_context async_context;
   napi_threadsafe_function_call_js call_js_cb;
   bool handles_closing;
 };


### PR DESCRIPTION
private field 'async_context' is not used [-Wunused-private-field]

Refs: https://github.com/nodejs/node/pull/17887

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
