### PR TITLE
test: replace third argument with comment in strict equals

### DIFF
--- a/test/parallel/test-tls-env-bad-extra-ca.js
+++ b/test/parallel/test-tls-env-bad-extra-ca.js
@@ -29,7 +29,8 @@ let stderr = '';
 
 fork(__filename, opts)
   .on('exit', common.mustCall(function(status) {
-    assert.strictEqual(status, 0, 'client did not succeed in connecting');
+    // Check that client succeeded in connecting.
+    assert.strictEqual(status, 0);
   }))
   .on('close', common.mustCall(function() {
     // TODO(addaleax): Make `SafeGetenv` work like `process.env`


### PR DESCRIPTION
As suggested by @Trott as a good first issue, this PR replaces the the third argument of a strictEqual with a comment.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
