### PR TITLE
zlib: fix memory leak for unused zlib instances

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -90,6 +90,7 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
         refs_(0),
         gzip_id_bytes_read_(0),
         write_result_(nullptr) {
+    MakeWeak();
   }
 
 

--- a/test/parallel/test-zlib-unused-weak.js
+++ b/test/parallel/test-zlib-unused-weak.js
@@ -1,0 +1,18 @@
+'use strict';
+// Flags: --expose-gc
+require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+// Tests that native zlib handles start out their life as weak handles.
+
+const before = process.memoryUsage().external;
+for (let i = 0; i < 100; ++i)
+  zlib.createGzip();
+const afterCreation = process.memoryUsage().external;
+global.gc();
+const afterGC = process.memoryUsage().external;
+
+assert((afterGC - before) / (afterCreation - before) <= 0.05,
+       `Expected after-GC delta ${afterGC - before} to be less than 5 %` +
+       ` of before-GC delta ${afterCreation - before}`);


### PR DESCRIPTION
An oversight in an earlier commit led to a memory leak
in the untypical situation that zlib instances are created
but never used, because zlib handles no longer started
out their life as weak handles.

The bug was introduced in bd201102862a194f3f5ce669e0a3c8143eafc900.

Refs: https://github.com/nodejs/node/pull/20455

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
