### PR TITLE
doc: fix some typos in N-API docs

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1414,7 +1414,7 @@ value.
 
 On the main thread, values are removed from the queue associated with the
 thread-safe function in an idle loop. This error indicates that an error
-has occurred when attemping to start the loop.
+has occurred when attempting to start the loop.
 
 <a id="ERR_NAPI_TSFN_STOP_IDLE_LOOP"></a>
 ### ERR_NAPI_TSFN_STOP_IDLE_LOOP

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4066,10 +4066,10 @@ napi_create_threadsafe_function(napi_env env,
 - `[in] func`: The JavaScript function to call from another thread.
 - `[in] async_resource`: An optional object associated with the async work that
 will be passed to possible `async_hooks` [`init` hooks][].
-- `[in] async_resource_name`: A javaScript string to provide an identifier for
+- `[in] async_resource_name`: A JavaScript string to provide an identifier for
 the kind of resource that is being provided for diagnostic information exposed
 by the `async_hooks` API.
-- `[in] max_queue_size`: Maximum size of the queue. 0 for no limit.
+- `[in] max_queue_size`: Maximum size of the queue. `0` for no limit.
 - `[in] initial_thread_count`: The initial number of threads, including the main
 thread, which will be making use of this function.
 - `[in] thread_finalize_data`: Data to be passed to `thread_finalize_cb`.
@@ -4097,7 +4097,7 @@ napi_get_threadsafe_function_context(napi_threadsafe_function func,
 ```
 
 - `[in] func`: The thread-safe function for which to retrieve the context.
-- `[out] context`: The location where to store the context.
+- `[out] result`: The location where to store the context.
 
 This API may be called from any thread which makes use of `func`.
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
