### PR TITLE
doc: fix heading level in errors.md

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -457,7 +457,7 @@ added properties.
 
 ### Class: SystemError
 
-### error.info
+#### error.info
 
 `SystemError` instances may have an additional `info` property whose
 value is an object with additional details about the error conditions.


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Current structure seems wrong:

![err](https://user-images.githubusercontent.com/10393198/42137662-13e5b412-7d79-11e8-83b5-8f0035cc2641.png)
