### PR TITLE
test: check type for Worker filename argument

### DIFF
--- a/test/parallel/test-worker-type-check.js
+++ b/test/parallel/test-worker-type-check.js
@@ -1,0 +1,28 @@
+// Flags: --experimental-worker
+'use strict';
+
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+{
+  [
+    undefined,
+    null,
+    false,
+    0,
+    Symbol('test'),
+    {},
+    [],
+    () => {}
+  ].forEach((val) => {
+    common.expectsError(
+      () => new Worker(val),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "filename" argument must be of type string. ' +
+                 `Received type ${typeof val}`
+      }
+    );
+  });
+}


### PR DESCRIPTION
Add test to check type for first argument of Worker to increase
coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
