### PR TITLE
lib: switch to object spread where possible

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,4 +1,5 @@
 rules:
+  prefer-object-spread: error
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -288,7 +288,7 @@ function initRead(tls, wrapped) {
  */
 
 function TLSSocket(socket, opts) {
-  const tlsOptions = Object.assign({}, opts);
+  const tlsOptions = { ...opts };
 
   if (tlsOptions.ALPNProtocols)
     tls.convertALPNProtocols(tlsOptions.ALPNProtocols, tlsOptions);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -132,7 +132,7 @@ function normalizeExecArgs(command, options, callback) {
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
+  options = { ...options };
   options.shell = typeof options.shell === 'string' ? options.shell : true;
 
   return {
@@ -467,7 +467,7 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
+  options = { ...options };
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');

--- a/lib/console.js
+++ b/lib/console.js
@@ -214,9 +214,11 @@ Console.prototype.warn = function warn(...args) {
 Console.prototype.error = Console.prototype.warn;
 
 Console.prototype.dir = function dir(object, options) {
-  options = Object.assign({
-    customInspect: false
-  }, this[kGetInspectOptions](this._stdout), options);
+  options = {
+    customInspect: false,
+    ...this[kGetInspectOptions](this._stdout),
+    ...options
+  };
   write(this._ignoreErrors,
         this._stdout,
         util.inspect(object, options),
@@ -334,11 +336,15 @@ Console.prototype.table = function(tabularData, properties) {
   const final = (k, v) => this.log(cliTable(k, v));
 
   const inspect = (v) => {
-    const opt = { depth: 0, maxArrayLength: 3 };
-    if (v !== null && typeof v === 'object' &&
-      !isArray(v) && ObjectKeys(v).length > 2)
-      opt.depth = -1;
-    Object.assign(opt, this[kGetInspectOptions](this._stdout));
+    const depth = v !== null &&
+                  typeof v === 'object' &&
+                  !isArray(v) &&
+                  ObjectKeys(v).length > 2 ? -1 : 0;
+    const opt = {
+      depth,
+      maxArrayLength: 3,
+      ...this[kGetInspectOptions](this._stdout)
+    };
     return util.inspect(v, opt);
   };
   const getIndexArray = (length) => ArrayFrom({ length }, (_, i) => inspect(i));

--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -10,7 +10,7 @@ const {
 } = require('internal/bootstrap/loaders');
 
 module.exports = {
-  builtinSource: Object.assign({}, NativeModule._source),
+  builtinSource: { ...NativeModule._source },
   codeCache: internalBinding('code_cache'),
   compiledWithoutCache: NativeModule.compiledWithoutCache,
   compiledWithCache: NativeModule.compiledWithCache,

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -619,7 +619,7 @@ function setupChannel(target, channel) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
 
-    options = Object.assign({ swallowErrors: false }, options);
+    options = { swallowErrors: false, ...options };
 
     if (this.connected) {
       return this._send(message, handle, options, callback);

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -510,7 +510,7 @@ class Http2ServerResponse extends Stream {
   }
 
   getHeaders() {
-    return Object.assign({}, this[kHeaders]);
+    return { ...this[kHeaders] };
   }
 
   hasHeader(name) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -727,7 +727,7 @@ function pingCallback(cb) {
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
 function validateSettings(settings) {
-  settings = Object.assign({}, settings);
+  settings = { ...settings };
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
                     0, kMaxInt);
@@ -1369,7 +1369,7 @@ class ClientHttp2Session extends Http2Session {
     assertIsObject(options, 'options');
 
     headers = Object.assign(Object.create(null), headers);
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
@@ -1765,7 +1765,7 @@ class Http2Stream extends Duplex {
       throw new ERR_HTTP2_INVALID_STREAM();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
     validatePriorityOptions(options);
 
     const priorityFn = submitPriority.bind(this, options);
@@ -2168,7 +2168,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new ERR_INVALID_CALLBACK();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
     options.endStream = !!options.endStream;
 
     assertIsObject(headers, 'headers');
@@ -2235,7 +2235,7 @@ class ServerHttp2Stream extends Http2Stream {
     const state = this[kState];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
@@ -2297,7 +2297,7 @@ class ServerHttp2Stream extends Http2Stream {
     const session = this[kSession];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
@@ -2360,7 +2360,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new ERR_HTTP2_HEADERS_SENT();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
@@ -2587,10 +2587,10 @@ function connectionListener(socket) {
 
 function initializeOptions(options) {
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = { ...options };
   options.allowHalfOpen = true;
   assertIsObject(options.settings, 'options.settings');
-  options.settings = Object.assign({}, options.settings);
+  options.settings = { ...options.settings };
 
   // Used only with allowHTTP1
   options.Http1IncomingMessage = options.Http1IncomingMessage ||
@@ -2695,7 +2695,7 @@ function connect(authority, options, listener) {
   }
 
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = { ...options };
 
   if (typeof authority === 'string')
     authority = new URL(authority);

--- a/lib/os.js
+++ b/lib/os.js
@@ -153,7 +153,7 @@ function networkInterfaces() {
       const suffix = getCIDRSuffix(v.netmask, protocol);
       const cidr = suffix ? `${v.address}/${suffix}` : null;
 
-      return Object.assign({}, v, { cidr });
+      return { ...v, cidr };
     });
     return acc;
   }, {});

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -119,8 +119,7 @@ function hasOwnProperty(obj, prop) {
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options =
-    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
+writer.options = { ...util.inspect.defaultOptions, showProxy: true };
 
 exports._builtinLibs = builtinLibs;
 
@@ -489,7 +488,7 @@ function REPLServer(prompt,
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = Object.assign({}, writer.options, { colors: true });
+    self.writer.options = { ...writer.options, colors: true };
   }
 
   function filterInternalStackFrames(error, structuredStack) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -255,9 +255,8 @@ class SecurePair extends EventEmitter {
     this.credentials = secureContext;
 
     this.encrypted = socket1;
-    this.cleartext = new exports.TLSSocket(socket2, Object.assign({
-      secureContext, isServer, requestCert, rejectUnauthorized
-    }, options));
+    this.cleartext = new exports.TLSSocket(socket2, {
+      secureContext, isServer, requestCert, rejectUnauthorized, ...options });
     this.cleartext.once('secure', () => this.emit('secure'));
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -207,11 +207,11 @@ function formatWithOptions(inspectOptions, f) {
             break;
           case 111: // 'o'
           {
-            const opts = Object.assign({}, inspectOptions, {
+            const opts = { ...inspectOptions, ...{
               showHidden: true,
               showProxy: true,
               depth: 4
-            });
+            } };
             tempStr = inspect(arguments[a++], opts);
             break;
           }

--- a/lib/util.js
+++ b/lib/util.js
@@ -207,11 +207,12 @@ function formatWithOptions(inspectOptions, f) {
             break;
           case 111: // 'o'
           {
-            const opts = { ...inspectOptions, ...{
+            const opts = {
+              ...inspectOptions,
               showHidden: true,
               showProxy: true,
               depth: 4
-            } };
+            };
             tempStr = inspect(arguments[a++], opts);
             break;
           }

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -260,9 +260,7 @@ function runInContext(code, contextifiedSandbox, options) {
       [kParsingContext]: contextifiedSandbox
     };
   } else {
-    options = Object.assign({}, options, {
-      [kParsingContext]: contextifiedSandbox
-    });
+    options = { ...options, [kParsingContext]: contextifiedSandbox };
   }
   return createScript(code, options)
     .runInContext(contextifiedSandbox, options);
@@ -273,9 +271,7 @@ function runInNewContext(code, sandbox, options) {
     options = { filename: options };
   }
   sandbox = createContext(sandbox, getContextOptions(options));
-  options = Object.assign({}, options, {
-    [kParsingContext]: sandbox
-  });
+  options = { ...options, [kParsingContext]: sandbox };
   return createScript(code, options).runInNewContext(sandbox, options);
 }
 


### PR DESCRIPTION
Use the object spread notation instead of using Object.assign.
It is not only easier to read, it is also faster as of V8 6.7.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
