### PR TITLE
doc: unify spelling of backpressure

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -637,7 +637,7 @@ state, attaching a listener for the `'data'` event, calling the
 `readable.readableFlowing` to `true`, causing the `Readable` to begin
 actively emitting events as data is generated.
 
-Calling `readable.pause()`, `readable.unpipe()`, or receiving "back pressure"
+Calling `readable.pause()`, `readable.unpipe()`, or receiving backpressure
 will cause the `readable.readableFlowing` to be set as `false`,
 temporarily halting the flowing of events but *not* halting the generation of
 data. While in this state, attaching a listener for the `'data'` event


### PR DESCRIPTION
Everywhere else in the doc folder, it's spelled `backpressure` (without quotes).

Spelling it the same makes it easier to search for.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
