### PR TITLE
src: remove using directives from spawn_sync.h

### DIFF
--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -29,18 +29,6 @@
 
 namespace node {
 
-using v8::Array;
-using v8::Context;
-using v8::FunctionCallbackInfo;
-using v8::HandleScope;
-using v8::Integer;
-using v8::Isolate;
-using v8::Local;
-using v8::Null;
-using v8::Number;
-using v8::Object;
-using v8::String;
-using v8::Value;
 
 
 class SyncProcessOutputBuffer;
@@ -94,7 +82,7 @@ class SyncProcessStdioPipe {
   int Start();
   void Close();
 
-  Local<Object> GetOutputAsBuffer(Environment* env) const;
+  v8::Local<v8::Object> GetOutputAsBuffer(Environment* env) const;
 
   inline bool readable() const;
   inline bool writable() const;
@@ -151,10 +139,10 @@ class SyncProcessRunner {
   };
 
  public:
-  static void Initialize(Local<Object> target,
-                         Local<Value> unused,
-                         Local<Context> context);
-  static void Spawn(const FunctionCallbackInfo<Value>& args);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
+  static void Spawn(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
   friend class SyncProcessStdioPipe;
@@ -164,8 +152,8 @@ class SyncProcessRunner {
 
   inline Environment* env() const;
 
-  Local<Object> Run(Local<Value> options);
-  void TryInitializeAndRunLoop(Local<Value> options);
+  v8::Local<v8::Object> Run(v8::Local<v8::Value> options);
+  void TryInitializeAndRunLoop(v8::Local<v8::Value> options);
   void CloseHandlesAndDeleteLoop();
 
   void CloseStdioPipes();
@@ -181,12 +169,12 @@ class SyncProcessRunner {
   void SetError(int error);
   void SetPipeError(int pipe_error);
 
-  Local<Object> BuildResultObject();
-  Local<Array> BuildOutputArray();
+  v8::Local<v8::Object> BuildResultObject();
+  v8::Local<v8::Array> BuildOutputArray();
 
-  int ParseOptions(Local<Value> js_value);
-  int ParseStdioOptions(Local<Value> js_value);
-  int ParseStdioOption(int child_fd, Local<Object> js_stdio_option);
+  int ParseOptions(v8::Local<v8::Value> js_value);
+  int ParseStdioOptions(v8::Local<v8::Value> js_value);
+  int ParseStdioOption(int child_fd, v8::Local<v8::Object> js_stdio_option);
 
   inline int AddStdioIgnore(uint32_t child_fd);
   inline int AddStdioPipe(uint32_t child_fd,
@@ -195,9 +183,9 @@ class SyncProcessRunner {
                           uv_buf_t input_buffer);
   inline int AddStdioInheritFD(uint32_t child_fd, int inherit_fd);
 
-  static bool IsSet(Local<Value> value);
-  int CopyJsString(Local<Value> js_value, const char** target);
-  int CopyJsStringArray(Local<Value> js_value, char** target);
+  static bool IsSet(v8::Local<v8::Value> value);
+  int CopyJsString(v8::Local<v8::Value> js_value, const char** target);
+  int CopyJsStringArray(v8::Local<v8::Value> js_value, char** target);
 
   static void ExitCallback(uv_process_t* handle,
                            int64_t exit_status,


### PR DESCRIPTION
I noticed that there were a few using declarations what were unused and
instead of just removing them, this commit removes all of them and uses
qualified names instead since they are in a header.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
