### PR TITLE
test: fix parallel/test-tls-env-extra-ca.js

### DIFF
--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -39,6 +39,7 @@ const server = tls.createServer(options, common.mustCall(function(s) {
   });
 
   fork(__filename, { env }).on('exit', common.mustCall(function(status) {
-    assert.strictEqual(status, 0, 'client did not succeed in connecting');
+    // client did not succeed in connecting
+    assert.strictEqual(status, 0);
   }));
 }));


### PR DESCRIPTION
fix args in final assert.strictEqual() call

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines
