### PR TITLE
console: console.countReset() should emit warning

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -107,6 +107,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   if (typeof colorMode !== 'boolean' && colorMode !== 'auto')
     throw new ERR_INVALID_ARG_VALUE('colorMode', colorMode);
 
+  // Corresponds to https://console.spec.whatwg.org/#count-map
   this[kCounts] = new Map();
   this[kColorMode] = colorMode;
 
@@ -308,12 +309,14 @@ Console.prototype.count = function count(label = 'default') {
   this.log(`${label}: ${count}`);
 };
 
-// Not yet defined by the https://console.spec.whatwg.org, but
-// proposed to be added and currently implemented by Edge. Having
-// the ability to reset counters is important to help prevent
-// the counter from being a memory leak.
+// Defined by: https://console.spec.whatwg.org/#countreset
 Console.prototype.countReset = function countReset(label = 'default') {
   const counts = this[kCounts];
+  if (!counts.has(label)) {
+    process.emitWarning(`Count for '${label}' does not exist`);
+    return;
+  }
+
   counts.delete(`${label}`);
 };
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -36,15 +36,15 @@ common.expectWarning(
   'Warning',
   [
     ['Count for \'noLabel\' does not exist', common.noWarnCode],
-    ['No such label \'nolabel\' for console.timeLog()', common.noWarnCode],
-    ['No such label \'nolabel\' for console.timeEnd()', common.noWarnCode],
+    ['No such label \'noLabel\' for console.timeLog()', common.noWarnCode],
+    ['No such label \'noLabel\' for console.timeEnd()', common.noWarnCode],
     ['Label \'test\' already exists for console.time()', common.noWarnCode]
   ]
 );
 
 console.countReset('noLabel');
-console.timeLog('nolabel');
-console.timeEnd('nolabel');
+console.timeLog('noLabel');
+console.timeEnd('noLabel');
 
 console.time('label');
 console.timeEnd('label');
@@ -247,6 +247,6 @@ common.hijackStderr(common.mustCall(function(data) {
 
   // stderr.write will catch sync error, so use `process.nextTick` here
   process.nextTick(function() {
-    assert.strictEqual(data.includes('nolabel'), true);
+    assert.strictEqual(data.includes('noLabel'), true);
   });
 }));

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -35,14 +35,16 @@ if (common.isMainThread) {
 common.expectWarning(
   'Warning',
   [
-    ['No such label \'nolabel\' for console.timeEnd()', common.noWarnCode],
+    ['Count for \'noLabel\' does not exist', common.noWarnCode],
     ['No such label \'nolabel\' for console.timeLog()', common.noWarnCode],
+    ['No such label \'nolabel\' for console.timeEnd()', common.noWarnCode],
     ['Label \'test\' already exists for console.time()', common.noWarnCode]
   ]
 );
 
-console.timeEnd('nolabel');
+console.countReset('noLabel');
 console.timeLog('nolabel');
+console.timeEnd('nolabel');
 
 console.time('label');
 console.timeEnd('label');


### PR DESCRIPTION
The Console Standard specifies that console.countReset()
should emit some type of a warning when given a label that
has no previous account associated with it. This PR brings
node's implementation of console.countReset() up-to-spec and
adds a test asserting that a warning is emitted.

Fixes: https://github.com/nodejs/node/issues/20524

----

/cc @TimothyGu @devsnek 

It would probably be worth adding more tests for console.countReset(), similarly to what https://github.com/nodejs/node/pull/21312/ is doing, but that can probably be take care of outside of this. I can file another issue if that seems reasonable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
