### PR TITLE
tty: make _read throw ERR_TTY_WRITABLE_NOT_READABLE

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1684,6 +1684,12 @@ A `Transform` stream finished with data still in the write buffer.
 
 The initialization of a TTY failed due to a system error.
 
+<a id="ERR_TTY_WRITABLE_NOT_READABLE"></a>
+### ERR_TTY_WRITABLE_NOT_READABLE
+
+This `Error` is thrown when a read is attempted on a TTY `WriteStream`,
+such as `process.stdout.on('data')`.
+
 <a id="ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET"></a>
 ### ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -825,6 +825,9 @@ E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
 E('ERR_TRANSFORM_WITH_LENGTH_0',
   'Calling transform done when writableState.length != 0', Error);
 E('ERR_TTY_INIT_FAILED', 'TTY initialization failed', SystemError);
+E('ERR_TTY_WRITABLE_NOT_READABLE',
+  'The Writable side of a TTY is not Readable',
+  Error);
 E('ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
   '`process.setupUncaughtExceptionCapture()` was called while a capture ' +
     'callback was already active',

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -25,7 +25,11 @@ const { inherits, _extend } = require('util');
 const net = require('net');
 const { TTY, isTTY } = process.binding('tty_wrap');
 const errors = require('internal/errors');
-const { ERR_INVALID_FD, ERR_TTY_INIT_FAILED } = errors.codes;
+const {
+  ERR_INVALID_FD,
+  ERR_TTY_INIT_FAILED,
+  ERR_TTY_WRITABLE_NOT_READABLE
+} = errors.codes;
 const { getColorDepth } = require('internal/tty');
 
 // Lazy loaded for startup performance.
@@ -120,6 +124,13 @@ WriteStream.prototype._refreshSize = function() {
     this.rows = newRows;
     this.emit('resize');
   }
+};
+
+// A WriteStream is not readable from, so _read become a no-op.
+// this method could still be called because net.Socket()
+// is a duplex
+WriteStream.prototype._read = function() {
+  this.destroy(new ERR_TTY_WRITABLE_NOT_READABLE());
 };
 
 // Backwards-compat

--- a/test/pseudo-tty/test-tty-write-stream-resume-crash.js
+++ b/test/pseudo-tty/test-tty-write-stream-resume-crash.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const { WriteStream } = require('tty');
+const fd = common.getTTYfd();
+
+// Calling resume on a tty.WriteStream should be a no-op
+// Ref: https://github.com/nodejs/node/issues/21203
+
+const stream = new WriteStream(fd);
+stream.resume();
+
+stream.on('error', common.expectsError({
+  code: 'ERR_TTY_WRITABLE_NOT_READABLE',
+  type: Error,
+  message: 'The Writable side of a TTY is not Readable'
+}));


### PR DESCRIPTION
This change avoid an 'read ENOTCONN' error introduced by libuv 1.20.0
when trying to read from a TTY WriteStream. Instead, we are throwing
a more actionable ERR_TTY_WRITABLE_NOT_READABLE.

~~This changes fixes a regression introduced by libuv 1.20.0.
Calling .resume() on stdout and stderr started to error because of that
change.~~

See: https://github.com/nodejs/node/commit/ae2b5bcb7c17a2d2a488f234c736201eed8200db
Fixes: https://github.com/nodejs/node/issues/21203

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
