### PR TITLE
test: fix pummel/test-net-connect-memleak

### DIFF
--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -37,8 +37,7 @@ let before = 0;
 {
   // 2**26 == 64M entries
   global.gc();
-  let junk = [0];
-  for (let i = 0; i < 26; ++i) junk = junk.concat(junk);
+  const junk = new Array(2 ** 26).fill(0);
   before = process.memoryUsage().rss;
 
   net.createConnection(common.PORT, '127.0.0.1', function() {


### PR DESCRIPTION
A loop that generates a long array is resulting in a RangeError. Moving
to Array.prototype.fill() along with the ** operator instead of using a
loop fixes the issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
