### PR TITLE
inspector: expose original console

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -28,6 +28,17 @@ started.
 If wait is `true`, will block until a client has connected to the inspect port
 and flow control has been passed to the debugger client.
 
+### inspector.console
+
+An object to send messages to the remote inspector console.
+
+```js
+require('inspector').console.log('a message');
+```
+
+The inspector console does not have API parity with Node.js
+console.
+
 ### inspector.close()
 
 Deactivate the inspector. Blocks until there are no active connections.

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -11,6 +11,7 @@ const {
 } = require('internal/errors').codes;
 const util = require('util');
 const { Connection, open, url } = process.binding('inspector');
+const { originalConsole } = require('internal/process/per_thread');
 
 if (!Connection || !require('internal/worker').isMainThread)
   throw new ERR_INSPECTOR_NOT_AVAILABLE();
@@ -103,5 +104,6 @@ module.exports = {
   open: (port, host, wait) => open(port, host, !!wait),
   close: process._debugEnd,
   url: url,
+  console: originalConsole,
   Session
 };

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -120,6 +120,8 @@
 
     const browserGlobals = !process._noBrowserGlobals;
     if (browserGlobals) {
+      // we are setting this here to foward it to the inspector later
+      perThreadSetup.originalConsole = global.console;
       setupGlobalTimeouts();
       setupGlobalConsole();
       setupGlobalURL();

--- a/test/sequential/test-inspector-console.js
+++ b/test/sequential/test-inspector-console.js
@@ -1,0 +1,39 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const { NodeInstance } = require('../common/inspector-helper.js');
+const assert = require('assert');
+
+async function runTest() {
+  const script = 'require(\'inspector\').console.log(\'hello world\');';
+  const child = new NodeInstance('--inspect-brk=0', script, '');
+
+  let out = '';
+  child.on('stdout', (line) => out += line);
+
+  const session = await child.connectInspectorSession();
+
+  const commands = [
+    { 'method': 'Runtime.enable' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' }
+  ];
+
+  session.send(commands);
+
+  const msg = await session.waitForNotification('Runtime.consoleAPICalled');
+
+  assert.strictEqual(msg.params.type, 'log');
+  assert.deepStrictEqual(msg.params.args, [{
+    type: 'string',
+    value: 'hello world'
+  }]);
+  assert.strictEqual(out, '');
+
+  session.disconnect();
+}
+
+common.crashOnUnhandledRejection();
+runTest();


### PR DESCRIPTION
Adds require('inspector').console, mapping it to the original
global.console of V8. This enables applications to send messages to
the inspector console programmatically.

Fixes: https://github.com/nodejs/node/issues/21651


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
