### PR TITLE
doc: fix HTTP res 'finish' description

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1031,8 +1031,6 @@ emitted when the last segment of the response headers and body have been
 handed off to the operating system for transmission over the network. It
 does not imply that the client has received anything yet.
 
-After this event, no more events will be emitted on the response object.
-
 ### response.addTrailers(headers)
 <!-- YAML
 added: v0.3.0


### PR DESCRIPTION
In addition to #21047, after #20611 `close` event will be emitted on response object after `finish`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
