### PR TITLE
doc: fix module.children description

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -693,7 +693,7 @@ added: v0.1.16
 
 * {module[]}
 
-The module objects required by this one.
+The module objects required for the first time by this one.
 
 ### module.exports
 <!-- YAML


### PR DESCRIPTION
Updates the module.children description in the docs to match current
functionality in that it will only contain the modules required for the
first time by this module.

Fixes: https://github.com/nodejs/node/issues/9371

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

**Note**: This is my first contribution to Node.js, and I chose a small issue with the good-first-issue tag. I tried to follow all of the guidelines 💯 