### PR TITLE
process: add nice() function

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1653,7 +1653,7 @@ Returns the new nice value of the process.
 
 The `process.nice()` method sets or gets the nice value of the process.
 (See nice(2).) The `inc` is supposed to be an integer, consisting of the
-_difference_ the user wants to add to the current nice value.
+_difference_ to be added to the current nice value of the process.
 The higher the nice value of the process, the nicer the process and the less
 time is given by the scheduler (effectively lowering the priority).
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1642,6 +1642,40 @@ This function is only available on POSIX platforms (i.e. not Windows or
 Android).
 This feature is not available in [`Worker`][] threads.
 
+## process.nice(inc)
+<!-- YAML
+added: v10.?.?
+-->
+
+* `inc` {integer} The new nice value for the process.
+
+The `process.nice()` method sets or gets the nice value of the process.
+(See nice(2).) The `inc` is supposed to be an integer, consisting of the
+_difference_ you want to add to the current nice value.
+The higher the nice value of the process, the nicer the process and the less
+time is given by the scheduler.
+
+You can get the current nice value by passing 0 or nothing to the method.
+
+Unless you have super user permissions, you can only increase your nice value.
+Though, it is also possible to increase the priority if a limit (RLIMIT_NICE)
+is set. (See getrlimit(2).)
+
+**NOTE**: Once you incremented your niceness, you can no longer reduce it!
+
+```js
+if (process.nice) {
+  const currentNice = process.nice();
+  console.log(currentNice); // Prints the current nice value
+
+  process.nice(1); // Increases nice value - giving it less priority.
+}
+```
+
+This function is only available on POSIX platforms (i.e. not Windows or
+Android).
+This feature is not available in [`Worker`][] threads.
+
 ## process.setgid(id)
 <!-- YAML
 added: v0.1.31

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1647,21 +1647,22 @@ This feature is not available in [`Worker`][] threads.
 added: REPLACEME
 -->
 
-* `inc` {integer} The new nice value for the process.
+* `inc` {integer} The nice value which is added to the current nice value.
+
+Returns the new nice value of the process.
 
 The `process.nice()` method sets or gets the nice value of the process.
 (See nice(2).) The `inc` is supposed to be an integer, consisting of the
-_difference_ you want to add to the current nice value.
+_difference_ the user wants to add to the current nice value.
 The higher the nice value of the process, the nicer the process and the less
-time is given by the scheduler.
+time is given by the scheduler (effectively lowering the priority).
 
-You can get the current nice value by passing 0 or nothing to the method.
+It is possible to get the current nice value by passing 0 or `undefined`
+to the method.
 
-Unless you have super user permissions, you can only increase your nice value.
-Though, it is also possible to increase the priority if a limit (RLIMIT_NICE)
-is set. (See getrlimit(2).)
-
-**NOTE**: Once you incremented your niceness, you can no longer reduce it!
+In a common environment, it is only possible to increase the nice value.
+A decrease of the value at a later time might not be possible (unless
+the specified permissions are set) (See getrlimit(2).)
 
 ```js
 if (process.nice) {
@@ -1672,8 +1673,7 @@ if (process.nice) {
 }
 ```
 
-This function is only available on POSIX platforms (i.e. not Windows or
-Android).
+This function is only available on POSIX platforms (i.e. not Windows).
 This feature is not available in [`Worker`][] threads.
 
 ## process.setgid(id)

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1447,6 +1447,40 @@ The next tick queue is completely drained on each pass of the event loop
 `nextTick()` callbacks will block any I/O from happening, just like a
 `while(true);` loop.
 
+## process.nice([inc])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `inc` {integer} The nice value which is added to the current nice value.
+* Returns: {integer} The new nice value for the process.
+
+The `process.nice()` method sets or gets the nice value of the process.
+(See nice(2).) The `inc` is supposed to be an integer, consisting of the
+_difference_ to be added to the current nice value of the process.
+The higher the nice value of the process, the nicer the process and the less
+time is given by the scheduler (effectively lowering the priority).
+
+It is possible to get the current nice value by passing `0` or `undefined`
+to the method.
+
+In a common environment, it is only possible to increase the nice value.
+A decrease of the value at a later time might not be possible (unless
+the specified permissions are set). (See getrlimit(2).)
+
+```js
+if (process.platform !== 'win32') {
+  const currentNice = process.nice();
+  console.log(currentNice); // Prints the current nice value.
+
+  process.nice(1); // Increases nice value - giving it less priority.
+}
+```
+
+This function works only on POSIX platforms and throws not implemented errors
+on other platforms.
+This feature is not available in [`Worker`][] threads.
+
 ## process.noDeprecation
 <!-- YAML
 added: v0.8.0
@@ -1640,40 +1674,6 @@ if (process.geteuid && process.seteuid) {
 
 This function is only available on POSIX platforms (i.e. not Windows or
 Android).
-This feature is not available in [`Worker`][] threads.
-
-## process.nice(inc)
-<!-- YAML
-added: REPLACEME
--->
-
-* `inc` {integer} The nice value which is added to the current nice value.
-
-Returns the new nice value of the process.
-
-The `process.nice()` method sets or gets the nice value of the process.
-(See nice(2).) The `inc` is supposed to be an integer, consisting of the
-_difference_ to be added to the current nice value of the process.
-The higher the nice value of the process, the nicer the process and the less
-time is given by the scheduler (effectively lowering the priority).
-
-It is possible to get the current nice value by passing 0 or `undefined`
-to the method.
-
-In a common environment, it is only possible to increase the nice value.
-A decrease of the value at a later time might not be possible (unless
-the specified permissions are set) (See getrlimit(2).)
-
-```js
-if (process.nice) {
-  const currentNice = process.nice();
-  console.log(currentNice); // Prints the current nice value
-
-  process.nice(1); // Increases nice value - giving it less priority.
-}
-```
-
-This function is only available on POSIX platforms (i.e. not Windows).
 This feature is not available in [`Worker`][] threads.
 
 ## process.setgid(id)

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1644,7 +1644,7 @@ This feature is not available in [`Worker`][] threads.
 
 ## process.nice(inc)
 <!-- YAML
-added: v10.?.?
+added: REPLACEME
 -->
 
 * `inc` {integer} The new nice value for the process.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -21,7 +21,7 @@
                                 _hrtime, _hrtimeBigInt,
                                 _memoryUsage, _rawDebug,
                                 _umask, _initgroups, _setegid, _seteuid,
-                                _setgid, _setuid, _setgroups,
+                                _nice, _setgid, _setuid, _setgroups,
                                 _shouldAbortOnUncaughtToggle },
                               { internalBinding, NativeModule }) {
   const exceptionHandlerState = { captureFn: null };
@@ -77,7 +77,7 @@
     if (isMainThread) {
       mainThreadSetup.setupStdio();
       mainThreadSetup.setupProcessMethods(
-        _chdir, _umask, _initgroups, _setegid, _seteuid,
+        _chdir, _umask, _initgroups, _setegid, _seteuid, _nice,
         _setgid, _setuid, _setgroups
       );
     } else {

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -108,9 +108,7 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
   function validateInc(inc) {
     if (typeof inc === 'number') {
       validateInt32(inc, 'nice');
-    } else if (typeof inc === 'undefined') {
-      // placeholder..
-    } else {
+    } else if (inc !== undefined) {
       throw new ERR_INVALID_ARG_TYPE('nice', ['number', 'undefined'], inc);
     }
   }

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -12,7 +12,8 @@ const {
 } = require('internal/errors');
 const {
   validateMode,
-  validateUint32
+  validateUint32,
+  validateInt32
 } = require('internal/validators');
 
 const {
@@ -29,9 +30,10 @@ function setupStdio() {
 // Non-POSIX platforms like Windows don't have certain methods.
 // Workers also lack these methods since they change process-global state.
 function setupProcessMethods(_chdir, _umask, _initgroups, _setegid,
-                             _seteuid, _setgid, _setuid, _setgroups) {
+                             _seteuid, _nice, _setgid, _setuid,
+                             _setgroups) {
   if (_setgid !== undefined) {
-    setupPosixMethods(_initgroups, _setegid, _seteuid,
+    setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
                       _setgid, _setuid, _setgroups);
   }
 
@@ -52,7 +54,7 @@ function setupProcessMethods(_chdir, _umask, _initgroups, _setegid,
   };
 }
 
-function setupPosixMethods(_initgroups, _setegid, _seteuid,
+function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
                            _setgid, _setuid, _setgroups) {
 
   process.initgroups = function initgroups(user, extraGroup) {
@@ -73,6 +75,10 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid,
 
   process.seteuid = function seteuid(id) {
     return execId(id, 'User', _seteuid);
+  };
+
+  process.nice = function nice(inc) {
+    return validateInc(inc);
   };
 
   process.setgid = function setgid(id) {
@@ -97,6 +103,18 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid,
       throw new ERR_UNKNOWN_CREDENTIAL('Group', groups[result - 1]);
     }
   };
+
+  function validateInc(inc) {
+    const tInc = typeof inc;
+    if (tInc === 'number') {
+      validateInt32(inc, 'nice');
+      return _nice(inc);
+    } else if (tInc === 'undefined') {
+      return _nice(inc);
+    } else {
+      throw new ERR_INVALID_ARG_TYPE('nice', ['number', 'undefined'], inc);
+    }
+  }
 
   function execId(id, type, method) {
     validateId(id, 'id');

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -7,7 +7,8 @@ const {
   errnoException,
   codes: {
     ERR_INVALID_ARG_TYPE,
-    ERR_UNKNOWN_CREDENTIAL
+    ERR_UNKNOWN_CREDENTIAL,
+    ERR_METHOD_NOT_IMPLEMENTED
   }
 } = require('internal/errors');
 const {
@@ -32,10 +33,20 @@ function setupStdio() {
 function setupProcessMethods(_chdir, _umask, _initgroups, _setegid,
                              _seteuid, _nice, _setgid, _setuid,
                              _setgroups) {
+
   if (_setgid !== undefined) {
-    setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
+    setupPosixMethods(_initgroups, _setegid, _seteuid,
                       _setgid, _setuid, _setgroups);
   }
+
+  process.nice = function nice(inc) {
+    if (process.platform === 'win32') {
+      throw new ERR_METHOD_NOT_IMPLEMENTED('nice()');
+    }
+
+    validateInc(inc);
+    return _nice(inc);
+  };
 
   process.chdir = function chdir(directory) {
     if (typeof directory !== 'string') {
@@ -52,9 +63,17 @@ function setupProcessMethods(_chdir, _umask, _initgroups, _setegid,
     mask = validateMode(mask, 'mask');
     return _umask(mask);
   };
+
+  function validateInc(inc) {
+    if (typeof inc === 'number') {
+      validateInt32(inc, 'nice');
+    } else if (inc !== undefined) {
+      throw new ERR_INVALID_ARG_TYPE('nice', ['number', 'undefined'], inc);
+    }
+  }
 }
 
-function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
+function setupPosixMethods(_initgroups, _setegid, _seteuid,
                            _setgid, _setuid, _setgroups) {
 
   process.initgroups = function initgroups(user, extraGroup) {
@@ -75,11 +94,6 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
 
   process.seteuid = function seteuid(id) {
     return execId(id, 'User', _seteuid);
-  };
-
-  process.nice = function nice(inc) {
-    validateInc(inc);
-    return _nice(inc);
   };
 
   process.setgid = function setgid(id) {
@@ -104,14 +118,6 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
       throw new ERR_UNKNOWN_CREDENTIAL('Group', groups[result - 1]);
     }
   };
-
-  function validateInc(inc) {
-    if (typeof inc === 'number') {
-      validateInt32(inc, 'nice');
-    } else if (inc !== undefined) {
-      throw new ERR_INVALID_ARG_TYPE('nice', ['number', 'undefined'], inc);
-    }
-  }
 
   function execId(id, type, method) {
     validateId(id, 'id');

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -78,7 +78,8 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
   };
 
   process.nice = function nice(inc) {
-    return validateInc(inc);
+    validateInc(inc);
+    return _nice(inc);
   };
 
   process.setgid = function setgid(id) {
@@ -105,12 +106,10 @@ function setupPosixMethods(_initgroups, _setegid, _seteuid, _nice,
   };
 
   function validateInc(inc) {
-    const tInc = typeof inc;
-    if (tInc === 'number') {
+    if (typeof inc === 'number') {
       validateInt32(inc, 'nice');
-      return _nice(inc);
-    } else if (tInc === 'undefined') {
-      return _nice(inc);
+    } else if (typeof inc === 'undefined') {
+      // placeholder..
     } else {
       throw new ERR_INVALID_ARG_TYPE('nice', ['number', 'undefined'], inc);
     }

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -118,6 +118,7 @@ void SetupBootstrapObject(Environment* env,
     BOOTSTRAP_METHOD(_initgroups, InitGroups);
     BOOTSTRAP_METHOD(_setegid, SetEGid);
     BOOTSTRAP_METHOD(_seteuid, SetEUid);
+    BOOTSTRAP_METHOD(_nice, Nice);
     BOOTSTRAP_METHOD(_setgid, SetGid);
     BOOTSTRAP_METHOD(_setuid, SetUid);
     BOOTSTRAP_METHOD(_setgroups, SetGroups);

--- a/src/node.cc
+++ b/src/node.cc
@@ -101,7 +101,7 @@ typedef int mode_t;
 #else
 #include <pthread.h>
 #include <sys/resource.h>  // getrlimit, setrlimit
-#include <unistd.h>  // setuid, getuid
+#include <unistd.h>  // setuid, getuid, nice
 #endif
 
 #if defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -953,6 +953,7 @@ void SetGid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetEGid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetUid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetEUid(const v8::FunctionCallbackInfo<v8::Value>& args);
+void Nice(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetGroups(const v8::FunctionCallbackInfo<v8::Value>& args);
 void InitGroups(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetUid(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -948,12 +948,15 @@ void StopProfilerIdleNotifier(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Umask(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Uptime(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+#if defined(__POSIX__) && !defined(__CloudABI__)
+void Nice(const v8::FunctionCallbackInfo<v8::Value>& args);
+#endif  // __POSIX__ && !defined(__CloudABI__)
+
 #if defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)
 void SetGid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetEGid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetUid(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetEUid(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Nice(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SetGroups(const v8::FunctionCallbackInfo<v8::Value>& args);
 void InitGroups(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetUid(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -33,6 +33,7 @@ using v8::BigUint64Array;
 using v8::Float64Array;
 using v8::FunctionCallbackInfo;
 using v8::HeapStatistics;
+using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
@@ -444,7 +445,7 @@ void Nice(const FunctionCallbackInfo<Value>& args) {
   // ..only check type if argument is int32
   if (!args[0]->IsUndefined()) {
     CHECK(args[0]->IsInt32());
-    inc = args[0]->Int32Value();
+    inc = args[0].As<Int32>()->Value();
   }
 
   errno = 0;

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -434,6 +434,30 @@ void SetEUid(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+void Nice(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
+
+  CHECK_EQ(args.Length(), 1);
+
+  int inc = 0;
+  // ..only check type if argument is int32
+  if (!args[0]->IsUndefined()) {
+    CHECK(args[0]->IsInt32());
+    inc = args[0]->Int32Value();
+  }
+
+  errno = 0;
+  int nice_result = nice(inc);
+
+  if (errno != 0) {
+    env->ThrowErrnoException(errno, "nice");
+  } else {
+    args.GetReturnValue().Set(nice_result);
+  }
+}
+
+
 void GetGroups(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 

--- a/test/parallel/test-process-nice.js
+++ b/test/parallel/test-process-nice.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (common.isWindows || !common.isMainThread) {
+  assert.strictEqual(process.nice, undefined);
+  return;
+}
+
+assert.throws(
+  () => {
+    process.nice(NaN);
+  },
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "nice" is out of range. It must be ' +
+             'an integer. Received NaN'
+  }
+);
+
+assert.throws(
+  () => {
+    process.nice(Infinity);
+  },
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError [ERR_OUT_OF_RANGE]',
+    message: 'The value of "nice" is out of range. It must be ' +
+             'an integer. Received Infinity'
+  }
+);
+
+[null, false, true, {}, [], () => {}, 'text'].forEach((val) => {
+  assert.throws(
+    () => {
+      process.nice(val);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "nice" argument must be ' +
+               'one of type number or undefined. ' +
+               `Received type ${typeof val}`
+    }
+  );
+});


### PR DESCRIPTION
The nice function allows us to fine-tune the process to meet desired
scheduling behavior. If our process needs less schedule time because
it is a long-running one, we can increase the nice value and cause
the scheduler to select the process not so often.

If desired, here's the technical documentation: http://man7.org/linux/man-pages/man2/nice.2.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
