### PR TITLE
lto: enabling lto at configure

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -176,6 +176,17 @@
           ['OS!="mac" and OS!="win"', {
             'cflags': [ '-fno-omit-frame-pointer' ],
           }],
+          ['OS=="linux"', {
+            'variables': {
+              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ',
+            },
+            'conditions': [
+              ['enable_lto=="true"', {
+                'cflags': ['<(lto)'],
+                'ldflags': ['<(lto)'],
+              },],
+            ],
+          },],
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
             'ldflags': [ '-fPIE', '-pie' ]

--- a/configure
+++ b/configure
@@ -157,6 +157,11 @@ parser.add_option("--enable-vtune-profiling",
          "JavaScript code executed in nodejs. This feature is only available "
          "for x32, x86, and x64 architectures.")
 
+parser.add_option("--enable-lto",
+    action="store_true",
+    dest="enable_lto",
+    help="Enable compiling with lto of a binary. This feature is only available "
+         "on linux with gcc and g++.")
 
 parser.add_option("--link-module",
     action="append",
@@ -931,6 +936,23 @@ def configure_node(o):
        'architectures.')
   else:
     o['variables']['node_enable_v8_vtunejit'] = 'false'
+
+  if flavor != 'linux' and (options.enable_lto):
+    raise Exception(
+      'The lto option is supported only on linux.')
+
+  if flavor == 'linux':
+    if options.enable_lto:
+      version_checked = '5.4.1'
+      for compiler in [(CC, 'c'), (CXX, 'c++')]:
+        ok, is_clang, clang_version, compiler_version = \
+          try_check_compiler(compiler[0], compiler[1])
+        if is_clang or compiler_version < version_checked:
+          raise Exception(
+            'The option --enable-lto is supported for '
+            'gcc and gxx 5.4.1 or newer only.')
+
+  o['variables']['enable_lto'] = b(options.enable_lto)
 
   if flavor in ('solaris', 'mac', 'linux', 'freebsd'):
     use_dtrace = not options.without_dtrace

--- a/configure
+++ b/configure
@@ -943,14 +943,16 @@ def configure_node(o):
 
   if flavor == 'linux':
     if options.enable_lto:
-      version_checked = '5.4.1'
+      version_checked = (5, 4, 1)
       for compiler in [(CC, 'c'), (CXX, 'c++')]:
         ok, is_clang, clang_version, compiler_version = \
           try_check_compiler(compiler[0], compiler[1])
-        if is_clang or compiler_version < version_checked:
+        compiler_version_num = tuple(map(int, compiler_version))
+        if is_clang or compiler_version_num < version_checked:
+          version_checked_str = ".".join(map(str, version_checked))
           raise Exception(
-            'The option --enable-lto is supported for '
-            'gcc and gxx 5.4.1 or newer only.')
+            'The option --enable-lto is supported for gcc and gxx %s'
+            ' or newer only.' % (version_checked_str))
 
   o['variables']['enable_lto'] = b(options.enable_lto)
 


### PR DESCRIPTION
This modification allows for compiling with link time optimization (lto) using the flag --enable-lto.

Refs: https://github.com/nodejs/node/issues/7400

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This is a modification proposed towards enabling lto compilation. From some preliminary results, I observed that there are no major changes in performance when running Node-DC-EIS. However, when coupling lto with pgo, see also Refs: https://github.com/nodejs/node/issues/21583, I observed improvements of even more than 10% in Node-DC-EIS. 

The proposed solution, when enabling lto, manifests a test failure, which seems to be not very critical. In this context, please see comments and feedback from @addaleax at Refs: https://github.com/nodejs/node/issues/7400.

The experiments were done on 
Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz
and
Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz.