### PR TITLE
test: fix test-tls-connect-memleak

### DIFF
--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -44,9 +44,7 @@ tls.createServer({
 
 {
   // 2**26 == 64M entries
-  let junk = [0];
-
-  for (let i = 0; i < 26; ++i) junk = junk.concat(junk);
+  const junk = new Array(2 ** 26).fill(0);
 
   const options = { rejectUnauthorized: false };
   tls.connect(common.PORT, '127.0.0.1', options, function() {


### PR DESCRIPTION
A loop that generates a long array is resulting in a RangeError. Moving
to Array.prototype.fill() along with the ** operator instead of using a
loop fixes the issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
