### PR TITLE
dgram: remove unnecessary fd property from Socket

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -85,7 +85,6 @@ function Socket(type, listener) {
 
   this[async_id_symbol] = handle.getAsyncId();
   this.type = type;
-  this.fd = null; // compatibility hack
 
   if (typeof listener === 'function')
     this.on('message', listener);
@@ -116,7 +115,6 @@ function startListening(socket) {
   state.handle.recvStart();
   state.receiving = true;
   state.bindState = BIND_STATE_BOUND;
-  socket.fd = -42; // compatibility hack
 
   if (state.recvBufferSize)
     bufferSize(socket, state.recvBufferSize, RECV_BUFFER);
@@ -677,7 +675,6 @@ function stopReceiving(socket) {
 
   state.handle.recvStop();
   state.receiving = false;
-  socket.fd = null; // compatibility hack
 }
 
 


### PR DESCRIPTION
It seems the property `socket.fd` is used long before for the compatibility reason but it's not used anymore. 

It's also not documented in docs so that it's not a public api/property.

Keep the property also makes the code a bit confusing as `socket._handle.fd` is the actual property representing fd.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]