### PR TITLE
n-api: create functions directly

### DIFF
--- a/test/addons-napi/test_function/test.js
+++ b/test/addons-napi/test_function/test.js
@@ -1,10 +1,11 @@
 'use strict';
+// Flags: --expose-gc
+
 const common = require('../../common');
 const assert = require('assert');
 
 // testing api calls for function
 const test_function = require(`./build/${common.buildType}/test_function`);
-
 
 function func1() {
   return 1;
@@ -29,3 +30,8 @@ assert.strictEqual(test_function.TestCall(func4, 1), 2);
 
 assert.strictEqual(test_function.TestName.name, 'Name');
 assert.strictEqual(test_function.TestNameShort.name, 'Name_');
+
+let tracked_function = test_function.MakeTrackedFunction(common.mustCall());
+assert(!!tracked_function);
+tracked_function = null;
+global.gc();

--- a/test/addons-napi/test_function/test_function.c
+++ b/test/addons-napi/test_function/test_function.c
@@ -30,6 +30,78 @@ static napi_value TestFunctionName(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static void finalize_function(napi_env env, void* data, void* hint) {
+  napi_ref ref = data;
+
+  // Retrieve the JavaScript undefined value.
+  napi_value undefined;
+  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+
+  // Retrieve the JavaScript function we must call.
+  napi_value js_function;
+  NAPI_CALL_RETURN_VOID(env, napi_get_reference_value(env, ref, &js_function));
+
+  // Call the JavaScript function to indicate that the generated JavaScript
+  // function is about to be gc-ed.
+  NAPI_CALL_RETURN_VOID(env, napi_call_function(env,
+                                                undefined,
+                                                js_function,
+                                                0,
+                                                NULL,
+                                                NULL));
+
+  // Destroy the persistent reference to the function we just called so as to
+  // properly clean up.
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
+}
+
+static napi_value MakeTrackedFunction(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value js_finalize_cb;
+  napi_valuetype arg_type;
+
+  // Retrieve and validate from the arguments the function we will use to
+  // indicate to JavaScript that the function we are about to create is about to
+  // be gc-ed.
+  NAPI_CALL(env, napi_get_cb_info(env,
+                                  info,
+                                  &argc,
+                                  &js_finalize_cb,
+                                  NULL,
+                                  NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NAPI_CALL(env, napi_typeof(env, js_finalize_cb, &arg_type));
+  NAPI_ASSERT(env, arg_type == napi_function, "Argument must be a function");
+
+  // Dynamically create a function.
+  napi_value result;
+  NAPI_CALL(env, napi_create_function(env,
+                                      "TrackedFunction",
+                                      NAPI_AUTO_LENGTH,
+                                      TestFunctionName,
+                                      NULL,
+                                      &result));
+
+  // Create a strong reference to the function we will call when the tracked
+  // function is about to be gc-ed.
+  napi_ref js_finalize_cb_ref;
+  NAPI_CALL(env, napi_create_reference(env,
+                                       js_finalize_cb,
+                                       1,
+                                       &js_finalize_cb_ref));
+
+  // Attach a finalizer to the dynamically created function and pass it the
+  // strong reference we created in the previous step.
+  NAPI_CALL(env, napi_wrap(env,
+                           result,
+                           js_finalize_cb_ref,
+                           finalize_function,
+                           NULL,
+                           NULL));
+
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value fn1;
   NAPI_CALL(env, napi_create_function(
@@ -43,9 +115,21 @@ static napi_value Init(napi_env env, napi_value exports) {
   NAPI_CALL(env, napi_create_function(
       env, "Name_extra", 5, TestFunctionName, NULL, &fn3));
 
+  napi_value fn4;
+  NAPI_CALL(env, napi_create_function(env,
+                                      "MakeTrackedFunction",
+                                      NAPI_AUTO_LENGTH,
+                                      MakeTrackedFunction,
+                                      NULL,
+                                      &fn4));
+
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestCall", fn1));
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestName", fn2));
   NAPI_CALL(env, napi_set_named_property(env, exports, "TestNameShort", fn3));
+  NAPI_CALL(env, napi_set_named_property(env,
+                                         exports,
+                                         "MakeTrackedFunction",
+                                         fn4));
 
   return exports;
 }


### PR DESCRIPTION
Avoid using `v8::FunctionTemplate::New()` when using
`v8::Function::New()` suffices. This ensures that individual functions
can be gc-ed and that functions can be created dynamically without
running out of memory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
