### PR TITLE
http2: order declarations in core.js

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2,22 +2,31 @@
 
 /* eslint-disable no-use-before-define */
 
-const internalUtil = require('internal/util');
-internalUtil.assertCrypto();
+const {
+  assertCrypto,
+  customInspectSymbol: kInspect,
+  promisify
+} = require('internal/util');
 
-const { internalBinding } = require('internal/bootstrap/loaders');
-const { async_id_symbol } = require('internal/async_hooks').symbols;
-const { UV_EOF } = process.binding('uv');
-const http = require('http');
-const binding = process.binding('http2');
-const { FileHandle } = process.binding('fs');
-const { StreamPipe } = internalBinding('stream_pipe');
+assertCrypto();
+
 const assert = require('assert');
 const EventEmitter = require('events');
-const net = require('net');
-const tls = require('tls');
-const util = require('util');
 const fs = require('fs');
+const http = require('http');
+const net = require('net');
+const { Duplex } = require('stream');
+const tls = require('tls');
+const { URL } = require('url');
+const util = require('util');
+
+const { kIncomingMessage } = require('_http_common');
+const { kServerResponse } = require('_http_server');
+const { StreamWrap } = require('_stream_wrap');
+
+const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
+const { async_id_symbol } = require('internal/async_hooks').symbols;
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   codes: {
     ERR_HTTP2_ALTSVC_INVALID_ORIGIN,
@@ -61,30 +70,11 @@ const {
     ERR_SOCKET_CLOSED
   }
 } = require('internal/errors');
-const { StreamWrap } = require('_stream_wrap');
-const { Duplex } = require('stream');
-const { URL } = require('url');
+const { utcDate } = require('internal/http');
 const { onServerStream,
         Http2ServerRequest,
         Http2ServerResponse,
 } = require('internal/http2/compat');
-const { utcDate } = require('internal/http');
-const {
-  promisify,
-  customInspectSymbol: kInspect
-} = internalUtil;
-const { isArrayBufferView } = require('internal/util/types');
-const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
-const { _connectionListener: httpConnectionListener } = http;
-const { createPromise, promiseResolve } = process.binding('util');
-const debug = util.debuglog('http2');
-
-const kMaxFrameSize = (2 ** 24) - 1;
-const kMaxInt = (2 ** 32) - 1;
-const kMaxStreams = (2 ** 31) - 1;
-
-// eslint-disable-next-line no-control-regex
-const kQuotedString = /^[\x09\x20-\x5b\x5d-\x7e\x80-\xff]*$/;
 
 const {
   assertIsObject,
@@ -104,26 +94,39 @@ const {
   updateOptionsBuffer,
   updateSettingsBuffer
 } = require('internal/http2/util');
-
-const {
-  kTimeout,
-  setUnrefTimeout,
-  validateTimerDuration
-} = require('internal/timers');
 const {
   createWriteWrap,
   writeGeneric,
   writevGeneric
 } = require('internal/stream_base_commons');
+const {
+  kTimeout,
+  setUnrefTimeout,
+  validateTimerDuration
+} = require('internal/timers');
+const { isArrayBufferView } = require('internal/util/types');
 
+const { FileHandle } = process.binding('fs');
+const binding = process.binding('http2');
 const { ShutdownWrap } = process.binding('stream_wrap');
+const { createPromise, promiseResolve } = process.binding('util');
+const { UV_EOF } = process.binding('uv');
+
+const { StreamPipe } = internalBinding('stream_pipe');
+const { _connectionListener: httpConnectionListener } = http;
+const debug = util.debuglog('http2');
+
+const kMaxFrameSize = (2 ** 24) - 1;
+const kMaxInt = (2 ** 32) - 1;
+const kMaxStreams = (2 ** 31) - 1;
+
+// eslint-disable-next-line no-control-regex
+const kQuotedString = /^[\x09\x20-\x5b\x5d-\x7e\x80-\xff]*$/;
+
 const { constants, nameForErrorCode } = binding;
 
 const NETServer = net.Server;
 const TLSServer = tls.Server;
-
-const { kIncomingMessage } = require('_http_common');
-const { kServerResponse } = require('_http_server');
 
 const kAlpnProtocol = Symbol('alpnProtocol');
 const kAuthority = Symbol('authority');
@@ -2815,13 +2818,13 @@ function getUnpackedSettings(buf, options = {}) {
 
 // Exports
 module.exports = {
+  connect,
   constants,
+  createServer,
+  createSecureServer,
   getDefaultSettings,
   getPackedSettings,
   getUnpackedSettings,
-  createServer,
-  createSecureServer,
-  connect,
   Http2Session,
   Http2Stream,
   Http2ServerRequest,


### PR DESCRIPTION
Not sure how this will be received because maybe there's an ordering in there already that I'm not detecting, but I find the lengthy declarations at the start of core.js kind of arbitrary and hard to follow. This brings some ordering to it, and hopefully makes it easier to follow or at least not any more difficult to follow.

Order declarations:

* public modules in alphabetical order
* internal modules in alphabetical order
* process.binding() calls in alphabetical order
* exports in alphabetical order

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
