### PR TITLE
stream: flow for 'data' listeners upon removal of last 'readable' listener

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -801,8 +801,8 @@ Readable.prototype.on = function(ev, fn) {
     // a few lines down. This is needed to support once('readable').
     state.readableListening = this.listenerCount('readable') > 0;
 
-    // Try start flowing on next tick if stream isn't explicitly paused
-    if (state.flowing !== false)
+    // Try start flowing on next tick for data if stream isn't explicitly paused
+    if (!state.readableListening && state.flowing !== false)
       this.resume();
   } else if (ev === 'readable') {
     if (!state.endEmitted && !state.readableListening) {
@@ -855,13 +855,14 @@ Readable.prototype.removeAllListeners = function(ev) {
 function updateReadableListening(self) {
   const state = self._readableState;
   state.readableListening = self.listenerCount('readable') > 0;
+
   // try to start flowing for 'data' listeners
   // (if pipesCount is not 0 then we have already 'flowed')
-  if (!state.readableListening &&
-      self.listenerCount('data') > 0 &&
-      state.pipesCount === 0) {
+  if (self.listenerCount('data') > 0 &&
+      !self.isPaused() &&
+      state.pipesCount === 0 &&
+      !state.readableListening)
     self.resume();
-  }
 }
 
 function nReadingNextTick(self) {
@@ -875,9 +876,7 @@ Readable.prototype.resume = function() {
   var state = this._readableState;
   if (!state.flowing) {
     debug('resume');
-    // we flow only if there is no one listening
-    // for readable
-    state.flowing = !state.readableListening;
+    state.flowing = true;
     resume(this, state);
   }
   return this;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -853,7 +853,15 @@ Readable.prototype.removeAllListeners = function(ev) {
 };
 
 function updateReadableListening(self) {
-  self._readableState.readableListening = self.listenerCount('readable') > 0;
+  const state = self._readableState;
+  state.readableListening = self.listenerCount('readable') > 0;
+  // try to start flowing for 'data' listeners
+  // (if pipesCount is not 0 then we have already 'flowed')
+  if (!state.readableListening &&
+      self.listenerCount('data') > 0 &&
+      state.pipesCount === 0) {
+    self.resume();
+  }
 }
 
 function nReadingNextTick(self) {

--- a/test/parallel/test-stream-readable-and-data-pause.js
+++ b/test/parallel/test-stream-readable-and-data-pause.js
@@ -4,10 +4,9 @@ const common = require('../common');
 
 // This test ensures that if we have both 'readable' and 'data'
 // listeners on Readable instance once all of the 'readable' listeners
-// are gone and there are still 'data' listeners stream will try
-// to flow to satisfy the 'data' listeners.
+// are gone and there are still 'data' listeners stream will *not*
+// try to flow if it was explicitly paused.
 
-const assert = require('assert');
 const { Readable } = require('stream');
 
 const r = new Readable({
@@ -16,12 +15,11 @@ const r = new Readable({
 
 const data = ['foo', 'bar', 'baz'];
 
-let receivedData = '';
+r.pause();
+
+r.on('data', common.mustNotCall());
+r.on('end', common.mustNotCall());
 r.once('readable', common.mustCall());
-r.on('data', (chunk) => receivedData += chunk);
-r.once('end', common.mustCall(() => {
-  assert.strictEqual(receivedData, data.join(''));
-}));
 
 for (const d of data)
   r.push(d);

--- a/test/parallel/test-stream-readable-and-data.js
+++ b/test/parallel/test-stream-readable-and-data.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that if we have both 'readable' and 'data'
+// listeners on Readable instance once the 'readable' listeners
+// are gone and there are still 'data' listeners stream will try
+// to flow to satisfy the 'data' listeners.
+
+const assert = require('assert');
+const { Readable } = require('stream');
+
+const r = new Readable({
+  read: () => {},
+});
+
+const data = ['foo', 'bar', 'baz'];
+
+let receivedData = '';
+r.once('readable', common.mustCall());
+r.on('data', (chunk) => receivedData += chunk);
+r.once('end', common.mustCall(() => {
+  assert.strictEqual(receivedData, data.join(''));
+}));
+
+r.push(data[0]);
+r.push(data[1]);
+r.push(data[2]);
+r.push(null);

--- a/test/parallel/test-stream-readable-pipe.js
+++ b/test/parallel/test-stream-readable-pipe.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that if have 'readable' listener
+// on Readable instance it will not disrupt the pipe.
+
+const assert = require('assert');
+const { Readable, Writable } = require('stream');
+
+let receivedData = '';
+const w = new Writable({
+  write: (chunk, env, callback) => {
+    receivedData += chunk;
+    callback();
+  },
+});
+
+const data = ['foo', 'bar', 'baz'];
+const r = new Readable({
+  read: () => {},
+});
+
+r.on('readable', common.mustCall());
+
+r.pipe(w);
+r.push(data[0]);
+r.push(data[1]);
+r.push(data[2]);
+r.push(null);
+
+w.on('finish', common.mustCall(() => {
+  assert.strictEqual(receivedData, data.join(''));
+}));

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -143,7 +143,7 @@ const Readable = require('stream').Readable;
   readable.push('pushed');
 
   // we are still not flowing, we will be resuming in the next tick
-  assert.strictEqual(state.flowing, false);
+  assert.strictEqual(state.flowing, null);
 
   // wait for nextTick, so the readableListener flag resets
   process.nextTick(function() {

--- a/test/parallel/test-stream-readable-remove-pipe.js
+++ b/test/parallel/test-stream-readable-remove-pipe.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that if we remove last 'readable' listener
+// on Readable instance that is piped it will not disrupt the pipe.
+
+const assert = require('assert');
+const { Readable, Writable } = require('stream');
+
+let receivedData = '';
+const w = new Writable({
+  write: (chunk, env, callback) => {
+    receivedData += chunk;
+    callback();
+  },
+});
+
+const data = ['foo', 'bar', 'baz'];
+const r = new Readable({
+  read: () => {},
+});
+
+const listener = common.mustNotCall();
+r.on('readable', listener);
+
+r.pipe(w);
+r.push(data[0]);
+
+r.removeListener('readable', listener);
+
+process.nextTick(() => {
+  r.push(data[1]);
+  r.push(data[2]);
+  r.push(null);
+});
+
+w.on('finish', common.mustCall(() => {
+  assert.strictEqual(receivedData, data.join(''));
+}));


### PR DESCRIPTION
When there is at least one 'data' listener try to flow when
last 'readable' listener gets removed and the stream is not piped.

Currently if we have both 'readable' and 'data' listeners set only
'readable' listener will get called and stream will be stalled without
'data' and 'end' events if 'readable' listener neither read()'s nor
resume()'s the stream.

Fixes: https://github.com/nodejs/node/issues/21398

##### Checklist

- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
