### PR TITLE
doc: remove _Node.js style callback_

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -127,12 +127,11 @@ exactly how errors raised by those methods are propagated.
 <!--type=misc-->
 
 Most asynchronous methods exposed by the Node.js core API follow an idiomatic
-pattern referred to as an _error-first callback_ (sometimes referred to as
-a _Node.js style callback_). With this pattern, a callback function is passed
-to the method as an argument. When the operation either completes or an error
-is raised, the callback function is called with
-the `Error` object (if any) passed as the first argument. If no error was
-raised, the first argument will be passed as `null`.
+pattern referred to as an _error-first callback_. With this pattern, a callback
+function is passed to the method as an argument. When the operation either
+completes or an error is raised, the callback function is called with the
+`Error` object (if any) passed as the first argument. If no error was raised,
+the first argument will be passed as `null`.
 
 ```js
 const fs = require('fs');


### PR DESCRIPTION
We refer to them only as _error-first callbacks_ in our docs. We don't
call them _Node.js style callbacks_ so let's take this opporutnity to
keep things a bit more concise

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
