### PR TITLE
test: check option start or end is not safe integer

### DIFF
--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -65,3 +65,12 @@ fs.createReadStream(example, { start: 1, end: 5 });
 
 // Case 6: Should throw RangeError if start is greater than end
 createReadStreamErr(example, { start: 5, end: 1 }, rangeError);
+
+// Case 7: Should throw RangeError if start or end is not safe integer
+const NOT_SAFE_INTEGER = 2 ** 53;
+[
+  { start: NOT_SAFE_INTEGER, end: Infinity },
+  { start: 0, end: NOT_SAFE_INTEGER }
+].forEach((opts) =>
+  createReadStreamErr(example, opts, rangeError)
+);


### PR DESCRIPTION
To increase fs readstream coverage, added test to check error when
option.start or end is not safe integer.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
