### PR TITLE
 test: add test of fs.promises write for non-string buffers

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 // The following tests validate base functionality for the fs.promises
-// FileHandle.read method.
+// FileHandle.write method.
 
 const fs = require('fs');
 const { open } = fs.promises;

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -45,8 +45,22 @@ async function validateNonUint8ArrayWrite() {
   assert.deepStrictEqual(Buffer.from(buffer, 'utf8'), readFileData);
 }
 
+async function validateNonStringValuesWrite() {
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-non-string-write.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  const nonStringValues = [123, {}, new Map()];
+  for (const nonStringValue of nonStringValues) {
+    await fileHandle.write(nonStringValue);
+  }
+
+  const readFileData = fs.readFileSync(filePathForHandle);
+  const expected = ['123', '[object Object]', '[object Map]'].join('');
+  assert.deepStrictEqual(Buffer.from(expected, 'utf8'), readFileData);
+}
+
 Promise.all([
   validateWrite(),
   validateEmptyWrite(),
-  validateNonUint8ArrayWrite()
+  validateNonUint8ArrayWrite(),
+  validateNonStringValuesWrite()
 ]).then(common.mustCall());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

- To increase fs promises coverage, add test of fs.promises write for non-string buffers.
- Fix comment of fs.promises write that was "read", despite "write".

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
