### PR TITLE
workers: fix invalid exit code in parent upon uncaught exception

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -445,6 +445,9 @@ function setupChild(evalScript) {
 
   function fatalException(error) {
     debug(`[${threadId}] gets fatal exception`);
+
+    process.exitCode = 1;
+
     let caught = false;
     try {
       caught = originalFatalException.call(this, error);

--- a/test/parallel/test-worker-uncaught-exception-async.js
+++ b/test/parallel/test-worker-uncaught-exception-async.js
@@ -12,6 +12,10 @@ if (!process.env.HAS_STARTED_WORKER) {
   w.on('error', common.mustCall((err) => {
     assert(/^Error: foo$/.test(err));
   }));
+  w.on('exit', common.mustCall((code) => {
+    // uncaughtException is code 1
+    assert.strictEqual(code, 1);
+  }));
 } else {
   setImmediate(() => {
     throw new Error('foo');

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -12,6 +12,10 @@ if (!process.env.HAS_STARTED_WORKER) {
   w.on('error', common.mustCall((err) => {
     assert(/^Error: foo$/.test(err));
   }));
+  w.on('exit', common.mustCall((code) => {
+    // uncaughtException is code 1
+    assert.strictEqual(code, 1);
+  }));
 } else {
   throw new Error('foo');
 }


### PR DESCRIPTION
Now worker.on('exit') reports correct exit code (1) if worker has exited
with uncaught exception.

Fixes: https://github.com/nodejs/node/issues/21707

##### Checklist

- [x] `make -j4 test` (UNIX) passes
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Also, if there is any standard shorthand for uncaughtException then please tell me. I'd like to get the message down to 50 columns =).