### PR TITLE
[v8.x backport] test: remove --harmony-sharedarraybuffer usage

### DIFF
--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-util-format-shared-arraybuffer.js
+++ b/test/parallel/test-util-format-shared-arraybuffer.js
@@ -1,5 +1,3 @@
-// Flags: --harmony_sharedarraybuffer
-
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-v8-serdes-sharedarraybuffer.js
+++ b/test/parallel/test-v8-serdes-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
This flag has been enabled by default since v8
7662e0634c3a057fa5d746912ee5af76e285c274.

PR-URL: https://github.com/nodejs/node/pull/16343
Reviewed-By: Jeremiah Senkpiel <fishrock123@rocketmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Anatoli Papirovski <apapirovski@mac.com>
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Timothy Gu <timothygu99@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Backport, as requested, of https://github.com/nodejs/node/pull/16343 