### PR TITLE
[v8.x backport] tls: accept array of protocols in TLSSocket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -262,11 +262,15 @@ function initRead(tls, wrapped) {
  * Provides a wrap of socket stream to do encrypted communication.
  */
 
-function TLSSocket(socket, options) {
-  if (options === undefined)
-    this._tlsOptions = {};
-  else
-    this._tlsOptions = options;
+function TLSSocket(socket, opts) {
+  const tlsOptions = Object.assign({}, opts);
+
+  if (tlsOptions.NPNProtocols)
+    tls.convertNPNProtocols(tlsOptions.NPNProtocols, tlsOptions);
+  if (tlsOptions.ALPNProtocols)
+    tls.convertALPNProtocols(tlsOptions.ALPNProtocols, tlsOptions);
+
+  this._tlsOptions = tlsOptions;
   this._secureEstablished = false;
   this._securePending = false;
   this._newSessionPending = false;
@@ -1044,11 +1048,8 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
                  options.host ||
                  (options.socket && options.socket._host) ||
                  'localhost';
-  const NPN = {};
-  const ALPN = {};
+
   const context = options.secureContext || tls.createSecureContext(options);
-  tls.convertNPNProtocols(options.NPNProtocols, NPN);
-  tls.convertALPNProtocols(options.ALPNProtocols, ALPN);
 
   var socket = new TLSSocket(options.socket, {
     pipe: !!options.path,
@@ -1057,8 +1058,8 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
     requestCert: true,
     rejectUnauthorized: options.rejectUnauthorized !== false,
     session: options.session,
-    NPNProtocols: NPN.NPNProtocols,
-    ALPNProtocols: ALPN.ALPNProtocols,
+    NPNProtocols: options.NPNProtocols,
+    ALPNProtocols: options.ALPNProtocols,
     requestOCSP: options.requestOCSP
   });
 

--- a/test/parallel/test-tls-socket-constructor-alpn-npn-options-parsing.js
+++ b/test/parallel/test-tls-socket-constructor-alpn-npn-options-parsing.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Test that TLSSocket can take arrays of strings for ALPNProtocols and
+// NPNProtocols.
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+new tls.TLSSocket(null, {
+  ALPNProtocols: ['http/1.1'],
+  NPNProtocols: ['http/1.1']
+});
+
+if (!process.features.tls_npn)
+  common.skip('node compiled without NPN feature of OpenSSL');
+
+if (!process.features.tls_alpn)
+  common.skip('node compiled without ALPN feature of OpenSSL');
+
+const assert = require('assert');
+const net = require('net');
+const fixtures = require('../common/fixtures');
+
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+
+const protocols = [];
+
+const server = net.createServer(common.mustCall((s) => {
+  const tlsSocket = new tls.TLSSocket(s, {
+    isServer: true,
+    server,
+    key,
+    cert,
+    ALPNProtocols: ['http/1.1'],
+    NPNProtocols: ['http/1.1']
+  });
+
+  tlsSocket.on('secure', common.mustCall(() => {
+    protocols.push({
+      alpnProtocol: tlsSocket.alpnProtocol,
+      npnProtocol: tlsSocket.npnProtocol
+    });
+    tlsSocket.end();
+  }));
+}, 2));
+
+server.listen(0, common.mustCall(() => {
+  const alpnOpts = {
+    port: server.address().port,
+    rejectUnauthorized: false,
+    ALPNProtocols: ['h2', 'http/1.1']
+  };
+  const npnOpts = {
+    port: server.address().port,
+    rejectUnauthorized: false,
+    NPNProtocols: ['h2', 'http/1.1']
+  };
+
+  tls.connect(alpnOpts, function() {
+    this.end();
+
+    tls.connect(npnOpts, function() {
+      this.end();
+
+      server.close();
+
+      assert.deepStrictEqual(protocols, [
+        { alpnProtocol: 'http/1.1', npnProtocol: false },
+        { alpnProtocol: false, npnProtocol: 'http/1.1' }
+      ]);
+    });
+  });
+}));


### PR DESCRIPTION
Brings the ALPNProtocols & NPNProtocols options of TLSSocket in line
with the documentation. i.e. an array of strings for protocols may be
used, not only a buffer.

PR-URL: https://github.com/nodejs/node/pull/16655
Fixes: https://github.com/node/issues/16643
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Anatoli Papirovski <apapirovski@mac.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Backport, as requested, of https://github.com/nodejs/node/pull/16655 