### PR TITLE
n-api: test uint32 truncation

### DIFF
--- a/test/addons-napi/test_number/test.js
+++ b/test/addons-napi/test_number/test.js
@@ -35,6 +35,20 @@ testNumber(Number.POSITIVE_INFINITY);
 testNumber(Number.NEGATIVE_INFINITY);
 testNumber(Number.NaN);
 
+function testUint32(input, expected = input) {
+  assert.strictEqual(expected, test_number.TestUint32Truncation(input));
+}
+
+// Test zero
+testUint32(0.0, 0);
+testUint32(-0.0, 0);
+
+// Test overflow scenarios
+testUint32(4294967295);
+testUint32(4294967296, 0);
+testUint32(4294967297, 1);
+testUint32(17 * 4294967296 + 1, 1);
+
 // validate documented behavior when value is retrieved as 32-bit integer with
 // `napi_get_value_int32`
 function testInt32(input, expected = input) {

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -23,6 +23,28 @@ static napi_value Test(napi_env env, napi_callback_info info) {
   return output;
 }
 
+static napi_value TestUint32Truncation(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_number,
+      "Wrong type of arguments. Expects a number as first argument.");
+
+  uint32_t input;
+  NAPI_CALL(env, napi_get_value_uint32(env, args[0], &input));
+
+  napi_value output;
+  NAPI_CALL(env, napi_create_uint32(env, input, &output));
+
+  return output;
+}
+
 static napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
@@ -71,6 +93,7 @@ static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
     DECLARE_NAPI_PROPERTY("TestInt32Truncation", TestInt32Truncation),
+    DECLARE_NAPI_PROPERTY("TestUint32Truncation", TestUint32Truncation),
     DECLARE_NAPI_PROPERTY("TestInt64Truncation", TestInt64Truncation),
   };
 


### PR DESCRIPTION
Re: https://github.com/nodejs/abi-stable-node/issues/55#issuecomment-403382424

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
