### PR TITLE
[v8.x-backport] n-api: throw when entry point is null

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -879,6 +879,12 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
                              void* priv) {
   napi_module* mod = static_cast<napi_module*>(priv);
 
+  if (mod->nm_register_func == nullptr) {
+    node::Environment::GetCurrent(context)->ThrowError(
+        "Module has no declared entry point.");
+    return;
+  }
+
   // Create a new napi_env for this module or reference one if a pre-existing
   // one is found.
   napi_env env = v8impl::GetEnv(context);

--- a/test/addons-napi/test_null_init/binding.gyp
+++ b/test/addons-napi/test_null_init/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'test_null_init',
+      'sources': [ 'test_null_init.c' ]
+    }
+  ]
+}

--- a/test/addons-napi/test_null_init/test.js
+++ b/test/addons-napi/test_null_init/test.js
@@ -1,0 +1,7 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+assert.throws(
+  () => require(`./build/${common.buildType}/test_null_init`),
+  /Module has no declared entry point[.]/);

--- a/test/addons-napi/test_null_init/test_null_init.c
+++ b/test/addons-napi/test_null_init/test_null_init.c
@@ -1,0 +1,3 @@
+#include <node_api.h>
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, NULL)


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/20779

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
