### PR TITLE
[v8.x backport] build: fix rm commands in tarball rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,11 @@ coverage-clean:
 	$(RM) -r gcovr build
 	$(RM) -r out/$(BUILDTYPE)/.coverage
 	$(RM) -r .cov_tmp
-	$(RM) out/$(BUILDTYPE)/obj.target/node/{src,gen}/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node/gen/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/tracing/*.gcda
-	$(RM) out/$(BUILDTYPE)/obj.target/node/{src,gen}/*.gcno
+	$(RM) out/$(BUILDTYPE)/obj.target/node/gen/*.gcno
+	$(RM) out/$(BUILDTYPE)/obj.target/node/src/*.gcno
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/tracing/*.gcno
 	$(RM) out/$(BUILDTYPE)/obj.target/cctest/src/*.gcno
 	$(RM) out/$(BUILDTYPE)/obj.target/cctest/test/cctest/*.gcno
@@ -175,7 +177,8 @@ coverage-build: all
 coverage-test: coverage-build
 	$(RM) -r out/$(BUILDTYPE)/.coverage
 	$(RM) -r .cov_tmp
-	$(RM) out/$(BUILDTYPE)/obj.target/node/{src,gen}/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node/gen/*.gcda
+	$(RM) out/$(BUILDTYPE)/obj.target/node/src/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/tracing/*.gcda
 	-$(MAKE) $(COVTESTS)
 	mv lib lib__
@@ -853,15 +856,32 @@ $(TARBALL): release-only $(NODE_EXE) doc
 	mkdir -p $(TARNAME)/doc/api
 	cp doc/node.1 $(TARNAME)/doc/node.1
 	cp -r out/doc/api/* $(TARNAME)/doc/api/
-	$(RM) -r $(TARNAME)/deps/v8/{test,samples,tools/profviz,tools/run-tests.py}
-	$(RM) -r $(TARNAME)/doc/images # too big
-	$(RM) -r $(TARNAME)/deps/uv/{docs,samples,test}
-	$(RM) -r $(TARNAME)/deps/openssl/openssl/{doc,demos,test}
+	$(RM) -r $(TARNAME)/.editorconfig
+	$(RM) -r $(TARNAME)/.git*
+	$(RM) -r $(TARNAME)/.mailmap
+	$(RM) -r $(TARNAME)/deps/openssl/openssl/demos
+	$(RM) -r $(TARNAME)/deps/openssl/openssl/doc
+	$(RM) -r $(TARNAME)/deps/openssl/openssl/test
+	$(RM) -r $(TARNAME)/deps/uv/docs
+	$(RM) -r $(TARNAME)/deps/uv/samples
+	$(RM) -r $(TARNAME)/deps/uv/test
+	$(RM) -r $(TARNAME)/deps/v8/samples
+	$(RM) -r $(TARNAME)/deps/v8/test
+	$(RM) -r $(TARNAME)/deps/v8/tools/profviz
+	$(RM) -r $(TARNAME)/deps/v8/tools/run-tests.py
 	$(RM) -r $(TARNAME)/deps/zlib/contrib # too big, unused
-	$(RM) -r $(TARNAME)/.{editorconfig,git*,mailmap}
-	$(RM) -r $(TARNAME)/tools/{eslint,eslint-rules,osx-pkg.pmdoc,pkgsrc,remark-cli,remark-preset-lint-node}
-	$(RM) -r $(TARNAME)/tools/{osx-*,license-builder.sh,cpplint.py}
+	$(RM) -r $(TARNAME)/doc/images # too big
 	$(RM) -r $(TARNAME)/test*.tap
+	$(RM) -r $(TARNAME)/tools/cpplint.py
+	$(RM) -r $(TARNAME)/tools/eslint
+	$(RM) -r $(TARNAME)/tools/eslint-rules
+	$(RM) -r $(TARNAME)/tools/license-builder.sh
+	$(RM) -r $(TARNAME)/tools/node_modules
+	$(RM) -r $(TARNAME)/tools/osx-*
+	$(RM) -r $(TARNAME)/tools/osx-pkg.pmdoc
+	$(RM) -r $(TARNAME)/tools/pkgsrc
+	$(RM) -r $(TARNAME)/tools/remark-cli
+	$(RM) -r $(TARNAME)/tools/remark-preset-lint-node
 	find $(TARNAME)/ -name ".eslint*" -maxdepth 2 | xargs $(RM)
 	find $(TARNAME)/ -type l | xargs $(RM) # annoying on windows
 	tar -cf $(TARNAME).tar $(TARNAME)


### PR DESCRIPTION
The `$(RM) {foo,bar,baz}` rules don't seem to work with GNU make 4.1.
Write them out in full and get rid of a few overlong lines in the
process.

PR-URL: https://github.com/nodejs/node/pull/18332
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: Jon Moss <me@jonathanmoss.me>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
