### PR TITLE
 process,worker: fix process.exitCode handling for fatalException 

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -151,9 +151,13 @@ added: v0.1.18
 
 The `'uncaughtException'` event is emitted when an uncaught JavaScript
 exception bubbles all the way back to the event loop. By default, Node.js
-handles such exceptions by printing the stack trace to `stderr` and exiting.
+handles such exceptions by printing the stack trace to `stderr` and exiting
+with code 1, overriding any previously set [`process.exitCode`][].
 Adding a handler for the `'uncaughtException'` event overrides this default
-behavior.
+behavior. You may also change the [`process.exitCode`][] in
+`'uncaughtException'` handler which will result in process exiting with
+provided exit code, otherwise in the presence of such handler the process will
+exit with 0.
 
 The listener function is called with the `Error` object passed as the only
 argument.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -475,6 +475,7 @@
         try {
           if (!process._exiting) {
             process._exiting = true;
+            process.exitCode = 1;
             process.emit('exit', 1);
           }
         } catch {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -467,6 +467,8 @@ function setupChild(evalScript) {
       else
         port.postMessage({ type: messageTypes.COULD_NOT_SERIALIZE_ERROR });
       clearAsyncIdStack();
+
+      process.exit();
     }
   }
 }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -454,9 +454,6 @@ function setupChild(evalScript) {
     debug(`[${threadId}] fatal exception caught = ${caught}`);
 
     if (!caught) {
-      // set correct code (uncaughtException) for [kOnExit](code) handler
-      process.exitCode = 1;
-
       let serialized;
       try {
         serialized = serializeError(error);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1438,7 +1438,16 @@ void FatalException(Isolate* isolate,
       exit(7);
     } else if (caught->IsFalse()) {
       ReportException(env, error, message);
-      exit(1);
+
+      // fatal_exception_function call before may have set a new exit code ->
+      // read it again, otherwise use default for uncaughtException 1
+      Local<String> exit_code = env->exit_code_string();
+      Local<Value> code;
+      if (!process_object->Get(env->context(), exit_code).ToLocal(&code) ||
+          !code->IsInt32()) {
+        exit(1);
+      }
+      exit(code.As<v8::Int32>()->Value());
     }
   }
 }

--- a/test/fixtures/process-exit-code-cases.js
+++ b/test/fixtures/process-exit-code-cases.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const assert = require('assert');
+
+const cases = [];
+module.exports = cases;
+
+function exitsOnExitCodeSet() {
+  process.exitCode = 42;
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 42);
+    assert.strictEqual(code, 42);
+  });
+}
+cases.push({ func: exitsOnExitCodeSet, result: 42 });
+
+function changesCodeViaExit() {
+  process.exitCode = 99;
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 42);
+    assert.strictEqual(code, 42);
+  });
+  process.exit(42);
+}
+cases.push({ func: changesCodeViaExit, result: 42 });
+
+function changesCodeZeroExit() {
+  process.exitCode = 99;
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 0);
+    assert.strictEqual(code, 0);
+  });
+  process.exit(0);
+}
+cases.push({ func: changesCodeZeroExit, result: 0 });
+
+function exitWithOneOnUncaught() {
+  process.exitCode = 99;
+  process.on('exit', (code) => {
+    // cannot use assert because it will be uncaughtException -> 1 exit code
+    // that will render this test useless
+    if (code !== 1 || process.exitCode !== 1) {
+      console.log('wrong code! expected 1 for uncaughtException');
+      process.exit(99);
+    }
+  });
+  throw new Error('ok');
+}
+cases.push({
+  func: exitWithOneOnUncaught,
+  result: 1,
+  error: /^Error: ok$/,
+});
+
+function changeCodeInsideExit() {
+  process.exitCode = 95;
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 95);
+    assert.strictEqual(code, 95);
+    process.exitCode = 99;
+  });
+}
+cases.push({ func: changeCodeInsideExit, result: 99 });
+
+function zeroExitWithUncaughtHandler() {
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 0);
+    assert.strictEqual(code, 0);
+  });
+  process.on('uncaughtException', () => {});
+  throw new Error('ok');
+}
+cases.push({ func: zeroExitWithUncaughtHandler, result: 0 });
+
+function changeCodeInUncaughtHandler() {
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 97);
+    assert.strictEqual(code, 97);
+  });
+  process.on('uncaughtException', () => {
+    process.exitCode = 97;
+  });
+  throw new Error('ok');
+}
+cases.push({ func: changeCodeInUncaughtHandler, result: 97 });
+
+function changeCodeInExitWithUncaught() {
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 98;
+  });
+  throw new Error('ok');
+}
+cases.push({
+  func: changeCodeInExitWithUncaught,
+  result: 98,
+  error: /^Error: ok$/,
+});
+
+function exitWithZeroInExitWithUncaught() {
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 0;
+  });
+  throw new Error('ok');
+}
+cases.push({
+  func: exitWithZeroInExitWithUncaught,
+  result: 0,
+  error: /^Error: ok$/,
+});

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -34,6 +34,14 @@ switch (process.argv[2]) {
     return child4();
   case 'child5':
     return child5();
+  case 'child6':
+    return child6();
+  case 'child7':
+    return child7();
+  case 'child8':
+    return child8();
+  case 'child9':
+    return child9();
   case undefined:
     return parent();
   default:
@@ -43,6 +51,7 @@ switch (process.argv[2]) {
 function child1() {
   process.exitCode = 42;
   process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 42);
     assert.strictEqual(code, 42);
   });
 }
@@ -50,6 +59,7 @@ function child1() {
 function child2() {
   process.exitCode = 99;
   process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 42);
     assert.strictEqual(code, 42);
   });
   process.exit(42);
@@ -58,6 +68,7 @@ function child2() {
 function child3() {
   process.exitCode = 99;
   process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 0);
     assert.strictEqual(code, 0);
   });
   process.exit(0);
@@ -66,7 +77,7 @@ function child3() {
 function child4() {
   process.exitCode = 99;
   process.on('exit', function(code) {
-    if (code !== 1) {
+    if (code !== 1 || process.exitCode !== 1) {
       console.log('wrong code! expected 1 for uncaughtException');
       process.exit(99);
     }
@@ -77,9 +88,48 @@ function child4() {
 function child5() {
   process.exitCode = 95;
   process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 95);
     assert.strictEqual(code, 95);
     process.exitCode = 99;
   });
+}
+
+function child6() {
+  process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 0);
+    assert.strictEqual(code, 0);
+  });
+  process.on('uncaughtException', () => {});
+  throw new Error('ok');
+}
+
+function child7() {
+  process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 97);
+    assert.strictEqual(code, 97);
+  });
+  process.on('uncaughtException', () => {
+    process.exitCode = 97;
+  });
+  throw new Error('ok');
+}
+
+function child8() {
+  process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 98;
+  });
+  throw new Error('ok');
+}
+
+function child9() {
+  process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 0;
+  });
+  throw new Error('ok');
 }
 
 function parent() {
@@ -102,4 +152,8 @@ function parent() {
   test('child3', 0);
   test('child4', 1);
   test('child5', 99);
+  test('child6', 0);
+  test('child7', 97);
+  test('child8', 98);
+  test('child9', 0);
 }

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -23,113 +23,18 @@
 require('../common');
 const assert = require('assert');
 
-switch (process.argv[2]) {
-  case 'child1':
-    return child1();
-  case 'child2':
-    return child2();
-  case 'child3':
-    return child3();
-  case 'child4':
-    return child4();
-  case 'child5':
-    return child5();
-  case 'child6':
-    return child6();
-  case 'child7':
-    return child7();
-  case 'child8':
-    return child8();
-  case 'child9':
-    return child9();
-  case undefined:
-    return parent();
-  default:
-    throw new Error('invalid');
-}
+const testCases = require('../fixtures/process-exit-code-cases');
 
-function child1() {
-  process.exitCode = 42;
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 42);
-    assert.strictEqual(code, 42);
-  });
-}
-
-function child2() {
-  process.exitCode = 99;
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 42);
-    assert.strictEqual(code, 42);
-  });
-  process.exit(42);
-}
-
-function child3() {
-  process.exitCode = 99;
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 0);
-    assert.strictEqual(code, 0);
-  });
-  process.exit(0);
-}
-
-function child4() {
-  process.exitCode = 99;
-  process.on('exit', function(code) {
-    if (code !== 1 || process.exitCode !== 1) {
-      console.log('wrong code! expected 1 for uncaughtException');
-      process.exit(99);
-    }
-  });
-  throw new Error('ok');
-}
-
-function child5() {
-  process.exitCode = 95;
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 95);
-    assert.strictEqual(code, 95);
-    process.exitCode = 99;
-  });
-}
-
-function child6() {
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 0);
-    assert.strictEqual(code, 0);
-  });
-  process.on('uncaughtException', () => {});
-  throw new Error('ok');
-}
-
-function child7() {
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 97);
-    assert.strictEqual(code, 97);
-  });
-  process.on('uncaughtException', () => {
-    process.exitCode = 97;
-  });
-  throw new Error('ok');
-}
-
-function child8() {
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 98;
-  });
-  throw new Error('ok');
-}
-
-function child9() {
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 0;
-  });
-  throw new Error('ok');
+if (!process.argv[2]) {
+  parent();
+} else {
+  const i = parseInt(process.argv[2]);
+  if (Number.isNaN(i)) {
+    console.log('Invalid test case index');
+    process.exit(100);
+    return;
+  }
+  testCases[i].func();
 }
 
 function parent() {
@@ -138,22 +43,14 @@ function parent() {
   const f = __filename;
   const option = { stdio: [ 0, 1, 'ignore' ] };
 
-  const test = (arg, exit) => {
+  const test = (arg, name = 'child', exit) => {
     spawn(node, [f, arg], option).on('exit', (code) => {
       assert.strictEqual(
         code, exit,
-        `wrong exit for ${arg}\nexpected:${exit} but got:${code}`);
+        `wrong exit for ${arg}-${name}\nexpected:${exit} but got:${code}`);
       console.log(`ok - ${arg} exited with ${exit}`);
     });
   };
 
-  test('child1', 42);
-  test('child2', 42);
-  test('child3', 0);
-  test('child4', 1);
-  test('child5', 99);
-  test('child6', 0);
-  test('child7', 97);
-  test('child8', 98);
-  test('child9', 0);
+  testCases.forEach((tc, i) => test(i, tc.func.name, tc.result));
 }

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -35,6 +35,10 @@ if (!process.env.HAS_STARTED_WORKER) {
         return child6();
       case 'child7':
         return child7();
+      case 'child8':
+        return child8();
+      case 'child9':
+        return child9();
       default:
         throw new Error('invalid');
     }
@@ -105,6 +109,24 @@ function child7() {
   throw new Error('ok');
 }
 
+function child8() {
+  process.on('exit', (code) => {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 98;
+  });
+  throw new Error('ok');
+}
+
+function child9() {
+  process.on('exit', function(code) {
+    assert.strictEqual(process.exitCode, 1);
+    assert.strictEqual(code, 1);
+    process.exitCode = 0;
+  });
+  throw new Error('ok');
+}
+
 function parent() {
   const test = (arg, exit, error = null) => {
     const w = new Worker(__filename);
@@ -116,7 +138,9 @@ function parent() {
     }));
     if (error) {
       w.on('error', common.mustCall((err) => {
-        assert(error.test(err));
+        console.log(err);
+        assert(error.test(err),
+               `wrong error for ${arg}\nexpected:${error} but got:${err}`);
       }));
     }
     w.postMessage(arg);
@@ -129,4 +153,6 @@ function parent() {
   test('child5', 99);
   test('child6', 0);
   test('child7', 97);
+  test('child8', 98, /^Error: ok$/);
+  test('child9', 0, /^Error: ok$/);
 }

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -9,6 +9,8 @@ const assert = require('assert');
 const worker = require('worker_threads');
 const { Worker, parentPort } = worker;
 
+const testCases = require('../fixtures/process-exit-code-cases');
+
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {
   process.env.HAS_STARTED_WORKER = 1;
@@ -19,121 +21,16 @@ if (!process.env.HAS_STARTED_WORKER) {
     process.exit(100);
     return;
   }
-  parentPort.once('message', (msg) => {
-    switch (msg) {
-      case 'child1':
-        return child1();
-      case 'child2':
-        return child2();
-      case 'child3':
-        return child3();
-      case 'child4':
-        return child4();
-      case 'child5':
-        return child5();
-      case 'child6':
-        return child6();
-      case 'child7':
-        return child7();
-      case 'child8':
-        return child8();
-      case 'child9':
-        return child9();
-      default:
-        throw new Error('invalid');
-    }
-  });
-}
-
-function child1() {
-  process.exitCode = 42;
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 42);
-  });
-}
-
-function child2() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 42);
-  });
-  process.exit(42);
-}
-
-function child3() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 0);
-  });
-  process.exit(0);
-}
-
-function child4() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    // cannot use assert because it will be uncaughtException -> 1 exit code
-    // that will render this test useless
-    if (code !== 1) {
-      console.error('wrong code! expected 1 for uncaughtException');
-      process.exit(99);
-    }
-  });
-  throw new Error('ok');
-}
-
-function child5() {
-  process.exitCode = 95;
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 95);
-    process.exitCode = 99;
-  });
-}
-
-function child6() {
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 0);
-  });
-  process.on('uncaughtException', common.mustCall(() => {
-    // handle
-  }));
-  throw new Error('ok');
-}
-
-function child7() {
-  process.on('exit', (code) => {
-    assert.strictEqual(code, 97);
-  });
-  process.on('uncaughtException', common.mustCall(() => {
-    process.exitCode = 97;
-  }));
-  throw new Error('ok');
-}
-
-function child8() {
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 98;
-  });
-  throw new Error('ok');
-}
-
-function child9() {
-  process.on('exit', function(code) {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 0;
-  });
-  throw new Error('ok');
+  parentPort.once('message', (msg) => testCases[msg].func());
 }
 
 function parent() {
-  const test = (arg, exit, error = null) => {
+  const test = (arg, name = 'worker', exit, error = null) => {
     const w = new Worker(__filename);
     w.on('exit', common.mustCall((code) => {
       assert.strictEqual(
         code, exit,
-        `wrong exit for ${arg}\nexpected:${exit} but got:${code}`);
+        `wrong exit for ${arg}-${name}\nexpected:${exit} but got:${code}`);
       console.log(`ok - ${arg} exited with ${exit}`);
     }));
     if (error) {
@@ -146,13 +43,5 @@ function parent() {
     w.postMessage(arg);
   };
 
-  test('child1', 42);
-  test('child2', 42);
-  test('child3', 0);
-  test('child4', 1, /^Error: ok$/);
-  test('child5', 99);
-  test('child6', 0);
-  test('child7', 97);
-  test('child8', 98, /^Error: ok$/);
-  test('child9', 0, /^Error: ok$/);
+  testCases.forEach((tc, i) => test(i, tc.func.name, tc.result, tc.error));
 }

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -27,5 +27,9 @@ if (!process.env.HAS_STARTED_WORKER) {
       assert.fail('Exit callback called twice in worker');
     }
   });
+
+  setTimeout(() => assert.fail('Timeout executed after uncaughtException'),
+             2000);
+
   throw new Error('foo');
 }

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -10,6 +10,7 @@ if (!process.env.HAS_STARTED_WORKER) {
   const w = new Worker(__filename);
   w.on('message', common.mustNotCall());
   w.on('error', common.mustCall((err) => {
+    console.log(err.message);
     assert(/^Error: foo$/.test(err));
   }));
   w.on('exit', common.mustCall((code) => {
@@ -17,5 +18,14 @@ if (!process.env.HAS_STARTED_WORKER) {
     assert.strictEqual(code, 1);
   }));
 } else {
+  // cannot use common.mustCall as it cannot catch this
+  let called = false;
+  process.on('exit', (code) => {
+    if (!called) {
+      called = true;
+    } else {
+      assert.fail('Exit callback called twice in worker');
+    }
+  });
   throw new Error('foo');
 }


### PR DESCRIPTION
* set process.exitCode before calling 'exit' handlers so that there will
  not be a situation where process.exitCode !== code in 'exit' callback
  during uncaughtException handling
* don't ignore process.exitCode set in 'exit' callback when failed with
  uncaughtException and there is no uncaughtException listener

* fix duplicate call of 'exit' callbacks in case of uncaught exception in worker

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] tests and are included
- [ ] documentation is changed or added (I'm not sure if this is reflected anywhere, so leaving unchecked for now)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

~~This PR depends on https://github.com/nodejs/node/pull/21713 for workers test.~~

I've found a bug in workers where in case on uncaughtException 'exit' event is actually called twice. I think this is due to both, having `_fatalException` called presumably via [`FatalException()`](https://github.com/nodejs/node/blob/master/src/node.cc#L1404) and usual exit from worker  as I understand [here](https://github.com/nodejs/node/blob/master/src/node_worker.cc#L197) which results in 2 calls to 'exit' callbacks.
I have fixed it with second commit, but I'm not sure if it's a correct fix, so awaiting feedback.

Edit: The case for the bug is when worker exits with unhandled exception and there is an 'exit' event listener and **no** 'unhandledException' listeners. This way worker's local 'exit' callbacks will be called twice. (see [test-worker-uncaught-exception.js](https://github.com/nodejs/node/pull/21739/files#diff-336ff635d2ed9bcd3a676887181dd1baR19)). Current node 10.6.0 always fails on this.

/cc @addaleax
