### PR TITLE
src: enable more detailed memory tracking

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -423,6 +423,8 @@
         'src/node_revert.h',
         'src/node_i18n.h',
         'src/node_worker.h',
+        'src/memory_tracker.h',
+        'src/memory_tracker-inl.h',
         'src/pipe_wrap.h',
         'src/tty_wrap.h',
         'src/tcp_wrap.h',

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -173,7 +173,6 @@ class AsyncWrap : public BaseObject {
       int argc,
       v8::Local<v8::Value>* argv);
 
-  virtual size_t self_size() const = 0;
   virtual std::string diagnostic_name() const;
 
   static void WeakCallback(const v8::WeakCallbackInfo<DestroyParam> &info);

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -61,11 +61,11 @@ Persistent<v8::Object>& BaseObject::persistent() {
 }
 
 
-v8::Local<v8::Object> BaseObject::object() {
+v8::Local<v8::Object> BaseObject::object() const {
   return PersistentToLocal(env_->isolate(), persistent_handle_);
 }
 
-v8::Local<v8::Object> BaseObject::object(v8::Isolate* isolate) {
+v8::Local<v8::Object> BaseObject::object(v8::Isolate* isolate) const {
   v8::Local<v8::Object> handle = object();
 #ifdef DEBUG
   CHECK_EQ(handle->CreationContext()->GetIsolate(), isolate);
@@ -88,12 +88,6 @@ BaseObject* BaseObject::FromJSObject(v8::Local<v8::Object> obj) {
 template <typename T>
 T* BaseObject::FromJSObject(v8::Local<v8::Object> object) {
   return static_cast<T*>(FromJSObject(object));
-}
-
-
-void BaseObject::DeleteMe(void* data) {
-  BaseObject* self = static_cast<BaseObject*>(data);
-  delete self;
 }
 
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -121,10 +121,12 @@ inline const char* ToErrorCodeString(int status) {
 
 class ChannelWrap;
 
-struct node_ares_task {
+struct node_ares_task : public MemoryRetainer {
   ChannelWrap* channel;
   ares_socket_t sock;
   uv_poll_t poll_watcher;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
 };
 
 struct TaskHash {
@@ -167,7 +169,12 @@ class ChannelWrap : public AsyncWrap {
   inline int active_query_count() { return active_query_count_; }
   inline node_ares_task_list* task_list() { return &task_list_; }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    if (timer_handle_ != nullptr)
+      tracker->TrackFieldWithSize("timer handle", sizeof(*timer_handle_));
+    tracker->TrackField("task list", task_list_);
+  }
 
   static void AresTimeout(uv_timer_t* handle);
 
@@ -180,6 +187,11 @@ class ChannelWrap : public AsyncWrap {
   int active_query_count_;
   node_ares_task_list task_list_;
 };
+
+void node_ares_task::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackThis(this);
+  tracker->TrackField("channel", channel);
+}
 
 ChannelWrap::ChannelWrap(Environment* env,
                          Local<Object> object)
@@ -209,7 +221,10 @@ class GetAddrInfoReqWrap : public ReqWrap<uv_getaddrinfo_t> {
                      Local<Object> req_wrap_obj,
                      bool verbatim);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
   bool verbatim() const { return verbatim_; }
 
  private:
@@ -228,7 +243,9 @@ class GetNameInfoReqWrap : public ReqWrap<uv_getnameinfo_t> {
  public:
   GetNameInfoReqWrap(Environment* env, Local<Object> req_wrap_obj);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 };
 
 GetNameInfoReqWrap::GetNameInfoReqWrap(Environment* env,
@@ -270,13 +287,13 @@ void ares_poll_cb(uv_poll_t* watcher, int status, int events) {
 
 void ares_poll_close_cb(uv_poll_t* watcher) {
   node_ares_task* task = ContainerOf(&node_ares_task::poll_watcher, watcher);
-  free(task);
+  delete task;
 }
 
 
 /* Allocates and returns a new node_ares_task */
 node_ares_task* ares_task_create(ChannelWrap* channel, ares_socket_t sock) {
-  auto task = node::UncheckedMalloc<node_ares_task>(1);
+  auto task = new node_ares_task();
 
   if (task == nullptr) {
     /* Out of memory. */
@@ -1172,7 +1189,9 @@ class QueryAnyWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1349,7 +1368,9 @@ class QueryAWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1393,7 +1414,9 @@ class QueryAaaaWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1437,7 +1460,9 @@ class QueryCnameWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1468,7 +1493,9 @@ class QueryMxWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1499,7 +1526,9 @@ class QueryNsWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1530,7 +1559,9 @@ class QueryTxtWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1560,7 +1591,9 @@ class QuerySrvWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1589,7 +1622,9 @@ class QueryPtrWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1620,7 +1655,9 @@ class QueryNaptrWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1650,7 +1687,9 @@ class QuerySoaWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1729,7 +1768,9 @@ class GetHostByAddrWrap: public QueryWrap {
     return 0;
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void Parse(struct hostent* host) override {

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -16,7 +16,9 @@ class ConnectWrap : public ReqWrap<uv_connect_t> {
               v8::Local<v8::Object> req_wrap_obj,
               AsyncWrap::ProviderType provider);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 };
 
 }  // namespace node

--- a/src/env.cc
+++ b/src/env.cc
@@ -734,4 +734,18 @@ void Environment::stop_sub_worker_contexts() {
   }
 }
 
+// Not really any better place than env.cc at this moment.
+void BaseObject::DeleteMe(void* data) {
+  BaseObject* self = static_cast<BaseObject*>(data);
+  delete self;
+}
+
+Local<Object> BaseObject::WrappedObject() const {
+  return object();
+}
+
+bool BaseObject::IsRootNode() const {
+  return !persistent_handle_.IsWeak();
+}
+
 }  // namespace node

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -56,7 +56,10 @@ class FSEventWrap: public HandleWrap {
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void GetInitialized(const FunctionCallbackInfo<Value>& args);
-  size_t self_size() const override { return sizeof(*this); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   static const encoding kDefaultEncoding = UTF8;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -103,7 +103,11 @@ class JSBindingsConnection : public AsyncWrap {
     }
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackField("callback", callback_);
+    tracker->TrackFieldWithSize("session", sizeof(*session_));
+  }
 
  private:
   std::unique_ptr<InspectorSession> session_;

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -27,7 +27,9 @@ class JSStream : public AsyncWrap, public StreamBase {
               size_t count,
               uv_stream_t* send_handle) override;
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   JSStream(Environment* env, v8::Local<v8::Object> obj);

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -1,0 +1,108 @@
+#ifndef SRC_MEMORY_TRACKER_INL_H_
+#define SRC_MEMORY_TRACKER_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "memory_tracker.h"
+
+namespace node {
+
+template <typename T>
+void MemoryTracker::TrackThis(const T* obj) {
+  accumulated_size_ += sizeof(T);
+}
+
+void MemoryTracker::TrackFieldWithSize(const char* name, size_t size) {
+  accumulated_size_ += size;
+}
+
+void MemoryTracker::TrackField(const char* name, const MemoryRetainer& value) {
+  TrackField(name, &value);
+}
+
+void MemoryTracker::TrackField(const char* name, const MemoryRetainer* value) {
+  if (track_only_self_ || value == nullptr || seen_.count(value) > 0) return;
+  seen_.insert(value);
+  Track(value);
+}
+
+template <typename T>
+void MemoryTracker::TrackField(const char* name,
+                               const std::unique_ptr<T>& value) {
+  TrackField(name, value.get());
+}
+
+template <typename T, typename Iterator>
+void MemoryTracker::TrackField(const char* name, const T& value) {
+  if (value.begin() == value.end()) return;
+  size_t index = 0;
+  for (Iterator it = value.begin(); it != value.end(); ++it)
+    TrackField(std::to_string(index++).c_str(), *it);
+}
+
+template <typename T>
+void MemoryTracker::TrackField(const char* name, const std::queue<T>& value) {
+  struct ContainerGetter : public std::queue<T> {
+    static const typename std::queue<T>::container_type& Get(
+        const std::queue<T>& value) {
+      return value.*&ContainerGetter::c;
+    }
+  };
+
+  const auto& container = ContainerGetter::Get(value);
+  TrackField(name, container);
+}
+
+template <typename T, typename test_for_number, typename dummy>
+void MemoryTracker::TrackField(const char* name, const T& value) {
+  // For numbers, creating new nodes is not worth the overhead.
+  CurrentNode()->size_ += sizeof(T);
+}
+
+template <typename T, typename U>
+void MemoryTracker::TrackField(const char* name, const std::pair<T, U>& value) {
+  TrackField("first", value.first);
+  TrackField("second", value.second);
+}
+
+template <typename T>
+void MemoryTracker::TrackField(const char* name,
+                               const std::basic_string<T>& value) {
+  TrackFieldWithSize(name, value.size() * sizeof(T));
+}
+
+template <typename T, typename Traits>
+void MemoryTracker::TrackField(const char* name,
+                               const v8::Persistent<T, Traits>& value) {
+}
+
+template <typename T>
+void MemoryTracker::TrackField(const char* name, const v8::Local<T>& value) {
+}
+
+template <typename T>
+void MemoryTracker::TrackField(const char* name,
+                               const MallocedBuffer<T>& value) {
+  TrackFieldWithSize(name, value.size);
+}
+
+void MemoryTracker::TrackField(const char* name, const uv_buf_t& value) {
+  TrackFieldWithSize(name, value.len);
+}
+
+template <class NativeT, class V8T>
+void MemoryTracker::TrackField(const char* name,
+                       const AliasedBuffer<NativeT, V8T>& value) {
+  TrackField(name, value.GetJSArray());
+}
+
+void MemoryTracker::Track(const MemoryRetainer* value) {
+  v8::HandleScope handle_scope(isolate_);
+  value->MemoryInfo(this);
+}
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_MEMORY_TRACKER_INL_H_

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -56,7 +56,7 @@ void MemoryTracker::TrackField(const char* name, const std::queue<T>& value) {
 template <typename T, typename test_for_number, typename dummy>
 void MemoryTracker::TrackField(const char* name, const T& value) {
   // For numbers, creating new nodes is not worth the overhead.
-  CurrentNode()->size_ += sizeof(T);
+  TrackFieldWithSize(name, sizeof(T));
 }
 
 template <typename T, typename U>
@@ -97,7 +97,6 @@ void MemoryTracker::TrackField(const char* name,
 }
 
 void MemoryTracker::Track(const MemoryRetainer* value) {
-  v8::HandleScope handle_scope(isolate_);
   value->MemoryInfo(this);
 }
 

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -1,0 +1,86 @@
+#ifndef SRC_MEMORY_TRACKER_H_
+#define SRC_MEMORY_TRACKER_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include <unordered_set>
+#include <queue>
+#include <limits>
+#include <uv.h>
+#include <aliased_buffer.h>
+
+namespace node {
+
+class MemoryTracker;
+
+namespace crypto {
+class NodeBIO;
+}
+
+class MemoryRetainer {
+ public:
+  virtual ~MemoryRetainer() {}
+
+  // Subclasses should implement this to provide information for heap snapshots.
+  virtual void MemoryInfo(MemoryTracker* tracker) const = 0;
+
+  virtual v8::Local<v8::Object> WrappedObject() const {
+    return v8::Local<v8::Object>();
+  }
+
+  virtual bool IsRootNode() const { return false; }
+};
+
+class MemoryTracker {
+ public:
+  template <typename T>
+  inline void TrackThis(const T* obj);
+
+  inline void TrackFieldWithSize(const char* name, size_t size);
+
+  inline void TrackField(const char* name, const MemoryRetainer& value);
+  inline void TrackField(const char* name, const MemoryRetainer* value);
+  template <typename T>
+  inline void TrackField(const char* name, const std::unique_ptr<T>& value);
+  template <typename T, typename Iterator = typename T::const_iterator>
+  inline void TrackField(const char* name, const T& value);
+  template <typename T>
+  inline void TrackField(const char* name, const std::queue<T>& value);
+  template <typename T>
+  inline void TrackField(const char* name, const std::basic_string<T>& value);
+  template <typename T, typename test_for_number =
+      char[std::numeric_limits<T>::is_specialized * 2 - 1],
+      typename dummy = bool>
+  inline void TrackField(const char* name, const T& value);
+  template <typename T, typename U>
+  inline void TrackField(const char* name, const std::pair<T, U>& value);
+  template <typename T, typename Traits>
+  inline void TrackField(const char* name,
+                         const v8::Persistent<T, Traits>& value);
+  template <typename T>
+  inline void TrackField(const char* name, const v8::Local<T>& value);
+  template <typename T>
+  inline void TrackField(const char* name, const MallocedBuffer<T>& value);
+  inline void TrackField(const char* name, const uv_buf_t& value);
+  template <class NativeT, class V8T>
+  inline void TrackField(const char* name,
+                         const AliasedBuffer<NativeT, V8T>& value);
+
+  inline void Track(const MemoryRetainer* value);
+  inline size_t accumulated_size() const { return accumulated_size_; }
+
+  inline void set_track_only_self(bool value) { track_only_self_ = value; }
+
+  inline MemoryTracker() {}
+
+ private:
+  bool track_only_self_ = false;
+  size_t accumulated_size_ = 0;
+  std::unordered_set<const MemoryRetainer*> seen_;
+};
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_MEMORY_TRACKER_H_

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -49,7 +49,8 @@ class MemoryTracker {
   template <typename T>
   inline void TrackField(const char* name, const std::basic_string<T>& value);
   template <typename T, typename test_for_number =
-      char[std::numeric_limits<T>::is_specialized * 2 - 1],
+      typename std::enable_if<
+          std::numeric_limits<T>::is_specialized, bool>::type,
       typename dummy = bool>
   inline void TrackField(const char* name, const T& value);
   template <typename T, typename U>

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -33,6 +33,12 @@ class ModuleWrap : public BaseObject {
       v8::Local<v8::Module> module,
       v8::Local<v8::Object> meta);
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackField("url", url_);
+    tracker->TrackField("resolve_cache", resolve_cache_);
+  }
+
  private:
   ModuleWrap(Environment* env,
              v8::Local<v8::Object> object,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -588,6 +588,10 @@ class ContextifyScript : public BaseObject {
  private:
   Persistent<UnboundScript> script_;
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  public:
   static void Init(Environment* env, Local<Object> target) {
     HandleScope scope(env->isolate());

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -49,6 +49,7 @@ class ContextifyContext {
         context()->GetEmbedderData(ContextEmbedderIndex::kSandboxObject));
   }
 
+
   template <typename T>
   static ContextifyContext* Get(const v8::PropertyCallbackInfo<T>& args);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4582,6 +4582,8 @@ bool ECDH::IsKeyPairValid() {
 }
 
 
+// TODO(addaleax): If there is an `AsyncWrap`, it currently has no access to
+// this object. This makes proper reporting of memory usage impossible.
 struct CryptoJob : public ThreadPoolWork {
   Environment* const env;
   std::unique_ptr<AsyncWrap> async_wrap;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -105,6 +105,10 @@ class SecureContext : public BaseObject {
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
   SSLCtxPointer ctx_;
   X509Pointer cert_;
   X509Pointer issuer_;
@@ -337,6 +341,10 @@ class CipherBase : public BaseObject {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  protected:
   enum CipherKind {
     kCipher,
@@ -407,6 +415,10 @@ class Hmac : public BaseObject {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  protected:
   void HmacInit(const char* hash_type, const char* key, int key_len);
   bool HmacUpdate(const char* data, int len);
@@ -429,6 +441,10 @@ class Hmac : public BaseObject {
 class Hash : public BaseObject {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
   bool HashInit(const char* hash_type);
   bool HashUpdate(const char* data, int len);
@@ -468,6 +484,10 @@ class SignBase : public BaseObject {
 
   Error Init(const char* sign_type);
   Error Update(const char* data, int len);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   void CheckThrow(Error error);
@@ -581,6 +601,10 @@ class DiffieHellman : public BaseObject {
     MakeWeak();
   }
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  private:
   static void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
                        const BIGNUM* (*get_field)(const DH*),
@@ -605,6 +629,10 @@ class ECDH : public BaseObject {
                                       const EC_GROUP* group,
                                       char* data,
                                       size_t len);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, ECKeyPointer&& key)

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -32,7 +32,7 @@
 namespace node {
 namespace crypto {
 
-class NodeBIO {
+class NodeBIO : public MemoryRetainer {
  public:
   NodeBIO() : env_(nullptr),
               initial_(kInitialBufferLength),
@@ -109,6 +109,11 @@ class NodeBIO {
   }
 
   static NodeBIO* FromBIO(BIO* bio);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackFieldWithSize("buffer", length_);
+  }
 
  private:
   static int New(BIO* bio);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -155,8 +155,9 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  size_t self_size() const override {
-    return sizeof(*this);
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackField("current_buffer", current_buffer_);
   }
 
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -250,6 +250,10 @@ class ConverterObject : public BaseObject, Converter {
     }
   }
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  protected:
   ConverterObject(Environment* env,
                   v8::Local<v8::Object> wrap,

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -52,6 +52,11 @@ class SerializerContext : public BaseObject,
   static void WriteUint64(const FunctionCallbackInfo<Value>& args);
   static void WriteDouble(const FunctionCallbackInfo<Value>& args);
   static void WriteRawBytes(const FunctionCallbackInfo<Value>& args);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  private:
   ValueSerializer serializer_;
 };
@@ -76,6 +81,11 @@ class DeserializerContext : public BaseObject,
   static void ReadUint64(const FunctionCallbackInfo<Value>& args);
   static void ReadDouble(const FunctionCallbackInfo<Value>& args);
   static void ReadRawBytes(const FunctionCallbackInfo<Value>& args);
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  private:
   const uint8_t* data_;
   const size_t length_;

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -44,7 +44,9 @@ class StatWatcher : public HandleWrap {
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   static void Callback(uv_fs_poll_t* handle,

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -27,6 +27,11 @@ class NodeCategorySet : public BaseObject {
 
   const std::set<std::string>& GetCategories() { return categories_; }
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackField("categories", categories_);
+  }
+
  private:
   NodeCategorySet(Environment* env,
                   Local<Object> wrap,

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -403,10 +403,6 @@ void Worker::Exit(int code) {
   }
 }
 
-size_t Worker::self_size() const {
-  return sizeof(*this);
-}
-
 namespace {
 
 // Return the MessagePort that is global for this Environment and communicates

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -25,7 +25,14 @@ class Worker : public AsyncWrap {
   // Wait for the worker thread to stop (in a blocking manner).
   void JoinThread();
 
-  size_t self_size() const override;
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackFieldWithSize("isolate_data", sizeof(IsolateData));
+    tracker->TrackFieldWithSize("env", sizeof(Environment));
+    tracker->TrackFieldWithSize("thread_exit_async", sizeof(uv_async_t));
+    tracker->TrackField("parent_port", parent_port_);
+  }
+
   bool is_stopped() const;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -646,7 +646,12 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     }
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackFieldWithSize("dictionary", dictionary_len_);
+    tracker->TrackFieldWithSize("zlib memory",
+        zlib_memory_ + unreported_allocations_);
+  }
 
  private:
   void Ref() {

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -45,7 +45,9 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   PipeWrap(Environment* env,

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -71,7 +71,9 @@ class ProcessWrap : public HandleWrap {
     target->Set(processString, constructor->GetFunction());
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {

--- a/src/sharedarraybuffer_metadata.cc
+++ b/src/sharedarraybuffer_metadata.cc
@@ -47,6 +47,10 @@ class SABLifetimePartner : public BaseObject {
     MakeWeak();
   }
 
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
   SharedArrayBufferMetadataReference reference;
 };
 

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -62,7 +62,9 @@ class SignalWrap : public HandleWrap {
     target->Set(signalString, constructor->GetFunction());
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -346,7 +346,10 @@ class SimpleShutdownWrap : public ShutdownWrap, public OtherBase {
                      v8::Local<v8::Object> req_wrap_obj);
 
   AsyncWrap* GetAsyncWrap() override { return this; }
-  size_t self_size() const override { return sizeof(*this); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 };
 
 template <typename OtherBase>
@@ -356,7 +359,11 @@ class SimpleWriteWrap : public WriteWrap, public OtherBase {
                   v8::Local<v8::Object> req_wrap_obj);
 
   AsyncWrap* GetAsyncWrap() override { return this; }
-  size_t self_size() const override { return sizeof(*this) + StorageSize(); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+    tracker->TrackFieldWithSize("storage", StorageSize());
+  }
 };
 
 }  // namespace node

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -18,7 +18,9 @@ class StreamPipe : public AsyncWrap {
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unpipe(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   StreamBase* source();

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -44,7 +44,9 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context);
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   typedef uv_tcp_t HandleType;

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -71,7 +71,9 @@ class TimerWrap : public HandleWrap {
                    ->GetFunction(env->context()).ToLocalChecked()).FromJust();
   }
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   static void SetupTimers(const FunctionCallbackInfo<Value>& args) {

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -864,6 +864,15 @@ void TLSWrap::GetWriteQueueSize(const FunctionCallbackInfo<Value>& info) {
 }
 
 
+void TLSWrap::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackThis(this);
+  tracker->TrackField("error", error_);
+  tracker->TrackField("pending_cleartext_input", pending_cleartext_input_);
+  tracker->TrackField("enc_in", crypto::NodeBIO::FromBIO(enc_in_));
+  tracker->TrackField("enc_out", crypto::NodeBIO::FromBIO(enc_out_));
+}
+
+
 void TLSWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
                          Local<Context> context) {

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -76,7 +76,7 @@ class TLSWrap : public AsyncWrap,
 
   void NewSessionDoneCb();
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override;
 
  protected:
   inline StreamBase* underlying_stream() {

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -38,7 +38,9 @@ class TTYWrap : public LibuvStreamWrap {
 
   uv_tty_t* UVHandle();
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   TTYWrap(Environment* env,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -55,7 +55,11 @@ class SendWrap : public ReqWrap<uv_udp_send_t> {
   SendWrap(Environment* env, Local<Object> req_wrap_obj, bool have_callback);
   inline bool have_callback() const;
   size_t msg_size;
-  size_t self_size() const override { return sizeof(*this); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
+
  private:
   const bool have_callback_;
 };

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -64,7 +64,9 @@ class UDPWrap: public HandleWrap {
                                            SocketType type);
   uv_udp_t* UVHandle();
 
-  size_t self_size() const override { return sizeof(*this); }
+  void MemoryInfo(MemoryTracker* tracker) const override {
+    tracker->TrackThis(this);
+  }
 
  private:
   typedef uv_udp_t HandleType;


### PR DESCRIPTION
Splitting out from https://github.com/nodejs/node/pull/21741:

This will enable more detailed heap snapshots based on
a newer V8 API.

This commit itself is not tied to that API and could
be backported.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
