### PR TITLE
tools: avoid global install of dmn for lint update

### DIFF
--- a/tools/update-eslint.sh
+++ b/tools/update-eslint.sh
@@ -2,7 +2,7 @@
 
 # Shell script to update ESLint in the source tree to the latest release.
 
-# Depends on npm and node being in $PATH.
+# Depends on npm, npx, and node being in $PATH.
 
 # This script must be be in the tools directory when it runs because it uses
 # $BASH_SOURCE[0] to determine directories to work in.
@@ -19,11 +19,8 @@ cd node_modules/eslint
 npm install --no-bin-links --production --no-package-lock eslint-plugin-markdown@next
 cd ../..
 
-# Install dmn if it is not in path.
-type -P dmn || npm install -g dmn
-
 # Use dmn to remove some unneeded files.
-dmn -f clean
+npx dmn -f clean
 
 cd ..
 mv eslint-tmp/node_modules/eslint node_modules/eslint


### PR DESCRIPTION
When updating ESLint, use npx to run dmn rather than installing dmn
globally.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
