### PR TITLE
fs: fix readdirSync docs, doesn't accept a callback

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2336,7 +2336,7 @@ Synchronous readdir(3).
 
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use for
-the filenames passed to the callback. If the `encoding` is set to `'buffer'`,
+the filenames returned. If the `encoding` is set to `'buffer'`,
 the filenames returned will be passed as `Buffer` objects.
 
 ## fs.readFile(path[, options], callback)


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](s)
