### PR TITLE
crypto: Provide name for anonymous function in crypto.js

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -242,7 +242,7 @@ Object.defineProperties(exports, {
   Credentials: {
     configurable: true,
     enumerable: true,
-    get: deprecate(function() {
+    get: deprecate(function getTlsSecureContext() {
       return require('tls').SecureContext;
     }, 'crypto.Credentials is deprecated. ' +
        'Use tls.SecureContext instead.', 'DEP0011')


### PR DESCRIPTION
Naming an anonymous function as outlined in #8913 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
