### PR TITLE
http2: remove `waitTrailers` listener after closing a stream

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -392,7 +392,7 @@ function onStreamCloseResponse() {
 
   this[kProxySocket] = null;
 
-  this.off('wantTrailers', onStreamTrailersReady);
+  this.removeListener('wantTrailers', onStreamTrailersReady);
   this[kResponse] = undefined;
 
   res.emit('finish');

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -391,6 +391,8 @@ function onStreamCloseResponse() {
   state.closed = true;
 
   this[kProxySocket] = null;
+
+  this.off('wantTrailers', onStreamTrailersReady);
   this[kResponse] = undefined;
 
   res.emit('finish');

--- a/test/parallel/test-http2-compat-serverresponse-end-after-statuses-withou-body.js
+++ b/test/parallel/test-http2-compat-serverresponse-end-after-statuses-withou-body.js
@@ -15,15 +15,15 @@ const {
   HTTP_STATUS_NOT_MODIFIED
 } = h2.constants;
 
-const STATUS_WITHOUT_BODY = [
+const statusWithouBody = [
   HTTP_STATUS_NO_CONTENT,
   HTTP_STATUS_RESET_CONTENT,
   HTTP_STATUS_NOT_MODIFIED,
 ];
-const STATUS_CODES_COUNT = STATUS_WITHOUT_BODY.length;
+const STATUS_CODES_COUNT = statusWithouBody.length;
 
 const server = h2.createServer(common.mustCall(function(req, res) {
-  res.writeHead(STATUS_WITHOUT_BODY.pop());
+  res.writeHead(statusWithouBody.pop());
   res.end();
 }, STATUS_CODES_COUNT));
 

--- a/test/parallel/test-http2-compat-serverresponse-end-after-statuses-withou-body.js
+++ b/test/parallel/test-http2-compat-serverresponse-end-after-statuses-withou-body.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+// This test case ensures that calling of res.end after sending
+// 204, 205 and 304 HTTP statuses will not cause an error
+// See issue: https://github.com/nodejs/node/issues/21740
+
+const {
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_RESET_CONTENT,
+  HTTP_STATUS_NOT_MODIFIED
+} = h2.constants;
+
+const STATUS_WITHOUT_BODY = [
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_RESET_CONTENT,
+  HTTP_STATUS_NOT_MODIFIED,
+];
+const STATUS_CODES_COUNT = STATUS_WITHOUT_BODY.length;
+
+const server = h2.createServer(common.mustCall(function(req, res) {
+  res.writeHead(STATUS_WITHOUT_BODY.pop());
+  res.end();
+}, STATUS_CODES_COUNT));
+
+server.listen(0, common.mustCall(function() {
+  const url = `http://localhost:${server.address().port}`;
+  const client = h2.connect(url, common.mustCall(() => {
+    let responseCount = 0;
+    const closeAfterResponse = () => {
+      if (STATUS_CODES_COUNT === ++responseCount) {
+        client.destroy();
+        server.close();
+      }
+    };
+
+    for (let i = 0; i < STATUS_CODES_COUNT; i++) {
+      const request = client.request();
+      request.on('response', common.mustCall(closeAfterResponse));
+    }
+
+  }));
+}));


### PR DESCRIPTION
When `writeHear` of `Http2ServerResponse` instance are called with 204,
205 and 304 status codes an underlying stream closes.
If call `end` method after sending any of these status codes it will
cause an error `TypeError: Cannot read property 'Symbol(trailers)' of
undefined` because a reference to `Http2ServerResponse` instance
associated with Http2Stream already was deleted.
The closing of stream causes emitting `watiTrailers` event and, when
this event handles inside `onStreamTrailerReady`  handler, there is
no reference to Http2ServerResponse instance.

Fises: https://github.com/nodejs/node/issues/21740

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

After applying this changes trailing headers won't be sent if 204/205 and 204 status has been sent. 
However, I don't think It is a problem, as according to standard for this HTTP status codes server shouldn't generate payload and have to close a connection after sending the blank line terminating the header section.

204 - https://tools.ietf.org/html/rfc7231#section-6.3.5
205 - https://tools.ietf.org/html/rfc7231#section-6.3.6
304 - https://tools.ietf.org/html/rfc7232#section-4.1

Additional info:
https://tools.ietf.org/html/rfc7230#section-3.3.3 (point 1)
https://tools.ietf.org/html/rfc7540#section-8.1.2.4
