### PR TITLE
[v8.x] deps: cherry-pick 09b53ee from upstream V8

### DIFF
--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -42,7 +42,7 @@ Alexis Campailla <alexis@janeasystems.com>
 Andreas Anyuru <andreas.anyuru@gmail.com>
 Andrew Paprocki <andrew@ishiboo.com>
 Andrei Kashcha <anvaka@gmail.com>
-Anna Henningsen <addaleax@gmail.com>
+Anna Henningsen <anna@addaleax.net>
 Bangfu Tao <bangfu.tao@samsung.com>
 Ben Noordhuis <info@bnoordhuis.nl>
 Benjamin Tan <demoneaux@gmail.com>

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 60
+#define V8_PATCH_LEVEL 61
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/messages.cc
+++ b/deps/v8/src/messages.cc
@@ -114,6 +114,9 @@ void MessageHandler::ReportMessage(Isolate* isolate, const MessageLocation* loc,
       }
 
       if (!maybe_stringified.ToHandle(&stringified)) {
+        DCHECK(isolate->has_pending_exception());
+        isolate->clear_pending_exception();
+        isolate->set_external_caught_exception(false);
         stringified =
             isolate->factory()->NewStringFromAsciiChecked("exception");
       }


### PR DESCRIPTION
This fixes a failure in the v8.x test suite in CI in debug mode. The test is marked flaky, but CI still shows up red for some reason – let’s fix that by actually adressing the bug :)

---

Original commit message:

    [api] Make running scripts in AddMessageListener callback work in debug mode

    The existance of an `AllowJavascriptExecutionDebugOnly` scope in
    `Isolate::ReportPendingMessages()` indicates that the API supports
    running arbitrary JS code in a `AddMessageListener` callback.

    Currently, this can fail in debug mode: The
    `!isolate->external_caught_exception()` condition is checked when
    entering API methods inside such a handler. However, if there is
    a verbose `TryCatch` active when the exception occurs, this
    check fails, and when calling `ToString()` on the exception object
    leaves a pending exception itself, the flag is re-set to `true`.

    Fix this problem by clearing the flag and the pending exception if
    there was one during `ToString()`. This matches the code a few lines
    up in `messages.cc`, so the exception state is now consistent
    during the callback.

    This currently makes a Node.js test fail in debug mode
    (`parallel/test-error-reporting`).

    Bug: node:7144
    Bug: node:17016
    Change-Id: I060d00fea3e9a497f4df34c6ff8d6e29ebe96321
    Reviewed-on: https://chromium-review.googlesource.com/718096
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#49466}

Refs: https://github.com/v8/v8/commit/09b53eef4ca65a48e74fe0b199b2ee892a4321ed

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

