### PR TITLE
src: add HandleWrap::AddWrapMethods

### DIFF
--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -132,7 +132,7 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
 
 
 void HandleWrap::AddWrapMethods(Environment* env,
-                               Local<FunctionTemplate> t) {
+                                Local<FunctionTemplate> t) {
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethodNoSideEffect(t, "hasRef", HandleWrap::HasRef);
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -29,6 +29,7 @@ namespace node {
 
 using v8::Context;
 using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
@@ -127,6 +128,15 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
       .FromMaybe(false)) {
     wrap->MakeCallback(env->handle_onclose_symbol(), 0, nullptr);
   }
+}
+
+
+void HandleWrap::AddWrapMethods(Environment* env,
+                               Local<FunctionTemplate> t) {
+  env->SetProtoMethod(t, "close", HandleWrap::Close);
+  env->SetProtoMethodNoSideEffect(t, "hasRef", HandleWrap::HasRef);
+  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
+  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
 }
 
 

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -73,6 +73,9 @@ class HandleWrap : public AsyncWrap {
   virtual void Close(
       v8::Local<v8::Value> close_callback = v8::Local<v8::Value>());
 
+  static void AddWrapMethods(Environment* env,
+                             v8::Local<v8::FunctionTemplate> constructor);
+
  protected:
   HandleWrap(Environment* env,
              v8::Local<v8::Object> object,

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -718,15 +718,12 @@ MaybeLocal<Function> GetMessagePortConstructor(
     m->InstanceTemplate()->SetInternalFieldCount(1);
 
     AsyncWrap::AddWrapMethods(env, m);
+    HandleWrap::AddWrapMethods(env, m);
 
     env->SetProtoMethod(m, "postMessage", MessagePort::PostMessage);
     env->SetProtoMethod(m, "start", MessagePort::Start);
     env->SetProtoMethod(m, "stop", MessagePort::Stop);
     env->SetProtoMethod(m, "drain", MessagePort::Drain);
-    env->SetProtoMethod(m, "close", HandleWrap::Close);
-    env->SetProtoMethod(m, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(m, "ref", HandleWrap::Ref);
-    env->SetProtoMethod(m, "hasRef", HandleWrap::HasRef);
 
     env->set_message_port_constructor_template(m);
   }

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -52,11 +52,9 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
   t->SetClassName(statWatcherString);
 
   AsyncWrap::AddWrapMethods(env, t);
+  HandleWrap::AddWrapMethods(env, t);
+
   env->SetProtoMethod(t, "start", StatWatcher::Start);
-  env->SetProtoMethod(t, "close", HandleWrap::Close);
-  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
 
   target->Set(statWatcherString, t->GetFunction());
 }

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -77,12 +77,7 @@ void PipeWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   AsyncWrap::AddWrapMethods(env, t);
-
-  env->SetProtoMethod(t, "close", HandleWrap::Close);
-  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
-
+  HandleWrap::AddWrapMethods(env, t);
   LibuvStreamWrap::AddMethods(env, t);
 
   env->SetProtoMethod(t, "bind", Bind);

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -58,15 +58,10 @@ class ProcessWrap : public HandleWrap {
     constructor->SetClassName(processString);
 
     AsyncWrap::AddWrapMethods(env, constructor);
-
-    env->SetProtoMethod(constructor, "close", HandleWrap::Close);
+    HandleWrap::AddWrapMethods(env, constructor);
 
     env->SetProtoMethod(constructor, "spawn", Spawn);
     env->SetProtoMethod(constructor, "kill", Kill);
-
-    env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
-    env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "hasRef", HandleWrap::HasRef);
 
     target->Set(processString, constructor->GetFunction());
   }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -52,10 +52,8 @@ class SignalWrap : public HandleWrap {
     constructor->SetClassName(signalString);
 
     AsyncWrap::AddWrapMethods(env, constructor);
-    env->SetProtoMethod(constructor, "close", HandleWrap::Close);
-    env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
-    env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "hasRef", HandleWrap::HasRef);
+    HandleWrap::AddWrapMethods(env, constructor);
+
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -86,13 +86,7 @@ void TCPWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->Set(env->onconnection_string(), Null(env->isolate()));
 
   AsyncWrap::AddWrapMethods(env, t, AsyncWrap::kFlagHasReset);
-
-  env->SetProtoMethod(t, "close", HandleWrap::Close);
-
-  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
-
+  HandleWrap::AddWrapMethods(env, t);
   LibuvStreamWrap::AddMethods(env, t);
 
   env->SetProtoMethod(t, "open", Open);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -55,11 +55,7 @@ class TimerWrap : public HandleWrap {
     env->SetTemplateMethod(constructor, "now", Now);
 
     AsyncWrap::AddWrapMethods(env, constructor);
-
-    env->SetProtoMethod(constructor, "close", HandleWrap::Close);
-    env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
-    env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "hasRef", HandleWrap::HasRef);
+    HandleWrap::AddWrapMethods(env, constructor);
 
     env->SetProtoMethod(constructor, "start", Start);
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -54,12 +54,7 @@ void TTYWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   AsyncWrap::AddWrapMethods(env, t);
-
-  env->SetProtoMethod(t, "close", HandleWrap::Close);
-  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethodNoSideEffect(t, "hasRef", HandleWrap::HasRef);
-
+  HandleWrap::AddWrapMethods(env, t);
   LibuvStreamWrap::AddMethods(env, t);
 
   env->SetProtoMethodNoSideEffect(t, "getWindowSize", TTYWrap::GetWindowSize);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -115,7 +115,6 @@ void UDPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "send", Send);
   env->SetProtoMethod(t, "bind6", Bind6);
   env->SetProtoMethod(t, "send6", Send6);
-  env->SetProtoMethod(t, "close", Close);
   env->SetProtoMethod(t, "recvStart", RecvStart);
   env->SetProtoMethod(t, "recvStop", RecvStop);
   env->SetProtoMethod(t, "getsockname",
@@ -129,11 +128,8 @@ void UDPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setTTL", SetTTL);
   env->SetProtoMethod(t, "bufferSize", BufferSize);
 
-  env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
-
   AsyncWrap::AddWrapMethods(env, t);
+  HandleWrap::AddWrapMethods(env, t);
 
   target->Set(udpString, t->GetFunction());
   env->set_udp_constructor_function(t->GetFunction());


### PR DESCRIPTION
Extracts common setters to a single location

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
