### PR TITLE
build,win,v8: allow precompiling objects-inl.h

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -17,6 +17,7 @@
     'node_use_bundled_v8%': 'true',
     'node_module_version%': '',
     'node_with_ltcg%': '',
+    'node_use_pch%': 'false',
 
     'node_tag%': '',
     'uv_library%': 'static_library',

--- a/configure
+++ b/configure
@@ -433,6 +433,11 @@ parser.add_option('--with-ltcg',
     dest='with_ltcg',
     help='Use Link Time Code Generation. This feature is only available on Windows.')
 
+parser.add_option('--without-pch',
+    action='store_true',
+    dest='without_pch',
+    help='Do not use Precompiled Headers (only available on Windows).')
+
 intl_optgroup.add_option('--download',
     action='store',
     dest='download_list',
@@ -970,6 +975,11 @@ def configure_node(o):
   o['variables']['node_with_ltcg'] = b(options.with_ltcg)
   if flavor != 'win' and options.with_ltcg:
     raise Exception('Link Time Code Generation is only supported on Windows.')
+
+  if flavor == 'win':
+    o['variables']['node_use_pch'] = b(not options.without_pch)
+  else:
+    o['variables']['node_use_pch'] = 'false'
 
   if options.tag:
     o['variables']['node_tag'] = '-' + options.tag

--- a/configure
+++ b/configure
@@ -433,10 +433,10 @@ parser.add_option('--with-ltcg',
     dest='with_ltcg',
     help='Use Link Time Code Generation. This feature is only available on Windows.')
 
-parser.add_option('--without-pch',
+parser.add_option('--with-pch',
     action='store_true',
-    dest='without_pch',
-    help='Do not use Precompiled Headers (only available on Windows).')
+    dest='with_pch',
+    help='Use Precompiled Headers (only available on Windows).')
 
 intl_optgroup.add_option('--download',
     action='store',
@@ -977,7 +977,7 @@ def configure_node(o):
     raise Exception('Link Time Code Generation is only supported on Windows.')
 
   if flavor == 'win':
-    o['variables']['node_use_pch'] = b(not options.without_pch)
+    o['variables']['node_use_pch'] = b(options.with_pch)
   else:
     o['variables']['node_use_pch'] = 'false'
 

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -1795,10 +1795,20 @@
             'gyp_generators': '<!(echo $GYP_GENERATORS)',
           },
           'msvs_disabled_warnings': [4351, 4355, 4800],
-          # When building Official, the .lib is too large and exceeds the 2G
-          # limit. This breaks it into multiple pieces to avoid the limit.
-          # See http://crbug.com/485155.
-          'msvs_shard': 4,
+          'conditions': [
+            ['node_use_pch!="true"', {
+              # When building Official, the .lib is too large and exceeds the 2G
+              # limit. This breaks it into multiple pieces to avoid the limit.
+              # See http://crbug.com/485155.
+              'msvs_shard': 4,
+            }, {
+              'msvs_precompiled_header': 'tools/msvs/pch/pch_v8_base.h',
+              'msvs_precompiled_source': '../../../tools/msvs/pch/pch_v8_base.cc',
+              'sources': [
+                '../../../tools/msvs/pch/pch_v8_base.cc',
+              ],
+            }],
+          ],
           # This will prevent V8's .cc files conflicting with the inspector's
           # .cpp files in the same shard.
           'msvs_settings': {

--- a/tools/msvs/pch/pch_v8_base.cc
+++ b/tools/msvs/pch/pch_v8_base.cc
@@ -1,0 +1,1 @@
+#include "tools/msvs/pch/pch_v8_base.h"

--- a/tools/msvs/pch/pch_v8_base.h
+++ b/tools/msvs/pch/pch_v8_base.h
@@ -1,0 +1,1 @@
+#include "src/objects-inl.h"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -16,6 +16,7 @@ set config=Release
 set target=Build
 set target_arch=x64
 set ltcg=
+set nopch=
 set target_env=
 set noprojgen=
 set projgen=
@@ -62,7 +63,7 @@ set doc=
 :next-arg
 if "%1"=="" goto args-done
 if /i "%1"=="debug"         set config=Debug&goto arg-ok
-if /i "%1"=="release"       set config=Release&set ltcg=1&goto arg-ok
+if /i "%1"=="release"       set config=Release&set ltcg=1&set nopch=1&goto arg-ok
 if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
@@ -77,6 +78,7 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
+if /i "%1"=="nopch"         set nopch=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set lint_cpp=1&set lint_js=1&set lint_md=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %common_test_suites%&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&goto arg-ok
@@ -153,6 +155,7 @@ if defined build_release (
   set i18n_arg=small-icu
   set projgen=1
   set ltcg=1
+  set nopch=1
 )
 
 :: assign path to node_exe
@@ -166,6 +169,7 @@ if defined nosnapshot       set configure_flags=%configure_flags% --without-snap
 if defined noetw            set configure_flags=%configure_flags% --without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr        set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
 if defined ltcg             set configure_flags=%configure_flags% --with-ltcg
+if defined nopch            set configure_flags=%configure_flags% --without-pch
 if defined release_urlbase  set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
 if defined download_arg     set configure_flags=%configure_flags% %download_arg%
 if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling
@@ -660,7 +664,7 @@ del .used_configure_flags
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [doc] [test/test-ci/test-all/test-addons/test-addons-napi/test-internet/test-pummel/test-simple/test-message/test-gc/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-async-hooks/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [noetw] [noperfctr] [ltcg] [licensetf] [sign] [ia32/x86/x64] [vs2017] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-js-ci/lint-md] [lint-md-build] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [no-cctest] [openssl-no-asm]
+echo vcbuild.bat [debug/release] [msi] [doc] [test/test-ci/test-all/test-addons/test-addons-napi/test-internet/test-pummel/test-simple/test-message/test-gc/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-async-hooks/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [noetw] [noperfctr] [ltcg] [nopch] [licensetf] [sign] [ia32/x86/x64] [vs2017] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-js-ci/lint-md] [lint-md-build] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [no-cctest] [openssl-no-asm]
 echo Examples:
 echo   vcbuild.bat                          : builds release build
 echo   vcbuild.bat debug                    : builds debug build

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -16,7 +16,7 @@ set config=Release
 set target=Build
 set target_arch=x64
 set ltcg=
-set nopch=
+set pch=1
 set target_env=
 set noprojgen=
 set projgen=
@@ -63,7 +63,7 @@ set doc=
 :next-arg
 if "%1"=="" goto args-done
 if /i "%1"=="debug"         set config=Debug&goto arg-ok
-if /i "%1"=="release"       set config=Release&set ltcg=1&set nopch=1&goto arg-ok
+if /i "%1"=="release"       set config=Release&set ltcg=1&set "pch="&goto arg-ok
 if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
@@ -78,7 +78,7 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
-if /i "%1"=="nopch"         set nopch=1&goto arg-ok
+if /i "%1"=="nopch"         set "pch="&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set lint_cpp=1&set lint_js=1&set lint_md=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %common_test_suites%&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&goto arg-ok
@@ -155,7 +155,7 @@ if defined build_release (
   set i18n_arg=small-icu
   set projgen=1
   set ltcg=1
-  set nopch=1
+  set "pch="
 )
 
 :: assign path to node_exe
@@ -169,7 +169,7 @@ if defined nosnapshot       set configure_flags=%configure_flags% --without-snap
 if defined noetw            set configure_flags=%configure_flags% --without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr        set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
 if defined ltcg             set configure_flags=%configure_flags% --with-ltcg
-if defined nopch            set configure_flags=%configure_flags% --without-pch
+if defined pch              set configure_flags=%configure_flags% --with-pch
 if defined release_urlbase  set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
 if defined download_arg     set configure_flags=%configure_flags% %download_arg%
 if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling


### PR DESCRIPTION
This makes compiling `v8_base` much faster on Windows. On my machine, the total node build time drops from 25m29.597s to 10m58.554s.

This is enabled by default when using calling `vcbuild` without `release` or `build-release` (similar to `ltcg`). All node tests pass, but this force-includes `objects-inl.h` in every file for `v8_base`, so it is possible that this causes subtle issues and is thus disabled in CI and for releases. This includes only `objects-inl.h` to minimize the chance for issues, it is already included in many files. Adding other headers only improves the build time in the order of seconds.

Sharding is disabled because the header would have to be precompiled for each shard but is only once. The library is much smaller, so sharding is not necessary with this either way.

Can the changes in `v8.gyp` be floated on top of V8 updates, or does this need to be submitted upstream? Are we maintaining the gyp files? (cc @nodejs/v8-update)

cc @nodejs/platform-windows

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
