### PR TITLE
[v10.x] fs: stop lazy loading stream constructors

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -52,6 +52,7 @@ const {
 } = errors.codes;
 
 const { FSReqWrap, statValues } = binding;
+const { ReadStream, WriteStream } = require('internal/fs/streams');
 const internalFS = require('internal/fs/utils');
 const { getPathFromURL } = require('internal/url');
 const internalUtil = require('internal/util');
@@ -91,13 +92,6 @@ let fs;
 let promises;
 let watchers;
 let ReadFileContext;
-let ReadStream;
-let WriteStream;
-
-// These have to be separate because of how graceful-fs happens to do it's
-// monkeypatching.
-let FileReadStream;
-let FileWriteStream;
 
 const isWindows = process.platform === 'win32';
 
@@ -1697,20 +1691,11 @@ function copyFileSync(src, dest, flags) {
   handleErrorFromBinding(ctx);
 }
 
-function lazyLoadStreams() {
-  if (!ReadStream) {
-    ({ ReadStream, WriteStream } = require('internal/fs/streams'));
-    [ FileReadStream, FileWriteStream ] = [ ReadStream, WriteStream ];
-  }
-}
-
 function createReadStream(path, options) {
-  lazyLoadStreams();
   return new ReadStream(path, options);
 }
 
 function createWriteStream(path, options) {
-  lazyLoadStreams();
   return new WriteStream(path, options);
 }
 
@@ -1793,43 +1778,12 @@ module.exports = fs = {
   writeSync,
   Stats,
 
-  get ReadStream() {
-    lazyLoadStreams();
-    return ReadStream;
-  },
-
-  set ReadStream(val) {
-    ReadStream = val;
-  },
-
-  get WriteStream() {
-    lazyLoadStreams();
-    return WriteStream;
-  },
-
-  set WriteStream(val) {
-    WriteStream = val;
-  },
-
-  // Legacy names... these have to be separate because of how graceful-fs
-  // (and possibly other) modules monkey patch the values.
-  get FileReadStream() {
-    lazyLoadStreams();
-    return FileReadStream;
-  },
-
-  set FileReadStream(val) {
-    FileReadStream = val;
-  },
-
-  get FileWriteStream() {
-    lazyLoadStreams();
-    return FileWriteStream;
-  },
-
-  set FileWriteStream(val) {
-    FileWriteStream = val;
-  },
+  // Stream constructors
+  ReadStream,
+  WriteStream,
+  // Legacy names...
+  FileReadStream: ReadStream,
+  FileWriteStream: WriteStream,
 
   // For tests
   _toUnixTimestamp: toUnixTimestamp

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -8,7 +8,6 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
-const fs = require('fs');
 const { Buffer } = require('buffer');
 const {
   copyObject,
@@ -17,6 +16,13 @@ const {
 const { Readable, Writable } = require('stream');
 const { getPathFromURL } = require('internal/url');
 const util = require('util');
+
+let fs;
+function lazyFs() {
+  if (fs === undefined)
+    fs = require('fs');
+  return fs;
+}
 
 const kMinPoolSpace = 128;
 
@@ -92,7 +98,7 @@ function ReadStream(path, options) {
 util.inherits(ReadStream, Readable);
 
 ReadStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, (er, fd) => {
+  lazyFs().open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -142,7 +148,7 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  fs.read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
+  lazyFs().read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -177,7 +183,7 @@ ReadStream.prototype._destroy = function(err, cb) {
 };
 
 function closeFsStream(stream, cb, err) {
-  fs.close(stream.fd, (er) => {
+  lazyFs().close(stream.fd, (er) => {
     er = er || err;
     cb(er);
     stream.closed = true;
@@ -242,7 +248,7 @@ WriteStream.prototype._final = function(callback) {
 };
 
 WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, (er, fd) => {
+  lazyFs().open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -270,7 +276,7 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     });
   }
 
-  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
+  lazyFs().write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/21489

/cc @nodejs/fs @SimenB 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
