### PR TITLE
console: fix timeEnd() not coercing the input

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -236,6 +236,8 @@ Console.prototype.time = function time(label = 'default') {
 };
 
 Console.prototype.timeEnd = function timeEnd(label = 'default') {
+  // Coerces everything other than Symbol to a string
+  label = `${label}`;
   const hasWarned = timeLogImpl(this, 'timeEnd', label);
   if (!hasWarned) {
     this._times.delete(label);
@@ -243,13 +245,13 @@ Console.prototype.timeEnd = function timeEnd(label = 'default') {
 };
 
 Console.prototype.timeLog = function timeLog(label, ...data) {
+  // Coerces everything other than Symbol to a string
+  label = `${label}`;
   timeLogImpl(this, 'timeLog', label, data);
 };
 
 // Returns true if label was not found
 function timeLogImpl(self, name, label = 'default', data) {
-  // Coerces everything other than Symbol to a string
-  label = `${label}`;
   const time = self._times.get(label);
   if (!time) {
     process.emitWarning(`No such label '${label}' for console.${name}()`);

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -135,9 +135,12 @@ console.timeEnd('constructor');
 console.time('hasOwnProperty');
 console.timeEnd('hasOwnProperty');
 
-// verify that values are coerced to strings
+// Verify that values are coerced to strings.
 console.time([]);
 console.timeEnd([]);
+console.time({});
+console.timeEnd({});
+// Repeat the object call to verify that everything really worked.
 console.time({});
 console.timeEnd({});
 console.time(null);


### PR DESCRIPTION
The input of console.timeEnd() was not coerced to a string. That way
labels were not found and the entry was not removed anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
