### PR TITLE
trace_events: add more process metadata

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2147,8 +2147,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(release, "name",
                     OneByteString(env->isolate(), NODE_RELEASE));
 
-  auto traced_release = tracing::TracedValue::Create();
-
 #if NODE_VERSION_IS_LTS
   READONLY_PROPERTY(release, "lts",
                     OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -32,6 +32,7 @@
 #include "uv.h"
 #include "v8.h"
 #include "tracing/trace_event.h"
+#include "tracing/traced_value.h"
 #include "node_perf_common.h"
 #include "node_debug_options.h"
 #include "node_api.h"

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -32,7 +32,6 @@
 #include "uv.h"
 #include "v8.h"
 #include "tracing/trace_event.h"
-#include "tracing/traced_value.h"
 #include "node_perf_common.h"
 #include "node_debug_options.h"
 #include "node_api.h"

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -62,9 +62,7 @@ proc.once('exit', common.mustCall(() => {
         trace.args.process.platform === process.platform &&
         trace.args.process.release.name === process.release.name &&
         (!process.release.lts ||
-          trace.args.process.release.lts === process.release.lts) &&
-        Array.isArray(trace.args.process.argv) &&
-        Array.isArray(trace.args.process.execArgv)));
+          trace.args.process.release.lts === process.release.lts)));
 
     if (!common.isSunOS) {
       // Changing process.title is currently unsupported on SunOS/SmartOS

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -23,25 +23,55 @@ const proc = cp.spawn(process.execPath,
 proc.once('exit', common.mustCall(() => {
   assert(common.fileExists(FILE_NAME));
   fs.readFile(FILE_NAME, common.mustCall((err, data) => {
-    const traces = JSON.parse(data.toString()).traceEvents;
+    const traces = JSON.parse(data.toString()).traceEvents
+      .filter((trace) => trace.cat === '__metadata');
     assert(traces.length > 0);
     assert(traces.some((trace) =>
-      trace.cat === '__metadata' && trace.name === 'thread_name' &&
+      trace.name === 'thread_name' &&
         trace.args.name === 'JavaScriptMainThread'));
     assert(traces.some((trace) =>
-      trace.cat === '__metadata' && trace.name === 'thread_name' &&
+      trace.name === 'thread_name' &&
         trace.args.name === 'BackgroundTaskRunner'));
     assert(traces.some((trace) =>
-      trace.cat === '__metadata' && trace.name === 'version' &&
+      trace.name === 'version' &&
         trace.args.node === process.versions.node));
+
+    assert(traces.some((trace) =>
+      trace.name === 'node' &&
+        trace.args.process.versions.http_parser ===
+          process.versions.http_parser &&
+        trace.args.process.versions.node ===
+          process.versions.node &&
+        trace.args.process.versions.v8 ===
+          process.versions.v8 &&
+        trace.args.process.versions.uv ===
+          process.versions.uv &&
+        trace.args.process.versions.zlib ===
+          process.versions.zlib &&
+        trace.args.process.versions.ares ===
+          process.versions.ares &&
+        trace.args.process.versions.modules ===
+          process.versions.modules &&
+        trace.args.process.versions.nghttp2 ===
+          process.versions.nghttp2 &&
+        trace.args.process.versions.napi ===
+          process.versions.napi &&
+        trace.args.process.versions.openssl ===
+          process.versions.openssl &&
+        trace.args.process.arch === process.arch &&
+        trace.args.process.platform === process.platform &&
+        trace.args.process.release.name === process.release.name &&
+        (!process.release.lts ||
+          trace.args.process.release.lts === process.release.lts) &&
+        Array.isArray(trace.args.process.argv) &&
+        Array.isArray(trace.args.process.execArgv)));
+
     if (!common.isSunOS) {
       // Changing process.title is currently unsupported on SunOS/SmartOS
       assert(traces.some((trace) =>
-        trace.cat === '__metadata' && trace.name === 'process_name' &&
-          trace.args.name === 'foo'));
+        trace.name === 'process_name' && trace.args.name === 'foo'));
       assert(traces.some((trace) =>
-        trace.cat === '__metadata' && trace.name === 'process_name' &&
-          trace.args.name === 'bar'));
+        trace.name === 'process_name' && trace.args.name === 'bar'));
     }
   }));
 }));


### PR DESCRIPTION
Now that TracedValue has landed, add more detailed
process `__metadata` including versions, arch, platform,
release detail, and argv/execArgv to the trace event
log.

This adds an entry like:

```json
{
  "pid":46021,
  "tid":46021,
  "ts":4996201438,
  "tts":31331,
  "ph":"M",
  "cat":"__metadata",
  "name":"node",
  "dur":0,
  "tdur":0,
  "args":{
    "process":{
      "versions":{
        "http_parser":"2.8.0",
        "node":"11.0.0-pre",
        "v8":"6.7.288.46-node.14",
        "uv":"1.22.0",
        "zlib":"1.2.11",
        "ares":"1.14.0",
        "modules":"64",
        "nghttp2":"1.32.0",
        "napi":"3",
        "openssl":"1.1.0h"
      },
      "arch":"x64",
      "platform":"linux",
      "release":{
        "name":"node"
      },
      "argv":["./node"],
      "execArgv":["--trace-event-categories","node.perf"]
    }
  }
}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
