### PR TITLE
node-gyp: support for Chromium versions of Python

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/configure.js
+++ b/deps/npm/node_modules/node-gyp/lib/configure.js
@@ -459,6 +459,10 @@ PythonFinder.prototype = {
         this.log.silly('stripping "rc" identifier from version')
         version = version.replace(/rc(.*)$/ig, '')
       }
+      if (~version.indexOf('chromium')) {
+        this.log.silly('stripping "chromium" identifier from version')
+        version = version.replace(/chromium(.*)$/ig, '')
+      }
       var range = semver.Range('>=2.5.0 <3.0.0')
       var valid = false
       try {


### PR DESCRIPTION
V8's test infrastructure uses a particular brand of Python. We have been floating this fix on our Node.js branch for quite a while. I am hoping that we can land this upstream too.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
