### PR TITLE
test: fix timeouts when running worker tests with `--worker`

### DIFF
--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -7,9 +7,11 @@ const common = require('../common');
 
 const assert = require('assert');
 const worker = require('worker_threads');
-const { Worker, isMainThread, parentPort } = worker;
+const { Worker, parentPort } = worker;
 
-if (isMainThread) {
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
   parent();
 } else {
   if (!parentPort) {

--- a/test/parallel/test-worker-onmessage.js
+++ b/test/parallel/test-worker-onmessage.js
@@ -2,9 +2,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, parentPort } = require('worker_threads');
 
-if (isMainThread) {
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
   const w = new Worker(__filename);
   w.on('message', common.mustCall((message) => {
     assert.strictEqual(message, 4);


### PR DESCRIPTION
These tests have been added after the original workers PR and
time out when run inside a worker by themselves.
This is needed for enabling `--worker` tests in our regular CI.

Refs: https://github.com/nodejs/build/issues/1318

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
