### PR TITLE
test: fix weird string error

### DIFF
--- a/test/parallel/test-stdio-pipe-access.js
+++ b/test/parallel/test-stdio-pipe-access.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 if (!common.isMainThread)
-  common.skip('Workers don’t have process-like stdio');
+  common.skip("Workers don't have process-like stdio");
 
 // Test if Node handles acessing process.stdin if it is a redirected
 // pipe without deadlocking

--- a/test/parallel/test-stdio-pipe-redirect.js
+++ b/test/parallel/test-stdio-pipe-redirect.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 if (!common.isMainThread)
-  common.skip('Workers don’t have process-like stdio');
+  common.skip("Workers don't have process-like stdio");
 
 // Test if Node handles redirecting one child process stdout to another
 // process stdin without crashing.


### PR DESCRIPTION
Previously getting this error when running `tap2junit` (what parses our
`.tap` files in CI):

```
Traceback (most recent call last):
  File "/usr/local/bin/tap2junit", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/tap2junit/__main__.py", line 46, in main
    result.to_file(args.output, [result], prettyprint=False)
  File "/usr/local/lib/python2.7/site-packages/junit_xml/__init__.py", line 289, in to_file
    test_suites, prettyprint=prettyprint, encoding=encoding)
  File "/usr/local/lib/python2.7/site-packages/junit_xml/__init__.py", line 257, in to_xml_string
    ts_xml = ts.build_xml_doc(encoding=encoding)
  File "/usr/local/lib/python2.7/site-packages/junit_xml/__init__.py", line 221, in build_xml_doc
    attrs['message'] = decode(case.skipped_message, encoding)
  File "/usr/local/lib/python2.7/site-packages/junit_xml/__init__.py", line 68, in decode
    ret = unicode(var)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 11: ordinal not in range(128)
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)