### PR TITLE
build: move to `npm ci` where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -651,6 +651,7 @@ available-node = \
 	fi;
 
 run-npm-install = $(PWD)/$(NPM) install --production --no-package-lock
+run-npm-ci = $(PWD)/$(NPM) ci
 
 tools/doc/node_modules/js-yaml/package.json:
 	cd tools/doc && $(call available-node,$(run-npm-install))
@@ -1060,12 +1061,12 @@ lint-md-clean:
 
 tools/remark-cli/node_modules: tools/remark-cli/package.json
 	@echo "Markdown linter: installing remark-cli into tools/"
-	@cd tools/remark-cli && $(call available-node,$(run-npm-install))
+	@cd tools/remark-cli && $(call available-node,$(run-npm-ci))
 
 tools/remark-preset-lint-node/node_modules: \
 	tools/remark-preset-lint-node/package.json
 	@echo "Markdown linter: installing remark-preset-lint-node into tools/"
-	@cd tools/remark-preset-lint-node && $(call available-node,$(run-npm-install))
+	@cd tools/remark-preset-lint-node && $(call available-node,$(run-npm-ci))
 
 .PHONY: lint-md-build
 lint-md-build: tools/remark-cli/node_modules \

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -614,12 +614,12 @@ if not defined lint_md_build goto lint-md
 SETLOCAL
 echo Markdown linter: installing remark-cli into tools\
 cd tools\remark-cli
-%npm_exe% install
+%npm_exe% ci
 cd ..\..
 if errorlevel 1 goto lint-md-build-failed
 echo Markdown linter: installing remark-preset-lint-node into tools\
 cd tools\remark-preset-lint-node
-%npm_exe% install
+%npm_exe% ci
 cd ..\..
 if errorlevel 1 goto lint-md-build-failed
 ENDLOCAL


### PR DESCRIPTION
Recent events (involving a maliciously published version of a popular
module's dependency) have reinvigorated my interest in seeing us move to
`npm ci` instead of `npm install`. This moves us to `npm ci` where
possible in Makefile and vcbuild.bat.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
