### PR TITLE
n-api: move cleanup_hook to version 4

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -623,6 +623,10 @@ NAPI_EXTERN napi_status napi_close_callback_scope(napi_env env,
 
 NAPI_EXTERN napi_status napi_fatal_exception(napi_env env, napi_value err);
 
+#endif  // NAPI_VERSION >= 3
+
+#if NAPI_VERSION >= 4
+
 NAPI_EXTERN napi_status napi_add_env_cleanup_hook(napi_env env,
                                                   void (*fun)(void* arg),
                                                   void* arg);
@@ -631,7 +635,7 @@ NAPI_EXTERN napi_status napi_remove_env_cleanup_hook(napi_env env,
                                                      void (*fun)(void* arg),
                                                      void* arg);
 
-#endif  // NAPI_VERSION >= 3
+#endif  // NAPI_VERSION >= 4
 
 #ifdef NAPI_EXPERIMENTAL
 

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -114,6 +114,6 @@
 #define NODE_MODULE_VERSION 64
 
 // the NAPI_VERSION provided by this version of the runtime
-#define NAPI_VERSION  3
+#define NAPI_VERSION 4
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/addons-napi/test_cleanup_hook/binding.cc
+++ b/test/addons-napi/test_cleanup_hook/binding.cc
@@ -1,3 +1,4 @@
+#define NAPI_VERSION 4
 #include "node_api.h"
 #include "uv.h"
 #include "../common.h"

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -33,8 +33,8 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // test version management functions
-// expected version is currently 3
-assert.strictEqual(test_general.testGetVersion(), 3);
+// expected version is currently 4
+assert.strictEqual(test_general.testGetVersion(), 4);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],


### PR DESCRIPTION
Update N-API to version 4 and move the `cleanup_hook` API into it.

Continuation from https://github.com/nodejs/node/pull/19962#issuecomment-402548941, I made the code changes but the viability is still pending.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
