### PR TITLE
crypto: prevent Sign::SignFinal from crashing

### DIFF
--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -61,7 +61,7 @@ function getIntOption(name, defaultValue, options) {
     if (value === value >> 0) {
       return value;
     } else {
-      throw new ERR_INVALID_OPT_VALUE(name, options[name]);
+      throw new ERR_INVALID_OPT_VALUE(name, value);
     }
   }
   return defaultValue;

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -57,8 +57,9 @@ function getSaltLength(options) {
 
 function getIntOption(name, defaultValue, options) {
   if (options.hasOwnProperty(name)) {
-    if (options[name] === options[name] >> 0) {
-      return options[name];
+    const value = options[name];
+    if (value === value >> 0) {
+      return value;
     } else {
       throw new ERR_INVALID_OPT_VALUE(name, options[name]);
     }


### PR DESCRIPTION
The validation logic could be tricked into assuming an option was valid using malicious getters, leading to an invalid value being passed to the C++ layer, thus crashing the process.

Copy this into the REPL to crash the process:

```js
const key = `-----BEGIN RSA PRIVATE KEY-----
             MIICXQIBAAKBgQDx3wdzpq2rvwm3Ucun1qAD/ClB+wW+RhR1nVix286QvaNqePAd
             CAwwLL82NqXcVQRbQ4s95splQnwvjgkFdKVXFTjPKKJI5aV3wSRN61EBVPdYpCre
             535yfG/uDysZFCnVQdnCZ1tnXAR8BirxCNjHqbVyIyBGjsNoNCEPb2R35QIDAQAB
             AoGBAJNem9C4ftrFNGtQ2DB0Udz7uDuucepkErUy4MbFsc947GfENjDKJXr42Kx0
             kYx09ImS1vUpeKpH3xiuhwqe7tm4FsCBg4TYqQle14oxxm7TNeBwwGC3OB7hiokb
             aAjbPZ1hAuNs6ms3Ybvvj6Lmxzx42m8O5DXCG2/f+KMvaNUhAkEA/ekrOsWkNoW9
             2n3m+msdVuxeek4B87EoTOtzCXb1dybIZUVv4J48VAiM43hhZHWZck2boD/hhwjC
             M5NWd4oY6QJBAPPcgBVNdNZSZ8hR4ogI4nzwWrQhl9MRbqqtfOn2TK/tjMv10ALg
             lPmn3SaPSNRPKD2hoLbFuHFERlcS79pbCZ0CQQChX3PuIna/gDitiJ8oQLOg7xEM
             wk9TRiDK4kl2lnhjhe6PDpaQN4E4F0cTuwqLAoLHtrNWIcOAQvzKMrYdu1MhAkBm
             Et3qDMnjDAs05lGT72QeN90/mPAcASf5eTTYGahv21cb6IBxM+AnwAPpqAAsHhYR
             9h13Y7uYbaOjvuF23LRhAkBoI9eaSMn+l81WXOVUHnzh3ZwB4GuTyxMXXNOhuiFd
             0z4LKAMh99Z4xQmqSoEkXsfM4KPpfhYjF/bwIcP5gOei
             -----END RSA PRIVATE KEY-----`;

crypto.createSign('SHA256').update('Test123').sign({
  counter: 0,
  get padding() {
    if (++this.counter < 3)
      return crypto.constants.RSA_PKCS1_PSS_PADDING;
    return null;
  },
  key
});
```