### PR TITLE
test: extract globals & use in test-abort-backtrace

### DIFF
--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -1,5 +1,6 @@
+/* eslint-disable node-core/required-modules */
 'use strict';
-const common = require('../common');
+const common = require('../common/globals');
 const assert = require('assert');
 const cp = require('child_process');
 

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -1,0 +1,71 @@
+/* eslint-disable node-core/required-modules */
+'use strict';
+const assert = require('assert');
+
+let knownGlobals = [
+  Buffer,
+  clearImmediate,
+  clearInterval,
+  clearTimeout,
+  global,
+  process,
+  setImmediate,
+  setInterval,
+  setTimeout
+];
+
+if (global.gc) {
+  knownGlobals.push(global.gc);
+}
+
+if (global.DTRACE_HTTP_SERVER_RESPONSE) {
+  knownGlobals.push(DTRACE_HTTP_SERVER_RESPONSE);
+  knownGlobals.push(DTRACE_HTTP_SERVER_REQUEST);
+  knownGlobals.push(DTRACE_HTTP_CLIENT_RESPONSE);
+  knownGlobals.push(DTRACE_HTTP_CLIENT_REQUEST);
+  knownGlobals.push(DTRACE_NET_STREAM_END);
+  knownGlobals.push(DTRACE_NET_SERVER_CONNECTION);
+}
+
+if (global.COUNTER_NET_SERVER_CONNECTION) {
+  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION);
+  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION_CLOSE);
+  knownGlobals.push(COUNTER_HTTP_SERVER_REQUEST);
+  knownGlobals.push(COUNTER_HTTP_SERVER_RESPONSE);
+  knownGlobals.push(COUNTER_HTTP_CLIENT_REQUEST);
+  knownGlobals.push(COUNTER_HTTP_CLIENT_RESPONSE);
+}
+
+if (process.env.NODE_TEST_KNOWN_GLOBALS) {
+  const knownFromEnv = process.env.NODE_TEST_KNOWN_GLOBALS.split(',');
+  allowGlobals(...knownFromEnv);
+}
+
+function allowGlobals(...whitelist) {
+  knownGlobals = knownGlobals.concat(whitelist);
+}
+exports.allowGlobals = allowGlobals;
+
+function leakedGlobals() {
+  const leaked = [];
+
+  for (const val in global) {
+    if (!knownGlobals.includes(global[val])) {
+      leaked.push(val);
+    }
+  }
+
+  if (global.__coverage__) {
+    return leaked.filter((varname) => !/^(?:cov_|__cov)/.test(varname));
+  } else {
+    return leaked;
+  }
+}
+exports.leakedGlobals = leakedGlobals;
+
+process.on('exit', function() {
+  const leaked = leakedGlobals();
+  if (leaked.length > 0) {
+    assert.fail(`Unexpected global(s) found: ${leaked.join(', ')}`);
+  }
+});

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -32,6 +32,9 @@ const util = require('util');
 const { hasTracing } = process.binding('config');
 const { fixturesDir } = require('./fixtures');
 const tmpdir = require('./tmpdir');
+const { allowGlobals, leakedGlobals } = require('./globals');
+exports.allowGlobals = allowGlobals;
+exports.leakedGlobals = leakedGlobals;
 
 const noop = () => {};
 
@@ -328,74 +331,6 @@ exports.platformTimeout = function(ms) {
 
   return ms; // ARMv8+
 };
-
-let knownGlobals = [
-  Buffer,
-  clearImmediate,
-  clearInterval,
-  clearTimeout,
-  global,
-  process,
-  setImmediate,
-  setInterval,
-  setTimeout
-];
-
-if (global.gc) {
-  knownGlobals.push(global.gc);
-}
-
-if (global.DTRACE_HTTP_SERVER_RESPONSE) {
-  knownGlobals.push(DTRACE_HTTP_SERVER_RESPONSE);
-  knownGlobals.push(DTRACE_HTTP_SERVER_REQUEST);
-  knownGlobals.push(DTRACE_HTTP_CLIENT_RESPONSE);
-  knownGlobals.push(DTRACE_HTTP_CLIENT_REQUEST);
-  knownGlobals.push(DTRACE_NET_STREAM_END);
-  knownGlobals.push(DTRACE_NET_SERVER_CONNECTION);
-}
-
-if (global.COUNTER_NET_SERVER_CONNECTION) {
-  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION);
-  knownGlobals.push(COUNTER_NET_SERVER_CONNECTION_CLOSE);
-  knownGlobals.push(COUNTER_HTTP_SERVER_REQUEST);
-  knownGlobals.push(COUNTER_HTTP_SERVER_RESPONSE);
-  knownGlobals.push(COUNTER_HTTP_CLIENT_REQUEST);
-  knownGlobals.push(COUNTER_HTTP_CLIENT_RESPONSE);
-}
-
-if (process.env.NODE_TEST_KNOWN_GLOBALS) {
-  const knownFromEnv = process.env.NODE_TEST_KNOWN_GLOBALS.split(',');
-  allowGlobals(...knownFromEnv);
-}
-
-function allowGlobals(...whitelist) {
-  knownGlobals = knownGlobals.concat(whitelist);
-}
-exports.allowGlobals = allowGlobals;
-
-function leakedGlobals() {
-  const leaked = [];
-
-  for (const val in global) {
-    if (!knownGlobals.includes(global[val])) {
-      leaked.push(val);
-    }
-  }
-
-  if (global.__coverage__) {
-    return leaked.filter((varname) => !/^(?:cov_|__cov)/.test(varname));
-  } else {
-    return leaked;
-  }
-}
-exports.leakedGlobals = leakedGlobals;
-
-process.on('exit', function() {
-  const leaked = leakedGlobals();
-  if (leaked.length > 0) {
-    assert.fail(`Unexpected global(s) found: ${leaked.join(', ')}`);
-  }
-});
 
 const mustCallChecks = [];
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -252,6 +252,7 @@ try {
   assert.deepStrictEqual(children, {
     'common/index.js': {
       'common/fixtures.js': {},
+      'common/globals.js': {},
       'common/tmpdir.js': {}
     },
     'fixtures/not-main-module.js': {},


### PR DESCRIPTION
It was suggested that extracting globals from test/common/index.js so that it
can be required individually will pare down test dependencies could ultimately
improve test performance. 

See discussion on this issue, especially the linked comment:
https://github.com/nodejs/node/issues/20128#issuecomment-389933546

This diff demonstrates first steps towards not needing to require
test/common/index.js in all tests. 

If enough/all the dependent tests were refactored, benchmarks could be shown.
Although, it seems sensible to break those forthcoming refactors into separate,
reasonably small PRs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
