### PR TITLE
doc: fix vm.runInNewContext signature

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -758,7 +758,7 @@ console.log(util.inspect(sandbox));
 // { globalVar: 1024 }
 ```
 
-## vm.runInNewContext(code[, sandbox][, options])
+## vm.runInNewContext(code[, sandbox[, options]])
 <!-- YAML
 added: v0.3.1
 -->


### PR DESCRIPTION
The `options` parameter cannot be passed without `sandbox`.


##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
