### PR TITLE
test: fix flaky test-debug-prompt

### DIFF
--- a/test/sequential/test-debug-prompt.js
+++ b/test/sequential/test-debug-prompt.js
@@ -7,9 +7,12 @@ const spawn = require('child_process').spawn;
 const proc = spawn(process.execPath, ['inspect', 'foo']);
 proc.stdout.setEncoding('utf8');
 
+let needToSendExit = true;
 let output = '';
 proc.stdout.on('data', (data) => {
   output += data;
-  if (output.includes('debug> '))
+  if (output.includes('debug> ') && needToSendExit) {
     proc.stdin.write('.exit\n');
+    needToSendExit = false;
+  }
 });


### PR DESCRIPTION
Be sure to send `.exit` only once to avoid spurious EPIPE and possibly
other errors.

Fixes: https://github.com/nodejs/node/issues/21724

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
