### PR TITLE
http2: remove unused nghttp2 error list

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -326,58 +326,6 @@ enum padding_strategy_type {
   PADDING_STRATEGY_CALLBACK
 };
 
-// These are the error codes provided by the underlying nghttp2 implementation.
-#define NGHTTP2_ERROR_CODES(V)                                                 \
-  V(NGHTTP2_ERR_INVALID_ARGUMENT)                                              \
-  V(NGHTTP2_ERR_BUFFER_ERROR)                                                  \
-  V(NGHTTP2_ERR_UNSUPPORTED_VERSION)                                           \
-  V(NGHTTP2_ERR_WOULDBLOCK)                                                    \
-  V(NGHTTP2_ERR_PROTO)                                                         \
-  V(NGHTTP2_ERR_INVALID_FRAME)                                                 \
-  V(NGHTTP2_ERR_EOF)                                                           \
-  V(NGHTTP2_ERR_DEFERRED)                                                      \
-  V(NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE)                                       \
-  V(NGHTTP2_ERR_STREAM_CLOSED)                                                 \
-  V(NGHTTP2_ERR_STREAM_CLOSING)                                                \
-  V(NGHTTP2_ERR_STREAM_SHUT_WR)                                                \
-  V(NGHTTP2_ERR_INVALID_STREAM_ID)                                             \
-  V(NGHTTP2_ERR_INVALID_STREAM_STATE)                                          \
-  V(NGHTTP2_ERR_DEFERRED_DATA_EXIST)                                           \
-  V(NGHTTP2_ERR_START_STREAM_NOT_ALLOWED)                                      \
-  V(NGHTTP2_ERR_GOAWAY_ALREADY_SENT)                                           \
-  V(NGHTTP2_ERR_INVALID_HEADER_BLOCK)                                          \
-  V(NGHTTP2_ERR_INVALID_STATE)                                                 \
-  V(NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE)                                     \
-  V(NGHTTP2_ERR_FRAME_SIZE_ERROR)                                              \
-  V(NGHTTP2_ERR_HEADER_COMP)                                                   \
-  V(NGHTTP2_ERR_FLOW_CONTROL)                                                  \
-  V(NGHTTP2_ERR_INSUFF_BUFSIZE)                                                \
-  V(NGHTTP2_ERR_PAUSE)                                                         \
-  V(NGHTTP2_ERR_TOO_MANY_INFLIGHT_SETTINGS)                                    \
-  V(NGHTTP2_ERR_PUSH_DISABLED)                                                 \
-  V(NGHTTP2_ERR_DATA_EXIST)                                                    \
-  V(NGHTTP2_ERR_SESSION_CLOSING)                                               \
-  V(NGHTTP2_ERR_HTTP_HEADER)                                                   \
-  V(NGHTTP2_ERR_HTTP_MESSAGING)                                                \
-  V(NGHTTP2_ERR_REFUSED_STREAM)                                                \
-  V(NGHTTP2_ERR_INTERNAL)                                                      \
-  V(NGHTTP2_ERR_CANCEL)                                                        \
-  V(NGHTTP2_ERR_FATAL)                                                         \
-  V(NGHTTP2_ERR_NOMEM)                                                         \
-  V(NGHTTP2_ERR_CALLBACK_FAILURE)                                              \
-  V(NGHTTP2_ERR_BAD_CLIENT_MAGIC)                                              \
-  V(NGHTTP2_ERR_FLOODED)
-
-const char* nghttp2_errname(int rv) {
-  switch (rv) {
-#define V(code) case code: return #code;
-  NGHTTP2_ERROR_CODES(V)
-#undef V
-    default:
-      return "NGHTTP2_UNKNOWN_ERROR";
-  }
-}
-
 enum session_state_flags {
   SESSION_STATE_NONE = 0x0,
   SESSION_STATE_HAS_SCOPE = 0x1,


### PR DESCRIPTION
Remove a list of HTTP2 errors as well as `nghttp2_errname()`
that converted an integer nghttp2 error code to a string
representation.

We already use `nghttp2_strerror()` for this, which
is provided by nghttp2 returns a better error string anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
