### PR TITLE
test: fix assert messages in case of failure

### DIFF
--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -31,11 +31,10 @@ const backslash = /\\/g;
 
 console.error('load test-module-loading.js');
 
-// assert that this is the main module.
-assert.strictEqual(require.main.id, '.', 'main module should have id of \'.\'');
-assert.strictEqual(require.main, module, 'require.main should === module');
-assert.strictEqual(process.mainModule, module,
-                   'process.mainModule should === module');
+assert.strictEqual(require.main.id, '.');
+assert.strictEqual(require.main, module);
+assert.strictEqual(process.mainModule, module);
+
 // assert that it's *not* the main module in the required module.
 require('../fixtures/not-main-module.js');
 
@@ -102,12 +101,9 @@ const d2 = require('../fixtures/b/d');
   assert.notStrictEqual(threeFolder, three);
 }
 
-assert.strictEqual(require('../fixtures/packages/index').ok, 'ok',
-                   'Failed loading package');
-assert.strictEqual(require('../fixtures/packages/main').ok, 'ok',
-                   'Failed loading package');
-assert.strictEqual(require('../fixtures/packages/main-index').ok, 'ok',
-                   'Failed loading package with index.js in main subdir');
+assert.strictEqual(require('../fixtures/packages/index').ok, 'ok');
+assert.strictEqual(require('../fixtures/packages/main').ok, 'ok');
+assert.strictEqual(require('../fixtures/packages/main-index').ok, 'ok');
 
 {
   console.error('test cycles containing a .. path');
@@ -165,8 +161,7 @@ require.extensions['.test'] = function(module) {
 
 assert.strictEqual(require('../fixtures/registerExt2').custom, 'passed');
 
-assert.strictEqual(require('../fixtures/foo').foo, 'ok',
-                   'require module with no extension');
+assert.strictEqual(require('../fixtures/foo').foo, 'ok');
 
 // Should not attempt to load a directory
 try {
@@ -181,13 +176,12 @@ try {
   console.error('load order');
 
   const loadOrder = '../fixtures/module-load-order/';
-  const msg = 'Load order incorrect.';
 
   require.extensions['.reg'] = require.extensions['.js'];
   require.extensions['.reg2'] = require.extensions['.js'];
 
-  assert.strictEqual(require(`${loadOrder}file1`).file1, 'file1', msg);
-  assert.strictEqual(require(`${loadOrder}file2`).file2, 'file2.js', msg);
+  assert.strictEqual(require(`${loadOrder}file1`).file1, 'file1');
+  assert.strictEqual(require(`${loadOrder}file2`).file2, 'file2.js');
   try {
     require(`${loadOrder}file3`);
   } catch (e) {
@@ -197,9 +191,10 @@ try {
     else
       assert.ok(/file3\.node/.test(e.message.replace(backslash, '/')));
   }
-  assert.strictEqual(require(`${loadOrder}file4`).file4, 'file4.reg', msg);
-  assert.strictEqual(require(`${loadOrder}file5`).file5, 'file5.reg2', msg);
-  assert.strictEqual(require(`${loadOrder}file6`).file6, 'file6/index.js', msg);
+
+  assert.strictEqual(require(`${loadOrder}file4`).file4, 'file4.reg');
+  assert.strictEqual(require(`${loadOrder}file5`).file5, 'file5.reg2');
+  assert.strictEqual(require(`${loadOrder}file6`).file6, 'file6/index.js');
   try {
     require(`${loadOrder}file7`);
   } catch (e) {
@@ -208,10 +203,9 @@ try {
     else
       assert.ok(/file7\/index\.node/.test(e.message.replace(backslash, '/')));
   }
-  assert.strictEqual(require(`${loadOrder}file8`).file8, 'file8/index.reg',
-                     msg);
-  assert.strictEqual(require(`${loadOrder}file9`).file9, 'file9/index.reg2',
-                     msg);
+
+  assert.strictEqual(require(`${loadOrder}file8`).file8, 'file8/index.reg');
+  assert.strictEqual(require(`${loadOrder}file9`).file9, 'file9/index.reg2');
 }
 
 {


### PR DESCRIPTION
When there are three arguments in strictEqual() call and
AssertionError exists, the previous two values are not printed.
This improves debugging messages visibility when there is a fail.
The messages were removed where the instruction is self-explanatory.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
