### PR TITLE
test: remove timeout from test-pipe-stream

### DIFF
--- a/test/parallel/test-pipe-stream.js
+++ b/test/parallel/test-pipe-stream.js
@@ -49,15 +49,10 @@ function test(clazz, cb) {
     });
   }
 
-  const timeout = setTimeout(function() {
-    server.close();
-  }, 2000);
-
   const server = net.Server();
   server.listen(common.PIPE, ping);
   server.on('connection', pong);
   server.on('close', function() {
-    clearTimeout(timeout);
     check();
     cb && cb();
   });


### PR DESCRIPTION
The timeout is unnecessary and the suspected cause of the following
failure (even though I could not reproduce it locally):

    11:53:54 not ok 197 parallel/test-pipe-stream
    11:53:54   ---
    11:53:54   duration_ms: 6.253
    11:53:54   severity: fail
    11:53:54   exitcode: 1
    11:53:54   stack: |-
    11:53:54     assert.js:338
    11:53:54         throw err;
    11:53:54         ^
    11:53:54
    11:53:54     AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    11:53:54
    11:53:54       assert.ok(have_ping)
    11:53:54
    11:53:54         at check (/home/iojs/build/workspace/node-test-binary-arm/test/parallel/test-pipe-stream.js:14:12)
    11:53:54         at Server.<anonymous> (/home/iojs/build/workspace/node-test-binary-arm/test/parallel/test-pipe-stream.js:61:5)
    11:53:54         at Server.emit (events.js:182:13)
    11:53:54         at emitCloseNT (net.js:1668:8)
    11:53:54         at process._tickCallback (internal/process/next_tick.js:63:19)

(From https://ci.nodejs.org/job/node-test-binary-arm/2235/RUN_SUBSET=5,label=pi3-docker/console.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
