### PR TITLE
fs: improve fs.watch ENOSPC error message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -244,7 +244,7 @@ function getMessage(key, args) {
  */
 function uvException(ctx) {
   const [ code, uvmsg ] = errmap.get(ctx.errno);
-  let message = `${code}: ${ctx.description || uvmsg}, ${ctx.syscall}`;
+  let message = `${code}: ${ctx.message || uvmsg}, ${ctx.syscall}`;
 
   let path;
   let dest;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -244,7 +244,7 @@ function getMessage(key, args) {
  */
 function uvException(ctx) {
   const [ code, uvmsg ] = errmap.get(ctx.errno);
-  let message = `${code}: ${uvmsg}, ${ctx.syscall}`;
+  let message = `${code}: ${ctx.description || uvmsg}, ${ctx.syscall}`;
 
   let path;
   let dest;

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -167,7 +167,7 @@ FSWatcher.prototype.start = function(filename,
       errno: err,
       syscall: 'watch',
       path: filename,
-      description: err === UV_ENOSPC ?
+      message: err === UV_ENOSPC ?
         'System limit for number of file watchers reached' : ''
     });
     error.filename = filename;

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -7,6 +7,7 @@ const {
   StatWatcher: _StatWatcher
 } = process.binding('fs');
 const { FSEvent } = internalBinding('fs_event_wrap');
+const { UV_ENOSPC } = internalBinding('uv');
 const { EventEmitter } = require('events');
 const {
   getStatsFromBinding,
@@ -165,7 +166,9 @@ FSWatcher.prototype.start = function(filename,
     const error = errors.uvException({
       errno: err,
       syscall: 'watch',
-      path: filename
+      path: filename,
+      description: err === UV_ENOSPC ?
+        'System limit for number of file watchers reached' : ''
     });
     error.filename = filename;
     throw error;

--- a/test/sequential/test-fs-watch-system-limit.js
+++ b/test/sequential/test-fs-watch-system-limit.js
@@ -37,7 +37,6 @@ spawnProcesses();
 let accumulated = '';
 gatherStderr.on('data', common.mustCallAtLeast((chunk) => {
   accumulated += chunk;
-  // console.log(chunk);
   if (accumulated.includes('Error:') && !finished) {
     assert(
       accumulated.includes('ENOSPC: System limit for number ' +

--- a/test/sequential/test-fs-watch-system-limit.js
+++ b/test/sequential/test-fs-watch-system-limit.js
@@ -6,6 +6,8 @@ const stream = require('stream');
 
 if (!common.isLinux)
   common.skip('The fs watch limit is OS-dependent');
+if (!common.enoughTestCpu)
+  common.skip('This test is resource-intensive');
 
 const processes = [];
 const gatherStderr = new stream.PassThrough();

--- a/test/sequential/test-fs-watch-system-limit.js
+++ b/test/sequential/test-fs-watch-system-limit.js
@@ -1,0 +1,50 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const stream = require('stream');
+
+if (!common.isLinux)
+  common.skip('The fs watch limit is OS-dependent');
+
+const processes = [];
+const gatherStderr = new stream.PassThrough();
+gatherStderr.setEncoding('utf8');
+gatherStderr.setMaxListeners(Infinity);
+
+let finished = false;
+function spawnProcesses() {
+  for (let i = 0; i < 10; ++i) {
+    const proc = child_process.spawn(
+      process.execPath,
+      [ '-e',
+        `process.chdir(${JSON.stringify(__dirname)});
+        for (const file of fs.readdirSync('.'))
+          fs.watch(file, () => {});`
+      ], { stdio: ['inherit', 'inherit', 'pipe'] });
+    proc.stderr.pipe(gatherStderr);
+    processes.push(proc);
+  }
+
+  setTimeout(() => {
+    if (!finished && processes.length < 200)
+      spawnProcesses();
+  }, 100);
+}
+
+spawnProcesses();
+
+let accumulated = '';
+gatherStderr.on('data', common.mustCallAtLeast((chunk) => {
+  accumulated += chunk;
+  // console.log(chunk);
+  if (accumulated.includes('Error:') && !finished) {
+    assert(
+      accumulated.includes('ENOSPC: System limit for number ' +
+                           'of file watchers reached'),
+      accumulated);
+    console.log(`done after ${processes.length} processes, cleaning up`);
+    finished = true;
+    processes.forEach((proc) => proc.kill());
+  }
+}, 1));


### PR DESCRIPTION
Providing `No space left on device` is misleading in this case.
Replace it with something that describes it more accurately.

Refs: https://stackoverflow.com/questions/22475849/node-js-error-enospc/32600959

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
