### PR TITLE
deps: backport crypto/init.c fix for openssl110

### DIFF
--- a/deps/openssl/openssl/crypto/init.c
+++ b/deps/openssl/openssl/crypto/init.c
@@ -91,7 +91,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
      */
     base_inited = 1;
 
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if defined(OPENSSL_NO_STATIC_ENGINE) && \
+    !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
 # ifdef DSO_WIN32
     {
         HMODULE handle = NULL;
@@ -621,7 +622,8 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
+#if defined(OPENSSL_NO_STATIC_ENGINE) && \
+    !defined(OPENSSL_NO_DSO) && !defined(OPENSSL_USE_NODELETE)
     {
         union {
             void *sym;


### PR DESCRIPTION
The statically linked program should not try to keep loaded
by dlopen trick.

Fixes: #21845
Refs: openssl/openssl#6725

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
