### PR TITLE
src: fix formatting of PIDs

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -315,7 +315,7 @@ void Environment::PrintSyncTrace() const {
   Local<v8::StackTrace> stack =
       StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
 
-  fprintf(stderr, "(node:%u) WARNING: Detected use of sync API\n",
+  fprintf(stderr, "(node:%d) WARNING: Detected use of sync API\n",
           uv_os_getpid());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -115,7 +115,7 @@ std::string GetHumanReadableProcessName() {
 void GetHumanReadableProcessName(char (*name)[1024]) {
   char title[1024] = "Node.js";
   uv_get_process_title(title, sizeof(title));
-  snprintf(*name, sizeof(*name), "%s[%u]", title, uv_os_getpid());
+  snprintf(*name, sizeof(*name), "%s[%d]", title, uv_os_getpid());
 }
 
 }  // namespace node


### PR DESCRIPTION
`uv_pid_t` seems to be signed on all supported platforms, so `%d` seems appropriate.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
