### PR TITLE
deps: cherry-pick 804a693 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -28,7 +28,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -211,6 +211,9 @@ consts_misc = [
         'value': 'Context::EXTENSION_INDEX' },
     { 'name': 'context_min_slots',
         'value': 'Context::MIN_CONTEXT_SLOTS' },
+    { 'name': 'context_idx_embedder_data',
+        'value': 'Internals::kContextEmbedderDataIndex' },
+
 
     { 'name': 'namedictionaryshape_prefix_size',
         'value': 'NameDictionaryShape::kPrefixSize' },
@@ -231,6 +234,8 @@ consts_misc = [
         'value': 'SimpleNumberDictionaryShape::kPrefixSize' },
     { 'name': 'simplenumberdictionaryshape_entry_size',
         'value': 'SimpleNumberDictionaryShape::kEntrySize' },
+
+    { 'name': 'type_JSError__JS_ERROR_TYPE', 'value': 'JS_ERROR_TYPE' },
 ];
 
 #


### PR DESCRIPTION
Original commit message:

    [postmortem] add JS_ERROR_TYPE and context embedder index

      * JS_ERROR_TYPE is required for postmortem tools to inspect JSError
        objects (see https://github.com/nodejs/llnode/pull/215 for a usage
        example)
      * The context embedder index is required for postmortem tools to
        access embedder data stored in the context (see
        https://github.com/nodejs/llnode/pull/204 for a usage example)

    R=bmeurer@google.com, yangguo@google.com

    Change-Id: Ib7c7eb44f6ad327fc71a1d45f510c49377db7a25
    Reviewed-on: https://chromium-review.googlesource.com/1138493
    Reviewed-by: Benedikt Meurer <bmeurer@chromium.org>
    Commit-Queue: Benedikt Meurer <bmeurer@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#54475}

Refs: https://github.com/v8/v8/commit/804a693eb4ac2fed160c683d16444a53b541cbf2


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

--------------------

The metadata introduced in this commit is essential to fix a longstanding issue
with Error object inspection with llnode 
(https://github.com/nodejs/llnode/issues/143).

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)