### PR TITLE
performance,events: use Map to store events in EventEmitter

### DIFF
--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -2,15 +2,22 @@
 const common = require('../common.js');
 const events = require('events');
 
-const bench = common.createBenchmark(main, { n: [1e6] });
+const bench = common.createBenchmark(main, {
+  n: [5e6],
+  staleEventsCount: [0, 5],
+  listenerCount: [1, 5],
+});
 
-function main({ n }) {
+function main({ n, staleEventsCount, listenerCount }) {
   const ee = new events.EventEmitter();
   const listeners = [];
 
   var k;
-  for (k = 0; k < 10; k += 1)
+  for (k = 0; k < listenerCount; k += 1)
     listeners.push(function() {});
+
+  for (k = 0; k < staleEventsCount; k++)
+    ee.on(`dummyunused${k}`, () => {});
 
   bench.start();
   for (var i = 0; i < n; i += 1) {

--- a/benchmark/events/ee-emit-multi.js
+++ b/benchmark/events/ee-emit-multi.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
+
+const bench = common.createBenchmark(main, {
+  n: [2e7],
+  listenerCount: [1, 5, 10],
+});
+
+function main({ n, listenerCount }) {
+  const ee = new EventEmitter();
+
+  for (var k = 0; k < listenerCount; k += 1) {
+    ee.on('dummy', function() {});
+    ee.on(`dummy${k}`, function() {});
+  }
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    if (i % 3 === 0)
+      ee.emit('dummy', true, 5);
+    else if (i % 2 === 0)
+      ee.emit('dummy', true, 5, 10, false);
+    else
+      ee.emit('dummy');
+  }
+  bench.end(n);
+}

--- a/benchmark/events/ee-emit.js
+++ b/benchmark/events/ee-emit.js
@@ -5,13 +5,13 @@ const EventEmitter = require('events').EventEmitter;
 const bench = common.createBenchmark(main, {
   n: [2e6],
   argc: [0, 2, 4, 10],
-  listeners: [1, 5, 10],
+  listenerCount: [1, 5, 10],
 });
 
-function main({ n, argc, listeners }) {
+function main({ n, argc, listenerCount }) {
   const ee = new EventEmitter();
 
-  for (var k = 0; k < listeners; k += 1)
+  for (var k = 0; k < listenerCount; k += 1)
     ee.on('dummy', function() {});
 
   var i;

--- a/benchmark/events/ee-event-names.js
+++ b/benchmark/events/ee-event-names.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
+
+const bench = common.createBenchmark(main, { n: [1e6] });
+
+function main({ n }) {
+  const ee = new EventEmitter();
+
+  for (var k = 0; k < 9; k += 1) {
+    ee.on(`dummy0${k}`, function() {});
+    ee.on(`dummy1${k}`, function() {});
+    ee.on(`dummy2${k}`, function() {});
+  }
+
+  ee.removeAllListeners('dummy01');
+  ee.removeAllListeners('dummy11');
+  ee.removeAllListeners('dummy21');
+  ee.removeAllListeners('dummy06');
+  ee.removeAllListeners('dummy16');
+  ee.removeAllListeners('dummy26');
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    ee.eventNames();
+  }
+  bench.end(n);
+}

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 const EventEmitter = require('events').EventEmitter;
 
-const bench = common.createBenchmark(main, { n: [5e6] });
+const bench = common.createBenchmark(main, { n: [1e7] });
 
 function main({ n }) {
   const ee = new EventEmitter();

--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -2,17 +2,22 @@
 const common = require('../common.js');
 const EventEmitter = require('events').EventEmitter;
 
-const bench = common.createBenchmark(main, { n: [2e7] });
+const bench = common.createBenchmark(main, {
+  n: [5e6],
+  listenerCount: [1, 5, 10],
+});
 
-function main({ n }) {
+
+function main({ n, listenerCount }) {
   const ee = new EventEmitter();
 
   function listener() {}
 
   bench.start();
-  for (var i = 0; i < n; i += 1) {
+  for (var i = 0; i < n; ++i) {
     const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
-    ee.once(dummy, listener);
+    for (var j = 0; j < listenerCount; ++j)
+      ee.once(dummy, listener);
     ee.emit(dummy);
   }
   bench.end(n);

--- a/deps/v8/src/builtins/builtins-collections-gen.cc
+++ b/deps/v8/src/builtins/builtins-collections-gen.cc
@@ -1474,14 +1474,17 @@ TF_BUILTIN(MapPrototypeDelete, CollectionsBuiltinsAssembler) {
       LoadFixedArrayElement(table, OrderedHashMap::kNumberOfBucketsIndex);
 
   // If there fewer elements than #buckets / 2, shrink the table.
-  Label shrink(this);
-  GotoIf(SmiLessThan(SmiAdd(number_of_elements, number_of_elements),
-                     number_of_buckets),
-         &shrink);
-  Return(TrueConstant());
+  Label dont_shrink(this);
+  GotoIf(SmiGreaterThanOrEqual(SmiAdd(number_of_elements, number_of_elements),
+                               number_of_buckets),
+         &dont_shrink);
+  // If #buckets is less than 8 then don't shrink the table
+  GotoIf(SmiLessThan(number_of_buckets, SmiConstant(8)),
+         &dont_shrink);
 
-  BIND(&shrink);
   CallRuntime(Runtime::kMapShrink, context, receiver);
+
+  BIND(&dont_shrink);
   Return(TrueConstant());
 }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -21,6 +21,9 @@
 
 'use strict';
 
+const kEvents = Symbol('events');
+const kEventsProxy = Symbol('events-proxy');
+
 var spliceOne;
 
 function EventEmitter() {
@@ -33,7 +36,8 @@ EventEmitter.EventEmitter = EventEmitter;
 
 EventEmitter.usingDomains = false;
 
-EventEmitter.prototype._events = undefined;
+EventEmitter.prototype[kEvents] = undefined;
+EventEmitter.prototype[kEventsProxy] = undefined;
 EventEmitter.prototype._eventsCount = 0;
 EventEmitter.prototype._maxListeners = undefined;
 
@@ -64,11 +68,80 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   }
 });
 
+const proxyEventsHandler = {
+  get(emitter, prop) {
+    const events = emitter[kEvents];
+    if (events === undefined)
+      return undefined;
+    return events.get(prop);
+  },
+  set(emitter, prop, value) {
+    let events = emitter[kEvents];
+    if (events === undefined) {
+      events = emitter[kEvents] = new Map();
+      emitter._eventsCount = 0;
+    }
+    events.set(prop, value);
+    return true;
+  },
+  has(emitter, prop) {
+    const events = emitter[kEvents];
+    return events !== undefined && events.has(prop);
+  },
+  getPrototypeOf() {
+    return null;
+  },
+  deleteProperty(emitter, prop) {
+    const events = emitter[kEvents];
+    if (events !== undefined)
+      events.delete(prop);
+    return true;
+  },
+  ownKeys(emitter) {
+    return emitter.eventNames();
+  },
+  defineProperty(emitter, prop, descriptor) {
+    if (!descriptor.writable || !descriptor.configurable)
+      return false;
+    proxyEventsHandler.set(emitter, prop, descriptor.value);
+    return true;
+  },
+  getOwnPropertyDescriptor(emitter, prop) {
+    const value = proxyEventsHandler.get(emitter, prop);
+    if (value === undefined)
+      return undefined;
+    return {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    };
+  },
+};
+
+Object.defineProperty(EventEmitter.prototype, '_events', {
+  enumerable: true,
+  get: function() {
+    let proxy = this[kEventsProxy];
+    if (proxy === undefined && this[kEvents] !== undefined)
+      proxy = new Proxy(this, proxyEventsHandler);
+    return proxy;
+  },
+  set: function(value) {
+    if (this[kEvents] === undefined)
+      this.init();
+    if (!value || Array.isArray(value) && value.length === 0) {
+      this[kEvents] = new Map();
+      this._eventsCount = 0;
+    }
+  }
+});
+
 EventEmitter.init = function() {
 
-  if (this._events === undefined ||
-      this._events === Object.getPrototypeOf(this)._events) {
-    this._events = new Map();
+  if (this[kEvents] === undefined ||
+      this[kEvents] === Object.getPrototypeOf(this)[kEvents]) {
+    this[kEvents] = new Map();
     this._eventsCount = 0;
   }
 
@@ -140,7 +213,7 @@ function enhanceStackTrace(err, own) {
 EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
-  const events = this._events;
+  const events = this[kEvents];
   if (events !== undefined)
     doError = (doError && !events.has('error'));
   else if (!doError)
@@ -200,11 +273,8 @@ function _addListener(target, type, listener, prepend) {
     throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
   }
 
-  events = target._events;
-  if (events === undefined) {
-    events = target._events = new Map();
-    target._eventsCount = 0;
-  } else {
+  events = target[kEvents];
+  if (events !== undefined) {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
     if (events.has('newListener')) {
@@ -212,10 +282,13 @@ function _addListener(target, type, listener, prepend) {
                   listener.listener ? listener.listener : listener);
 
       // Re-assign `events` because a newListener handler could have caused the
-      // this._events to be assigned to a new object
-      events = target._events;
+      // this[kEvents] to be assigned to a new object
+      events = target[kEvents];
     }
     existing = events.get(type);
+  } else {
+    events = target[kEvents] = new Map();
+    target._eventsCount = 0;
   }
 
   if (existing === undefined) {
@@ -228,10 +301,10 @@ function _addListener(target, type, listener, prepend) {
       existing = prepend ? [listener, existing] : [existing, listener];
       events.set(type, existing);
       // If we've already got an array, just append.
-    } else if (prepend) {
-      existing.unshift(listener);
-    } else {
+    } else if (!prepend) {
       existing.push(listener);
+    } else {
+      existing.unshift(listener);
     }
 
     // Check for listener leak
@@ -311,7 +384,7 @@ EventEmitter.prototype.removeListener =
         throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
       }
 
-      events = this._events;
+      events = this[kEvents];
       if (events === undefined)
         return this;
 
@@ -320,14 +393,10 @@ EventEmitter.prototype.removeListener =
         return this;
 
       if (list === listener || list.listener === listener) {
-        if (--this._eventsCount === 0) {
-          // this._events.clear();
-          this._events = new Map();
-        } else {
-          events.delete(type);
-          if (events.has('removeListener'))
-            this.emit('removeListener', type, list.listener || listener);
-        }
+        --this._eventsCount;
+        events.delete(type);
+        if (events.has('removeListener'))
+          this.emit('removeListener', type, list.listener || listener);
       } else if (typeof list !== 'function') {
         position = -1;
 
@@ -344,6 +413,8 @@ EventEmitter.prototype.removeListener =
 
         if (position === 0)
           list.shift();
+        else if (position === list.length - 1)
+          list.length -= 1;
         else {
           if (spliceOne === undefined)
             spliceOne = require('internal/util').spliceOne;
@@ -366,38 +437,37 @@ EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
       var listeners, events, i;
 
-      events = this._events;
+      events = this[kEvents];
       if (events === undefined)
         return this;
 
       // not listening for removeListener, no need to emit
       if (!events.has('removeListener')) {
         if (arguments.length === 0) {
-          // this._events.clear();
-          this._events = new Map();
+          this[kEvents] = new Map();
           this._eventsCount = 0;
-        } else if (events.has(type)) {
-          if (--this._eventsCount === 0)
-            this._events = new Map();
-            // this._events.clear();
-          else
-            events.delete(type);
+        } else if (events.delete(type)) {
+          --this._eventsCount;
         }
         return this;
       }
 
       // emit removeListener for all listeners on all events
       if (arguments.length === 0) {
-        var keys = Array.from(events.keys());
+        const len = events.size;
+        var keys = new Array(len);
+        i = 0;
+        for (var value of events.keys())
+          keys[i++] = value;
+
         var key;
-        for (i = 0; i < keys.length; ++i) {
+        for (i = 0; i < len; ++i) {
           key = keys[i];
           if (key === 'removeListener') continue;
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        // this._events.clear();
-        this._events = new Map();
+        this[kEvents] = new Map();
         this._eventsCount = 0;
         return this;
       }
@@ -417,7 +487,7 @@ EventEmitter.prototype.removeAllListeners =
     };
 
 function _listeners(target, type, unwrap) {
-  const events = target._events;
+  const events = target[kEvents];
 
   if (events === undefined)
     return [];
@@ -451,23 +521,32 @@ EventEmitter.listenerCount = function(emitter, type) {
 
 EventEmitter.prototype.listenerCount = listenerCount;
 function listenerCount(type) {
-  const events = this._events;
+  const events = this[kEvents];
 
   if (events !== undefined) {
     const evlistener = events.get(type);
 
-    if (typeof evlistener === 'function') {
+    if (typeof evlistener === 'function')
       return 1;
-    } else if (evlistener !== undefined) {
+    else if (evlistener !== undefined)
       return evlistener.length;
-    }
   }
 
   return 0;
 }
 
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? Array.from(this._events.keys()) : [];
+  if (this._eventsCount === 0)
+    return [];
+
+  const map = this[kEvents];
+  const len = map.size;
+  const names = new Array(len);
+  var i = 0;
+  for (var key of map.keys()) {
+    names[i++] = key;
+  }
+  return names;
 };
 
 function arrayClone(arr, n) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -68,7 +68,7 @@ EventEmitter.init = function() {
 
   if (this._events === undefined ||
       this._events === Object.getPrototypeOf(this)._events) {
-    this._events = Object.create(null);
+    this._events = new Map();
     this._eventsCount = 0;
   }
 
@@ -142,7 +142,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
 
   const events = this._events;
   if (events !== undefined)
-    doError = (doError && events.error === undefined);
+    doError = (doError && !events.has('error'));
   else if (!doError)
     return false;
 
@@ -173,7 +173,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     throw err; // Unhandled 'error' event
   }
 
-  const handler = events[type];
+  const handler = events.get(type);
 
   if (handler === undefined)
     return false;
@@ -202,12 +202,12 @@ function _addListener(target, type, listener, prepend) {
 
   events = target._events;
   if (events === undefined) {
-    events = target._events = Object.create(null);
+    events = target._events = new Map();
     target._eventsCount = 0;
   } else {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
-    if (events.newListener !== undefined) {
+    if (events.has('newListener')) {
       target.emit('newListener', type,
                   listener.listener ? listener.listener : listener);
 
@@ -215,18 +215,18 @@ function _addListener(target, type, listener, prepend) {
       // this._events to be assigned to a new object
       events = target._events;
     }
-    existing = events[type];
+    existing = events.get(type);
   }
 
   if (existing === undefined) {
     // Optimize the case of one listener. Don't need the extra array object.
-    existing = events[type] = listener;
+    events.set(type, listener);
     ++target._eventsCount;
   } else {
     if (typeof existing === 'function') {
       // Adding the second element, need to change to array.
-      existing = events[type] =
-        prepend ? [listener, existing] : [existing, listener];
+      existing = prepend ? [listener, existing] : [existing, listener];
+      events.set(type, existing);
       // If we've already got an array, just append.
     } else if (prepend) {
       existing.unshift(listener);
@@ -315,16 +315,17 @@ EventEmitter.prototype.removeListener =
       if (events === undefined)
         return this;
 
-      list = events[type];
+      list = events.get(type);
       if (list === undefined)
         return this;
 
       if (list === listener || list.listener === listener) {
-        if (--this._eventsCount === 0)
-          this._events = Object.create(null);
-        else {
-          delete events[type];
-          if (events.removeListener)
+        if (--this._eventsCount === 0) {
+          // this._events.clear();
+          this._events = new Map();
+        } else {
+          events.delete(type);
+          if (events.has('removeListener'))
             this.emit('removeListener', type, list.listener || listener);
         }
       } else if (typeof list !== 'function') {
@@ -350,9 +351,9 @@ EventEmitter.prototype.removeListener =
         }
 
         if (list.length === 1)
-          events[type] = list[0];
+          events.set(type, list[0]);
 
-        if (events.removeListener !== undefined)
+        if (events.has('removeListener'))
           this.emit('removeListener', type, originalListener || listener);
       }
 
@@ -370,22 +371,24 @@ EventEmitter.prototype.removeAllListeners =
         return this;
 
       // not listening for removeListener, no need to emit
-      if (events.removeListener === undefined) {
+      if (!events.has('removeListener')) {
         if (arguments.length === 0) {
-          this._events = Object.create(null);
+          // this._events.clear();
+          this._events = new Map();
           this._eventsCount = 0;
-        } else if (events[type] !== undefined) {
+        } else if (events.has(type)) {
           if (--this._eventsCount === 0)
-            this._events = Object.create(null);
+            this._events = new Map();
+            // this._events.clear();
           else
-            delete events[type];
+            events.delete(type);
         }
         return this;
       }
 
       // emit removeListener for all listeners on all events
       if (arguments.length === 0) {
-        var keys = Object.keys(events);
+        var keys = Array.from(events.keys());
         var key;
         for (i = 0; i < keys.length; ++i) {
           key = keys[i];
@@ -393,12 +396,13 @@ EventEmitter.prototype.removeAllListeners =
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        this._events = Object.create(null);
+        // this._events.clear();
+        this._events = new Map();
         this._eventsCount = 0;
         return this;
       }
 
-      listeners = events[type];
+      listeners = events.get(type);
 
       if (typeof listeners === 'function') {
         this.removeListener(type, listeners);
@@ -418,7 +422,7 @@ function _listeners(target, type, unwrap) {
   if (events === undefined)
     return [];
 
-  const evlistener = events[type];
+  const evlistener = events.get(type);
   if (evlistener === undefined)
     return [];
 
@@ -450,7 +454,7 @@ function listenerCount(type) {
   const events = this._events;
 
   if (events !== undefined) {
-    const evlistener = events[type];
+    const evlistener = events.get(type);
 
     if (typeof evlistener === 'function') {
       return 1;
@@ -463,7 +467,7 @@ function listenerCount(type) {
 }
 
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
+  return this._eventsCount > 0 ? Array.from(this._events.keys()) : [];
 };
 
 function arrayClone(arr, n) {

--- a/test/parallel/test-benchmark-events.js
+++ b/test/parallel/test-benchmark-events.js
@@ -5,5 +5,5 @@ require('../common');
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('events',
-             ['argc=0', 'listeners=1', 'n=1'],
+             ['argc=0', 'staleEventsCount=0', 'listenerCount=1', 'n=1'],
              { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
I've had some time to play around with Map as backing storage for EE and the results turned out to be pretty good. I'm not sure if this is an appropriate change so feel free to note this and close.

If this is acceptable then this should probably be a semver-major, even though _events is 'private'.

<details/>
  <summary>EE benchmarks</summary>

```
 ➔ dev/node/node cat compare-events-pr.csv | Rscript benchmark/compare.R        59s events-perf :: ● :: ⬡
                                                     confidence improvement accuracy (*)    (**)   (***)
 events/ee-add-remove.js n=1000000                          ***     11.29 %       ±5.75%  ±7.70% ±10.14%
 events/ee-emit.js listeners=1 argc=0 n=2000000             ***     16.70 %       ±8.86% ±11.89% ±15.66%
 events/ee-emit.js listeners=1 argc=10 n=2000000                     8.69 %      ±10.88% ±14.58% ±19.18%
 events/ee-emit.js listeners=1 argc=2 n=2000000                      5.96 %       ±7.76% ±10.41% ±13.73%
 events/ee-emit.js listeners=1 argc=4 n=2000000              **     10.72 %       ±7.08%  ±9.49% ±12.51%
 events/ee-emit.js listeners=10 argc=0 n=2000000                     2.64 %      ±10.67% ±14.30% ±18.80%
 events/ee-emit.js listeners=10 argc=10 n=2000000                    1.67 %       ±7.19%  ±9.63% ±12.67%
 events/ee-emit.js listeners=10 argc=2 n=2000000                    -0.33 %       ±5.85%  ±7.85% ±10.36%
 events/ee-emit.js listeners=10 argc=4 n=2000000                    -4.62 %       ±6.34%  ±8.51% ±11.24%
 events/ee-emit.js listeners=5 argc=0 n=2000000                     -2.17 %       ±9.37% ±12.56% ±16.53%
 events/ee-emit.js listeners=5 argc=10 n=2000000                    -0.05 %       ±8.56% ±11.48% ±15.11%
 events/ee-emit.js listeners=5 argc=2 n=2000000                     -0.02 %       ±8.38% ±11.24% ±14.80%
 events/ee-emit.js listeners=5 argc=4 n=2000000                      4.58 %       ±6.30%  ±8.45% ±11.15%
 events/ee-listener-count-on-prototype.js n=50000000        ***     22.49 %       ±8.90% ±12.00% ±15.95%
 events/ee-listeners-many.js n=5000000                        *      9.11 %       ±7.27%  ±9.80% ±13.02%
 events/ee-listeners.js n=5000000                                   -3.90 %       ±8.99% ±12.04% ±15.84%
 events/ee-once.js n=20000000                                        0.76 %       ±4.47%  ±5.99%  ±7.87%
```

</details>

-----

Also I'd like some help on understanding why is `.clear()` is so much worse than creating a new Map, I thought that this should be the other way around. (it shows regression of around -25% for ee-once). Comments with `_events.clear()` are there to show where I intended to use it. I'll remove them later.


Perf with `new Map`
![image](https://user-images.githubusercontent.com/9109612/42836617-33ef7c42-8a04-11e8-810d-fe8ce4c799ff.png)
Perf with `map.clear()`
![image](https://user-images.githubusercontent.com/9109612/42836685-57030a32-8a04-11e8-81a3-75cb5200d2c0.png)

Perf of master if needed:
![image](https://user-images.githubusercontent.com/9109612/42836841-d2ac0e0e-8a04-11e8-8fd5-2cc07de173f6.png)


##### Checklist

- [x] `make -j4 test` (UNIX) passes
- [x] benchmarks are included
- [ ] documentation is changed or added (there is single mention in events.md in the console log of EE)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/performance
