### PR TITLE
util: expose promise events

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1631,6 +1631,80 @@ const module = new WebAssembly.Module(wasmBuffer);
 util.types.isWebAssemblyCompiledModule(module);  // Returns true
 ```
 
+### util.createPromiseHook(hooks)
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `hooks` {Object}
+  * `resolve` {Function} Called when a promise resolve function is called. The
+    promise is not fulfilled or rejected at this point.
+  * `rejectWithNoHandler` {Function} Called when a promise rejects without any
+    handler.
+  * `handlerAddedAfterReject` {Function} Called when a promise handler is added
+    to a promise that rejected without a handler.
+  * `rejectAfterResolved` {Function} Called when a promise reject function is
+    called after resolution.
+  * `resolveAfterResolved` {Function} Called when a promise resolve function is
+    called after resolution.
+
+Returns: {Object}
+  * `enable` {Function} Enables the hook
+  * `disable` {Function} Disables the hook
+
+Registers the promise hook `hook` to be called for certain promise debugging
+events.
+
+```js
+util.createPromiseHook({
+  resolve(promise) {
+    console.log('Promise did resolve');
+  },
+  rejectWithNoHandler(promise, value) {
+    console.log('Promise did rejectWithNoHandler with', value);
+  },
+  handlerAddedAfterReject(promise) {
+    console.log('Promise did handlerAddedAfterReject');
+  },
+}).enable();
+
+const x = Promise.resolve('success')
+  .then(() => Promise.reject('error'));
+
+setTimeout(() => {
+  x.catch(() => {});
+}, 10);
+
+// Promise did resolve
+// Promise did resolve
+// Promise did rejectWithNoHandler with 'error'
+// Promise did resolve
+// Promise did handlerAddedAfterReject
+// Promise did resolve
+// Promise did rejectWithNoHandler with 'error'
+// Promise did resolve
+// Promise did handlerAddedAfterReject
+// Promise did resolve
+```
+
+```js
+util.createPromiseHook({
+  rejectAfterResolved(promise, value) {
+    console.log('Promise did rejectAfterResolved with', value);
+  },
+}).enable();
+
+new Promise((resolve, reject) => {
+  resolve('success');
+
+  reject('oops');
+});
+
+// Promise did rejectAfterResolved with 'oops'
+```
+
 ## Deprecated APIs
 
 The following APIs are deprecated and should no longer be used. Existing

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,6 +21,7 @@
 
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const errors = require('internal/errors');
 const {
   ERR_FALSY_VALUE_REJECTION,
@@ -37,8 +38,8 @@ const {
   kRejected,
   previewEntries
 } = process.binding('util');
+const { setPromiseHook } = internalBinding('safe_util');
 
-const { internalBinding } = require('internal/bootstrap/loaders');
 const types = internalBinding('types');
 Object.assign(types, require('internal/util/types'));
 const {
@@ -1464,6 +1465,72 @@ function getSystemErrorName(err) {
   return internalErrorName(err);
 }
 
+const promiseEventTypes = [
+  'init',
+  'resolve',
+  'before',
+  'after',
+  'rejectWithNoHandler',
+  'handlerAddedAfterReject',
+  'rejectAfterResolved',
+  'resolveAfterResolved',
+];
+const promiseHooks = new Set();
+let promiseHookWarned = false;
+let resolveHookRef = 0;
+function promiseHookCallback(type, promise, value) {
+  type = promiseEventTypes[type];
+  for (const hooks of promiseHooks) {
+    try {
+      const hook = hooks[type];
+      if (typeof hook === 'function') {
+        hook(promise, value);
+      }
+    } catch (e) {
+      process.nextTick(() => { throw e; });
+    }
+  }
+}
+function createPromiseHook(hooks) {
+  if (!promiseHookWarned) {
+    promiseHookWarned = true;
+    process.emitWarning('The util.createPromiseHook API is experimental.',
+                        'ExperimentalWarning');
+  }
+
+  const hasResolve = 'resolve' in hooks;
+
+  promiseEventTypes.forEach((type) => {
+    const hook = hooks[type];
+    if (hook === undefined) {
+      return;
+    }
+
+    if (typeof hook !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE(`hooks.${type}`, 'function', hook);
+    }
+  });
+
+  return {
+    enable() {
+      promiseHooks.add(hooks);
+      if (hasResolve) {
+        resolveHookRef++;
+      }
+      setPromiseHook(promiseHookCallback, resolveHookRef > 0);
+    },
+    disable() {
+      promiseHooks.delete(hooks);
+      if (hasResolve) {
+        resolveHookRef--;
+      }
+      setPromiseHook(
+        hooks.size === 0 ? null : promiseHookCallback,
+        resolveHookRef > 0);
+    },
+  };
+}
+
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
   _errnoException: errors.errnoException,
@@ -1504,6 +1571,8 @@ module.exports = exports = {
   TextDecoder,
   TextEncoder,
   types,
+
+  createPromiseHook,
 
   // Deprecated Old Stuff
   debug: deprecate(debug,

--- a/src/env.h
+++ b/src/env.h
@@ -346,6 +346,7 @@ struct PackageConfig {
   V(tls_wrap_constructor_function, v8::Function)                              \
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \
+  V(util_promise_hook_callback, v8::Function)                                 \
   V(url_constructor_function, v8::Function)                                   \
   V(write_wrap_template, v8::ObjectTemplate)
 
@@ -808,8 +809,10 @@ class Environment {
   inline HandleWrapQueue* handle_wrap_queue() { return &handle_wrap_queue_; }
   inline ReqWrapQueue* req_wrap_queue() { return &req_wrap_queue_; }
 
-  void AddPromiseHook(promise_hook_func fn, void* arg);
+  bool AddPromiseHook(promise_hook_func fn, void* arg);
   bool RemovePromiseHook(promise_hook_func fn, void* arg);
+  bool AddPromiseRejectHook(promise_hook_func fn, void* arg);
+  bool RemovePromiseRejectHook(promise_hook_func fn, void* arg);
   inline bool EmitProcessEnvWarning() {
     bool current_value = emit_env_nonstring_warning_;
     emit_env_nonstring_warning_ = false;
@@ -945,9 +948,9 @@ class Environment {
   struct PromiseHookCallback {
     promise_hook_func cb_;
     void* arg_;
-    size_t enable_count_;
   };
   std::vector<PromiseHookCallback> promise_hooks_;
+  std::vector<PromiseHookCallback> promise_reject_hooks_;
 
   struct NativeImmediateCallback {
     native_immediate_callback cb_;
@@ -990,6 +993,7 @@ class Environment {
   static void EnvPromiseHook(v8::PromiseHookType type,
                              v8::Local<v8::Promise> promise,
                              v8::Local<v8::Value> parent);
+  static void EnvPromiseRejectCallback(v8::PromiseRejectMessage message);
 
   template <typename T>
   void ForEachBaseObject(T&& iterator);

--- a/src/node.h
+++ b/src/node.h
@@ -616,9 +616,20 @@ NODE_EXTERN void AtExit(void (*cb)(void* arg), void* arg = 0);
  */
 NODE_EXTERN void AtExit(Environment* env, void (*cb)(void* arg), void* arg = 0);
 
-typedef void (*promise_hook_func) (v8::PromiseHookType type,
+typedef enum {
+  kInit,
+  kResolve,
+  kBefore,
+  kAfter,
+  kRejectWithNoHandler,
+  kHandlerAddedAfterReject,
+  kRejectAfterResolved,
+  kResolveAfterResolved,
+} PromiseHookType;
+
+typedef void (*promise_hook_func) (PromiseHookType type,
                                    v8::Local<v8::Promise> promise,
-                                   v8::Local<v8::Value> parent,
+                                   v8::Local<v8::Value> value,
                                    void* arg);
 
 typedef double async_id;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -139,6 +139,7 @@ struct sockaddr;
     V(udp_wrap)                                                               \
     V(url)                                                                    \
     V(util)                                                                   \
+    V(safe_util)                                                              \
     V(uv)                                                                     \
     V(v8)                                                                     \
     V(worker)                                                                 \
@@ -150,7 +151,7 @@ struct sockaddr;
   NODE_BUILTIN_ICU_MODULES(V)
 
 #define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
-  static node::node_module _module = {                                        \
+  static node::node_module _module_##modname = {                              \
     NODE_MODULE_VERSION,                                                      \
     flags,                                                                    \
     nullptr,                                                                  \
@@ -162,7 +163,7 @@ struct sockaddr;
     nullptr                                                                   \
   };                                                                          \
   void _register_ ## modname() {                                              \
-    node_module_register(&_module);                                           \
+    node_module_register(&_module_##modname);                                 \
   }
 
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -6,9 +6,11 @@ namespace util {
 
 using v8::Array;
 using v8::Context;
+using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Integer;
 using v8::Local;
+using v8::Number;
 using v8::Object;
 using v8::Private;
 using v8::Promise;
@@ -140,7 +142,7 @@ void SafeGetenv(const FunctionCallbackInfo<Value>& args) {
             v8::NewStringType::kNormal).ToLocalChecked());
 }
 
-void Initialize(Local<Object> target,
+void InitializeBase(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
@@ -186,7 +188,68 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "safeGetenv", SafeGetenv);
 }
 
+void InitializeUnsafe(Local<Object> target,
+                      Local<Value> unused,
+                      Local<Context> context) {
+  InitializeBase(target, unused, context);
+}
+
+void PromiseHook(PromiseHookType type,
+                 Local<Promise> promise,
+                 Local<Value> value,
+                 void* arg) {
+  switch (type) {
+    case PromiseHookType::kResolve:
+    case PromiseHookType::kRejectWithNoHandler:
+    case PromiseHookType::kHandlerAddedAfterReject:
+    case PromiseHookType::kRejectAfterResolved:
+    case PromiseHookType::kResolveAfterResolved: {
+      Environment* env = static_cast<Environment*>(arg);
+      Local<Function> cb = env->util_promise_hook_callback();
+      int argc = value.IsEmpty() ? 2 : 3;
+      Local<Value> args[] = {
+        Number::New(env->isolate(), type),
+        promise,
+        value,
+      };
+      FatalTryCatch try_catch(env);
+      USE(cb->Call(env->context(), Undefined(env->isolate()), argc, args));
+      break;
+    }
+    default:
+      return;
+  }
+}
+
+void SetPromiseHook(const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+
+  if (info[0]->IsNull()) {
+    env->RemovePromiseRejectHook(PromiseHook, env);
+    env->RemovePromiseHook(PromiseHook, env);
+  } else {
+    CHECK(info[0]->IsFunction());
+    CHECK(info[1]->IsBoolean());
+    env->set_util_promise_hook_callback(info[0].As<Function>());
+    env->AddPromiseRejectHook(PromiseHook, env);
+    if (info[1]->IsTrue()) {
+      env->AddPromiseHook(PromiseHook, env);
+    }
+  }
+}
+
+void InitializeSafe(Local<Object> target,
+                    Local<Value> unused,
+                    Local<Context> context) {
+  InitializeBase(target, unused, context);
+
+  Environment* env = Environment::GetCurrent(context);
+
+  env->SetMethod(target, "setPromiseHook", SetPromiseHook);
+}
+
 }  // namespace util
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(util, node::util::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(safe_util, node::util::InitializeSafe)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(util, node::util::InitializeUnsafe)

--- a/test/parallel/test-util-promise-hooks-async.js
+++ b/test/parallel/test-util-promise-hooks-async.js
@@ -1,0 +1,37 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+const calls = [];
+
+const makeHook = (type) => (promise, value) => {
+  calls.push({ type, promise, value });
+};
+util.createPromiseHook({
+  resolve: makeHook('resolve'),
+  rejectWithNoHandler: makeHook('rejectWithNoHandler'),
+  handlerAddedAfterReject: makeHook('handlerAddedAfterReject'),
+  rejectAfterResolved: makeHook('rejectAfterResolved'),
+  resolveAfterResolved: makeHook('resolveAfterResolved'),
+}).enable();
+
+const x = (async () => {
+  throw 'error'; // eslint-disable-line no-throw-literal
+})();
+
+const check = (item, type, value) => {
+  assert.strictEqual(item.type, type);
+  assert.strictEqual(item.value, value);
+};
+
+process.nextTick(() => {
+  x.catch(() => {});
+
+  assert.strictEqual(calls.length, 3);
+
+  check(calls[0], 'resolve', undefined);
+  check(calls[1], 'rejectWithNoHandler', 'error');
+  check(calls[2], 'handlerAddedAfterReject', undefined);
+});

--- a/test/parallel/test-util-promise-hooks.js
+++ b/test/parallel/test-util-promise-hooks.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { disableCrashOnUnhandledRejection } = require('../common');
+disableCrashOnUnhandledRejection();
+process.on('unhandledRejection', () => {});
+
+const assert = require('assert');
+
+const util = require('util');
+
+let calls = [];
+
+const makeHook = (type) => (promise, value) => {
+  calls.push({ type, promise, value });
+};
+util.createPromiseHook({
+  resolve: makeHook('resolve'),
+  rejectWithNoHandler: makeHook('rejectWithNoHandler'),
+  handlerAddedAfterReject: makeHook('handlerAddedAfterReject'),
+  rejectAfterResolved: makeHook('rejectAfterResolved'),
+  resolveAfterResolved: makeHook('resolveAfterResolved'),
+}).enable();
+
+const first = Promise.resolve('success');
+let second;
+const third = first.then(() => {
+  second = Promise.reject('error');
+  return second;
+});
+
+
+const check = (item, type, promise, value) => {
+  assert.strictEqual(item.type, type);
+  assert.strictEqual(item.promise, promise);
+  assert.strictEqual(item.value, value);
+};
+
+setTimeout(() => {
+  const fourth = third.catch(() => {});
+
+  calls = calls.filter((c) =>
+    [first, second, third, fourth].includes(c.promise));
+
+  assert.strictEqual(calls.length, 8);
+
+  check(calls[0], 'resolve', first, undefined);
+
+  check(calls[1], 'resolve', second, undefined);
+
+  check(calls[2], 'rejectWithNoHandler', second, 'error');
+
+  check(calls[3], 'resolve', third, undefined);
+
+  check(calls[4], 'handlerAddedAfterReject', second, undefined);
+
+  check(calls[5], 'resolve', third, undefined);
+
+  check(calls[6], 'rejectWithNoHandler', third, 'error');
+
+  check(calls[7], 'handlerAddedAfterReject', third, undefined);
+}, 10);


### PR DESCRIPTION
Refs https://github.com/nodejs/promises-debugging/issues/8
Closes https://github.com/nodejs/promises-debugging/issues/8

exposes env promise hooks to userland

/cc @nodejs/promises-debugging @nodejs/async_hooks @BridgeAR @ljharb

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
