### PR TITLE
Add missing require to http createSecureServer example

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1921,6 +1921,7 @@ instances.
 
 ```js
 const http2 = require('http2');
+const fs = require('fs');
 
 const options = {
   key: fs.readFileSync('server-key.pem'),


### PR DESCRIPTION
Minor docs update, adding a missing require for an example.