### PR TITLE
test: pass through stderr in benchmark tests

### DIFF
--- a/test/common/benchmark.js
+++ b/test/common/benchmark.js
@@ -20,7 +20,10 @@ function runBenchmark(name, args, env) {
 
   const mergedEnv = Object.assign({}, process.env, env);
 
-  const child = fork(runjs, argv, { env: mergedEnv, stdio: 'pipe' });
+  const child = fork(runjs, argv, {
+    env: mergedEnv,
+    stdio: ['inherit', 'pipe', 'inherit', 'ipc']
+  });
   child.stdout.setEncoding('utf8');
 
   let stdout = '';


### PR DESCRIPTION
This helps a lot with debugging failing benchmark tests,
which would otherwise just print an assertion for the
exit code (something like `+1 -0`, which yields almost no
information about a failure).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
