### PR TITLE
test: refactor cluster-net-listen-relative-path

### DIFF
--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -1,12 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
-const cluster = require('cluster');
-const net = require('net');
-const path = require('path');
-const fs = require('fs');
-
-const tmpdir = require('../common/tmpdir');
 
 if (common.isWindows)
   common.skip('On Windows named pipes live in their own ' +
@@ -14,35 +7,40 @@ if (common.isWindows)
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 
+const assert = require('assert');
+const cluster = require('cluster');
+const fs = require('fs');
+const net = require('net');
+const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
+
 // Choose a socket name such that the absolute path would exceed 100 bytes.
 const socketDir = './unix-socket-dir';
 const socketName = 'A'.repeat(100 - socketDir.length - 1);
 
-// Make sure we're not in a weird environment
-assert.strictEqual(path.resolve(socketDir, socketName).length > 100, true,
-                   'absolute socket path should be longer than 100 bytes');
+// Make sure we're not in a weird environment.
+assert.ok(path.resolve(socketDir, socketName).length > 100,
+          'absolute socket path should be longer than 100 bytes');
 
 if (cluster.isMaster) {
-  // ensure that the worker exits peacefully
+  // Ensure that the worker exits peacefully.
   tmpdir.refresh();
   process.chdir(tmpdir.path);
   fs.mkdirSync(socketDir);
-  cluster.fork().on('exit', common.mustCall(function(statusCode) {
+  cluster.fork().on('exit', common.mustCall((statusCode) => {
     assert.strictEqual(statusCode, 0);
 
-    assert.strictEqual(
-      fs.existsSync(path.join(socketDir, socketName)), false,
-      'Socket should be removed when the worker exits');
+    assert.ok(!fs.existsSync(path.join(socketDir, socketName)),
+              'Socket should be removed when the worker exits');
   }));
 } else {
   process.chdir(socketDir);
 
   const server = net.createServer(common.mustNotCall());
 
-  server.listen(socketName, common.mustCall(function() {
-    assert.strictEqual(
-      fs.existsSync(socketName), true,
-      'Socket created in CWD');
+  server.listen(socketName, common.mustCall(() => {
+    assert.ok(fs.existsSync(socketName), 'Socket created in CWD');
 
     process.disconnect();
   }));


### PR DESCRIPTION
Refactor test-cluster-net-listen-relative-path:

* Use arrow funcitons for callbacks.
* Move skip-test code closer to start of file.
* Use assert.ok() where appropriate.
* Capitalize and punctuate comments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
