### PR TITLE
n-api: guard against cond null dereference

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3782,7 +3782,7 @@ class TsFn: public node::AsyncResource {
     if (thread_count == 0 || mode == napi_tsfn_abort) {
       if (!is_closing) {
         is_closing = (mode == napi_tsfn_abort);
-        if (is_closing) {
+        if (is_closing && max_queue_size > 0) {
           cond->Signal(lock);
         }
         if (uv_async_send(&async) != 0) {
@@ -3872,7 +3872,9 @@ class TsFn: public node::AsyncResource {
         if (size == 0) {
           if (thread_count == 0) {
             is_closing = true;
-            cond->Signal(lock);
+            if (max_queue_size > 0) {
+              cond->Signal(lock);
+            }
             CloseHandlesAndMaybeDelete();
           } else {
             if (uv_idle_stop(&idle) != 0) {
@@ -3939,7 +3941,9 @@ class TsFn: public node::AsyncResource {
     if (set_closing) {
       node::Mutex::ScopedLock lock(this->mutex);
       is_closing = true;
-      cond->Signal(lock);
+      if (max_queue_size > 0) {
+        cond->Signal(lock);
+      }
     }
     if (handles_closing) {
       return;

--- a/test/addons-napi/test_threadsafe_function/test.js
+++ b/test/addons-napi/test_threadsafe_function/test.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'child') {
     if (callCount === 2) {
       binding.Unref();
     }
-  }, false /* abort */, true /* launchSecondary */);
+  }, false /* abort */, true /* launchSecondary */, +process.argv[3]);
 
   // Release the thread-safe function from the main thread so that it may be
   // torn down via the environment cleanup handler.
@@ -37,6 +37,7 @@ function testWithJSMarshaller({
   threadStarter,
   quitAfter,
   abort,
+  maxQueueSize,
   launchSecondary }) {
   return new Promise((resolve) => {
     const array = [];
@@ -49,7 +50,7 @@ function testWithJSMarshaller({
           }), !!abort);
         });
       }
-    }, !!abort, !!launchSecondary);
+    }, !!abort, !!launchSecondary, maxQueueSize);
     if (threadStarter === 'StartThreadNonblocking') {
       // Let's make this thread really busy for a short while to ensure that
       // the queue fills and the thread receives a napi_queue_full.
@@ -57,6 +58,24 @@ function testWithJSMarshaller({
       while (Date.now() - start < 200);
     }
   });
+}
+
+function testUnref(queueSize) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    const child = fork(__filename, ['child', queueSize], {
+      stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(output.match(/\S+/g));
+      } else {
+        reject(new Error('Child process died with code ' + code));
+      }
+    });
+    child.stdout.on('data', (data) => (output += data.toString()));
+  })
+  .then((result) => assert.strictEqual(result.indexOf(0), -1));
 }
 
 new Promise(function testWithoutJSMarshaller(resolve) {
@@ -73,13 +92,23 @@ new Promise(function testWithoutJSMarshaller(resolve) {
         }), false);
       });
     }
-  }, false /* abort */, false /* launchSecondary */);
+  }, false /* abort */, false /* launchSecondary */, binding.MAX_QUEUE_SIZE);
 })
 
 // Start the thread in blocking mode, and assert that all values are passed.
 // Quit after it's done.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: binding.ARRAY_LENGTH
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode with an infinite queue, and assert that all
+// values are passed. Quit after it's done.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: 0,
   quitAfter: binding.ARRAY_LENGTH
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
@@ -88,6 +117,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 // Quit after it's done.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
   quitAfter: binding.ARRAY_LENGTH
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
@@ -96,6 +126,16 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 // Quit early, but let the thread finish.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  quitAfter: 1
+}))
+.then((result) => assert.deepStrictEqual(result, expectedArray))
+
+// Start the thread in blocking mode with an infinite queue, and assert that all
+// values are passed. Quit early, but let the thread finish.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  maxQueueSize: 0,
   quitAfter: 1
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
@@ -104,6 +144,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 // Quit early, but let the thread finish.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
   quitAfter: 1
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
@@ -114,6 +155,7 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
   quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
   launchSecondary: true
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
@@ -124,15 +166,27 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',
   quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
   launchSecondary: true
 }))
 .then((result) => assert.deepStrictEqual(result, expectedArray))
 
 // Start the thread in blocking mode, and assert that it could not finish.
-// Quit early and aborting.
+// Quit early by aborting.
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThread',
   quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
+  abort: true
+}))
+.then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+// Start the thread in blocking mode with an infinite queue, and assert that it
+// could not finish. Quit early by aborting.
+.then(() => testWithJSMarshaller({
+  threadStarter: 'StartThread',
+  quitAfter: 1,
+  maxQueueSize: 0,
   abort: true
 }))
 .then((result) => assert.strictEqual(result.indexOf(0), -1))
@@ -142,25 +196,13 @@ new Promise(function testWithoutJSMarshaller(resolve) {
 .then(() => testWithJSMarshaller({
   threadStarter: 'StartThreadNonblocking',
   quitAfter: 1,
+  maxQueueSize: binding.MAX_QUEUE_SIZE,
   abort: true
 }))
 .then((result) => assert.strictEqual(result.indexOf(0), -1))
 
 // Start a child process to test rapid teardown
-.then(() => {
-  return new Promise((resolve, reject) => {
-    let output = '';
-    const child = fork(__filename, ['child'], {
-      stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
-    });
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(output.match(/\S+/g));
-      } else {
-        reject(new Error('Child process died with code ' + code));
-      }
-    });
-    child.stdout.on('data', (data) => (output += data.toString()));
-  });
-})
-.then((result) => assert.strictEqual(result.indexOf(0), -1));
+.then(() => testUnref(binding.MAX_QUEUE_SIZE))
+
+// Start a child process with an infinite queue to test rapid teardown
+.then(() => testUnref(0));


### PR DESCRIPTION
A condition variable is only created by the thread-safe function if the
queue size is set to something larger than zero. This adds tests for the
case where the queue size is zero.

Fixes: https://github.com/nodejs/help/issues/1387

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
