### PR TITLE
tools: make getnodeversion.py python3-compatible

### DIFF
--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -17,4 +17,4 @@ for line in f:
   if re.match('^#define NODE_PATCH_VERSION', line):
     patch = line.split()[2]
 
-print '%(major)s.%(minor)s.%(patch)s'% locals()
+print('%(major)s.%(minor)s.%(patch)s'% locals())


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

When the system's `python` is Python 3, this script which is used during `make lint` failed with a syntax error. This adds `print` braces so it is compatible with both Python 2 and 3.