### PR TITLE
doc: add req for sec wg review in some cases

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -381,13 +381,21 @@ A Pull Request should be raised and approved like any other change.
 
 ### Additions to the Cryptography and Security APIs
 
-Semver-minor commits that add or change cryptograpy/security APIs should be
-treated with extra care. Due to the potential impact, it is important that
-these APIs be constructed to reduce the potential for incorrect
-usage.
+Semver-minor commits that add or change cryptograpy APIs and Security APIs
+should be treated with extra care. Due to the potential impact, it is
+important that these APIs be constructed to reduce the potential for
+incorrect usage.
 
-These commits must have an approval from at least one member from the 
-[security working group](https://github.com/nodejs/security-wg).
+Semver-minor commits changing or adding cryptography or security APIs
+should be made visible to the crypto team and the security working group
+through an @nodejs/security-wg and @nodejs/crypto mention in the PR.
+
+For Semver-minor commits changing cryptography APIs, they must have
+an approval from at least one member from the crypto team.
+
+For Semver-minor commits changing Security API's(other than those
+related to cryptography) must have an approval from at least
+one member from the [security working group](https://github.com/nodejs/security-wg).
 
 ### Introducing New Modules
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -20,6 +20,7 @@
     - [Breaking Changes to Internal Elements](#breaking-changes-to-internal-elements)
     - [When Breaking Changes Actually Break Things](#when-breaking-changes-actually-break-things)
       - [Reverting commits](#reverting-commits)
+  - [Additions to the Cryptography and Security APIs](#additions-to-the-cryptography-and-security-apis)
   - [Introducing New Modules](#introducing-new-modules)
   - [Deprecations](#deprecations)
   - [Involving the TSC](#involving-the-tsc)
@@ -377,6 +378,16 @@ Commits are reverted with `git revert <HASH>`, or `git revert <FROM>..<TO>` for
 multiple commits. Commit metadata and the reason for the revert should be
 appended. Commit message rules about line length and subsystem can be ignored.
 A Pull Request should be raised and approved like any other change.
+
+### Additions to the Cryptography and Security APIs
+
+Semver-minor commits that add or change cryptograpy/security APIs should be
+treated with extra care. Due to the potential impact, it is important that
+these APIs be constructed to reduce the potential for incorrect
+usage.
+
+These commits must have an approval from at least one member from the 
+[security working group](https://github.com/nodejs/security-wg).
 
 ### Introducing New Modules
 


### PR DESCRIPTION
Some recent dicsussions point to it being
a good idea to require reviews from the security-wg
for security related PRs. See https://github.com/nodejs/node/issues/21766

Add this requirement to the collaborator guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
