### PR TITLE
tls: warn on NODE_TLS_REJECT_UNAUTHORIZED = '0'

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1098,14 +1098,25 @@ function onConnectEnd() {
   }
 }
 
+let warnOnAllowUnauthorized = true;
+
 // Arguments: [port,] [host,] [options,] [cb]
 exports.connect = function connect(...args) {
   args = normalizeConnectArgs(args);
   var options = args[0];
   var cb = args[1];
+  const allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
+
+  if (allowUnauthorized && warnOnAllowUnauthorized) {
+    warnOnAllowUnauthorized = false;
+    process.emitWarning('Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
+                        'environment variable to \'0\' makes TLS connections ' +
+                        'and HTTPS requests insecure by disabling ' +
+                        'certificate verification.');
+  }
 
   var defaults = {
-    rejectUnauthorized: '0' !== process.env.NODE_TLS_REJECT_UNAUTHORIZED,
+    rejectUnauthorized: !allowUnauthorized,
     ciphers: tls.DEFAULT_CIPHERS,
     checkServerIdentity: tls.checkServerIdentity,
     minDHSize: 1024

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -28,6 +28,14 @@ if (!common.hasCrypto)
 // disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+common.expectWarning(
+  'Warning',
+  'Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to \'0\' ' +
+  'makes TLS connections and HTTPS requests insecure by disabling ' +
+  'certificate verification.',
+  common.noWarnCode
+);
+
 const assert = require('assert');
 const https = require('https');
 


### PR DESCRIPTION
Warn on the first request that sets the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `'0'`.

Refs: https://github.com/nodejs/node/issues/21774

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
