### PR TITLE
util: Fix number format for `pad`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1326,7 +1326,7 @@ function isPrimitive(arg) {
 }
 
 function pad(n) {
-  return n < 10 ? `0${n.toString(10)}` : n.toString(10);
+  return n.toString().padStart(2, '0');
 }
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',


### PR DESCRIPTION
`pad` is now using `toString(10)`, actually we don't need to do this. As for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString, `toString(N)` is a radix converter, which isn't proper here for time conversion.

PS：Since this is a private function with `n` a decimal number, so I suspect the code writer wanted to use `toString(10)` to convert a number to a two-digit number, and if the number < 10, a `0` is automatically added before the number itself. Obveriously this isn't a right way. Though the final answer is right.

Hope you all take what I mean.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
