### PR TITLE
doc : Fix incorrect method name

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -198,7 +198,7 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
     });
   // Since module has no dependencies, the linker function will never be called.
   await module.link(() => {});
-  module.initialize();
+  module.instantiate();
   await module.evaluate();
 
   // Now, Object.prototype.secret will be equal to 42.


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/21904

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
