### PR TITLE
doc: fix incorrect method invocation on vm.Module instance

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -198,7 +198,7 @@ const contextifiedSandbox = vm.createContext({ secret: 42 });
     });
   // Since module has no dependencies, the linker function will never be called.
   await module.link(() => {});
-  module.initialize();
+  module.instantiate();
   await module.evaluate();
 
   // Now, Object.prototype.secret will be equal to 42.


### PR DESCRIPTION
In the VM docs, under section `Constructor: new vm.Module`, the code
example incorrectly uses `module.initialize()`.

Change it to the correct method `module.instantiate()`.

Fixes: https://github.com/nodejs/node/issues/21904

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
