### PR TITLE
util: Adding warnings when NODE_DEBUG is set as http/http2

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -306,11 +306,23 @@ if (process.env.NODE_DEBUG) {
   debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
 }
 
+// Emits warning when user sets
+// NODE_DEBUG=http or NODE_DEBUG=http2.
+function emitWarningIfNeeded(set) {
+  if ('HTTP' === set || 'HTTP2' === set) {
+    process.emitWarning('Setting the NODE_DEBUG environment variable ' +
+      'to \'' + set.toLowerCase() + '\' can expose sensitive ' +
+      'data (such as passwords, tokens and authentication headers) ' +
+      'in the resulting log.');
+  }
+}
+
 function debuglog(set) {
   set = set.toUpperCase();
   if (!debugs[set]) {
     if (debugEnvRegex.test(set)) {
       const pid = process.pid;
+      emitWarningIfNeeded(set);
       debugs[set] = function debug() {
         const msg = exports.format.apply(exports, arguments);
         console.error('%s %d: %s', set, pid, msg);

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -30,6 +30,7 @@ const options = {
   port: undefined
 };
 
+process.env.NODE_DEBUG = 'http';
 // start a tcp server that closes incoming connections immediately
 const server = net.createServer(function(client) {
   client.destroy();

--- a/test/parallel/test-http-debug.js
+++ b/test/parallel/test-http-debug.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const path = require('path');
+
+process.env.NODE_DEBUG = 'http';
+const { stderr } = child_process.spawnSync(process.execPath, [
+  path.resolve(__dirname, 'test-http-conn-reset.js')
+], { encoding: 'utf8' });
+
+assert(stderr.match(/Setting the NODE_DEBUG environment variable to 'http' can expose sensitive data \(such as passwords, tokens and authentication headers\) in the resulting log\./),
+       stderr);

--- a/test/parallel/test-http2-debug.js
+++ b/test/parallel/test-http2-debug.js
@@ -7,10 +7,13 @@ const child_process = require('child_process');
 const path = require('path');
 
 process.env.NODE_DEBUG_NATIVE = 'http2';
+process.env.NODE_DEBUG = 'http2';
 const { stdout, stderr } = child_process.spawnSync(process.execPath, [
   path.resolve(__dirname, 'test-http2-ping.js')
 ], { encoding: 'utf8' });
 
+assert(stderr.match(/Setting the NODE_DEBUG environment variable to 'http2' can expose sensitive data \(such as passwords, tokens and authentication headers\) in the resulting log\./),
+       stderr);
 assert(stderr.match(/Http2Session client \(\d+\) handling data frame for stream \d+/),
        stderr);
 assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] reading starting/),


### PR DESCRIPTION
I have fixed the issue https://github.com/nodejs/node/issues/21774 (related to `NODE_DEBUG=http` part). There are couple of things I wanted to understand here:

1. Not sure `util.js` is the right place for inserting this check. This should be fine I guess. Please let me know otherwise. 
2. The test case, that I had written is actually failing. I debugged it, looks like for some reason `debugEnvRegex` `test` is not working when we set the `NODE_DEBUG` from code, so warning is not getting triggered. I did `make -j4` and tested manually with build, and I could able to see warning like the following:

```
(node:75788) Warning: Setting the NODE_DEBUG environment variable to 'http' can exposes sensitive data of your application.
```

So somewhere, I'm making a mistake in my test. 

Thanks for your time on this. 

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)