### PR TITLE
build: remove redundant Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,11 +612,6 @@ apiassets = $(subst api_assets,api/assets,$(addprefix out/,$(wildcard doc/api_as
 .PHONY: doc-only
 doc-only: tools/doc/node_modules \
 	$(apidoc_dirs) $(apiassets)  ## Builds the docs with the local or the global Node.js binary.
-# If it's a source tarball, assets are already in doc/api/assets,
-# no need to install anything, we have already copied the docs over
-	if [ ! -d doc/api/assets ]; then \
-		$(MAKE) tools/doc/node_modules/js-yaml/package.json; \
-	fi;
 	@$(MAKE) out/doc/api/all.html out/doc/api/all.json
 
 .PHONY: doc
@@ -654,9 +649,6 @@ available-node = \
 
 run-npm-install = $(PWD)/$(NPM) install --production --no-package-lock
 run-npm-ci = $(PWD)/$(NPM) ci
-
-tools/doc/node_modules/js-yaml/package.json:
-	cd tools/doc && $(call available-node,$(run-npm-install))
 
 gen-json = tools/doc/generate.js --format=json $< > $@
 gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html \


### PR DESCRIPTION
The only target that uses the
`tools/doc/node_modules/js-yaml/package.json` target is `doc-only`. As a
result of a recent change, it has `tools/doc/node_modules` as a
prerequisite, which does the exact same npm install as
`tools/doc/node_modules/js-yaml/package.json`. Remove
`tools/doc/node_modules/js-yaml/package.json` as unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
