### PR TITLE
http2: release request()'s "connect" event listener after it runs

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1426,7 +1426,7 @@ class ClientHttp2Session extends Http2Session {
 
     const onConnect = requestOnConnect.bind(stream, headersList, options);
     if (this.connecting) {
-      this.on('connect', onConnect);
+      this.once('connect', onConnect);
     } else {
       onConnect();
     }

--- a/test/parallel/test-http2-request-remove-connect-listener.js
+++ b/test/parallel/test-http2-request-remove-connect-listener.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond();
+  stream.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  client.once('connect', common.mustCall());
+
+  req.on('response', common.mustCall(() => {
+    assert.strictEqual(client.listenerCount('connect'), 0);
+  }));
+  req.on('close', common.mustCall(() => {
+    server.close();
+    client.close();
+  }));
+}));


### PR DESCRIPTION
The `Http2Session#request()` method internally listens to the "connect"
event if the session has not yet established a connection so that the
actual request can be sent after the connection has been established.

This commit removes the event listener after it runs and carries out
the request and is no longer needed. In practice this shouldn't affect
the behavior of the session object since the "connect" event fires only
once anyway, but removing the listener releases its references. The
rest of this class subscribes to the "connect" event with `once`
instead of `on` as well.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
