### PR TITLE
inspector: fixed V8InspectorClient::currentTimeMS method

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -187,8 +187,6 @@ static int StartDebugSignalHandler() {
 #endif  // _WIN32
 
 
-// Used in NodeInspectorClient::currentTimeMS() below.
-const int NANOS_PER_MSEC = 1000000;
 const int CONTEXT_GROUP_ID = 1;
 
 class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
@@ -593,7 +591,7 @@ class NodeInspectorClient : public V8InspectorClient {
   }
 
   double currentTimeMS() override {
-    return uv_hrtime() * 1.0 / NANOS_PER_MSEC;
+    return env_->isolate_data()->platform()->CurrentClockTimeMillis();
   }
 
   node::Environment* env_;


### PR DESCRIPTION
On inspector side inside V8 we assume that this method should
return number of ms since epoch. It is important for different inspector parts,
e.g. timestamp of reported console messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
