### PR TITLE
test: run ESM tests in parallel

### DIFF
--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -3,7 +3,6 @@
 import common from './index.js';
 
 const {
-  PORT,
   isMainThread,
   isWindows,
   isWOW64,
@@ -63,7 +62,6 @@ const {
 } = common;
 
 export {
-  PORT,
   isMainThread,
   isWindows,
   isWOW64,

--- a/test/es-module/testcfg.py
+++ b/test/es-module/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.SimpleTestConfiguration(context, root, 'es-module')
+  return testpy.ParallelTestConfiguration(context, root, 'es-module')


### PR DESCRIPTION
This reduces `make jstest` runs by 4-5 seconds on my machine (12 cores)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
