### PR TITLE
tools: build API TOC using raw headers

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -340,8 +340,10 @@ function buildToc({ filename }) {
 
       depth = node.depth;
       const realFilename = path.basename(realFilenames[0], '.md');
-      const headingText = node.children.map((child) => child.value)
-        .join().trim();
+      const headingText = node.children.map((child) =>
+        file.contents.slice(child.position.start.offset,
+                            child.position.end.offset)
+      ).join('').trim();
       const id = getId(`${realFilename}_${headingText}`, idCounters);
 
       const hasStability = node.stability !== undefined;


### PR DESCRIPTION
Markdown interprets the syntax for optional arguments as a form of a link,
so instead of trying to build up the contents using the node value, 
grab the raw original markup instead.

Fixes regression noted in https://github.com/nodejs/node/pull/21490#issuecomment-406785023

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
