### PR TITLE
test: don't fail http2 abort test if 'data' is called multiple times

### DIFF
--- a/test/parallel/test-http2-respond-with-file-connection-abort.js
+++ b/test/parallel/test-http2-respond-with-file-connection-abort.js
@@ -24,7 +24,7 @@ server.listen(0, common.mustCall(() => {
   const req = client.request();
 
   req.on('response', common.mustCall(() => {}));
-  req.on('data', common.mustCallAtLeast(() => {
+  req.once('data', common.mustCall(() => {
     net.Socket.prototype.destroy.call(client.socket);
     server.close();
   }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I'm seeing a regression in `make test` on `master` on macOS High Sierra Version 10.13.5.  The error I'm seeing is:

```
=== release test-http2-respond-with-file-connection-abort ===                  
Path: parallel/test-http2-respond-with-file-connection-abort
Mismatched <anonymous> function calls. Expected exactly 1, actual 2.
    at Object.exports.mustCall (/Users/rubys/git/node/test/common/index.js:427:10)
    at Http2Server.server.listen.common.mustCall (/Users/rubys/git/node/test/parallel/test-http2-respond-with-file-connection-abort.js:25:25)
    at Http2Server.<anonymous> (/Users/rubys/git/node/test/common/index.js:467:15)
    at Object.onceWrapper (events.js:273:13)
    at Http2Server.emit (events.js:182:13)
    at emitListeningNT (net.js:1370:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:266:19)
(node:20069) ExperimentalWarning: The http2 module is an experimental API.
Command: out/Release/node /Users/rubys/git/node/test/parallel/test-http2-respond-with-file-connection-abort.js
[02:54|% 100|+ 2354|-   1]: Done   
```

It seems that the test case is assuming that a `data` event will be emitted exactly once, but I see no reason why that should be guaranteed to be the case.

With this fix, the new results are:

```
[02:55|% 100|+ 2355|-   0]: Done                                               

```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
