### PR TITLE
src: remove calls to deprecated v8 functions (NewFromUtf8)

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1926,7 +1926,9 @@ void CanonicalizeIP(const FunctionCallbackInfo<Value>& args) {
   char canonical_ip[INET6_ADDRSTRLEN];
   const int af = (rc == 4 ? AF_INET : AF_INET6);
   CHECK_EQ(0, uv_inet_ntop(af, &result, canonical_ip, sizeof(canonical_ip)));
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, canonical_ip));
+  v8::NewStringType type = v8::NewStringType::kNormal;
+  v8::MaybeLocal<String> val = String::NewFromUtf8(isolate, canonical_ip, type);
+  args.GetReturnValue().Set(val.ToLocalChecked());
 }
 
 void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1926,9 +1926,9 @@ void CanonicalizeIP(const FunctionCallbackInfo<Value>& args) {
   char canonical_ip[INET6_ADDRSTRLEN];
   const int af = (rc == 4 ? AF_INET : AF_INET6);
   CHECK_EQ(0, uv_inet_ntop(af, &result, canonical_ip, sizeof(canonical_ip)));
-  v8::NewStringType type = v8::NewStringType::kNormal;
-  v8::MaybeLocal<String> val = String::NewFromUtf8(isolate, canonical_ip, type);
-  args.GetReturnValue().Set(val.ToLocalChecked());
+  v8::Local<String> val = String::NewFromUtf8(isolate, canonical_ip,
+      v8::NewStringType::kNormal).ToLocalChecked();
+  args.GetReturnValue().Set(val);
 }
 
 void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -66,18 +66,20 @@ Local<Value> ErrnoException(Isolate* isolate,
 }
 
 static Local<String> StringFromPath(Isolate* isolate, const char* path) {
-  v8::NewStringType type = v8::NewStringType::kNormal;
 #ifdef _WIN32
   if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
     return String::Concat(FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
-                          String::NewFromUtf8(isolate, path + 8, type)
+                          String::NewFromUtf8(isolate, path + 8,
+                                              v8::NewStringType::kNormal)
                               .ToLocalChecked());
   } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-    return String::NewFromUtf8(isolate, path + 4, type).ToLocalChecked();
+    return String::NewFromUtf8(isolate, path + 4, v8::NewStringType::kNormal)
+        .ToLocalChecked();
   }
 #endif
 
-  return String::NewFromUtf8(isolate, path, type).ToLocalChecked();
+  return String::NewFromUtf8(isolate, path, v8::NewStringType::kNormal)
+      .ToLocalChecked();
 }
 
 
@@ -182,13 +184,13 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   }
   Local<String> message = OneByteString(env->isolate(), msg);
 
-  v8::NewStringType type = v8::NewStringType::kNormal;
   if (path) {
     Local<String> cons1 =
         String::Concat(message, FIXED_ONE_BYTE_STRING(isolate, " '"));
     Local<String> cons2 =
         String::Concat(cons1,
-            String::NewFromUtf8(isolate, path, type).ToLocalChecked());
+            String::NewFromUtf8(isolate, path, v8::NewStringType::kNormal)
+                .ToLocalChecked());
     Local<String> cons3 =
         String::Concat(cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
     e = Exception::Error(cons3);
@@ -201,7 +203,8 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
   if (path != nullptr) {
     obj->Set(env->path_string(),
-        String::NewFromUtf8(isolate, path, type).ToLocalChecked());
+             String::NewFromUtf8(isolate, path, v8::NewStringType::kNormal)
+                 .ToLocalChecked());
   }
 
   if (syscall != nullptr) {

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -39,8 +39,8 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = String::NewFromUtf8(
-        env->isolate(), path, v8::NewStringType::kNormal).ToLocalChecked();
+    path_string = String::NewFromUtf8(env->isolate(), path,
+        v8::NewStringType::kNormal).ToLocalChecked();
   }
 
   if (path_string.IsEmpty() == false) {
@@ -66,17 +66,18 @@ Local<Value> ErrnoException(Isolate* isolate,
 }
 
 static Local<String> StringFromPath(Isolate* isolate, const char* path) {
+  v8::NewStringType type = v8::NewStringType::kNormal;
 #ifdef _WIN32
   if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-    v8::NewStringType type = v8::NewStringType::kNormal;
     return String::Concat(FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
-                          String::NewFromUtf8(isolate, path + 8));
+                          String::NewFromUtf8(isolate, path + 8, type)
+                              .ToLocalChecked());
   } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-    return String::NewFromUtf8(isolate, path + 4);
+    return String::NewFromUtf8(isolate, path + 4, type).ToLocalChecked();
   }
 #endif
 
-  return String::NewFromUtf8(isolate, path, v8::NewStringType::kNormal).ToLocalChecked();
+  return String::NewFromUtf8(isolate, path, type).ToLocalChecked();
 }
 
 
@@ -181,11 +182,13 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   }
   Local<String> message = OneByteString(env->isolate(), msg);
 
+  v8::NewStringType type = v8::NewStringType::kNormal;
   if (path) {
     Local<String> cons1 =
         String::Concat(message, FIXED_ONE_BYTE_STRING(isolate, " '"));
     Local<String> cons2 =
-        String::Concat(cons1, String::NewFromUtf8(isolate, path));
+        String::Concat(cons1,
+            String::NewFromUtf8(isolate, path, type).ToLocalChecked());
     Local<String> cons3 =
         String::Concat(cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
     e = Exception::Error(cons3);
@@ -197,7 +200,8 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   obj->Set(env->errno_string(), Integer::New(isolate, errorno));
 
   if (path != nullptr) {
-    obj->Set(env->path_string(), String::NewFromUtf8(isolate, path));
+    obj->Set(env->path_string(),
+        String::NewFromUtf8(isolate, path, type).ToLocalChecked());
   }
 
   if (syscall != nullptr) {

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -39,7 +39,8 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = String::NewFromUtf8(env->isolate(), path);
+    path_string = String::NewFromUtf8(
+        env->isolate(), path, v8::NewStringType::kNormal).ToLocalChecked();
   }
 
   if (path_string.IsEmpty() == false) {
@@ -67,6 +68,7 @@ Local<Value> ErrnoException(Isolate* isolate,
 static Local<String> StringFromPath(Isolate* isolate, const char* path) {
 #ifdef _WIN32
   if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
+    v8::NewStringType type = v8::NewStringType::kNormal;
     return String::Concat(FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
                           String::NewFromUtf8(isolate, path + 8));
   } else if (strncmp(path, "\\\\?\\", 4) == 0) {
@@ -74,7 +76,7 @@ static Local<String> StringFromPath(Isolate* isolate, const char* path) {
   }
 #endif
 
-  return String::NewFromUtf8(isolate, path);
+  return String::NewFromUtf8(isolate, path, v8::NewStringType::kNormal).ToLocalChecked();
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -965,7 +965,8 @@ void AppendExceptionLine(Environment* env,
   arrow[off] = '\n';
   arrow[off + 1] = '\0';
 
-  Local<String> arrow_str = String::NewFromUtf8(env->isolate(), arrow);
+  Local<String> arrow_str = String::NewFromUtf8(env->isolate(), arrow,
+      v8::NewStringType::kNormal).ToLocalChecked();
 
   const bool can_set_arrow = !arrow_str.IsEmpty() && !err_obj.IsEmpty();
   // If allocating arrow_str failed, print it out. There's not much else to do.
@@ -1742,7 +1743,8 @@ static void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> module = Object::New(env->isolate());
   Local<Object> exports = Object::New(env->isolate());
-  Local<String> exports_prop = String::NewFromUtf8(env->isolate(), "exports");
+  Local<String> exports_prop = String::NewFromUtf8(env->isolate(), "exports",
+      v8::NewStringType::kNormal).ToLocalChecked();
   module->Set(exports_prop, exports);
 
   if (mod->nm_context_register_func != nullptr) {
@@ -1765,7 +1767,8 @@ static void ProcessTitleGetter(Local<Name> property,
                                const PropertyCallbackInfo<Value>& info) {
   char buffer[512];
   uv_get_process_title(buffer, sizeof(buffer));
-  info.GetReturnValue().Set(String::NewFromUtf8(info.GetIsolate(), buffer));
+  info.GetReturnValue().Set(String::NewFromUtf8(info.GetIsolate(), buffer,
+      v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 
@@ -1790,7 +1793,8 @@ static void EnvGetter(Local<Name> property,
   node::Utf8Value key(isolate, property);
   const char* val = getenv(*key);
   if (val) {
-    return info.GetReturnValue().Set(String::NewFromUtf8(isolate, val));
+    return info.GetReturnValue().Set(String::NewFromUtf8(isolate, val,
+        v8::NewStringType::kNormal).ToLocalChecked());
   }
 #else  // _WIN32
   node::TwoByteValue key(isolate, property);
@@ -1918,8 +1922,8 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
     const int length = s ? s - var : strlen(var);
     argv[idx] = String::NewFromUtf8(isolate,
                                     var,
-                                    String::kNormalString,
-                                    length);
+                                    v8::NewStringType::kNormal,
+                                    length).ToLocalChecked();
     if (++idx >= arraysize(argv)) {
       fn->Call(ctx, envarr, idx, argv).ToLocalChecked();
       idx = 0;
@@ -2196,14 +2200,16 @@ void SetupProcessObject(Environment* env,
   // process.argv
   Local<Array> arguments = Array::New(env->isolate(), argc);
   for (int i = 0; i < argc; ++i) {
-    arguments->Set(i, String::NewFromUtf8(env->isolate(), argv[i]));
+    arguments->Set(i, String::NewFromUtf8(env->isolate(), argv[i],
+        v8::NewStringType::kNormal).ToLocalChecked());
   }
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "argv"), arguments);
 
   // process.execArgv
   Local<Array> exec_arguments = Array::New(env->isolate(), exec_argc);
   for (int i = 0; i < exec_argc; ++i) {
-    exec_arguments->Set(i, String::NewFromUtf8(env->isolate(), exec_argv[i]));
+    exec_arguments->Set(i, String::NewFromUtf8(env->isolate(), exec_argv[i],
+        v8::NewStringType::kNormal).ToLocalChecked());
   }
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "execArgv"),
                exec_arguments);
@@ -2235,7 +2241,8 @@ void SetupProcessObject(Environment* env,
   if (eval_string) {
     READONLY_PROPERTY(process,
                       "_eval",
-                      String::NewFromUtf8(env->isolate(), eval_string));
+                      String::NewFromUtf8(env->isolate(), eval_string,
+                          v8::NewStringType::kNormal).ToLocalChecked());
   }
 
   // -p, --print
@@ -2258,7 +2265,9 @@ void SetupProcessObject(Environment* env,
     Local<Array> array = Array::New(env->isolate());
     for (unsigned int i = 0; i < preload_modules.size(); ++i) {
       Local<String> module = String::NewFromUtf8(env->isolate(),
-                                                 preload_modules[i].c_str());
+                                                 preload_modules[i].c_str(),
+                                                 v8::NewStringType::kNormal)
+                                 .ToLocalChecked();
       array->Set(i, module);
     }
     READONLY_PROPERTY(process,
@@ -2343,10 +2352,11 @@ void SetupProcessObject(Environment* env,
   if (uv_exepath(exec_path, &exec_path_len) == 0) {
     exec_path_value = String::NewFromUtf8(env->isolate(),
                                           exec_path,
-                                          String::kNormalString,
-                                          exec_path_len);
+                                          v8::NewStringType::kNormal,
+                                          exec_path_len).ToLocalChecked();
   } else {
-    exec_path_value = String::NewFromUtf8(env->isolate(), argv[0]);
+    exec_path_value = String::NewFromUtf8(env->isolate(), argv[0],
+        v8::NewStringType::kNormal).ToLocalChecked();
   }
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
                exec_path_value);

--- a/src/node.cc
+++ b/src/node.cc
@@ -2352,11 +2352,11 @@ void SetupProcessObject(Environment* env,
   if (uv_exepath(exec_path, &exec_path_len) == 0) {
     exec_path_value = String::NewFromUtf8(env->isolate(),
                                           exec_path,
-                                          v8::NewStringType::kNormal,
+                                          v8::NewStringType::kInternalized,
                                           exec_path_len).ToLocalChecked();
   } else {
     exec_path_value = String::NewFromUtf8(env->isolate(), argv[0],
-        v8::NewStringType::kNormal).ToLocalChecked();
+        v8::NewStringType::kInternalized).ToLocalChecked();
   }
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
                exec_path_value);

--- a/src/node.h
+++ b/src/node.h
@@ -303,7 +303,8 @@ NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
     v8::Isolate* isolate = target->GetIsolate();                              \
     v8::Local<v8::Context> context = isolate->GetCurrentContext();            \
     v8::Local<v8::String> constant_name =                                     \
-        v8::String::NewFromUtf8(isolate, #constant);                          \
+        v8::String::NewFromUtf8(isolate, #constant,                           \
+            v8::NewStringType::kNormal).ToLocalChecked();                     \
     v8::Local<v8::Number> constant_value =                                    \
         v8::Number::New(isolate, static_cast<double>(constant));              \
     v8::PropertyAttribute constant_attributes =                               \
@@ -344,7 +345,8 @@ inline void NODE_SET_METHOD(v8::Local<v8::Template> recv,
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
                                                                 callback);
-  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
+  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
+      v8::NewStringType::kNormal).ToLocalChecked();
   t->SetClassName(fn_name);
   recv->Set(fn_name, t);
 }
@@ -358,7 +360,8 @@ inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
   v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
                                                                 callback);
   v8::Local<v8::Function> fn = t->GetFunction();
-  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
+  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
+      v8::NewStringType::kNormal).ToLocalChecked();
   fn->SetName(fn_name);
   recv->Set(fn_name, fn);
 }
@@ -374,7 +377,8 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
   v8::Local<v8::Signature> s = v8::Signature::New(isolate, recv);
   v8::Local<v8::FunctionTemplate> t =
       v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), s);
-  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
+  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
+      v8::NewStringType::kNormal).ToLocalChecked();
   t->SetClassName(fn_name);
   recv->PrototypeTemplate()->Set(fn_name, t);
 }

--- a/src/node.h
+++ b/src/node.h
@@ -304,7 +304,7 @@ NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
     v8::Local<v8::Context> context = isolate->GetCurrentContext();            \
     v8::Local<v8::String> constant_name =                                     \
         v8::String::NewFromUtf8(isolate, #constant,                           \
-            v8::NewStringType::kNormal).ToLocalChecked();                     \
+            v8::NewStringType::kInternalized).ToLocalChecked();               \
     v8::Local<v8::Number> constant_value =                                    \
         v8::Number::New(isolate, static_cast<double>(constant));              \
     v8::PropertyAttribute constant_attributes =                               \
@@ -346,7 +346,7 @@ inline void NODE_SET_METHOD(v8::Local<v8::Template> recv,
   v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
                                                                 callback);
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
-      v8::NewStringType::kNormal).ToLocalChecked();
+      v8::NewStringType::kInternalized).ToLocalChecked();
   t->SetClassName(fn_name);
   recv->Set(fn_name, t);
 }
@@ -361,7 +361,7 @@ inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
                                                                 callback);
   v8::Local<v8::Function> fn = t->GetFunction();
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
-      v8::NewStringType::kNormal).ToLocalChecked();
+      v8::NewStringType::kInternalized).ToLocalChecked();
   fn->SetName(fn_name);
   recv->Set(fn_name, fn);
 }
@@ -378,7 +378,7 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
   v8::Local<v8::FunctionTemplate> t =
       v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), s);
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
-      v8::NewStringType::kNormal).ToLocalChecked();
+      v8::NewStringType::kInternalized).ToLocalChecked();
   t->SetClassName(fn_name);
   recv->PrototypeTemplate()->Set(fn_name, t);
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1569,8 +1569,8 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     BIO_get_mem_ptr(bio.get(), &mem);
     info->Set(context, env->subject_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
-                                  String::kNormalString,
-                                  mem->length)).FromJust();
+                                  NewStringType::kNormal,
+                                  mem->length).ToLocalChecked()).FromJust();
   }
   USE(BIO_reset(bio.get()));
 
@@ -1579,8 +1579,8 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     BIO_get_mem_ptr(bio.get(), &mem);
     info->Set(context, env->issuer_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
-                                  String::kNormalString,
-                                  mem->length)).FromJust();
+                                  NewStringType::kNormal,
+                                  mem->length).ToLocalChecked()).FromJust();
   }
   USE(BIO_reset(bio.get()));
 
@@ -1607,8 +1607,8 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     BIO_get_mem_ptr(bio.get(), &mem);
     info->Set(context, keys[i],
               String::NewFromUtf8(env->isolate(), mem->data,
-                                  String::kNormalString,
-                                  mem->length)).FromJust();
+                                  NewStringType::kNormal,
+                                  mem->length).ToLocalChecked()).FromJust();
 
     USE(BIO_reset(bio.get()));
   }
@@ -1626,8 +1626,8 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     BIO_get_mem_ptr(bio.get(), &mem);
     info->Set(context, env->modulus_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
-                                  String::kNormalString,
-                                  mem->length)).FromJust();
+                                  NewStringType::kNormal,
+                                  mem->length).ToLocalChecked()).FromJust();
     USE(BIO_reset(bio.get()));
 
     uint64_t exponent_word = static_cast<uint64_t>(BN_get_word(e));
@@ -1641,8 +1641,8 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     BIO_get_mem_ptr(bio.get(), &mem);
     info->Set(context, env->exponent_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
-                                  String::kNormalString,
-                                  mem->length)).FromJust();
+                                  NewStringType::kNormal,
+                                  mem->length).ToLocalChecked()).FromJust();
     USE(BIO_reset(bio.get()));
 
     int size = i2d_RSA_PUBKEY(rsa.get(), nullptr);
@@ -1661,16 +1661,16 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
   BIO_get_mem_ptr(bio.get(), &mem);
   info->Set(context, env->valid_from_string(),
             String::NewFromUtf8(env->isolate(), mem->data,
-                                String::kNormalString,
-                                mem->length)).FromJust();
+                                NewStringType::kNormal,
+                                mem->length).ToLocalChecked()).FromJust();
   USE(BIO_reset(bio.get()));
 
   ASN1_TIME_print(bio.get(), X509_get_notAfter(cert));
   BIO_get_mem_ptr(bio.get(), &mem);
   info->Set(context, env->valid_to_string(),
             String::NewFromUtf8(env->isolate(), mem->data,
-                                String::kNormalString,
-                                mem->length)).FromJust();
+                                NewStringType::kNormal,
+                                mem->length).ToLocalChecked()).FromJust();
   bio.reset();
 
   unsigned char md[EVP_MAX_MD_SIZE];

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -794,8 +794,8 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
     Local<String> chars_string =
         String::NewFromUtf8(env->isolate(),
                             &chars[start],
-                            String::kNormalString,
-                            size);
+                            v8::NewStringType::kNormal,
+                            size).ToLocalChecked();
     args.GetReturnValue().Set(chars_string);
   }
 }

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -550,7 +550,7 @@ void GetVersion(const FunctionCallbackInfo<Value>& args) {
             TYPE_ICU ","
             TYPE_UNICODE ","
             TYPE_CLDR ","
-            TYPE_TZ), v8::NewStringType::kNormal).ToLocalChecked();
+            TYPE_TZ, v8::NewStringType::kNormal).ToLocalChecked());
   } else {
     CHECK_GE(args.Length(), 1);
     CHECK(args[0]->IsString());

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -550,7 +550,7 @@ void GetVersion(const FunctionCallbackInfo<Value>& args) {
             TYPE_ICU ","
             TYPE_UNICODE ","
             TYPE_CLDR ","
-            TYPE_TZ));
+            TYPE_TZ), v8::NewStringType::kNormal).ToLocalChecked();
   } else {
     CHECK_GE(args.Length(), 1);
     CHECK(args[0]->IsString());
@@ -563,7 +563,7 @@ void GetVersion(const FunctionCallbackInfo<Value>& args) {
       // Success.
       args.GetReturnValue().Set(
           String::NewFromUtf8(env->isolate(),
-          versionString));
+          versionString, v8::NewStringType::kNormal).ToLocalChecked());
     }
   }
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -76,7 +76,7 @@ struct sockaddr;
             .ToLocalChecked();                                                \
     v8::Local<v8::String> constant_value =                                    \
         v8::String::NewFromUtf8(isolate, constant, v8::NewStringType::kNormal)\
-            .ToLocalChecked()                                                 \
+            .ToLocalChecked();                                                \
     v8::PropertyAttribute constant_attributes =                               \
         static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);    \
     target->DefineOwnProperty(isolate->GetCurrentContext(),                   \

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -72,9 +72,11 @@ struct sockaddr;
   do {                                                                        \
     v8::Isolate* isolate = target->GetIsolate();                              \
     v8::Local<v8::String> constant_name =                                     \
-        v8::String::NewFromUtf8(isolate, name);                               \
+        v8::String::NewFromUtf8(isolate, name, v8::NewStringType::kNormal)    \
+            .ToLocalChecked();                                                \
     v8::Local<v8::String> constant_value =                                    \
-        v8::String::NewFromUtf8(isolate, constant);                           \
+        v8::String::NewFromUtf8(isolate, constant, v8::NewStringType::kNormal)\
+            .ToLocalChecked()                                                 \
     v8::PropertyAttribute constant_attributes =                               \
         static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);    \
     target->DefineOwnProperty(isolate->GetCurrentContext(),                   \

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -257,15 +257,13 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   for (i = 0; i < count; i++) {
     const char* const raw_name = interfaces[i].name;
 
-    // On Windows, the interface name is the UTF8-encoded friendly name and may
-    // contain non-ASCII characters.  On UNIX, it's just a binary string with
-    // no particular encoding but we treat it as a one-byte Latin-1 string.
-#ifdef _WIN32
+    // Use UTF-8 on both Windows and Unixes (While it may be true that UNIX
+    // systems are somewhat encoding-agnostic here, it’s more than reasonable
+    // to assume UTF8 as the default as well. It’s what people will expect if
+    // they name the interface from any input that uses UTF-8, which should be
+    // the most frequent case by far these days.)
     name = String::NewFromUtf8(env->isolate(), raw_name,
         v8::NewStringType::kNormal).ToLocalChecked();
-#else
-    name = OneByteString(env->isolate(), raw_name);
-#endif
 
     if (ret->Has(env->context(), name).FromJust()) {
       ifarr = Local<Array>::Cast(ret->Get(name));

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -261,7 +261,8 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
     // contain non-ASCII characters.  On UNIX, it's just a binary string with
     // no particular encoding but we treat it as a one-byte Latin-1 string.
 #ifdef _WIN32
-    name = String::NewFromUtf8(env->isolate(), raw_name);
+    name = String::NewFromUtf8(env->isolate(), raw_name,
+        v8::NewStringType::kNormal).ToLocalChecked();
 #else
     name = OneByteString(env->isolate(), raw_name);
 #endif
@@ -335,8 +336,8 @@ static void GetHomeDirectory(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> home = String::NewFromUtf8(env->isolate(),
                                            buf,
-                                           String::kNormalString,
-                                           len);
+                                           v8::NewStringType::kNormal,
+                                           len).ToLocalChecked();
   args.GetReturnValue().Set(home);
 }
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -75,14 +75,18 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
                          env->name_string(),
                          String::NewFromUtf8(isolate,
                                              entry.name().c_str(),
-                                             String::kNormalString),
-                         attr).FromJust();
+                                             v8::NewStringType::kNormal)
+                             .ToLocalChecked(),
+                         attr)
+      .FromJust();
   obj->DefineOwnProperty(context,
                          FIXED_ONE_BYTE_STRING(isolate, "entryType"),
                          String::NewFromUtf8(isolate,
                                              entry.type().c_str(),
-                                             String::kNormalString),
-                         attr).FromJust();
+                                             v8::NewStringType::kNormal)
+                             .ToLocalChecked(),
+                         attr)
+      .FromJust();
   obj->DefineOwnProperty(context,
                          FIXED_ONE_BYTE_STRING(isolate, "startTime"),
                          Number::New(isolate, entry.startTime()),

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -114,8 +114,8 @@ void Cwd(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> cwd = String::NewFromUtf8(env->isolate(),
                                           buf,
-                                          String::kNormalString,
-                                          cwd_len);
+                                          v8::NewStringType::kNormal,
+                                          cwd_len).ToLocalChecked();
   args.GetReturnValue().Set(cwd);
 }
 

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -683,7 +683,9 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
   if (term_signal_ > 0)
     js_result->Set(context, env()->signal_string(),
                    String::NewFromUtf8(env()->isolate(),
-                                       signo_string(term_signal_))).FromJust();
+                                       signo_string(term_signal_), v8::NewStringType::kNormal)
+                       .ToLocalChecked())
+        .FromJust();
   else
     js_result->Set(context, env()->signal_string(),
                    Null(env()->isolate())).FromJust();

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -683,7 +683,8 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
   if (term_signal_ > 0)
     js_result->Set(context, env()->signal_string(),
                    String::NewFromUtf8(env()->isolate(),
-                                       signo_string(term_signal_), v8::NewStringType::kNormal)
+                                       signo_string(term_signal_),
+                                       v8::NewStringType::kNormal)
                        .ToLocalChecked())
         .FromJust();
   else


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here: String::NewFromUtf8) inside
the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Files

- [x] src/async_wrap.cc
- [x] src/cares_wrap.cc
- [x] src/env-inl.h
- [x] src/exceptions.cc
- [x] src/heap_utils.cc
- [x] src/module_wrap.cc
- [x] src/node.cc
- [x] src/node.h
- [x] src/node_api.cc
- [x] src/node_config.cc
- [x] src/node_crypto.cc
- [x] src/node_file.cc
- [x] src/node_i18n.cc
- [x] src/node_internals.h
- [x] src/node_os.cc
- [x] src/node_perf.cc
- [x] src/node_process.cc
- [x] src/node_trace_events.cc
- [x] src/node_url.cc
- [x] src/node_util.cc
- [x] src/node_v8.cc
- [x] src/spawn_sync.cc
- [x] src/string_bytes.cc
- [x] src/string_decoder.cc

