### PR TITLE
doc: add how to access URL constructor

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -54,6 +54,12 @@ WHATWG URL's `origin` property includes `protocol` and `host`, but not
 (all spaces in the "" line should be ignored — they are purely for formatting)
 ```
 
+The `URL` constructor can be accessed using:
+
+```js
+const { URL } = require('url');
+```
+
 Parsing the URL string using the WHATWG API:
 
 ```js


### PR DESCRIPTION
It was unclear to me how to access the constructor. This should clear things up for future users.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
