### PR TITLE
test: Refactor test-http2-compat-serverresponse-finished.js

### DIFF
--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -9,14 +9,14 @@ const net = require('net');
 
 // Http2ServerResponse.finished
 const server = h2.createServer();
-server.listen(0, common.mustCall(function() {
+server.listen(0, common.mustCall(() => {
   const port = server.address().port;
-  server.once('request', common.mustCall(function(request, response) {
+  server.once('request', common.mustCall((request, response) => {
     assert.ok(response.socket instanceof net.Socket);
     assert.ok(response.connection instanceof net.Socket);
     assert.strictEqual(response.socket, response.connection);
 
-    response.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(() => {
       assert.strictEqual(response.socket, undefined);
       assert.strictEqual(response.connection, undefined);
       process.nextTick(common.mustCall(() => {
@@ -30,7 +30,7 @@ server.listen(0, common.mustCall(function() {
   }));
 
   const url = `http://localhost:${port}`;
-  const client = h2.connect(url, common.mustCall(function() {
+  const client = h2.connect(url, common.mustCall(() => {
     const headers = {
       ':path': '/',
       ':method': 'GET',
@@ -38,7 +38,7 @@ server.listen(0, common.mustCall(function() {
       ':authority': `localhost:${port}`
     };
     const request = client.request(headers);
-    request.on('end', common.mustCall(function() {
+    request.on('end', common.mustCall(() => {
       client.close();
     }));
     request.end();


### PR DESCRIPTION
Just a simple refactor change:

1. Changed from strictEqual to assert.ok where I left its needed. 
2. Arrow functions. 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
