### PR TITLE
gitignore: ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ icu_config.gypi
 .eslintcache
 node_trace.*.log
 coverage/
+compile_commands.json
 
 /out
 


### PR DESCRIPTION
Add compile_commands.json (required by cquery, a popular C/C++ language
server) to the list of files ignored by git

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

P.S. Had a hard time choosing between adding this to the project VS ignoring it, but ignoring seems to be the better option IMO because:
1. It's trivial to generate
2. Let's shift the responsibility of ensuring updates to the person using the language server
3. Everyone else ignores it too? (eg: v8, chromium)
