### PR TITLE
src: remove calls to deprecated v8 functions (ToString)

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -236,7 +236,9 @@ MaybeLocal<Object> New(Isolate* isolate,
                        enum encoding enc) {
   EscapableHandleScope scope(isolate);
 
-  const size_t length = StringBytes::Size(isolate, string, enc);
+  size_t length;
+  if (!StringBytes::Size(isolate, string, enc).To(&length))
+    return Local<Object>();
   size_t actual = 0;
   char* data = nullptr;
 
@@ -828,7 +830,8 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   const size_t haystack_length = (enc == UCS2) ?
       ts_obj_length &~ 1 : ts_obj_length;  // NOLINT(whitespace/operators)
 
-  const size_t needle_length = StringBytes::Size(isolate, needle, enc);
+  size_t needle_length;
+  if (!StringBytes::Size(isolate, needle, enc).To(&needle_length)) return;
 
   int64_t opt_offset = IndexOfOffset(haystack_length,
                                      offset_i64,
@@ -868,7 +871,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
 
     if (IsBigEndian()) {
       StringBytes::InlineDecoder decoder;
-      decoder.Decode(env, needle, args[3], UCS2);
+      if (decoder.Decode(env, needle, args[3], UCS2).IsNothing()) return;
       const uint16_t* decoded_string =
           reinterpret_cast<const uint16_t*>(decoder.out());
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3055,7 +3055,8 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
   // Only copy the data if we have to, because it's a string
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;
-    if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8))
+    if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)
+             .FromMaybe(false))
       return;
     r = cipher->Update(decoder.out(), decoder.size(), &out, &out_len);
   } else {
@@ -3241,7 +3242,8 @@ void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
   bool r = false;
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;
-    if (decoder.Decode(env, args[0].As<String>(), args[1], UTF8)) {
+    if (decoder.Decode(env, args[0].As<String>(), args[1], UTF8)
+            .FromMaybe(false)) {
       r = hmac->HmacUpdate(decoder.out(), decoder.size());
     }
   } else {
@@ -3348,7 +3350,8 @@ void Hash::HashUpdate(const FunctionCallbackInfo<Value>& args) {
   bool r = true;
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;
-    if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)) {
+    if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)
+             .FromMaybe(false)) {
       args.GetReturnValue().Set(false);
       return;
     }

--- a/src/node_encoding.cc
+++ b/src/node_encoding.cc
@@ -121,7 +121,7 @@ ssize_t DecodeBytes(Isolate* isolate,
                     enum encoding encoding) {
   HandleScope scope(isolate);
 
-  return StringBytes::Size(isolate, val, encoding);
+  return StringBytes::Size(isolate, val, encoding).FromMaybe(-1);
 }
 
 // Returns number of bytes written.

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1819,7 +1819,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
 
   if (is_async) {  // write(fd, string, pos, enc, req)
     CHECK_NOT_NULL(req_wrap_async);
-    len = StringBytes::StorageSize(env->isolate(), value, enc);
+    if (!StringBytes::StorageSize(env->isolate(), value, enc).To(&len)) return;
     FSReqBase::FSReqBuffer& stack_buffer =
         req_wrap_async->Init("write", len, enc);
     // StorageSize may return too large a char, so correct the actual length
@@ -1847,7 +1847,8 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
     FSReqWrapSync req_wrap_sync;
     FSReqBase::FSReqBuffer stack_buffer;
     if (buf == nullptr) {
-      len = StringBytes::StorageSize(env->isolate(), value, enc);
+      if (!StringBytes::StorageSize(env->isolate(), value, enc).To(&len))
+        return;
       stack_buffer.AllocateSufficientStorage(len + 1);
       // StorageSize may return too large a char, so correct the actual length
       // by the write size

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -981,7 +981,8 @@ int SyncProcessRunner::CopyJsString(Local<Value> js_value,
   if (js_value->IsString())
     js_string = js_value.As<String>();
   else
-    js_string = js_value->ToString(env()->isolate());
+    js_string = js_value->ToString(env()->isolate()->GetCurrentContext())
+                    .ToLocalChecked();
 
   // Include space for null terminator byte.
   size = StringBytes::StorageSize(isolate, js_string, UTF8) + 1;
@@ -1025,7 +1026,12 @@ int SyncProcessRunner::CopyJsStringArray(Local<Value> js_value,
     auto value = js_array->Get(context, i).ToLocalChecked();
 
     if (!value->IsString())
-      js_array->Set(context, i, value->ToString(env()->isolate())).FromJust();
+      js_array
+          ->Set(context,
+                i,
+                value->ToString(env()->isolate()->GetCurrentContext())
+                    .ToLocalChecked())
+          .FromJust();
 
     data_size += StringBytes::StorageSize(isolate, value, UTF8) + 1;
     data_size = ROUND_UP(data_size, sizeof(void*));

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -152,8 +152,8 @@ class SyncProcessRunner {
 
   inline Environment* env() const;
 
-  v8::Local<v8::Object> Run(v8::Local<v8::Value> options);
-  void TryInitializeAndRunLoop(v8::Local<v8::Value> options);
+  v8::MaybeLocal<v8::Object> Run(v8::Local<v8::Value> options);
+  v8::Maybe<bool> TryInitializeAndRunLoop(v8::Local<v8::Value> options);
   void CloseHandlesAndDeleteLoop();
 
   void CloseStdioPipes();
@@ -172,7 +172,7 @@ class SyncProcessRunner {
   v8::Local<v8::Object> BuildResultObject();
   v8::Local<v8::Array> BuildOutputArray();
 
-  int ParseOptions(v8::Local<v8::Value> js_value);
+  v8::Maybe<int> ParseOptions(v8::Local<v8::Value> js_value);
   int ParseStdioOptions(v8::Local<v8::Value> js_value);
   int ParseStdioOption(int child_fd, v8::Local<v8::Object> js_stdio_option);
 
@@ -184,8 +184,10 @@ class SyncProcessRunner {
   inline int AddStdioInheritFD(uint32_t child_fd, int inherit_fd);
 
   static bool IsSet(v8::Local<v8::Value> value);
-  int CopyJsString(v8::Local<v8::Value> js_value, const char** target);
-  int CopyJsStringArray(v8::Local<v8::Value> js_value, char** target);
+  v8::Maybe<int> CopyJsString(v8::Local<v8::Value> js_value,
+                              const char** target);
+  v8::Maybe<int> CopyJsStringArray(v8::Local<v8::Value> js_value,
+                                   char** target);
 
   static void ExitCallback(uv_process_t* handle,
                            int64_t exit_status,

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -410,7 +410,8 @@ size_t StringBytes::StorageSize(Isolate* isolate,
     return Buffer::Length(val);
   }
 
-  Local<String> str = val->ToString(isolate);
+  Local<String> str =
+      val->ToString(isolate->GetCurrentContext()).ToLocalChecked();
 
   switch (encoding) {
     case ASCII:
@@ -456,7 +457,8 @@ size_t StringBytes::Size(Isolate* isolate,
   if (Buffer::HasInstance(val) && (encoding == BUFFER || encoding == LATIN1))
     return Buffer::Length(val);
 
-  Local<String> str = val->ToString(isolate);
+  Local<String> str =
+      val->ToString(isolate->GetCurrentContext()).ToLocalChecked();
 
   switch (encoding) {
     case ASCII:

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -41,8 +41,11 @@ namespace node {
 
 using v8::HandleScope;
 using v8::Isolate;
+using v8::Just;
 using v8::Local;
+using v8::Maybe;
 using v8::MaybeLocal;
+using v8::Nothing;
 using v8::String;
 using v8::Value;
 
@@ -399,20 +402,20 @@ bool StringBytes::IsValidString(Local<String> string,
 // Quick and dirty size calculation
 // Will always be at least big enough, but may have some extra
 // UTF8 can be as much as 3x the size, Base64 can have 1-2 extra bytes
-v8::Maybe<size_t> StringBytes::StorageSize(Isolate* isolate,
-                                           Local<Value> val,
-                                           enum encoding encoding) {
+Maybe<size_t> StringBytes::StorageSize(Isolate* isolate,
+                                       Local<Value> val,
+                                       enum encoding encoding) {
   HandleScope scope(isolate);
   size_t data_size = 0;
   bool is_buffer = Buffer::HasInstance(val);
 
   if (is_buffer && (encoding == BUFFER || encoding == LATIN1)) {
-    return v8::Just(Buffer::Length(val));
+    return Just(Buffer::Length(val));
   }
 
   Local<String> str;
   if (!val->ToString(isolate->GetCurrentContext()).ToLocal(&str))
-    return v8::Nothing<size_t>();
+    return Nothing<size_t>();
 
   switch (encoding) {
     case ASCII:
@@ -446,40 +449,40 @@ v8::Maybe<size_t> StringBytes::StorageSize(Isolate* isolate,
       break;
   }
 
-  return v8::Just(data_size);
+  return Just(data_size);
 }
 
-v8::Maybe<size_t> StringBytes::Size(Isolate* isolate,
-                                    Local<Value> val,
-                                    enum encoding encoding) {
+Maybe<size_t> StringBytes::Size(Isolate* isolate,
+                                Local<Value> val,
+                                enum encoding encoding) {
   HandleScope scope(isolate);
 
   if (Buffer::HasInstance(val) && (encoding == BUFFER || encoding == LATIN1))
-    return v8::Just(Buffer::Length(val));
+    return Just(Buffer::Length(val));
 
   Local<String> str;
   if (!val->ToString(isolate->GetCurrentContext()).ToLocal(&str))
-    return v8::Nothing<size_t>();
+    return Nothing<size_t>();
 
   switch (encoding) {
     case ASCII:
     case LATIN1:
-      return v8::Just<size_t>(str->Length());
+      return Just<size_t>(str->Length());
 
     case BUFFER:
     case UTF8:
-      return v8::Just<size_t>(str->Utf8Length(isolate));
+      return Just<size_t>(str->Utf8Length(isolate));
 
     case UCS2:
-      return v8::Just(str->Length() * sizeof(uint16_t));
+      return Just(str->Length() * sizeof(uint16_t));
 
     case BASE64: {
       String::Value value(isolate, str);
-      return v8::Just(base64_decoded_size(*value, value.length()));
+      return Just(base64_decoded_size(*value, value.length()));
     }
 
     case HEX:
-      return v8::Just<size_t>(str->Length() / 2);
+      return Just<size_t>(str->Length() / 2);
   }
 
   UNREACHABLE();

--- a/src/util.cc
+++ b/src/util.cc
@@ -37,9 +37,8 @@ template <typename T>
 static void MakeUtf8String(Isolate* isolate,
                            Local<Value> value,
                            T* target) {
-  Local<String> string = value->ToString(isolate);
-  if (string.IsEmpty())
-    return;
+  Local<String> string;
+  if (!value->ToString(isolate->GetCurrentContext()).ToLocal(&string)) return;
 
   const size_t storage = StringBytes::StorageSize(isolate, string, UTF8) + 1;
   target->AllocateSufficientStorage(storage);
@@ -63,9 +62,8 @@ TwoByteValue::TwoByteValue(Isolate* isolate, Local<Value> value) {
     return;
   }
 
-  Local<String> string = value->ToString(isolate);
-  if (string.IsEmpty())
-    return;
+  Local<String> string;
+  if (!value->ToString(isolate->GetCurrentContext()).ToLocal(&string)) return;
 
   // Allocate enough space to include the null terminator
   const size_t storage = string->Length() + 1;

--- a/src/util.cc
+++ b/src/util.cc
@@ -40,7 +40,9 @@ static void MakeUtf8String(Isolate* isolate,
   Local<String> string;
   if (!value->ToString(isolate->GetCurrentContext()).ToLocal(&string)) return;
 
-  const size_t storage = StringBytes::StorageSize(isolate, string, UTF8) + 1;
+  size_t storage;
+  if (!StringBytes::StorageSize(isolate, string, UTF8).To(&storage)) return;
+  storage += 1;
   target->AllocateSufficientStorage(storage);
   const int flags =
       String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8;


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here: Value::ToString) inside
the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @hashseed 