### PR TITLE
doc: replace deprecated CI job

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -210,7 +210,7 @@ is the standard CI run we do to check Pull Requests. It triggers
 `node-test-commit`, which runs the `build-ci` and `test-ci` targets on all
 supported platforms.
 
-* [`node-test-pull-request-lite`](https://ci.nodejs.org/job/node-test-pull-request-lite/)
+* [`node-test-pull-request-lite-pipeline`](https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/)
 only runs the linter job, as well as the tests on LinuxONE, which is very fast.
 This is useful for changes that only affect comments or documentation.
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -213,7 +213,7 @@ needs to be pointed out separately during the onboarding.
 * Optionally, include your personal pronouns.
 * Label your pull request with the `doc` and `notable-change` labels.
 * Run CI on the PR. Because the PR does not affect any code, use the
-  `node-test-pull-request-lite` CI task. Alternatively, use the usual
+  `node-test-pull-request-lite-pipeline` CI task. Alternatively, use the usual
   `node-test-pull-request` CI task and cancel it after the linter and one other
   subtask have passed.
 * After one or two approvals, land the PR (PRs of this type do not need to wait


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

`node-test-pull-request-lite` CI job is deprecated now and https://ci.nodejs.org/job/node-test-pull-request-lite/ has this note: "DEPRECATED: please use the node-test-pull-request-lite-pipeline job".