### PR TITLE
src: add proper MemoryInfoName to wrappers

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -174,7 +174,7 @@ class AsyncWrap : public BaseObject {
       v8::Local<v8::Value>* argv);
 
   virtual std::string diagnostic_name() const;
-  std::string MemoryInfoName() const override;
+  virtual std::string MemoryInfoName() const;
 
   static void WeakCallback(const v8::WeakCallbackInfo<DestroyParam> &info);
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -33,6 +33,11 @@ namespace node {
 
 class Environment;
 
+#define ADD_MEMORY_INFO_NAME(name)                                          \
+  std::string MemoryInfoName() const override {                             \
+    return #name;                                                           \
+  }
+
 class BaseObject : public MemoryRetainer {
  public:
   // Associates this object with `object`. It uses the 0th internal field for

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -127,6 +127,7 @@ struct node_ares_task : public MemoryRetainer {
   uv_poll_t poll_watcher;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
+  ADD_MEMORY_INFO_NAME(node_ares_task)
 };
 
 struct TaskHash {
@@ -173,8 +174,10 @@ class ChannelWrap : public AsyncWrap {
     tracker->TrackThis(this);
     if (timer_handle_ != nullptr)
       tracker->TrackFieldWithSize("timer handle", sizeof(*timer_handle_));
-    tracker->TrackField("task list", task_list_);
+    tracker->TrackField("node_ares_task_list", task_list_);
   }
+
+  ADD_MEMORY_INFO_NAME(ChannelWrap)
 
   static void AresTimeout(uv_timer_t* handle);
 
@@ -225,6 +228,8 @@ class GetAddrInfoReqWrap : public ReqWrap<uv_getaddrinfo_t> {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(GetAddrInfoReqWrap)
+
   bool verbatim() const { return verbatim_; }
 
  private:
@@ -246,6 +251,8 @@ class GetNameInfoReqWrap : public ReqWrap<uv_getnameinfo_t> {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(GetNameInfoReqWrap)
 };
 
 GetNameInfoReqWrap::GetNameInfoReqWrap(Environment* env,
@@ -1193,6 +1200,8 @@ class QueryAnyWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryAnyWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1372,6 +1381,8 @@ class QueryAWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryAWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1417,6 +1428,8 @@ class QueryAaaaWrap: public QueryWrap {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(QueryAaaaWrap)
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1464,6 +1477,8 @@ class QueryCnameWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryCnameWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1496,6 +1511,8 @@ class QueryMxWrap: public QueryWrap {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(QueryMxWrap)
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1530,6 +1547,8 @@ class QueryNsWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryNsWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1563,6 +1582,8 @@ class QueryTxtWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryTxtWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1595,6 +1616,8 @@ class QuerySrvWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QuerySrvWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1625,6 +1648,8 @@ class QueryPtrWrap: public QueryWrap {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(QueryPtrWrap)
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1659,6 +1684,8 @@ class QueryNaptrWrap: public QueryWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(QueryNaptrWrap)
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -1690,6 +1717,8 @@ class QuerySoaWrap: public QueryWrap {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(QuerySoaWrap)
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -1771,6 +1800,8 @@ class GetHostByAddrWrap: public QueryWrap {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(GetHostByAddrWrap)
 
  protected:
   void Parse(struct hostent* host) override {

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -19,6 +19,8 @@ class ConnectWrap : public ReqWrap<uv_connect_t> {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(ConnectWrap)
 };
 
 }  // namespace node

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -61,6 +61,8 @@ class FSEventWrap: public HandleWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(FSEventWrap)
+
  private:
   static const encoding kDefaultEncoding = UTF8;
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -109,6 +109,8 @@ class JSBindingsConnection : public AsyncWrap {
     tracker->TrackFieldWithSize("session", sizeof(*session_));
   }
 
+  ADD_MEMORY_INFO_NAME(JSBindingsConnection)
+
  private:
   std::unique_ptr<InspectorSession> session_;
   Persistent<Function> callback_;

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -31,6 +31,8 @@ class JSStream : public AsyncWrap, public StreamBase {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(JSStream)
+
  protected:
   JSStream(Environment* env, v8::Local<v8::Object> obj);
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -39,6 +39,8 @@ class ModuleWrap : public BaseObject {
     tracker->TrackField("resolve_cache", resolve_cache_);
   }
 
+  ADD_MEMORY_INFO_NAME(ModuleWrap)
+
  private:
   ModuleWrap(Environment* env,
              v8::Local<v8::Object> object,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -592,6 +592,8 @@ class ContextifyScript : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(ContextifyScript)
+
  public:
   static void Init(Environment* env, Local<Object> target) {
     HandleScope scope(env->isolate());

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -109,6 +109,8 @@ class SecureContext : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(SecureContext)
+
   SSLCtxPointer ctx_;
   X509Pointer cert_;
   X509Pointer issuer_;
@@ -345,6 +347,8 @@ class CipherBase : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(CipherBase)
+
  protected:
   enum CipherKind {
     kCipher,
@@ -419,6 +423,8 @@ class Hmac : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(Hmac)
+
  protected:
   void HmacInit(const char* hash_type, const char* key, int key_len);
   bool HmacUpdate(const char* data, int len);
@@ -445,6 +451,8 @@ class Hash : public BaseObject {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(Hash)
 
   bool HashInit(const char* hash_type);
   bool HashUpdate(const char* data, int len);
@@ -488,6 +496,8 @@ class SignBase : public BaseObject {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(SignBase)
 
  protected:
   void CheckThrow(Error error);
@@ -605,6 +615,8 @@ class DiffieHellman : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(DiffieHellman)
+
  private:
   static void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
                        const BIGNUM* (*get_field)(const DH*),
@@ -633,6 +645,8 @@ class ECDH : public BaseObject {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(ECDH)
 
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, ECKeyPointer&& key)

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -115,6 +115,8 @@ class NodeBIO : public MemoryRetainer {
     tracker->TrackFieldWithSize("buffer", length_);
   }
 
+  ADD_MEMORY_INFO_NAME(NodeBIO)
+
  private:
   static int New(BIO* bio);
   static int Free(BIO* bio);

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -99,6 +99,8 @@ class FSReqWrap : public FSReqBase {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(FSReqWrap)
+
  private:
   DISALLOW_COPY_AND_ASSIGN(FSReqWrap);
 };
@@ -162,6 +164,8 @@ class FSReqPromise : public FSReqBase {
     tracker->TrackField("stats_field_array", stats_field_array_);
   }
 
+  ADD_MEMORY_INFO_NAME(FSReqPromise)
+
  private:
   bool finished_ = false;
   AliasedBuffer<NativeT, V8T> stats_field_array_;
@@ -200,6 +204,8 @@ class FileHandleReadWrap : public ReqWrap<uv_fs_t> {
     tracker->TrackThis(this);
     tracker->TrackField("buffer", buffer_);
   }
+
+  ADD_MEMORY_INFO_NAME(FileHandleReadWrap)
 
  private:
   FileHandle* file_handle_;
@@ -252,6 +258,8 @@ class FileHandle : public AsyncWrap, public StreamBase {
     tracker->TrackField("current_read", current_read_);
   }
 
+  ADD_MEMORY_INFO_NAME(FileHandle)
+
  private:
   // Synchronous close that emits a warning
   void Close();
@@ -283,6 +291,8 @@ class FileHandle : public AsyncWrap, public StreamBase {
       tracker->TrackField("promise", promise_);
       tracker->TrackField("ref", ref_);
     }
+
+    ADD_MEMORY_INFO_NAME(CloseReq)
 
     void Resolve();
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -575,6 +575,8 @@ class Http2Stream : public AsyncWrap,
     tracker->TrackField("queue", queue_);
   }
 
+  ADD_MEMORY_INFO_NAME(Http2Stream)
+
   std::string diagnostic_name() const override;
 
   // JavaScript API
@@ -760,6 +762,8 @@ class Http2Session : public AsyncWrap, public StreamListener {
     tracker->TrackFieldWithSize("pending_rst_streams",
                                 pending_rst_streams_.size() * sizeof(int32_t));
   }
+
+  ADD_MEMORY_INFO_NAME(Http2Session)
 
   std::string diagnostic_name() const override;
 
@@ -1081,6 +1085,8 @@ class Http2Session::Http2Ping : public AsyncWrap {
     tracker->TrackField("session", session_);
   }
 
+  ADD_MEMORY_INFO_NAME(Http2Ping)
+
   void Send(uint8_t* payload);
   void Done(bool ack, const uint8_t* payload = nullptr);
 
@@ -1103,6 +1109,8 @@ class Http2Session::Http2Settings : public AsyncWrap {
     tracker->TrackThis(this);
     tracker->TrackField("session", session_);
   }
+
+  ADD_MEMORY_INFO_NAME(Http2Settings)
 
   void Send();
   void Done(bool ack);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -160,6 +160,7 @@ class Parser : public AsyncWrap, public StreamListener {
     tracker->TrackField("current_buffer", current_buffer_);
   }
 
+  ADD_MEMORY_INFO_NAME(Parser)
 
   int on_message_begin() {
     num_fields_ = num_values_ = 0;

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -254,6 +254,8 @@ class ConverterObject : public BaseObject, Converter {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(ConverterObject)
+
  protected:
   ConverterObject(Environment* env,
                   v8::Local<v8::Object> wrap,

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -57,6 +57,8 @@ class Message : public MemoryRetainer {
 
   void MemoryInfo(MemoryTracker* tracker) const override;
 
+  ADD_MEMORY_INFO_NAME(Message)
+
  private:
   MallocedBuffer<char> main_message_buf_;
   std::vector<MallocedBuffer<char>> array_buffer_contents_;
@@ -97,6 +99,8 @@ class MessagePortData : public MemoryRetainer {
   void Disentangle();
 
   void MemoryInfo(MemoryTracker* tracker) const override;
+
+  ADD_MEMORY_INFO_NAME(MessagePortData)
 
  private:
   // After disentangling this message port, the owner handle (if any)
@@ -186,6 +190,8 @@ class MessagePort : public HandleWrap {
     tracker->TrackThis(this);
     tracker->TrackField("data", data_);
   }
+
+  ADD_MEMORY_INFO_NAME(MessagePort)
 
  private:
   void OnClose() override;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -57,6 +57,8 @@ class SerializerContext : public BaseObject,
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(SerializerContext)
+
  private:
   ValueSerializer serializer_;
 };
@@ -85,6 +87,8 @@ class DeserializerContext : public BaseObject,
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(DeserializerContext)
 
  private:
   const uint8_t* data_;

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -48,6 +48,8 @@ class StatWatcher : public HandleWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(StatWatcher)
+
  private:
   static void Callback(uv_fs_poll_t* handle,
                        int status,

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -32,6 +32,8 @@ class NodeCategorySet : public BaseObject {
     tracker->TrackField("categories", categories_);
   }
 
+  ADD_MEMORY_INFO_NAME(NodeCategorySet)
+
  private:
   NodeCategorySet(Environment* env,
                   Local<Object> wrap,

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -33,6 +33,9 @@ class Worker : public AsyncWrap {
     tracker->TrackField("parent_port", parent_port_);
   }
 
+
+  ADD_MEMORY_INFO_NAME(Worker)
+
   bool is_stopped() const;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -653,6 +653,9 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
         zlib_memory_ + unreported_allocations_);
   }
 
+
+  ADD_MEMORY_INFO_NAME(ZCtx)
+
  private:
   void Ref() {
     if (++refs_ == 1) {

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -49,6 +49,8 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(PipeWrap)
+
  private:
   PipeWrap(Environment* env,
            v8::Local<v8::Object> object,

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -70,6 +70,8 @@ class ProcessWrap : public HandleWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(ProcessWrap)
+
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {
     // This constructor should not be exposed to public javascript.

--- a/src/sharedarraybuffer_metadata.cc
+++ b/src/sharedarraybuffer_metadata.cc
@@ -51,6 +51,8 @@ class SABLifetimePartner : public BaseObject {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(SABLifetimePartner)
+
   SharedArrayBufferMetadataReference reference;
 };
 

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -64,6 +64,8 @@ class SignalWrap : public HandleWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(SignalWrap)
+
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {
     // This constructor should not be exposed to public javascript.

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -350,6 +350,8 @@ class SimpleShutdownWrap : public ShutdownWrap, public OtherBase {
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackThis(this);
   }
+
+  ADD_MEMORY_INFO_NAME(SimpleShutdownWrap)
 };
 
 template <typename OtherBase>
@@ -364,6 +366,9 @@ class SimpleWriteWrap : public WriteWrap, public OtherBase {
     tracker->TrackThis(this);
     tracker->TrackFieldWithSize("storage", StorageSize());
   }
+
+
+  ADD_MEMORY_INFO_NAME(SimpleWriteWrap)
 };
 
 }  // namespace node

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -22,6 +22,8 @@ class StreamPipe : public AsyncWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(StreamPipe)
+
  private:
   inline StreamBase* source();
   inline StreamBase* sink();

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -48,6 +48,17 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
     tracker->TrackThis(this);
   }
 
+  std::string MemoryInfoName() const override {
+    switch (provider_type()) {
+      case ProviderType::PROVIDER_TCPWRAP:
+        return "TCPSocketWrap";
+      case ProviderType::PROVIDER_TCPSERVERWRAP:
+        return "TCPServerWrap";
+      default:
+        UNREACHABLE();
+    }
+  }
+
  private:
   typedef uv_tcp_t HandleType;
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -78,6 +78,8 @@ class TLSWrap : public AsyncWrap,
 
   void MemoryInfo(MemoryTracker* tracker) const override;
 
+  ADD_MEMORY_INFO_NAME(TLSWrap)
+
  protected:
   inline StreamBase* underlying_stream() {
     return static_cast<StreamBase*>(stream_);

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -42,6 +42,8 @@ class TTYWrap : public LibuvStreamWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(TTYWrap)
+
  private:
   TTYWrap(Environment* env,
           v8::Local<v8::Object> object,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -60,6 +60,8 @@ class SendWrap : public ReqWrap<uv_udp_send_t> {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(SendWrap)
+
  private:
   const bool have_callback_;
 };

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -68,6 +68,8 @@ class UDPWrap: public HandleWrap {
     tracker->TrackThis(this);
   }
 
+  ADD_MEMORY_INFO_NAME(UDPWrap)
+
  private:
   typedef uv_udp_t HandleType;
 

--- a/test/parallel/test-heapdump-dns.js
+++ b/test/parallel/test-heapdump-dns.js
@@ -3,14 +3,15 @@
 require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 
-validateSnapshotNodes('DNSCHANNEL', []);
+validateSnapshotNodes('ChannelWrap', []);
 const dns = require('dns');
-validateSnapshotNodes('DNSCHANNEL', [{}]);
+validateSnapshotNodes('ChannelWrap', [{}]);
 dns.resolve('localhost', () => {});
-validateSnapshotNodes('DNSCHANNEL', [
+validateSnapshotNodes('ChannelWrap', [
   {
     children: [
-      { name: 'task list' },
+      { name: 'node_ares_task_list' },
+      // `Node / ChannelWrap` (C++) -> `ChannelWrap` (JS)
       { name: 'ChannelWrap' }
     ]
   }

--- a/test/parallel/test-heapdump-fs-promise.js
+++ b/test/parallel/test-heapdump-fs-promise.js
@@ -4,9 +4,9 @@ require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 const fs = require('fs').promises;
 
-validateSnapshotNodes('FSREQPROMISE', []);
+validateSnapshotNodes('FSReqPromise', []);
 fs.stat(__filename);
-validateSnapshotNodes('FSREQPROMISE', [
+validateSnapshotNodes('FSReqPromise', [
   {
     children: [
       { name: 'FSReqPromise' },

--- a/test/parallel/test-heapdump-http2.js
+++ b/test/parallel/test-heapdump-http2.js
@@ -8,8 +8,8 @@ if (!common.hasCrypto)
 
 {
   const state = recordState();
-  state.validateSnapshotNodes('HTTP2SESSION', []);
-  state.validateSnapshotNodes('HTTP2STREAM', []);
+  state.validateSnapshotNodes('Http2Session', []);
+  state.validateSnapshotNodes('Http2Stream', []);
 }
 
 const server = http2.createServer();
@@ -22,42 +22,48 @@ server.listen(0, () => {
 
   req.on('response', common.mustCall(() => {
     const state = recordState();
-    state.validateSnapshotNodes('HTTP2STREAM', [
+
+    // `Node / Http2Stream` (C++) -> Http2Stream (JS)
+    state.validateSnapshotNodes('Http2Stream', [
       {
         children: [
           { name: 'Http2Stream' }
         ]
       },
     ], { loose: true });
-    state.validateSnapshotNodes('FILEHANDLE', [
+
+    // `Node / FileHandle` (C++) -> FileHandle (JS)
+    state.validateSnapshotNodes('FileHandle', [
       {
         children: [
           { name: 'FileHandle' }
         ]
       }
     ]);
-    state.validateSnapshotNodes('TCPWRAP', [
+    state.validateSnapshotNodes('TCPSocketWrap', [
       {
         children: [
           { name: 'TCP' }
         ]
       }
     ], { loose: true });
-    state.validateSnapshotNodes('TCPSERVERWRAP', [
+    state.validateSnapshotNodes('TCPServerWrap', [
       {
         children: [
           { name: 'TCP' }
         ]
       }
     ], { loose: true });
-    state.validateSnapshotNodes('STREAMPIPE', [
+    // `Node / StreamPipe` (C++) -> StreamPipe (JS)
+    state.validateSnapshotNodes('StreamPipe', [
       {
         children: [
           { name: 'StreamPipe' }
         ]
       }
     ]);
-    state.validateSnapshotNodes('HTTP2SESSION', [
+    // `Node / Http2Session` (C++) -> Http2Session (JS)
+    state.validateSnapshotNodes('Http2Session', [
       {
         children: [
           { name: 'Http2Session' },

--- a/test/parallel/test-heapdump-inspector.js
+++ b/test/parallel/test-heapdump-inspector.js
@@ -8,9 +8,9 @@ const { validateSnapshotNodes } = require('../common/heap');
 const inspector = require('inspector');
 
 const session = new inspector.Session();
-validateSnapshotNodes('INSPECTORJSBINDING', []);
+validateSnapshotNodes('JSBindingsConnection', []);
 session.connect();
-validateSnapshotNodes('INSPECTORJSBINDING', [
+validateSnapshotNodes('JSBindingsConnection', [
   {
     children: [
       { name: 'session' },

--- a/test/parallel/test-heapdump-tls.js
+++ b/test/parallel/test-heapdump-tls.js
@@ -9,7 +9,7 @@ const { validateSnapshotNodes } = require('../common/heap');
 const net = require('net');
 const tls = require('tls');
 
-validateSnapshotNodes('TLSWRAP', []);
+validateSnapshotNodes('TLSWrap', []);
 
 const server = net.createServer(common.mustCall((c) => {
   c.end();
@@ -21,11 +21,12 @@ const server = net.createServer(common.mustCall((c) => {
   }));
   c.write('hello');
 
-  validateSnapshotNodes('TLSWRAP', [
+  validateSnapshotNodes('TLSWrap', [
     {
       children: [
-        { name: 'enc_out' },
-        { name: 'enc_in' },
+        { name: 'NodeBIO' },
+        { name: 'NodeBIO' },
+        // `Node / TLSWrap` (C++) -> `TLSWrap` (JS)
         { name: 'TLSWrap' }
       ]
     }

--- a/test/parallel/test-heapdump-worker.js
+++ b/test/parallel/test-heapdump-worker.js
@@ -4,22 +4,22 @@ require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 const { Worker } = require('worker_threads');
 
-validateSnapshotNodes('WORKER', []);
+validateSnapshotNodes('Worker', []);
 const worker = new Worker('setInterval(() => {}, 100);', { eval: true });
-validateSnapshotNodes('WORKER', [
+validateSnapshotNodes('Worker', [
   {
     children: [
       { name: 'thread_exit_async' },
       { name: 'env' },
-      { name: 'MESSAGEPORT' },
+      { name: 'MessagePort' },
       { name: 'Worker' }
     ]
   }
 ]);
-validateSnapshotNodes('MESSAGEPORT', [
+validateSnapshotNodes('MessagePort', [
   {
     children: [
-      { name: 'data' },
+      { name: 'MessagePortData' },
       { name: 'MessagePort' }
     ]
   }

--- a/test/parallel/test-heapdump-zlib.js
+++ b/test/parallel/test-heapdump-zlib.js
@@ -4,10 +4,10 @@ require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 const zlib = require('zlib');
 
-validateSnapshotNodes('ZLIB', []);
+validateSnapshotNodes('ZCtx', []);
 // eslint-disable-next-line no-unused-vars
 const gunzip = zlib.createGunzip();
-validateSnapshotNodes('ZLIB', [
+validateSnapshotNodes('ZCtx', [
   {
     children: [
       { name: 'Zlib' },


### PR DESCRIPTION
- Use camel case names for memory retainers inherited from AsyncWrap
  instead of their provider names (which are all in upper case)
- Assign class names to wraps so that they appear in the heap snapshot
  as nodes with class names as node names. Previously some nodes are
  named with reference names, which are supposed to be edge names
  instead.

Before (in DevTools):
<img width="340" alt="screen shot 2018-07-22 at 9 13 32 am" src="https://user-images.githubusercontent.com/4299420/43055111-591f14d4-8e67-11e8-9227-fdd5d487ff1e.png">

After:
<img width="382" alt="screen shot 2018-07-22 at 9 11 46 am" src="https://user-images.githubusercontent.com/4299420/43055109-58ac431e-8e67-11e8-85b7-04a3fc32744d.png">


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
