### PR TITLE
child-process: support any shells on Windows

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -415,7 +415,7 @@ changes:
     [Default Windows Shell][]. **Default:** `false` (no shell).
   * `windowsVerbatimArguments` {boolean} No quoting or escaping of arguments is
     done on Windows. Ignored on Unix. This is set to `true` automatically
-    when `shell` is specified. **Default:** `false`.
+    when `shell` is specified and is CMD. **Default:** `false`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `true`.
 * Returns: {ChildProcess}
@@ -867,7 +867,7 @@ changes:
     [Default Windows Shell][]. **Default:** `false` (no shell).
   * `windowsVerbatimArguments` {boolean} No quoting or escaping of arguments is
     done on Windows. Ignored on Unix. This is set to `true` automatically
-    when `shell` is specified. **Default:** `false`.
+    when `shell` is specified and is CMD. **Default:** `false`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `true`.
 * Returns: {Object}

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1432,8 +1432,9 @@ to `stdout` although there are only 4 characters.
 
 ## Shell Requirements
 
-The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
-On Windows, command line parsing should be compatible with `'cmd.exe'`.
+The shell should understand the `-c` switch. If the shell is `'cmd.exe'`, it
+should understand the `/d /s /c` switches and command line parsing should be
+compatible.
 
 ## Default Windows Shell
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -478,10 +478,10 @@ function normalizeSpawnArguments(file, args, options) {
       // '/d /s /c' is used only for cmd.exe.
       if (file.endsWith('cmd.exe') || file.endsWith('cmd')) {
         args = ['/d', '/s', '/c', `"${command}"`];
-        options.windowsVerbatimArguments = true;
       } else {
         args = ['-c', command];
       }
+      options.windowsVerbatimArguments = true;
     } else {
       if (typeof options.shell === 'string')
         file = options.shell;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -146,8 +146,8 @@ function normalizeExecArgs(command, options, callback) {
 exports.exec = function exec(/* command , options, callback */) {
   const opts = normalizeExecArgs.apply(null, arguments);
   return exports.execFile(opts.file,
-                          opts.options,
-                          opts.callback);
+    opts.options,
+    opts.callback);
 };
 
 const customPromiseExecFunction = (orig) => {
@@ -383,7 +383,7 @@ const _deprecatedCustomFds = deprecate(
       return fd === -1 ? 'pipe' : fd;
     });
   }, 'child_process: options.customFds option is deprecated. ' +
-     'Use options.stdio instead.', 'DEP0006');
+  'Use options.stdio instead.', 'DEP0006');
 
 function _convertCustomFds(options) {
   if (options.customFds && !options.stdio) {
@@ -400,7 +400,7 @@ function normalizeSpawnArguments(file, args, options) {
   if (Array.isArray(args)) {
     args = args.slice(0);
   } else if (args !== undefined &&
-             (args === null || typeof args !== 'object')) {
+    (args === null || typeof args !== 'object')) {
     throw new ERR_INVALID_ARG_TYPE('args', 'object', args);
   } else {
     options = args;
@@ -414,15 +414,15 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Validate the cwd, if present.
   if (options.cwd != null &&
-      typeof options.cwd !== 'string') {
+    typeof options.cwd !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('options.cwd', 'string', options.cwd);
   }
 
   // Validate detached, if present.
   if (options.detached != null &&
-      typeof options.detached !== 'boolean') {
+    typeof options.detached !== 'boolean') {
     throw new ERR_INVALID_ARG_TYPE('options.detached',
-                                   'boolean', options.detached);
+      'boolean', options.detached);
   }
 
   // Validate the uid, if present.
@@ -437,31 +437,31 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Validate the shell, if present.
   if (options.shell != null &&
-      typeof options.shell !== 'boolean' &&
-      typeof options.shell !== 'string') {
+    typeof options.shell !== 'boolean' &&
+    typeof options.shell !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('options.shell',
-                                   ['boolean', 'string'], options.shell);
+      ['boolean', 'string'], options.shell);
   }
 
   // Validate argv0, if present.
   if (options.argv0 != null &&
-      typeof options.argv0 !== 'string') {
+    typeof options.argv0 !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('options.argv0', 'string', options.argv0);
   }
 
   // Validate windowsHide, if present.
   if (options.windowsHide != null &&
-      typeof options.windowsHide !== 'boolean') {
+    typeof options.windowsHide !== 'boolean') {
     throw new ERR_INVALID_ARG_TYPE('options.windowsHide',
-                                   'boolean', options.windowsHide);
+      'boolean', options.windowsHide);
   }
 
   // Validate windowsVerbatimArguments, if present.
   if (options.windowsVerbatimArguments != null &&
-      typeof options.windowsVerbatimArguments !== 'boolean') {
+    typeof options.windowsVerbatimArguments !== 'boolean') {
     throw new ERR_INVALID_ARG_TYPE('options.windowsVerbatimArguments',
-                                   'boolean',
-                                   options.windowsVerbatimArguments);
+      'boolean',
+      options.windowsVerbatimArguments);
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
@@ -469,13 +469,18 @@ function normalizeSpawnArguments(file, args, options) {
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');
-
+    // Set the shell, switches, and commands.
     if (process.platform === 'win32') {
       if (typeof options.shell === 'string')
         file = options.shell;
       else
         file = process.env.comspec || 'cmd.exe';
-      args = ['/d', '/s', '/c', `"${command}"`];
+      // "/d /s /c" is used only for cmd.exe.
+      if (file.endsWith("cmd.exe") || file.endsWith("cmd")) {
+        args = ['/d', '/s', '/c', `"${command}"`];
+      } else {
+        args = ['-c', `"${command}"`];
+      }
       options.windowsVerbatimArguments = true;
     } else {
       if (typeof options.shell === 'string')
@@ -583,7 +588,7 @@ function spawnSync(/* file, args, options */) {
                                         'TypedArray',
                                         'DataView',
                                         'string'],
-                                       input);
+          input);
       }
     }
   }
@@ -660,8 +665,8 @@ function validateTimeout(timeout) {
 function validateMaxBuffer(maxBuffer) {
   if (maxBuffer != null && !(typeof maxBuffer === 'number' && maxBuffer >= 0)) {
     throw new ERR_OUT_OF_RANGE('options.maxBuffer',
-                               'a positive number',
-                               maxBuffer);
+      'a positive number',
+      maxBuffer);
   }
 }
 
@@ -671,7 +676,7 @@ function sanitizeKillSignal(killSignal) {
     return convertToValidSignal(killSignal);
   } else if (killSignal != null) {
     throw new ERR_INVALID_ARG_TYPE('options.killSignal',
-                                   ['string', 'number'],
-                                   killSignal);
+      ['string', 'number'],
+      killSignal);
   }
 }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -145,7 +145,8 @@ function normalizeExecArgs(command, options, callback) {
 
 exports.exec = function exec(/* command , options, callback */) {
   const opts = normalizeExecArgs.apply(null, arguments);
-  return exports.execFile(opts.file,
+  return exports.execFile(
+    opts.file,
     opts.options,
     opts.callback);
 };
@@ -421,7 +422,8 @@ function normalizeSpawnArguments(file, args, options) {
   // Validate detached, if present.
   if (options.detached != null &&
     typeof options.detached !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.detached',
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.detached',
       'boolean', options.detached);
   }
 
@@ -439,7 +441,8 @@ function normalizeSpawnArguments(file, args, options) {
   if (options.shell != null &&
     typeof options.shell !== 'boolean' &&
     typeof options.shell !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('options.shell',
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.shell',
       ['boolean', 'string'], options.shell);
   }
 
@@ -452,14 +455,17 @@ function normalizeSpawnArguments(file, args, options) {
   // Validate windowsHide, if present.
   if (options.windowsHide != null &&
     typeof options.windowsHide !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.windowsHide',
-      'boolean', options.windowsHide);
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.windowsHide',
+      'boolean',
+      options.windowsHide);
   }
 
   // Validate windowsVerbatimArguments, if present.
   if (options.windowsVerbatimArguments != null &&
     typeof options.windowsVerbatimArguments !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.windowsVerbatimArguments',
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.windowsVerbatimArguments',
       'boolean',
       options.windowsVerbatimArguments);
   }
@@ -476,7 +482,7 @@ function normalizeSpawnArguments(file, args, options) {
       else
         file = process.env.comspec || 'cmd.exe';
       // "/d /s /c" is used only for cmd.exe.
-      if (file.endsWith("cmd.exe") || file.endsWith("cmd")) {
+      if (file.endsWith('cmd.exe') || file.endsWith('cmd')) {
         args = ['/d', '/s', '/c', `"${command}"`];
       } else {
         args = ['-c', `"${command}"`];
@@ -583,7 +589,7 @@ function spawnSync(/* file, args, options */) {
       } else if (typeof input === 'string') {
         pipe.input = Buffer.from(input, options.encoding);
       } else {
-        throw new ERR_INVALID_ARG_TYPE(`options.stdio[${i}]`,
+        throw new ERR_INVALID_ARG_TYPE(
                                        ['Buffer',
                                         'TypedArray',
                                         'DataView',
@@ -664,7 +670,8 @@ function validateTimeout(timeout) {
 
 function validateMaxBuffer(maxBuffer) {
   if (maxBuffer != null && !(typeof maxBuffer === 'number' && maxBuffer >= 0)) {
-    throw new ERR_OUT_OF_RANGE('options.maxBuffer',
+    throw new ERR_OUT_OF_RANGE(
+      'options.maxBuffer',
       'a positive number',
       maxBuffer);
   }
@@ -675,7 +682,8 @@ function sanitizeKillSignal(killSignal) {
   if (typeof killSignal === 'string' || typeof killSignal === 'number') {
     return convertToValidSignal(killSignal);
   } else if (killSignal != null) {
-    throw new ERR_INVALID_ARG_TYPE('options.killSignal',
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.killSignal',
       ['string', 'number'],
       killSignal);
   }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -476,7 +476,7 @@ function normalizeSpawnArguments(file, args, options) {
       else
         file = process.env.comspec || 'cmd.exe';
       // '/d /s /c' is used only for cmd.exe.
-      if (file.endsWith('cmd.exe') || file.endsWith('cmd')) {
+      if (/^(?:.*\\)?cmd(?:\.exe)?$/i.test(file)) {
         args = ['/d', '/s', '/c', `"${command}"`];
       } else {
         args = ['-c', command];

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -145,10 +145,9 @@ function normalizeExecArgs(command, options, callback) {
 
 exports.exec = function exec(/* command , options, callback */) {
   const opts = normalizeExecArgs.apply(null, arguments);
-  return exports.execFile(
-    opts.file,
-    opts.options,
-    opts.callback);
+  return exports.execFile(opts.file,
+                          opts.options,
+                          opts.callback);
 };
 
 const customPromiseExecFunction = (orig) => {
@@ -384,7 +383,7 @@ const _deprecatedCustomFds = deprecate(
       return fd === -1 ? 'pipe' : fd;
     });
   }, 'child_process: options.customFds option is deprecated. ' +
-  'Use options.stdio instead.', 'DEP0006');
+     'Use options.stdio instead.', 'DEP0006');
 
 function _convertCustomFds(options) {
   if (options.customFds && !options.stdio) {
@@ -401,7 +400,7 @@ function normalizeSpawnArguments(file, args, options) {
   if (Array.isArray(args)) {
     args = args.slice(0);
   } else if (args !== undefined &&
-    (args === null || typeof args !== 'object')) {
+             (args === null || typeof args !== 'object')) {
     throw new ERR_INVALID_ARG_TYPE('args', 'object', args);
   } else {
     options = args;
@@ -415,16 +414,15 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Validate the cwd, if present.
   if (options.cwd != null &&
-    typeof options.cwd !== 'string') {
+      typeof options.cwd !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('options.cwd', 'string', options.cwd);
   }
 
   // Validate detached, if present.
   if (options.detached != null &&
-    typeof options.detached !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.detached',
-      'boolean', options.detached);
+      typeof options.detached !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE('options.detached',
+                                   'boolean', options.detached);
   }
 
   // Validate the uid, if present.
@@ -439,35 +437,31 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Validate the shell, if present.
   if (options.shell != null &&
-    typeof options.shell !== 'boolean' &&
-    typeof options.shell !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.shell',
-      ['boolean', 'string'], options.shell);
+      typeof options.shell !== 'boolean' &&
+      typeof options.shell !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('options.shell',
+                                   ['boolean', 'string'], options.shell);
   }
 
   // Validate argv0, if present.
   if (options.argv0 != null &&
-    typeof options.argv0 !== 'string') {
+      typeof options.argv0 !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('options.argv0', 'string', options.argv0);
   }
 
   // Validate windowsHide, if present.
   if (options.windowsHide != null &&
     typeof options.windowsHide !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.windowsHide',
-      'boolean',
-      options.windowsHide);
+    throw new ERR_INVALID_ARG_TYPE('options.windowsHide',
+                                   'boolean', options.windowsHide);
   }
 
   // Validate windowsVerbatimArguments, if present.
   if (options.windowsVerbatimArguments != null &&
-    typeof options.windowsVerbatimArguments !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.windowsVerbatimArguments',
-      'boolean',
-      options.windowsVerbatimArguments);
+      typeof options.windowsVerbatimArguments !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE('options.windowsVerbatimArguments',
+                                   'boolean',
+                                   options.windowsVerbatimArguments);
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
@@ -589,12 +583,12 @@ function spawnSync(/* file, args, options */) {
       } else if (typeof input === 'string') {
         pipe.input = Buffer.from(input, options.encoding);
       } else {
-        throw new ERR_INVALID_ARG_TYPE(
+        throw new ERR_INVALID_ARG_TYPE(`options.stdio[${i}]`,
                                        ['Buffer',
                                         'TypedArray',
                                         'DataView',
                                         'string'],
-          input);
+                                       input);
       }
     }
   }
@@ -670,10 +664,9 @@ function validateTimeout(timeout) {
 
 function validateMaxBuffer(maxBuffer) {
   if (maxBuffer != null && !(typeof maxBuffer === 'number' && maxBuffer >= 0)) {
-    throw new ERR_OUT_OF_RANGE(
-      'options.maxBuffer',
-      'a positive number',
-      maxBuffer);
+    throw new ERR_OUT_OF_RANGE('options.maxBuffer',
+                               'a positive number',
+                               maxBuffer);
   }
 }
 
@@ -682,9 +675,8 @@ function sanitizeKillSignal(killSignal) {
   if (typeof killSignal === 'string' || typeof killSignal === 'number') {
     return convertToValidSignal(killSignal);
   } else if (killSignal != null) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.killSignal',
-      ['string', 'number'],
-      killSignal);
+    throw new ERR_INVALID_ARG_TYPE('options.killSignal',
+                                   ['string', 'number'],
+                                   killSignal);
   }
 }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -451,7 +451,7 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Validate windowsHide, if present.
   if (options.windowsHide != null &&
-    typeof options.windowsHide !== 'boolean') {
+      typeof options.windowsHide !== 'boolean') {
     throw new ERR_INVALID_ARG_TYPE('options.windowsHide',
                                    'boolean', options.windowsHide);
   }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -478,10 +478,10 @@ function normalizeSpawnArguments(file, args, options) {
       // '/d /s /c' is used only for cmd.exe.
       if (/^(?:.*\\)?cmd(?:\.exe)?$/i.test(file)) {
         args = ['/d', '/s', '/c', `"${command}"`];
+        options.windowsVerbatimArguments = true;
       } else {
         args = ['-c', command];
       }
-      options.windowsVerbatimArguments = true;
     } else {
       if (typeof options.shell === 'string')
         file = options.shell;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -481,13 +481,13 @@ function normalizeSpawnArguments(file, args, options) {
         file = options.shell;
       else
         file = process.env.comspec || 'cmd.exe';
-      // "/d /s /c" is used only for cmd.exe.
+      // '/d /s /c' is used only for cmd.exe.
       if (file.endsWith('cmd.exe') || file.endsWith('cmd')) {
         args = ['/d', '/s', '/c', `"${command}"`];
+        options.windowsVerbatimArguments = true;
       } else {
-        args = ['-c', `"${command}"`];
+        args = ['-c', command];
       }
-      options.windowsVerbatimArguments = true;
     } else {
       if (typeof options.shell === 'string')
         file = options.shell;

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -2,6 +2,8 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
 
 // This test is only relevant on Windows.
 if (!common.isWindows)
@@ -9,28 +11,54 @@ if (!common.isWindows)
 
 // This test ensures that child_process.exec can work with any shells.
 
+tmpdir.refresh();
+const tmpPath = `${tmpdir.path}\\path with spaces`;
+fs.mkdirSync(tmpPath);
+
 const test = (shell) => {
-  cp.exec('echo foo bar', { shell: shell }, (error, stdout, stderror) => {
-    assert.ok(!error && !stderror);
-    assert.ok(stdout.includes('foo') && stdout.includes('bar'));
-  });
+  cp.exec('echo foo bar', { shell: shell },
+          common.mustCall((error, stdout, stderror) => {
+            assert.ok(!error && !stderror);
+            assert.ok(stdout.includes('foo') && stdout.includes('bar'));
+          }));
+};
+const testCopy = (shellName, shellPath) => {
+  // Copy the executable to a path with spaces, to ensure there are no issues
+  // related to quoting of argv0
+  const copyPath = `${tmpPath}\\${shellName}`;
+  fs.copyFileSync(shellPath, copyPath);
+  test(copyPath);
 };
 
+const system32 = `${process.env.SystemRoot}\\System32`;
+
+// Test CMD
+test(true);
 test('cmd');
+testCopy('cmd.exe', `${system32}\\cmd.exe`);
 test('cmd.exe');
 test('CMD');
+
+// Test PowerShell
 test('powershell');
-
-cp.exec('where bash', (error, stdout) => {
-  if (error) {
-    return;
-  }
-  test(stdout.split(/[\r\n]+/g)[0].trim());
-});
-
+testCopy('powershell.exe',
+         `${system32}\\WindowsPowerShell\\v1.0\\powershell.exe`);
 cp.exec(`Get-ChildItem "${__dirname}" | Select-Object -Property Name`,
-        { shell: 'PowerShell' }, (error, stdout, stderror) => {
+        { shell: 'PowerShell' }, common.mustCall((error, stdout, stderror) => {
           assert.ok(!error && !stderror);
           assert.ok(stdout.includes(
             'test-child-process-exec-any-shells-windows.js'));
-        });
+        }));
+
+// Test Bash (from WSL and Git), if available
+cp.exec('where bash', common.mustCall((error, stdout) => {
+  if (error) {
+    return;
+  }
+  const lines = stdout.trim().split(/[\r\n]+/g);
+  for (let i = 0; i < lines.length; ++i) {
+    const bashPath = lines[i].trim();
+    test(bashPath);
+    testCopy(`bash_${i}.exe`, bashPath);
+  }
+}));

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -25,7 +25,7 @@ cp.exec('where bash', (error, stdout) => {
   if (error) {
     return;
   }
-  test(stdout.trim());
+  test(stdout.split(/[\r\n]+/g)[0].trim());
 });
 
 cp.exec(`Get-ChildItem "${__dirname}" | Select-Object -Property Name`,

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -12,7 +12,7 @@ if (!common.isWindows)
 const test = (shell) => {
   cp.exec('echo foo bar', { shell: shell }, (error, stdout, stderror) => {
     assert.ok(!error && !stderror);
-    assert.ok(stdout.startsWith('foo bar'));
+    assert.ok(stdout.includes('foo') && stdout.includes('bar'));
   });
 };
 

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -18,10 +18,19 @@ const test = (shell) => {
 
 test('cmd');
 test('cmd.exe');
+test('CMD');
 test('powershell');
+
 cp.exec('where bash', (error, stdout) => {
   if (error) {
     return;
   }
   test(stdout.trim());
 });
+
+cp.exec(`Get-ChildItem "${__dirname}" | Select-Object -Property Name`,
+        { shell: 'PowerShell' }, (error, stdout, stderror) => {
+          assert.ok(!error && !stderror);
+          assert.ok(stdout.includes(
+            'test-child-process-exec-any-shells-windows.js'));
+        });

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -18,6 +18,10 @@ const test = (shell) => {
 
 test('cmd');
 test('cmd.exe');
-test('C:\\WINDOWS\\system32\\cmd.exe');
 test('powershell');
-test('C:\\Program Files\\Git\\bin\\bash.exe');
+cp.exec('where bash', (error, stdout) => {
+  if (error) {
+    return;
+  }
+  test(stdout.trim());
+});

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+// This test is only relevant on Windows.
+if (!common.isWindows)
+  common.skip('Windows specific test.');
+
+// This test ensures that child_process.exec can work with any shells.
+
+const test = (shell) => {
+  cp.exec('echo foo bar', { shell: shell }, (error, stdout, stderror) => {
+    assert.ok(!error && !stderror);
+    assert.ok(stdout.startsWith('foo bar'));
+  });
+};
+
+test('cmd');
+test('cmd.exe');
+test('C:\\WINDOWS\\system32\\cmd.exe');
+test('powershell');
+test('C:\\Program Files\\Git\\bin\\bash.exe');

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -43,12 +43,16 @@ test('CMD');
 test('powershell');
 testCopy('powershell.exe',
          `${system32}\\WindowsPowerShell\\v1.0\\powershell.exe`);
-cp.exec(`Get-ChildItem "${__dirname}" | Select-Object -Property Name`,
-        { shell: 'PowerShell' }, common.mustCall((error, stdout, stderror) => {
-          assert.ok(!error && !stderror);
-          assert.ok(stdout.includes(
-            'test-child-process-exec-any-shells-windows.js'));
-        }));
+fs.writeFile(`${tmpPath}\\test file`, 'Test', common.mustCall((err) => {
+  assert.ifError(err);
+  cp.exec(`Get-ChildItem "${tmpPath}" | Select-Object -Property Name`,
+          { shell: 'PowerShell' },
+          common.mustCall((error, stdout, stderror) => {
+            assert.ok(!error && !stderror);
+            assert.ok(stdout.includes(
+              'test file'));
+          }));
+}));
 
 // Test Bash (from WSL and Git), if available
 cp.exec('where bash', common.mustCall((error, stdout) => {

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -54,11 +54,13 @@ assert.strictEqual(env.stdout.toString().trim(), 'buzz');
 
   function test(testPlatform, shell, shellOutput) {
     platform = testPlatform;
-
+    const isCmd = shellOutput.endsWith('cmd.exe') ||
+                   shellOutput.endsWith('cmd');
     const cmd = 'not_a_real_command';
-    const shellFlags = platform === 'win32' ? ['/d', '/s', '/c'] : ['-c'];
-    const outputCmd = platform === 'win32' ? `"${cmd}"` : cmd;
-    const windowsVerbatim = platform === 'win32' ? true : undefined;
+
+    const shellFlags = isCmd ? ['/d', '/s', '/c'] : ['-c'];
+    const outputCmd = isCmd ? `"${cmd}"` : cmd;
+    const windowsVerbatim = isCmd ? true : undefined;
     internalCp.spawnSync = common.mustCall(function(opts) {
       assert.strictEqual(opts.file, shellOutput);
       assert.deepStrictEqual(opts.args,

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -59,7 +59,7 @@ assert.strictEqual(env.stdout.toString().trim(), 'buzz');
 
     const shellFlags = isCmd ? ['/d', '/s', '/c'] : ['-c'];
     const outputCmd = isCmd ? `"${cmd}"` : cmd;
-    const windowsVerbatim = platform === 'win32' ? true : undefined;
+    const windowsVerbatim = isCmd ? true : undefined;
     internalCp.spawnSync = common.mustCall(function(opts) {
       assert.strictEqual(opts.file, shellOutput);
       assert.deepStrictEqual(opts.args,

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -54,13 +54,12 @@ assert.strictEqual(env.stdout.toString().trim(), 'buzz');
 
   function test(testPlatform, shell, shellOutput) {
     platform = testPlatform;
-    const isCmd = shellOutput.endsWith('cmd.exe') ||
-                   shellOutput.endsWith('cmd');
+    const isCmd = /^(?:.*\\)?cmd(?:\.exe)?$/i.test(shellOutput);
     const cmd = 'not_a_real_command';
 
     const shellFlags = isCmd ? ['/d', '/s', '/c'] : ['-c'];
     const outputCmd = isCmd ? `"${cmd}"` : cmd;
-    const windowsVerbatim = isCmd ? true : undefined;
+    const windowsVerbatim = platform === 'win32' ? true : undefined;
     internalCp.spawnSync = common.mustCall(function(opts) {
       assert.strictEqual(opts.file, shellOutput);
       assert.deepStrictEqual(opts.args,


### PR DESCRIPTION
On Windows, child_process methods like `exec` supported only cmd.exe as the shell.  This change enables these methods to accept any shells using `-c` switch like Unix shells.

Fixes: https://github.com/nodejs/node/issues/21905
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
