### PR TITLE
dns: type check for dns.setServers argument.

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -12,6 +12,7 @@ const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
 const {
   ERR_DNS_SET_SERVERS_FAILED,
+  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_IP_ADDRESS,
   ERR_INVALID_OPT_VALUE
 } = errors.codes;
@@ -37,13 +38,20 @@ class Resolver {
   }
 
   setServers(servers) {
+    if (!Array.isArray(servers)) {
+      throw new ERR_INVALID_ARG_TYPE('servers', 'Array', servers);
+    }
+
     // Cache the original servers because in the event of an error while
     // setting the servers, c-ares won't have any servers available for
     // resolution.
     const orig = this._handle.getServers();
     const newSet = [];
 
-    servers.forEach((serv) => {
+    servers.forEach((serv, index) => {
+      if (typeof serv !== 'string') {
+        throw new ERR_INVALID_ARG_TYPE(`servers[${index}]`, 'string', serv);
+      }
       var ipVersion = isIP(serv);
 
       if (ipVersion !== 0)

--- a/test/internet/test-dns-setservers-type-check.js
+++ b/test/internet/test-dns-setservers-type-check.js
@@ -1,0 +1,88 @@
+'use strict';
+require('../common');
+const { addresses } = require('../common/internet');
+const assert = require('assert');
+const dns = require('dns');
+const resolver = new dns.promises.Resolver();
+const dnsPromises = dns.promises;
+const promiseResolver = new dns.promises.Resolver();
+
+{
+  [
+    null,
+    undefined,
+    Number(addresses.DNS4_SERVER),
+    addresses.DNS4_SERVER,
+    {
+      address: addresses.DNS4_SERVER
+    }
+  ].forEach((val) => {
+    const errObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "servers" argument must be of type Array. Received type ' +
+      typeof val
+    };
+    assert.throws(
+      () => {
+        dns.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        resolver.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        dnsPromises.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        promiseResolver.setServers(val);
+      }, errObj
+    );
+  });
+}
+
+{
+  [
+    [null],
+    [undefined],
+    [Number(addresses.DNS4_SERVER)],
+    [addresses.DNS4_SERVER],
+    [
+      {
+        address: addresses.DNS4_SERVER
+      }
+    ]
+  ].forEach((val) => {
+    const errObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "servers[0]" argument must be of type string.' +
+               `Received type ${typeof val[0]}`
+    };
+    assert.throws(
+      () => {
+        dns.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        resolver.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        dnsPromises.setServers(val);
+      }, errObj
+    );
+    assert.throws(
+      () => {
+        promiseResolver.setServers(val);
+      }, errObj
+    );
+  });
+}

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -51,7 +51,6 @@ const promiseResolver = new dns.promises.Resolver();
     [null],
     [undefined],
     [Number(addresses.DNS4_SERVER)],
-    [addresses.DNS4_SERVER],
     [
       {
         address: addresses.DNS4_SERVER

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -61,7 +61,7 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-      message: 'The "servers[0]" argument must be of type string.' +
+      message: 'The "servers[0]" argument must be of type string. ' +
                `Received type ${typeof val[0]}`
     };
     assert.throws(


### PR DESCRIPTION
Added type check for argument for dns.setServers and dnsPromises.setServers.

Refs #21930
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
