### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -53,6 +53,11 @@ import string
 import sys
 import unicodedata
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 
 logger = logging.getLogger('testrunner')
 


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  This PR ensures similar functionality on both Python 2 and Python 3.

Discovered via https://travis-ci.com/nodejs/node/builds/79706150 (https://github.com/nodejs/node/pull/21942)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
