### PR TITLE
doc: add missing worker error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1672,11 +1672,12 @@ the `--without-v8-platform` flag.
 <a id="ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER"></a>
 ### ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER
 
-A `SharedArrayBuffer` whose memory is not managed by the JavaScript engine or by Node.js was 
-encountered during serialization. Such a `SharedArrayBuffer` can not be serialized.
+A `SharedArrayBuffer` whose memory is not managed by the JavaScript engine 
+or by Node.js was encountered during serialization. Such a `SharedArrayBuffer`
+cannot be serialized.
 
-This can only happen when native addons create `SharedArrayBuffer`s in "externalized" mode, or put
-existing `SharedArrayBuffer` into externalized mode.
+This can only happen when native addons create `SharedArrayBuffer`s in 
+"externalized" mode, or put existing `SharedArrayBuffer` into externalized mode.
 
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1672,9 +1672,11 @@ the `--without-v8-platform` flag.
 <a id="ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER"></a>
 ### ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER
 
-A SharedArrayBuffer object was transfered but we do not see a lifetime partner 
-object and it was not us who externalized it - we are not sure how to serialize
-it because it's unclear how the memory is actually owned.
+A `SharedArrayBuffer` whose memory is not managed by the JavaScript engine or by Node.js was 
+encountered during serialization. Such a `SharedArrayBuffer` can not be serialized.
+
+This can only happen when native addons create `SharedArrayBuffer`s in "externalized" mode, or put
+existing `SharedArrayBuffer` into externalized mode.
 
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1669,6 +1669,13 @@ category.
 The `trace_events` module could not be loaded because Node.js was compiled with
 the `--without-v8-platform` flag.
 
+<a id="ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER"></a>
+### ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER
+
+A SharedArrayBuffer object was transfered but we do not see a lifetime partner 
+object and it was not us who externalized it - we are not sure how to serialize
+it because it's unclear how the memory is actually owned.
+
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING
 


### PR DESCRIPTION
@ChALkeR noticed that `ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER` was missing from the docs. This PR adds it there based on the wording @addaleax used in the her PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
