### PR TITLE
Makefile: Add lint-python which uses flake8

### DIFF
--- a/tools/pip/.gitignore
+++ b/tools/pip/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+site-packages

--- a/tools/pip/sitecustomize.py
+++ b/tools/pip/sitecustomize.py
@@ -1,0 +1,3 @@
+import os
+import site
+site.addsitedir(os.path.dirname(os.path.realpath(__file__)) + '/site-packages')


### PR DESCRIPTION
Add a __lint-python__ section to __Makefile__ which pip installs [__flake8__](http://flake8.pycqa.org) and then executes:
* __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

Based on the experimentation done at  https://travis-ci.com/nodejs/node/builds/79706150 - #21942

These tests currently __exclude__ several directories and files:
* __./deps/npm/node_modules/node-gyp__ -- this repo currently has no automated testing
* __./deps/v8__ -- contains several Python 3 only features such as __async def__
* __./src/noperfctr_macros.py__ -- contains __"macros"__ which Python AST views as syntax errors
* __./src/notrace_macros.py__ -- contains __"macros"__ which Python AST views as syntax errors
* __./tools__ -- contains __"macros"__ which Python AST views as syntax errors

Hopefully this list can be reduced in future PRs with code modifications or the use of [_# noqa_](http://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors)

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
