### PR TITLE
Travis CI: Add flake8 jobs for Python 2.7 and Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       script:
         - make -j2 test-ci
     - os: linux
+      language: python
       python: 2.7
       install:
         - pip install flake8
@@ -28,6 +29,7 @@ matrix:
         - EXCLUDE=./deps/npm/node_modules/node-gyp,./deps/v8,./src/noperfctr_macros.py,./src/notrace_macros.py,./tools
         - flake8 . --count --exclude=${EXCLUDE} --select=E901,E999,F821,F822,F823 --show-source --statistics
     - os: linux
+      language: python
       python: 3.7
       dist: xenial  # required for Python 3.7
       sudo: true    # required for Python 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ compiler:
 sudo: false
 cache: ccache
 matrix:
+  allow_failures:
+    - python: 3.7
   include:
     - os: linux
       node_js: "latest"
@@ -17,7 +19,25 @@ matrix:
         - make -j2 V=
       script:
         - make -j2 test-ci
+    - os: linux
+      python: 2.7
+      install:
+        - pip install flake8
+      script:
+        - flake8 --version
+        - EXCLUDE=./deps/npm/node_modules/node-gyp,./deps/v8,./src/noperfctr_macros.py,./src/notrace_macros.py,./tools
+        - flake8 . --count --exclude=${EXCLUDE} --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - os: linux
+      python: 3.7
+      dist: xenial  # required for Python 3.7
+      sudo: true    # required for Python 3.7
+      install:
+        - pip install flake8
+      script:
+        - flake8 --version
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+
 before_install:
   - export CXX="ccache clang++ -Qunused-arguments"
   - export CC="ccache clang -Qunused-arguments -Wno-unknown-warning-option"
-  - export JOBS=2
+  - export JOBS=4


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
An alternative approach to #21952 that runs [__flake8__](http://flake8.pycqa.org) in parallel Travis CI jobs on both Python 2.7 and Python 3.7.  The Python 3.7 job is run in __allow_failures__ mode.

See #21952 for more details on the --exclude and --select choices.  A mix of these two PRs is also possible.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
