### PR TITLE
test: Remove `usc-2` and `usc2`

### DIFF
--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -5,9 +5,9 @@ const assert = require('assert');
 
 const groupedInputs = {
   group_common: ['undefined', 'utf8', 'utf-8', 'base64',
-                 'binary', 'latin1', 'ucs-2', 'usc-2'],
+                 'binary', 'latin1', 'ucs-2'],
   group_upper: ['UTF-8', 'UTF8', 'UCS2', 'UTF-16LE',
-                'UTF16LE', 'BASE64', 'UCS-2', 'USC-2'],
+                'UTF16LE', 'BASE64', 'UCS-2'],
   group_uncommon: ['foo', '1', 'false', 'undefined', '[]', '{}'],
   group_misc: ['', 'utf16le', 'usc2', 'hex', 'HEX', 'BINARY']
 };
@@ -17,9 +17,7 @@ const inputs = [
   'utf8', 'utf-8', 'UTF-8',
   'UTF8', 'Utf8', 'uTf-8', 'utF-8',
   'ucs2', 'UCS2', 'UcS2',
-  'USC2', 'usc2', 'uSc2',
   'ucs-2', 'UCS-2', 'UcS-2',
-  'usc-2', 'USC-2', 'uSc-2',
   'utf16le', 'utf-16le', 'UTF-16LE', 'UTF16LE',
   'binary', 'BINARY', 'latin1', 'base64', 'BASE64',
   'hex', 'HEX', 'foo', '1', 'false', 'undefined', '[]', '{}'];


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/21963

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]