### PR TITLE
test: update setTimeout on file test/internet/test-net-connect-unref.js to use common.platformTimeout

### DIFF
--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -30,5 +30,3 @@ const client = net.createConnection(53, '8.8.8.8', function() {
 });
 
 client.on('close', common.mustNotCall());
-
-setTimeout(common.mustNotCall(), common.platformTimeout(TIMEOUT)).unref();

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -31,4 +31,4 @@ const client = net.createConnection(53, '8.8.8.8', function() {
 
 client.on('close', common.mustNotCall());
 
-setTimeout(common.mustNotCall(), TIMEOUT).unref();
+setTimeout(common.mustNotCall(), common.platformTimeout(TIMEOUT)).unref();

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -23,8 +23,6 @@
 const common = require('../common');
 const net = require('net');
 
-const TIMEOUT = 10 * 1000;
-
 const client = net.createConnection(53, '8.8.8.8', function() {
   client.unref();
 });


### PR DESCRIPTION
Hi! 

This is my first PR 😄 I'm sorry if I make any mistake.

This commit updates the time used on the `timeOut` function to confonform to the [recomendation given by the guide on writing tests. ](https://github.com/nodejs/node/blob/master/doc/guides/writing-tests.md#timers)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
