### PR TITLE
src,lib: rename FSReqWrap to FSReqCallback

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -52,7 +52,7 @@ const {
   ERR_INVALID_CALLBACK
 } = errors.codes;
 
-const { FSReqWrap, statValues } = binding;
+const { FSReqCallback, statValues } = binding;
 const internalFS = require('internal/fs/utils');
 const { getPathFromURL } = require('internal/url');
 const internalUtil = require('internal/util');
@@ -179,7 +179,7 @@ function access(path, mode, callback) {
   validatePath(path);
 
   mode = mode | 0;
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.access(pathModule.toNamespacedPath(path), mode, req);
 }
@@ -243,7 +243,7 @@ function readFileAfterOpen(err, fd) {
 
   context.fd = fd;
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = readFileAfterStat;
   req.context = context;
   binding.fstat(fd, false, req);
@@ -284,7 +284,7 @@ function readFile(path, options, callback) {
   const context = new ReadFileContext(callback, options.encoding);
   context.isUserFd = isFd(path); // file descriptor ownership
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.context = context;
   req.oncomplete = readFileAfterOpen;
 
@@ -393,7 +393,7 @@ function readFileSync(path, options) {
 
 function close(fd, callback) {
   validateUint32(fd, 'fd');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.close(fd, req);
 }
@@ -418,7 +418,7 @@ function open(path, flags, mode, callback) {
     callback = makeCallback(callback);
   }
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
 
   binding.open(pathModule.toNamespacedPath(path),
@@ -470,7 +470,7 @@ function read(fd, buffer, offset, length, position, callback) {
     callback && callback(err, bytesRead || 0, buffer);
   }
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = wrapper;
 
   binding.read(fd, buffer, offset, length, position, req);
@@ -519,7 +519,7 @@ function write(fd, buffer, offset, length, position, callback) {
 
   validateUint32(fd, 'fd');
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = wrapper;
 
   if (isUint8Array(buffer)) {
@@ -588,7 +588,7 @@ function rename(oldPath, newPath, callback) {
   validatePath(oldPath, 'oldPath');
   newPath = getPathFromURL(newPath);
   validatePath(newPath, 'newPath');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.rename(pathModule.toNamespacedPath(oldPath),
                  pathModule.toNamespacedPath(newPath),
@@ -622,7 +622,7 @@ function truncate(path, len, callback) {
   callback = maybeCallback(callback);
   fs.open(path, 'r+', function(er, fd) {
     if (er) return callback(er);
-    const req = new FSReqWrap();
+    const req = new FSReqCallback();
     req.oncomplete = function oncomplete(er) {
       fs.close(fd, function(er2) {
         callback(er || er2);
@@ -661,7 +661,7 @@ function ftruncate(fd, len = 0, callback) {
   validateUint32(fd, 'fd');
   validateInteger(len, 'len');
   len = Math.max(0, len);
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.ftruncate(fd, len, req);
 }
@@ -679,7 +679,7 @@ function rmdir(path, callback) {
   callback = makeCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.rmdir(pathModule.toNamespacedPath(path), req);
 }
@@ -694,7 +694,7 @@ function rmdirSync(path) {
 
 function fdatasync(fd, callback) {
   validateUint32(fd, 'fd');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.fdatasync(fd, req);
 }
@@ -708,7 +708,7 @@ function fdatasyncSync(fd) {
 
 function fsync(fd, callback) {
   validateUint32(fd, 'fd');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.fsync(fd, req);
 }
@@ -732,7 +732,7 @@ function mkdir(path, mode, callback) {
     mode = validateMode(mode, 'mode', 0o777);
   }
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.mkdir(pathModule.toNamespacedPath(path), mode, req);
 }
@@ -752,7 +752,7 @@ function readdir(path, options, callback) {
   path = getPathFromURL(path);
   validatePath(path);
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.readdir(pathModule.toNamespacedPath(path), options.encoding, req);
 }
@@ -774,7 +774,7 @@ function fstat(fd, options, callback) {
     options = {};
   }
   validateUint32(fd, 'fd');
-  const req = new FSReqWrap(options.bigint);
+  const req = new FSReqCallback(options.bigint);
   req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, options.bigint, req);
 }
@@ -787,7 +787,7 @@ function lstat(path, options, callback) {
   callback = makeStatsCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap(options.bigint);
+  const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
   binding.lstat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
@@ -800,7 +800,7 @@ function stat(path, options, callback) {
   callback = makeStatsCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap(options.bigint);
+  const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
@@ -838,7 +838,7 @@ function readlink(path, options, callback) {
   options = getOptions(options, {});
   path = getPathFromURL(path);
   validatePath(path, 'oldPath');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.readlink(pathModule.toNamespacedPath(path), options.encoding, req);
 }
@@ -864,7 +864,7 @@ function symlink(target, path, type_, callback_) {
   validatePath(path);
 
   const flags = stringToSymlinkType(type);
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
 
   binding.symlink(preprocessSymlinkDestination(target, type, path),
@@ -894,7 +894,7 @@ function link(existingPath, newPath, callback) {
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
 
   binding.link(pathModule.toNamespacedPath(existingPath),
@@ -920,7 +920,7 @@ function unlink(path, callback) {
   callback = makeCallback(callback);
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.unlink(pathModule.toNamespacedPath(path), req);
 }
@@ -938,7 +938,7 @@ function fchmod(fd, mode, callback) {
   mode = validateMode(mode, 'mode');
   callback = makeCallback(callback);
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.fchmod(fd, mode, req);
 }
@@ -989,7 +989,7 @@ function chmod(path, mode, callback) {
   mode = validateMode(mode, 'mode');
   callback = makeCallback(callback);
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.chmod(pathModule.toNamespacedPath(path), mode, req);
 }
@@ -1010,7 +1010,7 @@ function lchown(path, uid, gid, callback) {
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, req);
 }
@@ -1030,7 +1030,7 @@ function fchown(fd, uid, gid, callback) {
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.fchown(fd, uid, gid, req);
 }
@@ -1052,7 +1052,7 @@ function chown(path, uid, gid, callback) {
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.chown(pathModule.toNamespacedPath(path), uid, gid, req);
 }
@@ -1072,7 +1072,7 @@ function utimes(path, atime, mtime, callback) {
   path = getPathFromURL(path);
   validatePath(path);
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.utimes(pathModule.toNamespacedPath(path),
                  toUnixTimestamp(atime),
@@ -1094,7 +1094,7 @@ function futimes(fd, atime, mtime, callback) {
   validateUint32(fd, 'fd');
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.futimes(fd, atime, mtime, req);
 }
@@ -1635,7 +1635,7 @@ realpath.native = function(path, options, callback) {
   options = getOptions(options, {});
   path = getPathFromURL(path);
   validatePath(path);
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   return binding.realpath(path, options.encoding, req);
 };
@@ -1647,7 +1647,7 @@ function mkdtemp(prefix, options, callback) {
     throw new ERR_INVALID_ARG_TYPE('prefix', 'string', prefix);
   }
   nullCheck(prefix, 'prefix');
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.mkdtemp(`${prefix}XXXXXX`, options.encoding, req);
 }
@@ -1684,7 +1684,7 @@ function copyFile(src, dest, flags, callback) {
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);
   flags = flags | 0;
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
   binding.copyFile(src, dest, flags, req);
 }

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { FSReqWrap, close, read } = process.binding('fs');
+const { FSReqCallback, close, read } = process.binding('fs');
 
 const kReadFileBufferLength = 8 * 1024;
 
@@ -81,7 +81,7 @@ class ReadFileContext {
       length = Math.min(kReadFileBufferLength, this.size - this.pos);
     }
 
-    const req = new FSReqWrap();
+    const req = new FSReqCallback();
     req.oncomplete = readFileAfterRead;
     req.context = this;
 
@@ -89,7 +89,7 @@ class ReadFileContext {
   }
 
   close(err) {
-    const req = new FSReqWrap();
+    const req = new FSReqCallback();
     req.oncomplete = readFileAfterClose;
     req.context = this;
     this.err = err;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  FSReqWrap,
+  FSReqCallback,
   writeBuffers
 } = process.binding('fs');
 const {
@@ -313,7 +313,7 @@ function writev(fd, chunks, position, callback) {
     callback(err, written || 0, chunks);
   }
 
-  const req = new FSReqWrap();
+  const req = new FSReqCallback();
   req.oncomplete = wrapper;
   writeBuffers(fd, chunks, position, req);
 }

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -39,7 +39,7 @@ namespace node {
   V(FILEHANDLE)                                                               \
   V(FILEHANDLECLOSEREQ)                                                       \
   V(FSEVENTWRAP)                                                              \
-  V(FSREQWRAP)                                                                \
+  V(FSREQCALLBACK)                                                            \
   V(FSREQPROMISE)                                                             \
   V(GETADDRINFOREQWRAP)                                                       \
   V(GETNAMEINFOREQWRAP)                                                       \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -407,15 +407,15 @@ int FileHandle::DoShutdown(ShutdownWrap* req_wrap) {
 }
 
 
-void FSReqWrap::Reject(Local<Value> reject) {
+void FSReqCallback::Reject(Local<Value> reject) {
   MakeCallback(env()->oncomplete_string(), 1, &reject);
 }
 
-void FSReqWrap::ResolveStat(const uv_stat_t* stat) {
+void FSReqCallback::ResolveStat(const uv_stat_t* stat) {
   Resolve(node::FillGlobalStatsArray(env(), stat, use_bigint()));
 }
 
-void FSReqWrap::Resolve(Local<Value> value) {
+void FSReqCallback::Resolve(Local<Value> value) {
   Local<Value> argv[2] {
     Null(env()->isolate()),
     value
@@ -425,14 +425,14 @@ void FSReqWrap::Resolve(Local<Value> value) {
                argv);
 }
 
-void FSReqWrap::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
+void FSReqCallback::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().SetUndefined();
 }
 
-void NewFSReqWrap(const FunctionCallbackInfo<Value>& args) {
+void NewFSReqCallback(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  new FSReqWrap(env, args.This(), args[0]->IsTrue());
+  new FSReqCallback(env, args.This(), args[0]->IsTrue());
 }
 
 FSReqAfterScope::FSReqAfterScope(FSReqBase* wrap, uv_fs_t* req)
@@ -600,7 +600,7 @@ void AfterScanDir(uv_fs_t* req) {
 
 
 // This class is only used on sync fs calls.
-// For async calls FSReqWrap is used.
+// For async calls FSReqCallback is used.
 class FSReqWrapSync {
  public:
   FSReqWrapSync() {}
@@ -1954,13 +1954,13 @@ void Initialize(Local<Object> target,
 
   StatWatcher::Initialize(env, target);
 
-  // Create FunctionTemplate for FSReqWrap
+  // Create FunctionTemplate for FSReqCallback
   Local<FunctionTemplate> fst =
-      FunctionTemplate::New(env->isolate(), NewFSReqWrap);
+      FunctionTemplate::New(env->isolate(), NewFSReqCallback);
   fst->InstanceTemplate()->SetInternalFieldCount(1);
   AsyncWrap::AddWrapMethods(env, fst);
   Local<String> wrapString =
-      FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqWrap");
+      FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqCallback");
   fst->SetClassName(wrapString);
   target->Set(context, wrapString, fst->GetFunction()).FromJust();
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -269,7 +269,7 @@ void FileHandle::AfterClose() {
 
 
 FileHandleReadWrap::FileHandleReadWrap(FileHandle* handle, Local<Object> obj)
-  : ReqWrap(handle->env(), obj, AsyncWrap::PROVIDER_FSREQWRAP),
+  : ReqWrap(handle->env(), obj, AsyncWrap::PROVIDER_FSREQCALLBACK),
     file_handle_(handle) {}
 
 int FileHandle::ReadStart() {

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -88,7 +88,7 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
 class FSReqCallback : public FSReqBase {
  public:
   FSReqCallback(Environment* env, Local<Object> req, bool use_bigint)
-      : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQWRAP, use_bigint) { }
+      : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQCALLBACK, use_bigint) { }
 
   void Reject(Local<Value> reject) override;
   void Resolve(Local<Value> value) override;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -85,9 +85,9 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
   DISALLOW_COPY_AND_ASSIGN(FSReqBase);
 };
 
-class FSReqWrap : public FSReqBase {
+class FSReqCallback : public FSReqBase {
  public:
-  FSReqWrap(Environment* env, Local<Object> req, bool use_bigint)
+  FSReqCallback(Environment* env, Local<Object> req, bool use_bigint)
       : FSReqBase(env, req, AsyncWrap::PROVIDER_FSREQWRAP, use_bigint) { }
 
   void Reject(Local<Value> reject) override;
@@ -99,10 +99,10 @@ class FSReqWrap : public FSReqBase {
     tracker->TrackThis(this);
   }
 
-  ADD_MEMORY_INFO_NAME(FSReqWrap)
+  ADD_MEMORY_INFO_NAME(FSReqCallback)
 
  private:
-  DISALLOW_COPY_AND_ASSIGN(FSReqWrap);
+  DISALLOW_COPY_AND_ASSIGN(FSReqCallback);
 };
 
 template <typename NativeT = double, typename V8T = v8::Float64Array>

--- a/test/async-hooks/coverage.md
+++ b/test/async-hooks/coverage.md
@@ -2,30 +2,30 @@
 
 Showing which kind of async resource is covered by which test:
 
-| Resource Type        | Test                                   |
-|----------------------|----------------------------------------|
-| CONNECTION           | test-connection.ssl.js                 |
-| FSEVENTWRAP          | test-fseventwrap.js                    |
-| FSREQWRAP            | test-fsreqwrap-{access,readFile}.js    |
-| GETADDRINFOREQWRAP   | test-getaddrinforeqwrap.js             |
-| GETNAMEINFOREQWRAP   | test-getnameinforeqwrap.js             |
-| HTTPPARSER           | test-httpparser.{request,response}.js  |
-| Immediate            | test-immediate.js                      |
-| JSSTREAM             | TODO (crashes when accessing directly) |
-| PBKDF2REQUEST        | test-crypto-pbkdf2.js                  |
-| PIPECONNECTWRAP      | test-pipeconnectwrap.js                |
-| PIPEWRAP             | test-pipewrap.js                       |
-| PROCESSWRAP          | test-pipewrap.js                       |
-| QUERYWRAP            | test-querywrap.js                      |
-| RANDOMBYTESREQUEST   | test-crypto-randomBytes.js             |
-| SHUTDOWNWRAP         | test-shutdownwrap.js                   |
-| SIGNALWRAP           | test-signalwrap.js                     |
-| STATWATCHER          | test-statwatcher.js                    |
-| TCPCONNECTWRAP       | test-tcpwrap.js                        |
-| TCPWRAP              | test-tcpwrap.js                        |
-| TLSWRAP              | test-tlswrap.js                        |
-| TTYWRAP              | test-ttywrap.{read,write}stream.js     |
-| UDPSENDWRAP          | test-udpsendwrap.js                    |
-| UDPWRAP              | test-udpwrap.js                        |
-| WRITEWRAP            | test-writewrap.js                      |
-| ZLIB                 | test-zlib.zlib-binding.deflate.js      |
+| Resource Type        | Test                                       |
+|----------------------|--------------------------------------------|
+| CONNECTION           | test-connection.ssl.js                     |
+| FSEVENTWRAP          | test-fseventwrap.js                        |
+| FSREQCALLBACK        | test-fsreqcallback-{access,readFile}.js    |
+| GETADDRINFOREQWRAP   | test-getaddrinforeqwrap.js                 |
+| GETNAMEINFOREQWRAP   | test-getnameinforeqwrap.js                 |
+| HTTPPARSER           | test-httpparser.{request,response}.js      |
+| Immediate            | test-immediate.js                          |
+| JSSTREAM             | TODO (crashes when accessing directly)     |
+| PBKDF2REQUEST        | test-crypto-pbkdf2.js                      |
+| PIPECONNECTWRAP      | test-pipeconnectwrap.js                    |
+| PIPEWRAP             | test-pipewrap.js                           |
+| PROCESSWRAP          | test-pipewrap.js                           |
+| QUERYWRAP            | test-querywrap.js                          |
+| RANDOMBYTESREQUEST   | test-crypto-randomBytes.js                 |
+| SHUTDOWNWRAP         | test-shutdownwrap.js                       |
+| SIGNALWRAP           | test-signalwrap.js                         |
+| STATWATCHER          | test-statwatcher.js                        |
+| TCPCONNECTWRAP       | test-tcpwrap.js                            |
+| TCPWRAP              | test-tcpwrap.js                            |
+| TLSWRAP              | test-tlswrap.js                            |
+| TTYWRAP              | test-ttywrap.{read,write}stream.js         |
+| UDPSENDWRAP          | test-udpsendwrap.js                        |
+| UDPWRAP              | test-udpwrap.js                            |
+| WRITEWRAP            | test-writewrap.js                          |
+| ZLIB                 | test-zlib.zlib-binding.deflate.js          |

--- a/test/async-hooks/test-fsreqcallback-access.js
+++ b/test/async-hooks/test-fsreqcallback-access.js
@@ -13,7 +13,7 @@ hooks.enable();
 fs.access(__filename, common.mustCall(onaccess));
 
 function onaccess() {
-  const as = hooks.activitiesOfTypes('FSREQWRAP');
+  const as = hooks.activitiesOfTypes('FSREQCALLBACK');
   const a = as[0];
   checkInvocations(a, { init: 1, before: 1 },
                    'while in onaccess callback');
@@ -24,13 +24,13 @@ process.on('exit', onexit);
 
 function onexit() {
   hooks.disable();
-  hooks.sanityCheck('FSREQWRAP');
+  hooks.sanityCheck('FSREQCALLBACK');
 
-  const as = hooks.activitiesOfTypes('FSREQWRAP');
+  const as = hooks.activitiesOfTypes('FSREQCALLBACK');
   assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'FSREQWRAP');
+  assert.strictEqual(a.type, 'FSREQCALLBACK');
   assert.strictEqual(typeof a.uid, 'number');
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');

--- a/test/async-hooks/test-fsreqcallback-readFile.js
+++ b/test/async-hooks/test-fsreqcallback-readFile.js
@@ -16,11 +16,11 @@ hooks.enable();
 fs.readFile(__filename, common.mustCall(onread));
 
 function onread() {
-  const as = hooks.activitiesOfTypes('FSREQWRAP');
+  const as = hooks.activitiesOfTypes('FSREQCALLBACK');
   let lastParent = 1;
   for (let i = 0; i < as.length; i++) {
     const a = as[i];
-    assert.strictEqual(a.type, 'FSREQWRAP');
+    assert.strictEqual(a.type, 'FSREQCALLBACK');
     assert.strictEqual(typeof a.uid, 'number');
     assert.strictEqual(a.triggerAsyncId, lastParent);
     lastParent = a.uid;
@@ -43,8 +43,8 @@ process.on('exit', onexit);
 
 function onexit() {
   hooks.disable();
-  hooks.sanityCheck('FSREQWRAP');
-  const as = hooks.activitiesOfTypes('FSREQWRAP');
+  hooks.sanityCheck('FSREQCALLBACK');
+  const as = hooks.activitiesOfTypes('FSREQCALLBACK');
   const a = as.pop();
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');

--- a/test/async-hooks/test-graph.fsreq-readFile.js
+++ b/test/async-hooks/test-graph.fsreq-readFile.js
@@ -18,9 +18,9 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'FSREQWRAP', id: 'fsreq:1', triggerAsyncId: null },
-      { type: 'FSREQWRAP', id: 'fsreq:2', triggerAsyncId: 'fsreq:1' },
-      { type: 'FSREQWRAP', id: 'fsreq:3', triggerAsyncId: 'fsreq:2' },
-      { type: 'FSREQWRAP', id: 'fsreq:4', triggerAsyncId: 'fsreq:3' } ]
+    [ { type: 'FSREQCALLBACK', id: 'fsreq:1', triggerAsyncId: null },
+      { type: 'FSREQCALLBACK', id: 'fsreq:2', triggerAsyncId: 'fsreq:1' },
+      { type: 'FSREQCALLBACK', id: 'fsreq:3', triggerAsyncId: 'fsreq:2' },
+      { type: 'FSREQCALLBACK', id: 'fsreq:4', triggerAsyncId: 'fsreq:3' } ]
   );
 }

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -57,7 +57,7 @@ class TestReqWrap : public node::ReqWrap<uv_req_t> {
   TestReqWrap(node::Environment* env, v8::Local<v8::Object> object)
       : node::ReqWrap<uv_req_t>(env,
                                 object,
-                                node::AsyncWrap::PROVIDER_FSREQWRAP) {}
+                                node::AsyncWrap::PROVIDER_FSREQCALLBACK) {}
 };
 
 TEST_F(DebugSymbolsTest, ContextEmbedderEnvironmentIndex) {

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -133,11 +133,11 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   const binding = process.binding('fs');
   const path = require('path');
 
-  const FSReqWrap = binding.FSReqWrap;
-  const req = new FSReqWrap();
+  const FSReqCallback = binding.FSReqCallback;
+  const req = new FSReqCallback();
   req.oncomplete = () => { };
 
-  testInitialized(req, 'FSReqWrap');
+  testInitialized(req, 'FSReqCallback');
   binding.access(path.toNamespacedPath('../'), fs.F_OK, req);
 
   const StatWatcher = binding.StatWatcher;


### PR DESCRIPTION
Given that FSReqPromise does not inherit from FSReqWrap, FSReqWrap
should be renamed FSReqCallback to better describe what it does.

First of a few upcoming `fs` refactorings :)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)