### PR TITLE
tools: convert addon-verify to remark

### DIFF
--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -339,11 +339,6 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
       "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
     },
-    "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
-    },
     "mdast-util-definitions": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
@@ -589,6 +584,15 @@
         "character-entities-legacy": "^1.0.0",
         "is-alphanumerical": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "to-vfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-5.0.0.tgz",
+      "integrity": "sha512-sUeBtb4i09pNIzPtl/PMW20Xfe/NK82oV0IehtmoX/+PhIdvc6JHMRnmC4fjCIcy0LOwcNqB8iRMtTBzXHVbng==",
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^3.0.0"
       }
     },
     "trim": {

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,12 +7,12 @@
     "node": ">=6"
   },
   "dependencies": {
-    "marked": "^0.4.0",
     "rehype-raw": "^2.0.0",
     "rehype-stringify": "^3.0.0",
     "remark-html": "^7.0.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
+    "to-vfile": "^5.0.0",
     "unified": "^7.0.0",
     "unist-util-find": "^1.0.1",
     "unist-util-select": "^1.5.0",


### PR DESCRIPTION
This is the last use of the remark *module*.  tools/remark-cli and
tools/remark-preset-lint-node remain.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
