### PR TITLE
src: use available ReqWrap instance for libuv req

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1552,9 +1552,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
     len = StringBytes::Write(env->isolate(), *stack_buffer, len, args[1], enc);
     stack_buffer.SetLengthAndZeroTerminate(len);
     uv_buf_t uvbuf = uv_buf_init(*stack_buffer, len);
-    int err = uv_fs_write(env->event_loop(), req_wrap_async->req(),
-                          fd, &uvbuf, 1, pos, AfterInteger);
-    req_wrap_async->Dispatched();
+    int err = req_wrap_async->Dispatch(uv_fs_write, fd, &uvbuf, 1, pos, AfterInteger);
     if (err < 0) {
       uv_fs_t* uv_req = req_wrap_async->req();
       uv_req->result = err;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1552,7 +1552,12 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
     len = StringBytes::Write(env->isolate(), *stack_buffer, len, args[1], enc);
     stack_buffer.SetLengthAndZeroTerminate(len);
     uv_buf_t uvbuf = uv_buf_init(*stack_buffer, len);
-    int err = req_wrap_async->Dispatch(uv_fs_write, fd, &uvbuf, 1, pos, AfterInteger);
+    int err = req_wrap_async->Dispatch(uv_fs_write,
+                                       fd,
+                                       &uvbuf,
+                                       1,
+                                       pos,
+                                       AfterInteger);
     if (err < 0) {
       uv_fs_t* uv_req = req_wrap_async->req();
       uv_req->result = err;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -339,7 +339,12 @@ int LibuvStreamWrap::DoWrite(WriteWrap* req_wrap,
   if (send_handle == nullptr) {
     r = w->Dispatch(uv_write, stream(), bufs, count, AfterUvWrite);
   } else {
-    r = w->Dispatch(uv_write2, stream(), bufs, count, send_handle, AfterUvWrite);
+    r = w->Dispatch(uv_write2,
+                    stream(),
+                    bufs,
+                    count,
+                    send_handle,
+                    AfterUvWrite);
   }
 
   if (!r) {

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -276,10 +276,7 @@ WriteWrap* LibuvStreamWrap::CreateWriteWrap(Local<Object> object) {
 
 int LibuvStreamWrap::DoShutdown(ShutdownWrap* req_wrap_) {
   LibuvShutdownWrap* req_wrap = static_cast<LibuvShutdownWrap*>(req_wrap_);
-  int err;
-  err = uv_shutdown(req_wrap->req(), stream(), AfterUvShutdown);
-  req_wrap->Dispatched();
-  return err;
+  return req_wrap->Dispatch(uv_shutdown, stream(), AfterUvShutdown);
 }
 
 
@@ -340,9 +337,9 @@ int LibuvStreamWrap::DoWrite(WriteWrap* req_wrap,
   LibuvWriteWrap* w = static_cast<LibuvWriteWrap*>(req_wrap);
   int r;
   if (send_handle == nullptr) {
-    r = uv_write(w->req(), stream(), bufs, count, AfterUvWrite);
+    r = w->Dispatch(uv_write, stream(), bufs, count, AfterUvWrite);
   } else {
-    r = uv_write2(w->req(), stream(), bufs, count, send_handle, AfterUvWrite);
+    r = w->Dispatch(uv_write2, stream(), bufs, count, send_handle, AfterUvWrite);
   }
 
   if (!r) {
@@ -355,8 +352,6 @@ int LibuvStreamWrap::DoWrite(WriteWrap* req_wrap,
       NODE_COUNT_PIPE_BYTES_SENT(bytes);
     }
   }
-
-  w->Dispatched();
 
   return r;
 }


### PR DESCRIPTION
Use available `ReqWrap` descendant to make call to libuv -- avoid doing
call with the `ReqWrap`'s request member and then calling `Dispatched()`
afterwards.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)