### PR TITLE
test: remove unused config

### DIFF
--- a/benchmark/process/next-tick-depth-args.js
+++ b/benchmark/process/next-tick-depth-args.js
@@ -5,8 +5,6 @@ const bench = common.createBenchmark(main, {
   n: [12e6]
 });
 
-process.maxTickDepth = Infinity;
-
 function main({ n }) {
   let counter = n;
   function cb4(arg1, arg2, arg3, arg4) {

--- a/benchmark/process/next-tick-depth.js
+++ b/benchmark/process/next-tick-depth.js
@@ -4,8 +4,6 @@ const bench = common.createBenchmark(main, {
   n: [12e6]
 });
 
-process.maxTickDepth = Infinity;
-
 function main({ n }) {
   let counter = n;
   bench.start();

--- a/test/parallel/test-next-tick-intentional-starvation.js
+++ b/test/parallel/test-next-tick-intentional-starvation.js
@@ -23,12 +23,8 @@
 require('../common');
 const assert = require('assert');
 
-// this is the inverse of test-next-tick-starvation.
-// it verifies that process.nextTick will *always* come before other
-// events, up to the limit of the process.maxTickDepth value.
-
-// WARNING: unsafe!
-process.maxTickDepth = Infinity;
+// this is the inverse of test-next-tick-starvation. it verifies
+// that process.nextTick will *always* come before other events
 
 let ran = false;
 let starved = false;

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -22,12 +22,12 @@
 'use strict';
 const common = require('../common');
 const Readable = require('stream').Readable;
+
+// This tests synchronous read callbacks and verifies that even if they nest
+// heavily the process handles it without an error
+
 const r = new Readable();
 const N = 256 * 1024;
-
-// Go ahead and allow the pathological case for this test.
-// Yes, it's an infinite loop, that's the point.
-process.maxTickDepth = N + 2;
 
 let reads = 0;
 r._read = function(n) {

--- a/test/sequential/test-next-tick-error-spin.js
+++ b/test/sequential/test-next-tick-error-spin.js
@@ -39,7 +39,6 @@ if (process.argv[2] !== 'child') {
 
   const domain = require('domain');
   const d = domain.create();
-  process.maxTickDepth = 10;
 
   // in the error handler, we trigger several MakeCallback events
   d.on('error', function() {


### PR DESCRIPTION
`process.maxTickDepth` was removed in v0.12 a whole while ago and was mostly removed from our code base. There are still some places it was left in old benchmarks and tests.

This PR removes those. Wasn't sure if to label it `test` or `chore` or `benchmark` - seemed very insignificant to think a lot about it for this tiny PR.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
