### PR TITLE
v8: backport 22116dd6c884c026225e56dd8e442a660193e729

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -766,8 +766,11 @@ StartupData SnapshotCreator::CreateBlob(
       // Complete in-object slack tracking for all functions.
       fun->CompleteInobjectSlackTrackingIfActive();
 
-      // Also, clear out feedback vectors.
-      fun->feedback_cell()->set_value(isolate->heap()->undefined_value());
+      // Also, clear out feedback vectors, or any optimized code.
+      if (fun->has_feedback_vector()) {
+        fun->feedback_cell()->set_value(isolate->heap()->undefined_value());
+        fun->set_code(isolate->builtins()->builtin(i::Builtins::kCompileLazy));
+      }
     }
 
     // Clear out re-compilable data from all shared function infos. Any

--- a/deps/v8/src/snapshot/partial-serializer.cc
+++ b/deps/v8/src/snapshot/partial-serializer.cc
@@ -105,7 +105,7 @@ void PartialSerializer::SerializeObject(HeapObject* obj, HowToCode how_to_code,
     // Unconditionally reset the JSFunction to its SFI's code, since we can't
     // serialize optimized code anyway.
     JSFunction* closure = JSFunction::cast(obj);
-    closure->set_code(closure->shared()->GetCode());
+    if (closure->is_compiled()) closure->set_code(closure->shared()->GetCode());
   }
 
   CheckRehashability(obj);


### PR DESCRIPTION
This is a backport for v8 commit [22116dd6](https://github.com/v8/v8/commit/22116dd6c884c026225e56dd8e442a660193e729) which fixes [v8 issue #7857](https://bugs.chromium.org/p/v8/issues/detail?id=7857). The issue does not affect core nodejs but does affect my native npm module [isolated-vm](https://github.com/laverdet/isolated-vm). Essentially v8 will segfault if you try to create a startup snapshot of an isolate that contains a closure.

The snapshot crash as it pertains to isolated-vm was originally reported on superfly/fly#101.

The bug was introduced in v8 commit [6bd1d3c2](https://github.com/v8/v8/commit/6bd1d3c28015b31d33f082e019c8d3cccc22be0a), landed in v8 version 6.7.247, which made its way onto nodejs v10.2.0.

The fix landed in v8 version 6.9.186 will probably never see the light of day on the v10x branch of nodejs, which leads me to this PR :)

The patch applied cleanly with no conflicts.

```
Refs: https://github.com/v8/v8/commit/22116dd6c884c026225e56dd8e442a660193e729

Original commit message:

    [snapshot] fix resetting function code.

    Unconditionally setting the JSFunction code to that of the SFI
    may skip initializing the feedback vector.

    R=leszeks@chromium.org

    Bug: v8:7857
    Cq-Include-Trybots: luci.chromium.try:linux_chromium_rel_ng
    Change-Id: I65d4bf32493be4cade2eaf3d665d44f93e80f809
    Reviewed-on: https://chromium-review.googlesource.com/1107618
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#53881}
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
