### PR TITLE
gyp: muffle xcodebuild warnings

### DIFF
--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -495,7 +495,7 @@ class XcodeSettings(object):
     # Since the CLT has no SDK paths anyway, returning None is the
     # most sensible route and should still do the right thing.
     try:
-      return GetStdout(['xcrun', '--sdk', sdk, infoitem])
+      return GetStdoutQuiet(['xcrun', '--sdk', sdk, infoitem])
     except:
       pass
 
@@ -1394,7 +1394,7 @@ def XcodeVersion():
   if XCODE_VERSION_CACHE:
     return XCODE_VERSION_CACHE
   try:
-    version_list = GetStdout(['xcodebuild', '-version']).splitlines()
+    version_list = GetStdoutQuiet(['xcodebuild', '-version']).splitlines()
     # In some circumstances xcodebuild exits 0 but doesn't return
     # the right results; for example, a user on 10.7 or 10.8 with
     # a bogus path set via xcode-select
@@ -1442,6 +1442,18 @@ def CLTVersion():
       return re.search(regex, output).groupdict()['version']
     except:
       continue
+
+
+def GetStdoutQuiet(cmdlist):
+  """Returns the content of standard output returned by invoking |cmdlist|.
+  Ignores the stderr.
+  Raises |GypError| if the command return with a non-zero return code."""
+  job = subprocess.Popen(cmdlist, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+  out = job.communicate()[0]
+  if job.returncode != 0:
+    raise GypError('Error %d running %s' % (job.returncode, cmdlist[0]))
+  return out.rstrip('\n')
 
 
 def GetStdout(cmdlist):


### PR DESCRIPTION
Muffle xcodebuild warnings by introducing an alternative quieter
alternative to GetStdout, called GetStdoutQuiet, and call it selectively
in particularly noisy xcodebuild commands.

Co-authored-by: Gibson Fahnestock <gibfahn@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @gibfahn @nodejs/gyp 
