### PR TITLE
doc: documentation deprecation of process.binding

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1004,8 +1004,8 @@ The option `produceCachedData` has been deprecated. Use
 
 Type: Documentation-only
 
-The `process.binding()` API is intended for use by Node.js internal only
-code. Use of `process.binding()` by userland code is unsupported.
+The `process.binding()` API is intended for use by Node.js internal code
+only. Use of `process.binding()` by userland code is unsupported.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1004,9 +1004,8 @@ The option `produceCachedData` has been deprecated. Use
 
 Type: Documentation-only
 
-The `process.binding()` API is intended for use strictly by Node.js internal
-code to provide a bridge between Node.js' JavaScript and native code layer.
-Use of `process.binding()` by user-land code is unsupported.
+The `process.binding()` API is intended for use by Node.js internal only
+code. Use of `process.binding()` by userland code is unsupported.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -929,6 +929,9 @@ Type: Documentation-only (supports [`--pending-deprecation`][])
 Using `process.binding()` in general should be avoided. The type checking
 methods in particular can be replaced by using [`util.types`][].
 
+This deprecation has been superseded by the deprecation of the
+`process.binding()` API ([DEP00XX](#DEP00XX)).
+
 <a id="DEP0104"></a>
 ### DEP0104: process.env string coercion
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -999,6 +999,15 @@ Type: Documentation-only
 The option `produceCachedData` has been deprecated. Use
 [`script.createCachedData()`][] instead.
 
+<a id="DEP00XX"></a>
+### DEP00XX: process.binding()
+
+Type: Documentation-only
+
+The `process.binding()` API is intended for use strictly by Node.js internal
+code to provide a bridge between Node.js' JavaScript and native code layer.
+Use of `process.binding()` by user-land code is unsupported.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array


### PR DESCRIPTION
This is the first step in a long process of deprecating
`process.binding()` and replacing it with `internalBinding()`.

Eventually, once we have replaced internal uses of
`process.binding()` with `internalBinding()`, we can escalate
to a runtime deprecation and eventual end-of-life.

/cc @nodejs/tsc @nodejs/security-wg

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
