### PR TITLE
test: remove custom AsyncHooksTestConfiguration

### DIFF
--- a/test/async-hooks/testcfg.py
+++ b/test/async-hooks/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.AsyncHooksTestConfiguration(context, root, 'async-hooks')
+  return testpy.ParallelTestConfiguration(context, root, 'async-hooks')

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -165,18 +165,6 @@ class AddonTestConfiguration(SimpleTestConfiguration):
             SimpleTestCase(test, file_path, arch, mode, self.context, self, self.additional_flags))
     return result
 
-class AsyncHooksTestConfiguration(SimpleTestConfiguration):
-  def __init__(self, context, root, section, additional=None):
-    super(AsyncHooksTestConfiguration, self).__init__(context, root, section,
-                                                    additional)
-
-  def ListTests(self, current_path, path, arch, mode):
-    result = super(AsyncHooksTestConfiguration, self).ListTests(
-         current_path, path, arch, mode)
-    for test in result:
-      test.parallel = True
-    return result
-
 class AbortTestConfiguration(SimpleTestConfiguration):
   def __init__(self, context, root, section, additional=None):
     super(AbortTestConfiguration, self).__init__(context, root, section,


### PR DESCRIPTION
Has the same behavior as `ParallelTestConfiguration`, so switch to using that :)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)