### PR TITLE
dgram: deprecate all previous private APIs

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1009,6 +1009,18 @@ Type: Documentation-only
 The `process.binding()` API is intended for use by Node.js internal code
 only. Use of `process.binding()` by userland code is unsupported.
 
+<a id="DEP0112"></a>
+### DEP0112: dgram private APIs
+
+Type: Runtime
+
+The `dgram` module previously contained several APIs that were never meant to
+accessed outside of Node.js core: `Socket.prototype._handle`,
+`Socket.prototype._receiving`, `Socket.prototype._bindState`,
+`Socket.prototype._queue`, `Socket.prototype._reuseAddr`,
+`Socket.prototype._healthCheck()`, `Socket.prototype._stopReceiving()`, and
+`dgram._createSocketHandle()`.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -737,65 +737,65 @@ Socket.prototype.getSendBufferSize = function() {
 };
 
 
-// Legacy private APIs to be deprecated in the future.
+// Deprecated private APIs.
 Object.defineProperty(Socket.prototype, '_handle', {
-  get() {
+  get: util.deprecate(function() {
     return this[kStateSymbol].handle;
-  },
-  set(val) {
+  }, 'Socket.prototype._handle is deprecated', 'DEP0112'),
+  set: util.deprecate(function(val) {
     this[kStateSymbol].handle = val;
-  }
+  }, 'Socket.prototype._handle is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_receiving', {
-  get() {
+  get: util.deprecate(function() {
     return this[kStateSymbol].receiving;
-  },
-  set(val) {
+  }, 'Socket.prototype._receiving is deprecated', 'DEP0112'),
+  set: util.deprecate(function(val) {
     this[kStateSymbol].receiving = val;
-  }
+  }, 'Socket.prototype._receiving is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_bindState', {
-  get() {
+  get: util.deprecate(function() {
     return this[kStateSymbol].bindState;
-  },
-  set(val) {
+  }, 'Socket.prototype._bindState is deprecated', 'DEP0112'),
+  set: util.deprecate(function(val) {
     this[kStateSymbol].bindState = val;
-  }
+  }, 'Socket.prototype._bindState is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_queue', {
-  get() {
+  get: util.deprecate(function() {
     return this[kStateSymbol].queue;
-  },
-  set(val) {
+  }, 'Socket.prototype._queue is deprecated', 'DEP0112'),
+  set: util.deprecate(function(val) {
     this[kStateSymbol].queue = val;
-  }
+  }, 'Socket.prototype._queue is deprecated', 'DEP0112')
 });
 
 
 Object.defineProperty(Socket.prototype, '_reuseAddr', {
-  get() {
+  get: util.deprecate(function() {
     return this[kStateSymbol].reuseAddr;
-  },
-  set(val) {
+  }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112'),
+  set: util.deprecate(function(val) {
     this[kStateSymbol].reuseAddr = val;
-  }
+  }, 'Socket.prototype._reuseAddr is deprecated', 'DEP0112')
 });
 
 
-Socket.prototype._healthCheck = function() {
+Socket.prototype._healthCheck = util.deprecate(function() {
   healthCheck(this);
-};
+}, 'Socket.prototype._healthCheck() is deprecated', 'DEP0112');
 
 
-Socket.prototype._stopReceiving = function() {
+Socket.prototype._stopReceiving = util.deprecate(function() {
   stopReceiving(this);
-};
+}, 'Socket.prototype._stopReceiving() is deprecated', 'DEP0112');
 
 
 // Legacy alias on the C++ wrapper object. This is not public API, so we may
@@ -807,7 +807,11 @@ Object.defineProperty(UDP.prototype, 'owner', {
 
 
 module.exports = {
-  _createSocketHandle,
+  _createSocketHandle: util.deprecate(
+    _createSocketHandle,
+    'dgram._createSocketHandle() is deprecated',
+    'DEP0112'
+  ),
   createSocket,
   Socket
 };


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
