### PR TITLE
test: fix incorrect file mode check

### DIFF
--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -63,8 +63,8 @@ function randomPipePath() {
     }, common.mustCall(() => {
       if (process.platform !== 'win32') {
         const mode = fs.statSync(handlePath).mode;
-        assert.ok(mode & fs.constants.S_IROTH !== 0);
-        assert.ok(mode & fs.constants.S_IWOTH !== 0);
+        assert.notStrictEqual(mode & fs.constants.S_IROTH, 0);
+        assert.notStrictEqual(mode & fs.constants.S_IWOTH, 0);
       }
       srv.close();
     }));


### PR DESCRIPTION
`mode & fs.constants.S_IROTH !== 0` is in fact equivalent to `mode & (fs.constants.S_IROTH !== 0)`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
