### PR TITLE
test: improve reliability in http2-session-timeout

### DIFF
--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -3,13 +3,12 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const h2 = require('http2');
+const http2 = require('http2');
 
 const serverTimeout = common.platformTimeout(200);
-const callTimeout = common.platformTimeout(20);
 const mustNotCall = common.mustNotCall();
 
-const server = h2.createServer();
+const server = http2.createServer();
 server.timeout = serverTimeout;
 
 server.on('request', (req, res) => res.end());
@@ -19,7 +18,7 @@ server.listen(0, common.mustCall(() => {
   const port = server.address().port;
 
   const url = `http://localhost:${port}`;
-  const client = h2.connect(url);
+  const client = http2.connect(url);
   const startTime = process.hrtime();
   makeReq();
 
@@ -37,7 +36,7 @@ server.listen(0, common.mustCall(() => {
       const diff = process.hrtime(startTime);
       const milliseconds = (diff[0] * 1e3 + diff[1] / 1e6);
       if (milliseconds < serverTimeout * 2) {
-        setTimeout(makeReq, callTimeout);
+        setImmediate(makeReq);
       } else {
         server.removeListener('timeout', mustNotCall);
         server.close();


### PR DESCRIPTION
Use `setImmediate()` instead of `setTimeout()` to improve robustness of
test-http2-session-timeout.

Fixes: https://github.com/nodejs/node/issues/20628

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
