### PR TITLE
build: prevent C++ linker from overwriting executable

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -301,6 +301,12 @@
           # the executable and rename it back to node.exe later
           'product_name': '<(node_core_target_name)-win',
         }],
+        [ 'OS=="mac" or OS=="linux"', {
+          # On Unix builds, the build may replace the executable while it is
+          # running.  To avoid this, we provide a different PRODUCT_NAME for
+          # the executable and rename it back to node later
+          'product_name': '<(node_core_target_name)-unix',
+        }],
       ],
     },
     {
@@ -893,6 +899,34 @@
                 '<@(_inputs)',
                 '<@(OS)',
                 '<@(target_arch)',
+              ],
+            },
+          ],
+        } ],
+      ]
+    },
+    {
+      # When building executable in Mac OS/X, in order to avoid overwriting
+      # the executable while it it running, build it with a different name
+      # and then rename it back to node.
+      'target_name': 'rename_node_bin_mac',
+      'type': 'none',
+      'dependencies': [
+        '<(node_core_target_name)',
+      ],
+      'conditions': [
+        [ 'OS=="mac"', {
+          'actions': [
+            {
+              'action_name': 'rename_node_bin_mac',
+              'inputs': [
+                '<(PRODUCT_DIR)/<(node_core_target_name)-unix'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/<(node_core_target_name)',
+              ],
+              'action': [
+                'mv', '<@(_inputs)', '<@(_outputs)',
               ],
             },
           ],

--- a/node.gyp
+++ b/node.gyp
@@ -909,16 +909,16 @@
       # When building executable in Mac OS/X, in order to avoid overwriting
       # the executable while it it running, build it with a different name
       # and then rename it back to node.
-      'target_name': 'rename_node_bin_mac',
+      'target_name': 'rename_node_bin_unix',
       'type': 'none',
       'dependencies': [
         '<(node_core_target_name)',
       ],
       'conditions': [
-        [ 'OS=="mac"', {
+        [ 'OS=="mac" or OS=="linux"', {
           'actions': [
             {
-              'action_name': 'rename_node_bin_mac',
+              'action_name': 'rename_node_bin_unix',
               'inputs': [
                 '<(PRODUCT_DIR)/<(node_core_target_name)-unix'
               ],
@@ -968,6 +968,7 @@
       'dependencies': [
         '<(node_lib_target_name)',
         'rename_node_bin_win',
+        'rename_node_bin_unix',
         'deps/gtest/gtest.gyp:gtest',
         'node_js2c#host',
         'node_dtrace_header',


### PR DESCRIPTION
Running `make run-ci` with multiple jobs, it is possible for the C++ linker
to be invoked while build-addons is running, this can result in intermittent
ENOENT failures when spawning `nodeGyp`.  To prevent this, originally
provide a different name for the executable, and rename it to the correct
name only after the link completes successfully.

Fixes #22006.  Kinda.  Sorta.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
