### PR TITLE
src: move process.binding('performance') to internalBinding

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -84,7 +84,7 @@
       workerThreadSetup.setupStdio();
     }
 
-    const perf = process.binding('performance');
+    const perf = internalBinding('performance');
     const {
       NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE,
     } = perf.constants;

--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -5,10 +5,5 @@ process.emitWarning(
   'tracked by any versioning system or deprecation process.',
   'internal/test/binding');
 
-// These exports should be scoped as specifically as possible
-// to avoid exposing APIs because even with that warning and
-// this file being internal people will still try to abuse it.
 const { internalBinding } = require('internal/bootstrap/loaders');
-module.exports = {
-  ModuleWrap: internalBinding('module_wrap').ModuleWrap,
-};
+module.exports = { internalBinding };

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   PerformanceEntry,
   mark: _mark,
@@ -12,7 +13,7 @@ const {
   timeOriginTimestamp,
   timerify,
   constants
-} = process.binding('performance');
+} = internalBinding('performance');
 
 const {
   NODE_PERFORMANCE_ENTRY_TYPE_NODE,

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -454,4 +454,4 @@ void Initialize(Local<Object> target,
 }  // namespace performance
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(performance, node::performance::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(performance, node::performance::Initialize)

--- a/test/parallel/test-internal-module-wrap.js
+++ b/test/parallel/test-internal-module-wrap.js
@@ -5,7 +5,8 @@
 require('../common');
 const assert = require('assert');
 
-const { ModuleWrap } = require('internal/test/binding');
+const { internalBinding } = require('internal/test/binding');
+const { ModuleWrap } = internalBinding('module_wrap');
 const { getPromiseDetails, isPromise } = process.binding('util');
 const setTimeoutAsync = require('util').promisify(setTimeout);
 

--- a/test/parallel/test-performance-gc.js
+++ b/test/parallel/test-performance-gc.js
@@ -4,7 +4,8 @@
 const common = require('../common');
 const assert = require('assert');
 const {
-  PerformanceObserver
+  PerformanceObserver,
+  constants
 } = require('perf_hooks');
 
 const {
@@ -12,7 +13,7 @@ const {
   NODE_PERFORMANCE_GC_MINOR,
   NODE_PERFORMANCE_GC_INCREMENTAL,
   NODE_PERFORMANCE_GC_WEAKCB
-} = process.binding('performance').constants;
+} = constants;
 
 const kinds = [
   NODE_PERFORMANCE_GC_MAJOR,

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -1,11 +1,13 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
 const Countdown = require('../common/countdown');
 const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
 const {
   observerCounts: counts
-} = process.binding('performance');
+} = internalBinding('performance');
 const {
   performance,
   PerformanceObserver,


### PR DESCRIPTION
Migrate `process.binding('performance')` to `internalBinding('performance')` 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
