### PR TITLE
src: remove unused env->vm_parsing_context_symbol

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -23,14 +23,13 @@
 
 const {
   ContextifyScript,
-  kParsingContext,
   makeContext,
   isContext: _isContext,
 } = process.binding('contextify');
-
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { isUint8Array } = require('internal/util/types');
 const { validateInt32, validateUint32 } = require('internal/validators');
+const kParsingContext = Symbol('script parsing context');
 
 class Script extends ContextifyScript {
   constructor(code, options = {}) {

--- a/src/env.h
+++ b/src/env.h
@@ -359,7 +359,6 @@ struct PackageConfig {
   V(tls_wrap_constructor_function, v8::Function)                              \
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \
-  V(vm_parsing_context_symbol, v8::Symbol)                                    \
   V(url_constructor_function, v8::Function)                                   \
   V(write_wrap_template, v8::ObjectTemplate)
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -609,16 +609,6 @@ class ContextifyScript : public BaseObject {
 
     target->Set(class_name, script_tmpl->GetFunction());
     env->set_script_context_constructor_template(script_tmpl);
-
-    Local<Symbol> parsing_context_symbol =
-        Symbol::New(env->isolate(),
-                    FIXED_ONE_BYTE_STRING(env->isolate(),
-                                          "script parsing context"));
-    env->set_vm_parsing_context_symbol(parsing_context_symbol);
-    target->Set(env->context(),
-                FIXED_ONE_BYTE_STRING(env->isolate(), "kParsingContext"),
-                parsing_context_symbol)
-        .FromJust();
   }
 
 


### PR DESCRIPTION
Stopped being used via 77b52fd58f7398a81999c81afd21fe2e156c0766, was
originally added in d932e802317f9f61bd10988189fa43ed03ad0f61.

For the one remaining usecase inside of `lib/vm.js`, define a Symbol at
the top of the file.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)