### PR TITLE
tools: update to using dmn 1.0.11

### DIFF
--- a/tools/update-babel-eslint.sh
+++ b/tools/update-babel-eslint.sh
@@ -2,7 +2,7 @@
 
 # Shell script to update babel-eslint in the source tree to the latest release.
 
-# Depends on npm and node being in $PATH.
+# Depends on npm, npx, and node being in $PATH.
 
 # This script must be be in the tools directory when it runs because it uses
 # $BASH_SOURCE[0] to determine directories to work in.
@@ -15,11 +15,11 @@ npm init --yes
 
 npm install --global-style --no-bin-links --production --no-package-lock babel-eslint@latest
 
-# Install dmn if it is not in path.
-type -P dmn || npm install -g dmn
-
 # Use dmn to remove some unneeded files.
-dmn -f clean
+npx dmn@1.0.11 -f clean
+# Use removeNPMAbsolutePaths to remove unused data in package.json.
+# This avoids churn as absolute paths can change from one dev to another.
+npx removeNPMAbsolutePaths@1.0.4 .
 
 cd ..
 mv babel-eslint-tmp/node_modules/babel-eslint node_modules/babel-eslint

--- a/tools/update-eslint.sh
+++ b/tools/update-eslint.sh
@@ -20,7 +20,7 @@ npm install --no-bin-links --production --no-package-lock eslint-plugin-markdown
 cd ../..
 
 # Use dmn to remove some unneeded files.
-npx dmn@1.0.10 -f clean
+npx dmn@1.0.11 -f clean
 # Use removeNPMAbsolutePaths to remove unused data in package.json.
 # This avoids churn as absolute paths can change from one dev to another.
 npx removeNPMAbsolutePaths@1.0.4 .


### PR DESCRIPTION
dmn 1.0.11 is available. Update update-eslint.sh to use it. Update
update-babel-eslint.sh to use it too via npx. Add removeNPMAbsolutePaths
to the latter while we're at it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
