### PR TITLE
test: remove third argument from call to assert.strictEqual()

### DIFF
--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -100,9 +100,9 @@ fileStream.on('data', function(data) {
   sha1Hash.update(data);
 });
 fileStream.on('close', common.mustCall(function() {
+  // Test SHA1 of sample.png
   assert.strictEqual(sha1Hash.digest('hex'),
-                     '22723e553129a336ad96e10f6aecdf0f45e4149e',
-                     'Test SHA1 of sample.png');
+                     '22723e553129a336ad96e10f6aecdf0f45e4149e');
 }));
 
 // Issue https://github.com/nodejs/node-v0.x-archive/issues/2227: unknown digest


### PR DESCRIPTION
Removed the third argument from call to assert.strictEqual because it prevents the value of `sha1Hash.digest('hex')` from being displayed if an AssertionError occurs. The third argument is retained as a comment.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
