### PR TITLE
test: Remove third argument from assert.strictEqual()

### DIFF
--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -59,44 +59,54 @@ The order things are called
 const t = new stream.Transform({
   objectMode: true,
   transform: common.mustCall(function(chunk, _, next) {
-    assert.strictEqual(++state, chunk, 'transformCallback part 1');
+    // transformCallback part 1
+    assert.strictEqual(++state, chunk);
     this.push(state);
-    assert.strictEqual(++state, chunk + 2, 'transformCallback part 2');
+    // transformCallback part 2
+    assert.strictEqual(++state, chunk + 2);
     process.nextTick(next);
   }, 3),
   final: common.mustCall(function(done) {
     state++;
-    assert.strictEqual(state, 10, 'finalCallback part 1');
+    // finalCallback part 1
+    assert.strictEqual(state, 10);
     setTimeout(function() {
       state++;
-      assert.strictEqual(state, 11, 'finalCallback part 2');
+      // finalCallback part 2
+      assert.strictEqual(state, 11);
       done();
     }, 100);
   }, 1),
   flush: common.mustCall(function(done) {
     state++;
-    assert.strictEqual(state, 12, 'flushCallback part 1');
+    // flushCallback part 1
+    assert.strictEqual(state, 12);
     process.nextTick(function() {
       state++;
-      assert.strictEqual(state, 15, 'flushCallback part 2');
+      // flushCallback part 2
+      assert.strictEqual(state, 15);
       done();
     });
   }, 1)
 });
 t.on('finish', common.mustCall(function() {
   state++;
-  assert.strictEqual(state, 13, 'finishListener');
+  // finishListener
+  assert.strictEqual(state, 13);
 }, 1));
 t.on('end', common.mustCall(function() {
   state++;
-  assert.strictEqual(state, 16, 'end event');
+  // end event
+  assert.strictEqual(state, 16);
 }, 1));
 t.on('data', common.mustCall(function(d) {
-  assert.strictEqual(++state, d + 1, 'dataListener');
+  // dataListener
+  assert.strictEqual(++state, d + 1);
 }, 3));
 t.write(1);
 t.write(4);
 t.end(7, common.mustCall(function() {
   state++;
-  assert.strictEqual(state, 14, 'endMethodCallback');
+  // endMethodCallback
+  assert.strictEqual(state, 14);
 }, 1));


### PR DESCRIPTION
In file test/parallel/test-stream-transform-final.js the ten calls to
assert.strictEqual() use a string literal as third argument. When
a AssertionError occurs, it reports the string literal and not the
first two arguments, so the third agrument is removed and made a
comment just above the call to assert.strictEqual().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
