### PR TITLE
doc: fixup process.binding deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -930,7 +930,7 @@ Using `process.binding()` in general should be avoided. The type checking
 methods in particular can be replaced by using [`util.types`][].
 
 This deprecation has been superseded by the deprecation of the
-`process.binding()` API ([DEP00XX](#DEP00XX)).
+`process.binding()` API ([DEP0111](#DEP0111)).
 
 <a id="DEP0104"></a>
 ### DEP0104: process.env string coercion
@@ -1002,8 +1002,8 @@ Type: Documentation-only
 The option `produceCachedData` has been deprecated. Use
 [`script.createCachedData()`][] instead.
 
-<a id="DEP00XX"></a>
-### DEP00XX: process.binding()
+<a id="DEP0111"></a>
+### DEP0111: process.binding()
 
 Type: Documentation-only
 


### PR DESCRIPTION
Fixup deprecation code from https://github.com/nodejs/node/pull/22004

Missed assigning the actual code on landing.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
