### PR TITLE
deps: cherry-pick 09bca09 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -28,7 +28,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -828,6 +828,7 @@ action("postmortem-metadata") {
     "src/objects/js-regexp-string-iterator.h",
     "src/objects/map.h",
     "src/objects/map-inl.h",
+    "src/objects/scope-info.h",
     "src/objects/script.h",
     "src/objects/script-inl.h",
     "src/objects/shared-function-info.h",

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -2938,6 +2938,7 @@
             '../src/objects/js-regexp-string-iterator.h',
             '../src/objects/map.h',
             '../src/objects/map-inl.h',
+            '../src/objects/scope-info.h',
             '../src/objects/script.h',
             '../src/objects/script-inl.h',
             '../src/objects/shared-function-info.h',

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -58,6 +58,9 @@ consts_misc = [
     { 'name': 'APIObjectType',          'value': 'JS_API_OBJECT_TYPE' },
     { 'name': 'SpecialAPIObjectType',   'value': 'JS_SPECIAL_API_OBJECT_TYPE' },
 
+    { 'name': 'FirstContextType',     'value': 'FIRST_CONTEXT_TYPE' },
+    { 'name': 'LastContextType',     'value': 'LAST_CONTEXT_TYPE' },
+
     { 'name': 'IsNotStringMask',        'value': 'kIsNotStringMask' },
     { 'name': 'StringTag',              'value': 'kStringTag' },
 
@@ -289,7 +292,7 @@ extras_accessors = [
 expected_classes = [
     'ConsString', 'FixedArray', 'HeapNumber', 'JSArray', 'JSFunction',
     'JSObject', 'JSRegExp', 'JSValue', 'Map', 'Oddball', 'Script',
-    'SeqOneByteString', 'SharedFunctionInfo'
+    'SeqOneByteString', 'SharedFunctionInfo', 'ScopeInfo'
 ];
 
 


### PR DESCRIPTION
Original commit message:

    [postmortem] add ScopeInfo and Context types

    The metadata introduced in this patch will be useful for postmortem
    tools to inspect Contexts and ScopeInfos (see
    nodejs/llnode#211).

    R=bmeurer@google.com, yangguo@google.com

    Change-Id: I927fcab4014d128bd782046c1ecb9ee045723e95
    Reviewed-on: chromium-review.googlesource.com/1153858
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#54768}

Refs: v8/v8@09bca09


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
