### PR TITLE
test: see value of "hadError"

### DIFF
--- a/test/parallel/test-tls-hello-parser-failure.js
+++ b/test/parallel/test-tls-hello-parser-failure.js
@@ -60,6 +60,7 @@ const server = tls.createServer(options, function(c) {
   }));
 
   client.on('close', common.mustCall(function(hadError) {
-    assert.strictEqual(hadError, true, 'Client never errored');
+    // Confirm that client errored
+    assert.strictEqual(hadError, true);
   }));
 }));


### PR DESCRIPTION
The existing implementation created a state that if the assert failed
we got an error message without the values of hadError.
Removed the default error message and added a comment explaining the
assert.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
