### PR TITLE
src: remove calls to deprecated v8 functions (BooleanValue)

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -182,7 +182,7 @@ Cipher.prototype.final = function final(outputEncoding) {
 
 
 Cipher.prototype.setAutoPadding = function setAutoPadding(ap) {
-  if (!this._handle.setAutoPadding(ap))
+  if (!this._handle.setAutoPadding(!!ap))
     throw new ERR_CRYPTO_INVALID_STATE('setAutoPadding');
   return this;
 };

--- a/lib/internal/readline.js
+++ b/lib/internal/readline.js
@@ -36,9 +36,11 @@ if (process.binding('config').hasIntl) {
     options = options || {};
     if (!Number.isInteger(str))
       str = stripVTControlCharacters(String(str));
-    return icu.getStringWidth(str,
-                              Boolean(options.ambiguousAsFullWidth),
-                              Boolean(options.expandEmojiSequence));
+    return icu.getStringWidth(
+      str,
+      Boolean(options.ambiguousAsFullWidth),
+      Boolean(options.expandEmojiSequence)
+    );
   };
   isFullWidthCodePoint =
     function isFullWidthCodePoint(code, options) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1724,7 +1724,7 @@ if (process.platform === 'win32') {
     }
 
     if (handle._simultaneousAccepts !== simultaneousAccepts) {
-      handle.setSimultaneousAccepts(simultaneousAccepts);
+      handle.setSimultaneousAccepts(!!simultaneousAccepts);
       handle._simultaneousAccepts = simultaneousAccepts;
     }
   };

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5190,7 +5190,8 @@ void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
   CHECK(!force_fips_crypto);
   Environment* env = Environment::GetCurrent(args);
   const bool enabled = FIPS_mode();
-  const bool enable = args[0]->BooleanValue();
+  bool enable;
+  if (!args[0]->BooleanValue(env->context()).To(&enable)) return;
   if (enable == enabled)
     return;  // No action needed.
   if (!FIPS_mode_set(enable)) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3093,7 +3093,7 @@ void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
 
-  bool b = cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
+  bool b = cipher->SetAutoPadding(args.Length() < 1 || args[0]->IsTrue());
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1460,7 +1460,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 
-  bool with_types = args[2]->BooleanValue();
+  bool with_types = args[2]->IsTrue();
 
   FSReqBase* req_wrap_async = GetReqWrap(env, args[3]);
   if (req_wrap_async != nullptr) {  // readdir(path, encoding, withTypes, req)

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -815,8 +815,8 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 1)
     return;
 
-  bool ambiguous_as_full_width = args[1]->BooleanValue();
-  bool expand_emoji_sequence = args[2]->BooleanValue();
+  bool ambiguous_as_full_width = args[1]->IsTrue();
+  bool expand_emoji_sequence = args[2]->IsTrue();
 
   if (args[0]->IsNumber()) {
     args.GetReturnValue().Set(

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -168,7 +168,7 @@ void TCPWrap::SetNoDelay(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int enable = static_cast<int>(args[0]->BooleanValue());
+  int enable = static_cast<int>(args[0]->IsTrue());
   int err = uv_tcp_nodelay(&wrap->handle_, enable);
   args.GetReturnValue().Set(err);
 }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -192,7 +192,7 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  bool enable = args[0]->BooleanValue();
+  bool enable = args[0]->IsTrue();
   int err = uv_tcp_simultaneous_accepts(&wrap->handle_, enable);
   args.GetReturnValue().Set(err);
 }


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here:
Value::BooleanValue) inside the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

@addaleax @hashseed a quick one.