### PR TITLE
http: remove `pause()`/`resume()` from parser bindings

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -410,8 +410,6 @@ function socketOnDrain(socket, state) {
   // If we previously paused, then start reading again.
   if (socket._paused && !needPause) {
     socket._paused = false;
-    if (socket.parser)
-      socket.parser.resume();
     socket.resume();
   }
 }
@@ -538,12 +536,6 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
       socket.destroy();
     }
   }
-
-  if (socket._paused && socket.parser) {
-    // onIncoming paused the socket, we should pause the parser as well
-    debug('pause parser');
-    socket.parser.pause();
-  }
 }
 
 function resOnFinish(req, res, socket, state, server) {
@@ -611,9 +603,6 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     var ws = socket._writableState;
     if (ws.needDrain || state.outgoingData >= socket.writableHighWaterMark) {
       socket._paused = true;
-      // We also need to pause the parser, but don't do that until after
-      // the call to execute, because we may still be processing the last
-      // chunk.
       socket.pause();
     }
   }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -472,17 +472,6 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  template <bool should_pause>
-  static void Pause(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
-    Parser* parser;
-    ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
-    // Should always be called from the same context.
-    CHECK_EQ(env, parser->env());
-    http_parser_pause(&parser->parser_, should_pause);
-  }
-
-
   static void Consume(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
@@ -762,8 +751,6 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(t, "execute", Parser::Execute);
   env->SetProtoMethod(t, "finish", Parser::Finish);
   env->SetProtoMethod(t, "reinitialize", Parser::Reinitialize);
-  env->SetProtoMethod(t, "pause", Parser::Pause<true>);
-  env->SetProtoMethod(t, "resume", Parser::Pause<false>);
   env->SetProtoMethod(t, "consume", Parser::Consume);
   env->SetProtoMethod(t, "unconsume", Parser::Unconsume);
   env->SetProtoMethod(t, "getCurrentBuffer", Parser::GetCurrentBuffer);

--- a/test/parallel/test-http-highwatermark.js
+++ b/test/parallel/test-http-highwatermark.js
@@ -24,14 +24,14 @@ const server = http.createServer(function(req, res) {
     }));
   } else {
     // Case of needParse = true
-    const resume = req.connection.parser.resume.bind(req.connection.parser);
-    req.connection.parser.resume = common.mustCall((...args) => {
+    const resume = req.connection.resume.bind(req.connection);
+    req.connection.resume = common.mustCall((...args) => {
       const paused = req.connection._paused;
       assert(!paused, '_paused must be false because it become false by ' +
                       'socketOnDrain when outgoingData falls below ' +
                       'highWaterMark');
       return resume(...args);
-    });
+    }, 2);
   }
   assert(!res.write(body), 'res.write must return false because it will ' +
                            'exceed highWaterMark on this call');

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -12,7 +12,8 @@ const common = require('../common');
 // uncorks the readable stream, although we arent testing that part here.
 
 // The issue being tested exists in Node.js 0.10.20 and is resolved in 0.10.21
-// and newer.
+// and newer. As a security vulnerability, it has been assigned the identifier
+// CVE-2013-4450.
 
 switch (process.argv[2]) {
   case undefined:


### PR DESCRIPTION
As far as I can tell, these are effectively no-ops
(`http_parser_pause` only sets the `http_errno` flag,
but that isn’t read anywhere), so removing them cleans
things up a tiny bit.

The corresponding regression test remains intact.

/cc @nodejs/http-parser 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
