### PR TITLE
src: yield empty maybes for failed AsyncWrap::MakeCallback calls

### DIFF
--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -87,7 +87,7 @@ void InternalCallbackScope::Close() {
     AsyncWrap::EmitAfter(env_, async_context_.async_id);
   }
 
-  if (IsInnerMakeCallback()) {
+  if (env_->makecallback_depth() > 1) {
     return;
   }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -218,8 +218,8 @@ inline Environment::AsyncCallbackScope::~AsyncCallbackScope() {
   env_->makecallback_cntr_--;
 }
 
-inline bool Environment::AsyncCallbackScope::in_makecallback() const {
-  return env_->makecallback_cntr_ > 1;
+inline size_t Environment::makecallback_depth() const {
+  return makecallback_cntr_;
 }
 
 inline Environment::ImmediateInfo::ImmediateInfo(v8::Isolate* isolate)

--- a/src/env.h
+++ b/src/env.h
@@ -513,13 +513,14 @@ class Environment {
     AsyncCallbackScope() = delete;
     explicit AsyncCallbackScope(Environment* env);
     ~AsyncCallbackScope();
-    inline bool in_makecallback() const;
 
    private:
     Environment* env_;
 
     DISALLOW_COPY_AND_ASSIGN(AsyncCallbackScope);
   };
+
+  inline size_t makecallback_depth() const;
 
   class ImmediateInfo {
    public:

--- a/src/node.cc
+++ b/src/node.cc
@@ -757,7 +757,7 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
   CHECK(!recv.IsEmpty());
   InternalCallbackScope scope(env, recv, asyncContext);
   if (scope.Failed()) {
-    return Undefined(env->isolate());
+    return MaybeLocal<Value>();
   }
 
   Local<Function> domain_cb = env->domain_callback();
@@ -772,15 +772,13 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
   }
 
   if (ret.IsEmpty()) {
-    // NOTE: For backwards compatibility with public API we return Undefined()
-    // if the top level call threw.
     scope.MarkAsFailed();
-    return scope.IsInnerMakeCallback() ? ret : Undefined(env->isolate());
+    return MaybeLocal<Value>();
   }
 
   scope.Close();
   if (scope.Failed()) {
-    return Undefined(env->isolate());
+    return MaybeLocal<Value>();
   }
 
   return ret;
@@ -832,8 +830,14 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   // the two contexts need not be the same.
   Environment* env = Environment::GetCurrent(callback->CreationContext());
   Context::Scope context_scope(env->context());
-  return InternalMakeCallback(env, recv, callback,
-                              argc, argv, asyncContext);
+  MaybeLocal<Value> ret = InternalMakeCallback(env, recv, callback,
+                                               argc, argv, asyncContext);
+  if (ret.IsEmpty() && env->makecallback_depth() == 0) {
+    // This is only for legacy compatiblity and we may want to look into
+    // removing/adjusting it.
+    return Undefined(env->isolate());
+  }
+  return ret;
 }
 
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -543,9 +543,6 @@ class InternalCallbackScope {
 
   inline bool Failed() const { return failed_; }
   inline void MarkAsFailed() { failed_ = true; }
-  inline bool IsInnerMakeCallback() const {
-    return callback_scope_.in_makecallback();
-  }
 
  private:
   Environment* env_;


### PR DESCRIPTION
Use an empty `MaybeLocal<Value>` as the return value for
`AsyncWrap::MakeCallback()` if an exception occurred,
regardless of `MakeCallback` depth.

Unfortunately, the public API can not make this switch without
a breaking change (and possibly some kind of deprecation/renaming).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
