### PR TITLE
doc: fix header escaping regression (Issue #22065)

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -67,9 +67,9 @@ fs.readFile(filename, 'utf8', (er, input) => {
 
   const content = unified()
     .use(markdown)
+    .use(html.preprocessText)
     .use(json.jsonAPI, { filename })
     .use(html.firstHeader)
-    .use(html.preprocessText)
     .use(html.preprocessElements, { filename })
     .use(html.buildToc, { filename })
     .use(remark2rehype, { allowDangerousHTML: true })

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -199,6 +199,8 @@ function preprocessElements({ filename }) {
             type: 'text',
             value: file.contents.slice(
               position.start.offset, position.end.offset)
+              .replace('&lt;', '<')
+              .replace('&gt;', '>')
               .replace(/\\(.{1})/g, '$1'),
             position
           }];

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -199,7 +199,7 @@ function preprocessElements({ filename }) {
             type: 'text',
             value: file.contents.slice(
               position.start.offset, position.end.offset)
-              .replace(/\\(.{1})/g, '$1')
+              .replace(/\\(.{1})/g, '$1'),
             position
           }];
         }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -198,7 +198,8 @@ function preprocessElements({ filename }) {
           heading.children = [{
             type: 'text',
             value: file.contents.slice(
-              position.start.offset, position.end.offset),
+              position.start.offset, position.end.offset)
+              .replace(/\\./g, (match) => match[1]),
             position
           }];
         }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -199,7 +199,7 @@ function preprocessElements({ filename }) {
             type: 'text',
             value: file.contents.slice(
               position.start.offset, position.end.offset)
-              .replace(/\\./g, (match) => match[1]),
+              .replace(/\\.{1}/g, (match) => match[1]),
             position
           }];
         }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -199,7 +199,7 @@ function preprocessElements({ filename }) {
             type: 'text',
             value: file.contents.slice(
               position.start.offset, position.end.offset)
-              .replace(/\\.{1}/g, (match) => match[1]),
+              .replace(/\\(.{1})/g, '$1')
             position
           }];
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Remove backslashes in headers.

Fixes: #22065

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
