### PR TITLE
timers: support BigInt in timers API

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -255,9 +255,11 @@ Agent.prototype._evictSession = function _evictSession(key) {
 const globalAgent = new Agent();
 
 let urlWarningEmitted = false;
-function request(options, cb) {
-  if (typeof options === 'string') {
-    const urlStr = options;
+function request(...args) {
+  let options = {};
+
+  if (typeof args[0] === 'string') {
+    const urlStr = args.shift();
     try {
       options = urlToOptions(new URL(urlStr));
     } catch (err) {
@@ -273,19 +275,24 @@ function request(options, cb) {
           'DeprecationWarning', 'DEP0109');
       }
     }
-  } else if (options && options[searchParamsSymbol] &&
-             options[searchParamsSymbol][searchParamsSymbol]) {
+  } else if (args[0] && args[0][searchParamsSymbol] &&
+             args[0][searchParamsSymbol][searchParamsSymbol]) {
     // url.URL instance
-    options = urlToOptions(options);
-  } else {
-    options = util._extend({}, options);
+    options = urlToOptions(args.shift());
   }
+
+  if (args[0] && typeof args[0] !== 'function') {
+    options = util._extend(options, args.shift());
+  }
+
   options._defaultAgent = globalAgent;
-  return new ClientRequest(options, cb);
+  args.unshift(options);
+
+  return new ClientRequest(...args);
 }
 
-function get(options, cb) {
-  const req = request(options, cb);
+function get(input, options, cb) {
+  const req = request(input, options, cb);
   req.end();
   return req;
 }

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -54,7 +54,10 @@ function initAsyncResource(resource, type) {
 // Timer constructor function.
 // The entire prototype is defined in lib/timers.js
 function Timeout(callback, after, args, isRepeat) {
-  after *= 1; // coalesce to number or NaN
+  if (typeof after !== 'bigint') { // eslint-disable-line valid-typeof
+    after *= 1; // coalesce to number or NaN
+  }
+
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     if (after > TIMEOUT_MAX) {
       process.emitWarning(`${after} does not fit into` +
@@ -64,6 +67,11 @@ function Timeout(callback, after, args, isRepeat) {
     }
     after = 1; // schedule on next tick, follows browser behavior
   }
+
+  // at this point after is either a number or bigint and in both
+  // cases its value is in the limit of signed int so it is safe to
+  // convert after to number
+  after = Number(after);
 
   this._idleTimeout = after;
   this._idlePrev = this;
@@ -126,11 +134,14 @@ function setUnrefTimeout(callback, after, arg1, arg2, arg3) {
 
 // Type checking used by timers.enroll() and Socket#setTimeout()
 function validateTimerDuration(msecs) {
-  if (typeof msecs !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('msecs', 'number', msecs);
+  if ((typeof msecs !== 'number') &&
+    (typeof msecs !== 'bigint')) { // eslint-disable-line valid-typeof
+    throw new ERR_INVALID_ARG_TYPE('msecs', ['number', 'bigint'], msecs);
   }
 
-  if (msecs < 0 || !isFinite(msecs)) {
+  // ensure that msecs is non-negative and finite
+  // note: bigint is always a finite (typeof Infinity and NaN is 'number')
+  if (msecs < 0 || (typeof msecs === 'number' && !isFinite(msecs))) {
     throw new ERR_OUT_OF_RANGE('msecs', 'a non-negative finite number', msecs);
   }
 
@@ -142,5 +153,5 @@ function validateTimerDuration(msecs) {
     return TIMEOUT_MAX;
   }
 
-  return msecs;
+  return Number(msecs);
 }

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -21,7 +21,7 @@ server.on('stream', common.mustCall((stream) => {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message:
-        'The "msecs" argument must be of type number. Received type string'
+        'The "msecs" argument must be one of type number or bigint. Received type string'
     }
   );
   common.expectsError(

--- a/test/parallel/test-https-request-arguments.js
+++ b/test/parallel/test-https-request-arguments.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const https = require('https');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca: fixtures.readKey('ca1-cert.pem')
+};
+
+// Test providing both a url and options, with the options partially
+// replacing address and port portions of the URL provided.
+{
+  const server = https.createServer(
+    options,
+    common.mustCall((req, res) => {
+      assert.strictEqual(req.url, '/testpath');
+      res.end();
+      server.close();
+    })
+  );
+
+  server.listen(
+    0,
+    common.mustCall(() => {
+      https.get(
+        'https://example.com/testpath',
+
+        {
+          hostname: 'localhost',
+          port: server.address().port,
+          rejectUnauthorized: false
+        },
+
+        common.mustCall((res) => {
+          res.resume();
+        })
+      );
+    })
+  );
+}

--- a/test/parallel/test-timers-max-duration-warning.js
+++ b/test/parallel/test-timers-max-duration-warning.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const timers = require('timers');
 
 const OVERFLOW = Math.pow(2, 31); // TIMEOUT_MAX is 2^31-1
+const TEST_MATRIX = [OVERFLOW, BigInt(OVERFLOW)];
 
 function timerNotCanceled() {
   assert.fail('Timer should be canceled');
@@ -19,24 +20,25 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(lines[0], `${OVERFLOW} does not fit into a 32-bit signed` +
                                ' integer.');
   assert.strictEqual(lines.length, 2);
-}, 5));
+}, 8));
 
+for (let i = 0; i < TEST_MATRIX.length; i++) {
+  {
+    const timeout = setTimeout(timerNotCanceled, TEST_MATRIX[i]);
+    clearTimeout(timeout);
+  }
 
-{
-  const timeout = setTimeout(timerNotCanceled, OVERFLOW);
-  clearTimeout(timeout);
-}
+  {
+    const interval = setInterval(timerNotCanceled, TEST_MATRIX[i]);
+    clearInterval(interval);
+  }
 
-{
-  const interval = setInterval(timerNotCanceled, OVERFLOW);
-  clearInterval(interval);
-}
-
-{
-  const timer = {
-    _onTimeout: timerNotCanceled
-  };
-  timers.enroll(timer, OVERFLOW);
-  timers.active(timer);
-  timers.unenroll(timer);
+  {
+    const timer = {
+      _onTimeout: timerNotCanceled
+    };
+    timers.enroll(timer, TEST_MATRIX[i]);
+    timers.active(timer);
+    timers.unenroll(timer);
+  }
 }

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -48,7 +48,15 @@ const inputs = [
   1,
   1.0,
   2147483648,     // browser behavior: timeouts > 2^31-1 run on next tick
-  12345678901234  // ditto
+  12345678901234, // ditto
+  BigInt(2 ** 72),  // ditto
+  BigInt(0),
+  BigInt(-10),
+  BigInt(-1),
+  BigInt(true),
+  BigInt(false),
+  BigInt(1),
+  BigInt('')
 ];
 
 const timeouts = [];


### PR DESCRIPTION
Adding support for BigInt in timers API. 
This change allows passing a BigInt value as delay when calling setTimeout and setInterval.
The logic of timers was not changed, and the value limits are still enforced. 
Tests and docs were updated to include cases of passing BigInt to these interfaces. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#SimilarWeb_RnD