### PR TITLE
doc: update recommendations for createCipher

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -959,9 +959,9 @@ Type: Documentation-only
 Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] should be
 avoided as they use a weak key derivation function (MD5 with no salt) and static
 initialization vectors. It is recommended to derive a key using
-[`crypto.pbkdf2()`][] and to use [`crypto.createCipheriv()`][] and
-[`crypto.createDecipheriv()`][] to obtain the [`Cipher`][] and [`Decipher`][]
-objects respectively.
+[`crypto.pbkdf2()`][] or [`crypto.scrypt()`][] and to use
+[`crypto.createCipheriv()`][] and [`crypto.createDecipheriv()`][] to obtain the
+[`Cipher`][] and [`Decipher`][] objects respectively.
 
 <a id="DEP0107"></a>
 ### DEP0107: tls.convertNPNProtocols()
@@ -1035,6 +1035,7 @@ only. Use of `process.binding()` by userland code is unsupported.
 [`crypto.DEFAULT_ENCODING`]: crypto.html#crypto_crypto_default_encoding
 [`crypto.fips`]: crypto.html#crypto_crypto_fips
 [`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+[`crypto.scrypt()`]: crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback
 [`decipher.final()`]: crypto.html#crypto_decipher_final_outputencoding
 [`decipher.setAuthTag()`]: crypto.html#crypto_decipher_setauthtag_buffer
 [`domain`]: domain.html


### PR DESCRIPTION
Now that scrypt is supported, we should at least mention it as an alternative to PBKDF2.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
