### PR TITLE
crypto: move createCipher to runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -954,7 +954,7 @@ Type: End-of-Life
 <a id="DEP0106"></a>
 ### DEP0106: crypto.createCipher and crypto.createDecipher
 
-Type: Documentation-only
+Type: Runtime
 
 Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] should be
 avoided as they use a weak key derivation function (MD5 with no salt) and static

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -140,9 +140,7 @@ function createVerify(algorithm, options) {
 module.exports = exports = {
   // Methods
   _toBuf: toBuf,
-  createCipher,
   createCipheriv,
-  createDecipher,
   createDecipheriv,
   createDiffieHellman,
   createDiffieHellmanGroup,
@@ -209,6 +207,16 @@ function getFipsForced() {
 }
 
 Object.defineProperties(exports, {
+  createCipher: {
+    enumerable: false,
+    value: deprecate(createCipher,
+                     'crypto.createCipher is deprecated.', 'DEP0106')
+  },
+  createDecipher: {
+    enumerable: false,
+    value: deprecate(createDecipher,
+                     'crypto.createDecipher is deprecated.', 'DEP0106')
+  },
   // crypto.fips is deprecated. DEP0093. Use crypto.getFips()/crypto.setFips()
   fips: {
     get: !fipsMode ? getFipsDisabled :

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -71,8 +71,10 @@ const expectedWarnings = common.hasFipsCrypto ?
     ['Use Cipheriv for counter mode of aes-256-ccm', common.noWarnCode]
   ];
 
-const expectedDeprecationWarnings = ['crypto.DEFAULT_ENCODING is deprecated.',
-                                     'DEP0091'];
+const expectedDeprecationWarnings = [
+  ['crypto.DEFAULT_ENCODING is deprecated.', 'DEP0091'],
+  ['crypto.createCipher is deprecated.', 'DEP0106']
+];
 
 common.expectWarning({
   Warning: expectedWarnings,

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -10,6 +10,15 @@ if (common.hasFipsCrypto)
 const crypto = require('crypto');
 const assert = require('assert');
 
+common.expectWarning({
+  Warning: [
+    ['Use Cipheriv for counter mode of aes-256-gcm', common.noWarnCode]
+  ],
+  DeprecationWarning: [
+    ['crypto.createCipher is deprecated.', 'DEP0106']
+  ]
+});
+
 function testCipher1(key) {
   // Test encryption and decryption
   const plaintext = 'Keep this a secret? No! Tell everyone about node.js!';
@@ -234,10 +243,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
   const key = '0123456789';
   const aadbuf = Buffer.from('aadbuf');
   const data = Buffer.from('test-crypto-cipher-decipher');
-
-  common.expectWarning('Warning',
-                       'Use Cipheriv for counter mode of aes-256-gcm',
-                       common.noWarnCode);
 
   const cipher = crypto.createCipher('aes-256-gcm', key);
   cipher.setAAD(aadbuf);

--- a/test/parallel/test-process-emit-warning-from-native.js
+++ b/test/parallel/test-process-emit-warning-from-native.js
@@ -11,12 +11,17 @@ const crypto = require('crypto');
 const key = '0123456789';
 
 {
-  common.expectWarning('DeprecationWarning',
-                       'crypto.createCipher is deprecated.',
-                       'DEP0106');
+  common.expectWarning({
+    DeprecationWarning: [
+      ['crypto.createCipher is deprecated.', 'DEP0106']
+    ],
+    Warning: [
+      ['Use Cipheriv for counter mode of aes-256-gcm', common.noWarnCode]
+    ]
+  });
 
   // Emits regular warning expected by expectWarning()
-  crypto.createCipher('aes-256-cbc', key);
+  crypto.createCipher('aes-256-gcm', key);
 }
 
 const realEmitWarning = process.emitWarning;

--- a/test/parallel/test-process-emit-warning-from-native.js
+++ b/test/parallel/test-process-emit-warning-from-native.js
@@ -11,12 +11,12 @@ const crypto = require('crypto');
 const key = '0123456789';
 
 {
-  common.expectWarning('Warning',
-                       'Use Cipheriv for counter mode of aes-256-gcm',
-                       common.noWarnCode);
+  common.expectWarning('DeprecationWarning',
+                       'crypto.createCipher is deprecated.',
+                       'DEP0106');
 
   // Emits regular warning expected by expectWarning()
-  crypto.createCipher('aes-256-gcm', key);
+  crypto.createCipher('aes-256-cbc', key);
 }
 
 const realEmitWarning = process.emitWarning;


### PR DESCRIPTION
`createCipher` is still being used, but it seems appropriate to have a runtime deprecation in one of the next major releases. Reasons include:

- It uses static IVs: Encrypting the same message with the same password will always yield the same ciphertext. While this is generally considered bad practice and can lead to severe security issues on its own, it also means that any counter-mode cipher is more or less useless when used with `createCipher`, see https://github.com/nodejs/node/pull/13821.
- Its KDF is non-configurable and doesn't use a salt, meaning that the same password always results in the same key. It also allows brute-force attacks since computing MD5 with a single iteration is incredibly fast on modern processors / GPUs.
- There are instances where using `createCipher` is *relatively* secure, but its simple API makes it especially appealing to people who are new to cryptography, possibly leading to immense security risks.
- It has been documentation-only deprected since node 10, see https://github.com/nodejs/node/pull/19343.
- If people *want* to have this functionality for whatever reason, it is still possible by using `createCipheriv` (thanks to https://github.com/nodejs/node/pull/18644) and manually deriving the static key / IV. If people are using this for legitimate reasons, we can still un-deprecate it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)