### PR TITLE
src: remove calls to deprecated v8 functions (NumberValue)

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -410,7 +410,12 @@ void AsyncWrap::PopAsyncIds(const FunctionCallbackInfo<Value>& args) {
 void AsyncWrap::AsyncReset(const FunctionCallbackInfo<Value>& args) {
   AsyncWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-  double execution_async_id = args[0]->IsNumber() ? args[0]->NumberValue() : -1;
+  double execution_async_id =
+      args[0]->IsNumber()
+          ? args[0]
+                ->NumberValue(args.GetIsolate()->GetCurrentContext())
+                .ToChecked()
+          : -1;
   wrap->AsyncReset(execution_async_id);
 }
 
@@ -418,7 +423,8 @@ void AsyncWrap::AsyncReset(const FunctionCallbackInfo<Value>& args) {
 void AsyncWrap::QueueDestroyAsyncId(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsNumber());
   AsyncWrap::EmitDestroy(
-      Environment::GetCurrent(args), args[0]->NumberValue());
+      Environment::GetCurrent(args),
+      args[0]->NumberValue(args.GetIsolate()->GetCurrentContext()).ToChecked());
 }
 
 void AsyncWrap::AddWrapMethods(Environment* env,


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here:
Value::NumberValue) inside the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @addaleax @hashseed 