### PR TITLE
test: fix a problem that the test fails at the windows7 command prompt

### DIFF
--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -71,7 +71,11 @@ cp.exec(ddcmd, function(err, stdout, stderr) {
     res.writeHead(200);
 
     // Create the subprocess
-    const cat = cp.spawn('cat', [filename]);
+    let cat;
+    if (common.isWindows)
+      cat = cp.spawn('cmd.exe', ['/c', 'type', filename]);
+    else
+      cat = cp.spawn('cat', [filename]);
 
     // Stream the data through to the response as binary chunks
     cat.stdout.on('data', (data) => {


### PR DESCRIPTION
When testing with 'cmd.exe' of Windows 7,
'spawn cat ENOENT' error has occurred.
Since the standard 'cmd.exe' has no 'cat' command,
Instead will use the 'type' command

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
