### PR TITLE
deps: cherry-pick 6ee8345 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8-profiler.h
+++ b/deps/v8/include/v8-profiler.h
@@ -686,11 +686,14 @@ class V8_EXPORT EmbedderGraph {
   virtual Node* AddNode(std::unique_ptr<Node> node) = 0;
 
   /**
-   * Adds an edge that represents a strong reference from the given node
-   * |from| to the given node |to|. The nodes must be added to the graph
+   * Adds an edge that represents a strong reference from the given
+   * node |from| to the given node |to|. The nodes must be added to the graph
    * before calling this function.
+   *
+   * If name is nullptr, the edge will have auto-increment indexes, otherwise
+   * it will be named accordingly.
    */
-  virtual void AddEdge(Node* from, Node* to) = 0;
+  virtual void AddEdge(Node* from, Node* to, const char* name = nullptr) = 0;
 
   virtual ~EmbedderGraph() = default;
 };

--- a/deps/v8/src/profiler/heap-snapshot-generator.cc
+++ b/deps/v8/src/profiler/heap-snapshot-generator.cc
@@ -1989,6 +1989,7 @@ class EmbedderGraphImpl : public EmbedderGraph {
   struct Edge {
     Node* from;
     Node* to;
+    const char* name;
   };
 
   class V8NodeImpl : public Node {
@@ -2025,7 +2026,9 @@ class EmbedderGraphImpl : public EmbedderGraph {
     return result;
   }
 
-  void AddEdge(Node* from, Node* to) final { edges_.push_back({from, to}); }
+  void AddEdge(Node* from, Node* to, const char* name) final {
+    edges_.push_back({from, to, name});
+  }
 
   const std::vector<std::unique_ptr<Node>>& nodes() { return nodes_; }
   const std::vector<Edge>& edges() { return edges_; }
@@ -2318,8 +2321,13 @@ bool NativeObjectsExplorer::IterateAndExtractReferences(
       int from_index = from->index();
       HeapEntry* to = EntryForEmbedderGraphNode(edge.to);
       if (to) {
-        filler_->SetIndexedAutoIndexReference(HeapGraphEdge::kElement,
-                                              from_index, to);
+        if (edge.name == nullptr) {
+          filler_->SetIndexedAutoIndexReference(HeapGraphEdge::kElement,
+                                                from_index, to);
+        } else {
+          filler_->SetNamedReference(HeapGraphEdge::kInternal, from_index,
+                                     edge.name, to);
+        }
       }
     }
   } else {

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -76,8 +76,8 @@ class JSGraph : public EmbedderGraph {
     return n;
   }
 
-  void AddEdge(Node* from, Node* to) override {
-    edges_[from].insert(to);
+  void AddEdge(Node* from, Node* to, const char* name = nullptr) override {
+    edges_[from].insert(std::make_pair(name, to));
   }
 
   MaybeLocal<Array> CreateObject() const {
@@ -92,6 +92,7 @@ class JSGraph : public EmbedderGraph {
     Local<String> size_string = FIXED_ONE_BYTE_STRING(isolate_, "size");
     Local<String> value_string = FIXED_ONE_BYTE_STRING(isolate_, "value");
     Local<String> wraps_string = FIXED_ONE_BYTE_STRING(isolate_, "wraps");
+    Local<String> to_string = FIXED_ONE_BYTE_STRING(isolate_, "to");
 
     for (const std::unique_ptr<Node>& n : nodes_)
       info_objects[n.get()] = Object::New(isolate_);
@@ -141,10 +142,23 @@ class JSGraph : public EmbedderGraph {
       }
 
       size_t i = 0;
-      for (Node* target : edge_info.second) {
-        if (edges.As<Array>()->Set(context,
-                                   i++,
-                                   info_objects[target]).IsNothing()) {
+      size_t j = 0;
+      for (const auto& edge : edge_info.second) {
+        Local<Object> to_object = info_objects[edge.second];
+        Local<Object> edge_info = Object::New(isolate_);
+        Local<Value> edge_name_value;
+        const char* edge_name = edge.first;
+        if (edge_name != nullptr &&
+            !String::NewFromUtf8(
+                 isolate_, edge_name, v8::NewStringType::kNormal)
+                 .ToLocal(&edge_name_value)) {
+          return MaybeLocal<Array>();
+        } else {
+          edge_name_value = Number::New(isolate_, j++);
+        }
+        if (edge_info->Set(context, name_string, edge_name_value).IsNothing() ||
+            edge_info->Set(context, to_string, to_object).IsNothing() ||
+            edges.As<Array>()->Set(context, i++, edge_info).IsNothing()) {
           return MaybeLocal<Array>();
         }
       }
@@ -158,7 +172,7 @@ class JSGraph : public EmbedderGraph {
   std::unordered_set<std::unique_ptr<Node>> nodes_;
   std::unordered_set<JSGraphJSNode*, JSGraphJSNode::Hash, JSGraphJSNode::Equal>
       engine_nodes_;
-  std::unordered_map<Node*, std::unordered_set<Node*>> edges_;
+  std::unordered_map<Node*, std::set<std::pair<const char*, Node*>>> edges_;
 };
 
 void BuildEmbedderGraph(const FunctionCallbackInfo<Value>& args) {

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -47,15 +47,19 @@ class State {
     else
       assert.strictEqual(graph.length, expected.length);
     for (const expectedNode of expected) {
-      if (expectedNode.edges) {
+      if (expectedNode.children) {
         for (const expectedChild of expectedNode.children) {
-          const check = typeof expectedChild === 'function' ?
-            expectedChild : (node) => {
-              return node.name === expectedChild.name ||
-                (node.value &&
-                 node.value.constructor &&
-                 node.value.constructor.name === expectedChild.name);
-            };
+          const check = (edge) => {
+            // TODO(joyeecheung): check the edge names
+            const node = edge.to;
+            if (typeof expectedChild === 'function') {
+              return expectedChild(node);
+            }
+            return node.name === expectedChild.name ||
+              (node.value &&
+                node.value.constructor &&
+                node.value.constructor.name === expectedChild.name);
+          };
 
           assert(graph.some((node) => node.edges.some(check)),
                  `expected to find child ${util.inspect(expectedChild)} ` +


### PR DESCRIPTION
Original commit message:

    [heap-profiler] Allow embedder to specify edge names

    This patch adds a variant of EmbedderGraph::AddEdge() which
    allows the embedder to specify the name of an edge. The edges
    added without name are element edges with auto-incremented indexes
    while the edges added with names will be internal edges with
    the specified names for more meaningful output in the heap
    snapshot.

    Refs: https://github.com/nodejs/node/pull/21741
    Bug: v8:7938
    Cq-Include-Trybots: luci.chromium.try:linux_chromium_rel_ng
    Change-Id: I8feefa2cf6911743e24b3b2024e0e849b0c65cd3
    Reviewed-on: https://chromium-review.googlesource.com/1133299
    Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#54412}

Refs: https://github.com/v8/v8/commit/6ee834532d6f924f6057584085fa79b4777c396a

cc @addaleax 