### PR TITLE
crypto: explicitly enable auto cert chaining

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -461,6 +461,11 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv2);
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv3);
 
+  // Enable automatic cert chaining. This is enabled by default in OpenSSL, but
+  // disabled by default in BoringSSL. Enable it explicitly to make the
+  // behavior match when Node is built with BoringSSL.
+  SSL_CTX_clear_mode(sc->ctx_.get(), SSL_MODE_NO_AUTO_CHAIN);
+
   // SSL session cache configuration
   SSL_CTX_set_session_cache_mode(sc->ctx_.get(),
                                  SSL_SESS_CACHE_SERVER |


### PR DESCRIPTION
OpenSSL enables this feature by default, but BoringSSL doesn't, because it's expensive and unnecessary (see [boringssl/27](https://bugs.chromium.org/p/boringssl/issues/detail?id=27) and [boringssl/42](https://bugs.chromium.org/p/boringssl/issues/detail?id=42)). This change makes it so that when building node with BoringSSL, the behaviour matches OpenSSL's.

Electron will be building node.js with BoringSSL in future, and we've floated this patch on our fork (see electron/node#47).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
