### PR TITLE
 process: initial impl of feature access control 

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -52,6 +52,14 @@ If this flag is passed, the behavior can still be set to not abort through
 [`process.setUncaughtExceptionCaptureCallback()`][] (and through usage of the
 `domain` module that uses it).
 
+### `--disable=...`
+<!-- YAML
+added: REPLACEME
+-->
+
+Disable certain features of Node.js at startup. See [`process.accessControl`][]
+for more details.
+
 ### `--enable-fips`
 <!-- YAML
 added: v6.0.0
@@ -59,6 +67,15 @@ added: v6.0.0
 
 Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
 `./configure --openssl-fips`.)
+
+### `--experimental-access-control`
+<!-- YAML
+added: REPLACEME
+-->
+
+Allow disabling certain features of Node.js at runtime.
+See [`process.accessControl`][] for more details.
+The `--disable` flag implies this flag.
 
 ### `--experimental-modules`
 <!-- YAML
@@ -688,6 +705,7 @@ greater than `4` (its current default value). For more information, see the
 [`--openssl-config`]: #cli_openssl_config_file
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`process.accessControl`]: process.html#process_access_control
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -578,6 +578,14 @@ found [here][online].
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
+<a id="ERR_ACCESS_DENIED"></a>
+### ERR_ACCESS_DENIED
+
+> Stability: 1 - Experimental
+
+This error is thrown when an attempt was made to use a feature of Node.js
+which was previously disabled through the [`process.accessControl`][] mechanism.
+
 <a id="ERR_AMBIGUOUS_ARGUMENT"></a>
 ### ERR_AMBIGUOUS_ARGUMENT
 
@@ -1867,6 +1875,7 @@ A module file could not be resolved while attempting a [`require()`][] or
 [`net`]: net.html
 [`new URL(input)`]: url.html#url_constructor_new_url_input_base
 [`new URLSearchParams(iterable)`]: url.html#url_constructor_new_urlsearchparams_iterable
+[`process.accessControl`]: process.html#process_access_control
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [`require()`]: modules.html#modules_require

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2000,6 +2000,13 @@ Will generate an object similar to:
 
 > Stability: 1 - Experimental
 
+This feature is experimental and needs to be enabled by passing
+the `--experimental-access-control` flag, or the
+`--disable=restrictionA,restrictionB,...` flag to Node.js.
+
+The `--disable` flag takes a comma-separated list of identifiers as described
+below. For example, it can be used as `--disable=fsRead,fsWrite`.
+
 ### process.accessControl.apply(restrictions)
 <!-- YAML
 added: REPLACEME

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -305,6 +305,12 @@ if (isMainThread) {
 ```
 
 ### new Worker(filename[, options])
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/???
+    description: The `accessControl` option was added.
+-->
 
 * `filename` {string} The path to the Worker’s main script. Must be
   either an absolute path or a relative path (i.e. relative to the
@@ -312,6 +318,8 @@ if (isMainThread) {
   If `options.eval` is true, this is a string containing JavaScript code rather
   than a path.
 * `options` {Object}
+  * `accessControl` {Object} A set of access restrictions that will be applied
+    to the worker thread. See [`process.accessControl.apply()`][] for details.
   * `eval` {boolean} If true, interpret the first argument to the constructor
     as a script that is executed once the worker is online.
   * `workerData` {any} Any JavaScript value that will be cloned and made
@@ -326,6 +334,10 @@ if (isMainThread) {
     not automatically be piped through to `process.stdout` in the parent.
   * stderr {boolean} If this is set to `true`, then `worker.stderr` will
     not automatically be piped through to `process.stderr` in the parent.
+
+Note that if `accessControl.fsRead` is set to `false`, the worker thread will
+not be able to read its main script from the file system, so a source script
+should be passed in instead and the `eval` option should be set.
 
 ### Event: 'error'
 <!-- YAML
@@ -473,6 +485,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`port.on('message')`]: #worker_threads_event_message
 [`process.exit()`]: process.html#process_process_exit_code
 [`process.abort()`]: process.html#process_process_abort
+[`process.accessControl.apply()`]: process.html#process_process_accesscontrol_apply_restrictions
 [`process.chdir()`]: process.html#process_process_chdir_directory
 [`process.env`]: process.html#process_process_env
 [`process.stdin`]: process.html#process_process_stdin

--- a/doc/node.1
+++ b/doc/node.1
@@ -75,6 +75,12 @@ the next argument will be used as a script filename.
 .It Fl -abort-on-uncaught-exception
 Aborting instead of exiting causes a core file to be generated for analysis.
 .
+.It Fl -disable Ns = Ns Ar featureA,featureB,...
+Disables certain features of Node.js at startup.
+A full list of available restriction identifiers can be shown by running:
+.Pp
+.Sy ./node --experimental-access-control --print 'process.accessControl.getCurrent()'
+.
 .It Fl -enable-fips
 Enable FIPS-compliant crypto at startup.
 Requires Node.js to be built with
@@ -82,6 +88,12 @@ Requires Node.js to be built with
 .
 .It Fl -experimental-modules
 Enable experimental ES module support and caching modules.
+.
+.It Fl -experimental-access-control
+Allow disabling certain features of Node.js at runtime.
+The
+.Fl -disable
+flag implies this flag.
 .
 .It Fl -experimental-repl-await
 Enable experimental top-level

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -98,7 +98,8 @@
     perThreadSetup.setupMemoryUsage(_memoryUsage);
     perThreadSetup.setupKillAndExit();
 
-    process.accessControl = internalBinding('access_control');
+    if (process.binding('config').experimentalAccessControl)
+      process.accessControl = internalBinding('access_control');
 
     if (global.__coverage__)
       NativeModule.require('internal/process/write-coverage').setup();

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -98,6 +98,8 @@
     perThreadSetup.setupMemoryUsage(_memoryUsage);
     perThreadSetup.setupKillAndExit();
 
+    process.accessControl = internalBinding('access_control');
+
     if (global.__coverage__)
       NativeModule.require('internal/process/write-coverage').setup();
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -274,6 +274,12 @@ class Worker extends EventEmitter {
       publicPort: port2,
       hasStdin: !!options.stdin
     }, [port2]);
+
+    if (typeof options.accessControl === 'object' &&
+        options.accessControl !== null) {
+      this[kHandle].applyAccessControl(options.accessControl);
+    }
+
     // Actually start the new thread now that everything is in place.
     this[kHandle].startThread();
   }

--- a/node.gyp
+++ b/node.gyp
@@ -337,6 +337,7 @@
         'src/js_stream.cc',
         'src/module_wrap.cc',
         'src/node.cc',
+        'src/node_access_control.cc',
         'src/node_api.cc',
         'src/node_api.h',
         'src/node_api_types.h',

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1800,6 +1800,7 @@ class GetHostByAddrWrap: public QueryWrap {
 template <class Wrap>
 static void Query(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, netOutgoing);
   ChannelWrap* channel;
   ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
 
@@ -1949,6 +1950,7 @@ void CanonicalizeIP(const FunctionCallbackInfo<Value>& args) {
 
 void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, netOutgoing);
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());
@@ -2000,6 +2002,7 @@ void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
 
 void GetNameInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, netOutgoing);
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());

--- a/src/env.cc
+++ b/src/env.cc
@@ -178,6 +178,8 @@ Environment::Environment(IsolateData* isolate_data,
 
   isolate()->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
       BuildEmbedderGraph, this);
+
+  access_control()->apply(global_access_control);
 }
 
 Environment::~Environment() {

--- a/src/env.h
+++ b/src/env.h
@@ -457,6 +457,8 @@ class AccessControl {
   v8::MaybeLocal<v8::Object> ToObject(v8::Local<v8::Context> context);
   static v8::Maybe<AccessControl> FromObject(v8::Local<v8::Context> context,
                                              v8::Local<v8::Object> object);
+  static AccessControl FromString(const std::string& disabled_item_list,
+                                  std::string* unknown_item);
 
   static void ThrowAccessDenied(Environment* env, Permission perm);
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -134,6 +134,7 @@ void FSEventWrap::New(const FunctionCallbackInfo<Value>& args) {
 // wrap.start(filename, persistent, recursive, encoding)
 void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.This());
   CHECK_NOT_NULL(wrap);

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -75,6 +75,7 @@ class JSBindingsConnection : public AsyncWrap {
 
   static void New(const FunctionCallbackInfo<Value>& info) {
     Environment* env = Environment::GetCurrent(info);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, accessInspectorBindings);
     CHECK(info[0]->IsFunction());
     Local<Function> callback = info[0].As<Function>();
     new JSBindingsConnection(env, info.This(), callback);
@@ -122,7 +123,8 @@ static bool InspectorEnabled(Environment* env) {
 }
 
 void AddCommandLineAPI(const FunctionCallbackInfo<Value>& info) {
-  auto env = Environment::GetCurrent(info);
+  Environment* env = Environment::GetCurrent(info);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, accessInspectorBindings);
   Local<Context> context = env->context();
 
   // inspector.addCommandLineAPI takes 2 arguments: a string and a value.
@@ -135,6 +137,7 @@ void AddCommandLineAPI(const FunctionCallbackInfo<Value>& info) {
 
 void CallAndPauseOnStart(const FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, accessInspectorBindings);
   CHECK_GT(args.Length(), 1);
   CHECK(args[0]->IsFunction());
   SlicedArguments call_args(args, /* start */ 2);
@@ -237,6 +240,8 @@ void IsEnabled(const FunctionCallbackInfo<Value>& args) {
 
 void Open(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, accessInspectorBindings);
+
   Agent* agent = env->inspector_agent();
   bool wait_for_connect = false;
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -640,6 +640,7 @@ Maybe<URL> Resolve(Environment* env,
                    const std::string& specifier,
                    const URL& base,
                    PackageMainCheck check_pjson_main) {
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead, Nothing<URL>());
   URL pure_url(specifier);
   if (!(pure_url.flags() & URL_FLAGS_FAILED)) {
     // just check existence, without altering
@@ -668,6 +669,7 @@ Maybe<URL> Resolve(Environment* env,
 
 void ModuleWrap::Resolve(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   // module.resolve(specifier, url)
   CHECK_EQ(args.Length(), 2);

--- a/src/node_access_control.cc
+++ b/src/node_access_control.cc
@@ -56,6 +56,24 @@ Maybe<AccessControl> AccessControl::FromObject(Local<Context> context,
   return Just(ret);
 }
 
+AccessControl AccessControl::FromString(const std::string& disabled_item_list,
+                                        std::string* unknown_item) {
+  AccessControl ret;
+
+  std::set<std::string> items = ParseCommaSeparatedSet(disabled_item_list);
+  for (const std::string& item : items) {
+    Permission perm = PermissionFromString(item.c_str());
+    if (perm != kNumPermissions) {
+      ret.set_permission(perm, false);
+      continue;
+    }
+    if (unknown_item != nullptr)
+      *unknown_item = item;
+  }
+
+  return ret;
+}
+
 AccessControl::Permission AccessControl::PermissionFromString(const char* str) {
 #define V(kind) if (strcmp(str, #kind) == 0) return kind;
   ACCESS_CONTROL_FLAGS(V)

--- a/src/node_access_control.cc
+++ b/src/node_access_control.cc
@@ -1,0 +1,123 @@
+#include "node_internals.h"
+#include "node_errors.h"
+#include "env-inl.h"
+
+using v8::Boolean;
+using v8::Context;
+using v8::EscapableHandleScope;
+using v8::FunctionCallbackInfo;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Just;
+using v8::Local;
+using v8::Maybe;
+using v8::MaybeLocal;
+using v8::Nothing;
+using v8::Object;
+using v8::Value;
+
+namespace node {
+
+MaybeLocal<Object> AccessControl::ToObject(Local<Context> context) {
+  Isolate* isolate = context->GetIsolate();
+  EscapableHandleScope handle_scope(isolate);
+
+  Local<Object> obj = Object::New(isolate);
+
+#define V(kind)                                                               \
+  if (obj->Set(context,                                                       \
+               FIXED_ONE_BYTE_STRING(isolate, #kind),                         \
+               Boolean::New(isolate, has_permission(kind))).IsNothing()) {    \
+    return MaybeLocal<Object>();                                              \
+  }
+  ACCESS_CONTROL_FLAGS(V)
+#undef V
+
+  return handle_scope.Escape(obj);
+}
+
+Maybe<AccessControl> AccessControl::FromObject(Local<Context> context,
+                                               Local<Object> obj) {
+  Isolate* isolate = context->GetIsolate();
+  HandleScope scope(isolate);
+
+  AccessControl ret;
+
+  Local<Value> field;
+#define V(kind)                                                               \
+  if (!obj->Get(context, FIXED_ONE_BYTE_STRING(isolate, #kind))               \
+          .ToLocal(&field)) {                                                 \
+    return Nothing<AccessControl>();                                          \
+  }                                                                           \
+  ret.set_permission(kind, !field->IsFalse());
+  ACCESS_CONTROL_FLAGS(V)
+#undef V
+
+  return Just(ret);
+}
+
+AccessControl::Permission AccessControl::PermissionFromString(const char* str) {
+#define V(kind) if (strcmp(str, #kind) == 0) return kind;
+  ACCESS_CONTROL_FLAGS(V)
+#undef V
+  return kNumPermissions;
+}
+
+const char* AccessControl::PermissionToString(Permission perm) {
+  switch (perm) {
+#define V(kind) case kind: return #kind;
+    ACCESS_CONTROL_FLAGS(V)
+#undef V
+    default: return nullptr;
+  }
+}
+
+void AccessControl::ThrowAccessDenied(Environment* env, Permission perm) {
+  Local<Value> err = ERR_ACCESS_DENIED(env->isolate());
+  CHECK(err->IsObject());
+  err.As<Object>()->Set(
+      env->context(),
+      env->permission_string(),
+      v8::String::NewFromUtf8(env->isolate(),
+                              PermissionToString(perm),
+                              v8::NewStringType::kNormal).ToLocalChecked())
+          .FromMaybe(false);  // Nothing to do about an error at this point.
+  env->isolate()->ThrowException(err);
+}
+
+namespace ac {
+
+void Apply(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  AccessControl access_control;
+  Local<Object> obj;
+  if (!args[0]->ToObject(env->context()).ToLocal(&obj) ||
+      !AccessControl::FromObject(env->context(), obj).To(&access_control)) {
+    return;
+  }
+
+  env->access_control()->apply(access_control);
+}
+
+void GetCurrent(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  Local<Object> ret;
+  if (env->access_control()->ToObject(env->context()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+  env->SetMethod(target, "apply", Apply);
+  env->SetMethod(target, "getCurrent", GetCurrent);
+}
+
+}  // namespace ac
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(access_control, node::ac::Initialize)

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -81,6 +81,9 @@ static void Initialize(Local<Object> target,
   if (config_preserve_symlinks_main)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinksMain");
 
+  if (config_experimental_access_control)
+    READONLY_BOOLEAN_PROPERTY("experimentalAccessControl");
+
   if (config_experimental_modules) {
     READONLY_BOOLEAN_PROPERTY("experimentalModules");
     if (!config_userland_loader.empty()) {

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -21,6 +21,7 @@ namespace node {
 // a `Local<Value>` containing the TypeError with proper code and message
 
 #define ERRORS_WITH_CODE(V)                                                  \
+  V(ERR_ACCESS_DENIED, Error)                                                \
   V(ERR_BUFFER_OUT_OF_BOUNDS, RangeError)                                    \
   V(ERR_BUFFER_TOO_LARGE, Error)                                             \
   V(ERR_CANNOT_TRANSFER_OBJECT, TypeError)                                   \
@@ -61,6 +62,7 @@ namespace node {
 // Errors with predefined static messages
 
 #define PREDEFINED_ERROR_MESSAGES(V)                                         \
+  V(ERR_ACCESS_DENIED, "Access to this API has been restricted")             \
   V(ERR_CANNOT_TRANSFER_OBJECT, "Cannot transfer object of unsupported type")\
   V(ERR_CLOSED_MESSAGE_PORT, "Cannot send data on closed MessagePort")       \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")    \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -285,6 +285,8 @@ FileHandleReadWrap::FileHandleReadWrap(FileHandle* handle, Local<Object> obj)
 int FileHandle::ReadStart() {
   if (!IsAlive() || IsClosing())
     return UV_EOF;
+  if (!env()->access_control()->has_permission(AccessControl::fsRead))
+    return UV_EPERM;
 
   reading_ = true;
 
@@ -783,7 +785,7 @@ inline FSReqBase* GetReqWrap(Environment* env, Local<Value> value,
 
 void Access(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
-  HandleScope scope(env->isolate());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -836,6 +838,8 @@ void Close(const FunctionCallbackInfo<Value>& args) {
 // in the file.
 static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
+
   uv_loop_t* loop = env->event_loop();
 
   CHECK(args[0]->IsString());
@@ -903,6 +907,7 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
 // The speedup comes from not creating thousands of Stat and Error objects.
 static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   CHECK(args[0]->IsString());
   node::Utf8Value path(env->isolate(), args[0]);
@@ -920,6 +925,7 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -950,6 +956,7 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -981,6 +988,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1011,6 +1019,7 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
 
 static void Symlink(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   int argc = args.Length();
   CHECK_GE(argc, 4);
@@ -1039,6 +1048,7 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
 
 static void Link(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1065,6 +1075,7 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
 
 static void ReadLink(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1107,6 +1118,7 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
 
 static void Rename(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1133,6 +1145,7 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
 
 static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1159,6 +1172,7 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
 
 static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1181,6 +1195,7 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
 
 static void Fsync(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1203,6 +1218,7 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
 
 static void Unlink(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1225,6 +1241,7 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
 
 static void RMDir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1374,6 +1391,7 @@ int MKDirpAsync(uv_loop_t* loop,
 
 static void MKDir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 4);
@@ -1408,6 +1426,7 @@ static void MKDir(const FunctionCallbackInfo<Value>& args) {
 
 static void RealPath(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1451,6 +1470,7 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
 
 static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1586,6 +1606,11 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int flags = args[1].As<Int32>()->Value();
 
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
+  if ((flags & (O_WRONLY | O_RDWR | O_APPEND | O_CREAT)) != 0) {
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
+  }
+
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
@@ -1616,6 +1641,11 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int flags = args[1].As<Int32>()->Value();
 
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
+  if ((flags & (O_WRONLY | O_RDWR | O_APPEND | O_CREAT)) != 0) {
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
+  }
+
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
@@ -1641,6 +1671,7 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
 
 static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1681,7 +1712,7 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
 //             if null, write from the current position
 static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
   const int argc = args.Length();
   CHECK_GE(argc, 4);
 
@@ -1733,6 +1764,7 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 //             if null, write from the current position
 static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -1779,6 +1811,7 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
 // 3 enc       encoding of string
 static void WriteString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 4);
@@ -1879,6 +1912,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
  */
 static void Read(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
 
   const int argc = args.Length();
   CHECK_GE(argc, 5);
@@ -1926,6 +1960,7 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
  */
 static void Chmod(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1956,6 +1991,7 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
  */
 static void FChmod(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1986,6 +2022,7 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
  */
 static void Chown(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -2019,6 +2056,7 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
  */
 static void FChown(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -2049,6 +2087,7 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
 
 static void LChown(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -2079,6 +2118,7 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
 
 static void UTimes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -2108,6 +2148,7 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
 
 static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
@@ -2137,6 +2178,7 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
 
 static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsWrite);
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -105,6 +105,7 @@ struct sockaddr;
 // node is built as static library. No need to depends on the
 // __attribute__((constructor)) like mechanism in GCC.
 #define NODE_BUILTIN_STANDARD_MODULES(V)                                      \
+    V(access_control)                                                         \
     V(async_wrap)                                                             \
     V(buffer)                                                                 \
     V(cares_wrap)                                                             \

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -186,6 +186,12 @@ extern bool config_preserve_symlinks;
 // that is used by lib/module.js
 extern bool config_preserve_symlinks_main;
 
+// Set in node.cc by ParseArgs when --experimental-access-control is used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by the bootstrapper.
+extern bool config_experimental_access_control;
+extern AccessControl global_access_control;
+
 // Set in node.cc by ParseArgs when --experimental-modules is used.
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/module.js

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -321,6 +321,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
 
 static void GetHomeDirectory(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
   char buf[PATH_MAX];
 
   size_t len = sizeof(buf);
@@ -342,6 +343,7 @@ static void GetHomeDirectory(const FunctionCallbackInfo<Value>& args) {
 
 static void GetUserInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
   uv_passwd_t pwd;
   enum encoding encoding;
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -60,6 +60,7 @@ void Abort(const FunctionCallbackInfo<Value>& args) {
 
 void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
   CHECK(env->is_main_thread());
 
   CHECK_EQ(args.Length(), 1);
@@ -150,6 +151,7 @@ void HrtimeBigInt(const FunctionCallbackInfo<Value>& args) {
 
 void Kill(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, signalProcesses);
 
   if (args.Length() != 2)
     return env->ThrowError("Bad argument.");
@@ -364,6 +366,7 @@ void GetEGid(const FunctionCallbackInfo<Value>& args) {
 void SetGid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(env->is_main_thread());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
@@ -384,6 +387,7 @@ void SetGid(const FunctionCallbackInfo<Value>& args) {
 void SetEGid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(env->is_main_thread());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsUint32() || args[0]->IsString());
@@ -403,6 +407,7 @@ void SetEGid(const FunctionCallbackInfo<Value>& args) {
 
 void SetUid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
   CHECK(env->is_main_thread());
 
   CHECK_EQ(args.Length(), 1);
@@ -423,6 +428,7 @@ void SetUid(const FunctionCallbackInfo<Value>& args) {
 
 void SetEUid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
   CHECK(env->is_main_thread());
 
   CHECK_EQ(args.Length(), 1);
@@ -479,6 +485,7 @@ void GetGroups(const FunctionCallbackInfo<Value>& args) {
 
 void SetGroups(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsArray());
@@ -512,6 +519,7 @@ void SetGroups(const FunctionCallbackInfo<Value>& args) {
 
 void InitGroups(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setProcessAttrs);
 
   CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsUint32() || args[0]->IsString());

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -97,11 +97,14 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
   new StatWatcher(env, args.This(), args[0]->IsTrue());
 }
 
 // wrap.start(filename, interval)
 void StatWatcher::Start(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, fsRead);
   CHECK_EQ(args.Length(), 2);
 
   StatWatcher* wrap;

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -63,6 +63,7 @@ void NodeCategorySet::New(const FunctionCallbackInfo<Value>& args) {
 
 void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, modifyTraceEvents);
   NodeCategorySet* category_set;
   ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
   CHECK_NOT_NULL(category_set);
@@ -75,6 +76,7 @@ void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
 
 void NodeCategorySet::Disable(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, modifyTraceEvents);
   NodeCategorySet* category_set;
   ASSIGN_OR_RETURN_UNWRAP(&category_set, args.Holder());
   CHECK_NOT_NULL(category_set);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -111,6 +111,9 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 
 
 void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, setV8Flags);
+
   CHECK(args[0]->IsString());
   String::Utf8Value flags(args.GetIsolate(), args[0]);
   V8::SetFlagsFromString(*flags, flags.length());

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -103,6 +103,7 @@ Worker::Worker(Environment* env, Local<Object> wrap)
     env_->set_abort_on_uncaught_exception(false);
     env_->set_worker_context(this);
     env_->set_thread_id(thread_id_);
+    env_->access_control()->apply(*env->access_control());
 
     env_->Start(0, nullptr, 0, nullptr, env->profiler_idle_notifier_started());
   }
@@ -340,6 +341,7 @@ Worker::~Worker() {
 
 void Worker::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, createWorkers);
 
   CHECK(args.IsConstructCall());
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -39,6 +39,8 @@ class Worker : public AsyncWrap {
   bool is_stopped() const;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ApplyAccessControl(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StartThread(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StopThread(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetMessagePort(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -163,6 +163,7 @@ PipeWrap::PipeWrap(Environment* env,
 void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), fsWrite);
   node::Utf8Value name(args.GetIsolate(), args[0]);
   int err = uv_pipe_bind(&wrap->handle_, *name);
   args.GetReturnValue().Set(err);
@@ -182,6 +183,7 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
 void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), fsWrite);
   CHECK(args[0]->IsInt32());
   int mode = args[0].As<Int32>()->Value();
   int err = uv_pipe_chmod(reinterpret_cast<uv_pipe_t*>(&wrap->handle_),
@@ -193,6 +195,7 @@ void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), fsWrite);
   int backlog = args[0]->Int32Value();
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
                       backlog,
@@ -206,6 +209,7 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
 
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), fsWrite);
 
   int fd = args[0]->Int32Value();
 
@@ -222,6 +226,7 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), fsWrite);
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -21,6 +21,7 @@
 
 #include "env-inl.h"
 #include "handle_wrap.h"
+#include "node_errors.h"
 #include "node_internals.h"
 #include "node_wrap.h"
 #include "stream_base-inl.h"
@@ -141,6 +142,8 @@ class ProcessWrap : public HandleWrap {
 
   static void Spawn(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, childProcesses);
+
     Local<Context> context = env->context();
     ProcessWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
@@ -282,6 +285,8 @@ class ProcessWrap : public HandleWrap {
 
   static void Kill(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(env, signalProcesses);
+
     ProcessWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
     int signal = args[0]->Int32Value(env->context()).FromJust();

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -370,6 +370,7 @@ void SyncProcessRunner::Initialize(Local<Object> target,
 
 void SyncProcessRunner::Spawn(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env, childProcesses);
   env->PrintSyncTrace();
   SyncProcessRunner p(env);
   Local<Value> result = p.Run(args[0]);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -204,6 +204,14 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netIncoming) ||
+      !ac->has_permission(AccessControl::netOutgoing)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
+
   int fd = static_cast<int>(args[0]->IntegerValue());
   int err = uv_tcp_open(&wrap->handle_, fd);
 
@@ -219,6 +227,13 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netIncoming)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
+
   node::Utf8Value ip_address(args.GetIsolate(), args[0]);
   int port = args[1]->Int32Value();
   sockaddr_in addr;
@@ -237,6 +252,13 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netIncoming)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
+
   node::Utf8Value ip6_address(args.GetIsolate(), args[0]);
   int port = args[1]->Int32Value();
   sockaddr_in6 addr;
@@ -255,6 +277,13 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netIncoming)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
+
   int backlog = args[0]->Int32Value();
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
                       backlog,
@@ -270,6 +299,12 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netOutgoing)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());
@@ -305,6 +340,12 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+
+  AccessControl* ac = wrap->env()->access_control();
+  if (!ac->has_permission(AccessControl::netOutgoing)) {
+    args.GetReturnValue().Set(UV_EPERM);
+    return;
+  }
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -175,6 +175,7 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), netConnectionless);
 
   // bind(ip, port, flags)
   CHECK_EQ(args.Length(), 3);
@@ -340,6 +341,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), netConnectionless);
 
   // send(req, list, list.length, port, address, hasCallback)
   CHECK(args[0]->IsObject());
@@ -425,6 +427,8 @@ void UDPWrap::RecvStart(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+  THROW_IF_INSUFFICIENT_PERMISSIONS(wrap->env(), netConnectionless);
+
   int err = uv_udp_recv_start(&wrap->handle_, OnAlloc, OnRecv);
   // UV_EALREADY means that the socket is already bound but that's okay
   if (err == UV_EALREADY)

--- a/test/parallel/test-access-control.js
+++ b/test/parallel/test-access-control.js
@@ -1,0 +1,159 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const net = require('net');
+
+tmpdir.refresh();
+
+assert.deepStrictEqual(process.accessControl.getCurrent(), {
+  accessInspectorBindings: true,
+  childProcesses: true,
+  createWorkers: true,
+  fsRead: true,
+  fsWrite: true,
+  loadAddons: true,
+  modifyTraceEvents: true,
+  netConnectionless: true,
+  netIncoming: true,
+  netOutgoing: true,
+  setEnvironmentVariables: true,
+  setProcessAttrs: true,
+  setV8Flags: true,
+  signalProcesses: true
+});
+
+{
+  process.accessControl.apply({ setEnvironmentVariables: false });
+
+  assert.strictEqual(process.env.CANT_SET_ME, undefined);
+
+  common.expectsError(() => { process.env.CANT_SET_ME = 'bar'; }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  assert.strictEqual(process.env.CANT_SET_ME, undefined);
+
+  assert.strictEqual(process.accessControl.getCurrent().setEnvironmentVariables,
+                     false);
+
+  // Setting any other permission to 'false' will also disable child processes
+  // or loading addons.
+  assert.strictEqual(process.accessControl.getCurrent().childProcesses,
+                     false);
+  assert.strictEqual(process.accessControl.getCurrent().loadAddons,
+                     false);
+
+  // Setting values previously set to 'false' back to 'true' should not work.
+  process.accessControl.apply({ setEnvironmentVariables: true });
+  assert.strictEqual(process.accessControl.getCurrent().setEnvironmentVariables,
+                     false);
+
+  process.accessControl.apply({ childProcesses: true });
+  assert.strictEqual(process.accessControl.getCurrent().childProcesses,
+                     false);
+}
+
+if (common.isMainThread) {
+  process.accessControl.apply({ setProcessAttrs: false });
+
+  common.expectsError(() => { process.title = 'doesntwork'; }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+}
+
+{
+  // Spin up echo server.
+  const server = net.createServer((sock) => sock.pipe(sock))
+    .listen(0, common.mustCall(() => {
+      const existingSocket = net.connect(server.address().port, '127.0.0.1');
+      existingSocket.once('connect', common.mustCall(() => {
+        process.accessControl.apply({ netOutgoing: false });
+
+        existingSocket.write('foo');
+        existingSocket.setEncoding('utf8');
+        existingSocket.once('data', common.mustCall((data) => {
+          assert.strictEqual(data, 'foo');
+          existingSocket.end();
+          server.close();
+        }));
+
+        net.connect(server.address().port, '127.0.0.1')
+          .once('error', common.expectsError({
+            type: Error,
+            message: /connect EPERM 127\.0\.0\.1:\d+/,
+            code: 'EPERM'
+          }));
+      }));
+    }));
+}
+
+{
+  process.accessControl.apply({ netIncoming: false });
+
+  net.createServer().listen(0).once('error', common.expectsError({
+    type: Error,
+    message: /listen EPERM 0\.0\.0\.0/,
+    code: 'EPERM'
+  }));
+}
+
+{
+  const writeStream = fs.createWriteStream(
+    path.join(tmpdir.path, 'writable-stream.txt'));
+
+  process.accessControl.apply({ fsWrite: false });
+
+  common.expectsError(() => { fs.writeFileSync('foo.txt', 'blah'); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  // The 'open' event is emitted because permissions were still available
+  // originally, but...
+  writeStream.on('open', common.mustCall(() => {
+    // ... actually writing data is forbidden.
+    common.expectsError(() => { writeStream.write('X'); }, {
+      type: Error,
+      message: 'Access to this API has been restricted',
+      code: 'ERR_ACCESS_DENIED'
+    });
+  }));
+}
+
+{
+  const readStream = fs.createReadStream(__filename);
+
+  // The fs module kicks off reading automatically by calling .read().
+  // We want to intercept the exception, so we have to wrap .read():
+  readStream.read = common.mustCall(() => {
+    common.expectsError(() => {
+      fs.ReadStream.prototype.read.call(readStream);
+    }, {
+      type: Error,
+      message: 'Access to this API has been restricted',
+      code: 'ERR_ACCESS_DENIED'
+    });
+  });
+
+  process.accessControl.apply({ fsRead: false });
+
+  common.expectsError(() => { fs.readFileSync('foo.txt'); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  common.expectsError(() => { require('nonexistent.js'); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+}

--- a/test/parallel/test-access-control.js
+++ b/test/parallel/test-access-control.js
@@ -1,3 +1,4 @@
+// Flags: --experimental-access-control
 'use strict';
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-cli-access-control.js
+++ b/test/parallel/test-cli-access-control.js
@@ -1,0 +1,46 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+assert.strictEqual(
+  spawnSync(process.execPath, ['-p', 'process.accessControl'])
+    .stdout.toString().trim(), 'undefined');
+
+{
+  const { stdout, stderr } = spawnSync(
+    process.execPath,
+    ['--experimental-access-control', '-p', 'process.accessControl.apply']);
+  assert.strictEqual(stdout.toString().trim(), '[Function: apply]');
+  assert.strictEqual(
+    stderr.toString().trim(),
+    'Warning: Access control through disabling features is experimental and ' +
+    'may be changed at any time.');
+}
+
+{
+  const { stdout, stderr } = spawnSync(
+    process.execPath,
+    ['--disable=fsRead', '-p', 'process.accessControl.apply']);
+  assert.strictEqual(stdout.toString().trim(), '[Function: apply]');
+  assert.strictEqual(
+    stderr.toString().trim(),
+    'Warning: Access control through disabling features is experimental and ' +
+    'may be changed at any time.');
+}
+
+{
+  const { stderr } = spawnSync(process.execPath, ['--disable=unknown']);
+  assert.strictEqual(
+    stderr.toString().trim(),
+    `${process.execPath}: unknown --disable entry unknown`);
+}
+
+{
+  const { stderr } = spawnSync(
+    process.execPath,
+    ['--disable=fsRead', '-p', 'fs.readFileSync(process.execPath)']);
+  assert.ok(
+    stderr.toString().includes('Access to this API has been restricted'),
+    stderr);
+}

--- a/test/parallel/test-worker-access-control.js
+++ b/test/parallel/test-worker-access-control.js
@@ -1,0 +1,57 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const child_process = require('child_process');
+const { Worker } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename, {
+    accessControl: {
+      fsWrite: false,
+      childProcesses: false,
+      loadAddons: false,
+      createWorkers: false
+    }
+  });
+
+  w.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+} else {
+  // We needed fs read access to load modules before.
+  process.accessControl.apply({ fsRead: false });
+
+  common.expectsError(() => { fs.readFileSync(__filename); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  common.expectsError(() => { fs.writeFileSync(__filename, ''); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  common.expectsError(() => { child_process.spawnSync('node'); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  common.expectsError(() => { child_process.spawn('node'); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+
+  common.expectsError(() => { new Worker(__filename); }, {
+    type: Error,
+    message: 'Access to this API has been restricted',
+    code: 'ERR_ACCESS_DENIED'
+  });
+}

--- a/test/parallel/test-worker-access-control.js
+++ b/test/parallel/test-worker-access-control.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-worker
+// Flags: --experimental-worker --experimental-access-control
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
Just playing around with something here … this doesn’t need to happen, or can happen in a completely different way or by somebody else. I’d love to get ideas and feedback on this, though.

/cc @nodejs/security @nodejs/collaborators 

---

Implement `process.accessControl`, a simple API for restricting usage of certain in-process APIs,
and similarly an `accessControl` option when setting up workers.

Refs: #22107

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
