### PR TITLE
Remove unused 3rd argument in assert.strictEqual()

### DIFF
--- a/test/addons-napi/test_async/test-loop.js
+++ b/test/addons-napi/test_async/test-loop.js
@@ -6,7 +6,7 @@ const iterations = 500;
 
 let x = 0;
 const workDone = common.mustCall((status) => {
-  assert.strictEqual(status, 0, 'Work completed successfully');
+  assert.strictEqual(status, 0);
   if (++x < iterations) {
     setImmediate(() => test_async.DoRepeatedWork(workDone));
   }


### PR DESCRIPTION
 Line 9 contains a call to assert.strictEqual(). It has a string literal as the third argument. Unfortunately, that means that if there is an AssertionError, the value of status (the first argument) will not be reported. The third argument here is not adding any value (and in fact is reporting the *wrong* thing in the event of an AssertionError) so removed it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
