### PR TITLE
trace_events: fix dynamic enabling of trace events

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/libplatform/tracing/tracing-controller.cc
+++ b/deps/v8/src/libplatform/tracing/tracing-controller.cc
@@ -24,18 +24,17 @@ namespace tracing {
 // convert internally to determine the category name from the char enabled
 // pointer.
 const char* g_category_groups[MAX_CATEGORY_GROUPS] = {
-    "toplevel", "tracing already shutdown",
+    "toplevel",
     "tracing categories exhausted; must increase MAX_CATEGORY_GROUPS",
     "__metadata"};
 
 // The enabled flag is char instead of bool so that the API can be used from C.
 unsigned char g_category_group_enabled[MAX_CATEGORY_GROUPS] = {0};
 // Indexes here have to match the g_category_groups array indexes above.
-const int g_category_already_shutdown = 1;
-const int g_category_categories_exhausted = 2;
+const int g_category_categories_exhausted = 1;
 // Metadata category not used in V8.
-// const int g_category_metadata = 3;
-const int g_num_builtin_categories = 4;
+// const int g_category_metadata = 2;
+const int g_num_builtin_categories = 3;
 
 // Skip default categories.
 v8::base::AtomicWord g_category_index = g_num_builtin_categories;
@@ -103,10 +102,6 @@ void TracingController::UpdateTraceEventDuration(
 
 const uint8_t* TracingController::GetCategoryGroupEnabled(
     const char* category_group) {
-  if (!trace_buffer_) {
-    DCHECK(!g_category_group_enabled[g_category_already_shutdown]);
-    return &g_category_group_enabled[g_category_already_shutdown];
-  }
   return GetCategoryGroupEnabledInternal(category_group);
 }
 

--- a/test/parallel/test-trace-events-dynamic-enable.js
+++ b/test/parallel/test-trace-events-dynamic-enable.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { performance } = require('perf_hooks');
+const { Session } = require('inspector');
+
+const session = new Session();
+
+function post(message, data) {
+  return new Promise((resolve, reject) => {
+    session.post(message, data, (err, result) => {
+      if (err)
+        reject(new Error(JSON.stringify(err)));
+      else
+        resolve(result);
+    });
+  });
+}
+
+async function test() {
+  session.connect();
+
+  let traceNotification = null;
+  let tracingComplete = false;
+  session.on('NodeTracing.dataCollected', (n) => traceNotification = n);
+  session.on('NodeTracing.tracingComplete', () => tracingComplete = true);
+
+  // Generate a node.perf event before tracing is enabled.
+  performance.mark('mark1');
+
+  const traceConfig = { includedCategories: ['node.perf'] };
+  await post('NodeTracing.start', { traceConfig });
+
+  // Generate a node.perf event after tracing is enabled. This should be the
+  // mark event captured.
+  performance.mark('mark2');
+
+  await post('NodeTracing.stop', { traceConfig });
+
+  performance.mark('mark3');
+
+  session.disconnect();
+
+  assert.ok(tracingComplete);
+  assert.ok(traceNotification);
+  assert.ok(traceNotification.data && traceNotification.data.value);
+
+  const events = traceNotification.data.value;
+  const marks = events.filter((t) => null !== /node\.perf\.usertim/.exec(t.cat));
+  assert.strictEqual(marks.length, 1);
+  assert.strictEqual(marks[0].name, 'mark2');
+}
+
+test();


### PR DESCRIPTION
V8 was assuming that trace-events can only be enabled at startup and, once disabled, will never be enabled again. In Node.js we have a lot more dynamic control over tracing. Fix bug upstream. 

This PR back ports the fix and adds a test. This can be floated until (if) this is merged upstream.

/cc @nodejs/trace-events @nodejs/v8-update 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1570/
CI: https://ci.nodejs.org/job/node-test-pull-request/16180/