### PR TITLE
zlib: Remove useless parameters

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -198,12 +198,12 @@ function checkFiniteNumber(number, name) {
   throw err;
 }
 
-// 1. Returns def for undefined and NaN
+// 1. Returns def for number when it's undefined or NaN
 // 2. Returns number for finite numbers >= lower and <= upper
 // 3. Throws ERR_INVALID_ARG_TYPE for non-numbers
 // 4. Throws ERR_OUT_OF_RANGE for infinite numbers or numbers > upper or < lower
 function checkRangesOrGetDefault(number, name, lower, upper, def) {
-  if (!checkFiniteNumber(number, name, lower, upper)) {
+  if (!checkFiniteNumber(number, name)) {
     return def;
   }
   if (number < lower || number > upper) {


### PR DESCRIPTION
When `checkRangesOrGetDefault` calls `checkFiniteNumber`, the latter
function only has two parameters, so `lower` and `upper` don't need to
be passed for validation.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines