### PR TITLE
http: Adding doc and debug for calling empty string on write function

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -750,6 +750,9 @@ Returns `true` if the entire data was flushed successfully to the kernel
 buffer. Returns `false` if all or part of the data was queued in user memory.
 `'drain'` will be emitted when the buffer is free again.
 
+When `write` function is called with empty string or buffer, it does 
+nothing and waits for more input.
+
 ## Class: http.Server
 <!-- YAML
 added: v0.1.17

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -599,7 +599,10 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   // If we get an empty string or buffer, then just do nothing, and
   // signal the user to keep writing.
-  if (chunk.length === 0) return true;
+  if (chunk.length === 0) {
+    debug('received empty string or buffer and waiting for more input');
+    return true;
+  }
 
   if (!fromEnd && msg.connection && !msg[kIsCorked]) {
     msg.connection.cork();


### PR DESCRIPTION
Addresses the issue : https://github.com/nodejs/node/issues/22066

Removing the empty check would be a breaking change, however I'm not sure why such check is in first place. May be need input from the community. 

In the meantime,  I thought its worth to add documentation and at the same time to add `debug` log, so that when users feel `write` with empty string or buffer hangs, they can run in debug mode to find out the reason. 

If the content fits for the documentation, I guess we need to add the same to `http2` as well. 

Open to feedbacks and thoughts.  

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
