### PR TITLE
assert: add env to show the full error

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -123,8 +123,37 @@ assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
 //   ]
 ```
 
+By default colors are turned on in case a TTY is used as stderr and it supports
+colors. Please note that the color detection might fail and no colors are used
+in that case.
 To deactivate the colors, use the `NODE_DISABLE_COLORS` environment variable.
-Please note that this will also deactivate the colors in the REPL.
+Using that environment variable will also deactivate the colors in the REPL.
+
+The diff will also be minified in case more than three lines are identical or if
+either side of an loose equal check is longer than 128 characters. To prevent
+the minification use the `NODE_ASSERT_FULL` environment variable and set it to
+'1'.
+
+In this example the "3" and "4" would normally be visualized as "skipped lines".
+
+```js
+const assert = require('assert').strict;
+
+process.env.NODE_ASSERT_FULL = '1';
+
+assert.deepEqual([1, 2, 3, 4, 5], [2, 2, 3, 4, 5]);
+// AssertionError: Expected inputs to be strictly deep-equal:
+// + actual - expected
+//
+//  [
+// +   1,
+// -   2,
+//    2,
+//    3,
+//    4,
+//    5
+//  ]
+```
 
 ## Legacy mode
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -130,9 +130,8 @@ To deactivate the colors, use the `NODE_DISABLE_COLORS` environment variable.
 Using that environment variable will also deactivate the colors in the REPL.
 
 The diff will also be minified in case more than three lines are identical or if
-either side of an loose equal check is longer than 128 characters. To prevent
-the minification use the `NODE_ASSERT_FULL` environment variable and set it to
-'1'.
+either side of a loose equal check is longer than 128 characters. To prevent the
+minification use the `NODE_ASSERT_FULL` environment variable and set it to '1'.
 
 In this example the "3" and "4" would normally be visualized as "skipped lines".
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -472,6 +472,15 @@ Print node's version.
 
 ## Environment Variables
 
+### `NODE_ASSERT_FULL=1`
+<!-- YAML
+added: REPLACEME
+-->
+
+Setting this environment variable to `1` is going to deactivate any default
+minification in assertion error messages. For further details see
+[`strict mode`][].
+
 ### `NODE_DEBUG=module[,…]`
 <!-- YAML
 added: v0.1.32
@@ -682,6 +691,7 @@ greater than `4` (its current default value). For more information, see the
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
+[`strict mode`]: assert.html#assert_strict_mode
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [debugger]: debugger.html

--- a/doc/node.1
+++ b/doc/node.1
@@ -273,6 +273,11 @@ Print node's version.
 .\" =====================================================================
 .Sh ENVIRONMENT
 .Bl -tag -width 6n
+.It Ev NODE_ASSERT_FULL
+When set to
+.Ar 1 ,
+assertion error messages will not be minified (e.g., skipping identical input).
+
 .It Ev NODE_DEBUG Ar modules...
 Comma-separated list of core modules that should print debug information.
 .

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -108,7 +108,7 @@ function createErrDiff(actual, expected, operator) {
   let a = actualLines[actualLines.length - 1];
   let b = expectedLines[expectedLines.length - 1];
   while (a === b) {
-    if (i++ < 2) {
+    if (i++ < 2 || process.env.NODE_ASSERT_FULL === '1') {
       end = `\n  ${a}${end}`;
     } else {
       other = a;
@@ -129,15 +129,39 @@ function createErrDiff(actual, expected, operator) {
     const actualLines = inspectValue(actual);
 
     // Only remove lines in case it makes sense to collapse those.
-    // TODO: Accept env to always show the full error.
-    if (actualLines.length > 30) {
+    if (process.env.NODE_ASSERT_FULL !== '1' && actualLines.length > 30) {
       actualLines[26] = `${blue}...${white}`;
+      skipped = true;
       while (actualLines.length > 27) {
         actualLines.pop();
       }
     }
 
-    return `${kReadableOperator.notIdentical}\n\n${actualLines.join('\n')}\n`;
+    return kReadableOperator.notIdentical +
+           `\n${skipped ? `${skippedMsg}\n` : ''}\n${actualLines.join('\n')}`;
+  }
+
+  if (process.env.NODE_ASSERT_FULL === '1') {
+    for (i = 0; i < maxLines; i++) {
+      // Only extra expected lines exist
+      if (actualLines.length < i + 1) {
+        other += `\n${red}-${white} ${expectedLines[i]}`;
+      // Only extra actual lines exist
+      } else if (expectedLines.length < i + 1) {
+        res += `\n${green}+${white} ${actualLines[i]}`;
+      // Lines diverge
+      } else if (actualLines[i] !== expectedLines[i]) {
+        res += `\n${green}+${white} ${actualLines[i]}`;
+        other += `\n${red}-${white} ${expectedLines[i]}`;
+      // Lines are identical
+      } else {
+        res += other;
+        other = '';
+        res += `\n  ${actualLines[i]}`;
+      }
+    }
+
+    return `${msg}\n${res}${other}${end}${indicator}`;
   }
 
   if (i > 3) {
@@ -271,28 +295,33 @@ class AssertionError extends Error {
         const res = inspectValue(actual);
         const base = kReadableOperator[operator];
 
-        // Only remove lines in case it makes sense to collapse those.
-        // TODO: Accept env to always show the full error.
-        if (res.length > 30) {
-          res[26] = `${blue}...${white}`;
-          while (res.length > 27) {
-            res.pop();
-          }
-        }
-
-        // Only print a single input.
         if (res.length === 1) {
           super(`${base} ${res[0]}`);
         } else {
-          super(`${base}\n\n${res.join('\n')}\n`);
+          let skipped = false;
+          const skippedMsg = ` ${blue}...${white} Lines skipped\n`;
+
+          // Only remove lines in case it makes sense to collapse those.
+          if (process.env.NODE_ASSERT_FULL !== '1' && res.length > 30) {
+            res[26] = `${blue}...${white}`;
+            skipped = true;
+            while (res.length > 27) {
+              res.pop();
+            }
+          }
+
+          // Only print a single input.
+          super(`${base}\n${skipped ? skippedMsg : ''}\n${res.join('\n')}\n`);
         }
       } else {
         let res = inspect(actual);
         let other = inspect(expected);
-        if (res.length > 128)
-          res = `${res.slice(0, 125)}...`;
-        if (other.length > 128)
-          other = `${other.slice(0, 125)}...`;
+        if (process.env.NODE_ASSERT_FULL !== '1') {
+          if (res.length > 128)
+            res = `${res.slice(0, 125)}...`;
+          if (other.length > 128)
+            other = `${other.slice(0, 125)}...`;
+        }
         super(`${res} ${operator} ${other}`);
       }
     }

--- a/src/node.cc
+++ b/src/node.cc
@@ -2693,6 +2693,8 @@ static void PrintHelp() {
          "  -v, --version              print Node.js version\n"
          "\n"
          "Environment variables:\n"
+         "NODE_ASSERT_FULL             set to `1` to prevent assertion error\n"
+         "                             messages to be minified\n"
          "NODE_DEBUG                   ','-separated list of core modules\n"
          "                             that should print debug information\n"
          "NODE_DEBUG_NATIVE            ','-separated list of C++ core debug\n"

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -929,3 +929,30 @@ assert.throws(() => assert.deepStrictEqual(new Boolean(true), {}),
   );
   util.inspect.defaultOptions = tmp;
 }
+
+// Check full error diff.
+{
+  process.env.NODE_ASSERT_FULL = '1';
+  assert.throws(
+    () => assert.deepStrictEqual([1, 2, 3, 4, 5], [2, 2, 3, 4, 5]),
+    { message: /^[^.]+$/ }
+  );
+  assert.throws(
+    () => assert.notDeepStrictEqual(Array(100).fill(1), Array(100).fill(1)),
+    { message: /^[^.]+$/ }
+  );
+  assert.throws(
+    () => assert.strictEqual(
+      Array(100).fill(Symbol()),
+      Array(100).fill(Symbol())
+    ),
+    { message: /^[^.]+$/ }
+  );
+
+  assert.throws(
+    // eslint-disable-next-line no-restricted-properties
+    () => assert.deepEqual('a'.repeat(1000), 'b'.repeat(1000)),
+    { message: `'${'a'.repeat(1000)}' deepEqual '${'b'.repeat(1000)}'` }
+  );
+  delete process.env.NODE_ASSERT_FULL;
+}

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -617,6 +617,7 @@ assert.throws(
   );
 
   message = 'Expected "actual" not to be strictly deep-equal to:' +
+            '\n ... Lines skipped' +
             `\n\n[${'\n  1,'.repeat(25)}\n...\n`;
   const data = Array(31).fill(1);
   assert.throws(
@@ -1000,7 +1001,7 @@ assert.throws(() => { throw null; }, 'foo');
 assert.throws(
   () => assert.strictEqual([], []),
   {
-    message: 'Inputs identical but not reference equal:\n\n[]\n'
+    message: 'Inputs identical but not reference equal:\n\n[]'
   }
 );
 


### PR DESCRIPTION
This adds the `NODE_ASSERT_FULL` environment variable to give the
user the option to opt into seeing the full error message even though
the diff is at least partially identical.

Fixes: #19106

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
