### PR TITLE
assert: remove ERR_ASSERTION from name

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -68,7 +68,7 @@ try {
 } catch (err) {
   assert(err instanceof assert.AssertionError);
   assert.strictEqual(err.message, message);
-  assert.strictEqual(err.name, 'AssertionError [ERR_ASSERTION]');
+  assert.strictEqual(err.name, 'AssertionError');
   assert.strictEqual(err.actual, 1);
   assert.strictEqual(err.expected, 2);
   assert.strictEqual(err.code, 'ERR_ASSERTION');
@@ -376,7 +376,7 @@ assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol1]: 1 });
 // OK, because it is the same symbol on both objects.
 
 assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol2]: 1 });
-// AssertionError [ERR_ASSERTION]: Inputs identical but not reference equal:
+// AssertionError: Inputs identical but not reference equal:
 //
 // {
 //   [Symbol()]: 1
@@ -583,10 +583,10 @@ will be thrown instead of the `AssertionError`.
 const assert = require('assert').strict;
 
 assert.fail();
-// AssertionError [ERR_ASSERTION]: Failed
+// AssertionError: Failed
 
 assert.fail('boom');
-// AssertionError [ERR_ASSERTION]: boom
+// AssertionError: boom
 
 assert.fail(new TypeError('need array'));
 // TypeError: need array
@@ -626,16 +626,16 @@ given, the default message `Failed` will be used.
 const assert = require('assert').strict;
 
 assert.fail('a', 'b');
-// AssertionError [ERR_ASSERTION]: 'a' != 'b'
+// AssertionError: 'a' != 'b'
 
 assert.fail(1, 2, undefined, '>');
-// AssertionError [ERR_ASSERTION]: 1 > 2
+// AssertionError: 1 > 2
 
 assert.fail(1, 2, 'fail');
-// AssertionError [ERR_ASSERTION]: fail
+// AssertionError: fail
 
 assert.fail(1, 2, 'whoops', '>');
-// AssertionError [ERR_ASSERTION]: whoops
+// AssertionError: whoops
 
 assert.fail(1, 2, new TypeError('need array'));
 // TypeError: need array
@@ -651,7 +651,7 @@ function suppressFrame() {
   assert.fail('a', 'b', undefined, '!==', suppressFrame);
 }
 suppressFrame();
-// AssertionError [ERR_ASSERTION]: 'a' !== 'b'
+// AssertionError: 'a' !== 'b'
 //     at repl:1:1
 //     at ContextifyScript.Script.runInThisContext (vm.js:44:33)
 //     ...
@@ -683,11 +683,11 @@ const assert = require('assert').strict;
 assert.ifError(null);
 // OK
 assert.ifError(0);
-// AssertionError [ERR_ASSERTION]: ifError got unwanted exception: 0
+// AssertionError: ifError got unwanted exception: 0
 assert.ifError('error');
-// AssertionError [ERR_ASSERTION]: ifError got unwanted exception: 'error'
+// AssertionError: ifError got unwanted exception: 'error'
 assert.ifError(new Error());
-// AssertionError [ERR_ASSERTION]: ifError got unwanted exception: Error
+// AssertionError: ifError got unwanted exception: Error
 
 // Create some random error frames.
 let err;
@@ -698,7 +698,7 @@ let err;
 (function ifErrorFrame() {
   assert.ifError(err);
 })();
-// AssertionError [ERR_ASSERTION]: ifError got unwanted exception: test error
+// AssertionError: ifError got unwanted exception: test error
 //     at ifErrorFrame
 //     at errorFrame
 ```
@@ -883,9 +883,7 @@ assert.notStrictEqual(1, 2);
 // OK
 
 assert.notStrictEqual(1, 1);
-// AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to:
-//
-// 1
+// AssertionError: Expected "actual" to be strictly unequal to: 1
 
 assert.notStrictEqual(1, '1');
 // OK
@@ -1041,7 +1039,7 @@ determined by the [SameValue Comparison][].
 const assert = require('assert').strict;
 
 assert.strictEqual(1, 2);
-// AssertionError [ERR_ASSERTION]: Expected inputs to be strictly equal:
+// AssertionError: Expected inputs to be strictly equal:
 //
 // 1 !== 2
 
@@ -1049,7 +1047,7 @@ assert.strictEqual(1, 1);
 // OK
 
 assert.strictEqual('Hello foobar', 'Hello World!');
-// AssertionError [ERR_ASSERTION]: Expected inputs to be strictly equal:
+// AssertionError: Expected inputs to be strictly equal:
 // + actual - expected
 //
 // + 'Hello foobar'
@@ -1228,7 +1226,7 @@ assert.throws(throwingSecond, 'Second');
 
 // The string is only used (as message) in case the function does not throw:
 assert.throws(notThrowing, 'Second');
-// AssertionError [ERR_ASSERTION]: Missing expected exception: Second
+// AssertionError: Missing expected exception: Second
 
 // If it was intended to match for the error message do this instead:
 // It does not throw because the error messages match.

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -298,7 +298,7 @@ class AssertionError extends Error {
     }
 
     this.generatedMessage = !message;
-    this.name = 'AssertionError [ERR_ASSERTION]';
+    this.name = 'AssertionError';
     this.code = 'ERR_ASSERTION';
     this.actual = actual;
     this.expected = expected;

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 // With the current behavior of Node.js (at least as late as 8.1.0), this
 // test fails with the following error:
-// `AssertionError [ERR_ASSERTION]: worker 2 failed to bind port`
+// `AssertionError: worker 2 failed to bind port`
 // Ideally, there would be a way for the user to opt out of sequential port
 // assignment.
 //

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -2,7 +2,7 @@ assert.js:*
       throw err;
       ^
 
-AssertionError [ERR_ASSERTION]: Expected inputs to be strictly deep-equal:
+AssertionError: Expected inputs to be strictly deep-equal:
 + actual - expected
 
 + Comparison {}

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -3,7 +3,7 @@ assert.js:*
   throw new AssertionError(obj);
   ^
 
-AssertionError [ERR_ASSERTION]: Expected inputs to be strictly equal:
+AssertionError: Expected inputs to be strictly equal:
 
 1 !== 2
 

--- a/test/message/if-error-has-good-stack.out
+++ b/test/message/if-error-has-good-stack.out
@@ -2,7 +2,7 @@ assert.js:*
     throw newErr;
     ^
 
-AssertionError [ERR_ASSERTION]: ifError got unwanted exception: test error
+AssertionError: ifError got unwanted exception: test error
     at z (*if-error-has-good-stack.js:*:*
     at y (*if-error-has-good-stack.js:*:*)
     at x (*if-error-has-good-stack.js:*:*)

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -13,7 +13,7 @@ const promises = [];
   const rejectingFn = async () => assert.fail();
   const errObj = {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Failed'
   };
   // `assert.rejects` accepts a function or a promise as first argument.

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -634,31 +634,31 @@ assert.deepEqual(/a/igm, /a/igm);
 assert.throws(() => assert.deepEqual(/ab/, /a/),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: '/ab/ deepEqual /a/'
               });
 assert.throws(() => assert.deepEqual(/a/g, /a/),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: '/a/g deepEqual /a/'
               });
 assert.throws(() => assert.deepEqual(/a/i, /a/),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: '/a/i deepEqual /a/'
               });
 assert.throws(() => assert.deepEqual(/a/m, /a/),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: '/a/m deepEqual /a/'
               });
 assert.throws(() => assert.deepEqual(/a/igm, /a/im),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: '/a/gim deepEqual /a/im'
               });
 
@@ -749,7 +749,7 @@ assert.throws(
 assert.throws(
   () => assert.notDeepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Expected "actual" not to be strictly deep-equal to: ' +
              util.inspect(new Date(2000, 3, 14))
   }
@@ -766,35 +766,35 @@ assert.throws(
   () => assert.deepStrictEqual(/ab/, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /ab/\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/g, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/g\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/i, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/i\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/m, /a/),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/m\n- /a/`
   });
 assert.throws(
   () => assert.deepStrictEqual(/a/igm, /a/im),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n+ /a/gim\n- /a/im\n     ^`
   });
 
@@ -820,14 +820,14 @@ assert.deepStrictEqual({ a: 4, b: '2' }, { a: 4, b: '2' });
 assert.throws(() => assert.deepStrictEqual([4], ['4']),
               {
                 code: 'ERR_ASSERTION',
-                name: 'AssertionError [ERR_ASSERTION]',
+                name: 'AssertionError',
                 message: `${defaultMsgStartFull}\n\n  [\n+   4\n-   '4'\n  ]`
               });
 assert.throws(
   () => assert.deepStrictEqual({ a: 4 }, { a: 4, b: true }),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n  ` +
              '{\n+   a: 4\n-   a: 4,\n-   b: true\n  }'
   });
@@ -835,7 +835,7 @@ assert.throws(
   () => assert.deepStrictEqual(['a'], { 0: 'a' }),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: `${defaultMsgStartFull}\n\n` +
              "+ [\n+   'a'\n+ ]\n- {\n-   '0': 'a'\n- }"
   });

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -15,7 +15,7 @@ assert.throws(() => {
   assert.fail('first', 'second');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: '\'first\' != \'second\'',
   operator: '!=',
   actual: 'first',
@@ -27,7 +27,7 @@ assert.throws(() => {
   assert.fail('ignored', 'ignored', 'another custom message');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: 'another custom message',
   operator: undefined,
   actual: 'ignored',
@@ -47,7 +47,7 @@ assert.throws(() => {
   assert.fail('first', 'second', undefined, 'operator');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: '\'first\' operator \'second\'',
   operator: 'operator',
   actual: 'first',

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -8,7 +8,7 @@ assert.throws(
   () => { assert.fail(); },
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: 'Failed',
     operator: undefined,
     actual: undefined,
@@ -21,7 +21,7 @@ assert.throws(() => {
   assert.fail('custom message');
 }, {
   code: 'ERR_ASSERTION',
-  name: 'AssertionError [ERR_ASSERTION]',
+  name: 'AssertionError',
   message: 'custom message',
   operator: undefined,
   actual: undefined,

--- a/test/parallel/test-assert-first-line.js
+++ b/test/parallel/test-assert-first-line.js
@@ -9,7 +9,7 @@ const { path } = require('../common/fixtures');
 assert.throws(
   () => require(path('assert-first-line')),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: "The expression evaluated to a falsy value:\n\n  ässört.ok('')\n"
   }
 );
@@ -17,7 +17,7 @@ assert.throws(
 assert.throws(
   () => require(path('assert-long-line')),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: "The expression evaluated to a falsy value:\n\n  assert.ok('')\n"
   }
 );

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -72,7 +72,7 @@ assert.throws(
   () => a.notStrictEqual(2, 2),
   {
     message: 'Expected "actual" to be strictly unequal to: 2',
-    name: 'AssertionError [ERR_ASSERTION]'
+    name: 'AssertionError'
   }
 );
 
@@ -81,7 +81,7 @@ assert.throws(
   {
     message: 'Expected "actual" to be strictly unequal to: ' +
              `'${'a '.repeat(30)}'`,
-    name: 'AssertionError [ERR_ASSERTION]'
+    name: 'AssertionError'
   }
 );
 
@@ -142,7 +142,7 @@ assert.throws(() => thrower(TypeError));
 assert.throws(
   () => a.doesNotThrow(() => thrower(Error), 'user message'),
   {
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     code: 'ERR_ASSERTION',
     operator: 'doesNotThrow',
     message: 'Got unwanted exception: user message\n' +
@@ -414,7 +414,7 @@ assert.throws(
   () => assert.strictEqual(new Error('foo'), new Error('foobar')),
   {
     code: 'ERR_ASSERTION',
-    name: 'AssertionError [ERR_ASSERTION]',
+    name: 'AssertionError',
     message: strictEqualMessageStart +
              '+ actual - expected\n\n' +
              '+ [Error: foo]\n- [Error: foobar]\n             ^'
@@ -441,7 +441,7 @@ assert.throws(
     () => assert(...[]),
     {
       message: 'No value argument passed to `assert.ok()`',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       generatedMessage: true
     }
   );
@@ -449,7 +449,7 @@ assert.throws(
     () => a(),
     {
       message: 'No value argument passed to `assert.ok()`',
-      name: 'AssertionError [ERR_ASSERTION]'
+      name: 'AssertionError'
     }
   );
 
@@ -883,7 +883,7 @@ common.expectsError(
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: `${start}\n${actExp}\n\n` +
                "  Comparison {\n    name: 'TypeError',\n" +
                "    message: 'Wrong value',\n+   code: 404\n" +
@@ -897,7 +897,7 @@ common.expectsError(
     () => assert.throws(errFn, errObj),
     {
       code: 'ERR_ASSERTION',
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       message: `${start}\n${actExp}\n\n` +
                "  Comparison {\n    name: 'TypeError',\n" +
                "    message: 'Wrong value',\n+   code: 404\n" +
@@ -928,7 +928,7 @@ common.expectsError(
   assert.throws(
     () => assert.throws(() => { throw new TypeError('e'); }, new Error('e')),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       message: `${start}\n${actExp}\n\n` +
                "  Comparison {\n+   name: 'TypeError',\n-   name: 'Error'," +
@@ -938,7 +938,7 @@ common.expectsError(
   assert.throws(
     () => assert.throws(() => { throw new Error('foo'); }, new Error('')),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       generatedMessage: true,
       message: `${start}\n${actExp}\n\n` +
@@ -953,7 +953,7 @@ common.expectsError(
     // eslint-disable-next-line no-throw-literal
     () => a.doesNotThrow(() => { throw undefined; }),
     {
-      name: 'AssertionError [ERR_ASSERTION]',
+      name: 'AssertionError',
       code: 'ERR_ASSERTION',
       message: 'Got unwanted exception.\nActual message: "undefined"'
     }


### PR DESCRIPTION
The ERR_ASSERTION is obvious in this case and just makes the error
message more verbose. Therefore it is best to just remove that part
from the error message. Having the code as part of the error message
also pollutes the name and that is not good either.

The code is still present on the error itself tough.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
