### PR TITLE
trace_events: add trace category enabled tracking

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -16,7 +16,8 @@
                               // bootstrapper properties... destructured to
                               // avoid retaining a reference to the bootstrap
                               // object.
-                              { _setupProcessObject, _setupNextTick,
+                              { _setupTraceCategoryState,
+                                _setupProcessObject, _setupNextTick,
                                 _setupPromises, _chdir, _cpuUsage,
                                 _hrtime, _hrtimeBigInt,
                                 _memoryUsage, _rawDebug,
@@ -34,6 +35,8 @@
     Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
 
     EventEmitter.call(process);
+
+    setupTraceCategoryState();
 
     setupProcessObject();
 
@@ -97,18 +100,6 @@
 
     if (global.__coverage__)
       NativeModule.require('internal/process/write-coverage').setup();
-
-
-    {
-      const traceEvents = internalBinding('trace_events');
-      const traceEventCategory = 'node,node.async_hooks';
-
-      if (traceEvents.isTraceCategoryEnabled(traceEventCategory)) {
-        NativeModule.require('internal/trace_events_async_hooks')
-          .setup(traceEvents, traceEventCategory);
-      }
-    }
-
 
     if (process.config.variables.v8_enable_inspector) {
       NativeModule.require('internal/inspector_async_hook').setup();
@@ -309,6 +300,32 @@
         }
       }
     }
+  }
+
+  function setupTraceCategoryState() {
+    const { traceCategoryState } = internalBinding('trace_events');
+    const kCategoryAsyncHooks = 0;
+    let traceEventsAsyncHook;
+
+    function toggleTraceCategoryState() {
+      // Dynamically enable/disable the traceEventsAsyncHook
+      const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
+
+      if (asyncHooksEnabled) {
+        // Lazy load internal/trace_events_async_hooks only if the async_hooks
+        // trace event category is enabled.
+        if (!traceEventsAsyncHook) {
+          traceEventsAsyncHook =
+            NativeModule.require('internal/trace_events_async_hooks');
+        }
+        traceEventsAsyncHook.enable();
+      } else if (traceEventsAsyncHook) {
+        traceEventsAsyncHook.disable();
+      }
+    }
+
+    toggleTraceCategoryState();
+    _setupTraceCategoryState(toggleTraceCategoryState);
   }
 
   function setupProcessObject() {

--- a/lib/internal/trace_events_async_hooks.js
+++ b/lib/internal/trace_events_async_hooks.js
@@ -1,34 +1,39 @@
 'use strict';
 
-exports.setup = function(traceEvents, traceEventCategory) {
-  const { trace } = traceEvents;
-  const async_wrap = process.binding('async_wrap');
-  const async_hooks = require('async_hooks');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { trace } = internalBinding('trace_events');
+const async_wrap = process.binding('async_wrap');
+const async_hooks = require('async_hooks');
+const { SafeMap, SafeSet } = require('internal/safe_globals');
 
-  // Use small letters such that chrome://tracing groups by the name.
-  // The behavior is not only useful but the same as the events emitted using
-  // the specific C++ macros.
-  const BEFORE_EVENT = 'b'.charCodeAt(0);
-  const END_EVENT = 'e'.charCodeAt(0);
+// Use small letters such that chrome://tracing groups by the name.
+// The behavior is not only useful but the same as the events emitted using
+// the specific C++ macros.
+const kBeforeEvent = 'b'.charCodeAt(0);
+const kEndEvent = 'e'.charCodeAt(0);
+const kTraceEventCategory = 'node,node.async_hooks';
 
+const kEnabled = Symbol('enabled');
+
+// It is faster to emit traceEvents directly from C++. Thus, this happens
+// in async_wrap.cc. However, events emitted from the JavaScript API or the
+// Embedder C++ API can't be emitted from async_wrap.cc. Thus they are
+// emitted using the JavaScript API. To prevent emitting the same event
+// twice the async_wrap.Providers list is used to filter the events.
+const nativeProviders = new SafeSet(Object.keys(async_wrap.Providers));
+const typeMemory = new SafeMap();
+
+function createHook() {
   // In traceEvents it is not only the id but also the name that needs to be
   // repeated. Since async_hooks doesn't expose the provider type in the
   // non-init events, use a map to manually map the asyncId to the type name.
-  const typeMemory = new Map();
 
-  // It is faster to emit traceEvents directly from C++. Thus, this happens
-  // in async_wrap.cc. However, events emitted from the JavaScript API or the
-  // Embedder C++ API can't be emitted from async_wrap.cc. Thus they are
-  // emitted using the JavaScript API. To prevent emitting the same event
-  // twice the async_wrap.Providers list is used to filter the events.
-  const nativeProviders = new Set(Object.keys(async_wrap.Providers));
-
-  async_hooks.createHook({
+  const hook = async_hooks.createHook({
     init(asyncId, type, triggerAsyncId, resource) {
       if (nativeProviders.has(type)) return;
 
       typeMemory.set(asyncId, type);
-      trace(BEFORE_EVENT, traceEventCategory,
+      trace(kBeforeEvent, kTraceEventCategory,
             type, asyncId,
             {
               triggerAsyncId,
@@ -40,24 +45,43 @@ exports.setup = function(traceEvents, traceEventCategory) {
       const type = typeMemory.get(asyncId);
       if (type === undefined) return;
 
-      trace(BEFORE_EVENT, traceEventCategory, `${type}_CALLBACK`, asyncId);
+      trace(kBeforeEvent, kTraceEventCategory, `${type}_CALLBACK`, asyncId);
     },
 
     after(asyncId) {
       const type = typeMemory.get(asyncId);
       if (type === undefined) return;
 
-      trace(END_EVENT, traceEventCategory, `${type}_CALLBACK`, asyncId);
+      trace(kEndEvent, kTraceEventCategory, `${type}_CALLBACK`, asyncId);
     },
 
     destroy(asyncId) {
       const type = typeMemory.get(asyncId);
       if (type === undefined) return;
 
-      trace(END_EVENT, traceEventCategory, type, asyncId);
+      trace(kEndEvent, kTraceEventCategory, type, asyncId);
 
       // cleanup asyncId to type map
       typeMemory.delete(asyncId);
     }
-  }).enable();
-};
+  });
+
+  return {
+    enable() {
+      if (this[kEnabled])
+        return;
+      this[kEnabled] = true;
+      hook.enable();
+    },
+
+    disable() {
+      if (!this[kEnabled])
+        return;
+      this[kEnabled] = false;
+      hook.disable();
+      typeMemory.clear();
+    }
+  };
+}
+
+module.exports = createHook();

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -31,6 +31,12 @@ void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {
   args.GetIsolate()->RunMicrotasks();
 }
 
+void SetupTraceCategoryState(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsFunction());
+  env->set_trace_category_state_function(args[0].As<Function>());
+}
+
 void SetupNextTick(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -117,6 +123,7 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 // completes so that it can be gc'd as soon as possible.
 void SetupBootstrapObject(Environment* env,
                           Local<Object> bootstrapper) {
+  BOOTSTRAP_METHOD(_setupTraceCategoryState, SetupTraceCategoryState);
   BOOTSTRAP_METHOD(_setupProcessObject, SetupProcessObject);
   BOOTSTRAP_METHOD(_setupNextTick, SetupNextTick);
   BOOTSTRAP_METHOD(_setupPromises, SetupPromises);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -432,6 +432,11 @@ Environment::should_abort_on_uncaught_toggle() {
   return should_abort_on_uncaught_toggle_;
 }
 
+inline AliasedBuffer<uint8_t, v8::Uint8Array>&
+Environment::trace_category_state() {
+  return trace_category_state_;
+}
+
 Environment::ShouldNotAbortOnUncaughtScope::ShouldNotAbortOnUncaughtScope(
     Environment* env)
     : env_(env) {

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -127,6 +127,10 @@ void Initialize(Local<Object> target,
                   .FromJust();
   target->Set(context, trace,
               binding->Get(context, trace).ToLocalChecked()).FromJust();
+
+  target->Set(context,
+              FIXED_ONE_BYTE_STRING(env->isolate(), "traceCategoryState"),
+              env->trace_category_state().GetJSArray()).FromJust();
 }
 
 }  // namespace node

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -51,6 +51,8 @@ class AgentWriterHandle {
 
   inline Agent* agent() { return agent_; }
 
+  inline v8::TracingController* GetTracingController();
+
  private:
   inline AgentWriterHandle(Agent* agent, int id) : agent_(agent), id_(id) {}
 
@@ -153,6 +155,10 @@ void AgentWriterHandle::Enable(const std::set<std::string>& categories) {
 
 void AgentWriterHandle::Disable(const std::set<std::string>& categories) {
   if (agent_ != nullptr) agent_->Disable(id_, categories);
+}
+
+inline v8::TracingController* AgentWriterHandle::GetTracingController() {
+  return agent_ != nullptr ? agent_->GetTracingController() : nullptr;
 }
 
 }  // namespace tracing


### PR DESCRIPTION
Track state of async_hooks trace event category enablement.
Enable/disable the async_hooks trace event dynamically.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
