### PR TITLE
src: remove calls to deprecated v8 functions (IntegerValue)

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2384,11 +2384,10 @@ void DebugProcess(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Invalid number of arguments.");
   }
 
-  pid_t pid;
-  int r;
+  CHECK(args[0]->IsNumber());
+  pid_t pid = args[0].As<Integer>()->Value();
+  int r = kill(pid, SIGUSR1);
 
-  pid = args[0]->IntegerValue();
-  r = kill(pid, SIGUSR1);
   if (r != 0) {
     return env->ThrowErrnoException(errno, "kill");
   }
@@ -2406,7 +2405,6 @@ static int GetDebugSignalHandlerMappingName(DWORD pid, wchar_t* buf,
 static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = args.GetIsolate();
-  DWORD pid;
   HANDLE process = nullptr;
   HANDLE thread = nullptr;
   HANDLE mapping = nullptr;
@@ -2418,7 +2416,8 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
     goto out;
   }
 
-  pid = (DWORD) args[0]->IntegerValue();
+  CHECK(args[0]->IsNumber());
+  DWORD pid = args[0].As<Integer>()->Value();
 
   process = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
                             PROCESS_VM_OPERATION | PROCESS_VM_WRITE |

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -173,7 +173,8 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
     return true;
   }
 
-  int64_t tmp_i = arg->IntegerValue();
+  CHECK(arg->IsNumber());
+  int64_t tmp_i = arg.As<Integer>()->Value();
 
   if (tmp_i < 0)
     return false;
@@ -769,7 +770,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   Local<String> needle = args[1].As<String>();
-  int64_t offset_i64 = args[2]->IntegerValue();
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -885,7 +886,7 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[1]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
   SPREAD_BUFFER_ARG(args[1], buf);
-  int64_t offset_i64 = args[2]->IntegerValue();
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -955,7 +956,7 @@ void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   uint32_t needle = args[1].As<Uint32>()->Value();
-  int64_t offset_i64 = args[2]->IntegerValue();
+  int64_t offset_i64 = args[2].As<Integer>()->Value();
   bool is_forward = args[3]->IsTrue();
 
   int64_t opt_offset = IndexOfOffset(ts_obj_length, offset_i64, 1, is_forward);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -985,15 +985,16 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
+  int64_t val;
 
-  if (args.Length() != 1 || !args[0]->IntegerValue()) {
+  if (args.Length() != 1 ||
+      !args[0]->IntegerValue(args.GetIsolate()->GetCurrentContext()).To(&val)) {
     return THROW_ERR_INVALID_ARG_TYPE(
         sc->env(), "Options must be an integer value");
   }
 
-  SSL_CTX_set_options(
-      sc->ctx_.get(),
-      static_cast<long>(args[0]->IntegerValue()));  // NOLINT(runtime/int)
+  SSL_CTX_set_options(sc->ctx_.get(),
+                      static_cast<long>(val));  // NOLINT(runtime/int)
 }
 
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -288,12 +288,16 @@ class Parser : public AsyncWrap, public StreamListener {
     MaybeLocal<Value> head_response =
         MakeCallback(cb.As<Function>(), arraysize(argv), argv);
 
-    if (head_response.IsEmpty()) {
+    int64_t val;
+
+    if (head_response.IsEmpty() || !head_response.ToLocalChecked()
+                                        ->IntegerValue(env()->context())
+                                        .To(&val)) {
       got_exception_ = true;
       return -1;
     }
 
-    return head_response.ToLocalChecked()->IntegerValue();
+    return val;
   }
 
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -131,8 +131,9 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream = stream;
       } else {
         Local<String> fd_key = env->fd_string();
-        int fd = static_cast<int>(
-            stdio->Get(context, fd_key).ToLocalChecked()->IntegerValue());
+        Local<Value> fd_value = stdio->Get(context, fd_key).ToLocalChecked();
+        CHECK(fd_value->IsNumber());
+        int fd = static_cast<int>(fd_value.As<Integer>()->Value());
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
       }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -205,7 +205,10 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int fd = static_cast<int>(args[0]->IntegerValue());
+  int64_t val;
+  if (!args[0]->IntegerValue(args.GetIsolate()->GetCurrentContext()).To(&val))
+    return;
+  int fd = static_cast<int>(val);
   int err = uv_tcp_open(&wrap->handle_, fd);
 
   if (err == 0)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -215,7 +215,8 @@ void UDPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int fd = static_cast<int>(args[0]->IntegerValue());
+  CHECK(args[0]->IsNumber());
+  int fd = static_cast<int>(args[0].As<Integer>()->Value());
   int err = uv_udp_open(&wrap->handle_, fd);
 
   args.GetReturnValue().Set(err);


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here:
Value::IntegerValue) inside the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @addaleax @hashseed 