### PR TITLE
zlib: alter wrong argument number error message

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -431,9 +431,20 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
           "a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) "
           "that is compatible with Node.js 9 and above.\n");
     }
-    CHECK(args.Length() == 7 &&
-      "init(windowBits, level, memLevel, strategy, writeResult, writeCallback,"
-      " dictionary)");
+    // Refs: https://github.com/nodejs/node/issues/16987
+    if (args.Length() != 7) {
+      // Cloned from util.h
+      const char* const args[] = {__FILE__,
+                                  STRINGIFY(__LINE__ - 4),
+                                  // The -4 in the previous line makes it
+                                  // possible to refer to the actual line of
+                                  // the condition.
+                                  "args.Length() == 7 && init(windowBits,"
+                                  "level, memLevel, strategy, writeResult,"
+                                  " writeCallback, dictionary)",
+                                  ""};
+      node::Assert(&args);
+    }
 
     ZCtx* ctx;
     ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());


### PR DESCRIPTION
The ZCtx::Init function presents a standard CHECK to handle the
argument number. The correct number of arguments as of now is 7.

The CHECK usage follows the standard usage in the node C++ code, yet
this is the only instance where the error message is long enough so as
to be split in two lines. The macro CHECK displays this error message
incorrectly.

The fix revolves around a copy of the macro, injected in the point of
code where the previous CHECK was residing; it formats the message in
the same way the macro would have and cleanly exits the execution.

Fixes: https://github.com/nodejs/node/issues/16987

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Notes:
- Commit message guidelines followed, yet `core-validate-commit` fails due to absence of PR-URL and reviewer (might it be acceptable in opening the pull request?)
- I was not able to create a test for the code correction. I'd like to ask for support in how to create a test case.

I remain at disposal for every problem that maight arise.
Thanks!