### PR TITLE
crypto: simplify state failure handling

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -184,7 +184,7 @@ Cipher.prototype.final = function final(outputEncoding) {
 
 
 Cipher.prototype.setAutoPadding = function setAutoPadding(ap) {
-  if (this._handle.setAutoPadding(ap) === false)
+  if (!this._handle.setAutoPadding(ap))
     throw new ERR_CRYPTO_INVALID_STATE('setAutoPadding');
   return this;
 };
@@ -203,10 +203,7 @@ Cipher.prototype.setAuthTag = function setAuthTag(tagbuf) {
                                    ['Buffer', 'TypedArray', 'DataView'],
                                    tagbuf);
   }
-  // Do not do a normal falsy check because the method returns
-  // undefined if it succeeds. Returns false specifically if it
-  // errored
-  if (this._handle.setAuthTag(tagbuf) === false)
+  if (!this._handle.setAuthTag(tagbuf))
     throw new ERR_CRYPTO_INVALID_STATE('setAuthTag');
   return this;
 };
@@ -219,7 +216,7 @@ Cipher.prototype.setAAD = function setAAD(aadbuf, options) {
   }
 
   const plaintextLength = getUIntOption(options, 'plaintextLength');
-  if (this._handle.setAAD(aadbuf, plaintextLength) === false)
+  if (!this._handle.setAAD(aadbuf, plaintextLength))
     throw new ERR_CRYPTO_INVALID_STATE('setAAD');
   return this;
 };

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2939,6 +2939,8 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
 
   memset(cipher->auth_tag_, 0, sizeof(cipher->auth_tag_));
   memcpy(cipher->auth_tag_, Buffer::Data(args[0]), cipher->auth_tag_len_);
+
+  args.GetReturnValue().Set(true);
 }
 
 
@@ -2993,9 +2995,9 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   int plaintext_len = args[1].As<Int32>()->Value();
 
-  if (!cipher->SetAAD(Buffer::Data(args[0]), Buffer::Length(args[0]),
-                      plaintext_len))
-    args.GetReturnValue().Set(false);  // Report invalid state failure
+  bool b = cipher->SetAAD(Buffer::Data(args[0]), Buffer::Length(args[0]),
+                          plaintext_len);
+  args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
 
@@ -3107,8 +3109,8 @@ void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
 
-  if (!cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue()))
-    args.GetReturnValue().Set(false);  // Report invalid state failure
+  bool b = cipher->SetAutoPadding(args.Length() < 1 || args[0]->BooleanValue());
+  args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
 


### PR DESCRIPTION
It is more intuitive to return `true`/`false` than `undefined`/`false`. This also simplifies handling in the JS layer and removes two control-flow branches from C++.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
