### PR TITLE
crypto: simplify Hmac::HmacUpdate

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3252,15 +3252,14 @@ void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&hmac, args.Holder());
 
   // Only copy the data if we have to, because it's a string
-  bool r = true;
+  bool r = false;
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;
-    if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)) {
-      args.GetReturnValue().Set(false);
-      return;
+    if (decoder.Decode(env, args[0].As<String>(), args[1], UTF8)) {
+      r = hmac->HmacUpdate(decoder.out(), decoder.size());
     }
-    r = hmac->HmacUpdate(decoder.out(), decoder.size());
-  } else if (args[0]->IsArrayBufferView()) {
+  } else {
+    CHECK(args[0]->IsArrayBufferView());
     char* buf = Buffer::Data(args[0]);
     size_t buflen = Buffer::Length(args[0]);
     r = hmac->HmacUpdate(buf, buflen);


### PR DESCRIPTION
This makes `HmacUpdate` slightly simpler and introduces a `CHECK` instead of ignoring invalid input types. The JS layer shouldn't pass invalid inputs anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
