### PR TITLE
tools: do not autolink section to itself

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -226,8 +226,8 @@ function preprocessElements({ filename }) {
           }
 
           // Do not link to the section we are already in.
-          const noLinking = filename === 'documentation' &&
-            heading !== null && heading.value === 'Stability Index';
+          const noLinking = filename.includes('documentation') &&
+            heading !== null && heading.children[0].value === 'Stability Index';
 
           // collapse blockquote and paragraph into a single node
           node.type = 'paragraph';


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fix a regression in the new doc generation toolchain.

The only difference in the doc results after this PR:

<details>
<summary>Before</summary>

![1](https://user-images.githubusercontent.com/10393198/43687613-b9c11ed0-98e0-11e8-9cb9-7708a2a41cef.png)

</details><br>

<details>
<summary>After</summary>

![2](https://user-images.githubusercontent.com/10393198/43687615-c5687a4e-98e0-11e8-9057-5bb3aa4aa289.png)

</details><br>