### PR TITLE
tls: de-duplicate for TLSSocket methods

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -590,10 +590,6 @@ TLSSocket.prototype.setMaxSendFragment = function setMaxSendFragment(size) {
   return this._handle.setMaxSendFragment(size) === 1;
 };
 
-TLSSocket.prototype.getTLSTicket = function getTLSTicket() {
-  return this._handle.getTLSTicket();
-};
-
 TLSSocket.prototype._handleTimeout = function() {
   this._emitTLSError(new ERR_TLS_HANDSHAKE_TIMEOUT());
 };
@@ -672,51 +668,25 @@ TLSSocket.prototype.getPeerCertificate = function(detailed) {
   return null;
 };
 
-TLSSocket.prototype.getFinished = function() {
-  if (this._handle)
-    return this._handle.getFinished();
-};
+// Proxy TLSSocket handle methods
+function makeSocketMethodProxy(name) {
+  return function socketMethodProxy(...args) {
+    if (this._handle)
+      return this._handle[name].apply(this._handle, args);
+    return null;
+  };
+}
 
-TLSSocket.prototype.getPeerFinished = function() {
-  if (this._handle)
-    return this._handle.getPeerFinished();
-};
-
-TLSSocket.prototype.getSession = function() {
-  if (this._handle) {
-    return this._handle.getSession();
-  }
-
-  return null;
-};
-
-TLSSocket.prototype.isSessionReused = function() {
-  if (this._handle) {
-    return this._handle.isSessionReused();
-  }
-
-  return null;
-};
+[
+  'getFinished', 'getPeerFinished', 'getSession', 'isSessionReused',
+  'getEphemeralKeyInfo', 'getProtocol', 'getTLSTicket'
+].forEach((method) => {
+  TLSSocket.prototype[method] = makeSocketMethodProxy(method);
+});
 
 TLSSocket.prototype.getCipher = function(err) {
-  if (this._handle) {
+  if (this._handle)
     return this._handle.getCurrentCipher();
-  } else {
-    return null;
-  }
-};
-
-TLSSocket.prototype.getEphemeralKeyInfo = function() {
-  if (this._handle)
-    return this._handle.getEphemeralKeyInfo();
-
-  return null;
-};
-
-TLSSocket.prototype.getProtocol = function() {
-  if (this._handle)
-    return this._handle.getProtocol();
-
   return null;
 };
 


### PR DESCRIPTION
Similar approach is used for `TLSWrap`, where C++ handle methods are
mapped one-to-one in JS.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)