### PR TITLE
src: remove calls to deprecated v8 functions (Uint32Value)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -772,7 +772,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   } else if (isUint8Array(val)) {
     return indexOfBuffer(buffer, val, byteOffset, encoding, dir);
   } else if (typeof val === 'number') {
-    return indexOfNumber(buffer, val, byteOffset, dir);
+    return indexOfNumber(buffer, val >>> 0, byteOffset, dir);
   }
 
   throw new ERR_INVALID_ARG_TYPE(

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -21,6 +21,7 @@ using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Object;
 using v8::String;
+using v8::Uint32;
 using v8::Value;
 
 using v8_inspector::StringBuffer;
@@ -241,7 +242,7 @@ void Open(const FunctionCallbackInfo<Value>& args) {
   bool wait_for_connect = false;
 
   if (args.Length() > 0 && args[0]->IsUint32()) {
-    uint32_t port = args[0]->Uint32Value();
+    uint32_t port = args[0].As<Uint32>()->Value());
     agent->options()->host_port.port = port;
   }
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -242,7 +242,7 @@ void Open(const FunctionCallbackInfo<Value>& args) {
   bool wait_for_connect = false;
 
   if (args.Length() > 0 && args[0]->IsUint32()) {
-    uint32_t port = args[0].As<Uint32>()->Value());
+    uint32_t port = args[0].As<Uint32>()->Value();
     agent->options()->host_port.port = port;
   }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -569,11 +569,10 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
-  CHECK(args[2]->IsUint32());
-  CHECK(args[3]->IsUint32());
-
-  uint32_t start = args[2].As<Uint32>()->Value();
-  uint32_t end = args[3].As<Uint32>()->Value();
+  uint32_t start;
+  if (!args[2]->Uint32Value(ctx).To(&start)) return;
+  uint32_t end;
+  if (!args[3]->Uint32Value(ctx).To(&end)) return;
   size_t fill_length = end - start;
   Local<String> str_obj;
   size_t str_length;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -594,10 +594,9 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   // Then coerce everything that's not a string.
   if (!args[1]->IsString()) {
     uint32_t val;
-    if (args[1]->Uint32Value(ctx).To(&val)) {
-      int value = val & 255;
-      memset(ts_obj_data + start, value, fill_length);
-    }
+    if (!args[1]->Uint32Value(ctx).To(&val)) return;
+    int value = val & 255;
+    memset(ts_obj_data + start, value, fill_length);
     return;
   }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -564,15 +564,16 @@ void Copy(const FunctionCallbackInfo<Value> &args) {
 
 void Fill(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  Local<Context> ctx = env->context();
 
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
-  Local<Context> ctx = env->context();
-  uint32_t start, end;
-  if (!args[2]->Uint32Value(ctx).To(&start) ||
-      !args[3]->Uint32Value(ctx).To(&end))
-    return;
+  CHECK(args[2]->IsUint32());
+  CHECK(args[3]->IsUint32());
+
+  uint32_t start = args[2].As<Uint32>()->Value();
+  uint32_t end = args[3].As<Uint32>()->Value();
   size_t fill_length = end - start;
   Local<String> str_obj;
   size_t str_length;
@@ -1004,7 +1005,7 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
 }
 
 void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[1]->IsNumber());
+  CHECK(args[1]->IsUint32());
   CHECK(args[2]->IsNumber());
   CHECK(args[3]->IsBoolean());
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3871,7 +3871,8 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   char* buf = Buffer::Data(args[1]);
   ssize_t len = Buffer::Length(args[1]);
 
-  int padding = args[2]->Uint32Value();
+  uint32_t padding;
+  if (!args[2]->Uint32Value(env->context()).To(&padding)) return;
 
   String::Utf8Value passphrase(args.GetIsolate(), args[3]);
 
@@ -4436,8 +4437,10 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH public key");
 
   int size;
-  point_conversion_form_t form =
-      static_cast<point_conversion_form_t>(args[0]->Uint32Value());
+  uint32_t val;
+  if (!args[0]->Uint32Value(env->context()).To(&val))
+    return env->ThrowError("Failed to parse argument");
+  point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
   size = EC_POINT_point2oct(ecdh->group_, pub, form, nullptr, 0, nullptr);
   if (size == 0)
@@ -5052,8 +5055,10 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
   if (pub == nullptr)
     return env->ThrowError("Failed to convert Buffer to EC_POINT");
 
-  point_conversion_form_t form =
-      static_cast<point_conversion_form_t>(args[2]->Uint32Value());
+  uint32_t val;
+  if (!args[2]->Uint32Value(env->context()).To(&val))
+    return env->ThrowError("Failed to parse argument");
+  point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
   int size = EC_POINT_point2oct(
       group.get(), pub.get(), form, nullptr, 0, nullptr);
@@ -5152,7 +5157,8 @@ void InitCryptoOnce() {
 void SetEngine(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args.Length() >= 2 && args[0]->IsString());
-  unsigned int flags = args[1]->Uint32Value();
+  uint32_t flags;
+  if (!args[1]->Uint32Value(env->context()).To(&flags)) return;
 
   ClearErrorOnReturn clear_error_on_return;
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4437,9 +4437,8 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH public key");
 
   int size;
-  uint32_t val;
-  if (!args[0]->Uint32Value(env->context()).To(&val))
-    return env->ThrowError("Failed to parse argument");
+  CHECK(args[0]->IsUint32());
+  uint32_t val = args[0].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
   size = EC_POINT_point2oct(ecdh->group_, pub, form, nullptr, 0, nullptr);
@@ -5055,9 +5054,8 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
   if (pub == nullptr)
     return env->ThrowError("Failed to convert Buffer to EC_POINT");
 
-  uint32_t val;
-  if (!args[2]->Uint32Value(env->context()).To(&val))
-    return env->ThrowError("Failed to parse argument");
+  CHECK(args[2]->IsUint32());
+  uint32_t val = args[2].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
   int size = EC_POINT_point2oct(

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -820,8 +820,8 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
 
   if (args[0]->IsNumber()) {
     uint32_t val;
-    if (args[0]->Uint32Value(env->context()).To(&val))
-      args.GetReturnValue().Set(GetColumnWidth(val, ambiguous_as_full_width));
+    if (!args[0]->Uint32Value(env->context()).To(&val)) return;
+    args.GetReturnValue().Set(GetColumnWidth(val, ambiguous_as_full_width));
     return;
   }
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -819,9 +819,9 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   bool expand_emoji_sequence = args[2]->IsTrue();
 
   if (args[0]->IsNumber()) {
-    args.GetReturnValue().Set(
-        GetColumnWidth(args[0]->Uint32Value(),
-                       ambiguous_as_full_width));
+    uint32_t val;
+    if (args[0]->Uint32Value(env->context()).To(&val))
+      args.GetReturnValue().Set(GetColumnWidth(val, ambiguous_as_full_width));
     return;
   }
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -335,7 +335,7 @@ static const char* name_by_gid(gid_t gid) {
 
 static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<uid_t>(value->Uint32Value());
+    return static_cast<uid_t>(value.As<Uint32>()->Value());
   } else {
     Utf8Value name(isolate, value);
     return uid_by_name(*name);
@@ -345,7 +345,7 @@ static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
 
 static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<gid_t>(value->Uint32Value());
+    return static_cast<gid_t>(value.As<Uint32>()->Value());
   } else {
     Utf8Value name(isolate, value);
     return gid_by_name(*name);
@@ -538,7 +538,7 @@ void InitGroups(const FunctionCallbackInfo<Value>& args) {
   char* user;
 
   if (args[0]->IsUint32()) {
-    user = name_by_uid(args[0]->Uint32Value());
+    user = name_by_uid(args[0].As<Uint32>()->Value());
     must_free = true;
   } else {
     user = *arg0;

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -445,15 +445,15 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     // But on the decompression side, a value of 0 for windowBits tells zlib
     // to use the window size in the zlib header of the compressed stream.
     uint32_t windowBits;
-    bool winCheck = args[0]->Uint32Value(context).To(&windowBits);
+    if (!args[0]->Uint32Value(context).To(&windowBits)) return;
 
     if (!((windowBits == 0) &&
           (ctx->mode_ == INFLATE ||
            ctx->mode_ == GUNZIP ||
            ctx->mode_ == UNZIP))) {
-      CHECK((windowBits >= Z_MIN_WINDOWBITS && windowBits <= Z_MAX_WINDOWBITS &&
-             winCheck) &&
-            "invalid windowBits");
+      CHECK(
+          (windowBits >= Z_MIN_WINDOWBITS && windowBits <= Z_MAX_WINDOWBITS) &&
+          "invalid windowBits");
     }
 
     int level = args[1]->Int32Value();
@@ -461,16 +461,15 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
       "invalid compression level");
 
     uint32_t memLevel;
-    bool memCheck = args[2]->Uint32Value(context).To(&memLevel);
-    CHECK((memLevel >= Z_MIN_MEMLEVEL && memLevel <= Z_MAX_MEMLEVEL &&
-           memCheck) &&
+    if (!args[2]->Uint32Value(context).To(&memLevel)) return;
+    CHECK((memLevel >= Z_MIN_MEMLEVEL && memLevel <= Z_MAX_MEMLEVEL) &&
           "invalid memlevel");
 
     uint32_t strategy;
-    bool strategyCheck = args[3]->Uint32Value(context).To(&strategy);
+    if (!args[3]->Uint32Value(context).To(&strategy)) return;
     CHECK((strategy == Z_FILTERED || strategy == Z_HUFFMAN_ONLY ||
            strategy == Z_RLE || strategy == Z_FIXED ||
-           strategy == Z_DEFAULT_STRATEGY && strategyCheck) &&
+           strategy == Z_DEFAULT_STRATEGY) &&
           "invalid strategy");
 
     CHECK(args[4]->IsUint32Array());

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -156,7 +156,11 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
     CHECK_EQ(false, args[0]->IsUndefined() && "must provide flush value");
 
-    unsigned int flush = args[0].As<Uint32>()->Value();
+    Environment* env = ctx->env();
+    Local<Context> context = env->context();
+
+    unsigned int flush;
+    if (!args[0]->Uint32Value(context).To(&flush)) return;
 
     if (flush != Z_NO_FLUSH &&
         flush != Z_PARTIAL_FLUSH &&
@@ -171,8 +175,7 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
 
     Bytef* in;
     Bytef* out;
-    size_t in_off, in_len, out_off, out_len;
-    Environment* env = ctx->env();
+    uint32_t in_off, in_len, out_off, out_len;
 
     if (args[1]->IsNull()) {
       // just a flush
@@ -182,18 +185,18 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     } else {
       CHECK(Buffer::HasInstance(args[1]));
       Local<Object> in_buf;
-      in_buf = args[1]->ToObject(env->context()).ToLocalChecked();
-      in_off = args[2].As<Uint32>()->Value();
-      in_len = args[3].As<Uint32>()->Value();
+      in_buf = args[1]->ToObject(context).ToLocalChecked();
+      if (!args[2]->Uint32Value(context).To(&in_off)) return;
+      if (!args[3]->Uint32Value(context).To(&in_len)) return;
 
       CHECK(Buffer::IsWithinBounds(in_off, in_len, Buffer::Length(in_buf)));
       in = reinterpret_cast<Bytef *>(Buffer::Data(in_buf) + in_off);
     }
 
     CHECK(Buffer::HasInstance(args[4]));
-    Local<Object> out_buf = args[4]->ToObject(env->context()).ToLocalChecked();
-    in_off = args[2].As<Uint32>()->Value();
-    in_len = args[3].As<Uint32>()->Value();
+    Local<Object> out_buf = args[4]->ToObject(context).ToLocalChecked();
+    if (!args[5]->Uint32Value(context).To(&out_off)) return;
+    if (!args[6]->Uint32Value(context).To(&out_len)) return;
     CHECK(Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf)));
     out = reinterpret_cast<Bytef *>(Buffer::Data(out_buf) + out_off);
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -48,6 +48,7 @@ using v8::Integer;
 using v8::Local;
 using v8::Object;
 using v8::String;
+using v8::Uint32;
 using v8::Value;
 
 using AsyncHooks = Environment::AsyncHooks;
@@ -180,7 +181,7 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
   int enable = args[0]->Int32Value();
-  unsigned int delay = args[1]->Uint32Value();
+  unsigned int delay = args[1].As<Uint32>()->Value();
   int err = uv_tcp_keepalive(&wrap->handle_, enable, delay);
   args.GetReturnValue().Set(err);
 }
@@ -277,7 +278,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(env->isolate(), args[1]);
-  int port = args[2]->Uint32Value();
+  int port = args[2].As<Uint32>()->Value();
 
   sockaddr_in addr;
   int err = uv_ip4_addr(*ip_address, port, &addr);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -180,8 +180,11 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
   CHECK_EQ(args.Length(), 3);
 
   node::Utf8Value address(args.GetIsolate(), args[0]);
-  const int port = args[1]->Uint32Value();
-  const int flags = args[2]->Uint32Value();
+  Local<Context> ctx = args.GetIsolate()->GetCurrentContext();
+  uint32_t port, flags;
+  if (!args[1]->Uint32Value(ctx).To(&port) ||
+      !args[2]->Uint32Value(ctx).To(&flags))
+    return;
   char addr[sizeof(sockaddr_in6)];
   int err;
 
@@ -353,8 +356,8 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   Local<Array> chunks = args[1].As<Array>();
   // it is faster to fetch the length of the
   // array in js-land
-  size_t count = args[2]->Uint32Value();
-  const unsigned short port = args[3]->Uint32Value();
+  size_t count = args[2].As<Uint32>()->Value();
+  const unsigned short port = args[3].As<Uint32>()->Value();
   node::Utf8Value address(env->isolate(), args[4]);
   const bool have_callback = args[5]->IsTrue();
 


### PR DESCRIPTION
Remove all calls to deprecated v8 functions (here:
Value::Uint32Value) inside the code (src directory only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @addaleax @hashseed 