### PR TITLE
assert: fix loose assert with map and set

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -354,29 +354,38 @@ function setEquiv(a, b, strict, memo) {
   return true;
 }
 
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Loose_equality_using
 function findLooseMatchingPrimitives(prim) {
-  var values, number;
   switch (typeof prim) {
     case 'number':
-      values = ['' + prim];
-      if (prim === 1 || prim === 0)
-        values.push(Boolean(prim));
-      return values;
-    case 'string':
-      number = +prim;
-      if ('' + number === prim) {
-        values = [number];
-        if (number === 1 || number === 0)
-          values.push(Boolean(number));
+      if (prim === 0) {
+        return ['', '0', false];
       }
-      return values;
+      if (prim === 1) {
+        return ['1', true];
+      }
+      return ['' + prim];
+    case 'string':
+      if (prim === '' || prim === '0') {
+        return [0, false];
+      }
+      if (prim === '1') {
+        return [1, true];
+      }
+      const number = +prim;
+      if ('' + number === prim) {
+        return [number];
+      }
+      return;
     case 'undefined':
       return [null];
     case 'object': // Only pass in null as object!
       return [undefined];
     case 'boolean':
-      number = +prim;
-      return [number, '' + number];
+      if (prim === false) {
+        return ['', '0', 0];
+      }
+      return ['1', 1];
   }
 }
 

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -350,8 +350,8 @@ assertDeepAndStrictEqual(
   new Map([[1, undefined]])
 );
 assertOnlyDeepEqual(
-  new Map([[1, null]]),
-  new Map([['1', undefined]])
+  new Map([[1, null], ['', '0']]),
+  new Map([['1', undefined], [false, 0]])
 );
 assertNotDeepOrStrict(
   new Map([[1, undefined]]),
@@ -368,8 +368,12 @@ assertOnlyDeepEqual(
   new Map([[undefined, null]])
 );
 assertOnlyDeepEqual(
-  new Set([null]),
-  new Set([undefined])
+  new Set([null, '']),
+  new Set([undefined, 0])
+);
+assertNotDeepOrStrict(
+  new Set(['']),
+  new Set(['0'])
 );
 
 // GH-6416. Make sure circular refs don't throw.


### PR DESCRIPTION
There was an oversight when checking the possible loose comparisons.
This is now fixed by also accepting `''` instead of `0` or `false`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
