### PR TITLE
fs: require callback in read

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -445,13 +445,14 @@ function openSync(path, flags, mode) {
 function read(fd, buffer, offset, length, position, callback) {
   validateUint32(fd, 'fd');
   validateBuffer(buffer);
+  callback = maybeCallback(callback);
 
   offset |= 0;
   length |= 0;
 
   if (length === 0) {
     return process.nextTick(function tick() {
-      callback && callback(null, 0, buffer);
+      callback(null, 0, buffer);
     });
   }
 
@@ -467,7 +468,7 @@ function read(fd, buffer, offset, length, position, callback) {
 
   function wrapper(err, bytesRead) {
     // Retain a reference to buffer so that it can't be GC'ed too soon.
-    callback && callback(err, bytesRead || 0, buffer);
+    callback(err, bytesRead || 0, buffer);
   }
 
   const req = new FSReqCallback();

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -58,7 +58,6 @@ test(new Uint8Array(expected.length),
   // Reading beyond file length (3 in this case) should return no data.
   // This is a test for a bug where reads > uint32 would return data
   // from the current position in the file.
-  const fd = fs.openSync(filepath, 'r');
   const pos = 0xffffffff + 1; // max-uint32 + 1
   const nRead = fs.readSync(fd, Buffer.alloc(1), 0, 1, pos);
   assert.strictEqual(nRead, 0);
@@ -68,3 +67,11 @@ test(new Uint8Array(expected.length),
     assert.strictEqual(nRead, 0);
   }));
 }
+
+assert.throws(
+  () => fs.read(fd, Buffer.alloc(1), 0, 1, 0),
+  {
+    message: 'Callback must be a function',
+    code: 'ERR_INVALID_CALLBACK',
+  }
+);


### PR DESCRIPTION
Currently the read operation did not require the callback and that
was an oversight when callbacks became mandatory in 10.0.0.

I am not sure about the semverness in this case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
