### PR TITLE
build: add crypto check to build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,9 +321,13 @@ DOCBUILDSTAMP_PREREQS := $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
 endif
 
 test/addons/.docbuildstamp: $(DOCBUILDSTAMP_PREREQS) tools/doc/node_modules
+ifeq ($(node_use_openssl),true)
 	$(RM) -r test/addons/??_*/
 	[ -x $(NODE) ] && $(NODE) $< || node $<
 	touch $@
+else
+	@echo "Skipping .docbuildstamp (no crypto)"
+endif
 
 ADDONS_BINDING_GYPS := \
 	$(filter-out test/addons/??_*/binding.gyp, \
@@ -1062,7 +1066,11 @@ lint-md-build: tools/remark-cli/node_modules \
 
 .PHONY: tools/doc/node_modules
 tools/doc/node_modules:
-	@cd tools/doc && $(call available-node,$(run-npm-install))
+ifeq ($(node_use_openssl),true)
+	cd tools/doc && $(call available-node,$(run-npm-install))
+else
+	@echo "Skipping tools/doc/node_modules (no crypto)"
+endif
 
 .PHONY: lint-md
 ifneq ("","$(wildcard tools/remark-cli/node_modules/)")

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,8 @@ ifeq ($(OSTYPE),aix)
 DOCBUILDSTAMP_PREREQS := $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
 endif
 
+node_use_openssl = $(shell $(call available-node,"-p" \
+		   "process.versions.openssl != undefined"))
 test/addons/.docbuildstamp: $(DOCBUILDSTAMP_PREREQS) tools/doc/node_modules
 ifeq ($(node_use_openssl),true)
 	$(RM) -r test/addons/??_*/
@@ -1077,8 +1079,6 @@ ifneq ("","$(wildcard tools/remark-cli/node_modules/)")
 
 LINT_MD_DOC_FILES = $(shell ls doc/*.md doc/**/*.md)
 run-lint-doc-md = tools/remark-cli/cli.js -q -f $(LINT_MD_DOC_FILES)
-node_use_openssl = $(shell $(call available-node,"-p" \
-		   "process.versions.openssl != undefined"))
 # Lint all changed markdown files under doc/
 tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
 ifeq ($(node_use_openssl),true)

--- a/test/parallel/test-heapdump-http2.js
+++ b/test/parallel/test-heapdump-http2.js
@@ -2,9 +2,9 @@
 'use strict';
 const common = require('../common');
 const { recordState } = require('../common/heap');
-const http2 = require('http2');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const http2 = require('http2');
 
 {
   const state = recordState();

--- a/test/parallel/test-https-request-arguments.js
+++ b/test/parallel/test-https-request-arguments.js
@@ -1,11 +1,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const https = require('https');
 const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const https = require('https');
 
 const options = {
   key: fixtures.readKey('agent1-key.pem'),


### PR DESCRIPTION
Currently when configured without-ssl the build will fail when trying
to run the tools/doc/node_modules, and .docbuildstamp make targets:
```shell
internal/util.js:97
    throw new ERR_NO_CRYPTO();
    ^
Error [ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto support
    at assertCrypto (internal/util.js:97:11)
    at crypto.js:31:1
    ...
    at Object.<anonymous>
       (/node/deps/npm/node_modules/uuid/lib/rng.js:4:14)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    ...
make[1]: *** [tools/doc/node_modules] Error 1
```
This commit adds crypto check to these targets to allow the build to
pass.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
