### PR TITLE
repl: Adding code for handling multiline history

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -217,6 +217,7 @@ function Interface(input, output, completer, terminal) {
 
     // Current line
     this.line = '';
+    this.multiline = '';
 
     this._setRawMode(true);
     this.terminal = true;
@@ -327,6 +328,7 @@ Interface.prototype._addHistory = function() {
       if (dupIndex !== -1) this.history.splice(dupIndex, 1);
     }
 
+    this.multiline += this.line;
     this.history.unshift(this.line);
 
     // Only store so many
@@ -337,6 +339,29 @@ Interface.prototype._addHistory = function() {
   return this.history[0];
 };
 
+// Called when a multiline is seen by the repl
+Interface.prototype.undoHistory = function() {
+  if (this.terminal) {
+    this.history.shift();
+  }
+};
+
+// If it's a multiline code, then add history
+// accordingly.
+Interface.prototype.multilineHistory = function() {
+  // check if we got a multiline code
+  if (this.multiline !== '' && this.terminal) {
+    const dupIndex = this.history.indexOf(this.multiline);
+    if (dupIndex !== -1) this.history.splice(dupIndex, 1);
+    // Remove the last entered line as multiline
+    // already contains them.
+    this.history.shift();
+    this.history.unshift(this.multiline);
+  }
+
+  // clear the multiline buffer
+  this.multiline = '';
+};
 
 Interface.prototype._refreshLine = function() {
   // line length

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -779,6 +779,7 @@ exports.start = function(prompt,
 
 REPLServer.prototype.clearBufferedCommand = function clearBufferedCommand() {
   this[kBufferedCommandSymbol] = '';
+  REPLServer.super_.prototype.multilineHistory.call(this);
 };
 
 REPLServer.prototype.close = function close() {
@@ -893,6 +894,7 @@ REPLServer.prototype.displayPrompt = function(preserveCursor) {
     const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
     const levelInd = '..'.repeat(len);
     prompt += levelInd + ' ';
+    REPLServer.super_.prototype.undoHistory.call(this);
   }
 
   // Do not overwrite `_initialPrompt` here

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -111,6 +111,13 @@ const tests = [
     test: [UP],
     expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
   },
+  { // Tests multiline history
+    env: {},
+    test: ['{', '}', UP, CLEAR],
+    expected: [prompt, '{', '... ', '}', '{}\n',
+               prompt, `${prompt}{}`, prompt],
+    clean: false
+  },
   {
     before: function before() {
       if (common.isWindows) {


### PR DESCRIPTION
I always wanted to handle multiline history separately. For example, if I enter a multiline statement and then navigate between the history(s), its very annoying as it shows each **line**, but I expect it to show the **executed** line. 

~~This is work in progress, but yeah its working and all test cases are passing. I need to handle few~~ ~~more cases and write a unit test case. But thought, what others think over this? May be there is also~~ ~~a better way to do it.~~

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
