### PR TITLE
src, doc: Add missing command switch `--expose-internals`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -88,14 +88,14 @@ added: v10.5.0
 
 Enable experimental worker threads using the `worker_threads` module.
 
-### `--expose-internals, --expose_internals`
+### `--expose-internals`
 <!-- YAML
 added: v7.0.0
 -->
 
-Expose internal modules for usage.
-Notice: Nothing exposed by it is supported in any way by any release system
-or deprecation process.
+Expose modules that are normally for Node.js internal use only.
+Use of this flag is unsupported,
+It is exposed for Node.js testing and diagnostic purposes only.
 
 ### `--force-fips`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -88,6 +88,13 @@ added: v10.5.0
 
 Enable experimental worker threads using the `worker_threads` module.
 
+### `--expose-internals, --expose_internals`
+<!-- YAML
+added: v7.0.0
+-->
+
+Expose internal modules for usage.
+
 ### `--force-fips`
 <!-- YAML
 added: v6.0.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -94,6 +94,8 @@ added: v7.0.0
 -->
 
 Expose internal modules for usage.
+Notice: Nothing exposed by it is supported in any way by any release system
+or deprecation process.
 
 ### `--force-fips`
 <!-- YAML

--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -3,7 +3,7 @@
 // This is only exposed for internal build steps and testing purposes.
 // We create new copies of the source and the code cache
 // so the resources eventually used to compile builtin modules
-// cannot be tampered with even with --expose-internals
+// cannot be tampered even with `--expose-internals`
 
 const {
   NativeModule, internalBinding

--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -3,7 +3,7 @@
 // This is only exposed for internal build steps and testing purposes.
 // We create new copies of the source and the code cache
 // so the resources eventually used to compile builtin modules
-// cannot be tampered even with `--expose-internals`
+// cannot be tampered, even with `--expose-internals`
 
 const {
   NativeModule, internalBinding

--- a/src/node.cc
+++ b/src/node.cc
@@ -2598,6 +2598,8 @@ static void PrintHelp() {
          "                             in vm module\n"
 #endif  // defined(NODE_HAVE_I18N_SUPPORT)
          "  --experimental-worker      experimental threaded Worker support\n"
+         "  --expose-internals         expose internal modules for usage\n"
+         "  --expose_internals         alias for '--expose-internals'\n"
 #if HAVE_OPENSSL && NODE_FIPS_MODE
          "  --force-fips               force FIPS crypto (cannot be disabled)\n"
 #endif  // HAVE_OPENSSL && NODE_FIPS_MODE

--- a/src/node.cc
+++ b/src/node.cc
@@ -2598,8 +2598,8 @@ static void PrintHelp() {
          "                             in vm module\n"
 #endif  // defined(NODE_HAVE_I18N_SUPPORT)
          "  --experimental-worker      experimental threaded Worker support\n"
-         "  --expose-internals         expose internal modules for usage\n"
-         "  --expose_internals         alias for '--expose-internals'\n"
+         "  --expose-internals         expose modules that are normally for\n"
+         "                             Node.js internal use only\n"
 #if HAVE_OPENSSL && NODE_FIPS_MODE
          "  --force-fips               force FIPS crypto (cannot be disabled)\n"
 #endif  // HAVE_OPENSSL && NODE_FIPS_MODE


### PR DESCRIPTION
It seems that we can use `internal modules` for usages or tests and
this switch has been added directly. But the doc and lib's command
hints have missed that, Add up for that now.

![expose](https://user-images.githubusercontent.com/40081831/43752551-18358f9c-9a34-11e8-98f8-a19d58d6cfc6.PNG)

Notice that we always have a shortened command hint such as --i, --inspect……. and `--expose-internals,--expose_internals` seems to be too long that it will break the alignment of horizonal. On the other hand, I purposely mean `--expose_internals` is just the ALIGN FOR `--expose-internals` by two lines and explainations.

Any better ideas can be told to me.

Thanks anyway!

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]