### PR TITLE
Use \ for escaping in markdown

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -82,7 +82,7 @@ session.on('inspectorNotification', (message) => console.log(message.method));
 
 It is also possible to subscribe only to notifications with specific method:
 
-### Event: &lt;inspector-protocol-method&gt;
+### Event: \<inspector-protocol-method\>
 <!-- YAML
 added: v8.0.0
 -->


### PR DESCRIPTION
The HTML entities didn't "work", and the documentation contained them literally on the main site.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
