### PR TITLE
lib: fix JS linter

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -39,7 +39,7 @@ const {
   ERR_SOCKET_DGRAM_NOT_RUNNING,
   ERR_INVALID_FD_TYPE
 } = errors.codes;
-const { validateString } = require('internal/validators');
+const { isInt32, validateString } = require('internal/validators');
 const { Buffer } = require('buffer');
 const util = require('util');
 const { isUint8Array } = require('internal/util/types');
@@ -48,7 +48,6 @@ const {
   defaultTriggerAsyncIdScope,
   symbols: { async_id_symbol, owner_symbol }
 } = require('internal/async_hooks');
-const { isInt32 } = require('internal/validators');
 const { UV_UDP_REUSEADDR } = process.binding('constants').os;
 
 const { UDP, SendWrap } = process.binding('udp_wrap');


### PR DESCRIPTION
Not sure why CI (and `make -j8 test` at the time of landing) showed this
as being OK, but `make lint-js` is failing now.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)