### PR TITLE
test: handle errors correctly in test-gc-http-client-timeout.js

### DIFF
--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -39,7 +39,7 @@ function getall() {
       pathname: '/',
       port: server.address().port
     }, cb);
-    req.on('error', cb);
+
     req.setTimeout(10, function() {
       console.log('timeout (expected)');
     });


### PR DESCRIPTION
Before this, `test-gc-http-client-timeout.js` logs `res.resume is not a function` when errors are emitted.

This test sometimes fails on my OSX because `getaddrinfo` may return `ENOTFOUND`. (The actual uv error code is `UV_EAI_NONAME`.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
