### PR TITLE
module: accept Windows relative path

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -80,6 +80,8 @@ const {
   CHAR_9,
 } = require('internal/constants');
 
+const isWindows = process.platform === 'win32';
+
 function stat(filename) {
   filename = path.toNamespacedPath(filename);
   const cache = stat.cache;
@@ -310,7 +312,7 @@ Module._findPath = function(request, paths, isMain) {
 // 'node_modules' character codes reversed
 var nmChars = [ 115, 101, 108, 117, 100, 111, 109, 95, 101, 100, 111, 110 ];
 var nmLen = nmChars.length;
-if (process.platform === 'win32') {
+if (isWindows) {
   // 'from' is the __dirname of the module.
   Module._nodeModulePaths = function(from) {
     // guarantee that 'from' is absolute.
@@ -403,11 +405,12 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
     return (newReturn ? null : [request, []]);
   }
 
-  // Check for relative path
+  // Check for non-relative path
   if (request.length < 2 ||
       request.charCodeAt(0) !== CHAR_DOT ||
       (request.charCodeAt(1) !== CHAR_DOT &&
-       request.charCodeAt(1) !== CHAR_FORWARD_SLASH)) {
+       request.charCodeAt(1) !== CHAR_FORWARD_SLASH &&
+       (!isWindows || request.charCodeAt(1) !== CHAR_BACKWARD_SLASH))) {
     var paths = modulePaths;
     if (parent) {
       if (!parent.paths)
@@ -480,7 +483,9 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
 
   // make sure require('./path') and require('path') get distinct ids, even
   // when called from the toplevel js file
-  if (parentIdPath === '.' && id.indexOf('/') === -1) {
+  if (parentIdPath === '.' &&
+      id.indexOf('/') === -1 &&
+      (!isWindows || id.indexOf('\\') === -1)) {
     id = './' + id;
   }
 
@@ -746,8 +751,6 @@ Module.runMain = function() {
 };
 
 Module._initPaths = function() {
-  const isWindows = process.platform === 'win32';
-
   var homeDir;
   var nodePath;
   if (isWindows) {

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -4,20 +4,22 @@ const common = require('../common');
 const assert = require('assert');
 const _module = require('module'); // avoid collision with global.module
 
-function runTest(moduleName) {
-  const lookupResults = _module._resolveLookupPaths(moduleName);
-  let paths = lookupResults[1];
+// Current directory gets highest priority for local modules
+function testFirstInPath(moduleName, isLocalModule) {
+  const assertFunction = isLocalModule ?
+    assert.strictEqual :
+    assert.notStrictEqual;
 
-  // Current directory gets highest priority for local modules
-  assert.strictEqual(paths[0], '.');
+  const lookupResults = _module._resolveLookupPaths(moduleName);
+
+  let paths = lookupResults[1];
+  assertFunction(paths[0], '.');
 
   paths = _module._resolveLookupPaths(moduleName, null, true);
-
-  // Current directory gets highest priority for local modules
-  assert.strictEqual(paths && paths[0], '.');
+  assertFunction(paths && paths[0], '.');
 }
 
-runTest('./lodash');
-if (common.isWindows) {
-  runTest('.\\lodash');
-}
+testFirstInPath('./lodash', true);
+
+// Relative path on Windows, but a regular file name elsewhere
+testFirstInPath('.\\lodash', common.isWindows);

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -1,15 +1,23 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const _module = require('module'); // avoid collision with global.module
-const lookupResults = _module._resolveLookupPaths('./lodash');
-let paths = lookupResults[1];
 
-// Current directory gets highest priority for local modules
-assert.strictEqual(paths[0], '.');
+function runTest(moduleName) {
+  const lookupResults = _module._resolveLookupPaths(moduleName);
+  let paths = lookupResults[1];
 
-paths = _module._resolveLookupPaths('./lodash', null, true);
+  // Current directory gets highest priority for local modules
+  assert.strictEqual(paths[0], '.');
 
-// Current directory gets highest priority for local modules
-assert.strictEqual(paths && paths[0], '.');
+  paths = _module._resolveLookupPaths(moduleName, null, true);
+
+  // Current directory gets highest priority for local modules
+  assert.strictEqual(paths && paths[0], '.');
+}
+
+runTest('./lodash');
+if (common.isWindows) {
+  runTest('.\\lodash');
+}

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -132,6 +132,26 @@ childProcess.exec(
   }
 );
 
+// test that preloading with a relative path works
+process.chdir(fixtures.fixturesDir);
+childProcess.exec(
+  `"${nodeBinary}" ${preloadOption(['./printA.js'])} "${fixtureB}"`,
+  common.mustCall(function(err, stdout, stderr) {
+    assert.ifError(err);
+    assert.strictEqual(stdout, 'A\nB\n');
+  })
+);
+if (common.isWindows) {
+  // https://github.com/nodejs/node/issues/21918
+  childProcess.exec(
+    `"${nodeBinary}" ${preloadOption(['.\\printA.js'])} "${fixtureB}"`,
+    common.mustCall(function(err, stdout, stderr) {
+      assert.ifError(err);
+      assert.strictEqual(stdout, 'A\nB\n');
+    })
+  );
+}
+
 // https://github.com/nodejs/node/issues/1691
 process.chdir(fixtures.fixturesDir);
 childProcess.exec(


### PR DESCRIPTION
Before this change, `require('.\\test.js')`  failed while `require('./test.js')` succeeded. This changes `_resolveLookupPaths` so that both ways are accepted on Windows.

Fixes: https://github.com/nodejs/node/issues/21918 (cc @targos)



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
