### PR TITLE
build: make tools/doc/node_modules non-phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1066,8 +1066,7 @@ lint-md-build: tools/remark-cli/node_modules \
 	tools/doc/node_modules \
 	tools/remark-preset-lint-node/node_modules
 
-.PHONY: tools/doc/node_modules
-tools/doc/node_modules:
+tools/doc/node_modules: tools/doc/package.json
 ifeq ($(node_use_openssl),true)
 	cd tools/doc && $(call available-node,$(run-npm-install))
 else


### PR DESCRIPTION
This commit makes the target `tools/doc/node_modules` a non-phony target
and also adds `tools/doc/package.json` as a prerequisite to it to avoid
running it unnecessary. This is currently causing the target
`test/addons/.docbuildstamp` to be always be executed as it has
`tools/doc/node_modules` as a prerequisite.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
