### PR TITLE
test: remove second arg from assert.ifError()

### DIFF
--- a/test/parallel/test-fs-readfile.js
+++ b/test/parallel/test-fs-readfile.js
@@ -53,7 +53,7 @@ for (const e of fileInfo) {
 for (const e of fileInfo) {
   fs.readFile(e.name, common.mustCall((err, buf) => {
     console.log(`Validating readFile on file ${e.name} of length ${e.len}`);
-    assert.ifError(err, 'An error occurred');
+    assert.ifError(err);
     assert.deepStrictEqual(buf, e.contents, 'Incorrect file contents');
   }));
 }


### PR DESCRIPTION
`test/parallel/test-fs-readfile.js` has a call to `assert.ifError()` that receives two arguments.
There is no second argument used in `assert.ifError()`. This PR removes this argument.

This fix was recommended by @Trott via NodeTodo.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
