### PR TITLE
src: add function to reset arguments to default

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2600,6 +2600,64 @@ void Init(std::vector<std::string>* argv,
   node_is_initialized = true;
 }
 
+NODE_EXTERN void ResetArgumentsToDefault() {
+  print_eval = false;
+  force_repl = false;
+  syntax_check_only = false;
+  trace_deprecation = false;
+  throw_deprecation = false;
+  trace_sync_io = false;
+  no_force_async_hooks_checks = false;
+  track_heap_objects = false;
+  eval_string = nullptr;
+  preload_modules.clear();
+  v8_thread_pool_size = v8_default_thread_pool_size;
+  prof_process = false;
+  v8_is_profiling = false;
+  node_is_initialized = false;
+  modpending = nullptr;
+  modlist_builtin = nullptr;
+  modlist_internal = nullptr;
+  modlist_linked = nullptr;
+  modlist_addon = nullptr;
+  trace_enabled_categories.clear();
+  trace_file_pattern = "node_trace.${rotation}.log";
+  abort_on_uncaught_exception = false;
+  reverted = 0;
+  #if defined(NODE_HAVE_I18N_SUPPORT)
+  icu_data_dir.clear();
+  #endif
+  no_deprecation = false;
+  #if HAVE_OPENSSL
+    ssl_openssl_cert_store =
+  #if defined(NODE_OPENSSL_CERT_STORE)
+      true;
+  #else
+      false;
+  #endif
+  # if NODE_FIPS_MODE
+    enable_fips_crypto = false;
+    force_fips_crypto = false;
+  # endif  // NODE_FIPS_MODE
+    openssl_config.clear();
+  #endif  // HAVE_OPENSSL
+  no_process_warnings = false;
+  trace_warnings = false;
+  config_preserve_symlinks = false;
+  config_preserve_symlinks_main = false;
+  config_experimental_modules = false;
+  config_experimental_vm_modules = false;
+  config_experimental_worker = false;
+  config_experimental_repl_await = false;
+  config_userland_loader.clear();
+  config_pending_deprecation = false;
+  config_warning_file.clear();
+  config_expose_internals = false;
+  config_process_title.clear();
+  v8_initialized = false;
+  linux_at_secure = false;
+  debug_options = node::DebugOptions();
+}
 // TODO(addaleax): Deprecate and eventually remove this.
 void Init(int* argc,
           const char** argv,

--- a/src/node.cc
+++ b/src/node.cc
@@ -2600,63 +2600,8 @@ void Init(std::vector<std::string>* argv,
   node_is_initialized = true;
 }
 
-NODE_EXTERN void ResetArgumentsToDefault() {
-  print_eval = false;
-  force_repl = false;
-  syntax_check_only = false;
-  trace_deprecation = false;
-  throw_deprecation = false;
-  trace_sync_io = false;
-  no_force_async_hooks_checks = false;
-  track_heap_objects = false;
-  eval_string = nullptr;
-  preload_modules.clear();
-  v8_thread_pool_size = v8_default_thread_pool_size;
-  prof_process = false;
-  v8_is_profiling = false;
-  node_is_initialized = false;
-  modpending = nullptr;
-  modlist_builtin = nullptr;
-  modlist_internal = nullptr;
-  modlist_linked = nullptr;
-  modlist_addon = nullptr;
-  trace_enabled_categories.clear();
-  trace_file_pattern = "node_trace.${rotation}.log";
-  abort_on_uncaught_exception = false;
-  reverted = 0;
-  #if defined(NODE_HAVE_I18N_SUPPORT)
-  icu_data_dir.clear();
-  #endif
-  no_deprecation = false;
-  #if HAVE_OPENSSL
-    ssl_openssl_cert_store =
-  #if defined(NODE_OPENSSL_CERT_STORE)
-      true;
-  #else
-      false;
-  #endif
-  # if NODE_FIPS_MODE
-    enable_fips_crypto = false;
-    force_fips_crypto = false;
-  # endif  // NODE_FIPS_MODE
-    openssl_config.clear();
-  #endif  // HAVE_OPENSSL
-  no_process_warnings = false;
-  trace_warnings = false;
-  config_preserve_symlinks = false;
-  config_preserve_symlinks_main = false;
-  config_experimental_modules = false;
-  config_experimental_vm_modules = false;
-  config_experimental_worker = false;
-  config_experimental_repl_await = false;
-  config_userland_loader.clear();
-  config_pending_deprecation = false;
-  config_warning_file.clear();
-  config_expose_internals = false;
-  config_process_title.clear();
-  v8_initialized = false;
-  linux_at_secure = false;
-  debug_options = node::DebugOptions();
+NODE_EXTERN void ResetOptions() {
+  per_process_opts->Reset();
 }
 // TODO(addaleax): Deprecate and eventually remove this.
 void Init(int* argc,

--- a/src/node.h
+++ b/src/node.h
@@ -208,6 +208,7 @@ NODE_EXTERN void Init(int* argc,
                       const char** argv,
                       int* exec_argc,
                       const char*** exec_argv);
+NODE_EXTERN void ResetArgumentsToDefault();
 
 class ArrayBufferAllocator;
 

--- a/src/node.h
+++ b/src/node.h
@@ -208,7 +208,7 @@ NODE_EXTERN void Init(int* argc,
                       const char** argv,
                       int* exec_argc,
                       const char*** exec_argv);
-NODE_EXTERN void ResetArgumentsToDefault();
+NODE_EXTERN void ResetOptions();
 
 class ArrayBufferAllocator;
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -27,8 +27,49 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
   per_isolate->CheckOptions(errors);
 }
 
+void PerProcessOptions::Reset() {
+  per_isolate->Reset();
+  title = "";
+  trace_event_categories = "";
+  trace_event_file_pattern = "node_trace.${rotation}.log";
+  v8_thread_pool_size = 4;
+  zero_fill_all_buffers = false;
+
+  security_reverts.clear();
+  print_bash_completion = false;
+  print_help = false;
+  print_v8_help = false;
+  print_version = false;
+
+#ifdef NODE_HAVE_I18N_SUPPORT
+  icu_data_dir = "";
+#endif
+
+  // TODO(addaleax): Some of these could probably be per-Environment.
+#if HAVE_OPENSSL
+  openssl_config = "";
+  tls_cipher_list = DEFAULT_CIPHER_LIST_CORE;
+#ifdef NODE_OPENSSL_CERT_STORE
+  ssl_openssl_cert_store = true;
+#else
+  ssl_openssl_cert_store = false;
+#endif
+  use_openssl_ca = false;
+  use_bundled_ca = false;
+#if NODE_FIPS_MODE
+  enable_fips_crypto = false;
+  force_fips_crypto = false;
+#endif
+#endif
+}
+
 void PerIsolateOptions::CheckOptions(std::vector<std::string>* errors) {
   per_env->CheckOptions(errors);
+}
+
+void PerIsolateOptions::Reset() {
+  per_env->Reset();
+  track_heap_objects = false;
 }
 
 void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
@@ -40,6 +81,39 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
     errors->push_back("either --check or --eval can be used, not both");
   }
   debug_options->CheckOptions(errors);
+}
+
+void EnvironmentOptions::Reset() {
+  debug_options->Reset();
+  abort_on_uncaught_exception = false;
+  experimental_modules = false;
+  experimental_repl_await = false;
+  experimental_vm_modules = false;
+  experimental_worker = false;
+  expose_internals = false;
+  no_deprecation = false;
+  no_force_async_hooks_checks = false;
+  no_warnings = false;
+  pending_deprecation = false;
+  preserve_symlinks = false;
+  preserve_symlinks_main = false;
+  prof_process = false;
+  redirect_warnings = "";
+  throw_deprecation = false;
+  trace_deprecation = false;
+  trace_sync_io = false;
+  trace_warnings = false;
+  userland_loader = "";
+
+  syntax_check_only = false;
+  has_eval_string = false;
+  eval_string = "";
+  print_eval = false;
+  force_repl = false;
+
+  preload_modules.clear();
+
+  user_argv.clear();
 }
 
 namespace options_parser {

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -61,6 +61,14 @@ class DebugOptions : public Options {
   int port() {
     return host_port.port < 0 ? kDefaultInspectorPort : host_port.port;
   }
+
+  void Reset() {
+    inspector_enabled = false;
+    deprecated_debug = false;
+    break_first_line = false;
+    break_node_first_line = false;
+    host_port = {"127.0.0.1", -1};
+  }
 };
 
 class EnvironmentOptions : public Options {
@@ -98,6 +106,7 @@ class EnvironmentOptions : public Options {
 
   inline DebugOptions* get_debug_options();
   void CheckOptions(std::vector<std::string>* errors);
+  void Reset();
 };
 
 class PerIsolateOptions : public Options {
@@ -107,6 +116,7 @@ class PerIsolateOptions : public Options {
 
   inline EnvironmentOptions* get_per_env_options();
   void CheckOptions(std::vector<std::string>* errors);
+  void Reset();
 };
 
 class PerProcessOptions : public Options {
@@ -148,6 +158,7 @@ class PerProcessOptions : public Options {
 
   inline PerIsolateOptions* get_per_isolate_options();
   void CheckOptions(std::vector<std::string>* errors);
+  void Reset();
 };
 
 // The actual options parser, as opposed to the structs containing them:


### PR DESCRIPTION
Embedder can initialize nodejs to run scripts few times with different
arguments. But if arguments from old launch weren't restored to theirs
default values, nodejs can launch wrong next time.

This function allows to reset arguments, which was impossible
for embedder without modifying nodejs source code.

Fixes: https://github.com/nodejs/node/issues/21653

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
