### PR TITLE
util,assert: improve comparison performance

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -4,6 +4,7 @@ const { compare } = process.binding('buffer');
 const { isArrayBufferView } = require('internal/util/types');
 const { internalBinding } = require('internal/bootstrap/loaders');
 const { isDate, isMap, isRegExp, isSet } = internalBinding('types');
+const { getOwnNonIndicesProperties } = process.binding('util');
 
 const ReflectApply = Reflect.apply;
 
@@ -106,24 +107,11 @@ function strictDeepEqual(val1, val2, memos) {
     if (val1.length !== val2.length) {
       return false;
     }
-    const keys = objectKeys(val1);
-    if (keys.length !== objectKeys(val2).length) {
+    const keys1 = getOwnNonIndicesProperties(val1);
+    if (keys1.length !== getOwnNonIndicesProperties(val2).length) {
       return false;
     }
-    // Fast path for non sparse arrays (no key comparison for indices
-    // properties).
-    // See https://tc39.github.io/ecma262/#sec-ordinaryownpropertykeys
-    if (val1.length === keys.length) {
-      if (keys.length === 0 || keys[val1.length - 1] === `${val1.length - 1}`) {
-        return keyCheck(val1, val2, kStrict, memos, kIsArray, []);
-      }
-    } else if (keys.length > val1.length &&
-               keys[val1.length - 1] === `${val1.length - 1}`) {
-      const minimalKeys = keys.slice(val1.length);
-      return keyCheck(val1, val2, kStrict, memos, kIsArray, minimalKeys);
-    }
-    // Only set this to kIsArray in case the array is not sparse!
-    return keyCheck(val1, val2, kStrict, memos, kNoIterator, keys);
+    return keyCheck(val1, val2, kStrict, memos, kIsArray, keys1);
   }
   if (val1Tag === '[object Object]') {
     return keyCheck(val1, val2, kStrict, memos, kNoIterator);
@@ -148,18 +136,14 @@ function strictDeepEqual(val1, val2, memos) {
     if (!areSimilarTypedArrays(val1, val2)) {
       return false;
     }
-    // Buffer.compare returns true, so val1.length === val2.length
-    // if they both only contain numeric keys, we don't need to exam further.
-    const keys = objectKeys(val1);
-    if (keys.length !== objectKeys(val2).length) {
+    // Buffer.compare returns true, so val1.length === val2.length. If they both
+    // only contain numeric keys, we don't need to exam further than checking
+    // the symbols.
+    const keys1 = getOwnNonIndicesProperties(val1);
+    if (keys1.length !== getOwnNonIndicesProperties(val2).length) {
       return false;
     }
-    if (keys.length === val1.length) {
-      return keyCheck(val1, val2, kStrict, memos, kNoIterator, []);
-    }
-    // Only compare the special keys.
-    const minimalKeys = keys.slice(val1.length);
-    return keyCheck(val1, val2, kStrict, memos, kNoIterator, minimalKeys);
+    return keyCheck(val1, val2, kStrict, memos, kNoIterator, keys1);
   } else if (isSet(val1)) {
     if (!isSet(val2) || val1.size !== val2.size) {
       return false;
@@ -173,21 +157,10 @@ function strictDeepEqual(val1, val2, memos) {
   // TODO: Make the valueOf checks safe.
   } else if (typeof val1.valueOf === 'function') {
     const val1Value = val1.valueOf();
-    if (val1Value !== val1) {
-      if (typeof val2.valueOf !== 'function') {
-        return false;
-      }
-      if (!innerDeepEqual(val1Value, val2.valueOf(), true))
-        return false;
-      // Fast path for boxed primitive strings.
-      if (typeof val1Value === 'string') {
-        const keys = objectKeys(val1);
-        if (keys.length !== objectKeys(val2).length) {
-          return false;
-        }
-        const minimalKeys = keys.slice(val1.length);
-        return keyCheck(val1, val2, kStrict, memos, kNoIterator, minimalKeys);
-      }
+    if (val1Value !== val1 &&
+        (typeof val2.valueOf !== 'function' ||
+          !innerDeepEqual(val1Value, val2.valueOf(), kStrict))) {
+      return false;
     }
   }
   return keyCheck(val1, val2, kStrict, memos, kNoIterator);
@@ -277,7 +250,7 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
     }
   }
 
-  if (strict) {
+  if (strict && arguments.length === 5) {
     const symbolKeysA = getOwnPropertySymbols(val1);
     if (symbolKeysA.length !== 0) {
       let count = 0;
@@ -310,7 +283,7 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
   if (aKeys.length === 0 &&
       (iterationType === kNoIterator ||
         iterationType === kIsArray && val1.length === 0 ||
-      val1.size === 0)) {
+        val1.size === 0)) {
     return true;
   }
 
@@ -578,8 +551,28 @@ function objEquiv(a, b, strict, keys, memos, iterationType) {
     }
   } else if (iterationType === kIsArray) {
     for (; i < a.length; i++) {
-      if (!innerDeepEqual(a[i], b[i], strict, memos)) {
+      if (hasOwnProperty(a, i)) {
+        if (!hasOwnProperty(b, i) ||
+            !innerDeepEqual(a[i], b[i], strict, memos)) {
+          return false;
+        }
+      } else if (hasOwnProperty(b, i)) {
         return false;
+      } else {
+        // Array is sparse.
+        const keysA = objectKeys(a);
+        i++;
+        for (; i < keysA.length; i++) {
+          const key = keysA[i];
+          if (!hasOwnProperty(b, key) ||
+              !innerDeepEqual(a[key], b[i], strict, memos)) {
+            return false;
+          }
+        }
+        if (keysA.length !== objectKeys(b).length) {
+          return false;
+        }
+        return true;
       }
     }
   }

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -21,14 +21,21 @@ static void GetOwnNonIndicesProperties(
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
 
+  if (!args[0]->IsObject())
+    return;
+
   v8::Local<v8::Object> object = args[0].As<v8::Object>();
 
   // Return only non-enumerable properties by default.
-  v8::Local<v8::Array> properties = object
-    ->GetPropertyNames(context, v8::KeyCollectionMode::kOwnOnly,
-                       v8::ONLY_ENUMERABLE,
-                       v8::IndexFilter::kSkipIndices)
-      .ToLocalChecked();
+  v8::Local<v8::Array> properties;
+
+  if (!object->GetPropertyNames(
+        context, v8::KeyCollectionMode::kOwnOnly,
+        v8::ONLY_ENUMERABLE,
+        v8::IndexFilter::kSkipIndices)
+          .ToLocal(&properties)) {
+    return;
+  }
   args.GetReturnValue().Set(properties);
 }
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -16,6 +16,22 @@ using v8::Proxy;
 using v8::String;
 using v8::Value;
 
+static void GetOwnNonIndicesProperties(
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Local<Context> context = env->context();
+
+  v8::Local<v8::Object> object = args[0].As<v8::Object>();
+
+  // Return only non-enumerable properties by default.
+  v8::Local<v8::Array> properties = object
+    ->GetPropertyNames(context, v8::KeyCollectionMode::kOwnOnly,
+                       v8::ONLY_ENUMERABLE,
+                       v8::IndexFilter::kSkipIndices)
+      .ToLocalChecked();
+  args.GetReturnValue().Set(properties);
+}
+
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
@@ -177,6 +193,8 @@ void Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "getProxyDetails", GetProxyDetails);
   env->SetMethodNoSideEffect(target, "safeToString", SafeToString);
   env->SetMethodNoSideEffect(target, "previewEntries", PreviewEntries);
+  env->SetMethodNoSideEffect(target, "getOwnNonIndicesProperties",
+                                     GetOwnNonIndicesProperties);
 
   env->SetMethod(target, "startSigintWatchdog", StartSigintWatchdog);
   env->SetMethod(target, "stopSigintWatchdog", StopSigintWatchdog);

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -893,6 +893,17 @@ assert.deepStrictEqual(obj1, obj2);
                '  [\n    1,\n+   2\n-   2,\n-   3\n  ]' }
   );
   util.inspect.defaultOptions = tmp;
+
+  const invalidTrap = new Proxy([1, 2, 3], {
+    ownKeys() { return []; }
+  });
+  assert.throws(
+    () => assert.deepStrictEqual(invalidTrap, [1, 2, 3]),
+    {
+      name: 'TypeError',
+      message: "'ownKeys' on proxy: trap result did not include 'length'"
+    }
+  );
 }
 
 // Basic valueOf check.


### PR DESCRIPTION
This significantly improves the performance of `util.isDeepStrictEqual` and `assert.deepStrictEqual`.

<b>Update:</b>
I removed a lot of the original optimization. This is now condensed to the new API usage that allows to skip indices. This API is useful for all (typed) arrays. Depending on the input it is a huge performance boost.

These performance improvements are on top of the ones in #22258.

<details>
  <summary>Benchmark</summary>

```
 assert/deepequal-buffer.js method='deepEqual' strict=1 len=1000 n=20000                                                        ***   1510.77 %      ±62.77%  ±83.85% ±109.81%
 assert/deepequal-buffer.js method='deepEqual' strict=1 len=100 n=20000                                                         ***    186.07 %       ±9.69%  ±12.92%  ±16.86%
 assert/deepequal-buffer.js method='notDeepEqual' strict=1 len=1000 n=20000                                                              5.11 %       ±6.11%   ±8.10%  ±10.47%
 assert/deepequal-buffer.js method='notDeepEqual' strict=1 len=100 n=20000                                                               4.98 %       ±7.53%   ±9.98%  ±12.91%
 assert/deepequal-map.js method='deepEqual_mixed' strict=1 len=500 n=500                                                        ***     10.07 %       ±2.03%   ±2.69%   ±3.47%
 assert/deepequal-map.js method='deepEqual_objectOnly' strict=1 len=500 n=500                                                   ***     12.10 %       ±3.54%   ±4.72%   ±6.16%
 assert/deepequal-map.js method='deepEqual_primitiveOnly' strict=1 len=500 n=500                                                        -1.33 %       ±4.69%   ±6.21%   ±8.03%
 assert/deepequal-map.js method='notDeepEqual_mixed' strict=1 len=500 n=500                                                             -1.70 %       ±5.68%   ±7.53%   ±9.75%
 assert/deepequal-map.js method='notDeepEqual_objectOnly' strict=1 len=500 n=500                                                ***     12.22 %       ±2.23%   ±2.96%   ±3.83%
 assert/deepequal-map.js method='notDeepEqual_primitiveOnly' strict=1 len=500 n=500                                                      0.31 %       ±4.13%   ±5.47%   ±7.07%
 assert/deepequal-object.js method='deepEqual' strict=1 size=1000 n=5000                                                                -2.98 %       ±4.03%   ±5.35%   ±6.91%
 assert/deepequal-object.js method='deepEqual' strict=1 size=100 n=5000                                                                 -0.32 %       ±5.36%   ±7.11%   ±9.19%
 assert/deepequal-object.js method='deepEqual' strict=1 size=50000 n=5000                                                       ***     10.37 %       ±0.84%   ±1.11%   ±1.43%
 assert/deepequal-object.js method='notDeepEqual' strict=1 size=1000 n=5000                                                     ***     27.00 %       ±7.68%  ±10.18%  ±13.16%
 assert/deepequal-object.js method='notDeepEqual' strict=1 size=100 n=5000                                                       **     10.18 %       ±6.42%   ±8.51%  ±11.01%
 assert/deepequal-object.js method='notDeepEqual' strict=1 size=50000 n=5000                                                    ***    574.60 %      ±12.70%  ±16.96%  ±22.20%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Array' strict=1 len=20000 n=25 primitive='array'            ***    217.97 %      ±10.84%  ±14.45%  ±18.86%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Array' strict=1 len=20000 n=25 primitive='number'           ***    225.33 %      ±14.02%  ±18.68%  ±24.36%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Array' strict=1 len=20000 n=25 primitive='object'           ***    210.40 %       ±7.74%  ±10.28%  ±13.32%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Array' strict=1 len=20000 n=25 primitive='string'           ***    210.77 %      ±14.55%  ±19.39%  ±25.30%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Set' strict=1 len=20000 n=25 primitive='array'                       3.58 %       ±5.43%   ±7.19%   ±9.30%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Set' strict=1 len=20000 n=25 primitive='number'                     -1.19 %       ±6.23%   ±8.26%  ±10.68%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Set' strict=1 len=20000 n=25 primitive='object'                      0.43 %       ±5.42%   ±7.18%   ±9.28%
 assert/deepequal-prims-and-objs-big-array-set.js method='deepEqual_Set' strict=1 len=20000 n=25 primitive='string'                     -0.61 %       ±5.86%   ±7.76%  ±10.04%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Array' strict=1 len=20000 n=25 primitive='array'         ***    226.74 %      ±12.90%  ±17.19%  ±22.41%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Array' strict=1 len=20000 n=25 primitive='number'        ***    248.77 %      ±15.11%  ±20.15%  ±26.31%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Array' strict=1 len=20000 n=25 primitive='object'        ***    225.71 %      ±11.54%  ±15.36%  ±20.02%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Array' strict=1 len=20000 n=25 primitive='string'        ***    219.05 %      ±14.17%  ±18.89%  ±24.65%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Set' strict=1 len=20000 n=25 primitive='array'                    4.85 %       ±8.10%  ±10.75%  ±13.94%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Set' strict=1 len=20000 n=25 primitive='number'            *      8.82 %       ±6.70%   ±8.88%  ±11.48%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Set' strict=1 len=20000 n=25 primitive='object'                   3.88 %       ±6.65%   ±8.82%  ±11.41%
 assert/deepequal-prims-and-objs-big-array-set.js method='notDeepEqual_Set' strict=1 len=20000 n=25 primitive='string'                  -1.03 %       ±5.57%   ±7.40%   ±9.62%
 assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=20000 primitive='array'                                *      5.79 %       ±4.68%   ±6.20%   ±8.02%
 assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=20000 primitive='number'                                      3.38 %       ±4.70%   ±6.23%   ±8.06%
 assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=20000 primitive='object'                              **      7.03 %       ±4.76%   ±6.31%   ±8.16%
 assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=20000 primitive='string'                                      2.62 %       ±4.60%   ±6.10%   ±7.89%
 assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=20000 primitive='array'                           ***     10.33 %       ±5.99%   ±7.95%  ±10.32%
 assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=20000 primitive='number'                           **      8.16 %       ±4.97%   ±6.59%   ±8.52%
 assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=20000 primitive='object'                          ***      8.89 %       ±5.18%   ±6.87%   ±8.88%
 assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=20000 primitive='string'                           **      9.07 %       ±6.11%   ±8.09%  ±10.47%
 assert/deepequal-set.js method='deepEqual_mixed' strict=1 len=500 n=500                                                        ***     13.06 %       ±1.94%   ±2.56%   ±3.32%
 assert/deepequal-set.js method='deepEqual_objectOnly' strict=1 len=500 n=500                                                   ***     11.46 %       ±1.57%   ±2.09%   ±2.71%
 assert/deepequal-set.js method='deepEqual_primitiveOnly' strict=1 len=500 n=500                                                        -3.53 %       ±4.77%   ±6.31%   ±8.16%
 assert/deepequal-set.js method='notDeepEqual_mixed' strict=1 len=500 n=500                                                              2.25 %       ±4.51%   ±6.00%   ±7.79%
 assert/deepequal-set.js method='notDeepEqual_objectOnly' strict=1 len=500 n=500                                                ***     10.32 %       ±2.12%   ±2.81%   ±3.64%
 assert/deepequal-set.js method='notDeepEqual_primitiveOnly' strict=1 len=500 n=500                                                     -0.92 %       ±3.52%   ±4.67%   ±6.03%
 assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=500 type='Float32Array'                                  ***     99.81 %      ±11.33%  ±15.09%  ±19.66%
 assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=500 type='Float64Array'                                  ***     95.37 %       ±7.22%   ±9.59%  ±12.44%
 assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=500 type='Int8Array'                                     ***    103.86 %      ±11.88%  ±15.75%  ±20.39%
 assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=500 type='Uint8Array'                                    ***     99.22 %      ±11.20%  ±14.92%  ±19.44%
 assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=500 type='Uint8ClampedArray'                             ***     92.33 %      ±10.14%  ±13.47%  ±17.50%
 assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=500 type='Float32Array'                                 *      6.62 %       ±6.57%   ±8.71%  ±11.27%
 assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=500 type='Float64Array'                                        5.79 %       ±6.69%   ±8.87%  ±11.47%
 assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=500 type='Int8Array'                                   **     13.83 %       ±8.80%  ±11.72%  ±15.26%
 assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=500 type='Uint8Array'                                          2.87 %       ±5.09%   ±6.75%   ±8.73%
 assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=500 type='Uint8ClampedArray'                                   0.70 %       ±5.73%   ±7.60%   ±9.82%
 assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=500 type='Float32Array'                                 ***   2335.33 %      ±79.73% ±106.50% ±139.47%
 assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=500 type='Float64Array'                                 ***   2033.88 %     ±115.98% ±154.94% ±202.90%
 assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=500 type='Int8Array'                                    ***   2869.75 %     ±144.70% ±193.30% ±253.14%
 assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=500 type='Uint8Array'                                   ***   2840.20 %     ±147.94% ±197.63% ±258.81%
 assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=500 type='Uint8ClampedArray'                            ***   2824.27 %     ±131.85% ±176.13% ±230.65%
 assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=500 type='Float32Array'                                *      8.54 %       ±6.78%   ±9.01%  ±11.72%
 assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=500 type='Float64Array'                               **      9.54 %       ±6.63%   ±8.81%  ±11.45%
 assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=500 type='Int8Array'                                          2.08 %       ±5.25%   ±6.96%   ±9.00%
 assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=500 type='Uint8Array'                                         1.98 %       ±6.92%   ±9.17%  ±11.85%
 assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=500 type='Uint8ClampedArray'                           *      9.76 %       ±9.12%  ±12.13%  ±15.78%
```
</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
