### PR TITLE
Don't set `-fno-threadsafe-statics` on macOS as build option

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -447,7 +447,6 @@
           'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
           'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
-          'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
           'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
           'USE_HEADERMAP': 'NO',


### PR DESCRIPTION
This flag is not set on other platforms so it can produce inconsistent behaviour across platforms. For example, if you build an async node add-on which uses statics you can get race conditions due to static not supporting threads if the node add-on inherits from the Node common.gypi config. It is not disabled on other platforms such as Linux, it is not disabled by default in Xcode or clang.

This setting has been there since the initial commit that introduces `common.gypi` so it has been present since the start, it doesn't seem to be have added for any particular reason other than to potentially match the Xcode defaults at the time.

##### Checklist

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
