### PR TITLE
fixup: test: remove common.fileExists()

### DIFF
--- a/test/parallel/test-trace-event-promises.js
+++ b/test/parallel/test-trace-event-promises.js
@@ -33,7 +33,7 @@ if (process.argv[2] === 'child') {
   proc.once('exit', common.mustCall(() => {
     const file = path.join(tmpdir.path, 'node_trace.1.log');
 
-    assert(common.fileExists(file));
+    assert(fs.existsSync(file));
     fs.readFile(file, common.mustCall((err, data) => {
       const traces = JSON.parse(data.toString()).traceEvents
         .filter((trace) => trace.cat !== '__metadata');


### PR DESCRIPTION
test-trace-event-promises.js was added to the codebase between the last
CI for https://github.com/nodejs/node/pull/22151 and it landing.

Refs: https://github.com/nodejs/node/pull/22151

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
