### PR TITLE
build: add CONFIG_FLAGS to with-code-cache target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,13 +94,17 @@ $(NODE_G_EXE): config.gypi out/Makefile
 CODE_CACHE_DIR ?= out/$(BUILDTYPE)/obj/gen
 CODE_CACHE_FILE ?= $(CODE_CACHE_DIR)/node_code_cache.cc
 
+ifeq ($(BUILDTYPE),Debug)
+CONFIG_FLAGS += --debug
+endif
 .PHONY: with-code-cache
 with-code-cache:
-	$(PYTHON) ./configure
+	@echo $(CONFIG_FLAGS)
+	$(PYTHON) ./configure $(CONFIG_FLAGS)
 	$(MAKE)
 	mkdir -p $(CODE_CACHE_DIR)
 	out/$(BUILDTYPE)/$(NODE_EXE) --expose-internals tools/generate_code_cache.js $(CODE_CACHE_FILE)
-	$(PYTHON) ./configure --code-cache-path $(CODE_CACHE_FILE)
+	$(PYTHON) ./configure --code-cache-path $(CODE_CACHE_FILE) $(CONFIG_FLAGS)
 	$(MAKE)
 
 .PHONY: test-code-cache


### PR DESCRIPTION
This commit adds CONFIG_FLAGS to allow the `with-code-cache` target to be
used with a debug build. The motivation for this is to make it easier to
debug a build with the code cache enabled.

The suggested usage:
```shell
$ make BUILDTYPE=Debug with-code-cache
```
The `BUILDTYPE` option is not needed if ./configure was already
configured with --debug.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
