### PR TITLE
src: fix integer overflow in GetNow

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -617,7 +617,7 @@ Local<Value> Environment::GetNow() {
   CHECK_GE(now, timer_base());
   now -= timer_base();
   if (now <= 0xffffffff)
-    return Integer::New(isolate(), static_cast<uint32_t>(now));
+    return Integer::NewFromUnsigned(isolate(), static_cast<uint32_t>(now));
   else
     return Number::New(isolate(), static_cast<double>(now));
 }


### PR DESCRIPTION
Well, that was stupid... This check used to be for `0xfffffff` which was wrong (one `f` too few) so that got fixed, but that change was made based on it being cast to a uint32_t (2**32-1) rather than the correct int32_t. Of course, `Integer::New` just happily accepted it despite not actually being able to handle it. Fun stuff...

Fixes https://github.com/nodejs/node/issues/22149

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
