### PR TITLE
tools: install doc tools only when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1060,8 +1060,7 @@ lint-md-build: tools/remark-cli/node_modules \
 	tools/doc/node_modules \
 	tools/remark-preset-lint-node/node_modules
 
-.PHONY: tools/doc/node_modules
-tools/doc/node_modules:
+tools/doc/node_modules: tools/doc/package.json
 	@cd tools/doc && $(call available-node,$(run-npm-install))
 
 .PHONY: lint-md


### PR DESCRIPTION
Marking tools/doc/node_modules as PHONY result in constant
installation of the doctools whether it's changed or not
(which means `make lint-addon-docs` always install the tools).
Unmark it and fix the dependency to avoid unnecessary
installations if the package.json is not changed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
