### PR TITLE
tools,test: apply markdown linting to test dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1081,7 +1081,7 @@ else
 	@echo "Skipping Markdown linter on docs (no crypto)"
 endif
 
-LINT_MD_TARGETS = src lib benchmark tools/doc tools/icu
+LINT_MD_TARGETS = src lib benchmark test tools/doc tools/icu
 LINT_MD_ROOT_DOCS := $(wildcard *.md)
 LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
   -not -path '*node_modules*' -name '*.md') $(LINT_MD_ROOT_DOCS)

--- a/test/README.md
+++ b/test/README.md
@@ -13,25 +13,25 @@ GitHub with the `autocrlf` git config flag set to true.
 
 ## Test Directories
 
-|Directory          |Runs on CI     |Purpose        |
-|-------------------|---------------|---------------|
-|abort              |Yes            |Tests for when the  ``` --abort-on-uncaught-exception ``` flag is used.|
-|addons             |Yes            |Tests for [addon](https://nodejs.org/api/addons.html) functionality along with some tests that require an addon to function properly.|
-|addons-napi        |Yes            |Tests for [n-api](https://nodejs.org/api/n-api.html) functionality.|
-|async-hooks        |Yes            |Tests for [async_hooks](https://nodejs.org/api/async_hooks.html) functionality.|
-|cctest             |Yes            |C++ tests that are run as part of the build process.|
-|code-cache         |No             |Tests for a Node.js binary compiled with V8 code cache.|
-|common             |               |Common modules shared among many tests. [Documentation](./common/README.md)|
-|doctool            |Yes            |Tests for the documentation generator.|
-|es-module          |Yes            |Test ESM module loading.|
-|fixtures           |               |Test fixtures used in various tests throughout the test suite.|
-|internet           |No             |Tests that make real outbound connections (mainly networking related modules). Tests for networking related modules may also be present in        other directories, but those tests do not make outbound connections.|
-|known_issues       |Yes            |Tests reproducing known issues within the system. All tests inside of this directory are expected to fail consistently. If a test doesn't fail on certain platforms, those should be skipped via `known_issues.status`.|
-|message            |Yes            |Tests for messages that are output for various conditions (```console.log```, error messages etc.)|
-|parallel           |Yes            |Various tests that are able to be run in parallel.|
-|pseudo-tty         |Yes            |Tests that require stdin/stdout/stderr to be a TTY.|
-|pummel             |No             |Various tests for various modules / system functionality operating under load.|
-|sequential         |Yes            |Various tests that are run sequentially.|
-|testpy             |               |Test configuration utility used by various test suites.|
-|tick-processor     |No             |Tests for the V8 tick processor integration. The tests are for the logic in ```lib/internal/v8_prof_processor.js``` and  ```lib/internal/v8_prof_polyfill.js```. The tests confirm that the profile processor packages the correct set of scripts from V8 and introduces the correct platform specific logic.|
-|v8-updates         |No             |Tests for V8 performance integration.|
+| Directory           | Runs on CI      | Purpose         |
+| ------------------- | --------------- | --------------- |
+| `abort`             | Yes             | Tests for when the  ``` --abort-on-uncaught-exception ``` flag is used. |
+| `addons`            | Yes             | Tests for [addon](https://nodejs.org/api/addons.html) functionality along with some tests that require an addon to function properly. |
+| `addons-napi`        | Yes            | Tests for [n-api](https://nodejs.org/api/n-api.html) functionality. |
+| `async-hooks`        | Yes            | Tests for [async_hooks](https://nodejs.org/api/async_hooks.html) functionality. |
+| `cctest`             | Yes            | C++ tests that are run as part of the build process. |
+| `code-cache`         | No             | Tests for a Node.js binary compiled with V8 code cache. |
+| `common`             |                | Common modules shared among many tests. [Documentation](./common/README.md) |
+| `doctool`            | Yes            | Tests for the documentation generator. |
+| `es-module`          | Yes            | Test ESM module loading. |
+| `fixtures`           |                | Test fixtures used in various tests throughout the test suite. |
+| `internet`           | No             | Tests that make real outbound connections (mainly networking related modules). Tests for networking related modules may also be present in        other directories, but those tests do not make outbound connections. |
+| `known_issues`       | Yes            | Tests reproducing known issues within the system. All tests inside of this directory are expected to fail consistently. If a test doesn't fail on certain platforms, those should be skipped via `known_issues.status`. |
+| `message`            | Yes            | Tests for messages that are output for various conditions (```console.log```, error messages etc.) |
+| `parallel`           | Yes            | Various tests that are able to be run in parallel. |
+| `pseudo-tty`         | Yes            | Tests that require stdin/stdout/stderr to be a TTY. |
+| `pummel`             | No             | Various tests for various modules / system functionality operating under load. |
+| `sequential`         | Yes            | Various tests that are run sequentially. |
+| `testpy`             |                | Test configuration utility used by various test suites. |
+| `tick-processor`     | No             | Tests for the V8 tick processor integration. The tests are for the logic in ```lib/internal/v8_prof_processor.js``` and  ```lib/internal/v8_prof_polyfill.js```. The tests confirm that the profile processor packages the correct set of scripts from V8 and introduces the correct platform specific logic. |
+| `v8-updates`         | No             | Tests for V8 performance integration. |

--- a/test/async-hooks/coverage.md
+++ b/test/async-hooks/coverage.md
@@ -1,4 +1,4 @@
-## AsyncHooks Coverage Overview
+# AsyncHooks Coverage Overview
 
 Showing which kind of async resource is covered by which test:
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -572,7 +572,7 @@ one listed below. (`heap.validateSnapshotNodes(...)` is a shortcut for
 
 Create a heap dump and an embedder graph copy and validate occurrences.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 validateSnapshotNodes('TLSWRAP', [
   {
@@ -590,7 +590,7 @@ validateSnapshotNodes('TLSWRAP', [
 The http2.js module provides a handful of utilities for creating mock HTTP/2
 frames for testing of HTTP/2 endpoints
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-unused-vars, node-core/required-modules -->
 ```js
 const http2 = require('../common/http2');
 ```
@@ -600,7 +600,7 @@ const http2 = require('../common/http2');
 The `http2.Frame` is a base class that creates a `Buffer` containing a
 serialized HTTP/2 frame header.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 // length is a 24-bit unsigned integer
 // type is an 8-bit unsigned integer identifying the frame type
@@ -619,7 +619,7 @@ The serialized `Buffer` may be retrieved using the `frame.data` property.
 The `http2.DataFrame` is a subclass of `http2.Frame` that serializes a `DATA`
 frame.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 // id is the 32-bit stream identifier
 // payload is a Buffer containing the DATA payload
@@ -636,7 +636,7 @@ socket.write(frame.data);
 The `http2.HeadersFrame` is a subclass of `http2.Frame` that serializes a
 `HEADERS` frame.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 // id is the 32-bit stream identifier
 // payload is a Buffer containing the HEADERS payload (see either
@@ -654,7 +654,7 @@ socket.write(frame.data);
 The `http2.SettingsFrame` is a subclass of `http2.Frame` that serializes an
 empty `SETTINGS` frame.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 // ack is a boolean indicating whether or not to set the ACK flag.
 const frame = new http2.SettingsFrame(ack);
@@ -667,7 +667,7 @@ socket.write(frame.data);
 Set to a `Buffer` instance that contains a minimal set of serialized HTTP/2
 request headers to be used as the payload of a `http2.HeadersFrame`.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 const frame = new http2.HeadersFrame(1, http2.kFakeRequestHeaders, 0, true);
 
@@ -679,7 +679,7 @@ socket.write(frame.data);
 Set to a `Buffer` instance that contains a minimal set of serialized HTTP/2
 response headers to be used as the payload a `http2.HeadersFrame`.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 const frame = new http2.HeadersFrame(1, http2.kFakeResponseHeaders, 0, true);
 
@@ -691,7 +691,7 @@ socket.write(frame.data);
 Set to a `Buffer` containing the preamble bytes an HTTP/2 client must send
 upon initial establishment of a connection.
 
-<!-- eslint-disable no-undef, no-unused-vars, node-core/required-modules, strict -->
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 socket.write(http2.kClientMagic);
 ```

--- a/test/fixtures/0-dns/README.md
+++ b/test/fixtures/0-dns/README.md
@@ -1,3 +1,5 @@
+# 0-dns
+
 ## Purpose
 The test cert file for use `test/parallel/test-tls-0-dns-altname.js`
 can be created by using `asn1.js` and `asn1.js-rfc5280`,


### PR DESCRIPTION
Enable markdown linting of the test directory. This change is applied
only to Makefile and not vcbuild.bat because we do not currently lint
anything outside of the doc directory using vcbuild.bat. In the
Makefile, the other targets are called "misc" but that feature does not
currently exist in vcbuild.bat. Adding it would be good, but outside the
scope of this change.

@vsemozhetbyt 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
