### PR TITLE
doc: add missing argv0 option for child_process.spawnSync

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -829,6 +829,8 @@ changes:
   * `cwd` {string} Current working directory of the child process.
   * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
     to the spawned process. Supplying this value will override `stdio[0]`.
+  * `argv0` {string} Explicitly set the value of `argv[0]` sent to the child
+    process. This will be set to `command` if not specified.
   * `stdio` {string|Array} Child's stdio configuration.
   * `env` {Object} Environment key-value pairs.
   * `uid` {number} Sets the user identity of the process (see setuid(2)).


### PR DESCRIPTION
The [child_process docs](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options) include `argv0` as an option for `spawn` but not `spawnSync`.  This is a documentation oversight, because the actual functions share [the same options parsing logic](https://github.com/nodejs/node/blob/master/lib/child_process.js#L490).

##### Checklist
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
