### PR TITLE
js_stream: move process.binding('js_stream') to internalBinding

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -377,7 +377,8 @@
         'util',
         'async_wrap',
         'url',
-        'spawn_sync']);
+        'spawn_sync',
+        'js_stream']);
     process.binding = function binding(name) {
       return internalBindingWhitelist.has(name) ?
         internalBinding(name) :

--- a/lib/internal/wrap_js_stream.js
+++ b/lib/internal/wrap_js_stream.js
@@ -3,8 +3,8 @@
 const assert = require('assert');
 const util = require('util');
 const { Socket } = require('net');
-const { JSStream } = process.binding('js_stream');
 const { internalBinding } = require('internal/bootstrap/loaders');
+const { JSStream } = internalBinding('js_stream');
 const uv = internalBinding('uv');
 const debug = util.debuglog('stream_wrap');
 const { owner_symbol } = require('internal/async_hooks').symbols;

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -216,4 +216,4 @@ void JSStream::Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(js_stream, node::JSStream::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(js_stream, node::JSStream::Initialize)

--- a/test/parallel/test-js-stream-call-properties.js
+++ b/test/parallel/test-js-stream-call-properties.js
@@ -1,8 +1,11 @@
+// Flags: --expose-internals
+
 'use strict';
 
 require('../common');
 const util = require('util');
-const JSStream = process.binding('js_stream').JSStream;
+const { internalBinding } = require('internal/test/binding');
+const { JSStream } = internalBinding('js_stream');
 
 // Testing if will abort when properties are printed.
 util.inspect(new JSStream());

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -14,3 +14,4 @@ assert(process.binding('signal_wrap'));
 assert(process.binding('contextify'));
 assert(process.binding('url'));
 assert(process.binding('spawn_sync'));
+assert(process.binding('js_stream'));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -20,11 +20,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
-const JSStream = process.binding('js_stream').JSStream;
+const { JSStream } = internalBinding('js_stream');
 const util = require('util');
 const vm = require('vm');
 const { previewEntries } = internalBinding('util');

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,11 +1,12 @@
-// Flags: --experimental-vm-modules
+// Flags: --experimental-vm-modules --expose-internals
 'use strict';
 require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { types, inspect } = require('util');
 const vm = require('vm');
-const { JSStream } = process.binding('js_stream');
+const { internalBinding } = require('internal/test/binding');
+const { JSStream } = internalBinding('js_stream');
 
 const external = (new JSStream())._externalStream;
 const wasmBuffer = fixtures.readSync('test.wasm');

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -1,5 +1,8 @@
+// Flags: --expose-gc --expose-internals
+
 'use strict';
 
+const { internalBinding } = require('internal/test/binding');
 const common = require('../common');
 const assert = require('assert');
 const v8 = require('v8');
@@ -20,7 +23,7 @@ const objects = [
   circular
 ];
 
-const hostObject = new (process.binding('js_stream').JSStream)();
+const hostObject = new (internalBinding('js_stream').JSStream)();
 
 const serializerTypeError =
   /^TypeError: Class constructor Serializer cannot be invoked without 'new'$/;

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -94,7 +94,7 @@ function testInitialized(req, ctor_name) {
 
 
 {
-  const JSStream = process.binding('js_stream').JSStream;
+  const JSStream = internalBinding('js_stream').JSStream;
   testInitialized(new JSStream(), 'JSStream');
 }
 


### PR DESCRIPTION
Migration from `process.binding` to `internalBinding` (see : https://github.com/nodejs/node/issues/22160)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
