### PR TITLE
perf_hooks: avoid memory leak on gc observer

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -272,6 +272,9 @@ void MarkGarbageCollectionEnd(Isolate* isolate,
                               v8::GCCallbackFlags flags,
                               void* data) {
   Environment* env = static_cast<Environment*>(data);
+  // If no one is listening to gc performance entries, do not create them.
+  if (!env->performance_state()->observers[NODE_PERFORMANCE_ENTRY_TYPE_GC])
+    return;
   GCPerformanceEntry* entry =
       new GCPerformanceEntry(env,
                              static_cast<PerformanceGCKind>(type),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/22229

/cc @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
