### PR TITLE
util,assert: fix boxed primitives bug

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -120,6 +120,9 @@ function strictDeepEqual(val1, val2, memos) {
     const val1Value = val1.valueOf();
     // Note: Boxed string keys are going to be compared again by Object.keys
     if (val1Value !== val1) {
+      if (typeof val2.valueOf !== 'function') {
+        return false;
+      }
       if (!innerDeepEqual(val1Value, val2.valueOf(), true))
         return false;
       // Fast path for boxed primitives

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -890,3 +890,10 @@ assert.deepStrictEqual(obj1, obj2);
   );
   util.inspect.defaultOptions = tmp;
 }
+
+// Basic valueOf check.
+{
+  const a = new String(1);
+  a.valueOf = undefined;
+  assertNotDeepOrStrict(a, new String(1));
+}


### PR DESCRIPTION
Currently the comparison could throw an error in case a boxed
primitive has no valueOf function on one side of the assert call.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
