### PR TITLE
http2: remove `streamError` from docs

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1510,10 +1510,6 @@ added: v8.4.0
 
 * Extends: {net.Server}
 
-In `Http2Server`, there are no `'clientError'` events as there are in
-HTTP1. However, there are `'sessionError'`, and `'streamError'` events for
-errors emitted on the socket, or from `Http2Session` or `Http2Stream` instances.
-
 #### Event: 'checkContinue'
 <!-- YAML
 added: v8.5.0
@@ -1562,14 +1558,6 @@ added: v8.4.0
 
 The `'sessionError'` event is emitted when an `'error'` event is emitted by
 an `Http2Session` object associated with the `Http2Server`.
-
-#### Event: 'streamError'
-<!-- YAML
-added: v8.5.0
--->
-
-If a `ServerHttp2Stream` emits an `'error'` event, it will be forwarded here.
-The stream will already be destroyed when this event is triggered.
 
 #### Event: 'stream'
 <!-- YAML

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -115,9 +115,7 @@ function onStreamError(error) {
   //
   // errors in compatibility mode are
   // not forwarded to the request
-  // and response objects. However,
-  // they are forwarded to 'streamError'
-  // on the server by Http2Stream
+  // and response objects.
 }
 
 function onRequestPause() {

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -7,7 +7,7 @@ const http2 = require('http2');
 const Countdown = require('../common/countdown');
 
 // Check that destroying the Http2ServerResponse stream produces
-// the expected result
+// the expected result.
 
 const errors = [
   'test-error',

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -7,8 +7,7 @@ const http2 = require('http2');
 const Countdown = require('../common/countdown');
 
 // Check that destroying the Http2ServerResponse stream produces
-// the expected result, including the ability to throw an error
-// which is emitted on server.streamError
+// the expected result
 
 const errors = [
   'test-error',


### PR DESCRIPTION
`streamError` was removed quite some time ago but the docs and
code comments weren't updated. Fix that.

Fixes: https://github.com/nodejs/node/issues/20211

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
