### PR TITLE
deps: cherry-pick dbfcc48 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8-inspector.h
+++ b/deps/v8/include/v8-inspector.h
@@ -215,6 +215,11 @@ class V8_EXPORT V8InspectorClient {
   virtual bool canExecuteScripts(int contextGroupId) { return true; }
 
   virtual void maxAsyncCallStackDepthChanged(int depth) {}
+
+  virtual std::unique_ptr<StringBuffer> resourceNameToUrl(
+      const StringView& resourceName) {
+    return nullptr;
+  }
 };
 
 // These stack trace ids are intended to be passed between debuggers and be

--- a/deps/v8/src/inspector/v8-debugger-agent-impl.cc
+++ b/deps/v8/src/inspector/v8-debugger-agent-impl.cc
@@ -1396,7 +1396,7 @@ void V8DebuggerAgentImpl::didParseSource(
         protocol::StringUtil::parseJSON(inspected->auxData()));
   }
   bool isLiveEdit = script->isLiveEdit();
-  bool hasSourceURL = script->hasSourceURL();
+  bool hasSourceURLComment = script->hasSourceURLComment();
   bool isModule = script->isModule();
   String16 scriptId = script->scriptId();
   String16 scriptURL = script->sourceURL();
@@ -1416,7 +1416,8 @@ void V8DebuggerAgentImpl::didParseSource(
   Maybe<protocol::DictionaryValue> executionContextAuxDataParam(
       std::move(executionContextAuxData));
   const bool* isLiveEditParam = isLiveEdit ? &isLiveEdit : nullptr;
-  const bool* hasSourceURLParam = hasSourceURL ? &hasSourceURL : nullptr;
+  const bool* hasSourceURLParam =
+      hasSourceURLComment ? &hasSourceURLComment : nullptr;
   const bool* isModuleParam = isModule ? &isModule : nullptr;
   std::unique_ptr<V8StackTraceImpl> stack =
       V8StackTraceImpl::capture(m_inspector->debugger(), contextGroupId, 1);

--- a/deps/v8/src/inspector/v8-debugger-script.cc
+++ b/deps/v8/src/inspector/v8-debugger-script.cc
@@ -6,6 +6,7 @@
 
 #include "src/inspector/inspected-context.h"
 #include "src/inspector/string-util.h"
+#include "src/inspector/v8-inspector-impl.h"
 #include "src/inspector/wasm-translation.h"
 #include "src/utils.h"
 
@@ -110,9 +111,9 @@ class ActualScript : public V8DebuggerScript {
 
  public:
   ActualScript(v8::Isolate* isolate, v8::Local<v8::debug::Script> script,
-               bool isLiveEdit)
+               bool isLiveEdit, V8InspectorClient* client)
       : V8DebuggerScript(isolate, String16::fromInteger(script->Id()),
-                         GetNameOrSourceUrl(script)),
+                         GetScriptURL(script, client)),
         m_isLiveEdit(isLiveEdit) {
     Initialize(script);
   }
@@ -218,10 +219,18 @@ class ActualScript : public V8DebuggerScript {
   }
 
  private:
-  String16 GetNameOrSourceUrl(v8::Local<v8::debug::Script> script) {
-    v8::Local<v8::String> name;
-    if (script->Name().ToLocal(&name) || script->SourceURL().ToLocal(&name))
-      return toProtocolString(name);
+  String16 GetScriptURL(v8::Local<v8::debug::Script> script,
+                        V8InspectorClient* client) {
+    v8::Local<v8::String> sourceURL;
+    if (script->SourceURL().ToLocal(&sourceURL) && sourceURL->Length() > 0)
+      return toProtocolString(sourceURL);
+    v8::Local<v8::String> v8Name;
+    if (script->Name().ToLocal(&v8Name) && v8Name->Length() > 0) {
+      String16 name = toProtocolString(v8Name);
+      std::unique_ptr<StringBuffer> url =
+          client->resourceNameToUrl(toStringView(name));
+      return url ? toString16(url->string()) : name;
+    }
     return String16();
   }
 
@@ -231,7 +240,8 @@ class ActualScript : public V8DebuggerScript {
 
   void Initialize(v8::Local<v8::debug::Script> script) {
     v8::Local<v8::String> tmp;
-    if (script->SourceURL().ToLocal(&tmp)) m_sourceURL = toProtocolString(tmp);
+    m_hasSourceURLComment =
+        script->SourceURL().ToLocal(&tmp) && tmp->Length() > 0;
     if (script->SourceMappingURL().ToLocal(&tmp))
       m_sourceMappingURL = toProtocolString(tmp);
     m_startLine = script->LineOffset();
@@ -398,9 +408,9 @@ class WasmVirtualScript : public V8DebuggerScript {
 
 std::unique_ptr<V8DebuggerScript> V8DebuggerScript::Create(
     v8::Isolate* isolate, v8::Local<v8::debug::Script> scriptObj,
-    bool isLiveEdit) {
+    bool isLiveEdit, V8InspectorClient* client) {
   return std::unique_ptr<ActualScript>(
-      new ActualScript(isolate, scriptObj, isLiveEdit));
+      new ActualScript(isolate, scriptObj, isLiveEdit, client));
 }
 
 std::unique_ptr<V8DebuggerScript> V8DebuggerScript::CreateWasm(
@@ -418,12 +428,11 @@ V8DebuggerScript::V8DebuggerScript(v8::Isolate* isolate, String16 id,
 
 V8DebuggerScript::~V8DebuggerScript() {}
 
-const String16& V8DebuggerScript::sourceURL() const {
-  return m_sourceURL.isEmpty() ? m_url : m_sourceURL;
-}
-
 void V8DebuggerScript::setSourceURL(const String16& sourceURL) {
-  m_sourceURL = sourceURL;
+  if (sourceURL.length() > 0) {
+    m_hasSourceURLComment = true;
+    m_url = sourceURL;
+  }
 }
 
 bool V8DebuggerScript::setBreakpoint(const String16& condition,
@@ -431,5 +440,4 @@ bool V8DebuggerScript::setBreakpoint(const String16& condition,
   v8::HandleScope scope(m_isolate);
   return script()->SetBreakpoint(toV8String(m_isolate, condition), loc, id);
 }
-
 }  // namespace v8_inspector

--- a/deps/v8/src/inspector/v8-debugger-script.h
+++ b/deps/v8/src/inspector/v8-debugger-script.h
@@ -40,13 +40,14 @@
 namespace v8_inspector {
 
 // Forward declaration.
+class V8InspectorClient;
 class WasmTranslation;
 
 class V8DebuggerScript {
  public:
   static std::unique_ptr<V8DebuggerScript> Create(
       v8::Isolate* isolate, v8::Local<v8::debug::Script> script,
-      bool isLiveEdit);
+      bool isLiveEdit, V8InspectorClient* client);
   static std::unique_ptr<V8DebuggerScript> CreateWasm(
       v8::Isolate* isolate, WasmTranslation* wasmTranslation,
       v8::Local<v8::debug::WasmScript> underlyingScript, String16 id,
@@ -55,9 +56,9 @@ class V8DebuggerScript {
   virtual ~V8DebuggerScript();
 
   const String16& scriptId() const { return m_id; }
-  const String16& url() const { return m_url; }
-  bool hasSourceURL() const { return !m_sourceURL.isEmpty(); }
-  const String16& sourceURL() const;
+  bool hasSourceURLComment() const { return m_hasSourceURLComment; }
+  const String16& sourceURL() const { return m_url; }
+
   virtual const String16& sourceMappingURL() const = 0;
   virtual const String16& source() const = 0;
   virtual const String16& hash() const = 0;
@@ -95,7 +96,7 @@ class V8DebuggerScript {
 
   String16 m_id;
   String16 m_url;
-  String16 m_sourceURL;
+  bool m_hasSourceURLComment = false;
   int m_executionContextId = 0;
 
   v8::Isolate* m_isolate;

--- a/deps/v8/src/inspector/v8-profiler-agent-impl.cc
+++ b/deps/v8/src/inspector/v8-profiler-agent-impl.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "src/base/atomicops.h"
+#include "src/debug/debug-interface.h"
 #include "src/flags.h"  // TODO(jgruber): Remove include and DEPS entry.
 #include "src/inspector/protocol/Protocol.h"
 #include "src/inspector/string-util.h"
@@ -31,6 +32,15 @@ static const char typeProfileStarted[] = "typeProfileStarted";
 
 namespace {
 
+String16 resourceNameToUrl(V8InspectorImpl* inspector,
+                           v8::Local<v8::String> v8Name) {
+  String16 name = toProtocolString(v8Name);
+  if (!inspector) return name;
+  std::unique_ptr<StringBuffer> url =
+      inspector->client()->resourceNameToUrl(toStringView(name));
+  return url ? toString16(url->string()) : name;
+}
+
 std::unique_ptr<protocol::Array<protocol::Profiler::PositionTickInfo>>
 buildInspectorObjectForPositionTicks(const v8::CpuProfileNode* node) {
   unsigned lineCount = node->GetHitLineCount();
@@ -51,13 +61,14 @@ buildInspectorObjectForPositionTicks(const v8::CpuProfileNode* node) {
 }
 
 std::unique_ptr<protocol::Profiler::ProfileNode> buildInspectorObjectFor(
-    v8::Isolate* isolate, const v8::CpuProfileNode* node) {
+    V8InspectorImpl* inspector, const v8::CpuProfileNode* node) {
+  v8::Isolate* isolate = inspector->isolate();
   v8::HandleScope handleScope(isolate);
   auto callFrame =
       protocol::Runtime::CallFrame::create()
           .setFunctionName(toProtocolString(node->GetFunctionName()))
           .setScriptId(String16::fromInteger(node->GetScriptId()))
-          .setUrl(toProtocolString(node->GetScriptResourceName()))
+          .setUrl(resourceNameToUrl(inspector, node->GetScriptResourceName()))
           .setLineNumber(node->GetLineNumber() - 1)
           .setColumnNumber(node->GetColumnNumber() - 1)
           .build();
@@ -107,18 +118,19 @@ std::unique_ptr<protocol::Array<int>> buildInspectorObjectForTimestamps(
   return array;
 }
 
-void flattenNodesTree(v8::Isolate* isolate, const v8::CpuProfileNode* node,
+void flattenNodesTree(V8InspectorImpl* inspector,
+                      const v8::CpuProfileNode* node,
                       protocol::Array<protocol::Profiler::ProfileNode>* list) {
-  list->addItem(buildInspectorObjectFor(isolate, node));
+  list->addItem(buildInspectorObjectFor(inspector, node));
   const int childrenCount = node->GetChildrenCount();
   for (int i = 0; i < childrenCount; i++)
-    flattenNodesTree(isolate, node->GetChild(i), list);
+    flattenNodesTree(inspector, node->GetChild(i), list);
 }
 
 std::unique_ptr<protocol::Profiler::Profile> createCPUProfile(
-    v8::Isolate* isolate, v8::CpuProfile* v8profile) {
+    V8InspectorImpl* inspector, v8::CpuProfile* v8profile) {
   auto nodes = protocol::Array<protocol::Profiler::ProfileNode>::create();
-  flattenNodesTree(isolate, v8profile->GetTopDownRoot(), nodes.get());
+  flattenNodesTree(inspector, v8profile->GetTopDownRoot(), nodes.get());
   return protocol::Profiler::Profile::create()
       .setNodes(std::move(nodes))
       .setStartTime(static_cast<double>(v8profile->GetStartTime()))
@@ -320,7 +332,7 @@ std::unique_ptr<protocol::Profiler::CoverageRange> createCoverageRange(
 }
 
 Response coverageToProtocol(
-    v8::Isolate* isolate, const v8::debug::Coverage& coverage,
+    V8InspectorImpl* inspector, const v8::debug::Coverage& coverage,
     std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>>*
         out_result) {
   std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>> result =
@@ -361,8 +373,10 @@ Response coverageToProtocol(
     }
     String16 url;
     v8::Local<v8::String> name;
-    if (script->Name().ToLocal(&name) || script->SourceURL().ToLocal(&name)) {
+    if (script->SourceURL().ToLocal(&name) && name->Length()) {
       url = toProtocolString(name);
+    } else if (script->Name().ToLocal(&name) && name->Length()) {
+      url = resourceNameToUrl(inspector, name);
     }
     result->addItem(protocol::Profiler::ScriptCoverage::create()
                         .setScriptId(String16::fromInteger(script->Id()))
@@ -384,7 +398,7 @@ Response V8ProfilerAgentImpl::takePreciseCoverage(
   }
   v8::HandleScope handle_scope(m_isolate);
   v8::debug::Coverage coverage = v8::debug::Coverage::CollectPrecise(m_isolate);
-  return coverageToProtocol(m_isolate, coverage, out_result);
+  return coverageToProtocol(m_session->inspector(), coverage, out_result);
 }
 
 Response V8ProfilerAgentImpl::getBestEffortCoverage(
@@ -393,12 +407,12 @@ Response V8ProfilerAgentImpl::getBestEffortCoverage(
   v8::HandleScope handle_scope(m_isolate);
   v8::debug::Coverage coverage =
       v8::debug::Coverage::CollectBestEffort(m_isolate);
-  return coverageToProtocol(m_isolate, coverage, out_result);
+  return coverageToProtocol(m_session->inspector(), coverage, out_result);
 }
 
 namespace {
 std::unique_ptr<protocol::Array<protocol::Profiler::ScriptTypeProfile>>
-typeProfileToProtocol(v8::Isolate* isolate,
+typeProfileToProtocol(V8InspectorImpl* inspector,
                       const v8::debug::TypeProfile& type_profile) {
   std::unique_ptr<protocol::Array<protocol::Profiler::ScriptTypeProfile>>
       result = protocol::Array<protocol::Profiler::ScriptTypeProfile>::create();
@@ -426,8 +440,10 @@ typeProfileToProtocol(v8::Isolate* isolate,
     }
     String16 url;
     v8::Local<v8::String> name;
-    if (script->Name().ToLocal(&name) || script->SourceURL().ToLocal(&name)) {
+    if (script->SourceURL().ToLocal(&name) && name->Length()) {
       url = toProtocolString(name);
+    } else if (script->Name().ToLocal(&name) && name->Length()) {
+      url = resourceNameToUrl(inspector, name);
     }
     result->addItem(protocol::Profiler::ScriptTypeProfile::create()
                         .setScriptId(String16::fromInteger(script->Id()))
@@ -462,7 +478,7 @@ Response V8ProfilerAgentImpl::takeTypeProfile(
   v8::HandleScope handle_scope(m_isolate);
   v8::debug::TypeProfile type_profile =
       v8::debug::TypeProfile::Collect(m_isolate);
-  *out_result = typeProfileToProtocol(m_isolate, type_profile);
+  *out_result = typeProfileToProtocol(m_session->inspector(), type_profile);
   return Response::OK();
 }
 
@@ -491,7 +507,7 @@ std::unique_ptr<protocol::Profiler::Profile> V8ProfilerAgentImpl::stopProfiling(
       m_profiler->StopProfiling(toV8String(m_isolate, title));
   std::unique_ptr<protocol::Profiler::Profile> result;
   if (profile) {
-    if (serialize) result = createCPUProfile(m_isolate, profile);
+    if (serialize) result = createCPUProfile(m_session->inspector(), profile);
     profile->Delete();
   }
   --m_startedProfilesCount;

--- a/deps/v8/src/inspector/v8-stack-trace-impl.cc
+++ b/deps/v8/src/inspector/v8-stack-trace-impl.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include "src/inspector/v8-debugger.h"
+#include "src/inspector/v8-inspector-impl.h"
 #include "src/inspector/wasm-translation.h"
 
 namespace v8_inspector {
@@ -73,7 +74,10 @@ std::unique_ptr<protocol::Runtime::StackTrace> buildInspectorObjectCommon(
   std::unique_ptr<protocol::Array<protocol::Runtime::CallFrame>>
       inspectorFrames = protocol::Array<protocol::Runtime::CallFrame>::create();
   for (size_t i = 0; i < frames.size(); i++) {
-    inspectorFrames->addItem(frames[i]->buildInspectorObject());
+    V8InspectorClient* client = nullptr;
+    if (debugger && debugger->inspector())
+      client = debugger->inspector()->client();
+    inspectorFrames->addItem(frames[i]->buildInspectorObject(client));
   }
   std::unique_ptr<protocol::Runtime::StackTrace> stackTrace =
       protocol::Runtime::StackTrace::create()
@@ -117,7 +121,9 @@ StackFrame::StackFrame(v8::Local<v8::StackFrame> v8Frame)
       m_scriptId(String16::fromInteger(v8Frame->GetScriptId())),
       m_sourceURL(toProtocolString(v8Frame->GetScriptNameOrSourceURL())),
       m_lineNumber(v8Frame->GetLineNumber() - 1),
-      m_columnNumber(v8Frame->GetColumn() - 1) {
+      m_columnNumber(v8Frame->GetColumn() - 1),
+      m_hasSourceURLComment(v8Frame->GetScriptName() !=
+                            v8Frame->GetScriptNameOrSourceURL()) {
   DCHECK_NE(v8::Message::kNoLineNumberInfo, m_lineNumber + 1);
   DCHECK_NE(v8::Message::kNoColumnInfo, m_columnNumber + 1);
 }
@@ -137,12 +143,20 @@ int StackFrame::lineNumber() const { return m_lineNumber; }
 
 int StackFrame::columnNumber() const { return m_columnNumber; }
 
-std::unique_ptr<protocol::Runtime::CallFrame> StackFrame::buildInspectorObject()
-    const {
+std::unique_ptr<protocol::Runtime::CallFrame> StackFrame::buildInspectorObject(
+    V8InspectorClient* client) const {
+  String16 frameUrl = m_sourceURL;
+  if (client && !m_hasSourceURLComment && frameUrl.length() > 0) {
+    std::unique_ptr<StringBuffer> url =
+        client->resourceNameToUrl(toStringView(m_sourceURL));
+    if (url) {
+      frameUrl = toString16(url->string());
+    }
+  }
   return protocol::Runtime::CallFrame::create()
       .setFunctionName(m_functionName)
       .setScriptId(m_scriptId)
-      .setUrl(m_sourceURL)
+      .setUrl(frameUrl)
       .setLineNumber(m_lineNumber)
       .setColumnNumber(m_columnNumber)
       .build();

--- a/deps/v8/src/inspector/v8-stack-trace-impl.h
+++ b/deps/v8/src/inspector/v8-stack-trace-impl.h
@@ -33,7 +33,8 @@ class StackFrame {
   const String16& sourceURL() const;
   int lineNumber() const;    // 0-based.
   int columnNumber() const;  // 0-based.
-  std::unique_ptr<protocol::Runtime::CallFrame> buildInspectorObject() const;
+  std::unique_ptr<protocol::Runtime::CallFrame> buildInspectorObject(
+      V8InspectorClient* client) const;
   bool isEqual(StackFrame* frame) const;
 
  private:
@@ -42,6 +43,7 @@ class StackFrame {
   String16 m_sourceURL;
   int m_lineNumber;    // 0-based.
   int m_columnNumber;  // 0-based.
+  bool m_hasSourceURLComment;
 };
 
 class V8StackTraceImpl : public V8StackTrace {

--- a/deps/v8/test/inspector/debugger/resource-name-to-url-expected.txt
+++ b/deps/v8/test/inspector/debugger/resource-name-to-url-expected.txt
@@ -1,0 +1,122 @@
+Tests V8InspectorClient::resourceNameToUrl.
+Check script with url:
+{
+    method : Debugger.scriptParsed
+    params : {
+        endColumn : 16
+        endLine : 0
+        executionContextId : <executionContextId>
+        hasSourceURL : false
+        hash : 033b33d191ed51ed823355d865eb871d811403e2
+        isLiveEdit : false
+        isModule : false
+        length : 16
+        scriptId : <scriptId>
+        sourceMapURL : 
+        startColumn : 0
+        startLine : 0
+        url : prefix://url
+    }
+}
+Check script with sourceURL comment:
+{
+    method : Debugger.scriptParsed
+    params : {
+        endColumn : 37
+        endLine : 0
+        executionContextId : <executionContextId>
+        hasSourceURL : true
+        hash : 06c136ce206c5f505f32af524e6ec71b5baa0bbb
+        isLiveEdit : false
+        isModule : false
+        length : 37
+        scriptId : <scriptId>
+        sourceMapURL : 
+        startColumn : 0
+        startLine : 0
+        url : foo.js
+    }
+}
+Check script failed to parse:
+{
+    method : Debugger.scriptFailedToParse
+    params : {
+        endColumn : 15
+        endLine : 0
+        executionContextId : <executionContextId>
+        hasSourceURL : false
+        hash : 033b33d191ed51ed1f44cd0465eb871d811403e2
+        isModule : false
+        length : 15
+        scriptId : <scriptId>
+        sourceMapURL : 
+        startColumn : 0
+        startLine : 0
+        url : prefix://url
+    }
+}
+Check script failed to parse with sourceURL comment:
+{
+    method : Debugger.scriptFailedToParse
+    params : {
+        endColumn : 36
+        endLine : 0
+        executionContextId : <executionContextId>
+        hasSourceURL : true
+        hash : 23a2885951475580023e2a742563d78876d8f05e
+        isModule : false
+        length : 36
+        scriptId : <scriptId>
+        sourceMapURL : 
+        startColumn : 0
+        startLine : 0
+        url : foo.js
+    }
+}
+Test runtime stack trace:
+{
+    method : Runtime.consoleAPICalled
+    params : {
+        args : [
+            [0] : {
+                description : 42
+                type : number
+                value : 42
+            }
+        ]
+        executionContextId : <executionContextId>
+        stackTrace : {
+            callFrames : [
+                [0] : {
+                    columnNumber : 14
+                    functionName : foo
+                    lineNumber : 2
+                    scriptId : <scriptId>
+                    url : prefix://url
+                }
+                [1] : {
+                    columnNumber : 0
+                    functionName : 
+                    lineNumber : 0
+                    scriptId : <scriptId>
+                    url : boo.js
+                }
+                [2] : {
+                    columnNumber : 4
+                    functionName : 
+                    lineNumber : 4
+                    scriptId : <scriptId>
+                    url : prefix://url
+                }
+            ]
+        }
+        timestamp : <timestamp>
+        type : log
+    }
+}
+Test debugger stack trace:
+[
+    [0] : prefix://url
+    [1] : boo.js
+    [2] : prefix://url
+]

--- a/deps/v8/test/inspector/debugger/resource-name-to-url.js
+++ b/deps/v8/test/inspector/debugger/resource-name-to-url.js
@@ -1,0 +1,49 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let {session, contextGroup, Protocol} = InspectorTest.start(
+  'Tests V8InspectorClient::resourceNameToUrl.');
+
+(async function test(){
+  Protocol.Runtime.enable();
+  await Protocol.Debugger.enable();
+  contextGroup.addScript(`inspector.setResourceNamePrefix('prefix://')`);
+  await Protocol.Debugger.onceScriptParsed();
+
+  InspectorTest.log('Check script with url:');
+  contextGroup.addScript('function foo(){}', 0, 0, 'url');
+  InspectorTest.logMessage(await Protocol.Debugger.onceScriptParsed());
+
+  InspectorTest.log('Check script with sourceURL comment:');
+  contextGroup.addScript('function foo(){} //# sourceURL=foo.js', 0, 0, 'url');
+  InspectorTest.logMessage(await Protocol.Debugger.onceScriptParsed());
+
+  InspectorTest.log('Check script failed to parse:');
+  contextGroup.addScript('function foo(){', 0, 0, 'url');
+  InspectorTest.logMessage(await Protocol.Debugger.onceScriptFailedToParse());
+
+  InspectorTest.log('Check script failed to parse with sourceURL comment:');
+  contextGroup.addScript('function foo(){ //# sourceURL=foo.js', 0, 0, 'url');
+  InspectorTest.logMessage(await Protocol.Debugger.onceScriptFailedToParse());
+
+  InspectorTest.log('Test runtime stack trace:');
+  contextGroup.addScript(`
+    function foo() {
+      console.log(42);
+    }
+    eval('foo(); //# sourceURL=boo.js');
+  `, 0, 0, 'url');
+  InspectorTest.logMessage(await Protocol.Runtime.onceConsoleAPICalled());
+
+  InspectorTest.log('Test debugger stack trace:');
+  contextGroup.addScript(`
+    function foo() {
+      debugger;
+    }
+    eval('foo(); //# sourceURL=boo.js');
+  `, 0, 0, 'url');
+  const {params:{callFrames}} = await Protocol.Debugger.oncePaused();
+  InspectorTest.logMessage(callFrames.map(frame => frame.url));
+  InspectorTest.completeTest();
+})();

--- a/deps/v8/test/inspector/inspector-test.cc
+++ b/deps/v8/test/inspector/inspector-test.cc
@@ -712,6 +712,9 @@ class InspectorExtension : public IsolateData::SetupGlobalTask {
         ToV8String(isolate, "setAllowCodeGenerationFromStrings"),
         v8::FunctionTemplate::New(
             isolate, &InspectorExtension::SetAllowCodeGenerationFromStrings));
+    inspector->Set(ToV8String(isolate, "setResourceNamePrefix"),
+                   v8::FunctionTemplate::New(
+                       isolate, &InspectorExtension::SetResourceNamePrefix));
     global->Set(ToV8String(isolate, "inspector"), inspector);
   }
 
@@ -972,6 +975,18 @@ class InspectorExtension : public IsolateData::SetupGlobalTask {
     }
     args.GetIsolate()->GetCurrentContext()->AllowCodeGenerationFromStrings(
         args[0].As<v8::Boolean>()->Value());
+  }
+
+  static void SetResourceNamePrefix(
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    if (args.Length() != 1 || !args[0]->IsString()) {
+      fprintf(stderr, "Internal error: setResourceNamePrefix('prefix').");
+      Exit();
+    }
+    v8::Isolate* isolate = args.GetIsolate();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    IsolateData* data = IsolateData::FromContext(context);
+    data->SetResourceNamePrefix(v8::Local<v8::String>::Cast(args[0]));
   }
 };
 

--- a/deps/v8/test/inspector/isolate-data.h
+++ b/deps/v8/test/inspector/isolate-data.h
@@ -76,6 +76,7 @@ class IsolateData : public v8_inspector::V8InspectorClient {
   void FireContextCreated(v8::Local<v8::Context> context, int context_group_id);
   void FireContextDestroyed(v8::Local<v8::Context> context);
   void FreeContext(v8::Local<v8::Context> context);
+  void SetResourceNamePrefix(v8::Local<v8::String> prefix);
 
  private:
   struct VectorCompare {
@@ -114,6 +115,8 @@ class IsolateData : public v8_inspector::V8InspectorClient {
                          v8_inspector::V8StackTrace*) override;
   bool isInspectableHeapObject(v8::Local<v8::Object>) override;
   void maxAsyncCallStackDepthChanged(int depth) override;
+  std::unique_ptr<v8_inspector::StringBuffer> resourceNameToUrl(
+      const v8_inspector::StringView& resourceName) override;
 
   // The isolate gets deleted by its {Dispose} method, not by the default
   // deleter. Therefore we have to define a custom deleter for the unique_ptr to
@@ -141,6 +144,7 @@ class IsolateData : public v8_inspector::V8InspectorClient {
   bool log_console_api_message_calls_ = false;
   bool log_max_async_call_stack_depth_changed_ = false;
   v8::Global<v8::Private> not_inspectable_private_;
+  v8::Global<v8::String> resource_name_prefix_;
 
   DISALLOW_COPY_AND_ASSIGN(IsolateData);
 };

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2348,6 +2348,19 @@ std::string URL::ToFilePath() const {
 #endif
 }
 
+URL URL::FromFilePath(const std::string& file_path) {
+  URL url("file://");
+  std::string escaped_file_path;
+  for (size_t i = 0; i < file_path.length(); ++i) {
+    escaped_file_path += file_path[i];
+    if (file_path[i] == '%')
+      escaped_file_path += "25";
+  }
+  URL::Parse(escaped_file_path.c_str(), escaped_file_path.length(), kPathStart,
+             &url.context_, true, nullptr, false);
+  return url;
+}
+
 // This function works by calling out to a JS function that creates and
 // returns the JS URL object. Be mindful of the JS<->Native boundary
 // crossing that is required.

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -169,6 +169,8 @@ class URL {
   // Get the path of the file: URL in a format consumable by native file system
   // APIs. Returns an empty string if something went wrong.
   std::string ToFilePath() const;
+  // Get the file URL from native file system path.
+  static URL FromFilePath(const std::string& file_path);
 
   const Local<Value> ToObject(Environment* env) const;
 

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -124,10 +124,6 @@ TEST_F(URLTest, FromFilePath) {
   file_url = URL::FromFilePath("b:\\a\\%%.js");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("/b:/a/%25%25.js", file_url.path());
-
-  file_url = URL::FromFilePath("\\\\host\\a\\b\\c");
-  EXPECT_EQ("file:", file_url.protocol());
-  EXPECT_EQ("host/a/b/c", file_url.path());
 #else
   file_url = URL::FromFilePath("/");
   EXPECT_EQ("file:", file_url.protocol());

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -109,3 +109,36 @@ TEST_F(URLTest, ToFilePath) {
 
 #undef T
 }
+
+TEST_F(URLTest, FromFilePath) {
+  URL file_url;
+#ifdef _WIN32
+  file_url = URL::FromFilePath("C:\\Program Files\\");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/C:/Program%20Files/", file_url.path());
+
+  file_url = URL::FromFilePath("C:\\a\\b\\c");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/C:/a/b/c", file_url.path());
+
+  file_url = URL::FromFilePath("b:\\a\\%%.js");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/b:/a/%25%25.js", file_url.path());
+
+  file_url = URL::FromFilePath("\\\\host\\a\\b\\c");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("host/a/b/c", file_url.path());
+#else
+  file_url = URL::FromFilePath("/");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/", file_url.path());
+
+  file_url = URL::FromFilePath("/a/b/c");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/a/b/c", file_url.path());
+
+  file_url = URL::FromFilePath("/a/%%.js");
+  EXPECT_EQ("file:", file_url.protocol());
+  EXPECT_EQ("/a/%25%25.js", file_url.path());
+#endif
+}

--- a/test/parallel/test-inspector-multisession-js.js
+++ b/test/parallel/test-inspector-multisession-js.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 
@@ -6,6 +7,7 @@ common.skipIfInspectorDisabled();
 const assert = require('assert');
 const { Session } = require('inspector');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
 function debugged() {
   return 42;
@@ -32,8 +34,8 @@ async function test() {
 
   await new Promise((resolve, reject) => {
     session1.post('Debugger.setBreakpointByUrl', {
-      'lineNumber': 9,
-      'url': path.resolve(__dirname, __filename),
+      'lineNumber': 12,
+      'url': pathToFileURL(path.resolve(__dirname, __filename)).toString(),
       'columnNumber': 0,
       'condition': ''
     }, (error, result) => {

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -97,7 +97,7 @@ function getFixtureCoverage(fixtureFile, coverageDirectory) {
   for (const coverageFile of coverageFiles) {
     const coverage = require(path.join(coverageDirectory, coverageFile));
     for (const fixtureCoverage of coverage.result) {
-      if (fixtureCoverage.url.indexOf(`${path.sep}${fixtureFile}`) !== -1) {
+      if (fixtureCoverage.url.indexOf(`/${fixtureFile}`) !== -1) {
         return fixtureCoverage;
       }
     }

--- a/test/sequential/test-inspector-bindings.js
+++ b/test/sequential/test-inspector-bindings.js
@@ -1,9 +1,11 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 common.skipIfInspectorDisabled();
 const assert = require('assert');
 const inspector = require('inspector');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
 // This test case will set a breakpoint 4 lines below
 function debuggedFunction() {
@@ -84,8 +86,8 @@ function testSampleDebugSession() {
   }, TypeError);
   session.post('Debugger.enable', () => cbAsSecondArgCalled = true);
   session.post('Debugger.setBreakpointByUrl', {
-    'lineNumber': 12,
-    'url': path.resolve(__dirname, __filename),
+    'lineNumber': 14,
+    'url': pathToFileURL(path.resolve(__dirname, __filename)).toString(),
     'columnNumber': 0,
     'condition': ''
   });

--- a/test/sequential/test-inspector-break-when-eval.js
+++ b/test/sequential/test-inspector-break-when-eval.js
@@ -5,6 +5,7 @@ common.skipIfInspectorDisabled();
 const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
 const fixtures = require('../common/fixtures');
+const { pathToFileURL } = require('url');
 
 const script = fixtures.path('inspector-global-function.js');
 
@@ -26,7 +27,7 @@ async function breakOnLine(session) {
   const commands = [
     { 'method': 'Debugger.setBreakpointByUrl',
       'params': { 'lineNumber': 9,
-                  'url': script,
+                  'url': pathToFileURL(script).toString(),
                   'columnNumber': 0,
                   'condition': ''
       }
@@ -45,7 +46,7 @@ async function breakOnLine(session) {
     }
   ];
   session.send(commands);
-  await session.waitForBreakOnLine(9, script);
+  await session.waitForBreakOnLine(9, pathToFileURL(script).toString());
 }
 
 async function stepOverConsoleStatement(session) {

--- a/test/sequential/test-inspector-debug-brk-flag.js
+++ b/test/sequential/test-inspector-debug-brk-flag.js
@@ -24,7 +24,7 @@ async function testBreakpointOnStart(session) {
   ];
 
   session.send(commands);
-  await session.waitForBreakOnLine(0, session.scriptPath());
+  await session.waitForBreakOnLine(0, session.scriptURL());
 }
 
 async function runTests() {

--- a/test/sequential/test-inspector-exception.js
+++ b/test/sequential/test-inspector-exception.js
@@ -7,6 +7,7 @@ common.skipIfInspectorDisabled();
 
 const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
+const { pathToFileURL } = require('url');
 
 const script = fixtures.path('throws_error.js');
 
@@ -29,7 +30,7 @@ async function testBreakpointOnStart(session) {
   ];
 
   await session.send(commands);
-  await session.waitForBreakOnLine(21, script);
+  await session.waitForBreakOnLine(21, pathToFileURL(script).toString());
 }
 
 

--- a/test/sequential/test-inspector-resource-name-to-url.js
+++ b/test/sequential/test-inspector-resource-name-to-url.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+(async function test() {
+  const { strictEqual } = require('assert');
+  const { Session } = require('inspector');
+  const { promisify } = require('util');
+  const vm = require('vm');
+  const session = new Session();
+  session.connect();
+  session.post = promisify(session.post);
+  await session.post('Debugger.enable');
+  await check('http://example.com', 'http://example.com');
+  await check(undefined, 'evalmachine.<anonymous>');
+  await check('file:///foo.js', 'file:///foo.js');
+  await check('file:///foo.js', 'file:///foo.js');
+  await check('foo.js', 'foo.js');
+  await check('[eval]', '[eval]');
+  await check('%.js', '%.js');
+
+  if (common.isWindows) {
+    await check('C:\\foo.js', 'file:///C:/foo.js');
+    await check('C:\\a\\b\\c\\foo.js', 'file:///C:/a/b/c/foo.js');
+    await check('a:\\%.js', 'file:///a:/%25.js');
+  } else {
+    await check('/foo.js', 'file:///foo.js');
+    await check('/a/b/c/d/foo.js', 'file:///a/b/c/d/foo.js');
+    await check('/%%%.js', 'file:///%25%25%25.js');
+  }
+
+  async function check(filename, expected) {
+    const promise =
+      new Promise((resolve) => session.once('inspectorNotification', resolve));
+    new vm.Script('42', { filename }).runInThisContext();
+    const { params: { url } } = await promise;
+    strictEqual(url, expected);
+  }
+})();

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -69,7 +69,7 @@ async function testBreakpointOnStart(session) {
   ];
 
   await session.send(commands);
-  await session.waitForBreakOnLine(0, session.scriptPath());
+  await session.waitForBreakOnLine(0, session.scriptURL());
 }
 
 async function testBreakpoint(session) {
@@ -77,7 +77,7 @@ async function testBreakpoint(session) {
   const commands = [
     { 'method': 'Debugger.setBreakpointByUrl',
       'params': { 'lineNumber': 5,
-                  'url': session.scriptPath(),
+                  'url': session.scriptURL(),
                   'columnNumber': 0,
                   'condition': ''
       }
@@ -92,7 +92,7 @@ async function testBreakpoint(session) {
          `Script source is wrong: ${scriptSource}`);
 
   await session.waitForConsoleOutput('log', ['A message', 5]);
-  const paused = await session.waitForBreakOnLine(5, session.scriptPath());
+  const paused = await session.waitForBreakOnLine(5, session.scriptURL());
   const scopeId = paused.params.callFrames[0].scopeChain[0].object.objectId;
 
   console.log('[test]', 'Verify we can read current application state');


### PR DESCRIPTION
Original commit message:
```
[inspector] added V8InspectorClient::resourceNameToUrl

Some clients (see Node.js) use platform path as ScriptOrigin.
Reporting platform path in protocol makes using protocol much harder.
This CL introduced V8InspectorClient::resourceNameToUrl method that
is called for any reported using protocol url.
V8Inspector uses url internally as well so protocol client may generate
pattern for blackboxing with file urls only and does not need to build
complicated regexp that covers files urls and platform paths on
different platforms.

R=lushnikov@chromium.org
TBR=yangguo@chromium.org

Bug: none
Cq-Include-Trybots: luci.chromium.try:linux_chromium_headless_rel;luci.chromium.try:linux_chromium_rel_ng;master.tryserver.blink:linux_trusty_blink_rel
Change-Id: Iff302e7441df922fa5d689fe510f5a9bfd470b9b
Reviewed-on: https://chromium-review.googlesource.com/1164624
Commit-Queue: Aleksey Kozyatinskiy <kozyatinskiy@chromium.org>
Reviewed-by: Alexei Filippov <alph@chromium.org>
Cr-Commit-Position: refs/heads/master@{#55029}
```
Refs: v8/v8@dbfcc48
Needed for #22223

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
