### PR TITLE
doc: require two approvals to land changes

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -116,7 +116,7 @@ At least two Collaborators must approve a pull request before the pull request
 lands. (One Collaborator approval is enough if the pull request has been open
 for more than 7 days.) Approving a pull request indicates that the Collaborator
 accepts responsibility for the change. Approval must be from Collaborators who
-are not authors of the proposed changes.
+are not authors of the change.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -112,10 +112,9 @@ comment that explains why the PR does not require a CI run.
 
 ### Code Reviews
 
-All pull requests must be reviewed and accepted by a Collaborator with
-sufficient expertise who is able to take full responsibility for the
-change. In the case of pull requests proposed by an existing
-Collaborator, an additional Collaborator is required for sign-off.
+All pull requests must be reviewed and accepted by two Collaborators with
+sufficient expertise who are able to take full responsibility for the change.
+Approval must be from Collaborators who are not authors of the proposed changes.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -112,9 +112,10 @@ comment that explains why the PR does not require a CI run.
 
 ### Code Reviews
 
-All pull requests must be reviewed and accepted by at least two Collaborators
-who are able to take full responsibility for the change. Approval must be from
-Collaborators who are not authors of the proposed changes.
+At least two Collaborators must approve a pull request before the pull request
+lands. Approving a pull request indicates that the Collaborator accepts
+responsibility for the change. Approval must be from Collaborators who are not
+authors of the proposed changes.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -113,9 +113,8 @@ comment that explains why the PR does not require a CI run.
 ### Code Reviews
 
 All pull requests must be reviewed and accepted by at least two Collaborators
-with sufficient expertise who are able to take full responsibility for the
-change. Approval must be from Collaborators who are not authors of the proposed
-changes.
+who are able to take full responsibility for the change. Approval must be from
+Collaborators who are not authors of the proposed changes.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -112,9 +112,10 @@ comment that explains why the PR does not require a CI run.
 
 ### Code Reviews
 
-All pull requests must be reviewed and accepted by two Collaborators with
-sufficient expertise who are able to take full responsibility for the change.
-Approval must be from Collaborators who are not authors of the proposed changes.
+All pull requests must be reviewed and accepted by at least two Collaborators
+with sufficient expertise who are able to take full responsibility for the
+change. Approval must be from Collaborators who are not authors of the proposed
+changes.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -113,9 +113,10 @@ comment that explains why the PR does not require a CI run.
 ### Code Reviews
 
 At least two Collaborators must approve a pull request before the pull request
-lands. Approving a pull request indicates that the Collaborator accepts
-responsibility for the change. Approval must be from Collaborators who are not
-authors of the proposed changes.
+lands. (One Collaborator approval is enough if the pull request has been open
+for more than 7 days.) Approving a pull request indicates that the Collaborator
+accepts responsibility for the change. Approval must be from Collaborators who
+are not authors of the proposed changes.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,8 +32,11 @@ Their privileges include but are not limited to:
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
-Collaborators. At least two Collaborators must approve a pull request before the
-pull request lands. Approving a pull request indicates that the Collaborator
+Collaborators.
+
+At least two Collaborators must approve a pull request before the pull request
+lands. (One Collaborator approval is enough if the pull request has been open
+for more than 7 days.) Approving a pull request indicates that the Collaborator
 accepts responsibility for the change. Approval must be from Collaborators who
 are not authors of the proposed changes.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,9 +33,8 @@ Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
 Collaborators. All pull requests must be reviewed and accepted by at least two
-Collaborators with sufficient expertise who are able to take full
-responsibility for the change. Approval must be from Collaborators who are not
-authors of the proposed changes.
+Collaborators who are able to take full responsibility for the change. Approval
+must be from Collaborators who are not authors of the proposed changes.
 
 If one or more Collaborators oppose a proposed change, then the change cannot
 be accepted unless:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,11 +32,10 @@ Their privileges include but are not limited to:
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by a
-Collaborator with sufficient expertise who is able to take full
-responsibility for the change. In the case of pull requests proposed
-by an existing Collaborator, an additional Collaborator is required
-for sign-off.
+Collaborators. All pull requests must be reviewed and accepted by two
+Collaborators with sufficient expertise who are able to take full
+responsibility for the change. Approval must be from Collaborators who are not
+authors of the proposed changes.
 
 If one or more Collaborators oppose a proposed change, then the change cannot
 be accepted unless:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,7 +32,7 @@ Their privileges include but are not limited to:
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by two
+Collaborators. All pull requests must be reviewed and accepted by at least two
 Collaborators with sufficient expertise who are able to take full
 responsibility for the change. Approval must be from Collaborators who are not
 authors of the proposed changes.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,7 +38,7 @@ At least two Collaborators must approve a pull request before the pull request
 lands. (One Collaborator approval is enough if the pull request has been open
 for more than 7 days.) Approving a pull request indicates that the Collaborator
 accepts responsibility for the change. Approval must be from Collaborators who
-are not authors of the proposed changes.
+are not authors of the change.
 
 If one or more Collaborators oppose a proposed change, then the change cannot
 be accepted unless:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,9 +32,10 @@ Their privileges include but are not limited to:
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by at least two
-Collaborators who are able to take full responsibility for the change. Approval
-must be from Collaborators who are not authors of the proposed changes.
+Collaborators. At least two Collaborators must approve a pull request before the
+pull request lands. Approving a pull request indicates that the Collaborator
+accepts responsibility for the change. Approval must be from Collaborators who
+are not authors of the proposed changes.
 
 If one or more Collaborators oppose a proposed change, then the change cannot
 be accepted unless:


### PR DESCRIPTION
First in a series that will hopefully streamline/simplify our policies. I don't want this to slip in unnoticed and it's a significant procedural change being proposed, so: @nodejs/collaborators

Currently, changes require approval by one Collaborator in most cases.
However there are situations where two approvals are required. For
example, breaking changes require two approvals from TSC members. And
fast-tracking a request requires two approvals.

Additionally, although only one approval is strictly required, in
practice, we nearly always seek a second approval when there is only
one.

Lastly, concerns have been raised about (perhaps unintentionally) gaming
the one-approval system by suggesting a change to someone else, and then
approving that change when the user submits a pull request. This
resolves (or at least mitigates) that concern.

Refs: https://github.com/nodejs/node/issues/19564

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
