### PR TITLE
spawn_sync: move process.binding('spawn_sync') to internalBinding

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -368,7 +368,8 @@
         'contextify',
         'tcp_wrap',
         'tls_wrap',
-        'async_wrap']);
+        'async_wrap',
+        'spawn_sync']);
     process.binding = function binding(name) {
       return internalBindingWhitelist.has(name) ?
         internalBinding(name) :

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -22,7 +22,6 @@ const util = require('util');
 const assert = require('assert');
 
 const { internalBinding } = require('internal/bootstrap/loaders');
-
 const { Process } = internalBinding('process_wrap');
 const { WriteWrap } = internalBinding('stream_wrap');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
@@ -33,7 +32,7 @@ const SocketList = require('internal/socket_list');
 const { owner_symbol } = require('internal/async_hooks').symbols;
 const { convertToValidSignal } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
-const spawn_sync = process.binding('spawn_sync');
+const spawn_sync = internalBinding('spawn_sync');
 const { HTTPParser } = internalBinding('http_parser');
 const { freeParser } = require('_http_common');
 const { kStateSymbol } = require('internal/dgram');

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -1099,5 +1099,5 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(spawn_sync,
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(spawn_sync,
   node::SyncProcessRunner::Initialize)

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -12,3 +12,4 @@ assert(process.binding('v8'));
 assert(process.binding('stream_wrap'));
 assert(process.binding('signal_wrap'));
 assert(process.binding('contextify'));
+assert(process.binding('spawn_sync'));


### PR DESCRIPTION
Migration from process.binding to internalBinding (see : https://github.com/nodejs/node/issues/22160)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
