### PR TITLE
doc: list encodings supported by buffer.transcode

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2508,7 +2508,7 @@ encoding to another. Returns a new `Buffer` instance.
 Throws if the `fromEnc` or `toEnc` specify invalid character encodings or if
 conversion from `fromEnc` to `toEnc` is not permitted.
 
-Encodings supported by `buffer.transcode()` include: `'ascii'`, `'utf8'`,
+Encodings supported by `buffer.transcode()` are: `'ascii'`, `'utf8'`,
 `'utf16le'`, `'ucs2'`, `'latin1'`, and `'binary'`.
 
 The transcoding process will use substitution characters if a given byte

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2508,6 +2508,9 @@ encoding to another. Returns a new `Buffer` instance.
 Throws if the `fromEnc` or `toEnc` specify invalid character encodings or if
 conversion from `fromEnc` to `toEnc` is not permitted.
 
+Encodings supported by `buffer.transcode()` include: `'ascii'`, `'utf8'`,
+`'utf16le'`, `'ucs2'`, `'latin1'`, and `'binary'`.
+
 The transcoding process will use substitution characters if a given byte
 sequence cannot be adequately represented in the target encoding. For instance:
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/15632

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
