### PR TITLE
test: fix cctest URLTest.ToFilePath on Win32 without Intl

### DIFF
--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -88,7 +88,12 @@ TEST_F(URLTest, ToFilePath) {
   T("file:///C:/Program%20Files/", "C:\\Program Files\\");
   T("file:///C:/a/b/c?query#fragment", "C:\\a\\b\\c");
   T("file://host/path/a/b/c?query#fragment", "\\\\host\\path\\a\\b\\c");
+#if defined(NODE_HAVE_I18N_SUPPORT)
   T("file://xn--weird-prdj8vva.com/host/a", "\\\\wͪ͊eiͬ͋rd.com\\host\\a");
+#else
+  T("file://xn--weird-prdj8vva.com/host/a",
+    "\\\\xn--weird-prdj8vva.com\\host\\a");
+#endif
   T("file:///C:/a%2Fb", "");
   T("file:///", "");
   T("file:///home", "");


### PR DESCRIPTION
Skip one specific test that requires ICU

Fixes: https://github.com/nodejs/node/issues/19051

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
