### PR TITLE
assert, util: *DeepEqual() handles ArrayBuffers

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -3,7 +3,13 @@
 const { compare } = process.binding('buffer');
 const { isArrayBufferView } = require('internal/util/types');
 const { internalBinding } = require('internal/bootstrap/loaders');
-const { isDate, isMap, isRegExp, isSet } = internalBinding('types');
+const {
+  isAnyArrayBuffer,
+  isDate,
+  isMap,
+  isRegExp,
+  isSet
+} = internalBinding('types');
 const { getOwnNonIndexProperties } = process.binding('util');
 
 const ReflectApply = Reflect.apply;
@@ -55,6 +61,11 @@ function areSimilarTypedArrays(a, b) {
                  new Uint8Array(b.buffer, b.byteOffset, b.byteLength)) === 0;
 }
 
+function areEqualArrayBuffers(buf1, buf2) {
+  return buf1.byteLength === buf2.byteLength &&
+    compare(new Uint8Array(buf1), new Uint8Array(buf2)) === 0;
+}
+
 function isFloatTypedArrayTag(tag) {
   return tag === '[object Float32Array]' || tag === '[object Float64Array]';
 }
@@ -65,10 +76,6 @@ function isArguments(tag) {
 
 function isObjectOrArrayTag(tag) {
   return tag === '[object Array]' || tag === '[object Object]';
-}
-
-function isArrayBuffer(tag) {
-  return tag === '[object ArrayBuffer]' || tag === '[object SharedArrayBuffer]';
 }
 
 // Notes: Type tags are historical [[Class]] properties that can be set by
@@ -158,9 +165,8 @@ function strictDeepEqual(val1, val2, memos) {
       return false;
     }
     return keyCheck(val1, val2, kStrict, memos, kIsMap);
-  } else if (isArrayBuffer(val1Tag)) {
-    if (!areSimilarTypedArrays(new Uint8Array(val1),
-                               new Uint8Array(val2), 300)) {
+  } else if (isAnyArrayBuffer(val1)) {
+    if (!areEqualArrayBuffers(val1, val2)) {
       return false;
     }
   // TODO: Make the valueOf checks safe.
@@ -226,9 +232,8 @@ function looseDeepEqual(val1, val2, memos) {
   } else if (isSet(val2) || isMap(val2)) {
     return false;
   }
-  if (isArrayBuffer(val1Tag) && isArrayBuffer(val2Tag)) {
-    if (!areSimilarTypedArrays(new Uint8Array(val1),
-                               new Uint8Array(val2), 300)) {
+  if (isAnyArrayBuffer(val1) && isAnyArrayBuffer(val2)) {
+    if (!areEqualArrayBuffers(val1, val2)) {
       return false;
     }
   }

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -67,6 +67,10 @@ function isObjectOrArrayTag(tag) {
   return tag === '[object Array]' || tag === '[object Object]';
 }
 
+function isArrayBuffer(tag) {
+  return tag === '[object ArrayBuffer]' || tag === '[object SharedArrayBuffer]';
+}
+
 // Notes: Type tags are historical [[Class]] properties that can be set by
 // FunctionTemplate::SetClassName() in C++ or Symbol.toStringTag in JS
 // and retrieved using Object.prototype.toString.call(obj) in JS
@@ -154,6 +158,11 @@ function strictDeepEqual(val1, val2, memos) {
       return false;
     }
     return keyCheck(val1, val2, kStrict, memos, kIsMap);
+  } else if (isArrayBuffer(val1Tag)) {
+    if (!areSimilarTypedArrays(new Uint8Array(val1),
+                               new Uint8Array(val2), 300)) {
+      return false;
+    }
   // TODO: Make the valueOf checks safe.
   } else if (typeof val1.valueOf === 'function') {
     const val1Value = val1.valueOf();
@@ -216,6 +225,12 @@ function looseDeepEqual(val1, val2, memos) {
     return keyCheck(val1, val2, kLoose, memos, kIsMap);
   } else if (isSet(val2) || isMap(val2)) {
     return false;
+  }
+  if (isArrayBuffer(val1Tag) && isArrayBuffer(val2Tag)) {
+    if (!areSimilarTypedArrays(new Uint8Array(val1),
+                               new Uint8Array(val2), 300)) {
+      return false;
+    }
   }
   return keyCheck(val1, val2, kLoose, memos, kNoIterator);
 }

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -23,7 +23,9 @@ const equalArrayPairs = [
   [new Float32Array([+0.0]), new Float32Array([+0.0])],
   [new Uint8Array([1, 2, 3, 4]).subarray(1), new Uint8Array([2, 3, 4])],
   [new Uint16Array([1, 2, 3, 4]).subarray(1), new Uint16Array([2, 3, 4])],
-  [new Uint32Array([1, 2, 3, 4]).subarray(1, 3), new Uint32Array([2, 3])]
+  [new Uint32Array([1, 2, 3, 4]).subarray(1, 3), new Uint32Array([2, 3])],
+  [new ArrayBuffer(3), new ArrayBuffer(3)],
+  [new SharedArrayBuffer(3), new SharedArrayBuffer(3)]
 ];
 
 const looseEqualArrayPairs = [
@@ -31,7 +33,8 @@ const looseEqualArrayPairs = [
   [new Int16Array(256), new Uint16Array(256)],
   [new Int16Array([256]), new Uint16Array([256])],
   [new Float32Array([+0.0]), new Float32Array([-0.0])],
-  [new Float64Array([+0.0]), new Float64Array([-0.0])]
+  [new Float64Array([+0.0]), new Float64Array([-0.0])],
+  [new ArrayBuffer(3), new SharedArrayBuffer(3)]
 ];
 
 const notEqualArrayPairs = [
@@ -44,7 +47,19 @@ const notEqualArrayPairs = [
   [new Int16Array([-256]), new Uint16Array([0xff00])], // same bits
   [new Int32Array([-256]), new Uint32Array([0xffffff00])], // ditto
   [new Float32Array([0.1]), new Float32Array([0.0])],
-  [new Float64Array([0.1]), new Float64Array([0.0])]
+  [new Float64Array([0.1]), new Float64Array([0.0])],
+  [new Uint8Array([1, 2, 3]).buffer, new Uint8Array([4, 5, 6]).buffer],
+  [
+    new Uint8Array(new SharedArrayBuffer(3)).fill(1).buffer,
+    new Uint8Array(new SharedArrayBuffer(3)).fill(2).buffer
+  ],
+  [new ArrayBuffer(2), new ArrayBuffer(3)],
+  [new SharedArrayBuffer(2), new SharedArrayBuffer(3)],
+  [new ArrayBuffer(2), new SharedArrayBuffer(3)],
+  [
+    new Uint8Array(new ArrayBuffer(3)).fill(1).buffer,
+    new Uint8Array(new SharedArrayBuffer(3)).fill(2).buffer
+  ]
 ];
 
 equalArrayPairs.forEach((arrayPair) => {


### PR DESCRIPTION
Previously, all `ArrayBuffer`s and `SharedArrayBuffer`s were considered equal in `assert.deepEqual()`, `assert.deepStrictEqual()`, and `util.isDeepStrictEqual()`. Now, `ArrayBuffer`s and `SharedArrayBuffer`s must have the same byte lengths and contents to be considered equal. In loose mode, an `ArrayBuffer` is considered equal to a `SharedArrayBuffer` if they have the same contents, whereas in strict mode, the buffers must be both `ArrayBuffer`s or both `SharedArrayBuffer`s.

Here are 2 examples, both of which succeeded before but now throw:
````javascript
assert.deepEqual(new Uint8Array([1, 2, 3]).buffer, new Uint8Array([4, 5, 6]).buffer)
assert.deepStrictEqual(new ArrayBuffer(3), new ArrayBuffer(4))
````

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
