### PR TITLE
lib: Remove unused param for `filterInternalStackFrames`

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -494,7 +494,7 @@ function REPLServer(prompt,
     self.writer.options = Object.assign({}, writer.options, { colors: true });
   }
 
-  function filterInternalStackFrames(error, structuredStack) {
+  function filterInternalStackFrames(structuredStack) {
     // Search from the bottom of the call stack to
     // find the first frame with a null function name
     if (typeof structuredStack !== 'object')
@@ -509,7 +509,7 @@ function REPLServer(prompt,
 
   function prepareStackTrace(fn) {
     return (error, stackFrames) => {
-      const frames = filterInternalStackFrames(error, stackFrames);
+      const frames = filterInternalStackFrames(stackFrames);
       if (fn) {
         return fn(error, frames);
       }


### PR DESCRIPTION
Actually we don't refer the `error` directly in `filterInternalStackFrames`, so just remove it anyway.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
