### PR TITLE
process: wrap process.binding for selective fallthrough to internalBinding

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -321,20 +321,17 @@
 
     // Deprecated specific process.binding() modules, but not all, allow
     // selective fallback to internalBinding for the deprecated ones.
+    const { SafeSet } = NativeModule.require('internal/safe_globals');
     const processBinding = process.binding;
-    const internalBindingWhitelist = new Set(['uv']);
-    const internalBindingWarned = new Set();
+    // internalBindingWhitelist contains the name of internalBinding modules
+    // that are whitelisted for access via process.binding()... this is used
+    // to provide a transition path for modules that are being moved over to
+    // internalBinding.
+    const internalBindingWhitelist = new SafeSet(['uv']);
     process.binding = function binding(name) {
-      if (internalBindingWhitelist.has(name)) {
-        if (!internalBindingWarned.has(name)) {
-          process.emitWarning(
-            `Use of process.binding('${name}') is deprecated.`,
-            'DeprecationWarning', 'DEP0111');
-          internalBindingWarned.add(name);
-        }
-        return internalBinding(name);
-      }
-      return processBinding(name);
+      return internalBindingWhitelist.has(name) ?
+        internalBinding(name) :
+        processBinding(name);
     };
   }
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -318,6 +318,24 @@
       for (var i = 0; i < arguments.length; i++)
         this.push(arguments[i]);
     }
+
+    // Deprecated specific process.binding() modules, but not all, allow
+    // selective fallback to internalBinding for the deprecated ones.
+    const processBinding = process.binding;
+    const internalBindingWhitelist = new Set(['uv']);
+    const internalBindingWarned = new Set();
+    process.binding = function binding(name) {
+      if (internalBindingWhitelist.has(name)) {
+        if (!internalBindingWarned.has(name)) {
+          process.emitWarning(
+            `Use of process.binding('${name}') is deprecated.`,
+            'DeprecationWarning', 'DEP0111');
+          internalBindingWarned.add(name);
+        }
+        return internalBinding(name);
+      }
+      return processBinding(name);
+    };
   }
 
   function setupGlobalVariables() {

--- a/test/parallel/test-process-binding-deprecation.js
+++ b/test/parallel/test-process-binding-deprecation.js
@@ -1,0 +1,13 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'Use of process.binding(\'uv\') is deprecated.',
+  'DEP0111'
+);
+
+assert(process.binding('uv'));

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -1,7 +1,7 @@
 // Flags: --no-warnings
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 // Assert that whitelisted internalBinding modules are accessible via

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -4,10 +4,6 @@
 const common = require('../common');
 const assert = require('assert');
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Use of process.binding(\'uv\') is deprecated.',
-  'DEP0111'
-);
-
+// Assert that whitelisted internalBinding modules are accessible via
+// process.binding().
 assert(process.binding('uv'));


### PR DESCRIPTION
Selectively allow `process.binding()` to fall-through to `internalBinding()`

~~This adds a selective deprecation. We *might* want to make this a `PendingDeprecationWarning` instead of a regular `DeprecationWarning`.~~

Refs: https://github.com/nodejs/node/pull/22163

/cc @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
