### PR TITLE
path: remove unreachable branch in normalizeString

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -21,10 +21,7 @@
 
 'use strict';
 
-const {
-  ERR_ASSERTION,
-  ERR_INVALID_ARG_TYPE
-} = require('internal/errors').codes;
+const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const {
   CHAR_UPPERCASE_A,
   CHAR_LOWERCASE_A,
@@ -80,23 +77,16 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
             res.charCodeAt(res.length - 2) !== CHAR_DOT) {
           if (res.length > 2) {
             const lastSlashIndex = res.lastIndexOf(separator);
-            if (lastSlashIndex !== res.length - 1) {
-              if (lastSlashIndex === -1) {
-                res = '';
-                lastSegmentLength = 0;
-              } else {
-                res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
-              }
-              lastSlash = i;
-              dots = 0;
-              continue;
+            if (lastSlashIndex === -1) {
+              res = '';
+              lastSegmentLength = 0;
             } else {
-              throw new ERR_ASSERTION(
-                'invariant violation: unreachable: ' +
-                  JSON.stringify({ path, allowAboveRoot, separator })
-              );
+              res = res.slice(0, lastSlashIndex);
+              lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
             }
+            lastSlash = i;
+            dots = 0;
+            continue;
           } else if (res.length === 2 || res.length === 1) {
             res = '';
             lastSegmentLength = 0;

--- a/lib/path.js
+++ b/lib/path.js
@@ -21,7 +21,10 @@
 
 'use strict';
 
-const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+const {
+  ERR_ASSERTION,
+  ERR_INVALID_ARG_TYPE
+} = require('internal/errors').codes;
 const {
   CHAR_UPPERCASE_A,
   CHAR_LOWERCASE_A,
@@ -88,6 +91,11 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
               lastSlash = i;
               dots = 0;
               continue;
+            } else {
+              throw new ERR_ASSERTION(
+                'invariant violation: unreachable: ' +
+                  JSON.stringify({ path, allowAboveRoot, separator })
+              );
             }
           } else if (res.length === 2 || res.length === 1) {
             res = '';


### PR DESCRIPTION
There is an `if`-statement in `normalizeString` (a helper function for
`path.normalize`) whose `else`-branch is never taken. This patch removes
the branch entirely to make the code easier to understand, which
incidentally improves test coverage.

For a proof that the branch is in fact not reachable, see:
<https://github.com/nodejs/node/pull/22273#issuecomment-412633130>

(Summary of proof: the key invariants, proven by simultaneous induction,
are (a) that `res` does not end in a separator and (b) that `res` does
not contain two consecutive separators.)

Test Plan:
Existing unit tests pass. No additional tests are required.

wchargin-branch: normalizeString-dead-branch

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] existing tests pass; no new tests are required
- [x] commit message follows commit guidelines
