### PR TITLE
lib: Remove unused param for `exec` in `child_process`

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -142,8 +142,8 @@ function normalizeExecArgs(command, options, callback) {
 }
 
 
-exports.exec = function exec(command /* , options, callback */) {
-  var opts = normalizeExecArgs.apply(null, arguments);
+exports.exec = function exec(/* command , options, callback */) {
+  const opts = normalizeExecArgs.apply(null, arguments);
   return exports.execFile(opts.file,
                           opts.options,
                           opts.callback);


### PR DESCRIPTION
`exec`'s parameters are now deconstructored through `normalizeExecArgs.apply`. We don't need an exclipit parameter any more (and in fact it's NEVER referred in the code directly), like `spwan` or `spwanSync`.
So this might be missing.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
