### PR TITLE
tools: add no-misleading-character-class ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,7 @@ module.exports = {
     'no-invalid-regexp': 'error',
     'no-irregular-whitespace': 'error',
     'no-lonely-if': 'error',
+    'no-misleading-character-class': 'error',
     'no-mixed-requires': 'error',
     'no-mixed-spaces-and-tabs': 'error',
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

ESLint 5.3.0 adds a simple new rule that seems helpful for increasing Unicode support in JavaScript and Node.js:  [`no-misleading-character-class`]( https://eslint.org/docs/rules/no-misleading-character-class).

Since we [have already updated](https://github.com/nodejs/node/pull/22134) to the last version, we can toggle this rule on.

No relevant issues detected in our code or docs.