### PR TITLE
meta: improve approval process

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -111,10 +111,15 @@ comment that explains why the PR does not require a CI run.
 
 ### Code Reviews
 
-All pull requests must be reviewed and accepted by a Collaborator with
-sufficient expertise who is able to take full responsibility for the
-change. In the case of pull requests proposed by an existing
-Collaborator, an additional Collaborator is required for sign-off.
+All pull requests should be reviewed and accepted by at least two Collaborators
+with sufficient expertise to take responsibility for the change. Pull requests
+with only a single approval may land if: (a) a request for review from other
+individual Collaborators or teams has been made, (b) there are no objections
+after a period of 72 hours (3 days) from the time of that request, and (c) all
+other conditions to land have been met.
+
+In the case of pull requests proposed by an existing Collaborator, an additional
+Collaborator is required for sign-off.
 
 In some cases, it may be necessary to summon a GitHub team to a pull request for
 review by @-mention.
@@ -168,11 +173,17 @@ agenda.
 
 ### Waiting for Approvals
 
-Before landing pull requests, sufficient time should be left for input
-from other Collaborators. In general, leave at least 48 hours during the
-week and 72 hours over weekends to account for international time
-differences and work schedules. However, certain types of pull requests
-can be fast-tracked and may be landed after a shorter delay. For example:
+To provide enough time for pull requests to receive adequate review,
+all pull requests not approved for fast-tracking must remain open for at 48
+hours from either the time it was opened, or from the most recent request for
+review from specific individuals or teams.
+
+To qualify for fast-tracking, the changes proposed by a pull request must: (a)
+be labeled `fast-track`, (b) must have 2 or more Collaborators approving both
+the pull request and the fast-tracking request, and (c) must have the necessary
+CI testing complete.
+
+Example changes that qualify for `fast-track` include:
 
 * Focused changes that affect only documentation and/or the test suite:
   * `code-and-learn` tasks typically fall into this category.
@@ -180,11 +191,6 @@ can be fast-tracked and may be landed after a shorter delay. For example:
 * Changes that fix regressions:
   * Regressions that break the workflow (red CI or broken compilation).
   * Regressions that happen right before a release, or reported soon after.
-
-When a pull request is deemed suitable to be fast-tracked, label it with
-`fast-track`. The pull request can be landed once 2 or more Collaborators
-approve both the pull request and the fast-tracking request, and the necessary
-CI testing is done.
 
 ### Testing and CI
 

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -410,12 +410,17 @@ unhelpful is likely safe to ignore.
 
 ### Step 10: Landing
 
-In order to land, a Pull Request needs to be reviewed and [approved][] by
-at least one Node.js Collaborator and pass a
+In order to land, a Pull Request should be reviewed and [approved][] by
+at least two Node.js Collaborator and pass a
 [CI (Continuous Integration) test run][]. After that, as long as there are no
 objections from other contributors, the Pull Request can be merged. If you find
 your Pull Request waiting longer than you expect, see the
 [notes about the waiting time](#waiting-until-the-pull-request-gets-landed).
+
+Pull requests with only a single approval may land if: (a) a request for review
+from other individual Collaborators or teams has been made, (b) there are no
+objections after a period of 72 hours (3 days) from the time of that request,
+and (c) all other conditions to land have been met.
 
 When a collaborator lands your Pull Request, they will post
 a comment to the Pull Request page mentioning the commit(s) it
@@ -487,19 +492,15 @@ having good code.
 
 ### Respect the minimum wait time for comments
 
-There is a minimum waiting time which we try to respect for non-trivial
-changes, so that people who may have important input in such a distributed
-project are able to respond.
+To provide enough time for pull requests to receive adequate review,
+all pull requests not approved for fast-tracking must remain open for at 48
+hours from either the time it was opened, or from the most recent request for
+review from specific individuals or teams.
 
-For non-trivial changes, Pull Requests must be left open for *at least* 48
-hours during the week, and 72 hours on a weekend. In most cases, when the
-PR is relatively small and focused on a narrow set of changes, these periods
-provide more than enough time to adequately review. Sometimes changes take far
-longer to review, or need more specialized review from subject matter experts.
-When in doubt, do not rush.
-
-Trivial changes, typically limited to small formatting changes or fixes to
-documentation, may be landed within the minimum 48 hour window.
+To qualify for fast-tracking, the changes proposed by a pull request must: (a)
+be labeled `fast-track`, (b) must have 2 or more Collaborators approving both
+the pull request and the fast-tracking request, (c) must have the necessary
+CI testing complete.
 
 ### Abandoned or Stalled Pull Requests
 


### PR DESCRIPTION
* Require that all PRs stay open for at least 48 hours from either
  the time they were opened or the time of the most recent request
  for review.
* State that all PRs *should* have at least two reviews but include
  a three day escape hatch to prevent things from stalling.

Alternative to: https://github.com/nodejs/node/pull/22255 and https://github.com/nodejs/node/pull/22275

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
