### PR TITLE
util: fix sparse array inspection

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -967,33 +967,29 @@ function formatNamespaceObject(ctx, value, recurseTimes, keys) {
 function formatSpecialArray(ctx, value, recurseTimes, keys, maxLength, valLen) {
   const output = [];
   const keyLen = keys.length;
-  let visibleLength = 0;
   let i = 0;
-  if (keyLen !== 0 && numberRegExp.test(keys[0])) {
-    for (const key of keys) {
-      if (visibleLength === maxLength)
+  for (const key of keys) {
+    if (output.length === maxLength)
+      break;
+    const index = +key;
+    // Arrays can only have up to 2^32 - 1 entries
+    if (index > 2 ** 32 - 2)
+      break;
+    if (`${i}` !== key) {
+      if (!numberRegExp.test(key))
         break;
-      const index = +key;
-      // Arrays can only have up to 2^32 - 1 entries
-      if (index > 2 ** 32 - 2)
+      const emptyItems = index - i;
+      const ending = emptyItems > 1 ? 's' : '';
+      const message = `<${emptyItems} empty item${ending}>`;
+      output.push(ctx.stylize(message, 'undefined'));
+      i = index;
+      if (output.length === maxLength)
         break;
-      if (i !== index) {
-        if (!numberRegExp.test(key))
-          break;
-        const emptyItems = index - i;
-        const ending = emptyItems > 1 ? 's' : '';
-        const message = `<${emptyItems} empty item${ending}>`;
-        output.push(ctx.stylize(message, 'undefined'));
-        i = index;
-        if (++visibleLength === maxLength)
-          break;
-      }
-      output.push(formatProperty(ctx, value, recurseTimes, key, 1));
-      visibleLength++;
-      i++;
     }
+    output.push(formatProperty(ctx, value, recurseTimes, key, 1));
+    i++;
   }
-  if (i < valLen && visibleLength !== maxLength) {
+  if (i < valLen && output.length !== maxLength) {
     const len = valLen - i;
     const ending = len > 1 ? 's' : '';
     const message = `<${len} empty item${ending}>`;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -345,6 +345,19 @@ assert.strictEqual(
                      "[ <2 empty items>, '00': 1, '01': 2 ]");
   assert.strictEqual(util.inspect(arr2, { showHidden: true }),
                      "[ <2 empty items>, [length]: 2, '00': 1, '01': 2 ]");
+  delete arr2['00'];
+  arr2[0] = 0;
+  assert.strictEqual(util.inspect(arr2),
+                     "[ 0, <1 empty item>, '01': 2 ]");
+  assert.strictEqual(util.inspect(arr2, { showHidden: true }),
+                     "[ 0, <1 empty item>, [length]: 2, '01': 2 ]");
+  delete arr2['01'];
+  arr2[2 ** 32 - 2] = 'max';
+  arr2[2 ** 32 - 1] = 'too far';
+  assert.strictEqual(
+    util.inspect(arr2),
+    "[ 0, <4294967293 empty items>, 'max', '4294967295': 'too far' ]"
+  );
 
   const arr3 = [];
   arr3[-1] = -1;


### PR DESCRIPTION
For very special sparse arrays it was possible that util.inspect
visualized the entries not in the intended way.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
