### PR TITLE
util: improve empty typed array inspection

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -662,7 +662,7 @@ function formatValue(ctx, value, recurseTimes) {
       formatter = formatMap;
     } else if (isTypedArray(value)) {
       braces = [`${getPrefix(constructor, tag)}[`, ']'];
-      if (value.length === 0 && keyLength === 0)
+      if (value.length === 0 && keyLength === 0 && !ctx.showHidden)
         return `${braces[0]}]`;
       formatter = formatTypedArray;
     } else if (isMapIterator(value)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -662,6 +662,8 @@ function formatValue(ctx, value, recurseTimes) {
       formatter = formatMap;
     } else if (isTypedArray(value)) {
       braces = [`${getPrefix(constructor, tag)}[`, ']'];
+      if (value.length === 0 && keyLength === 0)
+        return `${braces[0]}]`;
       formatter = formatTypedArray;
     } else if (isMapIterator(value)) {
       braces = [`[${tag}] {`, '}'];

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -13,6 +13,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_VALUE',
     message: 'The argument \'buffer\' is empty and cannot be written. ' +
-    'Received Uint8Array [  ]'
+    'Received Uint8Array []'
   }
 );

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -26,6 +26,7 @@ const JSStream = process.binding('js_stream').JSStream;
 const util = require('util');
 const vm = require('vm');
 const { previewEntries } = process.binding('util');
+const { inspect } = util;
 
 assert.strictEqual(util.inspect(1), '1');
 assert.strictEqual(util.inspect(false), 'false');
@@ -79,6 +80,7 @@ assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': 2 } } }, false, 1),
 assert.strictEqual(util.inspect({ 'a': { 'b': ['c'] } }, false, 1),
                    '{ a: { b: [Array] } }');
 assert.strictEqual(util.inspect(new Uint8Array(0)), 'Uint8Array []');
+assert(inspect(new Uint8Array(0), { showHidden: true }).includes('[buffer]'));
 assert.strictEqual(
   util.inspect(
     Object.create(

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -78,7 +78,7 @@ assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': 2 } } }, false, 1),
                    '{ a: { b: [Object] } }');
 assert.strictEqual(util.inspect({ 'a': { 'b': ['c'] } }, false, 1),
                    '{ a: { b: [Array] } }');
-assert.strictEqual(util.inspect(new Uint8Array(0)), 'Uint8Array [  ]');
+assert.strictEqual(util.inspect(new Uint8Array(0)), 'Uint8Array []');
 assert.strictEqual(
   util.inspect(
     Object.create(


### PR DESCRIPTION
They should be aligned with all other empty objects. Therefore the
whitespace is removed and they got a fast path for that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
