### PR TITLE
util: prevent inspect tampering

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -108,6 +108,7 @@ function uncurryThis(func) {
 }
 
 const propertyIsEnumerable = uncurryThis(Object.prototype.propertyIsEnumerable);
+const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 const regExpToString = uncurryThis(RegExp.prototype.toString);
 const dateToISOString = uncurryThis(Date.prototype.toISOString);
 const errorToString = uncurryThis(Error.prototype.toString);
@@ -735,15 +736,22 @@ function formatValue(ctx, value, recurseTimes) {
       if (prefix === '') {
         prefix = isArrayBuffer(value) ? 'ArrayBuffer ' : 'SharedArrayBuffer ';
       }
-      if (keyLength === 0)
+      if (keyLength === 0) {
         return prefix +
               `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
+      }
       braces[0] = `${prefix}{`;
-      keys.unshift('byteLength');
+      if (!hasOwnProperty(value, 'byteLength')) {
+        keys.unshift('byteLength');
+      }
     } else if (isDataView(value)) {
       braces[0] = `${getPrefix(constructor, tag, 'DataView')}{`;
       // .buffer goes last, it's not a primitive like the others.
-      keys.unshift('byteLength', 'byteOffset', 'buffer');
+      for (const key of ['buffer', 'byteOffset', 'byteLength']) {
+        if (!hasOwnProperty(value, key)) {
+          keys.unshift(key);
+        }
+      }
     } else if (isPromise(value)) {
       braces[0] = `${getPrefix(constructor, tag, 'Promise')}{`;
       formatter = formatPromise;
@@ -1070,8 +1078,10 @@ function formatTypedArray(ctx, value, recurseTimes, keys) {
       'buffer'
     ];
     for (i = 0; i < extraKeys.length; i++) {
-      const str = formatValue(ctx, value[extraKeys[i]], recurseTimes);
-      output.push(`[${extraKeys[i]}]: ${str}`);
+      if (!hasOwnProperty(value, extraKeys[i])) {
+        const str = formatValue(ctx, value[extraKeys[i]], recurseTimes);
+        output.push(`[${extraKeys[i]}]: ${str}`);
+      }
     }
   }
   // TypedArrays cannot have holes. Therefore it is safe to assume that all
@@ -1090,7 +1100,7 @@ function formatSet(ctx, value, recurseTimes, keys) {
   // With `showHidden`, `length` will display as a hidden property for
   // arrays. For consistency's sake, do the same for `size`, even though this
   // property isn't selected by Object.getOwnPropertyNames().
-  if (ctx.showHidden)
+  if (ctx.showHidden && !hasOwnProperty(value, 'size'))
     output[i++] = `[size]: ${ctx.stylize(`${value.size}`, 'number')}`;
   for (var n = 0; n < keys.length; n++) {
     output[i++] = formatProperty(ctx, value, recurseTimes, keys[n], 0);
@@ -1105,7 +1115,7 @@ function formatMap(ctx, value, recurseTimes, keys) {
     output[i++] = `${formatValue(ctx, k, recurseTimes)} => ` +
       formatValue(ctx, v, recurseTimes);
   // See comment in formatSet
-  if (ctx.showHidden)
+  if (ctx.showHidden && !hasOwnProperty(value, 'size'))
     output[i++] = `[size]: ${ctx.stylize(`${value.size}`, 'number')}`;
   for (var n = 0; n < keys.length; n++) {
     output[i++] = formatProperty(ctx, value, recurseTimes, keys[n], 0);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -143,6 +143,10 @@ for (const showHidden of [true, false]) {
                      '  byteOffset: 1,\n' +
                      '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
                      '  y: 1337 }');
+  Object.defineProperty(dv, 'buffer', { value: true, enumerable: true });
+  assert.strictEqual(util.inspect(dv, showHidden),
+                     'DataView { byteLength: 2, byteOffset: 1, y: 1337, ' +
+                       'buffer: true }');
 }
 
 // Now do the same checks but from a different context.
@@ -856,8 +860,17 @@ if (typeof Symbol !== 'undefined') {
   const set = new Set(['foo']);
   set.bar = 42;
   assert.strictEqual(
-    util.inspect(set, true),
+    util.inspect(set, { showHidden: true }),
     "Set { 'foo', [size]: 1, bar: 42 }"
+  );
+  Object.defineProperty(set, 'size', { value: null, enumerable: true });
+  assert.strictEqual(
+    util.inspect(set),
+    "Set { 'foo', bar: 42, size: null }"
+  );
+  assert.strictEqual(
+    util.inspect(set, { showHidden: true }),
+    "Set { 'foo', bar: 42, size: null }"
   );
 }
 


### PR DESCRIPTION
This prevents entries from showing up twice if they were set with
Object.defineProperty().

This is a bit tricky since setting these values hides relevent information. However, this is already the case and when inspecting the value with `showHidden: true` it visualizes these entries twice.

We might decide not to guard against this kind of tampering but I guess it does not hurt either.

It would also be possible to partially recover the original information and show that as well (e.g., the `size` property of a set or map). The question would be how to distinguish both properties, since they both would have the same name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
