### PR TITLE
util: mark special entries as such

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -758,14 +758,14 @@ function formatValue(ctx, value, recurseTimes) {
       if (ctx.showHidden) {
         formatter = formatWeakSet;
       } else {
-        extra = '<items unknown>';
+        extra = ctx.stylize('<items unknown>', 'special');
       }
     } else if (isWeakMap(value)) {
       braces[0] = `${getPrefix(constructor, tag, 'WeakMap')}{`;
       if (ctx.showHidden) {
         formatter = formatWeakMap;
       } else {
-        extra = '<items unknown>';
+        extra = ctx.stylize('<items unknown>', 'special');
       }
     } else if (types.isModuleNamespaceObject(value)) {
       braces[0] = `[${tag}] {`;
@@ -1210,14 +1210,18 @@ function formatPromise(ctx, value, recurseTimes, keys) {
   let output;
   const [state, result] = getPromiseDetails(value);
   if (state === kPending) {
-    output = ['<pending>'];
+    output = [ctx.stylize('<pending>', 'special')];
   } else {
     // Using `formatValue` is correct here without the need to fix the
     // indentation level.
     ctx.indentationLvl += 2;
     const str = formatValue(ctx, result, recurseTimes);
     ctx.indentationLvl -= 2;
-    output = [state === kRejected ? `<rejected> ${str}` : str];
+    output = [
+      state === kRejected ?
+        `${ctx.stylize('<rejected>', 'special')} ${str}` :
+        str
+    ];
   }
   for (var n = 0; n < keys.length; n++) {
     output.push(formatProperty(ctx, value, recurseTimes, keys[n], 0));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1647,3 +1647,30 @@ assert.strictEqual(inspect(new BigUint64Array([0n])), 'BigUint64Array [ 0n ]');
     '{ [Non\\nenumerable\\tkey]: true }'
   );
 }
+
+// Check for special colors.
+{
+  const special = inspect.colors[inspect.styles.special];
+  const string = inspect.colors[inspect.styles.string];
+
+  assert.strictEqual(
+    inspect(new WeakSet(), { colors: true }),
+    `WeakSet { \u001b[${special[0]}m<items unknown>\u001b[${special[1]}m }`
+  );
+  assert.strictEqual(
+    inspect(new WeakMap(), { colors: true }),
+    `WeakMap { \u001b[${special[0]}m<items unknown>\u001b[${special[1]}m }`
+  );
+  assert.strictEqual(
+    inspect(new Promise(() => {}), { colors: true }),
+    `Promise { \u001b[${special[0]}m<pending>\u001b[${special[1]}m }`
+  );
+
+  const rejection = Promise.reject('Oh no!');
+  assert.strictEqual(
+    inspect(rejection, { colors: true }),
+    `Promise { \u001b[${special[0]}m<rejected>\u001b[${special[1]}m ` +
+    `\u001b[${string[0]}m'Oh no!'\u001b[${string[1]}m }`
+  );
+  rejection.catch(() => {});
+}


### PR DESCRIPTION
This adds the color code to special entries if colors are active.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
