### PR TITLE
buffer: show hidden item count

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -683,8 +683,9 @@ Buffer.prototype[customInspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
   str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim();
-  if (this.length > max)
-    str += ' ... ';
+  const remaining = this.length - max;
+  if (remaining > 0)
+    str += ` ... ${remaining} more item${remaining > 1 ? 's' : ''}`;
   return `<${this.constructor.name} ${str}>`;
 };
 Buffer.prototype.inspect = Buffer.prototype[customInspectSymbol];

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -685,7 +685,7 @@ Buffer.prototype[customInspectSymbol] = function inspect() {
   str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim();
   const remaining = this.length - max;
   if (remaining > 0)
-    str += ` ... ${remaining} more item${remaining > 1 ? 's' : ''}`;
+    str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
   return `<${this.constructor.name} ${str}>`;
 };
 Buffer.prototype.inspect = Buffer.prototype[customInspectSymbol];

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -33,7 +33,7 @@ b.fill('1234');
 let s = buffer.SlowBuffer(4);
 s.fill('1234');
 
-let expected = '<Buffer 31 32 ... 2 more items>';
+let expected = '<Buffer 31 32 ... 2 more bytes>';
 
 assert.strictEqual(util.inspect(b), expected);
 assert.strictEqual(util.inspect(s), expected);

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -33,7 +33,7 @@ b.fill('1234');
 let s = buffer.SlowBuffer(4);
 s.fill('1234');
 
-let expected = '<Buffer 31 32 ... >';
+let expected = '<Buffer 31 32 ... 2 more items>';
 
 assert.strictEqual(util.inspect(b), expected);
 assert.strictEqual(util.inspect(s), expected);

--- a/test/parallel/test-buffer-prototype-inspect.js
+++ b/test/parallel/test-buffer-prototype-inspect.js
@@ -19,5 +19,5 @@ const util = require('util');
 
 {
   const buf = Buffer.from('x'.repeat(51));
-  assert.ok(/^<Buffer (?:78 ){50}\.\.\. 1 more item>$/.test(util.inspect(buf)));
+  assert.ok(/^<Buffer (?:78 ){50}\.\.\. 1 more byte>$/.test(util.inspect(buf)));
 }

--- a/test/parallel/test-buffer-prototype-inspect.js
+++ b/test/parallel/test-buffer-prototype-inspect.js
@@ -19,5 +19,5 @@ const util = require('util');
 
 {
   const buf = Buffer.from('x'.repeat(51));
-  assert.ok(/^<Buffer (?:78 ){50}\.\.\. >$/.test(util.inspect(buf)));
+  assert.ok(/^<Buffer (?:78 ){50}\.\.\. 1 more item>$/.test(util.inspect(buf)));
 }


### PR DESCRIPTION
This adds the number of hidden items in case INSPECT_MAX_BYTES is
exceeded.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
