### PR TITLE
build: add test-doc to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ jstest: build-addons build-addons-napi ## Runs addon tests and JS tests
 test: all ## Runs default tests, linters, and builds docs.
 	@echo "Build the addons before running the tests so the test results"
 	@echo "can be displayed together"
+	$(MAKE) -s test-doc
 	$(MAKE) -s build-addons
 	$(MAKE) -s build-addons-napi
 	$(MAKE) -s cctest


### PR DESCRIPTION
This commit adds the test-doc target to the test recipe so that docs are
built and linters run. This used to happen but was removed at some
point.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
