### PR TITLE
test,doc: fix async-hooks coverage doc for md lint (v10.x backport problem)

### DIFF
--- a/test/async-hooks/coverage.md
+++ b/test/async-hooks/coverage.md
@@ -2,31 +2,31 @@
 
 Showing which kind of async resource is covered by which test:
 
-| Resource Type        | Test                                   |
-|----------------------|----------------------------------------|
-| CONNECTION           | test-connection.ssl.js                 |
-| FSEVENTWRAP          | test-fseventwrap.js                    |
-| FSREQWRAP            | test-fsreqwrap-{access,readFile}.js    |
-| GETADDRINFOREQWRAP   | test-getaddrinforeqwrap.js             |
-| GETNAMEINFOREQWRAP   | test-getnameinforeqwrap.js             |
-| HTTPPARSER           | test-httpparser.{request,response}.js  |
-| Immediate            | test-immediate.js                      |
-| JSSTREAM             | TODO (crashes when accessing directly) |
-| PBKDF2REQUEST        | test-crypto-pbkdf2.js                  |
-| PIPECONNECTWRAP      | test-pipeconnectwrap.js                |
-| PIPEWRAP             | test-pipewrap.js                       |
-| PROCESSWRAP          | test-pipewrap.js                       |
-| QUERYWRAP            | test-querywrap.js                      |
-| RANDOMBYTESREQUEST   | test-crypto-randomBytes.js             |
-| SHUTDOWNWRAP         | test-shutdownwrap.js                   |
-| SIGNALWRAP           | test-signalwrap.js                     |
-| STATWATCHER          | test-statwatcher.js                    |
-| TCPCONNECTWRAP       | test-tcpwrap.js                        |
-| TCPWRAP              | test-tcpwrap.js                        |
-| TIMERWRAP            | test-timerwrap.set{Timeout,Interval}.js|
-| TLSWRAP              | test-tlswrap.js                        |
-| TTYWRAP              | test-ttywrap.{read,write}stream.js     |
-| UDPSENDWRAP          | test-udpsendwrap.js                    |
-| UDPWRAP              | test-udpwrap.js                        |
-| WRITEWRAP            | test-writewrap.js                      |
-| ZLIB                 | test-zlib.zlib-binding.deflate.js      |
+| Resource Type        | Test                                    |
+|----------------------|-----------------------------------------|
+| CONNECTION           | test-connection.ssl.js                  |
+| FSEVENTWRAP          | test-fseventwrap.js                     |
+| FSREQWRAP            | test-fsreqwrap-{access,readFile}.js     |
+| GETADDRINFOREQWRAP   | test-getaddrinforeqwrap.js              |
+| GETNAMEINFOREQWRAP   | test-getnameinforeqwrap.js              |
+| HTTPPARSER           | test-httpparser.{request,response}.js   |
+| Immediate            | test-immediate.js                       |
+| JSSTREAM             | TODO (crashes when accessing directly)  |
+| PBKDF2REQUEST        | test-crypto-pbkdf2.js                   |
+| PIPECONNECTWRAP      | test-pipeconnectwrap.js                 |
+| PIPEWRAP             | test-pipewrap.js                        |
+| PROCESSWRAP          | test-pipewrap.js                        |
+| QUERYWRAP            | test-querywrap.js                       |
+| RANDOMBYTESREQUEST   | test-crypto-randomBytes.js              |
+| SHUTDOWNWRAP         | test-shutdownwrap.js                    |
+| SIGNALWRAP           | test-signalwrap.js                      |
+| STATWATCHER          | test-statwatcher.js                     |
+| TCPCONNECTWRAP       | test-tcpwrap.js                         |
+| TCPWRAP              | test-tcpwrap.js                         |
+| TIMERWRAP            | test-timerwrap.set{Timeout,Interval}.js |
+| TLSWRAP              | test-tlswrap.js                         |
+| TTYWRAP              | test-ttywrap.{read,write}stream.js      |
+| UDPSENDWRAP          | test-udpsendwrap.js                     |
+| UDPWRAP              | test-udpwrap.js                         |
+| WRITEWRAP            | test-writewrap.js                       |
+| ZLIB                 | test-zlib.zlib-binding.deflate.js       |


### PR DESCRIPTION
https://github.com/nodejs/node/pull/20894 / 2930bd1317 was introduced on master which removed an offending line in this doc before linting was applied to test/ in https://github.com/nodejs/node/pull/22221 / 56103aba59. Since #20894 is semver-major, the full changes were not
backported.

It's either this or back out the md linting for test/ on v10.x for now I think.

Note that the change that applies lint-md to test/ isn't on v10.x-staging yet, nor are the other changes required to get test/ up to scratch, they're on the release proposal for 10.9.0 @ #22295 though. I'll put this on top of the rest of those commits and it'll be happy (have confirmed this, manually, CI won't tell us anything interesting about this PR as is).

@Trott you're probably the best person to look at this.
