### PR TITLE
worker: remove redundant function call to `setupPortReferencing` in `setupChild`

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -408,7 +408,6 @@ function setupChild(evalScript) {
     if (message.type === messageTypes.LOAD_SCRIPT) {
       const { filename, doEval, workerData, publicPort, hasStdin } = message;
       publicWorker.parentPort = publicPort;
-      setupPortReferencing(publicPort, publicPort, 'message');
       publicWorker.workerData = workerData;
 
       if (!hasStdin)

--- a/test/parallel/test-worker-parent-port-ref.js
+++ b/test/parallel/test-worker-parent-port-ref.js
@@ -1,0 +1,25 @@
+// Flags: --experimental-worker
+'use strict';
+const assert = require('assert');
+const common = require('../common');
+const { isMainThread, parentPort, Worker } = require('worker_threads');
+
+// This test makes sure that we manipulate the references of
+// `parentPort` correctly so that any worker threads will
+// automatically exit when there are no any other references.
+{
+  if (isMainThread) {
+    const worker = new Worker(__filename);
+
+    worker.on('exit', common.mustCall((code) => {
+      assert.strictEqual(code, 0);
+    }), 1);
+
+    worker.on('online', common.mustCall());
+  } else {
+    const messageCallback = () => {};
+    parentPort.on('message', messageCallback);
+    // The thread won't exit if we don't make the 'message' listener off.
+    parentPort.off('message', messageCallback);
+  }
+}


### PR DESCRIPTION
There is no need to call `setupPortReferencing` in `setupChild` as which has been called with the same arguments in the `oninit` prototype method of `MessagePort`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
