### PR TITLE
test: rename some disturbing allegories

### DIFF
--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -70,7 +70,7 @@ if (process.argv[2] !== 'child') {
                   TIMEOUT);
     console.error('[PARENT] Fail');
 
-    killChildren(workers);
+    killSubprocesses(workers);
 
     process.exit(1);
   }, TIMEOUT);
@@ -102,7 +102,7 @@ if (process.argv[2] !== 'child') {
           console.error('[PARENT] All workers have died.');
           console.error('[PARENT] Fail');
 
-          killChildren(workers);
+          killSubprocesses(workers);
 
           process.exit(1);
         }
@@ -155,7 +155,7 @@ if (process.argv[2] !== 'child') {
 
             clearTimeout(timer);
             console.error('[PARENT] Success');
-            killChildren(workers);
+            killSubprocesses(workers);
           }
         }
       });
@@ -203,10 +203,10 @@ if (process.argv[2] !== 'child') {
     );
   };
 
-  function killChildren(children) {
-    Object.keys(children).forEach(function(key) {
-      const child = children[key];
-      child.kill();
+  function killSubprocesses(subprocesses) {
+    Object.keys(subprocesses).forEach(function(key) {
+      const subprocess = subprocesses[key];
+      subprocess.kill();
     });
   }
 }

--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -116,16 +116,16 @@ function launchChildProcess() {
 
         clearTimeout(timer);
         console.error('[PARENT] Success');
-        killChildren(workers);
+        killSubprocesses(workers);
       }
     }
   });
 }
 
-function killChildren(children) {
-  Object.keys(children).forEach(function(key) {
-    const child = children[key];
-    child.kill();
+function killSubprocesses(subprocesses) {
+  Object.keys(subprocesses).forEach(function(key) {
+    const subprocess = subprocesses[key];
+    subprocess.kill();
   });
 }
 
@@ -141,7 +141,7 @@ if (process.argv[2] !== 'child') {
                   TIMEOUT);
     console.error('[PARENT] Fail');
 
-    killChildren(workers);
+    killSubprocesses(workers);
 
     process.exit(1);
   }, TIMEOUT);

--- a/test/internet/test-dgram-multicast-set-interface-lo.js
+++ b/test/internet/test-dgram-multicast-set-interface-lo.js
@@ -89,7 +89,7 @@ if (process.argv[2] !== 'child') {
                   TIMEOUT);
     console.error('[PARENT] Skip');
 
-    killChildren(workers);
+    killSubprocesses(workers);
     common.skip('Check filter policy');
 
     process.exit(1);
@@ -132,7 +132,7 @@ if (process.argv[2] !== 'child') {
         console.error('[PARENT] All workers have died.');
         console.error('[PARENT] Fail');
 
-        killChildren(workers);
+        killSubprocesses(workers);
 
         process.exit(1);
       }
@@ -187,7 +187,7 @@ if (process.argv[2] !== 'child') {
 
           clearTimeout(timer);
           console.error('[PARENT] Success');
-          killChildren(workers);
+          killSubprocesses(workers);
         }
       }
     });
@@ -239,9 +239,9 @@ if (process.argv[2] !== 'child') {
     );
   };
 
-  function killChildren(children) {
-    for (const i in children)
-      children[i].kill();
+  function killSubprocesses(subprocesses) {
+    for (const i in subprocesses)
+      subprocesses[i].kill();
   }
 }
 

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -122,7 +122,7 @@ if (process.argv[2] === 'child') {
     while (j--) {
       const client = net.connect(this.address().port, '127.0.0.1');
       client.on('error', function() {
-        // This can happen if we kill the child too early.
+        // This can happen if we kill the subprocess too early.
         // The client should still get a close event afterwards.
         console.error('[m] CLIENT: error event');
       });

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -53,7 +53,7 @@ function test() {
   function next() {
     console.error('output from parent = %s', json);
     const child = JSON.parse(json);
-    // now make sure that we can request to the child, then kill it.
+    // now make sure that we can request to the subprocess, then kill it.
     http.get({
       server: 'localhost',
       port: child.port,
@@ -64,7 +64,7 @@ function test() {
         s += c.toString();
       });
       res.on('end', function() {
-        // kill the child before we start doing asserts.
+        // kill the subprocess before we start doing asserts.
         // it's really annoying when tests leave orphans!
         process.kill(child.pid, 'SIGKILL');
         try {

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -53,7 +53,7 @@ function test() {
   function next() {
     console.error('output from parent = %s', json);
     const child = JSON.parse(json);
-    // now make sure that we can request to the child, then kill it.
+    // now make sure that we can request to the subprocess, then kill it.
     http.get({
       server: 'localhost',
       port: child.port,
@@ -64,7 +64,7 @@ function test() {
         s += c.toString();
       });
       res.on('end', function() {
-        // kill the child before we start doing asserts.
+        // kill the subprocess before we start doing asserts.
         // it's really annoying when tests leave orphans!
         process.kill(child.pid, 'SIGKILL');
         try {

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -44,7 +44,7 @@ process.on('exit', function() {
 // concurrency in HTTP servers!  Use the cluster module, or if you want
 // a more low-level approach, use child process IPC manually.
 test(function(child, port) {
-  // now make sure that we can request to the child, then kill it.
+  // now make sure that we can request to the subprocess, then kill it.
   http.get({
     server: 'localhost',
     port: port,

--- a/test/sequential/test-child-process-fork-getconnections.js
+++ b/test/sequential/test-child-process-fork-getconnections.js
@@ -58,8 +58,8 @@ if (process.argv[2] === 'child') {
   const child = fork(process.argv[1], ['child']);
 
   child.on('exit', function(code, signal) {
-    if (!childKilled)
-      throw new Error('child died unexpectedly!');
+    if (!subprocessKilled)
+      throw new Error('subprocess died unexpectedly!');
   });
 
   const server = net.createServer();
@@ -86,10 +86,10 @@ if (process.argv[2] === 'child') {
     }
   });
 
-  let childKilled = false;
+  let subprocessKilled = false;
   function closeSockets(i) {
     if (i === count) {
-      childKilled = true;
+      subprocessKilled = true;
       server.close();
       child.kill();
       return;


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This somehow hit me in https://github.com/nodejs/node/issues/22303, so I thought we could do the same we had done for the `child_process` doc. I've renamed only some cases where renaming impact was not so big.