### PR TITLE
src: extract common DoBind and DoConnect methods

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -239,7 +239,9 @@ void TCPWrap::Bind(
   unsigned int flags = 0;
   if (!args[1]->Int32Value(env->context()).To(&port)) return;
   if (family == AF_INET6 &&
-      !args[2]->Uint32Value(env->context()).To(&flags)) return;
+      !args[2]->Uint32Value(env->context()).To(&flags)) {
+    return;
+  }
 
   T addr;
   int err = uv_ip_addr(*ip_address, port, &addr);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -224,8 +224,11 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-
-void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
+template <typename T>
+void TCPWrap::Bind(
+    const FunctionCallbackInfo<Value>& args,
+    int family,
+    std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
@@ -233,37 +236,29 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   Environment* env = wrap->env();
   node::Utf8Value ip_address(env->isolate(), args[0]);
   int port;
+  unsigned int flags = 0;
   if (!args[1]->Int32Value(env->context()).To(&port)) return;
-  sockaddr_in addr;
-  int err = uv_ip4_addr(*ip_address, port, &addr);
-  if (err == 0) {
-    err = uv_tcp_bind(&wrap->handle_,
-                      reinterpret_cast<const sockaddr*>(&addr),
-                      0);
-  }
-  args.GetReturnValue().Set(err);
-}
+  if (family == AF_INET6 &&
+      !args[2]->Uint32Value(env->context()).To(&flags)) return;
 
+  T addr;
+  int err = uv_ip_addr(*ip_address, port, &addr);
 
-void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
-  TCPWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap,
-                          args.Holder(),
-                          args.GetReturnValue().Set(UV_EBADF));
-  Environment* env = wrap->env();
-  node::Utf8Value ip6_address(env->isolate(), args[0]);
-  int port;
-  unsigned int flags;
-  if (!args[1]->Int32Value(env->context()).To(&port)) return;
-  if (!args[2]->Uint32Value(env->context()).To(&flags)) return;
-  sockaddr_in6 addr;
-  int err = uv_ip6_addr(*ip6_address, port, &addr);
   if (err == 0) {
     err = uv_tcp_bind(&wrap->handle_,
                       reinterpret_cast<const sockaddr*>(&addr),
                       flags);
   }
   args.GetReturnValue().Set(err);
+}
+
+void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
+  Bind<sockaddr_in>(args, AF_INET, uv_ip4_addr);
+}
+
+
+void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
+  Bind<sockaddr_in6>(args, AF_INET6, uv_ip6_addr);
 }
 
 

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -79,6 +79,11 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args,
       std::function<int(const char* ip_address, T* addr)> uv_ip_addr);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
+  template <typename T>
+  static void Bind(
+      const v8::FunctionCallbackInfo<v8::Value>& args,
+      int family,
+      std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr);
 
 #ifdef _WIN32
   static void SetSimultaneousAccepts(


### PR DESCRIPTION
`TCPWrap::Bind` and `TCPWrap::Bind6` share a large amount of functionality, so a common `DoBind` was extracted to remove duplication. `TCPWrap::Connect`/`TCPWrap::Connect6` follow this same pattern, so `DoConnect` was extracted from those two methods to also remove duplication. 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)