### PR TITLE
http2: move process.binding('http2') to internalBinding

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const Stream = require('stream');
 const Readable = Stream.Readable;
-const binding = process.binding('http2');
+const binding = internalBinding('http2');
 const constants = binding.constants;
 const {
   ERR_HTTP2_HEADERS_SENT,

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -10,6 +10,7 @@ const {
 
 assertCrypto();
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const assert = require('assert');
 const EventEmitter = require('events');
 const fs = require('fs');
@@ -31,7 +32,6 @@ const {
     owner_symbol,
   },
 } = require('internal/async_hooks');
-const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   codes: {
     ERR_HTTP2_ALTSVC_INVALID_ORIGIN,
@@ -114,7 +114,7 @@ const {
 const { isArrayBufferView } = require('internal/util/types');
 
 const { FileHandle } = process.binding('fs');
-const binding = process.binding('http2');
+const binding = internalBinding('http2');
 const { ShutdownWrap } = process.binding('stream_wrap');
 const { UV_EOF } = internalBinding('uv');
 

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const binding = process.binding('http2');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const binding = internalBinding('http2');
 const {
   ERR_HTTP2_HEADER_SINGLE_VALUE,
   ERR_HTTP2_INVALID_CONNECTION_HEADERS,

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -80,10 +80,11 @@ let sessionStats;
 let streamStats;
 
 function collectHttp2Stats(entry) {
+  const http2 = internalBinding('http2');
   switch (entry.name) {
     case 'Http2Stream':
       if (streamStats === undefined)
-        streamStats = process.binding('http2').streamStats;
+        streamStats = http2.streamStats;
       entry.id =
         streamStats[IDX_STREAM_STATS_ID] >>> 0;
       entry.timeToFirstByte =
@@ -99,7 +100,7 @@ function collectHttp2Stats(entry) {
       break;
     case 'Http2Session':
       if (sessionStats === undefined)
-        sessionStats = process.binding('http2').sessionStats;
+        sessionStats = http2.sessionStats;
       entry.type =
         sessionStats[IDX_SESSION_STATS_TYPE] >>> 0 === 0 ? 'server' : 'client';
       entry.pingRTT =

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2999,4 +2999,4 @@ HTTP_STATUS_CODES(V)
 }  // namespace http2
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(http2, node::http2::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(http2, node::http2::Initialize)

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -1,11 +1,13 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
 
-const binding = process.binding('http2');
+const binding = internalBinding('http2');
 const http2 = require('http2');
 
 assert(binding.Http2Session);

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -5,11 +5,12 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const { internalBinding } = require('internal/test/binding');
 const {
   constants,
   Http2Session,
   nghttp2ErrorString
-} = process.binding('http2');
+} = internalBinding('http2');
 const http2 = require('http2');
 const { NghttpError } = require('internal/http2/util');
 

--- a/test/parallel/test-http2-info-headers-errors.js
+++ b/test/parallel/test-http2-info-headers-errors.js
@@ -5,11 +5,12 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
+const { internalBinding } = require('internal/test/binding');
 const {
   constants,
   Http2Stream,
   nghttp2ErrorString
-} = process.binding('http2');
+} = internalBinding('http2');
 const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within additionalHeaders

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -5,7 +5,8 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
-const { Http2Stream } = process.binding('http2');
+const { internalBinding } = require('internal/test/binding');
+const { Http2Stream } = internalBinding('http2');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -5,11 +5,12 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
+const { internalBinding } = require('internal/test/binding');
 const {
   constants,
   Http2Stream,
   nghttp2ErrorString
-} = process.binding('http2');
+} = internalBinding('http2');
 const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within respond

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -10,11 +10,12 @@ const fixtures = require('../common/fixtures');
 
 const http2 = require('http2');
 
+const { internalBinding } = require('internal/test/binding');
 const {
   constants,
   Http2Stream,
   nghttp2ErrorString
-} = process.binding('http2');
+} = internalBinding('http2');
 const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within processRespondWithFD

--- a/test/parallel/test-http2-server-push-stream-errors.js
+++ b/test/parallel/test-http2-server-push-stream-errors.js
@@ -5,11 +5,12 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
+const { internalBinding } = require('internal/test/binding');
 const {
   constants,
   Http2Stream,
   nghttp2ErrorString
-} = process.binding('http2');
+} = internalBinding('http2');
 const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within pushStream

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const { mapToHeaders, toHeaderObject } = require('internal/http2/util');
-
+const { internalBinding } = require('internal/test/binding');
 const {
   HTTP2_HEADER_STATUS,
   HTTP2_HEADER_METHOD,
@@ -88,7 +88,7 @@ const {
   HTTP2_HEADER_HOST,
   HTTP2_HEADER_KEEP_ALIVE,
   HTTP2_HEADER_PROXY_CONNECTION
-} = process.binding('http2').constants;
+} = internalBinding('http2').constants;
 
 {
   const headers = {

--- a/test/parallel/test-http2-util-update-options-buffer.js
+++ b/test/parallel/test-http2-util-update-options-buffer.js
@@ -9,7 +9,8 @@ if (!common.hasCrypto)
 // by the http2 implementation.
 
 const { updateOptionsBuffer } = require('internal/http2/util');
-const { optionsBuffer } = process.binding('http2');
+const { internalBinding } = require('internal/test/binding');
+const { optionsBuffer } = internalBinding('http2');
 const { ok, strictEqual } = require('assert');
 
 const IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE = 0;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/22160

The `http2` module is still experimental.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
