### PR TITLE
deps: cherry-pick 9a23bdd from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,


### PR DESCRIPTION
Original commit message:

    [Isolate] Fix Isolate::PrintCurrentStackTrace for interpreted frames

    Previously we were getting the code object from the stack, so printed incorrect
    position details for interpreted frames.

    BUG=v8:7916

    Change-Id: I2f87584117d88b7db3f3b9bdbfe793c4d3e33fe9
    Reviewed-on: https://chromium-review.googlesource.com/1126313
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Ross McIlroy <rmcilroy@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#54253}

Refs: https://github.com/v8/v8/commit/9a23bdd7ea2eba9a7a4439a7844e72fbf42bb3c4
Fixes: https://github.com/nodejs/node/issues/21988

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
