### PR TITLE
tools: simplify ESLint invocation in Makefile

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -187,7 +187,7 @@ module.exports = {
         message: 'Use new keyword when throwing an Error.',
       }
     ],
-    /* eslint-enable max-len, quotes */
+    /* eslint-enable max-len */
     'no-return-await': 'error',
     'no-self-assign': 'error',
     'no-self-compare': 'error',

--- a/Makefile
+++ b/Makefile
@@ -1120,7 +1120,7 @@ endif
 LINT_JS_TARGETS = .eslintrc.js benchmark doc lib test tools
 
 run-lint-js = tools/node_modules/eslint/bin/eslint.js --cache \
-	--ext=.js,.mjs,.md $(LINT_JS_TARGETS) --ignore-pattern '!.eslintrc.js'
+	--ext=.js,.mjs,.md $(LINT_JS_TARGETS)
 run-lint-js-fix = $(run-lint-js) --fix
 
 .PHONY: lint-js-fix


### PR DESCRIPTION
Makefile currently enforces .eslintrc.js linting on the command line but
it is already enforced in the .estlintignore file.

This also simplifies an arguably-related comment in .estlinrc.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
