### PR TITLE
build: touch tools/doc/node_modules after run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1073,6 +1073,7 @@ lint-md-build: tools/remark-cli/node_modules \
 tools/doc/node_modules: tools/doc/package.json
 ifeq ($(node_use_openssl),true)
 	cd tools/doc && $(call available-node,$(run-npm-install))
+	@touch $@
 else
 	@echo "Skipping tools/doc/node_modules (no crypto)"
 endif


### PR DESCRIPTION
Currently, tools/doc/node_modules is not touched after running npm
install resulting in npm install being run every time. I missed this
while testing commit 88bff82624628df261a429386d81565023062e44 ("build:
make tools/doc/node_modules non-phony").


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
