### PR TITLE
doc/api: clarify the documentation of pipes and zlib objects in them

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -895,8 +895,8 @@ added: v0.9.4
 * `destination` {stream.Writable} The destination for writing data
 * `options` {Object} Pipe options
   * `end` {boolean} End the writer when the reader ends. **Default:** `true`.
-* Returns: {stream.Writable} making it possible to set up chains of piped
-  streams
+* Returns: {stream.Writable} The *destination*, allowing for a chain of pipes if
+  it is a [`Duplex`][] stream
 
 The `readable.pipe()` method attaches a [`Writable`][] stream to the `readable`,
 causing it to switch automatically into flowing mode and push all of its data

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -397,6 +397,9 @@ added: v0.5.8
 Not exported by the `zlib` module. It is documented here because it is the base
 class of the compressor/decompressor classes.
 
+This class inherits from [`stream.Transform`][], allowing `zlib` objects to be
+used in pipes and similar stream operations.
+
 ### zlib.bytesRead
 <!-- YAML
 added: v8.1.0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I made a first attempt to change the documentation for #22341. I don't know why `stream.Transform` didn't turn into a link in `zlib.md`. Somebody else would need to fix that if you accept this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
