### PR TITLE
doc: Make createPushResponse() more detailled.

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3150,13 +3150,17 @@ will result in a [`TypeError`][] being thrown.
 added: v8.4.0
 -->
 * `headers` {HTTP/2 Headers Object} An object describing the headers
-* `callback` {Function}
+* `callback` {Function} Called once `http2stream.pushStream()` is finished,
+  or either when the attempt to create the pushed `Http2Stream` has failed or
+  has been rejected, or the state of `Http2ServerRequest` is closed prior to
+  calling the `http2stream.pushStream()` method
+  * `err` {Error}
+  * `stream` {ServerHttp2Stream} The newly-created `ServerHttp2Stream` object
 
-Call [`http2stream.pushStream()`][] with the given headers, and wraps the
-given newly created [`Http2Stream`] on `Http2ServerResponse`.
-
-The callback will be called with an error with code `ERR_HTTP2_INVALID_STREAM`
-if the stream is closed.
+Call [`http2stream.pushStream()`][] with the given headers, and wrap the
+given [`Http2Stream`] on a newly created `Http2ServerResponse` as the callback
+parameter if successful. When `Http2ServerRequest` is closed, the callback is
+called with an error `ERR_HTTP2_INVALID_STREAM`.
 
 ## Collecting HTTP/2 Performance Metrics
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/22322

In summary:
We don't know what will return when successful or failure for
the callback of the function. So make it more detailled.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
