### PR TITLE
test: add test unknown credential error of process.setgroups

### DIFF
--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -45,3 +45,10 @@ assert.throws(
     }
   );
 });
+
+assert.throws(() => {
+  process.setgroups([1, 'fhqwhgadshgnsdhjsdbkhsdabkfabkveyb']);
+}, {
+  code: 'ERR_UNKNOWN_CREDENTIAL',
+  message: 'Group identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
+});


### PR DESCRIPTION
Added test to check ERR_UNKNOWN_CREDENTIAL of `process.setgroups` to increase
coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
