### PR TITLE
test: remove third argument from assert.strictEqual()

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -979,7 +979,7 @@ if (typeof Symbol !== 'undefined') {
       const npos = line.search(numRE);
       if (npos !== -1) {
         if (pos !== undefined) {
-          assert.strictEqual(pos, npos, 'container items not aligned');
+          assert.strictEqual(pos, npos);
         }
         pos = npos;
       }


### PR DESCRIPTION
`test/parallel/test-util-inspect.js` has a call to
`assert.strictEqual()` that receives three arguments.
The third argument is a string literal. Unfortunately,
calling assert.strictEqual() this way means that if
there is an AssertionError, the value of the variables
pos and npos are not reported.
This PR removes this argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
