### PR TITLE
refactor: Use the indexOf array instead of four ===

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -263,7 +263,7 @@ function uvException(ctx) {
   const err = new Error(message);
 
   for (const prop of Object.keys(ctx)) {
-    if (prop === 'message' || prop === 'path' || prop === 'dest') {
+    if (['message', 'path', 'dest'].indexOf(prop) !== -1) {
       continue;
     }
     err[prop] = ctx[prop];

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -263,7 +263,7 @@ function uvException(ctx) {
   const err = new Error(message);
 
   for (const prop of Object.keys(ctx)) {
-    if (['message', 'path', 'dest'].indexOf(prop) !== -1) {
+    if (['message', 'path', 'dest'].includes(prop)) {
       continue;
     }
     err[prop] = ctx[prop];


### PR DESCRIPTION
Four `===` looks a little redundant

##### Checklist


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
