### PR TITLE
async_hooks: Adding regression test case for async/await

### DIFF
--- a/test/parallel/test-async-hooks-async-await.js
+++ b/test/parallel/test-async-hooks-async-await.js
@@ -1,0 +1,26 @@
+// Test async-hooks fired on right
+// asyncIds & triggerAsyncId for async-await
+'use strict';
+
+require('../common');
+const async_hooks = require('async_hooks');
+const assert = require('assert');
+
+const asyncIds = [];
+async_hooks.createHook({
+  init: (asyncId, type, triggerAsyncId) => {
+    asyncIds.push([triggerAsyncId, asyncId]);
+  }
+}).enable();
+
+async function main() {
+  await null;
+}
+
+main().then(() => {
+  // Verify the relationships between async ids
+  // 1 => 2, 2 => 3 etc
+  assert.strictEqual(asyncIds[0][1], asyncIds[1][0]);
+  assert.strictEqual(asyncIds[0][1], asyncIds[3][0]);
+  assert.strictEqual(asyncIds[1][1], asyncIds[2][0]);
+});


### PR DESCRIPTION
This https://github.com/nodejs/node/issues/20274#issuecomment-395200647 is fixed by V8 update. This PR adds a regression test case.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
