### PR TITLE
[v8.x backport] doc: fix/add link to Android info

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -324,7 +324,7 @@ Equivalent to [`process.platform`][].
 
 *Note*: The value `'android'` may also be returned if the Node.js is built on
 the Android operating system. However, Android support in Node.js is considered
-to be experimental at this time.
+[to be experimental][Android building] at this time.
 
 ## os.release()
 <!-- YAML
@@ -1185,4 +1185,5 @@ The following error codes are specific to the Windows operating system:
 
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
+[Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [uname(3)]: https://linux.die.net/man/3/uname

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1394,7 +1394,7 @@ console.log(`This platform is ${process.platform}`);
 
 The value `'android'` may also be returned if the Node.js is built on the
 Android operating system. However, Android support in Node.js
-[is experimental][Supported platforms].
+[is experimental][Android building].
 
 ## process.ppid
 <!-- YAML
@@ -1921,6 +1921,7 @@ cases:
 [`promise.catch()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
 [`require.main`]: modules.html#modules_accessing_the_main_module
 [`setTimeout(fn, 0)`]: timers.html#timers_settimeout_callback_delay_args
+[Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [Child Process]: child_process.html
 [Cluster]: cluster.html
 [debugger]: debugger.html
@@ -1932,6 +1933,5 @@ cases:
 [Readable]: stream.html#stream_readable_streams
 [Signal Events]: #process_signal_events
 [Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
-[Supported platforms]: https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1
 [TTY]: tty.html#tty_tty
 [Writable]: stream.html#stream_writable_streams


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Backport of #19004
