### PR TITLE
os: destructure ERR_SYSTEM_ERROR properly

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -26,7 +26,7 @@ const constants = process.binding('constants').os;
 const { deprecate } = require('internal/util');
 const isWindows = process.platform === 'win32';
 
-const { ERR_SYSTEM_ERROR } = require('internal/errors');
+const { codes: { ERR_SYSTEM_ERROR } } = require('internal/errors');
 
 const {
   getCPUs,

--- a/test/parallel/test-os-checked-function.js
+++ b/test/parallel/test-os-checked-function.js
@@ -1,0 +1,15 @@
+'use strict';
+// Monkey patch the os binding before requiring any other modules, including
+// common, which requires the os module.
+process.binding('os').getHomeDirectory = function(ctx) {
+  ctx.syscall = 'foo';
+  ctx.code = 'bar';
+  ctx.message = 'baz';
+};
+
+const common = require('../common');
+const os = require('os');
+
+common.expectsError(os.homedir, {
+  message: /^A system error occurred: foo returned bar \(baz\)$/
+});


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
