### PR TITLE
doc: unify optional arguments format in headings

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -265,7 +265,7 @@ Calling `socket.ref()` multiples times will have no additional effect.
 The `socket.ref()` method returns a reference to the socket so calls can be
 chained.
 
-### socket.send(msg, [offset, length,] port [, address] [, callback])
+### socket.send(msg[, offset, length], port[, address][, callback])
 <!-- YAML
 added: v0.1.99
 changes:

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -349,7 +349,7 @@ Will be `true` if this `Http2Session` instance is still connecting, will be set
 to `false` before emitting `connect` event and/or calling the `http2.connect`
 callback.
 
-#### http2session.destroy([error,][code])
+#### http2session.destroy([error][, code])
 <!-- YAML
 added: v8.4.0
 -->
@@ -392,7 +392,7 @@ connected, `true` if the `Http2Session` is connected with a `TLSSocket`,
 and `false` if the `Http2Session` is connected to any other kind of socket
 or stream.
 
-#### http2session.goaway([code, [lastStreamID, [opaqueData]]])
+#### http2session.goaway([code[, lastStreamID[, opaqueData]]])
 <!-- YAML
 added: v9.4.0
 -->

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -433,7 +433,7 @@ buffered but not yet executed. This method is primarily intended to be
 called from within the action function for commands registered using the
 `replServer.defineCommand()` method.
 
-### replServer.parseREPLKeyword(keyword, [rest])
+### replServer.parseREPLKeyword(keyword[, rest])
 <!-- YAML
 added: v0.8.9
 deprecated: v9.0.0

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -435,7 +435,7 @@ added: v0.9.4
 
 Close the underlying handle.
 
-### zlib.flush([kind], callback)
+### zlib.flush([kind, ]callback)
 <!-- YAML
 added: v0.5.8
 -->


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Make space and comma distribution in some headings consistent with the majority of headings.

