### PR TITLE
perf_hooks: move strings to env

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -148,10 +148,12 @@ struct PackageConfig {
   V(dns_soa_string, "SOA")                                                    \
   V(dns_srv_string, "SRV")                                                    \
   V(dns_txt_string, "TXT")                                                    \
+  V(duration_string, "duration")                                              \
   V(emit_warning_string, "emitWarning")                                       \
   V(exchange_string, "exchange")                                              \
   V(encoding_string, "encoding")                                              \
   V(entries_string, "entries")                                                \
+  V(entry_type_string, "entryType")                                           \
   V(env_pairs_string, "envPairs")                                             \
   V(errno_string, "errno")                                                    \
   V(error_string, "error")                                                    \
@@ -187,6 +189,7 @@ struct PackageConfig {
   V(issuer_string, "issuer")                                                  \
   V(issuercert_string, "issuerCertificate")                                   \
   V(kill_signal_string, "killSignal")                                         \
+  V(kind_string, "kind")                                                      \
   V(mac_string, "mac")                                                        \
   V(main_string, "main")                                                      \
   V(max_buffer_string, "maxBuffer")                                           \
@@ -270,6 +273,7 @@ struct PackageConfig {
   V(sni_context_string, "sni_context")                                        \
   V(source_string, "source")                                                  \
   V(stack_string, "stack")                                                    \
+  V(start_time_string, "startTime")                                           \
   V(status_string, "status")                                                  \
   V(stdio_string, "stdio")                                                    \
   V(subject_string, "subject")                                                \

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -80,7 +80,7 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
                          attr)
       .FromJust();
   obj->DefineOwnProperty(context,
-                         FIXED_ONE_BYTE_STRING(isolate, "entryType"),
+                         env->entry_type_string(),
                          String::NewFromUtf8(isolate,
                                              entry.type().c_str(),
                                              v8::NewStringType::kNormal)
@@ -88,11 +88,11 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
                          attr)
       .FromJust();
   obj->DefineOwnProperty(context,
-                         FIXED_ONE_BYTE_STRING(isolate, "startTime"),
+                         env->start_time_string(),
                          Number::New(isolate, entry.startTime()),
                          attr).FromJust();
   obj->DefineOwnProperty(context,
-                         FIXED_ONE_BYTE_STRING(isolate, "duration"),
+                         env->duration_string(),
                          Number::New(isolate, entry.duration()),
                          attr).FromJust();
 }
@@ -249,7 +249,7 @@ void PerformanceGCCallback(Environment* env, void* ptr) {
     v8::PropertyAttribute attr =
         static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
     obj->DefineOwnProperty(context,
-                           FIXED_ONE_BYTE_STRING(env->isolate(), "kind"),
+                           env->kind_string(),
                            Integer::New(env->isolate(), entry->gckind()),
                            attr).FromJust();
     PerformanceEntry::Notify(env, entry->kind(), obj);


### PR DESCRIPTION
Move repeatedly created strings to env


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
