### PR TITLE
vm: move process.binding('contextify') to internalBinding

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -107,7 +107,7 @@
     };
   }
 
-  const { ContextifyScript } = process.binding('contextify');
+  const { ContextifyScript } = internalBinding('contextify');
 
   // Set up NativeModule
   function NativeModule(id) {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -351,7 +351,8 @@
         'v8',
         'stream_wrap',
         'signal_wrap',
-        'crypto']);
+        'crypto',
+        'contextify']);
     process.binding = function binding(name) {
       return internalBindingWhitelist.has(name) ?
         internalBinding(name) :

--- a/lib/internal/vm/source_text_module.js
+++ b/lib/internal/vm/source_text_module.js
@@ -2,7 +2,7 @@
 
 const { internalBinding } = require('internal/bootstrap/loaders');
 const { URL } = require('internal/url');
-const { isContext } = process.binding('contextify');
+const { isContext } = internalBinding('contextify');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_ALREADY_LINKED,

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -21,11 +21,12 @@
 
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   ContextifyScript,
   makeContext,
   isContext: _isContext,
-} = process.binding('contextify');
+} = internalBinding('contextify');
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { isUint8Array } = require('internal/util/types');
 const { validateInt32, validateUint32 } = require('internal/validators');

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -958,4 +958,4 @@ void Initialize(Local<Object> target,
 }  // namespace contextify
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(contextify, node::contextify::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(contextify, node::contextify::Initialize)

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -11,3 +11,4 @@ assert(process.binding('http_parser'));
 assert(process.binding('v8'));
 assert(process.binding('stream_wrap'));
 assert(process.binding('signal_wrap'));
+assert(process.binding('contextify'));


### PR DESCRIPTION
Refs: #22160

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
