### PR TITLE
crypto: move process.binding('crypto') to internal

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -34,8 +34,8 @@ const { SSL_OP_CIPHER_SERVER_PREFERENCE } = process.binding('constants').crypto;
 // Lazily loaded
 var crypto = null;
 
-const { SecureContext: NativeSecureContext } = process.binding('crypto');
-
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { SecureContext: NativeSecureContext } = internalBinding('crypto');
 function SecureContext(secureProtocol, secureOptions, context) {
   if (!(this instanceof SecureContext)) {
     return new SecureContext(secureProtocol, secureOptions, context);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -36,9 +36,8 @@ const tls_wrap = process.binding('tls_wrap');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 const { owner_symbol } = require('internal/async_hooks').symbols;
-const {
-  SecureContext: NativeSecureContext
-} = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { SecureContext: NativeSecureContext } = internalBinding('crypto');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_MULTIPLE_CALLBACK,

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -30,6 +30,7 @@ const {
 } = require('internal/util');
 assertCrypto();
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   ERR_CRYPTO_FIPS_FORCED,
   ERR_CRYPTO_FIPS_UNAVAILABLE
@@ -39,10 +40,7 @@ const {
   fipsMode,
   fipsForced
 } = process.binding('config');
-const {
-  getFipsCrypto,
-  setFipsCrypto,
-} = process.binding('crypto');
+const { getFipsCrypto, setFipsCrypto } = internalBinding('crypto');
 const {
   randomBytes,
   randomFill,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -350,7 +350,8 @@
         'http_parser',
         'v8',
         'stream_wrap',
-        'signal_wrap']);
+        'signal_wrap',
+        'crypto']);
     process.binding = function binding(name) {
       return internalBindingWhitelist.has(name) ?
         internalBinding(name) :

--- a/lib/internal/crypto/certificate.js
+++ b/lib/internal/crypto/certificate.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   certExportChallenge,
   certExportPublicKey,
   certVerifySpkac
-} = process.binding('crypto');
+} = internalBinding('crypto');
 
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { isArrayBufferView } = require('internal/util/types');

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -19,13 +19,14 @@ const {
 
 const { isArrayBufferView } = require('internal/util/types');
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   CipherBase,
   privateDecrypt: _privateDecrypt,
   privateEncrypt: _privateEncrypt,
   publicDecrypt: _publicDecrypt,
   publicEncrypt: _publicEncrypt
-} = process.binding('crypto');
+} = internalBinding('crypto');
 
 const assert = require('assert');
 const LazyTransform = require('internal/streams/lazy_transform');

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -2,7 +2,8 @@
 
 const { AsyncWrap, Providers } = process.binding('async_wrap');
 const { Buffer } = require('buffer');
-const { INT_MAX, pbkdf2: _pbkdf2 } = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { INT_MAX, pbkdf2: _pbkdf2 } = internalBinding('crypto');
 const { validateInt32 } = require('internal/validators');
 const {
   ERR_CRYPTO_INVALID_DIGEST,

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -2,7 +2,8 @@
 
 const { AsyncWrap, Providers } = process.binding('async_wrap');
 const { Buffer, kMaxLength } = require('buffer');
-const { randomBytes: _randomBytes } = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { randomBytes: _randomBytes } = internalBinding('crypto');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK,

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -2,7 +2,8 @@
 
 const { AsyncWrap, Providers } = process.binding('async_wrap');
 const { Buffer } = require('buffer');
-const { INT_MAX, scrypt: _scrypt } = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { INT_MAX, scrypt: _scrypt } = internalBinding('crypto');
 const { validateInt32 } = require('internal/validators');
 const {
   ERR_CRYPTO_SCRYPT_INVALID_PARAMETER,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -5,10 +5,8 @@ const {
   ERR_INVALID_OPT_VALUE
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
-const {
-  Sign: _Sign,
-  Verify: _Verify
-} = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const { Sign: _Sign, Verify: _Verify } = internalBinding('crypto');
 const {
   RSA_PSS_SALTLEN_AUTO,
   RSA_PKCS1_PADDING

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const { internalBinding } = require('internal/bootstrap/loaders');
 const {
   getCiphers: _getCiphers,
   getCurves: _getCurves,
   getHashes: _getHashes,
   setEngine: _setEngine,
   timingSafeEqual: _timingSafeEqual
-} = process.binding('crypto');
+} = internalBinding('crypto');
 
 const {
   ENGINE_METHOD_ALL

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -29,7 +29,8 @@ const { isUint8Array } = require('internal/util/types');
 
 const net = require('net');
 const url = require('url');
-const binding = process.binding('crypto');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const binding = internalBinding('crypto');
 const { Buffer } = require('buffer');
 const EventEmitter = require('events');
 const { URL } = require('internal/url');

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5256,4 +5256,4 @@ void Initialize(Local<Object> target,
 }  // namespace crypto
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(crypto, node::crypto::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(crypto, node::crypto::Initialize)

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -6,7 +7,8 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-if (typeof process.binding('crypto').scrypt !== 'function')
+const { internalBinding } = require('internal/test/binding');
+if (typeof internalBinding('crypto').scrypt !== 'function')
   common.skip('no scrypt support');
 
 const good = [

--- a/test/parallel/test-tls-clientcertengine-unsupported.js
+++ b/test/parallel/test-tls-clientcertengine-unsupported.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 
@@ -5,7 +6,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 // Monkey-patch SecureContext
-const binding = process.binding('crypto');
+const { internalBinding } = require('internal/test/binding');
+const binding = internalBinding('crypto');
 const NativeSecureContext = binding.SecureContext;
 
 binding.SecureContext = function() {

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -122,7 +122,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
     testInitialized(this, 'AsyncWrap');
   }));
 
-  if (typeof process.binding('crypto').scrypt === 'function') {
+  if (typeof internalBinding('crypto').scrypt === 'function') {
     crypto.scrypt('password', 'salt', 8, common.mustCall(function() {
       testInitialized(this, 'AsyncWrap');
     }));


### PR DESCRIPTION
This commit makes the crypto builtin an internal builtin, and
changes usage of the builtin from using process.binding('crypto')
to use internalBinding instead.

Refs: https://github.com/nodejs/node/issues/22160

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
