### PR TITLE
test: properly extend process.env in child_process

### DIFF
--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -26,23 +26,21 @@ const os = require('os');
 
 const spawn = require('child_process').spawn;
 
-const env = {
+const env = Object.assign({}, process.env, {
   'HELLO': 'WORLD',
   'UNDEFINED': undefined,
   'NULL': null,
   'EMPTY': ''
-};
+});
 Object.setPrototypeOf(env, {
   'FOO': 'BAR'
 });
 
 let child;
 if (common.isWindows) {
-  child = spawn('cmd.exe', ['/c', 'set'],
-                Object.assign({}, process.env, { env }));
+  child = spawn('cmd.exe', ['/c', 'set'], { env });
 } else {
-  child = spawn('/usr/bin/env', [],
-                Object.assign({}, process.env, { env }));
+  child = spawn('/usr/bin/env', [], { env });
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~: no api has changed
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Options on `child_process.spawn` was not properly constructed for `process.env` not assigned to `options.env`.