### PR TITLE
repl: improve error output

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -404,29 +404,50 @@ function REPLServer(prompt,
 
   self._domain.on('error', function debugDomainError(e) {
     debug('domain error');
-    const top = replMap.get(self);
-    const pstrace = Error.prepareStackTrace;
-    Error.prepareStackTrace = prepareStackTrace(pstrace);
-    if (typeof e === 'object')
+    let errStack = '';
+
+    if (typeof e === 'object' && e !== null) {
+      const pstrace = Error.prepareStackTrace;
+      Error.prepareStackTrace = prepareStackTrace(pstrace);
       internalUtil.decorateErrorStack(e);
-    Error.prepareStackTrace = pstrace;
-    const isError = internalUtil.isError(e);
-    if (!self.underscoreErrAssigned)
+      Error.prepareStackTrace = pstrace;
+
+      if (e.domainThrown) {
+        delete e.domain;
+        delete e.domainThrown;
+      }
+
+      if (internalUtil.isError(e)) {
+        if (e.stack) {
+          if (e instanceof SyntaxError) {
+            // Remove stack trace.
+            e.stack = e.stack
+              .replace(/^repl:\d+\r?\n/, '')
+              .replace(/^\s+at\s.*\n?/gm, '');
+          } else if (self.replMode === exports.REPL_MODE_STRICT) {
+            e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
+                                      (_, pre, line) => pre + (line - 1));
+          }
+        }
+        errStack = util.inspect(e);
+
+        // Remove one line error braces to keep the old style in place.
+        if (errStack[errStack.length - 1] === ']') {
+          errStack = errStack.slice(1, -1);
+        }
+      }
+    }
+
+    if (errStack === '') {
+      errStack = `Thrown: ${util.inspect(e)}`;
+    }
+
+    if (!self.underscoreErrAssigned) {
       self.lastError = e;
-    if (e instanceof SyntaxError && e.stack) {
-      // remove repl:line-number and stack trace
-      e.stack = e.stack
-        .replace(/^repl:\d+\r?\n/, '')
-        .replace(/^\s+at\s.*\n?/gm, '');
-    } else if (isError && self.replMode === exports.REPL_MODE_STRICT) {
-      e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
-                                (_, pre, line) => pre + (line - 1));
     }
-    if (isError && e.stack) {
-      top.outputStream.write(`${e.stack}\n`);
-    } else {
-      top.outputStream.write(`Thrown: ${String(e)}\n`);
-    }
+
+    const top = replMap.get(self);
+    top.outputStream.write(`${errStack}\n`);
     top.clearBufferedCommand();
     top.lines.level = [];
     top.displayPrompt();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -339,11 +339,6 @@ function REPLServer(prompt,
       } catch (e) {
         err = e;
 
-        if (err && err.code === 'ERR_SCRIPT_EXECUTION_INTERRUPTED') {
-          // The stack trace for this case is not very useful anyway.
-          Object.defineProperty(err, 'stack', { value: '' });
-        }
-
         if (process.domain) {
           debug('not recoverable, send to domain');
           process.domain.emit('error', err);
@@ -359,7 +354,11 @@ function REPLServer(prompt,
         if (self.breakEvalOnSigint) {
           const interrupt = new Promise((resolve, reject) => {
             sigintListener = () => {
-              reject(new ERR_SCRIPT_EXECUTION_INTERRUPTED());
+              const tmp = Error.stackTraceLimit;
+              Error.stackTraceLimit = 0;
+              const err = new ERR_SCRIPT_EXECUTION_INTERRUPTED();
+              Error.stackTraceLimit = tmp;
+              reject(err);
             };
             prioritizedSigintQueue.add(sigintListener);
           });
@@ -377,11 +376,6 @@ function REPLServer(prompt,
         }, (err) => {
           // Remove prioritized SIGINT listener if it was not called.
           prioritizedSigintQueue.delete(sigintListener);
-
-          if (err.code === 'ERR_SCRIPT_EXECUTION_INTERRUPTED') {
-            // The stack trace for this case is not very useful anyway.
-            Object.defineProperty(err, 'stack', { value: '' });
-          }
 
           unpause();
           if (err && process.domain) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -413,7 +413,7 @@ function REPLServer(prompt,
 
       if (internalUtil.isError(e)) {
         if (e.stack) {
-          if (e instanceof SyntaxError) {
+          if (e.name === 'SyntaxError') {
             // Remove stack trace.
             e.stack = e.stack
               .replace(/^repl:\d+\r?\n/, '')

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -158,7 +158,7 @@ async function ctrlCTest() {
     { ctrl: true, name: 'c' }
   ]), [
     'await timeout(100000)\r',
-    'Thrown: Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
+    'Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
       'Script execution was interrupted by `SIGINT`',
     PROMPT
   ]);

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -177,8 +177,12 @@ function testError() {
       '[Error: foo]',
 
       // The sync error, with individual property echoes
-      /Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
+      /^{ Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
       /Object\.readdirSync/,
+      '  errno: -2,',
+      "  syscall: 'scandir',",
+      "  code: 'ENOENT',",
+      "  path: '/nonexistent?' }",
       "'ENOENT'",
       "'scandir'",
 

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -179,7 +179,7 @@ function testError() {
       // The sync error, with individual property echoes
       /^{ Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
       /Object\.readdirSync/,
-      '  errno: -2,',
+      /^  errno: -(2|4058),$/,
       "  syscall: 'scandir',",
       "  code: 'ENOENT',",
       "  path: '/nonexistent?' }",

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -132,7 +132,11 @@ const errorTests = [
   // Uncaught error throws and prints out
   {
     send: 'throw new Error(\'test error\');',
-    expect: /^Error: test error/
+    expect: 'Error: test error'
+  },
+  {
+    send: "throw { foo: 'bar' };",
+    expect: "Thrown: { foo: 'bar' }"
   },
   // Common syntax error is treated as multiline command
   {
@@ -526,7 +530,7 @@ const errorTests = [
   {
     send: 'require("internal/repl")',
     expect: [
-      /^Error: Cannot find module 'internal\/repl'/,
+      /^{ Error: Cannot find module 'internal\/repl'/,
       /^    at .*/,
       /^    at .*/,
       /^    at .*/,


### PR DESCRIPTION
1) Currently extra properties on an error will be ignored, if thrown.
   This information will from now on be visible.
2) In case someone threw a non error object it would have resulted in
   `[object Object]`. Instead, the full object will now be visible.
3) Some cases were not detected properly as error before and "Thrown: "
   was visible before. That is now fixed.
4) Refactor ERR_SCRIPT_EXECUTION_INTERRUPTED stack handling.
5) Error objects contained the `domain` properties due to the internal
    handling. Those are now removed as they do not provide a benefit for
    the user.

Refs: #20253

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
