### PR TITLE
meta: PRs with infra failures can land

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -203,6 +203,9 @@ Pull Request, use "Resume Build" in the left navigation of the relevant
 that preserves all the green results from the current job but re-runs everything
 else.
 
+PRs with infrastructure failures (disk space, Jenkins crashes) can land
+after opening an issue at https://github.com/nodejs/build.
+
 #### Useful CI Jobs
 
 * [`node-test-pull-request`](https://ci.nodejs.org/job/node-test-pull-request/)


### PR DESCRIPTION
Amend the collaborator guide so that in case of severe infrastructure
failures we could still land PRs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
