### PR TITLE
doc: tweak macOS-firewall note position

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -135,17 +135,6 @@ More Developer Tools...`. This step will install `clang`, `clang++`, and
 If the path to your build directory contains a space, the build will likely
 fail.
 
-After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
-popups asking to accept incoming network connections when running tests.
-
-Running the following script on macOS will add the firewall rules for the
-executable `node` in the `out` directory and the symbolic `node` link in the
-project's root directory.
-
-```console
-$ sudo ./tools/macos-firewall.sh
-```
-
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo
 
@@ -168,6 +157,17 @@ for more information.
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
 and not a newer version.
+
+After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
+popups asking to accept incoming network connections when running tests.
+
+Running the following script on macOS will add the firewall rules for the
+executable `node` in the `out` directory and the symbolic `node` link in the
+project's root directory.
+
+```console
+$ sudo ./tools/macos-firewall.sh
+```
 
 #### Running Tests
 


### PR DESCRIPTION
Move the macOS-firewall note to the end of "Building Node.js" and above "Running Tests".

I think it's more reasonable when user prepare to build node step by step. 
Just read and build from top to end in case ignore the note.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
