### PR TITLE
test: remove common.is* platform checks

### DIFF
--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 
@@ -18,7 +18,7 @@ if (process.argv[2] === 'child') {
       assert.fail(`Each frame should start with a frame number:\n${stderr}`);
     }
 
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       const { getBinaryPath } = require('../common/shared-lib-util');
       if (!frames.some((frame) => frame.includes(`[${getBinaryPath()}]`))) {
         assert.fail(`Some frames should include the binary name:\n${stderr}`);

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -26,7 +26,7 @@ function run(flags, argv2, signals) {
 
   const child = spawn(node, args);
   child.on('exit', common.mustCall(function(code, sig) {
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       if (signals)
         assert.strictEqual(code, 0xC0000005);
       else

--- a/test/abort/test-addon-uv-handle-leak.js
+++ b/test/abort/test-addon-uv-handle-leak.js
@@ -49,10 +49,10 @@ if (process.argv[2] === 'child') {
   //         Close callback: 0x7f2df31de220 CloseCallback(uv_handle_s*) [...]
   //         Data: 0x42
 
-  if (!(common.isFreeBSD ||
-        common.isAIX ||
-        (common.isLinux && !common.isGlibc()) ||
-        common.isWindows)) {
+  if (!(process.platform === 'freebsd' ||
+        process.platform === 'aix' ||
+        (process.platform === 'linux' && !common.isGlibc()) ||
+        process.platform === 'win32')) {
     assert(stderr.includes('ExampleOwnerClass'), stderr);
     assert(stderr.includes('CloseCallback'), stderr);
     assert(stderr.includes('example_instance'), stderr);

--- a/test/abort/test-process-abort-exitcode.js
+++ b/test/abort/test-process-abort-exitcode.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
 } else {
   const child = spawn(process.execPath, [__filename, 'child']);
   child.on('exit', common.mustCall((code, signal) => {
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       assert.strictEqual(code, 134);
       assert.strictEqual(signal, null);
     } else {

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../../common');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dlopen global symbol loading is not supported on this os.');
 
 const assert = require('assert');

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -1,7 +1,9 @@
 'use strict';
 const common = require('../../common');
-if (common.isWOW64)
-  common.skip('doesn\'t work on WOW64');
+if (process.platform === 'win32' &&
+    (process.env.PROCESSOR_ARCHITEW6432 !== undefined)) {
+  common.skip('test does not work on WOW64');
+}
 
 const fs = require('fs');
 const path = require('path');

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -27,7 +27,7 @@ const stream = require('stream');
 const path = require('path');
 let buildPath = path.join(__dirname, 'build', common.buildType, 'binding');
 // On Windows, escape backslashes in the path before passing it to REPL.
-if (common.isWindows)
+if (process.platform === 'win32')
   buildPath = buildPath.replace(/\\/g, '/');
 let cb_ran = false;
 

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -87,7 +87,7 @@ assert.ok(!arg);
 
   child.on('close', (code, signal) => {
     clearTimeout(tO);
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       assert.strictEqual(code, 134);
       assert.strictEqual(signal, null);
     } else {

--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no signals on Windows');
 if (!common.isMainThread)
   common.skip('No signal handling available in Workers');

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no signals in Windows');
 if (!common.isMainThread)
   common.skip('No signal handling available in Workers');

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -199,51 +199,11 @@ the number of calls.
 
 Checks whether free BSD Jail is true or false.
 
-### isAIX
-* [&lt;boolean>]
-
-Platform check for Advanced Interactive eXecutive (AIX).
-
 ### isAlive(pid)
 * `pid` [&lt;number>]
 * return [&lt;boolean>]
 
 Attempts to 'kill' `pid`
-
-### isFreeBSD
-* [&lt;boolean>]
-
-Platform check for Free BSD.
-
-### isLinux
-* [&lt;boolean>]
-
-Platform check for Linux.
-
-### isLinuxPPCBE
-* [&lt;boolean>]
-
-Platform check for Linux on PowerPC.
-
-### isOSX
-* [&lt;boolean>]
-
-Platform check for macOS.
-
-### isSunOS
-* [&lt;boolean>]
-
-Platform check for SunOS.
-
-### isWindows
-* [&lt;boolean>]
-
-Platform check for Windows.
-
-### isWOW64
-* [&lt;boolean>]
-
-Platform check for Windows 32-bit on Windows 64-bit.
 
 ### isCPPSymbolsNotMapped
 * [&lt;boolean>]

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -4,15 +4,6 @@ import common from './index.js';
 
 const {
   isMainThread,
-  isWindows,
-  isWOW64,
-  isAIX,
-  isLinuxPPCBE,
-  isSunOS,
-  isFreeBSD,
-  isOpenBSD,
-  isLinux,
-  isOSX,
   isGlibc,
   enoughTestMem,
   enoughTestCpu,
@@ -62,15 +53,6 @@ const {
 
 export {
   isMainThread,
-  isWindows,
-  isWOW64,
-  isAIX,
-  isLinuxPPCBE,
-  isSunOS,
-  isFreeBSD,
-  isOpenBSD,
-  isLinux,
-  isOSX,
   isGlibc,
   enoughTestMem,
   enoughTestCpu,

--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -1,5 +1,5 @@
+/* eslint-disable node-core/required-modules */
 'use strict';
-const common = require('../common');
 const path = require('path');
 
 // If node executable is linked to shared lib, need to take care about the
@@ -30,9 +30,9 @@ exports.addLibraryPath = function(env) {
 
 // Get the full path of shared lib.
 exports.getSharedLibPath = function() {
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     return path.join(path.dirname(process.execPath), 'node.dll');
-  } else if (common.isOSX) {
+  } else if (process.platform === 'darwin') {
     return path.join(path.dirname(process.execPath),
                      `libnode.${process.config.variables.shlib_suffix}`);
   } else {

--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   common.skip('`make doc` does not run on Windows');
 }
 

--- a/test/internet/test-dgram-multicast-set-interface-lo.js
+++ b/test/internet/test-dgram-multicast-set-interface-lo.js
@@ -16,7 +16,7 @@ if (common.inFreeBSDJail) {
 // $ echo hi |socat STDIO \
 //   UDP4-DATAGRAM:224.0.0.115:12356,ip-multicast-if=127.0.0.1
 
-if (common.isSunOS) {
+if (process.platform === 'sunos') {
   common.skip('SunOs is not correctly delivering to loopback multicast.');
   return;
 }
@@ -34,7 +34,8 @@ const FAM = 'IPv4';
 // Windows wont bind on multicasts so its filtering is by port.
 const PORTS = {};
 for (let i = 0; i < MULTICASTS[FAM].length; i++) {
-  PORTS[MULTICASTS[FAM][i]] = common.PORT + (common.isWindows ? i : 0);
+  PORTS[MULTICASTS[FAM][i]] =
+    common.PORT + (process.platform === 'win32' ? i : 0);
 }
 
 const UDP = { IPv4: 'udp4', IPv6: 'udp6' };
@@ -285,7 +286,7 @@ if (process.argv[2] === 'child') {
     process.send({ listening: true });
   });
 
-  if (common.isWindows)
+  if (process.platform === 'win32')
     listenSocket.bind(PORTS[MULTICAST], ANY[FAM]);
   else
     listenSocket.bind(common.PORT, MULTICAST);

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -143,7 +143,7 @@ TEST(function test_lookup_ipv6_hint(done) {
   }, common.mustCall((err, ip, family) => {
     if (err) {
       // FreeBSD does not support V4MAPPED
-      if (common.isFreeBSD) {
+      if (process.platform === 'freebsd') {
         assert(err instanceof Error);
         assert.strictEqual(err.code, 'EAI_BADFLAGS');
         assert.strictEqual(err.hostname, addresses.INET_HOST);

--- a/test/known_issues/test-cwd-enoent-file.js
+++ b/test/known_issues/test-cwd-enoent-file.js
@@ -2,10 +2,12 @@
 // Refs: https://github.com/nodejs/node/pull/12022
 // If the cwd is deleted, Node cannot run files because the module system
 // relies on uv_cwd(). The -e and -p flags still work though.
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
-if (common.isSunOS || common.isWindows || common.isAIX) {
+if (process.platform === 'sunos' ||
+    process.platform === 'win32' ||
+    process.platform === 'aix') {
   // The current working directory cannot be removed on these platforms.
   // Change this to common.skip() when this is no longer a known issue test.
   assert.fail('cannot rmdir current working directory');

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -85,7 +85,7 @@ dns.lookup('::1', common.mustCall((error, result, addressType) => {
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts
 // so we disable this test on Windows.
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   dns.reverse('127.0.0.1', common.mustCall(function(error, domains) {
     assert.ifError(error);
     assert.ok(Array.isArray(domains));

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -58,7 +58,7 @@ function testCwd(options, forCode, forData) {
 
 // Assume these exist, and 'pwd' gives us the right directory back
 testCwd({ cwd: common.rootDir }, 0, common.rootDir);
-if (common.isWindows) {
+if (process.platform === 'win32') {
   testCwd({ cwd: process.env.windir }, 0, process.env.windir);
 } else {
   testCwd({ cwd: '/dev' }, 0, '/dev');

--- a/test/parallel/test-child-process-default-options.js
+++ b/test/parallel/test-child-process-default-options.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
@@ -28,7 +28,7 @@ const spawn = require('child_process').spawn;
 process.env.HELLO = 'WORLD';
 
 let child;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   child = spawn('cmd.exe', ['/c', 'set'], {});
 } else {
   child = spawn('/usr/bin/env', [], {});

--- a/test/parallel/test-child-process-double-pipe.js
+++ b/test/parallel/test-child-process-double-pipe.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const os = require('os');
 const spawn = require('child_process').spawn;
@@ -30,7 +30,7 @@ const spawn = require('child_process').spawn;
 
 let grep, sed, echo;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   grep = spawn('grep', ['--binary', 'o']),
   sed = spawn('sed', ['--binary', 's/o/O/']),
   echo = spawn('cmd.exe',

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const os = require('os');
 
@@ -37,7 +37,7 @@ Object.setPrototypeOf(env, {
 });
 
 let child;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   child = spawn('cmd.exe', ['/c', 'set'],
                 Object.assign({}, process.env, { env }));
 } else {

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -26,7 +26,7 @@ const exec = require('child_process').exec;
 
 let pwdcommand, dir;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   pwdcommand = 'echo %cd%';
   dir = 'c:\\windows';
 } else {

--- a/test/parallel/test-child-process-exec-env.js
+++ b/test/parallel/test-child-process-exec-env.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const exec = require('child_process').exec;
 let success_count = 0;
@@ -41,7 +41,7 @@ function after(err, stdout, stderr) {
   }
 }
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   child = exec('/usr/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
 } else {
   child = exec('set',

--- a/test/parallel/test-child-process-exec-error.js
+++ b/test/parallel/test-child-process-exec-error.js
@@ -31,7 +31,7 @@ function test(fn, code) {
   }));
 }
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   test(child_process.exec, 1); // exit code of cmd.exe
 } else {
   test(child_process.exec, 127); // exit code of /bin/sh

--- a/test/parallel/test-child-process-exec-stdout-stderr-data-string.js
+++ b/test/parallel/test-child-process-exec-stdout-stderr-data-string.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const exec = require('child_process').exec;
 
-const command = common.isWindows ? 'dir' : 'ls';
+const command = process.platform === 'win32' ? 'dir' : 'ls';
 
 exec(command).stdout.on('data', common.mustCallAtLeast());
 

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -19,7 +19,7 @@ cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   let sigterm = 'SIGTERM';
   assert.strictEqual(err.killed, true);
   // TODO OpenBSD returns a null signal and 143 for code
-  if (common.isOpenBSD) {
+  if (process.platform === 'openbsd') {
     assert.strictEqual(err.code, 143);
     sigterm = null;
   } else {
@@ -28,7 +28,7 @@ cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   // At least starting with Darwin Kernel Version 16.4.0, sending a SIGTERM to a
   // process that is still starting up kills it with SIGKILL instead of SIGTERM.
   // See: https://github.com/libuv/libuv/issues/1226
-  if (common.isOSX)
+  if (process.platform === 'darwin')
     assert.ok(err.signal === 'SIGTERM' || err.signal === 'SIGKILL');
   else
     assert.strictEqual(err.signal, sigterm);

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 // Windows' `echo` command is a built-in shell command and not an external
 // executable like on *nix
-const opts = { shell: common.isWindows };
+const opts = { shell: process.platform === 'win32' };
 
 const p = cp.spawn('echo', [], opts);
 

--- a/test/parallel/test-child-process-fork-closed-channel-segfault.js
+++ b/test/parallel/test-child-process-fork-closed-channel-segfault.js
@@ -18,7 +18,7 @@ if (!cluster.isMaster) {
 
 const server = net
   .createServer(function(s) {
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       s.on('error', function(err) {
         // Prevent possible ECONNRESET errors from popping up
         if (err.code !== 'ECONNRESET') throw err;

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -28,7 +28,7 @@
  */
 
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Sending dgram sockets to child processes is not supported');
 
 const dgram = require('dgram');

--- a/test/parallel/test-child-process-fork-no-shell.js
+++ b/test/parallel/test-child-process-fork-no-shell.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const expected = common.isWindows ? '%foo%' : '$foo';
+const expected = process.platform === 'win32' ? '%foo%' : '$foo';
 
 if (process.argv[2] === undefined) {
   const child = cp.fork(__filename, [expected], {

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const cat = spawn(common.isWindows ? 'cmd' : 'cat');
+const cat = spawn(process.platform === 'win32' ? 'cmd' : 'cat');
 
 cat.stdout.on('end', common.mustCall());
 cat.stderr.on('data', common.mustNotCall());

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -11,7 +11,7 @@ doesNotExist.on('error', common.mustNotCall());
 doesNotExist.on('exit', common.mustCall((code, signal) => {
   assert.strictEqual(signal, null);
 
-  if (common.isWindows)
+  if (process.platform === 'win32')
     assert.strictEqual(code, 1);    // Exit code of cmd.exe
   else
     assert.strictEqual(code, 127);  // Exit code of /bin/sh

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const { spawn, fork, execFile } = require('child_process');
 const fixtures = require('../common/fixtures');
-const cmd = common.isWindows ? 'rundll32' : 'ls';
+const cmd = process.platform === 'win32' ? 'rundll32' : 'ls';
 const invalidcmd = 'hopefully_you_dont_have_this_on_your_machine';
 
 const empty = fixtures.path('empty.js');

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -13,7 +13,7 @@ assert.notStrictEqual(doesNotExist.file, 'does-not-exist');
 assert.strictEqual(doesNotExist.error, undefined);
 assert.strictEqual(doesNotExist.signal, null);
 
-if (common.isWindows)
+if (process.platform === 'win32')
   assert.strictEqual(doesNotExist.status, 1);    // Exit code of cmd.exe
 else
   assert.strictEqual(doesNotExist.status, 127);  // Exit code of /bin/sh

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -3,11 +3,11 @@ const common = require('../common');
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 const signals = process.binding('constants').os.signals;
-const rootUser = common.isWindows ? false : process.getuid() === 0;
+const rootUser = process.platform === 'win32' ? false : process.getuid() === 0;
 
 const invalidArgTypeError = common.expectsError(
   { code: 'ERR_INVALID_ARG_TYPE', type: TypeError },
-  common.isWindows || rootUser ? 42 : 62);
+  process.platform === 'win32' || rootUser ? 42 : 62);
 
 const invalidRangeError =
   common.expectsError({ code: 'ERR_OUT_OF_RANGE', type: RangeError }, 20);
@@ -54,7 +54,7 @@ function fail(option, value, message) {
   fail('detached', common.mustNotCall(), invalidArgTypeError);
 }
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   {
     // Validate the uid option
     if (!rootUser) {

--- a/test/parallel/test-child-process-uid-gid.js
+++ b/test/parallel/test-child-process-uid-gid.js
@@ -1,16 +1,17 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const expectedError = common.isWindows ? /\bENOTSUP\b/ : /\bEPERM\b/;
+const expectedError = process.platform === 'win32' ? /\bENOTSUP\b/ : /\bEPERM\b/;
 
-if (common.isWindows || process.getuid() !== 0) {
+if (process.platform === 'win32' || process.getuid() !== 0) {
   assert.throws(() => {
     spawn('echo', ['fhqwhgads'], { uid: 0 });
   }, expectedError);
 }
 
-if (common.isWindows || !process.getgroups().some((gid) => gid === 0)) {
+if (process.platform === 'win32' ||
+    !process.getgroups().some((gid) => gid === 0)) {
   assert.throws(() => {
     spawn('echo', ['fhqwhgads'], { gid: 0 });
   }, expectedError);

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -143,7 +143,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
 // Regression test for https://github.com/nodejs/node/issues/3574.
 {
   let emptyFile = fixtures.path('empty.js');
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     emptyFile = emptyFile.replace(/\\/g, '\\\\');
   }
 

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -30,11 +30,11 @@ expect('--trace-event-categories node', 'B\n');
 // eslint-disable-next-line no-template-curly-in-string
 expect('--trace-event-file-pattern {pid}-${rotation}.trace_events', 'B\n');
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   expect('--perf-basic-prof', 'B\n');
 }
 
-if (common.isLinux && ['arm', 'x64'].includes(process.arch)) {
+if (process.platform === 'linux' && ['arm', 'x64'].includes(process.arch)) {
   // PerfJitLogger is only implemented in Linux.
   expect('--perf-prof', 'B\n');
 }

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('not reliable on Windows.');
 
 if (process.getuid() === 0)

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dgram clustering is currently not supported on Windows.');
 
 const NUM_WORKERS = 4;

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dgram clustering is currently not supported on Windows.');
 
 const NUM_WORKERS = 4;

--- a/test/parallel/test-cluster-dgram-bind-fd.js
+++ b/test/parallel/test-cluster-dgram-bind-fd.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dgram clustering is currently not supported on Windows.');
 
 const NUM_WORKERS = 4;

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dgram clustering is currently not supported on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -4,7 +4,7 @@
 // Ref: https://github.com/nodejs/node/issues/4205
 
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('This test does not apply to Windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -23,7 +23,7 @@
 
 const common = require('../common');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('on windows, because clustered dgram is ENOTSUP');
 
 const cluster = require('cluster');

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   common.skip(
     'It is not possible to send pipe handles over the IPC pipe on Windows');
 }

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('On Windows named pipes live in their own ' +
               'filesystem and don\'t have a ~100 byte limit');
 if (!common.isMainThread)

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('not reliable on Windows');
 
 if (process.getuid() === 0)

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -1,8 +1,11 @@
 'use strict';
 const common = require('../common');
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (common.isSunOS || common.isWindows || common.isAIX)
+if (process.platform === 'sunos' ||
+    process.platform === 'win32' ||
+    process.platform === 'aix') {
   common.skip('cannot rmdir current working directory');
+}
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -1,8 +1,11 @@
 'use strict';
 const common = require('../common');
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (common.isSunOS || common.isWindows || common.isAIX)
+if (process.platform === 'sunos' ||
+    process.platform === 'win32' ||
+    process.platform === 'aix') {
   common.skip('cannot rmdir current working directory');
+}
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -1,8 +1,11 @@
 'use strict';
 const common = require('../common');
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (common.isSunOS || common.isWindows || common.isAIX)
+if (process.platform === 'sunos' ||
+    process.platform === 'win32' ||
+    process.platform === 'aix') {
   common.skip('cannot rmdir current working directory');
+}
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 

--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -33,21 +33,21 @@ interfacer.on('line', function(line) {
       break;
     case 2:
       // Doesn't currently work on Windows.
-      if (!common.isWindows) {
+      if (process.platform !== 'win32') {
         expected = "Target process: 655555 doesn't exist.";
         assert.strictEqual(line, expected);
       }
       break;
 
     default:
-      if (!common.isWindows)
+      if (process.platform !== 'win32')
         assert.fail(`unexpected line received: ${line}`);
   }
 });
 
 interfacer.on('exit', function(code, signal) {
   assert.strictEqual(code, 1, `Got unexpected code: ${code}`);
-  if (!common.isWindows) {
+  if (process.platform !== 'win32') {
     assert.strictEqual(lineCount, 2);
   }
 });

--- a/test/parallel/test-dgram-bind-fd-error.js
+++ b/test/parallel/test-dgram-bind-fd-error.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Does not support binding fd on Windows');
 
 const dgram = require('dgram');

--- a/test/parallel/test-dgram-bind-fd.js
+++ b/test/parallel/test-dgram-bind-fd.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Does not support binding fd on Windows');
 
 const assert = require('assert');
@@ -75,7 +75,7 @@ const BUFFER_SIZE = 4096;
         const sendBufferSize = socket.getSendBufferSize();
 
         // note: linux will double the buffer size
-        const expectedBufferSize = common.isLinux ?
+        const expectedBufferSize = process.platform === 'linux' ?
           BUFFER_SIZE * 2 : BUFFER_SIZE;
         assert.strictEqual(recvBufferSize, expectedBufferSize);
         assert.strictEqual(sendBufferSize, expectedBufferSize);

--- a/test/parallel/test-dgram-cluster-close-during-bind.js
+++ b/test/parallel/test-dgram-cluster-close-during-bind.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('dgram clustering is currently not supported on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-dgram-create-socket-handle-fd.js
+++ b/test/parallel/test-dgram-create-socket-handle-fd.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Does not support binding fd on Windows');
 
 const assert = require('assert');

--- a/test/parallel/test-dgram-create-socket-handle.js
+++ b/test/parallel/test-dgram-create-socket-handle.js
@@ -21,7 +21,7 @@ const UDP = process.binding('udp_wrap').UDP;
   assert(handle instanceof UDP);
   assert.strictEqual(typeof handle.fd, 'number');
 
-  if (!common.isWindows)
+  if (process.platform !== 'win32')
     assert(handle.fd > 0);
 }
 

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -58,12 +58,12 @@ if (cluster.isMaster) {
     messages++;
     ports[rinfo.port] = true;
 
-    if (common.isWindows && messages === 2) {
+    if (process.platform === 'win32' && messages === 2) {
       assert.strictEqual(Object.keys(ports).length, 2);
       done();
     }
 
-    if (!common.isWindows && messages === 4) {
+    if (process.platform !== 'win32' && messages === 4) {
       assert.strictEqual(Object.keys(ports).length, 3);
       done();
     }
@@ -72,7 +72,7 @@ if (cluster.isMaster) {
   target.on('listening', function() {
     cluster.fork({ PORT: target.address().port });
     cluster.fork({ PORT: target.address().port });
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       cluster.fork({ BOUND: 'y', PORT: target.address().port });
       cluster.fork({ BOUND: 'y', PORT: target.address().port });
     }

--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (common.isOSX)
+if (process.platform === 'darwin')
   common.skip('because of 17894467 Apple bug');
 
 const assert = require('assert');

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isOSX)
+if (process.platform === 'darwin')
   common.skip('because of 17894467 Apple bug');
 
 const assert = require('assert');

--- a/test/parallel/test-dgram-send-empty-packet.js
+++ b/test/parallel/test-dgram-send-empty-packet.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isOSX)
+if (process.platform === 'darwin')
   common.skip('because of 17894467 Apple bug');
 
 const assert = require('assert');

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -13,12 +13,12 @@ const {
 } = internalBinding('uv');
 
 function getExpectedError(type) {
-  const code = common.isWindows ? 'ENOTSOCK' : 'EBADF';
-  const message = common.isWindows ?
+  const code = process.platform === 'win32' ? 'ENOTSOCK' : 'EBADF';
+  const message = process.platform === 'win32' ?
     'socket operation on non-socket' : 'bad file descriptor';
-  const errno = common.isWindows ? UV_ENOTSOCK : UV_EBADF;
+  const errno = process.platform === 'win32' ? UV_ENOTSOCK : UV_EBADF;
   const syscall = `uv_${type}_buffer_size`;
-  const suffix = common.isWindows ?
+  const suffix = process.platform === 'win32' ?
     'ENOTSOCK (socket operation on non-socket)' : 'EBADF (bad file descriptor)';
   const error = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
@@ -99,7 +99,7 @@ function getExpectedError(type) {
     socket.setSendBufferSize(10000);
 
     // note: linux will double the buffer size
-    const expectedBufferSize = common.isLinux ? 20000 : 10000;
+    const expectedBufferSize = process.platform === 'linux' ? 20000 : 10000;
     assert.strictEqual(socket.getRecvBufferSize(), expectedBufferSize);
     assert.strictEqual(socket.getSendBufferSize(), expectedBufferSize);
     socket.close();

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -203,7 +203,7 @@ if (process.argv[2] === 'child') {
 
   tests.forEach(function(test, testIndex) {
     let testCmd = '';
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       // Do not create core files, as it can take a lot of disk space on
       // continuous testing and developers' machines
       testCmd += 'ulimit -c 0 && ';

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -84,7 +84,7 @@ function runTestWithAbortOnUncaughtException() {
 function createTestCmdLine(options) {
   let testCmd = '';
 
-  if (!common.isWindows) {
+  if (process.platform !== 'win32') {
     // Do not create core files, as it can take a lot of disk space on
     // continuous testing and developers' machines
     testCmd += 'ulimit -c 0 && ';

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -93,7 +93,7 @@ if (process.argv[2] === 'child') {
       throwInDomainErrHandlerOpt = 'throwInDomainErrHandler';
 
     let cmdToExec = '';
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       // Do not create core files, as it can take a lot of disk space on
       // continuous testing and developers' machines
       cmdToExec += 'ulimit -c 0 && ';

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -50,7 +50,7 @@ createFileWithPerms(readWriteFile, 0o666);
  * continuous integration platform to take care of that.
  */
 let hasWriteAccessForReadonlyFile = false;
-if (!common.isWindows && process.getuid() === 0) {
+if (process.platform !== 'win32' && process.getuid() === 0) {
   hasWriteAccessForReadonlyFile = true;
   try {
     process.setuid('nobody');

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const join = require('path').join;
 const fs = require('fs');
@@ -77,7 +77,7 @@ fs.writeFileSync(filename4, currentFileData, { mode: m });
 fs.appendFileSync(filename4, num, { mode: m });
 
 // windows permissions aren't unix
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const st = fs.statSync(filename4);
   assert.strictEqual(st.mode & 0o700, m);
 }

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -140,7 +140,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     assert.ifError(e);
 
     // windows permissions aren't unix
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       const st = fs.statSync(filename);
       assert.strictEqual(st.mode & 0o700, m);
     }
@@ -162,7 +162,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   fs.promises.appendFile(filename, n, { mode: m })
     .then(common.mustCall(() => {
       // windows permissions aren't unix
-      if (!common.isWindows) {
+      if (process.platform !== 'win32') {
         const st = fs.statSync(filename);
         assert.strictEqual(st.mode & 0o700, m);
       }

--- a/test/parallel/test-fs-chmod-mask.js
+++ b/test/parallel/test-fs-chmod-mask.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 let mode;
 // On Windows chmod is only able to manipulate write permission
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mode = 0o444;  // read-only
 } else {
   mode = 0o777;

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -63,7 +63,7 @@ function closeSync() {
 
 
 // On Windows chmod is only able to manipulate write permission
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mode_async = 0o400;   // read-only
   mode_sync = 0o600;    // read-write
 } else {
@@ -83,14 +83,14 @@ fs.closeSync(fs.openSync(file1, 'w'));
 fs.chmod(file1, mode_async.toString(8), common.mustCall((err) => {
   assert.ifError(err);
 
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     assert.ok((fs.statSync(file1).mode & 0o777) & mode_async);
   } else {
     assert.strictEqual(mode_async, fs.statSync(file1).mode & 0o777);
   }
 
   fs.chmodSync(file1, mode_sync);
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     assert.ok((fs.statSync(file1).mode & 0o777) & mode_sync);
   } else {
     assert.strictEqual(mode_sync, fs.statSync(file1).mode & 0o777);
@@ -103,7 +103,7 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
   fs.fchmod(fd, mode_async.toString(8), common.mustCall((err) => {
     assert.ifError(err);
 
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       assert.ok((fs.fstatSync(fd).mode & 0o777) & mode_async);
     } else {
       assert.strictEqual(mode_async, fs.fstatSync(fd).mode & 0o777);
@@ -120,7 +120,7 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
     );
 
     fs.fchmodSync(fd, mode_sync);
-    if (common.isWindows) {
+    if (process.platform === 'win32') {
       assert.ok((fs.fstatSync(fd).mode & 0o777) & mode_sync);
     } else {
       assert.strictEqual(mode_sync, fs.fstatSync(fd).mode & 0o777);

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -585,7 +585,7 @@ function re(literals, ...values) {
 }
 
 // chown
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
     assert.strictEqual(
@@ -608,7 +608,7 @@ if (!common.isWindows) {
 }
 
 // utimes
-if (!common.isAIX) {
+if (process.platform !== 'aix') {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
     assert.strictEqual(
@@ -769,7 +769,7 @@ if (!common.isAIX) {
 }
 
 // fchown
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const validateError = (err) => {
     assert.strictEqual(err.message, 'EBADF: bad file descriptor, fchown');
     assert.strictEqual(err.errno, UV_EBADF);
@@ -832,7 +832,7 @@ if (!common.isWindows) {
 
 
 // futimes
-if (!common.isAIX) {
+if (process.platform !== 'aix') {
   const validateError = (err) => {
     assert.strictEqual(err.message, 'EBADF: bad file descriptor, futime');
     assert.strictEqual(err.errno, UV_EBADF);

--- a/test/parallel/test-fs-lchown.js
+++ b/test/parallel/test-fs-lchown.js
@@ -50,7 +50,7 @@ const { promises } = fs;
   });
 });
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const testFile = path.join(tmpdir.path, path.basename(__filename));
   const uid = process.geteuid();
   const gid = process.getegid();

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('this test is Windows-specific.');
 
 const fs = require('fs');

--- a/test/parallel/test-fs-mkdir-mode-mask.js
+++ b/test/parallel/test-fs-mkdir-mode-mask.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 let mode;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   common.skip('mode is not supported in mkdir on Windows');
   return;
 } else {

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -153,7 +153,8 @@ function nextdir() {
 
 // mkdirpSync dirname loop
 // XXX: windows and smartos have issues removing a directory that you're in.
-if (common.isMainThread && (common.isLinux || common.isOSX)) {
+if (common.isMainThread &&
+    (process.platform === 'linux' || process.platform === 'darwin')) {
   const pathname = path.join(tmpdir.path, nextdir());
   fs.mkdirSync(pathname);
   process.chdir(pathname);

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -87,7 +87,7 @@ common.expectsError(
   { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
 );
 
-if (common.isLinux || common.isOSX) {
+if (process.platform === 'linux' || process.platform === 'darwin') {
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
   const file = path.join(tmpdir.path, 'a.js');

--- a/test/parallel/test-fs-open-mode-mask.js
+++ b/test/parallel/test-fs-open-mode-mask.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 let mode;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mode = 0o444;
 } else {
   mode = 0o644;

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -24,7 +24,7 @@ async function validateFilePermission() {
   let expectedAccess;
   const newPermissions = 0o765;
 
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     // chmod in Windows will only toggle read only/write access. the
     // fs.Stats.mode in Windows is computed using read/write
     // bits (not exec). read only at best returns 444; r/w 666.

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -35,7 +35,7 @@ async function validateReadFileProc() {
   // - https://github.com/nodejs/node/issues/21331
 
   // Test is Linux-specific.
-  if (!common.isLinux)
+  if (process.platform !== 'linux')
     return;
 
   const fileHandle = await open('/proc/sys/kernel/hostname', 'r');

--- a/test/parallel/test-fs-promises-readfile.js
+++ b/test/parallel/test-fs-promises-readfile.js
@@ -32,7 +32,7 @@ async function validateReadFileProc() {
   // - https://github.com/nodejs/node/issues/21331
 
   // Test is Linux-specific.
-  if (!common.isLinux)
+  if (process.platform !== 'linux')
     return;
 
   const hostname = await readFile('/proc/sys/kernel/hostname');

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -115,7 +115,7 @@ function verifyStatObject(stat) {
     await chmod(dest, (0o10777));
     await handle.chmod(0o10777);
 
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       await chown(dest, process.getuid(), process.getgid());
       await handle.chown(process.getuid(), process.getgid());
     }
@@ -165,7 +165,7 @@ function verifyStatObject(stat) {
     if (common.canCreateSymLink()) {
       const newLink = path.resolve(tmpDir, 'baz3.js');
       await symlink(newPath, newLink);
-      if (!common.isWindows) {
+      if (process.platform !== 'win32') {
         await lchown(newLink, process.getuid(), process.getgid());
       }
       stats = await lstat(newLink);
@@ -177,7 +177,7 @@ function verifyStatObject(stat) {
                          (await readlink(newLink)).toLowerCase());
 
       const newMode = 0o666;
-      if (common.isOSX) {
+      if (process.platform === 'darwin') {
         // lchmod is only available on macOS
         await lchmod(newLink, newMode);
         stats = await lstat(newLink);

--- a/test/parallel/test-fs-read-file-sync-hostname.js
+++ b/test/parallel/test-fs-read-file-sync-hostname.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (!common.isLinux)
+if (process.platform !== 'linux')
   common.skip('Test is linux specific.');
 
 const assert = require('assert');

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -180,7 +180,7 @@ common.expectsError(
   }));
 }
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   // Verify that end works when start is not specified, and we do not try to
   // use positioned reads. This makes sure that this keeps working for
   // non-seekable file descriptors.

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (!common.isLinux)
+if (process.platform !== 'linux')
   common.skip('Test is linux specific.');
 
 const path = require('path');

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -27,7 +27,7 @@ const fs = require('fs');
 
 // `fs.readFile('/')` does not fail on FreeBSD, because you can open and read
 // the directory there.
-if (common.isFreeBSD)
+if (process.platform === 'freebsd')
   common.skip('platform not supported.');
 
 const assert = require('assert');

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -3,7 +3,7 @@ const common = require('../common');
 
 // simulate `cat readfile.js | node readfile.js`
 
-if (common.isWindows || common.isAIX)
+if (process.platform === 'win32' || process.platform === 'aix')
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -24,7 +24,7 @@ const common = require('../common');
 
 // simulate `cat readfile.js | node readfile.js`
 
-if (common.isWindows || common.isAIX)
+if (process.platform === 'win32' || process.platform === 'aix')
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');

--- a/test/parallel/test-fs-readfilesync-enoent.js
+++ b/test/parallel/test-fs-readfilesync-enoent.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 
 // This test is only relevant on Windows.
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('Windows specific test.');
 
 // This test ensures fs.realpathSync works on properly on Windows without

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -3,7 +3,7 @@ const common = require('../common');
 
 // simulate `cat readfile.js | node readfile.js`
 
-if (common.isWindows || common.isAIX)
+if (process.platform === 'win32' || process.platform === 'aix')
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');

--- a/test/parallel/test-fs-realpath-on-substed-drive.js
+++ b/test/parallel/test-fs-realpath-on-substed-drive.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('Test for Windows only');
 
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-fs-realpath-pipe.js
+++ b/test/parallel/test-fs-realpath-pipe.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (common.isWindows || common.isAIX)
+if (process.platform === 'win32' || process.platform === 'aix')
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -40,7 +40,7 @@ tmpdir.refresh();
 
 let root = '/';
 let assertEqualPath = assert.strictEqual;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // something like "C:\\"
   root = process.cwd().substr(0, 3);
   assertEqualPath = function(path_left, path_right, message) {
@@ -283,7 +283,7 @@ function test_relative_input_cwd(realpath, realpathSync, callback) {
 
 function test_deep_symlink_mix(realpath, realpathSync, callback) {
   console.log('test_deep_symlink_mix');
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     // This one is a mix of files and directories, and it's quite tricky
     // to get the file/dir links sorted out correctly.
     common.printSkipMessage('symlink test (no privs)');

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const promiseFs = require('fs').promises;
@@ -58,7 +58,8 @@ function verifyStats(bigintStats, numStats) {
         bigintStats.isSymbolicLink(),
         numStats.isSymbolicLink()
       );
-    } else if (common.isWindows && (key === 'blksize' || key === 'blocks')) {
+    } else if (process.platform === 'win32' &&
+               (key === 'blksize' || key === 'blocks')) {
       assert.strictEqual(bigintStats[key], undefined);
       assert.strictEqual(numStats[key], undefined);
     } else if (Number.isSafeInteger(val)) {
@@ -79,7 +80,7 @@ function verifyStats(bigintStats, numStats) {
   verifyStats(bigintStats, numStats);
 }
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const filename = getFilename();
   const link = `${filename}-link`;
   fs.symlinkSync(filename, link);
@@ -106,7 +107,7 @@ if (!common.isWindows) {
   });
 }
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   const filename = getFilename();
   const link = `${filename}-link`;
   fs.symlinkSync(filename, link);
@@ -135,7 +136,7 @@ if (!common.isWindows) {
   verifyStats(bigintStats, numStats);
 })();
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   (async function() {
     const filename = getFilename();
     const link = `${filename}-link`;

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -98,7 +98,7 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     'atime', 'mtime', 'ctime', 'birthtime',
     'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs'
   ];
-  if (!common.isWindows) {
+  if (process.platform !== 'win32') {
     keys.push('blocks', 'blksize');
   }
   const numberFields = [

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -38,7 +38,7 @@ function stat_resource(resource) {
     const stats = fs.fstatSync(resource);
     // ensure mtime has been written to disk
     // except for directories on AIX where it cannot be synced
-    if (common.isAIX && stats.isDirectory())
+    if (process.platform === 'aix' && stats.isDirectory())
       return stats;
     fs.fsyncSync(resource);
     return fs.fstatSync(resource);
@@ -124,7 +124,7 @@ function testIt(atime, mtime, callback) {
       expect_errno('utimes', 'foobarbaz', err, 'ENOENT');
 
       // don't close this fd
-      if (common.isWindows) {
+      if (process.platform === 'win32') {
         fd = fs.openSync(tmpdir.path, 'r+');
       } else {
         fd = fs.openSync(tmpdir.path, 'r');
@@ -187,7 +187,9 @@ const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
 // test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
-if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
+if (!process.arch.includes('arm') &&
+    process.platform !== 'openbsd' &&
+    process.platform !== 'sunos') {
   // because 2 ** 31 doesn't look right
   // eslint-disable-next-line space-infix-ops
   const Y2K38_mtime = 2**31;
@@ -196,7 +198,7 @@ if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
   assert.strictEqual(Y2K38_mtime, Y2K38_stats.mtime.getTime() / 1000);
 }
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // this value would get converted to (double)1713037251359.9998
   const truncate_mtime = 1713037251360;
   fs.utimesSync(path, truncate_mtime / 1000, truncate_mtime / 1000);

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -16,7 +16,7 @@ const common = require('../common');
 // The testcase makes use of folder watching, and causes
 // hang. This behavior is documented. Skip this for AIX.
 
-if (common.isAIX)
+if (process.platform === 'aix')
   common.skip('folder watch capability is limited in AIX.');
 
 const fs = require('fs');

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (!(common.isOSX || common.isWindows))
+if (!(process.platform === 'darwin' || process.platform === 'win32'))
   common.skip('recursive option is darwin/windows specific');
 
 const assert = require('assert');
@@ -30,7 +30,7 @@ watcher.on('change', function(event, filename) {
   if (filename !== relativePathOne)
     return;
 
-  if (common.isOSX) {
+  if (process.platform === 'darwin') {
     clearInterval(interval);
   }
   watcher.close();
@@ -38,7 +38,7 @@ watcher.on('change', function(event, filename) {
 });
 
 let interval;
-if (common.isOSX) {
+if (process.platform === 'darwin') {
   interval = setInterval(function() {
     fs.writeFileSync(filepathOne, 'world');
   }, 10);

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -21,14 +21,19 @@ class WatchTestCase {
 const cases = [
   // Watch on a directory should callback with a filename on supported systems
   new WatchTestCase(
-    common.isLinux || common.isOSX || common.isWindows || common.isAIX,
+    process.platform === 'linux' ||
+      process.platform === 'darwin' ||
+      process.platform === 'win32' ||
+      process.platform === 'aix',
     'watch1',
     'foo',
     'filePath'
   ),
   // Watch on a file should callback with a filename on supported systems
   new WatchTestCase(
-    common.isLinux || common.isOSX || common.isWindows,
+    process.platform === 'linux' ||
+      process.platform === 'darwin' ||
+      process.platform === 'win32',
     'watch2',
     'bar',
     'dirPath'
@@ -65,7 +70,7 @@ for (const testCase of cases) {
       clearInterval(interval);
       interval = null;
     }
-    if (common.isOSX)
+    if (process.platform === 'darwin')
       assert.strictEqual(['rename', 'change'].includes(eventType), true);
     else
       assert.strictEqual(eventType, 'change');

--- a/test/parallel/test-fs-watchfile-bigint.js
+++ b/test/parallel/test-fs-watchfile-bigint.js
@@ -15,10 +15,10 @@ const expectedStatObject = new fs.Stats(
   0n,                                        // uid
   0n,                                        // gid
   0n,                                        // rdev
-  common.isWindows ? undefined : 0n,         // blksize
+  process.platform === 'win32' ? undefined : 0n,         // blksize
   0n,                                        // ino
   0n,                                        // size
-  common.isWindows ? undefined : 0n,         // blocks
+  process.platform === 'win32' ? undefined : 0n,         // blocks
   0n,                                        // atim_msec
   0n,                                        // mtim_msec
   0n,                                        // ctim_msec

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -38,10 +38,10 @@ const expectedStatObject = new fs.Stats(
   0,                                        // uid
   0,                                        // gid
   0,                                        // rdev
-  common.isWindows ? undefined : 0,         // blksize
+  process.platform === 'win32' ? undefined : 0,         // blksize
   0,                                        // ino
   0,                                        // size
-  common.isWindows ? undefined : 0,         // blocks
+  process.platform === 'win32' ? undefined : 0,         // blocks
   Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
@@ -86,7 +86,9 @@ watcher.start();  // starting a started watcher should be a noop
 
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
-if (common.isLinux || common.isOSX || common.isWindows) {
+if (process.platform === 'linux' ||
+    process.platform === 'darwin' ||
+    process.platform === 'win32') {
   const dir = path.join(tmpdir.path, 'watch');
 
   fs.mkdir(dir, common.mustCall(function(err) {

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -11,7 +11,7 @@ const URL = require('url').URL;
 function pathToFileURL(p) {
   if (!path.isAbsolute(p))
     throw new Error('Path must be absolute');
-  if (common.isWindows && p.startsWith('\\\\'))
+  if (process.platform === 'win32' && p.startsWith('\\\\'))
     p = p.slice(2);
   return new URL(`file://${p}`);
 }
@@ -41,7 +41,7 @@ common.expectsError(
   });
 
 // pct-encoded characters in the path will be decoded and checked
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // encoded back and forward slashes are not permitted on windows
   ['%2f', '%2F', '%5c', '%5C'].forEach((i) => {
     common.expectsError(

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('This test is for Windows only.');
 
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -43,7 +43,7 @@ process.umask(0o000);
 
 // On Windows chmod is only able to manipulate read-only bit. Test if creating
 // the file in read-only mode works.
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mode = 0o444;
 } else {
   mode = 0o755;

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -70,7 +70,7 @@ fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
   assert.ifError(e);
 
   // windows permissions aren't unix
-  if (!common.isWindows) {
+  if (process.platform !== 'win32') {
     const st = fs.statSync(filename3);
     assert.strictEqual(st.mode & 0o700, m);
   }

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -7,7 +7,7 @@ const strictEqual = require('assert').strictEqual;
 // child_process
 {
   const spawn = require('child_process').spawn;
-  const cmd = common.isWindows ? 'rundll32' : 'ls';
+  const cmd = process.platform === 'win32' ? 'rundll32' : 'ls';
   const cp = spawn(cmd);
   strictEqual(Object.getPrototypeOf(cp._handle).hasOwnProperty('hasRef'),
               true, 'process_wrap: hasRef() missing');

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -33,7 +33,7 @@ const host = '*'.repeat(64);
 const MAX_TRIES = 5;
 
 let errCode = 'ENOTFOUND';
-if (common.isOpenBSD)
+if (process.platform === 'openbsd')
   errCode = 'EAI_FAIL';
 
 function tryGet(mod, tries) {

--- a/test/parallel/test-http2-respond-file-error-pipe-offset.js
+++ b/test/parallel/test-http2-respond-file-error-pipe-offset.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no mkfifo on Windows');
 const child_process = require('child_process');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-with-pipe.js
+++ b/test/parallel/test-http2-respond-file-with-pipe.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no mkfifo on Windows');
 const child_process = require('child_process');
 const path = require('path');

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('This test is disabled on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('This test is disabled on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('This test is disabled on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('This test is disabled on windows.');
 
 const assert = require('assert');

--- a/test/parallel/test-module-globalpaths-nodepath.js
+++ b/test/parallel/test-module-globalpaths-nodepath.js
@@ -20,14 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const mod = require('module');
 
 let partA, partB;
 const partC = '';
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   partA = 'C:\\Users\\Rocko Artischocko\\AppData\\Roaming\\npm';
   partB = 'C:\\Program Files (x86)\\nodejs\\';
   process.env.NODE_PATH = `${partA};${partB};${partC}`;

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -38,7 +38,7 @@ const errorMessages = errorMessagesByPlatform[process.platform] || [''];
 // On Windows, error messages are MUI dependent
 // Ref: https://github.com/nodejs/node/issues/13376
 let localeOk = true;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   const powerShellFindMUI =
     'powershell -NoProfile -ExecutionPolicy Unrestricted -c ' +
     '"(Get-UICulture).TwoLetterISOLanguageName"';

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
@@ -21,7 +21,7 @@ if (process.argv[2] === 'child') {
   const prefixPath = path.join(tmpdir.path, 'install');
   fs.mkdirSync(prefixPath);
   let testExecPath;
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     testExecPath = path.join(prefixPath, path.basename(process.execPath));
   } else {
     const prefixBinPath = path.join(prefixPath, 'bin');

--- a/test/parallel/test-module-nodemodulepaths.js
+++ b/test/parallel/test-module-nodemodulepaths.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const _module = require('module');
 
@@ -118,7 +118,7 @@ node-gyp/node_modules/glob/node_modules',
   }]
 };
 
-const platformCases = common.isWindows ? cases.WIN : cases.POSIX;
+const platformCases = process.platform === 'win32' ? cases.WIN : cases.POSIX;
 platformCases.forEach((c) => {
   const paths = _module._nodeModulePaths(c.file);
   assert.deepStrictEqual(

--- a/test/parallel/test-module-readonly.js
+++ b/test/parallel/test-module-readonly.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   // TODO: Similar checks on *nix-like systems (e.g using chmod or the like)
   common.skip('test only runs on Windows');
 }

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Does not support wrapping sockets with fd on Windows');
 
 const assert = require('assert');

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -26,7 +26,7 @@ const assert = require('assert');
 const net = require('net');
 
 const host = '*'.repeat(64);
-const errCode = common.isOpenBSD ? 'EAI_FAIL' : 'ENOTFOUND';
+const errCode = process.platform === 'openbsd' ? 'EAI_FAIL' : 'ENOTFOUND';
 
 const socket = net.connect(42, host, common.mustNotCall());
 socket.on('error', common.mustCall(function(err) {

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -31,7 +31,7 @@ const assert = require('assert');
 
 let emptyTxt;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // on Win, common.PIPE will be a named pipe, so we use an existing empty
   // file instead
   emptyTxt = fixtures.path('empty.txt');
@@ -77,7 +77,7 @@ noEntSocketClient.on('error', common.mustCall(function(err) {
 
 
 // On Windows or when running as root, a chmod has no effect on named pipes
-if (!common.isWindows && process.getuid() !== 0) {
+if (process.platform !== 'win32' && process.getuid() !== 0) {
   // Trying to connect to a socket one has no access to should result in EACCES
   const accessServer = net.createServer(
     common.mustNotCall('server callback should not run'));

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -51,7 +51,7 @@ function randomHandle(type) {
     assert.fail(`unable to bind ${handleName}: ${getSystemErrorName(errno)}`);
   }
 
-  if (!common.isWindows) {  // fd doesn't work on windows
+  if (process.platform !== 'win32') {  // fd doesn't work on windows
     // err >= 0 but fd = -1, should not happen
     assert.notStrictEqual(handle.fd, -1,
                           `Bound ${handleName} has fd -1 and errno ${errno}`);
@@ -79,7 +79,7 @@ function randomPipes(number) {
 }
 
 // Not a public API, used by child_process
-if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
+if (process.platform !== 'win32') {  // Windows doesn't support {fd: <n>}
   const handles = randomPipes(2);  // generate pipes in advance
   // Test listen(pipe)
   net.createServer()
@@ -107,7 +107,7 @@ if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
     .on('listening', closeServer());
 }
 
-if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
+if (process.platform !== 'win32') {  // Windows doesn't support {fd: <n>}
   // Test listen({fd: tcp.fd}, cb)
   net.createServer()
     .listen({ fd: randomHandle('tcp').fd }, closeServer());
@@ -117,7 +117,7 @@ if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
     .on('listening', closeServer());
 }
 
-if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
+if (process.platform !== 'win32') {  // Windows doesn't support {fd: <n>}
   const handles = randomPipes(6);  // generate pipes in advance
   // Test listen({handle: pipe}, cb)
   net.createServer()
@@ -142,7 +142,7 @@ if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
     .on('listening', closePipeServer(handles[5]));
 }
 
-if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
+if (process.platform !== 'win32') {  // Windows doesn't support {fd: <n>}
   // Test invalid fd
   const fd = fs.openSync(__filename, 'r');
   net.createServer()

--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -94,7 +94,7 @@ function makeConnection(index) {
   c.on('error', function(e) {
     // Retry if SmartOS and ECONNREFUSED. See
     // https://github.com/nodejs/node/issues/2663.
-    if (common.isSunOS && (e.code === 'ECONNREFUSED')) {
+    if (process.platform === 'sunos' && (e.code === 'ECONNREFUSED')) {
       c.connect(server.address().port);
     }
     console.error(`error ${index}: ${e}`);

--- a/test/parallel/test-os-eol.js
+++ b/test/parallel/test-os-eol.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const os = require('os');
 
-const eol = common.isWindows ? '\r\n' : '\n';
+const eol = process.platform === 'win32' ? '\r\n' : '\n';
 
 assert.strictEqual(os.EOL, eol);
 

--- a/test/parallel/test-os-homedir-no-envvar.js
+++ b/test/parallel/test-os-homedir-no-envvar.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const os = require('os');
@@ -7,7 +7,7 @@ const path = require('path');
 
 
 if (process.argv[2] === 'child') {
-  if (common.isWindows)
+  if (process.platform === 'win32')
     assert.strictEqual(process.env.USERPROFILE, undefined);
   else
     assert.strictEqual(process.env.HOME, undefined);
@@ -17,7 +17,7 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(typeof home, 'string');
   assert(home.includes(path.sep));
 } else {
-  if (common.isWindows)
+  if (process.platform === 'win32')
     delete process.env.USERPROFILE;
   else
     delete process.env.HOME;

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const os = require('os');
 const path = require('path');
@@ -46,7 +46,7 @@ const flatten = (arr) =>
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
-if (common.isWindows) {
+if (process.platform === 'win32') {
   assert.strictEqual(os.tmpdir(), '/temp');
   process.env.TEMP = '';
   assert.strictEqual(os.tmpdir(), '/tmp');
@@ -101,7 +101,7 @@ const release = os.release();
 is.string(release);
 assert.ok(release.length > 0);
 // TODO: Check format on more than just AIX
-if (common.isAIX)
+if (process.platform === 'aix')
   assert.ok(/^\d+\.\d+$/.test(release));
 
 const platform = os.platform();
@@ -112,7 +112,7 @@ const arch = os.arch();
 is.string(arch);
 assert.ok(arch.length > 0);
 
-if (!common.isSunOS) {
+if (process.platform !== 'sunos') {
   // not implemented yet
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);
@@ -172,7 +172,7 @@ flatten(Object.values(interfaces))
   });
 
 const EOL = os.EOL;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   assert.strictEqual(EOL, '\r\n');
 } else {
   assert.strictEqual(EOL, '\n');
@@ -182,12 +182,12 @@ const home = os.homedir();
 is.string(home);
 assert.ok(home.includes(path.sep));
 
-if (common.isWindows && process.env.USERPROFILE) {
+if (process.platform === 'win32' && process.env.USERPROFILE) {
   assert.strictEqual(home, process.env.USERPROFILE);
   delete process.env.USERPROFILE;
   assert.ok(os.homedir().includes(path.sep));
   process.env.USERPROFILE = home;
-} else if (!common.isWindows && process.env.HOME) {
+} else if (process.platform !== 'win32' && process.env.HOME) {
   assert.strictEqual(home, process.env.HOME);
   delete process.env.HOME;
   assert.ok(os.homedir().includes(path.sep));
@@ -198,7 +198,7 @@ const pwd = os.userInfo();
 is.object(pwd);
 const pwdBuf = os.userInfo({ encoding: 'buffer' });
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   assert.strictEqual(pwd.uid, -1);
   assert.strictEqual(pwd.gid, -1);
   assert.strictEqual(pwd.shell, null);

--- a/test/parallel/test-path-dirname.js
+++ b/test/parallel/test-path-dirname.js
@@ -1,10 +1,11 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 
 assert.strictEqual(path.dirname(__filename).substr(-13),
-                   common.isWindows ? 'test\\parallel' : 'test/parallel');
+                   process.platform === 'win32' ?
+                     'test\\parallel' : 'test/parallel');
 
 assert.strictEqual(path.posix.dirname('/a/b/'), '/a');
 assert.strictEqual(path.posix.dirname('/a/b'), '/a');

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   const file = fixtures.path('a.js');
   const resolvedFile = path.resolve(file);
 
@@ -56,7 +56,7 @@ assert.strictEqual(path.posix.toNamespacedPath(true), true);
 assert.strictEqual(path.posix.toNamespacedPath(1), 1);
 assert.strictEqual(path.posix.toNamespacedPath(), undefined);
 assert.strictEqual(path.posix.toNamespacedPath(emptyObj), emptyObj);
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // These tests cause resolve() to insert the cwd, so we cannot test them from
   // non-Windows platforms (easily)
   assert.strictEqual(path.win32.toNamespacedPath('foo\\bar').toLowerCase(),

--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const child = require('child_process');
@@ -44,9 +44,9 @@ resolveTests.forEach((test) => {
     const actual = resolve.apply(null, test[0]);
     let actualAlt;
     const os = resolve === path.win32.resolve ? 'win32' : 'posix';
-    if (resolve === path.win32.resolve && !common.isWindows)
+    if (resolve === path.win32.resolve && process.platform !== 'win32')
       actualAlt = actual.replace(backslashRE, '/');
-    else if (resolve !== path.win32.resolve && common.isWindows)
+    else if (resolve !== path.win32.resolve && process.platform === 'win32')
       actualAlt = actual.replace(slashRE, '\\');
 
     const expected = test[1];
@@ -59,7 +59,7 @@ resolveTests.forEach((test) => {
 });
 assert.strictEqual(failures.length, 0, failures.join(''));
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // Test resolving the current Windows drive letter from a spawned process.
   // See https://github.com/nodejs/node/issues/7215
   const currentDriveLetter = path.parse(process.cwd()).root.substring(0, 2);

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -67,7 +67,7 @@ assert.strictEqual(path.win32.delimiter, ';');
 // posix
 assert.strictEqual(path.posix.delimiter, ':');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   assert.strictEqual(path, path.win32);
 else
   assert.strictEqual(path, path.posix);

--- a/test/parallel/test-pipe-writev.js
+++ b/test/parallel/test-pipe-writev.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Unix-specific test');
 
 const assert = require('assert');

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 // Refs: https://github.com/nodejs/node/pull/2253
-if (common.isSunOS)
+if (process.platform === 'sunos')
   common.skip('unreliable on SunOS');
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');

--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const constants = process.binding('constants');
 
-if (common.isLinux) {
+if (process.platform === 'linux') {
   assert('O_NOATIME' in constants.fs);
   assert.strictEqual(constants.fs.O_NOATIME, 0x40000);
 } else {

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 // changes in environment should be visible to child processes
@@ -93,7 +93,7 @@ process.env.TEST = 'test';
 assert.strictEqual(process.env.TEST, 'test');
 // Check both mixed case and lower case, to avoid any regressions that might
 // simply convert input to lower case.
-if (common.isWindows) {
+if (process.platform === 'win32') {
   assert.strictEqual(process.env.test, 'test');
   assert.strictEqual(process.env.teST, 'test');
 } else {

--- a/test/parallel/test-process-euid-egid.js
+++ b/test/parallel/test-process-euid-egid.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (common.isWindows || !common.isMainThread) {
+if (process.platform === 'win32' || !common.isMainThread) {
   if (common.isMainThread) {
     assert.strictEqual(process.geteuid, undefined);
     assert.strictEqual(process.getegid, undefined);

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('symlinks are weird on windows');
 
 const assert = require('assert');

--- a/test/parallel/test-process-getgroups.js
+++ b/test/parallel/test-process-getgroups.js
@@ -24,7 +24,7 @@ const common = require('../common');
 
 // Check `id -G` and `process.getgroups()` return same groups.
 
-if (common.isOSX)
+if (process.platform === 'darwin')
   common.skip('Output of `id -G` is unreliable on Darwin.');
 
 const assert = require('assert');

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Win32 does not support signals.');
 
 const assert = require('assert');

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (common.isWindows || !common.isMainThread) {
+if (process.platform === 'win32' || !common.isMainThread) {
   assert.strictEqual(process.setgroups, undefined);
   return;
 }

--- a/test/parallel/test-process-title-cli.js
+++ b/test/parallel/test-process-title-cli.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 
-if (common.isSunOS)
+if (process.platform === 'sunos')
   common.skip(`Unsupported platform [${process.platform}]`);
 
 const assert = require('assert');

--- a/test/parallel/test-process-uid-gid.js
+++ b/test/parallel/test-process-uid-gid.js
@@ -24,7 +24,7 @@ const common = require('../common');
 
 const assert = require('assert');
 
-if (common.isWindows || !common.isMainThread) {
+if (process.platform === 'win32' || !common.isMainThread) {
   // uid/gid functions are POSIX only, setters are main-thread only.
   if (common.isMainThread) {
     assert.strictEqual(process.getuid, undefined);

--- a/test/parallel/test-process-umask-mask.js
+++ b/test/parallel/test-process-umask-mask.js
@@ -11,7 +11,7 @@ if (!common.isMainThread)
 
 let mask;
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mask = 0o600;
 } else {
   mask = 0o664;

--- a/test/parallel/test-process-umask.js
+++ b/test/parallel/test-process-umask.js
@@ -27,7 +27,7 @@ if (!common.isMainThread)
 
 // Note in Windows one can only set the "user" bits.
 let mask;
-if (common.isWindows) {
+if (process.platform === 'win32') {
   mask = '0600';
 } else {
   mask = '0664';

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -6,7 +6,7 @@
 
 const common = require('../common');
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   common.skip('Win32 uses ACLs for file permissions, ' +
               'modes are always 0666 and says nothing about group/other ' +
               'read access.');

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -113,7 +113,7 @@ const tests = [
   },
   {
     before: function before() {
-      if (common.isWindows) {
+      if (process.platform === 'win32') {
         const execSync = require('child_process').execSync;
         execSync(`ATTRIB +H "${emptyHiddenHistoryPath}"`, (err) => {
           assert.ifError(err);
@@ -126,7 +126,7 @@ const tests = [
   },
   {
     before: function before() {
-      if (!common.isWindows)
+      if (process.platform !== 'win32')
         fs.symlinkSync('/dev/null', devNullHistoryPath);
     },
     env: { NODE_REPL_HISTORY: devNullHistoryPath },

--- a/test/parallel/test-repl-sigint-nested-eval.js
+++ b/test/parallel/test-repl-sigint-nested-eval.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
 }

--- a/test/parallel/test-repl-sigint.js
+++ b/test/parallel/test-repl-sigint.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
 }

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -24,7 +24,7 @@ const putIn = new common.ArrayStream();
 repl.start('', putIn);
 let file = fixtures.path('syntax', 'bad_syntax');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   file = file.replace(/\\/g, '\\\\');
 
 putIn.run(['.clear']);

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('this test is Windows-specific.');
 
 const fs = require('fs');

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 // FIXME add sunos support
-if (common.isSunOS)
+if (process.platform === 'sunos')
   common.skip(`Unsupported platform [${process.platform}]`);
 if (!common.isMainThread)
   common.skip('Setting the process title from Workers is not supported');
@@ -22,12 +22,12 @@ process.title = title;
 assert.strictEqual(process.title, title);
 
 // Test setting the title but do not try to run `ps` on Windows.
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Windows does not have "ps" utility');
 
 // To pass this test on alpine, since Busybox `ps` does not
 // support `-p` switch, use `ps -o` and `grep` instead.
-const cmd = common.isLinux ?
+const cmd = process.platform === 'linux' ?
   `ps -o pid,args | grep '${process.pid} ${title}' | grep -v grep` :
   `ps -p ${process.pid} -o args=`;
 
@@ -36,7 +36,7 @@ exec(cmd, common.mustCall((error, stdout, stderr) => {
   assert.strictEqual(stderr, '');
 
   // freebsd always add ' (procname)' to the process title
-  if (common.isFreeBSD || common.isOpenBSD)
+  if (process.platform === 'freebsd' || process.platform === 'openbsd')
     title += ` (${path.basename(process.execPath)})`;
 
   // omitting trailing whitespace and \n

--- a/test/parallel/test-signal-args.js
+++ b/test/parallel/test-signal-args.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('Sending signals with process.kill is not supported on Windows');
 if (!common.isMainThread)
   common.skip('No signal handling available in Workers');

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -23,7 +23,7 @@
 
 const common = require('../common');
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('SIGUSR1 and SIGHUP signals are not supported');
 if (!common.isMainThread)
   common.skip('Signal handling in Workers is not supported');

--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 // This test is intended for Windows only
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('this test is Windows-specific.');
 
 const assert = require('assert');

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -5,7 +5,7 @@ const spawn = require('child_process').spawn;
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
-if (common.isWindows) {
+if (process.platform === 'win32') {
   if (process.argv[2] === 'child') {
     process.stdin;
     process.stdout;

--- a/test/parallel/test-tls-env-bad-extra-ca.js
+++ b/test/parallel/test-tls-env-bad-extra-ca.js
@@ -35,7 +35,7 @@ fork(__filename, opts)
   .on('close', common.mustCall(function() {
     // TODO(addaleax): Make `SafeGetenv` work like `process.env`
     // encoding-wise
-    if (!common.isWindows) {
+    if (process.platform !== 'win32') {
       const re = /Warning: Ignoring extra certs from.*no-such-file-exists-🐢.* load failed:.*No such file or directory/;
       assert(re.test(stderr), stderr);
     }

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -119,7 +119,8 @@ function doTest(testOptions, callback) {
         if (code !== 0) {
           // If SmartOS and connection refused, then retry. See
           // https://github.com/nodejs/node/issues/2663.
-          if (common.isSunOS && err.includes('Connection refused')) {
+          if (process.platform === 'sunos' &&
+              err.includes('Connection refused')) {
             requestCount = 0;
             spawnClient();
             return;

--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -14,7 +14,7 @@ const traceFile = 'node_trace.1.log';
 let gid = 1;
 let uid = 1;
 
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   gid = process.getgid();
   uid = process.getuid();
 }
@@ -128,10 +128,9 @@ for (const tr in tests) {
                               '-e', tests[tr] ],
                             { encoding: 'utf8' });
   // Some AIX versions don't support futimes or utimes, so skip.
-  if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.futimes') {
-    continue;
-  }
-  if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.utimes') {
+  if (process.platform === 'aix' &&
+      proc.status !== 0 &&
+      (tr === 'fs.sync.futimes' || tr === 'fs.sync.utimes')) {
     continue;
   }
 

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -64,7 +64,7 @@ proc.once('exit', common.mustCall(() => {
         (!process.release.lts ||
           trace.args.process.release.lts === process.release.lts)));
 
-    if (!common.isSunOS) {
+    if (process.platform !== 'sunos') {
       // Changing process.title is currently unsupported on SunOS/SmartOS
       assert(traces.some((trace) =>
         trace.name === 'process_name' && trace.args.name === 'foo'));

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -20,16 +20,17 @@ assert.throws(
 );
 
 {
-  const info = {
-    code: common.isWindows ? 'EBADF' : 'EINVAL',
-    message: common.isWindows ? 'bad file descriptor' : 'invalid argument',
-    errno: common.isWindows ? UV_EBADF : UV_EINVAL,
-    syscall: 'uv_tty_init'
-  };
+  const code = process.platform === 'win32' ? 'EBADF' : 'EINVAL';
+  const message =
+    process.platform === 'win32' ?
+      'bad file descriptor' :
+      'invalid argument';
+  const errno = process.platform === 'win32' ? UV_EBADF : UV_EINVAL;
+  const info = { code, message, errno, syscall: 'uv_tty_init' };
 
-  const suffix = common.isWindows ?
+  const suffix = process.platform === 'win32' ?
     'EBADF (bad file descriptor)' : 'EINVAL (invalid argument)';
-  const message = `TTY initialization failed: uv_tty_init returned ${suffix}`;
+  const msg = `TTY initialization failed: uv_tty_init returned ${suffix}`;
 
   assert.throws(
     () => {
@@ -39,7 +40,7 @@ assert.throws(
     }, {
       code: 'ERR_TTY_INIT_FAILED',
       name: 'SystemError [ERR_TTY_INIT_FAILED]',
-      message,
+      message: msg,
       info
     }
   );
@@ -52,7 +53,7 @@ assert.throws(
     }, {
       code: 'ERR_TTY_INIT_FAILED',
       name: 'SystemError [ERR_TTY_INIT_FAILED]',
-      message,
+      message: msg,
       info
     });
 }

--- a/test/parallel/test-util-sigint-watchdog.js
+++ b/test/parallel/test-util-sigint-watchdog.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
 }

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
 }

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (common.isWindows) {
+if (process.platform === 'win32') {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
 }

--- a/test/parallel/test-warn-sigprof.js
+++ b/test/parallel/test-warn-sigprof.js
@@ -7,7 +7,7 @@ const common = require('../common');
 
 common.skipIfInspectorDisabled();
 
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('test does not apply to Windows');
 
 common.expectWarning('Warning',

--- a/test/parallel/test-windows-abort-exitcode.js
+++ b/test/parallel/test-windows-abort-exitcode.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-if (!common.isWindows)
+if (process.platform !== 'win32')
   common.skip('test is windows specific');
 
 const assert = require('assert');

--- a/test/parallel/test-windows-failed-heap-allocation.js
+++ b/test/parallel/test-windows-failed-heap-allocation.js
@@ -3,7 +3,7 @@ const common = require('../common');
 
 // This test ensures that an out of memory error exits with code 134 on Windows
 
-if (!common.isWindows) return common.skip('Windows-only');
+if (process.platform !== 'win32') return common.skip('Windows-only');
 
 const assert = require('assert');
 const { exec } = require('child_process');

--- a/test/pseudo-tty/no_dropped_stdio.js
+++ b/test/pseudo-tty/no_dropped_stdio.js
@@ -1,7 +1,7 @@
 // https://github.com/nodejs/node/issues/6456#issuecomment-219320599
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
-const common = require('../common');
+require('../common');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
@@ -16,4 +16,4 @@ out += `${'o'.repeat(24)}O`;
 setTimeout(function() {
   process.stdout.write(out);
   process.exit(0);
-}, common.isAIX ? 200 : 0);
+}, process.platform === 'aix' ? 200 : 0);

--- a/test/pseudo-tty/no_interleaved_stdio.js
+++ b/test/pseudo-tty/no_interleaved_stdio.js
@@ -1,7 +1,7 @@
 // https://github.com/nodejs/node/issues/6456#issuecomment-219320599
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
-const common = require('../common');
+require('../common');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
@@ -18,4 +18,4 @@ const err = '__This is some stderr__';
 setTimeout(function() {
   process.stdout.write(out);
   process.stderr.write(err);
-}, common.isAIX ? 200 : 0);
+}, process.platform === 'aix' ? 200 : 0);

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -13,7 +13,7 @@ const wrap = (fn, ioStream, string) => {
       fn.call(ioStream);
     } catch (e) {
       // EINVAL happens on SmartOS if emulation is incomplete
-      if (!common.isSunOS || e.code !== 'EINVAL')
+      if (process.platform !== 'sunos' || e.code !== 'EINVAL')
         throw e;
     }
   });
@@ -31,4 +31,4 @@ process.stdout._refreshSize = wrap(originalRefreshSizeStdout,
 // can setup the readloop. Provide a reasonable delay.
 setTimeout(function() {
   process.emit('SIGWINCH');
-}, common.isAIX ? 200 : 0);
+}, process.platform === 'aix' ? 200 : 0);

--- a/test/pummel/test-abort-fatal-error.js
+++ b/test/pummel/test-abort-fatal-error.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no RLIMIT_NOFILE on Windows');
 
 const assert = require('assert');

--- a/test/pummel/test-child-process-spawn-loop.js
+++ b/test/pummel/test-child-process-spawn-loop.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
@@ -44,7 +44,7 @@ function doSpawn(i) {
 
   child.on('close', () => {
     // + 1 for \n or + 2 for \r\n on Windows
-    assert.strictEqual(SIZE + (common.isWindows ? 2 : 1), count);
+    assert.strictEqual(SIZE + (process.platform === 'win32' ? 2 : 1), count);
     if (i < N) {
       doSpawn(i + 1);
     } else {

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (!common.isSunOS)
+if (process.platform !== 'sunos')
   common.skip('no DTRACE support');
 
 const assert = require('assert');

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const exec = require('child_process').exec;
 
 let SLEEP3_COMMAND;
-if (!common.isWindows) {
+if (process.platform !== 'win32') {
   // Unix.
   SLEEP3_COMMAND = 'sleep 3';
 } else {

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -23,7 +23,7 @@
 
 // This test requires the program 'wrk'
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no `wrk` on windows');
 
 const assert = require('assert');

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -115,8 +115,8 @@ pingPongTest(common.PORT, 'localhost');
 pingPongTest(common.PORT + 1, null);
 
 // This IPv6 isn't working on Solaris
-if (!common.isSunOS) pingPongTest(common.PORT + 2, '::1');
+if (process.platform !== 'sunos') pingPongTest(common.PORT + 2, '::1');
 
 process.on('exit', function() {
-  assert.strictEqual(common.isSunOS ? 2 : 3, tests_run);
+  assert.strictEqual(process.platform === 'sunos' ? 2 : 3, tests_run);
 });

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-if (common.isWindows)
+if (process.platform === 'win32')
   common.skip('no RLIMIT_NOFILE on Windows');
 
 const assert = require('assert');

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -96,7 +96,7 @@ assert.strictEqual(ret, `${msg}\n`);
 // See https://github.com/nodejs/node-v0.x-archive/issues/7824.
 {
   const cwd = common.rootDir;
-  const cmd = common.isWindows ? 'echo %cd%' : 'pwd';
+  const cmd = process.platform === 'win32' ? 'echo %cd%' : 'pwd';
   const response = execSync(cmd, { cwd });
 
   assert.strictEqual(response.toString().trim(), cwd);

--- a/test/sequential/test-cluster-send-handle-large-payload.js
+++ b/test/sequential/test-cluster-send-handle-large-payload.js
@@ -43,7 +43,7 @@ if (cluster.isMaster) {
     // Send a second message after a delay on macOS.
     //
     // Refs: https://github.com/nodejs/node/issues/14747
-    if (common.isOSX)
+    if (process.platform === 'darwin')
       setTimeout(() => { process.send({ payload }, handle); }, 1000);
     else
       process.send({ payload }, handle);

--- a/test/sequential/test-dgram-bind-shared-ports.js
+++ b/test/sequential/test-dgram-bind-shared-ports.js
@@ -34,7 +34,7 @@ const WORKER2_NAME = 'wrker2';
 if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
-  if (common.isWindows) {
+  if (process.platform === 'win32') {
     worker1.on('error', common.mustCall((err) => {
       console.log(err);
       assert.strictEqual(err.code, 'ENOTSUP');

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -10,8 +10,10 @@ const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
-if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
+if (process.platform === 'aix' &&
+   (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength) {
   common.skip('intensive toString tests due to file size confinements');
+}
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -31,10 +31,10 @@ const tmpdir = require('../common/tmpdir');
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 
-const expectFilePath = common.isWindows ||
-                       common.isLinux ||
-                       common.isOSX ||
-                       common.isAIX;
+const expectFilePath = process.platform === 'win32' ||
+                       process.platform === 'linux' ||
+                       process.platform === 'darwin' ||
+                       process.platform === 'aix';
 
 const testDir = tmpdir.path;
 
@@ -88,7 +88,8 @@ tmpdir.refresh();
 
   const watcher =
     fs.watch(testsubdir, common.mustCall(function(event, filename) {
-      const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
+      const renameEv = process.platform === 'sunos' ||
+                       process.platform === 'aix' ? 'change' : 'rename';
       assert.strictEqual(event, renameEv);
       if (expectFilePath) {
         assert.strictEqual(filename, 'newfile.txt');

--- a/test/sequential/test-http-regr-gh-2928.js
+++ b/test/sequential/test-http-regr-gh-2928.js
@@ -31,7 +31,7 @@ function execAndClose() {
   socket.on('error', (e) => {
     // If SmartOS and ECONNREFUSED, then retry. See
     // https://github.com/nodejs/node/issues/2663.
-    if (common.isSunOS && e.code === 'ECONNREFUSED') {
+    if (process.platform === 'sunos' && e.code === 'ECONNREFUSED') {
       parsers.push(parser);
       socket.destroy();
       setImmediate(execAndClose);

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -25,7 +25,7 @@ async function testContextCreatedAndDestroyed() {
     session.post('Runtime.enable');
     const contextCreated = await mainContextPromise;
     const { name, origin, auxData } = contextCreated.params.context;
-    if (common.isSunOS || common.isWindows) {
+    if (process.platform === 'sunos' || process.platform === 'win32') {
       // uv_get_process_title() is unimplemented on Solaris-likes, it returns
       // an empty string.  On the Windows CI buildbots it returns
       // "Administrator: Windows PowerShell[42]" because of a GetConsoleTitle()

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const tmpdir = require('../common/tmpdir');
 
 const assert = require('assert');
@@ -186,10 +186,13 @@ try {
     require(`${loadOrder}file3`);
   } catch (e) {
     // Not a real .node module, but we know we require'd the right thing.
-    if (common.isOpenBSD) // OpenBSD errors with non-ELF object error
-      assert.ok(/File not an ELF object/.test(e.message.replace(backslash, '/')));
-    else
+    // OpenBSD errors with non-ELF object error
+    if (process.platform === 'openbsd') {
+      assert.ok(
+        /File not an ELF object/.test(e.message.replace(backslash, '/')));
+    } else {
       assert.ok(/file3\.node/.test(e.message.replace(backslash, '/')));
+    }
   }
 
   assert.strictEqual(require(`${loadOrder}file4`).file4, 'file4.reg');
@@ -198,10 +201,12 @@ try {
   try {
     require(`${loadOrder}file7`);
   } catch (e) {
-    if (common.isOpenBSD)
-      assert.ok(/File not an ELF object/.test(e.message.replace(backslash, '/')));
-    else
+    if (process.platform === 'openbsd') {
+      assert.ok(
+        /File not an ELF object/.test(e.message.replace(backslash, '/')));
+    } else {
       assert.ok(/file7\/index\.node/.test(e.message.replace(backslash, '/')));
+    }
   }
 
   assert.strictEqual(require(`${loadOrder}file8`).file8, 'file8/index.reg');

--- a/test/tick-processor/test-tick-processor-unknown.js
+++ b/test/tick-processor/test-tick-processor-unknown.js
@@ -6,7 +6,7 @@ const common = require('../common');
 // the full 64 bits and the result is that it does not process the
 // addresses correctly and runs out of memory
 // Disabling until we get a fix upstreamed into V8
-if (common.isAIX)
+if (process.platform === 'aix')
   common.skip('AIX address range too big for scripts.');
 
 if (!common.enoughTestCpu)

--- a/test/v8-updates/test-linux-perf.js
+++ b/test/v8-updates/test-linux-perf.js
@@ -43,7 +43,7 @@ const options = {
   encoding: 'utf-8',
 };
 
-if (!common.isLinux)
+if (process.platform !== 'linux')
   common.skip('only testing Linux for now');
 
 const perf = spawnSync('perf', perfArgs, options);

--- a/test/v8-updates/test-postmortem-metadata.js
+++ b/test/v8-updates/test-postmortem-metadata.js
@@ -15,10 +15,10 @@ const args = [
     getSharedLibPath() : process.execPath
 ];
 
-if (common.isAIX)
+if (process.platform === 'aix')
   args.unshift('-Xany', '-B');
 
-if (common.isOpenBSD)
+if (process.platform === 'openbsd')
   common.skip('no v8 debug symbols on OpenBSD');
 
 const nm = spawnSync('nm', args);


### PR DESCRIPTION
Start simplifying `require('../common')` by eliminating simple
convenience utility is* platform checks in favor of directly
checking the `process.platform` values.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
