### PR TITLE
test: add test for internalConnect() when address type is IPv6

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -197,6 +197,10 @@ Object.defineProperty(exports, 'localhostIPv4', {
   }
 });
 
+Object.defineProperty(exports, 'localhostIPv6', {
+  get: () => '::1'
+});
+
 // opensslCli defined lazily to reduce overhead of spawnSync
 Object.defineProperty(exports, 'opensslCli', { get: function() {
   if (opensslCli !== null) return opensslCli;

--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -20,7 +20,7 @@ const optionsIPv6 = {
   localAddress: common.localhostIPv6
 };
 
-const onError = (err, options) => {
+function onError(err, options) {
   assert.ok(expectedErrorCodes.includes(err.code));
   assert.strictEqual(err.syscall, 'connect');
   assert.strictEqual(err.localPort, options.localPort);
@@ -30,7 +30,7 @@ const onError = (err, options) => {
     `connect ${err.code} ${err.address}:${err.port} ` +
     `- Local (${err.localAddress}:${err.localPort})`
   );
-};
+}
 
 const clientIPv4 = net.connect(optionsIPv4);
 clientIPv4.on('error', common.mustCall((err) => onError(err, optionsIPv4)));

--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -6,20 +6,39 @@ const net = require('net');
 // EADDRINUSE is expected to occur on FreeBSD
 // Ref: https://github.com/nodejs/node/issues/13055
 const expectedErrorCodes = ['ECONNREFUSED', 'EADDRINUSE'];
-const client = net.connect({
+
+const optionsIPv4 = {
   port: common.PORT,
   localPort: common.PORT + 1,
   localAddress: common.localhostIPv4
-});
+};
 
-client.on('error', common.mustCall(function onError(err) {
+const optionsIPv6 = {
+  host: common.localhostIPv6,
+  port: common.PORT + 2,
+  localPort: common.PORT + 3,
+  localAddress: common.localhostIPv6
+};
+
+const onError = (err, options) => {
   assert.ok(expectedErrorCodes.includes(err.code));
   assert.strictEqual(err.syscall, 'connect');
-  assert.strictEqual(err.localPort, common.PORT + 1);
-  assert.strictEqual(err.localAddress, common.localhostIPv4);
+  assert.strictEqual(err.localPort, options.localPort);
+  assert.strictEqual(err.localAddress, options.localAddress);
   assert.strictEqual(
     err.message,
     `connect ${err.code} ${err.address}:${err.port} ` +
     `- Local (${err.localAddress}:${err.localPort})`
   );
-}));
+};
+
+const clientIPv4 = net.connect(optionsIPv4);
+clientIPv4.on('error', common.mustCall((err) => onError(err, optionsIPv4)));
+
+if (!common.hasIPv6) {
+  common.printSkipMessage('ipv6 part of test, no IPv6 support');
+  return;
+}
+
+const clientIPv6 = net.connect(optionsIPv6);
+clientIPv6.on('error', common.mustCall((err) => onError(err, optionsIPv6)));


### PR DESCRIPTION
According to the latest coverage report, internalConnect() is uncovered when address type is IPv6 (https://coverage.nodejs.org/coverage-36696cfe8479f3fd/root/net.js.html#L887). This PR adds a test for internalConnect() when address type is IPv6.

I didn't add a test when address type is neither IPv4 nor IPv6 since this condition isn't reachable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
