### PR TITLE
test: move common.ArrayStream to separate module

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -38,9 +38,6 @@ tasks.
 
 Takes `whitelist` and concats that with predefined `knownGlobals`.
 
-### arrayStream
-A stream to push an array into a REPL
-
 ### busyLoop(time)
 * `time` [&lt;number>]
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -413,6 +413,19 @@ Platform normalizes the `pwd` command.
 
 Synchronous version of `spawnPwd`.
 
+## ArrayStream Module
+
+The `ArrayStream` module provides a simple `Stream` that pushes elements from
+a given array.
+
+```js
+const ArrayStream = require('../common/arraystream');
+const stream = new ArrayStream();
+stream.run(['a', 'b', 'c']);
+```
+
+It can be used within tests as a simple mock stream.
+
 ## Countdown Module
 
 The `Countdown` module provides a simple countdown mechanism for tests that

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -418,6 +418,7 @@ Synchronous version of `spawnPwd`.
 The `ArrayStream` module provides a simple `Stream` that pushes elements from
 a given array.
 
+<!-- eslint-disable no-undef, node-core/required-modules -->
 ```js
 const ArrayStream = require('../common/arraystream');
 const stream = new ArrayStream();

--- a/test/common/arraystream.js
+++ b/test/common/arraystream.js
@@ -1,0 +1,24 @@
+/* eslint-disable node-core/required-modules */
+'use strict';
+
+const { Stream } = require('stream');
+const { inherits } = require('util');
+function noop() {}
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    data.forEach((line) => {
+      this.emit('data', `${line}\n`);
+    });
+  };
+}
+
+inherits(ArrayStream, Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.pause = noop;
+ArrayStream.prototype.resume = noop;
+ArrayStream.prototype.write = noop;
+
+module.exports = ArrayStream;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -27,7 +27,6 @@ const fs = require('fs');
 const assert = require('assert');
 const os = require('os');
 const { exec, execSync, spawn, spawnSync } = require('child_process');
-const stream = require('stream');
 const util = require('util');
 const { fixturesDir } = require('./fixtures');
 const tmpdir = require('./tmpdir');
@@ -527,23 +526,6 @@ exports.skip = function(msg) {
   exports.printSkipMessage(msg);
   process.exit(0);
 };
-
-// A stream to push an array into a REPL
-function ArrayStream() {
-  this.run = function(data) {
-    data.forEach((line) => {
-      this.emit('data', `${line}\n`);
-    });
-  };
-}
-
-util.inherits(ArrayStream, stream.Stream);
-exports.ArrayStream = ArrayStream;
-ArrayStream.prototype.readable = true;
-ArrayStream.prototype.writable = true;
-ArrayStream.prototype.pause = noop;
-ArrayStream.prototype.resume = noop;
-ArrayStream.prototype.write = noop;
 
 // Returns true if the exit code "exitCode" and/or signal name "signal"
 // represent the exit code and/or signal name of a node process that aborted,

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -21,11 +21,12 @@
 
 'use strict';
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const util = require('util');
 const repl = require('repl');
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 repl.start('', putIn, null, true);
 
 test1();

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -1,11 +1,12 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 const vm = require('vm');
 
 // Create a dummy stream that does nothing.
-const stream = new common.ArrayStream();
+const stream = new ArrayStream();
 
 // Test context when useGlobal is false.
 {

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -20,11 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 
 const repl = require('repl');
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 repl.start('', putIn);
 
 putIn.write = function(data) {

--- a/test/parallel/test-repl-editor.js
+++ b/test/parallel/test-repl-editor.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const repl = require('repl');
+const ArrayStream = require('../common/arraystream');
 
 // \u001b[1G - Moves the cursor to 1st column
 // \u001b[0J - Clear screen
@@ -11,7 +12,7 @@ const terminalCode = '\u001b[1G\u001b[0J> \u001b[3G';
 const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
 
 function run({ input, output, event, checkTerminalCodes = true }) {
-  const stream = new common.ArrayStream();
+  const stream = new ArrayStream();
   let found = '';
 
   stream.write = (msg) => found += msg.replace('\r', '');
@@ -74,8 +75,8 @@ tests.forEach(run);
 
 // Auto code alignment for .editor mode
 function testCodeAligment({ input, cursor = 0, line = '' }) {
-  const stream = new common.ArrayStream();
-  const outputStream = new common.ArrayStream();
+  const stream = new ArrayStream();
+  const outputStream = new ArrayStream();
 
   stream.write = () => { throw new Error('Writing not allowed!'); };
 

--- a/test/parallel/test-repl-end-emits-exit.js
+++ b/test/parallel/test-repl-end-emits-exit.js
@@ -20,14 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 let terminalExit = 0;
 let regularExit = 0;
 
 // Create a dummy stream that does nothing
-const stream = new common.ArrayStream();
+const stream = new ArrayStream();
 
 function testTerminalMode() {
   const r1 = repl.start({

--- a/test/parallel/test-repl-eval-scope.js
+++ b/test/parallel/test-repl-eval-scope.js
@@ -1,10 +1,11 @@
 'use strict';
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
 {
-  const stream = new common.ArrayStream();
+  const stream = new ArrayStream();
   const options = {
     eval: common.mustCall((cmd, context) => {
       assert.strictEqual(cmd, '.scope\n');

--- a/test/parallel/test-repl-inspector.js
+++ b/test/parallel/test-repl-inspector.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
@@ -8,7 +9,7 @@ common.skipIfInspectorDisabled();
 
 // This test verifies that the V8 inspector API is usable in the REPL.
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 let output = '';
 putIn.write = function(data) {
   output += data;

--- a/test/parallel/test-repl-let-process.js
+++ b/test/parallel/test-repl-let-process.js
@@ -1,8 +1,9 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const repl = require('repl');
 
 // Regression test for https://github.com/nodejs/node/issues/6802
-const input = new common.ArrayStream();
+const input = new ArrayStream();
 repl.start({ input, output: process.stdout, useGlobal: true });
 input.run(['let process']);

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -1,5 +1,6 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
@@ -20,8 +21,8 @@ undefined
 
 let accum = '';
 
-const inputStream = new common.ArrayStream();
-const outputStream = new common.ArrayStream();
+const inputStream = new ArrayStream();
+const outputStream = new ArrayStream();
 
 outputStream.write = (data) => accum += data.replace('\r', '');
 

--- a/test/parallel/test-repl-multiline.js
+++ b/test/parallel/test-repl-multiline.js
@@ -1,9 +1,10 @@
 'use strict';
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
-const inputStream = new common.ArrayStream();
-const outputStream = new common.ArrayStream();
+const inputStream = new ArrayStream();
+const outputStream = new ArrayStream();
 const input = ['var foo = {', '};', 'foo;'];
 let output = '';
 

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -21,11 +21,12 @@
 
 'use strict';
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
 // Create a dummy stream that does nothing
-const stream = new common.ArrayStream();
+const stream = new ArrayStream();
 
 // 1, mostly defaults
 const r1 = repl.start({

--- a/test/parallel/test-repl-pretty-custom-stack.js
+++ b/test/parallel/test-repl-pretty-custom-stack.js
@@ -1,5 +1,6 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
@@ -8,8 +9,8 @@ const repl = require('repl');
 function run({ command, expected }) {
   let accum = '';
 
-  const inputStream = new common.ArrayStream();
-  const outputStream = new common.ArrayStream();
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
 
   outputStream.write = (data) => accum += data.replace('\r', '');
 

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -1,5 +1,6 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
@@ -8,8 +9,8 @@ const repl = require('repl');
 function run({ command, expected }) {
   let accum = '';
 
-  const inputStream = new common.ArrayStream();
-  const outputStream = new common.ArrayStream();
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
 
   outputStream.write = (data) => accum += data.replace('\r', '');
 

--- a/test/parallel/test-repl-recoverable.js
+++ b/test/parallel/test-repl-recoverable.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
@@ -14,7 +15,7 @@ function customEval(code, context, file, cb) {
   return cb(evalCount === 1 ? new repl.Recoverable() : null, true);
 }
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 
 putIn.write = function(msg) {
   if (msg === '... ') {

--- a/test/parallel/test-repl-reset-event.js
+++ b/test/parallel/test-repl-reset-event.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 const util = require('util');
@@ -29,7 +29,7 @@ const util = require('util');
 common.allowGlobals(42);
 
 // Create a dummy stream that does nothing
-const dummy = new common.ArrayStream();
+const dummy = new ArrayStream();
 
 function testReset(cb) {
   const r = repl.start({

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const join = require('path').join;
 const fs = require('fs');
@@ -32,7 +33,7 @@ const repl = require('repl');
 
 const works = [['inner.one'], 'inner.o'];
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
 
@@ -59,7 +60,7 @@ assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
     'return "saved";',
     '}'
   ];
-  const putIn = new common.ArrayStream();
+  const putIn = new ArrayStream();
   const replServer = repl.start('', putIn);
 
   putIn.run(['.editor']);

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
@@ -10,7 +11,7 @@ process.on('exit', () => {
   assert.strictEqual(found, true);
 });
 
-common.ArrayStream.prototype.write = function(output) {
+ArrayStream.prototype.write = function(output) {
   // Matching only on a minimal piece of the stack because the string will vary
   // greatly depending on the JavaScript engine. V8 includes `;` because it
   // displays the line of code (`var foo bar;`) that is causing a problem.
@@ -20,7 +21,7 @@ common.ArrayStream.prototype.write = function(output) {
     found = true;
 };
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 repl.start('', putIn);
 let file = fixtures.path('syntax', 'bad_syntax');
 

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
-common.ArrayStream.prototype.write = () => {};
+ArrayStream.prototype.write = () => {};
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
 // https://github.com/nodejs/node/issues/3346

--- a/test/parallel/test-repl-tab-complete-no-warn.js
+++ b/test/parallel/test-repl-tab-complete-no-warn.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const repl = require('repl');
 const DEFAULT_MAX_LISTENERS = require('events').defaultMaxListeners;
 
-common.ArrayStream.prototype.write = () => {
+ArrayStream.prototype.write = () => {
 };
 
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
 // https://github.com/nodejs/node/issues/18284

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const common = require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const hasInspector = process.config.variables.v8_enable_inspector === 1;
@@ -44,7 +45,7 @@ function getNoResultsFunction() {
 }
 
 const works = [['inner.one'], 'inner.o'];
-const putIn = new common.ArrayStream();
+const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);
 
 // Some errors are passed to the domain, but do not callback
@@ -536,7 +537,7 @@ testCustomCompleterAsyncMode.complete('a', common.mustCall((error, data) => {
 }));
 
 // tab completion in editor mode
-const editorStream = new common.ArrayStream();
+const editorStream = new ArrayStream();
 const editor = repl.start({
   stream: editorStream,
   terminal: true,
@@ -559,7 +560,7 @@ editor.completer('var log = console.l', common.mustCall((error, data) => {
 
 {
   // tab completion of lexically scoped variables
-  const stream = new common.ArrayStream();
+  const stream = new ArrayStream();
   const testRepl = repl.start({ stream });
 
   stream.run([`

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
+const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const { stripVTControlCharacters } = require('internal/readline');
 const repl = require('repl');
@@ -9,7 +10,7 @@ const repl = require('repl');
 
 const PROMPT = 'await repl > ';
 
-class REPLStream extends common.ArrayStream {
+class REPLStream extends ArrayStream {
   constructor() {
     super();
     this.waitingForResponse = false;


### PR DESCRIPTION
In a continuing effort to de-monolithize `require('../common')`,
move `common.ArrayStream` out to a separate module that is
imported only when it is needed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
