### PR TITLE
test: remove third argument from assert.strictEqual()

### DIFF
--- a/test/parallel/test-wasm-simple.js
+++ b/test/parallel/test-wasm-simple.js
@@ -9,9 +9,9 @@ const buffer = fixtures.readSync('test.wasm');
 assert.ok(WebAssembly.validate(buffer), 'Buffer should be valid WebAssembly');
 
 WebAssembly.instantiate(buffer, {}).then((results) => {
+  // Exported function should add two numbers.
   assert.strictEqual(
     results.instance.exports.addTwo(10, 20),
-    30,
-    'Exported function should add two numbers.',
+    30
   );
 });


### PR DESCRIPTION
test: remove third argument from assert.strictEqual()

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
