### PR TITLE
tools: apply linting to first commit in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
         - NODE=$(which node)
       script:
         - make lint
+        # Lint the first commit in the PR.
+        - git log HEAD ^$TRAVIS_BRANCH --pretty=format:'%h' --no-merges | tail -1 | xargs npx core-validate-commit --no-validate-metadata
     - name: "Test Suite"
       install:
         - ./configure


### PR DESCRIPTION
First commit:

    tools: only use Travis-CI on master branch
    
    Limit Travis-CI to the master branch. One benefit is that it will
    simplify the logic for commit message linting.


Second commit:

    tools: apply linting to first commit in PRs
    
    Use Travis-CI to check the formatting of the first commit in a pull
    request. This will hopefully reduce formatting errors and nits about
    them in pull requests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
