### PR TITLE
lib: remove unnecessary symbols

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -147,7 +147,7 @@ function Readable(options) {
 
   // Checking for a Stream.Duplex instance is faster here instead of inside
   // the ReadableState constructor, at least with V8 6.5
-  const isDuplex = (this instanceof Stream.Duplex);
+  const isDuplex = this instanceof Stream.Duplex;
 
   this._readableState = new ReadableState(options, this, isDuplex);
 


### PR DESCRIPTION
Remove `(...)`, because this is a simple,sensitive expression.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]