### PR TITLE
test,stream: fix pipeline test so it runs well on Windows in older nodes

### DIFF
--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -165,8 +165,13 @@ const { promisify } = require('util');
 
 {
   const server = http.createServer((req, res) => {
+    let sent = false;
     const rs = new Readable({
       read() {
+        if (sent) {
+          return;
+        }
+        sent = true;
         rs.push('hello');
       },
       destroy: common.mustCall((err, cb) => {
@@ -195,8 +200,12 @@ const { promisify } = require('util');
 
 {
   const server = http.createServer((req, res) => {
+    let sent = 0;
     const rs = new Readable({
       read() {
+        if (sent++ > 10) {
+          return;
+        }
         rs.push('hello');
       },
       destroy: common.mustCall((err, cb) => {
@@ -242,8 +251,12 @@ const { promisify } = require('util');
       port: server.address().port
     });
 
+    let sent = 0;
     const rs = new Readable({
       read() {
+        if (sent++ > 10) {
+          return;
+        }
         rs.push('hello');
       }
     });


### PR DESCRIPTION
This test is ported automatically in readable-stream, and it fails there
on Windows and older Node.js versions because of some bad interactions
between the code and the event loop on Windows.

See: https://github.com/nodejs/readable-stream/issues/353

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
