### PR TITLE
crypto: deprecate _toBuf

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1031,6 +1031,14 @@ With the current crypto API, having `Cipher.setAuthTag()` and
 when called. They have never been documented and will be removed in a future
 release.
 
+<a id="DEP00XX"></a>
+### DEP00XX: crypto._toBuf()
+
+Type: Runtime
+
+The `crypto._toBuf()` function was not designed to be used by modules outside
+of Node.js core and will become unavailable in the future.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1037,7 +1037,7 @@ release.
 Type: Runtime
 
 The `crypto._toBuf()` function was not designed to be used by modules outside
-of Node.js core and will become unavailable in the future.
+of Node.js core and will be removed in the future.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -31,8 +31,8 @@ const {
 
 const { SSL_OP_CIPHER_SERVER_PREFERENCE } = process.binding('constants').crypto;
 
-// Lazily loaded
-var crypto = null;
+// Lazily loaded from internal/crypto/util.
+let toBuf = null;
 
 const { SecureContext: NativeSecureContext } = process.binding('crypto');
 
@@ -178,26 +178,26 @@ exports.createSecureContext = function createSecureContext(options, context) {
   }
 
   if (options.pfx) {
-    if (!crypto)
-      crypto = require('crypto');
+    if (!toBuf)
+      toBuf = require('internal/crypto/util').toBuf;
 
     if (Array.isArray(options.pfx)) {
       for (i = 0; i < options.pfx.length; i++) {
         const pfx = options.pfx[i];
         const raw = pfx.buf ? pfx.buf : pfx;
-        const buf = crypto._toBuf(raw);
+        const buf = toBuf(raw);
         const passphrase = pfx.passphrase || options.passphrase;
         if (passphrase) {
-          c.context.loadPKCS12(buf, crypto._toBuf(passphrase));
+          c.context.loadPKCS12(buf, toBuf(passphrase));
         } else {
           c.context.loadPKCS12(buf);
         }
       }
     } else {
-      const buf = crypto._toBuf(options.pfx);
+      const buf = toBuf(options.pfx);
       const passphrase = options.passphrase;
       if (passphrase) {
-        c.context.loadPKCS12(buf, crypto._toBuf(passphrase));
+        c.context.loadPKCS12(buf, toBuf(passphrase));
       } else {
         c.context.loadPKCS12(buf);
       }

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -139,7 +139,7 @@ function createVerify(algorithm, options) {
 
 module.exports = exports = {
   // Methods
-  _toBuf: toBuf,
+  _toBuf: deprecate(toBuf, 'crypto._toBuf is deprecated.', 'DEP00XX'),
   createCipheriv,
   createDecipheriv,
   createDiffieHellman,

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -25,6 +25,13 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+common.expectWarning({
+  DeprecationWarning: [
+    ['crypto.createCipher is deprecated.', 'DEP0106'],
+    ['crypto._toBuf is deprecated.', 'DEP00XX']
+  ]
+});
+
 const assert = require('assert');
 const crypto = require('crypto');
 const tls = require('tls');
@@ -294,3 +301,8 @@ testEncoding({
 testEncoding({
   defaultEncoding: 'latin1'
 }, assertionHashLatin1);
+
+{
+  // Test that the exported _toBuf function is deprecated.
+  crypto._toBuf(Buffer.alloc(0));
+}


### PR DESCRIPTION
This function is almost trivial and was not supposed to be visible outside of Node.js core.

I am not entirely happy with the wording in the deprecation documentation, suggestions are welcome.

Fixes: https://github.com/nodejs/node/issues/22425

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
