### PR TITLE
url: expose pathToFileURL and fileURLToPath

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -956,9 +956,10 @@ control characters are correctly encoded when converting into a File URL.
 For example:
 
 ```js
-new URL(__filename);                // Incorrect: throws (POSIX) or detects
-                                    // drive letter as the schema in Windows
-pathToFileURL(__filename);          // Correct:   file:///...
+new URL(__filename);                // Incorrect: throws (POSIX)
+new URL(__filename);                // Incorrect: C:\... (Windows)
+pathToFileURL(__filename);          // Correct:   file:///... (POSIX)
+pathToFileURL(__filename);          // Correct:   file:///C:/... (Windows)
 
 new URL('/foo#1', 'file:');         // Incorrect: file:///foo#
 pathToFileURL('/foo#');             // Correct:   file:///foo%231 (POSIX)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -924,7 +924,7 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 ## File URL Utility Functions
 
 When working with `file:///` URLs in Node.js (eg when working with ES modules
-which are keyed in the registry by File URL), the utility functions
+which are keyed in the module map by File URL), the utility functions
 `pathToFileURL` and `fileURLToPath` are provided to convert to and from file
 paths.
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -888,23 +888,21 @@ console.log(url.domainToUnicode('xn--iñvalid.com'));
 This function ensures the correct decodings of percent-encoded characters as
 well as ensuring a cross-platform valid absolute path string.
 
-When converting from URL to path, the following common errors can occur:
+For example:
 
 ```js
-// '/C:/path/' instead of 'C:\path\' (Windows)
-new URL('file:///C:/path/').pathname;
+new URL('file:///C:/path/').pathname;    // Incorrect: /C:/path/ (Windows)
+fileURLToPath('file:///C:/path/');       // Correct:   C:\path\
 
-// '/foo.txt' instead of '\\nas\foo.txt' (Windows)
-new URL('file://nas/foo.txt').pathname;
+new URL('file://nas/foo.txt').pathname;  // Incorrect: /foo.txt (Windows)
+fileURLToPath('file://nas/foo.txt');     // Correct:   \\nas\foo.txt
 
-// '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (POSIX)
-new URL('file:///你好.txt').pathname;
+new URL('file:///你好.txt').pathname;    // Incorrect: /%E4%BD%A0%E5%A5%BD.txt
+fileURLToPath('file:///你好.txt');       // Correct:   /你好.txt (POSIX)
 
-// '/hello%20world.txt' instead of '/hello world.txt' (POSIX)
-new URL('file:///hello world.txt').pathname;
+new URL('file:///hello world').pathname; // Incorrect: /hello%20world
+fileURLToPath('file:///hello world');    // Correct:   /hello world (POSIX)
 ```
-
-where using `url.fileURLToPath(fileURL)` can get the correct results above.
 
 ### url.format(URL[, options])
 <!-- YAML
@@ -949,30 +947,28 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 
 ### url.pathToFileURL(path)
 
-* `path` {string} The absolute path to convert to a File URL.
+* `path` {string} The path to convert to a File URL.
 * Returns: {URL} The file URL object.
 
-This function ensures the correct encodings of URL control characters in file
-paths when converting into File URLs.
+This function ensures that `path` is resolved absolutely, and that the URL control
+characters are correctly encoded when converting into a File URL.
 
-For example, the following errors can occur when converting from paths to URLs:
+For example:
 
 ```js
-// throws for missing schema (POSIX)
-// (in Windows the drive letter is detected as the protocol)
-new URL(__filename);
+new URL(__filename);                // Incorrect: throws in POSIX or detects drive
+                                    //            letter as the schema in Windows
+pathToFileURL(__filename);          // Correct:   file:///...
 
-// 'file:///foo#' instead of the correct 'file:///foo%231' (POSIX)
-new URL('/foo#1', 'file:');
+new URL('/foo#1', 'file:');         // Incorrect: file:///foo# (POSIX)
+pathToFileURL('/foo#');             // Correct:   file:///foo%231
 
-// 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (POSIX)
-new URL('//nas/foo.txt', 'file:');
+new URL('//nas/foo.txt', 'file:');  // Incorrect: file:///nas/foo.txt (Windows)
+pathToFileURL('//nas/foo.txt');     // Correct:   file://nas/foo.txt
 
-// 'file:///some/path%' instead of the correct 'file:///some/path%25' (POSIX)
-new URL('/some/path%.js', 'file:');
+new URL('/some/path%.js', 'file:'); // Incorrect: file:///some/path% (POSIX)
+pathToFileURL('/some/path%.js');    // Correct:   file:///some/path%25
 ```
-
-where using `url.pathToFileURL(path)` can get the correct results above.
 
 ## Legacy URL API
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -921,15 +921,13 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 // Prints 'https://你好你好/?abc'
 ```
 
-## File URL Utility Functions
+### url.pathToFileURL(path)
 
-When working with `file:///` URLs in Node.js (eg when working with ES modules
-which are keyed in the module map by File URL), the utility functions
-`pathToFileURL` and `fileURLToPath` are provided to convert to and from file
-paths.
+* `path` {string} The absolute path to convert to a File URL.
+* Returns: {URL} The file URL object.
 
-The edge cases handled by these functions include percent-encoding and decoding
-as well as cross-platform support.
+This function ensures the correct encodings of URL control characters in file
+paths when converting into File URLs.
 
 For example, the following errors can occur when converting from paths to URLs:
 
@@ -950,10 +948,18 @@ new URL(`sfile:${'/some/path%.js'}`);
 
 where using `pathToFileURL` we can get the correct results above.
 
+### url.fileURLToPath(url)
+
+* `url` {URL} | {string} The file URL string or URL object to convert to a path.
+* Returns: {URL} The fully-resolved platform-specific Node.js file path.
+
+This function ensures the correct decodings of percent-encoded characters as
+well as ensuring a cross-platform valid absolute path string.
+
 When converting from URL to path, the following common errors can occur:
 
 ```js
-// '/C:/path/' instead of 'C:\path\'
+// '/C:/path/' instead of 'C:\path\' (Windows)
 new URL('file:///C:/path/').pathname;
 
 // '/foo.txt' instead of '\\nas\foo.txt' (Windows)
@@ -962,27 +968,11 @@ new URL('file://nas/foo.txt').pathname;
 // '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (posix)
 new URL('file:///你好.txt').pathname;
 
-// '/hello%20world.txt' instead of '/hello world.txt'
+// '/hello%20world.txt' instead of '/hello world.txt' (posix)
 new URL('file:///hello world.txt').pathname;
 ```
 
 where using `fileURLToPath` we can get the correct results above.
-
-### pathToFileURL(path)
-
-* `path` {string} The absolute path to convert to a File URL.
-* Returns: {URL} The file URL object.
-
-This function ensures the correct encodings of URL control characters in file
-paths when converting into File URLs.
-
-### fileURLToPath(url)
-
-* `url` {URL} | {string} The file URL string or URL object to convert to a path.
-* Returns: {URL} The fully-resolved platform-specific Node.js file path.
-
-This function ensures the correct decodings of percent-encoded characters as
-well as ensuring a cross-platform valid absolute path string.
 
 ## Legacy URL API
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -925,7 +925,7 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 
 When working with `file:///` URLs in Node.js (eg when working with ES modules
 which are keyed in the registry by File URL), the utility functions
-`urlToFilePath` and `fileURLToPath` are provided to convert to and from file
+`pathToFileURL` and `fileURLToPath` are provided to convert to and from file
 paths.
 
 The edge cases handled by these functions include percent-encoding and decoding
@@ -942,10 +942,10 @@ new URL(__filename);
 new URL('./foo#1', 'file:///');
 
 // 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (posix)
-new URL('file://' + '//nas/foo.txt');
+new URL(`file://${'//nas/foo.txt'}`);
 
 // 'file:///some/path%' instead of the correct 'file:///some/path%25' (posix)
-new URL('file:' + '/some/path%.js');
+new URL(`sfile:${'/some/path%.js'}`);
 ```
 
 where using `pathToFileURL` we can get the correct results above.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -883,7 +883,7 @@ console.log(url.domainToUnicode('xn--iñvalid.com'));
 ### url.fileURLToPath(url)
 
 * `url` {URL | string} The file URL string or URL object to convert to a path.
-* Returns: {URL} The fully-resolved platform-specific Node.js file path.
+* Returns: {string} The fully-resolved platform-specific Node.js file path.
 
 This function ensures the correct decodings of percent-encoded characters as
 well as ensuring a cross-platform valid absolute path string.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -880,6 +880,32 @@ console.log(url.domainToUnicode('xn--iñvalid.com'));
 // Prints an empty string
 ```
 
+### url.fileURLToPath(url)
+
+* `url` {URL | string} The file URL string or URL object to convert to a path.
+* Returns: {URL} The fully-resolved platform-specific Node.js file path.
+
+This function ensures the correct decodings of percent-encoded characters as
+well as ensuring a cross-platform valid absolute path string.
+
+When converting from URL to path, the following common errors can occur:
+
+```js
+// '/C:/path/' instead of 'C:\path\' (Windows)
+new URL('file:///C:/path/').pathname;
+
+// '/foo.txt' instead of '\\nas\foo.txt' (Windows)
+new URL('file://nas/foo.txt').pathname;
+
+// '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (POSIX)
+new URL('file:///你好.txt').pathname;
+
+// '/hello%20world.txt' instead of '/hello world.txt' (POSIX)
+new URL('file:///hello world.txt').pathname;
+```
+
+where using `url.fileURLToPath` we can get the correct results above.
+
 ### url.format(URL[, options])
 <!-- YAML
 added: v7.6.0
@@ -932,47 +958,21 @@ paths when converting into File URLs.
 For example, the following errors can occur when converting from paths to URLs:
 
 ```js
-// throws for missing schema (posix)
+// throws for missing schema (POSIX)
 // (in Windows the drive letter is detected as the protocol)
 new URL(__filename);
 
-// 'file:///foo' instead of the correct 'file:///foo%231' (posix)
+// 'file:///foo' instead of the correct 'file:///foo%231' (POSIX)
 new URL('./foo#1', 'file:///');
 
-// 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (posix)
+// 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (POSIX)
 new URL(`file://${'//nas/foo.txt'}`);
 
-// 'file:///some/path%' instead of the correct 'file:///some/path%25' (posix)
-new URL(`sfile:${'/some/path%.js'}`);
+// 'file:///some/path%' instead of the correct 'file:///some/path%25' (POSIX)
+new URL(`file:${'/some/path%.js'}`);
 ```
 
-where using `pathToFileURL` we can get the correct results above.
-
-### url.fileURLToPath(url)
-
-* `url` {URL} | {string} The file URL string or URL object to convert to a path.
-* Returns: {URL} The fully-resolved platform-specific Node.js file path.
-
-This function ensures the correct decodings of percent-encoded characters as
-well as ensuring a cross-platform valid absolute path string.
-
-When converting from URL to path, the following common errors can occur:
-
-```js
-// '/C:/path/' instead of 'C:\path\' (Windows)
-new URL('file:///C:/path/').pathname;
-
-// '/foo.txt' instead of '\\nas\foo.txt' (Windows)
-new URL('file://nas/foo.txt').pathname;
-
-// '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (posix)
-new URL('file:///你好.txt').pathname;
-
-// '/hello%20world.txt' instead of '/hello world.txt' (posix)
-new URL('file:///hello world.txt').pathname;
-```
-
-where using `fileURLToPath` we can get the correct results above.
+where using `url.pathToFileURL` we can get the correct results above.
 
 ## Legacy URL API
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -891,11 +891,11 @@ well as ensuring a cross-platform valid absolute path string.
 For example:
 
 ```js
-new URL('file:///C:/path/').pathname;    // Incorrect: /C:/path/ (Windows)
-fileURLToPath('file:///C:/path/');       // Correct:   C:\path\
+new URL('file:///C:/path/').pathname;    // Incorrect: /C:/path/
+fileURLToPath('file:///C:/path/');       // Correct:   C:\path\ (Windows)
 
-new URL('file://nas/foo.txt').pathname;  // Incorrect: /foo.txt (Windows)
-fileURLToPath('file://nas/foo.txt');     // Correct:   \\nas\foo.txt
+new URL('file://nas/foo.txt').pathname;  // Incorrect: /foo.txt
+fileURLToPath('file://nas/foo.txt');     // Correct:   \\nas\foo.txt (Windows)
 
 new URL('file:///你好.txt').pathname;    // Incorrect: /%E4%BD%A0%E5%A5%BD.txt
 fileURLToPath('file:///你好.txt');       // Correct:   /你好.txt (POSIX)
@@ -960,14 +960,14 @@ new URL(__filename);                // Incorrect: throws (POSIX) or detects
                                     // drive letter as the schema in Windows
 pathToFileURL(__filename);          // Correct:   file:///...
 
-new URL('/foo#1', 'file:');         // Incorrect: file:///foo# (POSIX)
-pathToFileURL('/foo#');             // Correct:   file:///foo%231
+new URL('/foo#1', 'file:');         // Incorrect: file:///foo#
+pathToFileURL('/foo#');             // Correct:   file:///foo%231 (POSIX)
 
-new URL('//nas/foo.txt', 'file:');  // Incorrect: file:///nas/foo.txt (Windows)
-pathToFileURL('//nas/foo.txt');     // Correct:   file://nas/foo.txt
+new URL('//nas/foo.txt', 'file:');  // Incorrect: file:///nas/foo.txt
+pathToFileURL('//nas/foo.txt');     // Correct:   file://nas/foo.txt (Windows)
 
-new URL('/some/path%.js', 'file:'); // Incorrect: file:///some/path% (POSIX)
-pathToFileURL('/some/path%.js');    // Correct:   file:///some/path%25
+new URL('/some/path%.js', 'file:'); // Incorrect: file:///some/path%
+pathToFileURL('/some/path%.js');    // Correct:   file:///some/path%25 (POSIX)
 ```
 
 ## Legacy URL API

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -925,46 +925,61 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 
 When working with `file:///` URLs in Node.js (eg when working with ES modules
 which are keyed in the registry by File URL), the utility functions
-`urlToFilePath` and `fileUrlToPath` are provided to convert to and from file
+`urlToFilePath` and `fileURLToPath` are provided to convert to and from file
 paths.
 
 The edge cases handled by these functions include percent-encoding and decoding
 as well as cross-platform support.
 
-For example, instead of writing:
+For example, the following errors can occur when converting from paths to URLs:
 
 ```js
-// BAD:
-// - fails in Windows
-// - doesn't handle loading paths using extended non-latin characters
-fs.promises.readFile(fileUrl.pathname);
+// throws for missing schema (posix)
+// (in Windows the drive letter is detected as the protocol)
+new URL(__filename);
+
+// 'file:///foo' instead of the correct 'file:///foo%231' (posix)
+new URL('./foo#1', 'file:///');
+
+// 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (posix)
+new URL('file://' + '//nas/foo.txt');
+
+// 'file:///some/path%' instead of the correct 'file:///some/path%25' (posix)
+new URL('file:' + '/some/path%.js');
 ```
 
-write:
+where using `pathToFileURL` we can get the correct results above.
+
+When converting from URL to path, the following common errors can occur:
 
 ```js
-// GOOD:
-// - works in Windows
-// - handles emoji file paths
-const { fileUrlToPath } = require('url');
-fs.promises.readFile(fileUrlToPath(fileUrl));
+// '/foo.txt' instead of '//nas/foo.txt' (Windows)
+new URL('file://nas/foo.txt').pathname;
+
+// '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (posix)
+new URL('file:///你好.txt').pathname;
+
+// '/hello%20world.txt' instead of '/hello world.txt'
+new URL('file:///hello world.txt').pathname;
 ```
 
-### pathToFileUrl(path)
+where using `fileURLToPath` we can get the correct results above.
+
+### pathToFileURL(path)
 
 * `path` {string} The absolute path to convert to a File URL.
 * Returns: {URL} The file URL object.
 
-This function ensures the correct encodings of URL control characters in file paths
-when converting into File URLs.
+This function ensures the correct encodings of URL control characters in file
+paths when converting into File URLs.
 
-### fileUrlToPath(url)
+### fileURLToPath(url)
 
 * `url` {URL} | {string} The file URL string or URL object to convert to a path.
 * Returns: {URL} The fully-resolved platform-specific Node.js file path.
 
-This function ensures the correct decodings of percent-encoded characters as well
-as ensuring a cross-platform valid absolute path string.
+This function ensures the correct decodings of percent-encoded characters as
+well as ensuring a cross-platform valid absolute path string.
 
 ## Legacy URL API
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -930,8 +930,6 @@ string serializations of the URL. These are not, however, customizable in
 any way. The `url.format(URL[, options])` method allows for basic customization
 of the output.
 
-For example:
-
 ```js
 const myURL = new URL('https://a:b@你好你好?abc#foo');
 
@@ -953,19 +951,14 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 This function ensures that `path` is resolved absolutely, and that the URL
 control characters are correctly encoded when converting into a File URL.
 
-For example:
-
 ```js
 new URL(__filename);                // Incorrect: throws (POSIX)
 new URL(__filename);                // Incorrect: C:\... (Windows)
 pathToFileURL(__filename);          // Correct:   file:///... (POSIX)
 pathToFileURL(__filename);          // Correct:   file:///C:/... (Windows)
 
-new URL('/foo#1', 'file:');         // Incorrect: file:///foo#
-pathToFileURL('/foo#');             // Correct:   file:///foo%231 (POSIX)
-
-new URL('//nas/foo.txt', 'file:');  // Incorrect: file:///nas/foo.txt
-pathToFileURL('//nas/foo.txt');     // Correct:   file://nas/foo.txt (Windows)
+new URL('/foo#1', 'file:');         // Incorrect: file:///foo#1
+pathToFileURL('/foo#1');            // Correct:   file:///foo%231 (POSIX)
 
 new URL('/some/path%.js', 'file:'); // Incorrect: file:///some/path%
 pathToFileURL('/some/path%.js');    // Correct:   file:///some/path%25 (POSIX)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -950,14 +950,14 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 * `path` {string} The path to convert to a File URL.
 * Returns: {URL} The file URL object.
 
-This function ensures that `path` is resolved absolutely, and that the URL control
-characters are correctly encoded when converting into a File URL.
+This function ensures that `path` is resolved absolutely, and that the URL
+control characters are correctly encoded when converting into a File URL.
 
 For example:
 
 ```js
-new URL(__filename);                // Incorrect: throws in POSIX or detects drive
-                                    //            letter as the schema in Windows
+new URL(__filename);                // Incorrect: throws (POSIX) or detects
+                                    // drive letter as the schema in Windows
 pathToFileURL(__filename);          // Correct:   file:///...
 
 new URL('/foo#1', 'file:');         // Incorrect: file:///foo# (POSIX)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -904,7 +904,7 @@ new URL('file:///你好.txt').pathname;
 new URL('file:///hello world.txt').pathname;
 ```
 
-where using `url.fileURLToPath` we can get the correct results above.
+where using `url.fileURLToPath(fileURL)` can get the correct results above.
 
 ### url.format(URL[, options])
 <!-- YAML
@@ -962,17 +962,17 @@ For example, the following errors can occur when converting from paths to URLs:
 // (in Windows the drive letter is detected as the protocol)
 new URL(__filename);
 
-// 'file:///foo' instead of the correct 'file:///foo%231' (POSIX)
-new URL('./foo#1', 'file:///');
+// 'file:///foo#' instead of the correct 'file:///foo%231' (POSIX)
+new URL('/foo#1', 'file:');
 
 // 'file:///nas/foo.txt' instead of the correct 'file:///foo.txt' (POSIX)
-new URL(`file://${'//nas/foo.txt'}`);
+new URL('//nas/foo.txt', 'file:');
 
 // 'file:///some/path%' instead of the correct 'file:///some/path%25' (POSIX)
-new URL(`file:${'/some/path%.js'}`);
+new URL('/some/path%.js', 'file:');
 ```
 
-where using `url.pathToFileURL` we can get the correct results above.
+where using `url.pathToFileURL(path)` can get the correct results above.
 
 ## Legacy URL API
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -888,8 +888,6 @@ console.log(url.domainToUnicode('xn--iñvalid.com'));
 This function ensures the correct decodings of percent-encoded characters as
 well as ensuring a cross-platform valid absolute path string.
 
-For example:
-
 ```js
 new URL('file:///C:/path/').pathname;    // Incorrect: /C:/path/
 fileURLToPath('file:///C:/path/');       // Correct:   C:\path\ (Windows)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -953,7 +953,10 @@ where using `pathToFileURL` we can get the correct results above.
 When converting from URL to path, the following common errors can occur:
 
 ```js
-// '/foo.txt' instead of '//nas/foo.txt' (Windows)
+// '/C:/path/' instead of 'C:\path\'
+new URL('file:///C:/path/').pathname;
+
+// '/foo.txt' instead of '\\nas\foo.txt' (Windows)
 new URL('file://nas/foo.txt').pathname;
 
 // '/%E4%BD%A0%E5%A5%BD.txt' instead of '/你好.txt' (posix)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -921,6 +921,51 @@ console.log(url.format(myURL, { fragment: false, unicode: true, auth: false }));
 // Prints 'https://你好你好/?abc'
 ```
 
+## File URL Utility Functions
+
+When working with `file:///` URLs in Node.js (eg when working with ES modules
+which are keyed in the registry by File URL), the utility functions
+`urlToFilePath` and `fileUrlToPath` are provided to convert to and from file
+paths.
+
+The edge cases handled by these functions include percent-encoding and decoding
+as well as cross-platform support.
+
+For example, instead of writing:
+
+```js
+// BAD:
+// - fails in Windows
+// - doesn't handle loading paths using extended non-latin characters
+fs.promises.readFile(fileUrl.pathname);
+```
+
+write:
+
+```js
+// GOOD:
+// - works in Windows
+// - handles emoji file paths
+const { fileUrlToPath } = require('url');
+fs.promises.readFile(fileUrlToPath(fileUrl));
+```
+
+### pathToFileUrl(path)
+
+* `path` {string} The absolute path to convert to a File URL.
+* Returns: {URL} The file URL object.
+
+This function ensures the correct encodings of URL control characters in file paths
+when converting into File URLs.
+
+### fileUrlToPath(url)
+
+* `url` {URL} | {string} The file URL string or URL object to convert to a path.
+* Returns: {URL} The fully-resolved platform-specific Node.js file path.
+
+This function ensures the correct decodings of percent-encoded characters as well
+as ensuring a cross-platform valid absolute path string.
+
 ## Legacy URL API
 
 ### Legacy `urlObject`

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -54,7 +54,7 @@ const {
 
 const { FSReqCallback, statValues } = binding;
 const internalFS = require('internal/fs/utils');
-const { toPathIfFileUrl } = require('internal/url');
+const { toPathIfFileURL } = require('internal/url');
 const internalUtil = require('internal/util');
 const {
   copyObject,
@@ -177,7 +177,7 @@ function access(path, mode, callback) {
     mode = F_OK;
   }
 
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
 
   mode = mode | 0;
@@ -187,7 +187,7 @@ function access(path, mode, callback) {
 }
 
 function accessSync(path, mode) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
 
   if (mode === undefined)
@@ -297,7 +297,7 @@ function readFile(path, options, callback) {
     return;
   }
 
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   binding.open(pathModule.toNamespacedPath(path),
                stringToFlags(options.flag || 'r'),
@@ -409,7 +409,7 @@ function closeSync(fd) {
 }
 
 function open(path, flags, mode, callback) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const flagsNumber = stringToFlags(flags);
   if (arguments.length < 4) {
@@ -431,7 +431,7 @@ function open(path, flags, mode, callback) {
 
 
 function openSync(path, flags, mode) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const flagsNumber = stringToFlags(flags);
   mode = validateMode(mode, 'mode', 0o666);
@@ -587,9 +587,9 @@ function writeSync(fd, buffer, offset, length, position) {
 
 function rename(oldPath, newPath, callback) {
   callback = makeCallback(callback);
-  oldPath = toPathIfFileUrl(oldPath);
+  oldPath = toPathIfFileURL(oldPath);
   validatePath(oldPath, 'oldPath');
-  newPath = toPathIfFileUrl(newPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(newPath, 'newPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -599,9 +599,9 @@ function rename(oldPath, newPath, callback) {
 }
 
 function renameSync(oldPath, newPath) {
-  oldPath = toPathIfFileUrl(oldPath);
+  oldPath = toPathIfFileURL(oldPath);
   validatePath(oldPath, 'oldPath');
-  newPath = toPathIfFileUrl(newPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(newPath, 'newPath');
   const ctx = { path: oldPath, dest: newPath };
   binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -680,7 +680,7 @@ function ftruncateSync(fd, len = 0) {
 
 function rmdir(path, callback) {
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -688,7 +688,7 @@ function rmdir(path, callback) {
 }
 
 function rmdirSync(path) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
@@ -735,7 +735,7 @@ function mkdir(path, options, callback) {
     mode = 0o777
   } = options || {};
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
 
   validatePath(path);
   if (typeof recursive !== 'boolean')
@@ -751,7 +751,7 @@ function mkdirSync(path, options) {
   if (typeof options === 'number' || typeof options === 'string') {
     options = { mode: options };
   }
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   const {
     recursive = false,
     mode = 0o777
@@ -771,7 +771,7 @@ function mkdirSync(path, options) {
 function readdir(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
 
   const req = new FSReqCallback();
@@ -792,7 +792,7 @@ function readdir(path, options, callback) {
 
 function readdirSync(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   const result = binding.readdir(pathModule.toNamespacedPath(path),
@@ -819,7 +819,7 @@ function lstat(path, options, callback) {
     options = {};
   }
   callback = makeStatsCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
@@ -832,7 +832,7 @@ function stat(path, options, callback) {
     options = {};
   }
   callback = makeStatsCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
@@ -848,7 +848,7 @@ function fstatSync(fd, options = {}) {
 }
 
 function lstatSync(path, options = {}) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
@@ -858,7 +858,7 @@ function lstatSync(path, options = {}) {
 }
 
 function statSync(path, options = {}) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
@@ -870,7 +870,7 @@ function statSync(path, options = {}) {
 function readlink(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path, 'oldPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -879,7 +879,7 @@ function readlink(path, options, callback) {
 
 function readlinkSync(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path, 'oldPath');
   const ctx = { path };
   const result = binding.readlink(pathModule.toNamespacedPath(path),
@@ -892,8 +892,8 @@ function symlink(target, path, type_, callback_) {
   const type = (typeof type_ === 'string' ? type_ : null);
   const callback = makeCallback(arguments[arguments.length - 1]);
 
-  target = toPathIfFileUrl(target);
-  path = toPathIfFileUrl(path);
+  target = toPathIfFileURL(target);
+  path = toPathIfFileURL(path);
   validatePath(target, 'target');
   validatePath(path);
 
@@ -907,8 +907,8 @@ function symlink(target, path, type_, callback_) {
 
 function symlinkSync(target, path, type) {
   type = (typeof type === 'string' ? type : null);
-  target = toPathIfFileUrl(target);
-  path = toPathIfFileUrl(path);
+  target = toPathIfFileURL(target);
+  path = toPathIfFileURL(path);
   validatePath(target, 'target');
   validatePath(path);
   const flags = stringToSymlinkType(type);
@@ -923,8 +923,8 @@ function symlinkSync(target, path, type) {
 function link(existingPath, newPath, callback) {
   callback = makeCallback(callback);
 
-  existingPath = toPathIfFileUrl(existingPath);
-  newPath = toPathIfFileUrl(newPath);
+  existingPath = toPathIfFileURL(existingPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
 
@@ -937,8 +937,8 @@ function link(existingPath, newPath, callback) {
 }
 
 function linkSync(existingPath, newPath) {
-  existingPath = toPathIfFileUrl(existingPath);
-  newPath = toPathIfFileUrl(newPath);
+  existingPath = toPathIfFileURL(existingPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
 
@@ -952,7 +952,7 @@ function linkSync(existingPath, newPath) {
 
 function unlink(path, callback) {
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -960,7 +960,7 @@ function unlink(path, callback) {
 }
 
 function unlinkSync(path) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   binding.unlink(pathModule.toNamespacedPath(path), undefined, ctx);
@@ -1018,7 +1018,7 @@ function lchmodSync(path, mode) {
 
 
 function chmod(path, mode, callback) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
   callback = makeCallback(callback);
@@ -1029,7 +1029,7 @@ function chmod(path, mode, callback) {
 }
 
 function chmodSync(path, mode) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
 
@@ -1040,7 +1040,7 @@ function chmodSync(path, mode) {
 
 function lchown(path, uid, gid, callback) {
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1050,7 +1050,7 @@ function lchown(path, uid, gid, callback) {
 }
 
 function lchownSync(path, uid, gid) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1081,7 +1081,7 @@ function fchownSync(fd, uid, gid) {
 
 function chown(path, uid, gid, callback) {
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1092,7 +1092,7 @@ function chown(path, uid, gid, callback) {
 }
 
 function chownSync(path, uid, gid) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1103,7 +1103,7 @@ function chownSync(path, uid, gid) {
 
 function utimes(path, atime, mtime, callback) {
   callback = makeCallback(callback);
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
 
   const req = new FSReqCallback();
@@ -1115,7 +1115,7 @@ function utimes(path, atime, mtime, callback) {
 }
 
 function utimesSync(path, atime, mtime) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   binding.utimes(pathModule.toNamespacedPath(path),
@@ -1282,7 +1282,7 @@ function watch(filename, options, listener) {
 const statWatchers = new Map();
 
 function watchFile(filename, options, listener) {
-  filename = toPathIfFileUrl(filename);
+  filename = toPathIfFileURL(filename);
   validatePath(filename);
   filename = pathModule.resolve(filename);
   let stat;
@@ -1321,7 +1321,7 @@ function watchFile(filename, options, listener) {
 }
 
 function unwatchFile(filename, listener) {
-  filename = toPathIfFileUrl(filename);
+  filename = toPathIfFileURL(filename);
   validatePath(filename);
   filename = pathModule.resolve(filename);
   const stat = statWatchers.get(filename);
@@ -1393,7 +1393,7 @@ function realpathSync(p, options) {
     options = emptyObj;
   else
     options = getOptions(options, emptyObj);
-  p = toPathIfFileUrl(p);
+  p = toPathIfFileURL(p);
   if (typeof p !== 'string') {
     p += '';
   }
@@ -1525,7 +1525,7 @@ function realpathSync(p, options) {
 
 realpathSync.native = function(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
   const result = binding.realpath(path, options.encoding, undefined, ctx);
@@ -1540,7 +1540,7 @@ function realpath(p, options, callback) {
     options = emptyObj;
   else
     options = getOptions(options, emptyObj);
-  p = toPathIfFileUrl(p);
+  p = toPathIfFileURL(p);
   if (typeof p !== 'string') {
     p += '';
   }
@@ -1667,7 +1667,7 @@ function realpath(p, options, callback) {
 realpath.native = function(path, options, callback) {
   callback = makeCallback(callback || options);
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -1710,8 +1710,8 @@ function copyFile(src, dest, flags, callback) {
     throw new ERR_INVALID_CALLBACK();
   }
 
-  src = toPathIfFileUrl(src);
-  dest = toPathIfFileUrl(dest);
+  src = toPathIfFileURL(src);
+  dest = toPathIfFileURL(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
 
@@ -1725,8 +1725,8 @@ function copyFile(src, dest, flags, callback) {
 
 
 function copyFileSync(src, dest, flags) {
-  src = toPathIfFileUrl(src);
-  dest = toPathIfFileUrl(dest);
+  src = toPathIfFileURL(src);
+  dest = toPathIfFileURL(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -54,7 +54,7 @@ const {
 
 const { FSReqCallback, statValues } = binding;
 const internalFS = require('internal/fs/utils');
-const { getPathFromURL } = require('internal/url');
+const { toPathIfFileUrl } = require('internal/url');
 const internalUtil = require('internal/util');
 const {
   copyObject,
@@ -177,7 +177,7 @@ function access(path, mode, callback) {
     mode = F_OK;
   }
 
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
 
   mode = mode | 0;
@@ -187,7 +187,7 @@ function access(path, mode, callback) {
 }
 
 function accessSync(path, mode) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
 
   if (mode === undefined)
@@ -297,7 +297,7 @@ function readFile(path, options, callback) {
     return;
   }
 
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   binding.open(pathModule.toNamespacedPath(path),
                stringToFlags(options.flag || 'r'),
@@ -409,7 +409,7 @@ function closeSync(fd) {
 }
 
 function open(path, flags, mode, callback) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const flagsNumber = stringToFlags(flags);
   if (arguments.length < 4) {
@@ -431,7 +431,7 @@ function open(path, flags, mode, callback) {
 
 
 function openSync(path, flags, mode) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const flagsNumber = stringToFlags(flags);
   mode = validateMode(mode, 'mode', 0o666);
@@ -587,9 +587,9 @@ function writeSync(fd, buffer, offset, length, position) {
 
 function rename(oldPath, newPath, callback) {
   callback = makeCallback(callback);
-  oldPath = getPathFromURL(oldPath);
+  oldPath = toPathIfFileUrl(oldPath);
   validatePath(oldPath, 'oldPath');
-  newPath = getPathFromURL(newPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(newPath, 'newPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -599,9 +599,9 @@ function rename(oldPath, newPath, callback) {
 }
 
 function renameSync(oldPath, newPath) {
-  oldPath = getPathFromURL(oldPath);
+  oldPath = toPathIfFileUrl(oldPath);
   validatePath(oldPath, 'oldPath');
-  newPath = getPathFromURL(newPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(newPath, 'newPath');
   const ctx = { path: oldPath, dest: newPath };
   binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -680,7 +680,7 @@ function ftruncateSync(fd, len = 0) {
 
 function rmdir(path, callback) {
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -688,7 +688,7 @@ function rmdir(path, callback) {
 }
 
 function rmdirSync(path) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
@@ -735,7 +735,7 @@ function mkdir(path, options, callback) {
     mode = 0o777
   } = options || {};
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
 
   validatePath(path);
   if (typeof recursive !== 'boolean')
@@ -751,7 +751,7 @@ function mkdirSync(path, options) {
   if (typeof options === 'number' || typeof options === 'string') {
     options = { mode: options };
   }
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   const {
     recursive = false,
     mode = 0o777
@@ -771,7 +771,7 @@ function mkdirSync(path, options) {
 function readdir(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
 
   const req = new FSReqCallback();
@@ -792,7 +792,7 @@ function readdir(path, options, callback) {
 
 function readdirSync(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   const result = binding.readdir(pathModule.toNamespacedPath(path),
@@ -819,7 +819,7 @@ function lstat(path, options, callback) {
     options = {};
   }
   callback = makeStatsCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
@@ -832,7 +832,7 @@ function stat(path, options, callback) {
     options = {};
   }
   callback = makeStatsCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
@@ -848,7 +848,7 @@ function fstatSync(fd, options = {}) {
 }
 
 function lstatSync(path, options = {}) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
@@ -858,7 +858,7 @@ function lstatSync(path, options = {}) {
 }
 
 function statSync(path, options = {}) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
@@ -870,7 +870,7 @@ function statSync(path, options = {}) {
 function readlink(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path, 'oldPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -879,7 +879,7 @@ function readlink(path, options, callback) {
 
 function readlinkSync(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path, 'oldPath');
   const ctx = { path };
   const result = binding.readlink(pathModule.toNamespacedPath(path),
@@ -892,8 +892,8 @@ function symlink(target, path, type_, callback_) {
   const type = (typeof type_ === 'string' ? type_ : null);
   const callback = makeCallback(arguments[arguments.length - 1]);
 
-  target = getPathFromURL(target);
-  path = getPathFromURL(path);
+  target = toPathIfFileUrl(target);
+  path = toPathIfFileUrl(path);
   validatePath(target, 'target');
   validatePath(path);
 
@@ -907,8 +907,8 @@ function symlink(target, path, type_, callback_) {
 
 function symlinkSync(target, path, type) {
   type = (typeof type === 'string' ? type : null);
-  target = getPathFromURL(target);
-  path = getPathFromURL(path);
+  target = toPathIfFileUrl(target);
+  path = toPathIfFileUrl(path);
   validatePath(target, 'target');
   validatePath(path);
   const flags = stringToSymlinkType(type);
@@ -923,8 +923,8 @@ function symlinkSync(target, path, type) {
 function link(existingPath, newPath, callback) {
   callback = makeCallback(callback);
 
-  existingPath = getPathFromURL(existingPath);
-  newPath = getPathFromURL(newPath);
+  existingPath = toPathIfFileUrl(existingPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
 
@@ -937,8 +937,8 @@ function link(existingPath, newPath, callback) {
 }
 
 function linkSync(existingPath, newPath) {
-  existingPath = getPathFromURL(existingPath);
-  newPath = getPathFromURL(newPath);
+  existingPath = toPathIfFileUrl(existingPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
 
@@ -952,7 +952,7 @@ function linkSync(existingPath, newPath) {
 
 function unlink(path, callback) {
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -960,7 +960,7 @@ function unlink(path, callback) {
 }
 
 function unlinkSync(path) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   binding.unlink(pathModule.toNamespacedPath(path), undefined, ctx);
@@ -1018,7 +1018,7 @@ function lchmodSync(path, mode) {
 
 
 function chmod(path, mode, callback) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
   callback = makeCallback(callback);
@@ -1029,7 +1029,7 @@ function chmod(path, mode, callback) {
 }
 
 function chmodSync(path, mode) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
 
@@ -1040,7 +1040,7 @@ function chmodSync(path, mode) {
 
 function lchown(path, uid, gid, callback) {
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1050,7 +1050,7 @@ function lchown(path, uid, gid, callback) {
 }
 
 function lchownSync(path, uid, gid) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1081,7 +1081,7 @@ function fchownSync(fd, uid, gid) {
 
 function chown(path, uid, gid, callback) {
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1092,7 +1092,7 @@ function chown(path, uid, gid, callback) {
 }
 
 function chownSync(path, uid, gid) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -1103,7 +1103,7 @@ function chownSync(path, uid, gid) {
 
 function utimes(path, atime, mtime, callback) {
   callback = makeCallback(callback);
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
 
   const req = new FSReqCallback();
@@ -1115,7 +1115,7 @@ function utimes(path, atime, mtime, callback) {
 }
 
 function utimesSync(path, atime, mtime) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   binding.utimes(pathModule.toNamespacedPath(path),
@@ -1282,7 +1282,7 @@ function watch(filename, options, listener) {
 const statWatchers = new Map();
 
 function watchFile(filename, options, listener) {
-  filename = getPathFromURL(filename);
+  filename = toPathIfFileUrl(filename);
   validatePath(filename);
   filename = pathModule.resolve(filename);
   let stat;
@@ -1321,7 +1321,7 @@ function watchFile(filename, options, listener) {
 }
 
 function unwatchFile(filename, listener) {
-  filename = getPathFromURL(filename);
+  filename = toPathIfFileUrl(filename);
   validatePath(filename);
   filename = pathModule.resolve(filename);
   const stat = statWatchers.get(filename);
@@ -1393,7 +1393,7 @@ function realpathSync(p, options) {
     options = emptyObj;
   else
     options = getOptions(options, emptyObj);
-  p = getPathFromURL(p);
+  p = toPathIfFileUrl(p);
   if (typeof p !== 'string') {
     p += '';
   }
@@ -1525,7 +1525,7 @@ function realpathSync(p, options) {
 
 realpathSync.native = function(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const ctx = { path };
   const result = binding.realpath(path, options.encoding, undefined, ctx);
@@ -1540,7 +1540,7 @@ function realpath(p, options, callback) {
     options = emptyObj;
   else
     options = getOptions(options, emptyObj);
-  p = getPathFromURL(p);
+  p = toPathIfFileUrl(p);
   if (typeof p !== 'string') {
     p += '';
   }
@@ -1667,7 +1667,7 @@ function realpath(p, options, callback) {
 realpath.native = function(path, options, callback) {
   callback = makeCallback(callback || options);
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -1710,8 +1710,8 @@ function copyFile(src, dest, flags, callback) {
     throw new ERR_INVALID_CALLBACK();
   }
 
-  src = getPathFromURL(src);
-  dest = getPathFromURL(dest);
+  src = toPathIfFileUrl(src);
+  dest = toPathIfFileUrl(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
 
@@ -1725,8 +1725,8 @@ function copyFile(src, dest, flags, callback) {
 
 
 function copyFileSync(src, dest, flags) {
-  src = getPathFromURL(src);
-  dest = getPathFromURL(dest);
+  src = toPathIfFileUrl(src);
+  dest = toPathIfFileUrl(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -15,7 +15,7 @@ const {
   ERR_INVALID_ARG_VALUE,
   ERR_METHOD_NOT_IMPLEMENTED
 } = require('internal/errors').codes;
-const { getPathFromURL } = require('internal/url');
+const { toPathIfFileUrl } = require('internal/url');
 const { isUint8Array } = require('internal/util/types');
 const {
   copyObject,
@@ -172,7 +172,7 @@ async function readFileHandle(filehandle, options) {
 // All of the functions are defined as async in order to ensure that errors
 // thrown cause promise rejections rather than being thrown synchronously.
 async function access(path, mode = F_OK) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
 
   mode = mode | 0;
@@ -181,8 +181,8 @@ async function access(path, mode = F_OK) {
 }
 
 async function copyFile(src, dest, flags) {
-  src = getPathFromURL(src);
-  dest = getPathFromURL(dest);
+  src = toPathIfFileUrl(src);
+  dest = toPathIfFileUrl(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
   flags = flags | 0;
@@ -194,7 +194,7 @@ async function copyFile(src, dest, flags) {
 // Note that unlike fs.open() which uses numeric file descriptors,
 // fsPromises.open() uses the fs.FileHandle class.
 async function open(path, flags, mode) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   mode = validateMode(mode, 'mode', 0o666);
   return new FileHandle(
@@ -257,8 +257,8 @@ async function write(handle, buffer, offset, length, position) {
 }
 
 async function rename(oldPath, newPath) {
-  oldPath = getPathFromURL(oldPath);
-  newPath = getPathFromURL(newPath);
+  oldPath = toPathIfFileUrl(oldPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(oldPath, 'oldPath');
   validatePath(newPath, 'newPath');
   return binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -278,7 +278,7 @@ async function ftruncate(handle, len = 0) {
 }
 
 async function rmdir(path) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   return binding.rmdir(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -301,7 +301,7 @@ async function mkdir(path, options) {
     recursive = false,
     mode = 0o777
   } = options || {};
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
 
   validatePath(path);
   if (typeof recursive !== 'boolean')
@@ -314,7 +314,7 @@ async function mkdir(path, options) {
 
 async function readdir(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const result = await binding.readdir(pathModule.toNamespacedPath(path),
                                        options.encoding, !!options.withTypes,
@@ -326,7 +326,7 @@ async function readdir(path, options) {
 
 async function readlink(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path),
                           options.encoding, kUsePromises);
@@ -334,8 +334,8 @@ async function readlink(path, options) {
 
 async function symlink(target, path, type_) {
   const type = (typeof type_ === 'string' ? type_ : null);
-  target = getPathFromURL(target);
-  path = getPathFromURL(path);
+  target = toPathIfFileUrl(target);
+  path = toPathIfFileUrl(path);
   validatePath(target, 'target');
   validatePath(path);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
@@ -351,7 +351,7 @@ async function fstat(handle, options = { bigint: false }) {
 }
 
 async function lstat(path, options = { bigint: false }) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const result = await binding.lstat(pathModule.toNamespacedPath(path),
                                      options.bigint, kUsePromises);
@@ -359,7 +359,7 @@ async function lstat(path, options = { bigint: false }) {
 }
 
 async function stat(path, options = { bigint: false }) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   const result = await binding.stat(pathModule.toNamespacedPath(path),
                                     options.bigint, kUsePromises);
@@ -367,8 +367,8 @@ async function stat(path, options = { bigint: false }) {
 }
 
 async function link(existingPath, newPath) {
-  existingPath = getPathFromURL(existingPath);
-  newPath = getPathFromURL(newPath);
+  existingPath = toPathIfFileUrl(existingPath);
+  newPath = toPathIfFileUrl(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
   return binding.link(pathModule.toNamespacedPath(existingPath),
@@ -377,7 +377,7 @@ async function link(existingPath, newPath) {
 }
 
 async function unlink(path) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -389,7 +389,7 @@ async function fchmod(handle, mode) {
 }
 
 async function chmod(path, mode) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
   return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises);
@@ -404,7 +404,7 @@ async function lchmod(path, mode) {
 }
 
 async function lchown(path, uid, gid) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -420,7 +420,7 @@ async function fchown(handle, uid, gid) {
 }
 
 async function chown(path, uid, gid) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -429,7 +429,7 @@ async function chown(path, uid, gid) {
 }
 
 async function utimes(path, atime, mtime) {
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   return binding.utimes(pathModule.toNamespacedPath(path),
                         toUnixTimestamp(atime),
@@ -446,7 +446,7 @@ async function futimes(handle, atime, mtime) {
 
 async function realpath(path, options) {
   options = getOptions(options, {});
-  path = getPathFromURL(path);
+  path = toPathIfFileUrl(path);
   validatePath(path);
   return binding.realpath(path, options.encoding, kUsePromises);
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -15,7 +15,7 @@ const {
   ERR_INVALID_ARG_VALUE,
   ERR_METHOD_NOT_IMPLEMENTED
 } = require('internal/errors').codes;
-const { toPathIfFileUrl } = require('internal/url');
+const { toPathIfFileURL } = require('internal/url');
 const { isUint8Array } = require('internal/util/types');
 const {
   copyObject,
@@ -172,7 +172,7 @@ async function readFileHandle(filehandle, options) {
 // All of the functions are defined as async in order to ensure that errors
 // thrown cause promise rejections rather than being thrown synchronously.
 async function access(path, mode = F_OK) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
 
   mode = mode | 0;
@@ -181,8 +181,8 @@ async function access(path, mode = F_OK) {
 }
 
 async function copyFile(src, dest, flags) {
-  src = toPathIfFileUrl(src);
-  dest = toPathIfFileUrl(dest);
+  src = toPathIfFileURL(src);
+  dest = toPathIfFileURL(dest);
   validatePath(src, 'src');
   validatePath(dest, 'dest');
   flags = flags | 0;
@@ -194,7 +194,7 @@ async function copyFile(src, dest, flags) {
 // Note that unlike fs.open() which uses numeric file descriptors,
 // fsPromises.open() uses the fs.FileHandle class.
 async function open(path, flags, mode) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   mode = validateMode(mode, 'mode', 0o666);
   return new FileHandle(
@@ -257,8 +257,8 @@ async function write(handle, buffer, offset, length, position) {
 }
 
 async function rename(oldPath, newPath) {
-  oldPath = toPathIfFileUrl(oldPath);
-  newPath = toPathIfFileUrl(newPath);
+  oldPath = toPathIfFileURL(oldPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(oldPath, 'oldPath');
   validatePath(newPath, 'newPath');
   return binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -278,7 +278,7 @@ async function ftruncate(handle, len = 0) {
 }
 
 async function rmdir(path) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   return binding.rmdir(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -301,7 +301,7 @@ async function mkdir(path, options) {
     recursive = false,
     mode = 0o777
   } = options || {};
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
 
   validatePath(path);
   if (typeof recursive !== 'boolean')
@@ -314,7 +314,7 @@ async function mkdir(path, options) {
 
 async function readdir(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const result = await binding.readdir(pathModule.toNamespacedPath(path),
                                        options.encoding, !!options.withTypes,
@@ -326,7 +326,7 @@ async function readdir(path, options) {
 
 async function readlink(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path),
                           options.encoding, kUsePromises);
@@ -334,8 +334,8 @@ async function readlink(path, options) {
 
 async function symlink(target, path, type_) {
   const type = (typeof type_ === 'string' ? type_ : null);
-  target = toPathIfFileUrl(target);
-  path = toPathIfFileUrl(path);
+  target = toPathIfFileURL(target);
+  path = toPathIfFileURL(path);
   validatePath(target, 'target');
   validatePath(path);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
@@ -351,7 +351,7 @@ async function fstat(handle, options = { bigint: false }) {
 }
 
 async function lstat(path, options = { bigint: false }) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const result = await binding.lstat(pathModule.toNamespacedPath(path),
                                      options.bigint, kUsePromises);
@@ -359,7 +359,7 @@ async function lstat(path, options = { bigint: false }) {
 }
 
 async function stat(path, options = { bigint: false }) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   const result = await binding.stat(pathModule.toNamespacedPath(path),
                                     options.bigint, kUsePromises);
@@ -367,8 +367,8 @@ async function stat(path, options = { bigint: false }) {
 }
 
 async function link(existingPath, newPath) {
-  existingPath = toPathIfFileUrl(existingPath);
-  newPath = toPathIfFileUrl(newPath);
+  existingPath = toPathIfFileURL(existingPath);
+  newPath = toPathIfFileURL(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
   return binding.link(pathModule.toNamespacedPath(existingPath),
@@ -377,7 +377,7 @@ async function link(existingPath, newPath) {
 }
 
 async function unlink(path) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises);
 }
@@ -389,7 +389,7 @@ async function fchmod(handle, mode) {
 }
 
 async function chmod(path, mode) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
   return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises);
@@ -404,7 +404,7 @@ async function lchmod(path, mode) {
 }
 
 async function lchown(path, uid, gid) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -420,7 +420,7 @@ async function fchown(handle, uid, gid) {
 }
 
 async function chown(path, uid, gid) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
@@ -429,7 +429,7 @@ async function chown(path, uid, gid) {
 }
 
 async function utimes(path, atime, mtime) {
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   return binding.utimes(pathModule.toNamespacedPath(path),
                         toUnixTimestamp(atime),
@@ -446,7 +446,7 @@ async function futimes(handle, atime, mtime) {
 
 async function realpath(path, options) {
   options = getOptions(options, {});
-  path = toPathIfFileUrl(path);
+  path = toPathIfFileURL(path);
   validatePath(path);
   return binding.realpath(path, options.encoding, kUsePromises);
 }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -16,7 +16,7 @@ const {
   getOptions,
 } = require('internal/fs/utils');
 const { Readable, Writable } = require('stream');
-const { toPathIfFileUrl } = require('internal/url');
+const { toPathIfFileURL } = require('internal/url');
 const util = require('util');
 
 const kMinPoolSpace = 128;
@@ -52,7 +52,7 @@ function ReadStream(path, options) {
   Readable.call(this, options);
 
   // path will be ignored when fd is specified, so it can be falsy
-  this.path = toPathIfFileUrl(path);
+  this.path = toPathIfFileURL(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
@@ -240,7 +240,7 @@ function WriteStream(path, options) {
   Writable.call(this, options);
 
   // path will be ignored when fd is specified, so it can be falsy
-  this.path = toPathIfFileUrl(path);
+  this.path = toPathIfFileURL(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -16,7 +16,7 @@ const {
   getOptions,
 } = require('internal/fs/utils');
 const { Readable, Writable } = require('stream');
-const { getPathFromURL } = require('internal/url');
+const { toPathIfFileUrl } = require('internal/url');
 const util = require('util');
 
 const kMinPoolSpace = 128;
@@ -52,7 +52,7 @@ function ReadStream(path, options) {
   Readable.call(this, options);
 
   // path will be ignored when fd is specified, so it can be falsy
-  this.path = getPathFromURL(path);
+  this.path = toPathIfFileUrl(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
@@ -240,7 +240,7 @@ function WriteStream(path, options) {
   Writable.call(this, options);
 
   // path will be ignored when fd is specified, so it can be falsy
-  this.path = getPathFromURL(path);
+  this.path = toPathIfFileUrl(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -17,7 +17,7 @@ const {
 } = require('internal/async_hooks');
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
-const { getPathFromURL } = require('internal/url');
+const { toPathIfFileUrl } = require('internal/url');
 const util = require('util');
 const assert = require('assert');
 
@@ -70,7 +70,7 @@ StatWatcher.prototype.start = function(filename, persistent, interval) {
   // the sake of backwards compatibility
   this[kOldStatus] = -1;
 
-  filename = getPathFromURL(filename);
+  filename = toPathIfFileUrl(filename);
   validatePath(filename, 'filename');
   validateUint32(interval, 'interval');
   const err = this._handle.start(toNamespacedPath(filename), interval);
@@ -153,7 +153,7 @@ FSWatcher.prototype.start = function(filename,
     return;
   }
 
-  filename = getPathFromURL(filename);
+  filename = toPathIfFileUrl(filename);
   validatePath(filename, 'filename');
 
   const err = this._handle.start(toNamespacedPath(filename),

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -17,7 +17,7 @@ const {
 } = require('internal/async_hooks');
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
-const { toPathIfFileUrl } = require('internal/url');
+const { toPathIfFileURL } = require('internal/url');
 const util = require('util');
 const assert = require('assert');
 
@@ -70,7 +70,7 @@ StatWatcher.prototype.start = function(filename, persistent, interval) {
   // the sake of backwards compatibility
   this[kOldStatus] = -1;
 
-  filename = toPathIfFileUrl(filename);
+  filename = toPathIfFileURL(filename);
   validatePath(filename, 'filename');
   validateUint32(interval, 'interval');
   const err = this._handle.start(toNamespacedPath(filename), interval);
@@ -153,7 +153,7 @@ FSWatcher.prototype.start = function(filename,
     return;
   }
 
-  filename = toPathIfFileUrl(filename);
+  filename = toPathIfFileURL(filename);
   validatePath(filename, 'filename');
 
   const err = this._handle.start(toNamespacedPath(filename),

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -54,7 +54,7 @@ module.exports = Module;
 let asyncESM;
 let ModuleJob;
 let createDynamicModule;
-let pathToFileUrl;
+let pathToFileURL;
 let decorateErrorStack;
 
 function lazyLoadESM() {
@@ -63,7 +63,7 @@ function lazyLoadESM() {
   createDynamicModule = require(
     'internal/modules/esm/create_dynamic_module');
   decorateErrorStack = require('internal/util').decorateErrorStack;
-  pathToFileUrl = require('internal/url').pathToFileUrl;
+  pathToFileURL = require('internal/url').pathToFileURL;
 }
 
 const {
@@ -602,7 +602,7 @@ Module.prototype.load = function(filename) {
   if (experimentalModules) {
     if (asyncESM === undefined) lazyLoadESM();
     const ESMLoader = asyncESM.ESMLoader;
-    const url = pathToFileUrl(filename);
+    const url = pathToFileURL(filename);
     const urlString = `${url}`;
     const exports = this.exports;
     if (ESMLoader.moduleMap.has(urlString) !== true) {
@@ -731,7 +731,7 @@ Module.runMain = function() {
   if (experimentalModules) {
     if (asyncESM === undefined) lazyLoadESM();
     asyncESM.loaderPromise.then((loader) => {
-      return loader.import(pathToFileUrl(process.argv[1]).pathname);
+      return loader.import(pathToFileURL(process.argv[1]).pathname);
     })
     .catch((e) => {
       decorateErrorStack(e);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -54,7 +54,7 @@ module.exports = Module;
 let asyncESM;
 let ModuleJob;
 let createDynamicModule;
-let getURLFromFilePath;
+let pathToFileUrl;
 let decorateErrorStack;
 
 function lazyLoadESM() {
@@ -63,7 +63,7 @@ function lazyLoadESM() {
   createDynamicModule = require(
     'internal/modules/esm/create_dynamic_module');
   decorateErrorStack = require('internal/util').decorateErrorStack;
-  getURLFromFilePath = require('internal/url').getURLFromFilePath;
+  pathToFileUrl = require('internal/url').pathToFileUrl;
 }
 
 const {
@@ -602,7 +602,7 @@ Module.prototype.load = function(filename) {
   if (experimentalModules) {
     if (asyncESM === undefined) lazyLoadESM();
     const ESMLoader = asyncESM.ESMLoader;
-    const url = getURLFromFilePath(filename);
+    const url = pathToFileUrl(filename);
     const urlString = `${url}`;
     const exports = this.exports;
     if (ESMLoader.moduleMap.has(urlString) !== true) {
@@ -731,7 +731,7 @@ Module.runMain = function() {
   if (experimentalModules) {
     if (asyncESM === undefined) lazyLoadESM();
     asyncESM.loaderPromise.then((loader) => {
-      return loader.import(getURLFromFilePath(process.argv[1]).pathname);
+      return loader.import(pathToFileUrl(process.argv[1]).pathname);
     })
     .catch((e) => {
       decorateErrorStack(e);

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -15,7 +15,7 @@ const {
 } = require('internal/errors').codes;
 const { resolve: moduleWrapResolve } = internalBinding('module_wrap');
 const StringStartsWith = Function.call.bind(String.prototype.startsWith);
-const { getURLFromFilePath, getPathFromURL } = require('internal/url');
+const { pathToFileUrl, fileUrlToPath } = require('internal/url');
 
 const realpathCache = new Map();
 
@@ -62,7 +62,7 @@ function resolve(specifier, parentURL) {
   let url;
   try {
     url = search(specifier,
-                 parentURL || getURLFromFilePath(`${process.cwd()}/`).href);
+                 parentURL || pathToFileUrl(`${process.cwd()}/`).href);
   } catch (e) {
     if (typeof e.message === 'string' &&
         StringStartsWith(e.message, 'Cannot find module'))
@@ -73,11 +73,11 @@ function resolve(specifier, parentURL) {
   const isMain = parentURL === undefined;
 
   if (isMain ? !preserveSymlinksMain : !preserveSymlinks) {
-    const real = realpathSync(getPathFromURL(url), {
+    const real = realpathSync(fileUrlToPath(url), {
       [internalFS.realpathCacheKey]: realpathCache
     });
     const old = url;
-    url = getURLFromFilePath(real);
+    url = pathToFileUrl(real);
     url.search = old.search;
     url.hash = old.hash;
   }

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -15,7 +15,7 @@ const {
 } = require('internal/errors').codes;
 const { resolve: moduleWrapResolve } = internalBinding('module_wrap');
 const StringStartsWith = Function.call.bind(String.prototype.startsWith);
-const { pathToFileUrl, fileUrlToPath } = require('internal/url');
+const { pathToFileURL, fileURLToPath } = require('internal/url');
 
 const realpathCache = new Map();
 
@@ -62,7 +62,7 @@ function resolve(specifier, parentURL) {
   let url;
   try {
     url = search(specifier,
-                 parentURL || pathToFileUrl(`${process.cwd()}/`).href);
+                 parentURL || pathToFileURL(`${process.cwd()}/`).href);
   } catch (e) {
     if (typeof e.message === 'string' &&
         StringStartsWith(e.message, 'Cannot find module'))
@@ -73,11 +73,11 @@ function resolve(specifier, parentURL) {
   const isMain = parentURL === undefined;
 
   if (isMain ? !preserveSymlinksMain : !preserveSymlinks) {
-    const real = realpathSync(fileUrlToPath(url), {
+    const real = realpathSync(fileURLToPath(url), {
       [internalFS.realpathCacheKey]: realpathCache
     });
     const old = url;
-    url = pathToFileUrl(real);
+    url = pathToFileURL(real);
     url.search = old.search;
     url.hash = old.hash;
   }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -40,7 +40,7 @@ const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
 translators.set('cjs', async (url, isMain) => {
   debug(`Translating CJSModule ${url}`);
-  const pathname = internalURLModule.fileUrlToPath(new URL(url));
+  const pathname = internalURLModule.fileURLToPath(new URL(url));
   const module = CJSModule._cache[
     isWindows ? StringReplace(pathname, winSepRegEx, '\\') : pathname];
   if (module && module.loaded) {
@@ -81,7 +81,7 @@ translators.set('addon', async (url) => {
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading NativeModule ${url}`);
     const module = { exports: {} };
-    const pathname = internalURLModule.fileUrlToPath(new URL(url));
+    const pathname = internalURLModule.fileURLToPath(new URL(url));
     process.dlopen(module, _makeLong(pathname));
     reflect.exports.default.set(module.exports);
   });
@@ -92,7 +92,7 @@ translators.set('json', async (url) => {
   debug(`Translating JSONModule ${url}`);
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading JSONModule ${url}`);
-    const pathname = internalURLModule.fileUrlToPath(new URL(url));
+    const pathname = internalURLModule.fileURLToPath(new URL(url));
     const content = readFileSync(pathname, 'utf8');
     try {
       const exports = JsonParse(stripBOM(content));

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -40,7 +40,7 @@ const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
 translators.set('cjs', async (url, isMain) => {
   debug(`Translating CJSModule ${url}`);
-  const pathname = internalURLModule.getPathFromURL(new URL(url));
+  const pathname = internalURLModule.fileUrlToPath(new URL(url));
   const module = CJSModule._cache[
     isWindows ? StringReplace(pathname, winSepRegEx, '\\') : pathname];
   if (module && module.loaded) {
@@ -81,7 +81,7 @@ translators.set('addon', async (url) => {
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading NativeModule ${url}`);
     const module = { exports: {} };
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
+    const pathname = internalURLModule.fileUrlToPath(new URL(url));
     process.dlopen(module, _makeLong(pathname));
     reflect.exports.default.set(module.exports);
   });
@@ -92,7 +92,7 @@ translators.set('json', async (url) => {
   debug(`Translating JSONModule ${url}`);
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading JSONModule ${url}`);
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
+    const pathname = internalURLModule.fileUrlToPath(new URL(url));
     const content = readFileSync(pathname, 'utf8');
     try {
       const exports = JsonParse(stripBOM(content));

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -6,7 +6,7 @@ const {
   setInitializeImportMetaObjectCallback
 } = internalBinding('module_wrap');
 
-const { pathToFileUrl } = require('internal/url');
+const { pathToFileURL } = require('internal/url');
 const Loader = require('internal/modules/esm/loader');
 const path = require('path');
 const { URL } = require('url');
@@ -17,7 +17,7 @@ const {
 
 function normalizeReferrerURL(referrer) {
   if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
-    return pathToFileUrl(referrer).href;
+    return pathToFileURL(referrer).href;
   }
   return new URL(referrer).href;
 }
@@ -52,7 +52,7 @@ exports.setup = function() {
     const userLoader = process.binding('config').userLoader;
     if (userLoader) {
       const hooks = await ESMLoader.import(
-        userLoader, pathToFileUrl(`${process.cwd()}/`).href);
+        userLoader, pathToFileURL(`${process.cwd()}/`).href);
       ESMLoader = new Loader();
       ESMLoader.hook(hooks);
       exports.ESMLoader = ESMLoader;

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -6,7 +6,7 @@ const {
   setInitializeImportMetaObjectCallback
 } = internalBinding('module_wrap');
 
-const { getURLFromFilePath } = require('internal/url');
+const { pathToFileUrl } = require('internal/url');
 const Loader = require('internal/modules/esm/loader');
 const path = require('path');
 const { URL } = require('url');
@@ -17,7 +17,7 @@ const {
 
 function normalizeReferrerURL(referrer) {
   if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
-    return getURLFromFilePath(referrer).href;
+    return pathToFileUrl(referrer).href;
   }
   return new URL(referrer).href;
 }
@@ -52,7 +52,7 @@ exports.setup = function() {
     const userLoader = process.binding('config').userLoader;
     if (userLoader) {
       const hooks = await ESMLoader.import(
-        userLoader, getURLFromFilePath(`${process.cwd()}/`).href);
+        userLoader, pathToFileUrl(`${process.cwd()}/`).href);
       ESMLoader = new Loader();
       ESMLoader.hook(hooks);
       exports.ESMLoader = ESMLoader;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1410,17 +1410,21 @@ function fileURLToPath(path) {
 // as this is the only character that won't be percent encoded by
 // default URL percent encoding when pathname is set.
 const percentRegEx = /%/g;
+const backslashRegEx = /\\/g;
 function pathToFileURL(filepath) {
   let resolved = path.resolve(filepath);
   // path.resolve strips trailing slashes so we must add them back
   const filePathLast = filepath.charCodeAt(filepath.length - 1);
   if ((filePathLast === CHAR_FORWARD_SLASH ||
-       filePathLast === CHAR_BACKWARD_SLASH) &&
+       isWindows && filePathLast === CHAR_BACKWARD_SLASH) &&
       resolved[resolved.length - 1] !== path.sep)
     resolved += '/';
   const outURL = new URL('file://');
   if (resolved.includes('%'))
     resolved = resolved.replace(percentRegEx, '%25');
+  // in posix, "/" is a valid character in paths
+  if (!isWindows && resolved.includes('\\'))
+    resolved = resolved.replace(backslashRegEx, '%5C');
   outURL.pathname = resolved;
   return outURL;
 }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1392,11 +1392,9 @@ function getPathFromURLPosix(url) {
   return decodeURIComponent(pathname);
 }
 
-function getPathFromURL(path) {
-  if (path == null || !path[searchParams] ||
-      !path[searchParams][searchParams]) {
-    return path;
-  }
+function fileUrlToPath(path) {
+  if (typeof path === 'string')
+    path = new URL(path);
   if (path.protocol !== 'file:')
     throw new ERR_INVALID_URL_SCHEME('file');
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
@@ -1406,12 +1404,19 @@ function getPathFromURL(path) {
 // as this is the only character that won't be percent encoded by
 // default URL percent encoding when pathname is set.
 const percentRegEx = /%/g;
-function getURLFromFilePath(filepath) {
+function pathToFileUrl(filepath) {
   const tmp = new URL('file://');
   if (filepath.includes('%'))
     filepath = filepath.replace(percentRegEx, '%25');
   tmp.pathname = filepath;
   return tmp;
+}
+
+function toPathIfFileUrl(fileUrlOrPath) {
+  if (fileUrlOrPath == null || !fileUrlOrPath[searchParams] ||
+      !fileUrlOrPath[searchParams][searchParams])
+    return fileUrlOrPath;
+  return fileUrlToPath(fileUrlOrPath);
 }
 
 function NativeURL(ctx) {
@@ -1441,8 +1446,9 @@ setURLConstructor(constructUrl);
 
 module.exports = {
   toUSVString,
-  getPathFromURL,
-  getURLFromFilePath,
+  fileUrlToPath,
+  pathToFileUrl,
+  toPathIfFileUrl,
   URL,
   URLSearchParams,
   domainToASCII,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -20,12 +20,13 @@ const {
   ERR_MISSING_ARGS
 } = require('internal/errors').codes;
 const {
-  CHAR_PERCENT,
-  CHAR_PLUS,
   CHAR_AMPERSAND,
   CHAR_EQUAL,
+  CHAR_FORWARD_SLASH,
   CHAR_LOWERCASE_A,
   CHAR_LOWERCASE_Z,
+  CHAR_PERCENT,
+  CHAR_PLUS
 } = require('internal/constants');
 const path = require('path');
 
@@ -1411,14 +1412,14 @@ const percentRegEx = /%/g;
 function pathToFileURL(filepath) {
   let resolved = path.resolve(filepath);
   // path.resolve strips trailing slashes so we must add them back
-  if (filepath[filepath.length - 1] === '/' &&
-      resolved[resolved.length - 1] !== '/')
+  if (filepath.charCodeAt(filepath.length - 1) === CHAR_FORWARD_SLASH &&
+      resolved.charCodeAt(resolved.length - 1) !== CHAR_FORWARD_SLASH)
     resolved += '/';
-  const tmp = new URL('file://');
+  const outURL = new URL('file://');
   if (resolved.includes('%'))
     resolved = resolved.replace(percentRegEx, '%25');
-  tmp.pathname = resolved;
-  return tmp;
+  outURL.pathname = resolved;
+  return outURL;
 }
 
 function toPathIfFileURL(fileURLOrPath) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -21,6 +21,7 @@ const {
 } = require('internal/errors').codes;
 const {
   CHAR_AMPERSAND,
+  CHAR_BACKWARD_SLASH,
   CHAR_EQUAL,
   CHAR_FORWARD_SLASH,
   CHAR_LOWERCASE_A,
@@ -1412,8 +1413,10 @@ const percentRegEx = /%/g;
 function pathToFileURL(filepath) {
   let resolved = path.resolve(filepath);
   // path.resolve strips trailing slashes so we must add them back
-  if (filepath.charCodeAt(filepath.length - 1) === CHAR_FORWARD_SLASH &&
-      resolved.charCodeAt(resolved.length - 1) !== CHAR_FORWARD_SLASH)
+  const filePathLast = filepath.charCodeAt(filepath.length - 1);
+  if ((filePathLast === CHAR_FORWARD_SLASH ||
+       filePathLast === CHAR_BACKWARD_SLASH) &&
+      resolved[resolved.length - 1] !== path.sep)
     resolved += '/';
   const outURL = new URL('file://');
   if (resolved.includes('%'))

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -27,6 +27,7 @@ const {
   CHAR_LOWERCASE_A,
   CHAR_LOWERCASE_Z,
 } = require('internal/constants');
+const path = require('path');
 
 // Lazy loaded for startup performance.
 let querystring;
@@ -1395,6 +1396,8 @@ function getPathFromURLPosix(url) {
 function fileURLToPath(path) {
   if (typeof path === 'string')
     path = new URL(path);
+  else if (!(path instanceof URL))
+    throw new ERR_INVALID_ARG_TYPE('path', 'string or URL', path);
   if (path.protocol !== 'file:')
     throw new ERR_INVALID_URL_SCHEME('file');
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
@@ -1405,6 +1408,7 @@ function fileURLToPath(path) {
 // default URL percent encoding when pathname is set.
 const percentRegEx = /%/g;
 function pathToFileURL(filepath) {
+  filepath = path.resolve(filepath);
   const tmp = new URL('file://');
   if (filepath.includes('%'))
     filepath = filepath.replace(percentRegEx, '%25');

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1392,7 +1392,7 @@ function getPathFromURLPosix(url) {
   return decodeURIComponent(pathname);
 }
 
-function fileUrlToPath(path) {
+function fileURLToPath(path) {
   if (typeof path === 'string')
     path = new URL(path);
   if (path.protocol !== 'file:')
@@ -1404,7 +1404,7 @@ function fileUrlToPath(path) {
 // as this is the only character that won't be percent encoded by
 // default URL percent encoding when pathname is set.
 const percentRegEx = /%/g;
-function pathToFileUrl(filepath) {
+function pathToFileURL(filepath) {
   const tmp = new URL('file://');
   if (filepath.includes('%'))
     filepath = filepath.replace(percentRegEx, '%25');
@@ -1412,11 +1412,11 @@ function pathToFileUrl(filepath) {
   return tmp;
 }
 
-function toPathIfFileUrl(fileUrlOrPath) {
-  if (fileUrlOrPath == null || !fileUrlOrPath[searchParams] ||
-      !fileUrlOrPath[searchParams][searchParams])
-    return fileUrlOrPath;
-  return fileUrlToPath(fileUrlOrPath);
+function toPathIfFileURL(fileURLOrPath) {
+  if (fileURLOrPath == null || !fileURLOrPath[searchParams] ||
+      !fileURLOrPath[searchParams][searchParams])
+    return fileURLOrPath;
+  return fileURLToPath(fileURLOrPath);
 }
 
 function NativeURL(ctx) {
@@ -1446,9 +1446,9 @@ setURLConstructor(constructUrl);
 
 module.exports = {
   toUSVString,
-  fileUrlToPath,
-  pathToFileUrl,
-  toPathIfFileUrl,
+  fileURLToPath,
+  pathToFileURL,
+  toPathIfFileURL,
   URL,
   URLSearchParams,
   domainToASCII,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1396,8 +1396,9 @@ function getPathFromURLPosix(url) {
 function fileURLToPath(path) {
   if (typeof path === 'string')
     path = new URL(path);
-  else if (!(path instanceof URL))
-    throw new ERR_INVALID_ARG_TYPE('path', 'string or URL', path);
+  else if (path == null || !path[searchParams] ||
+           !path[searchParams][searchParams])
+    throw new ERR_INVALID_ARG_TYPE('path', ['string', 'URL'], path);
   if (path.protocol !== 'file:')
     throw new ERR_INVALID_URL_SCHEME('file');
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1408,11 +1408,15 @@ function fileURLToPath(path) {
 // default URL percent encoding when pathname is set.
 const percentRegEx = /%/g;
 function pathToFileURL(filepath) {
-  filepath = path.resolve(filepath);
+  let resolved = path.resolve(filepath);
+  // path.resolve strips trailing slashes so we must add them back
+  if (filepath[filepath.length - 1] === '/' &&
+      resolved[resolved.length - 1] !== '/')
+    resolved += '/';
   const tmp = new URL('file://');
-  if (filepath.includes('%'))
-    filepath = filepath.replace(percentRegEx, '%25');
-  tmp.pathname = filepath;
+  if (resolved.includes('%'))
+    resolved = resolved.replace(percentRegEx, '%25');
+  tmp.pathname = resolved;
   return tmp;
 }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -42,8 +42,8 @@ const {
   domainToUnicode,
   formatSymbol,
   encodeStr,
-  pathToFileUrl,
-  fileUrlToPath
+  pathToFileURL,
+  fileURLToPath
 } = require('internal/url');
 
 // Original url.parse() API
@@ -971,6 +971,6 @@ module.exports = {
   domainToUnicode,
 
   // Utilities
-  pathToFileUrl,
-  fileUrlToPath
+  pathToFileURL,
+  fileURLToPath
 };

--- a/lib/url.js
+++ b/lib/url.js
@@ -42,6 +42,8 @@ const {
   domainToUnicode,
   formatSymbol,
   encodeStr,
+  pathToFileUrl,
+  fileUrlToPath
 } = require('internal/url');
 
 // Original url.parse() API
@@ -966,5 +968,9 @@ module.exports = {
   URL,
   URLSearchParams,
   domainToASCII,
-  domainToUnicode
+  domainToUnicode,
+
+  // Utilities
+  pathToFileUrl,
+  fileUrlToPath
 };

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -6,7 +6,7 @@ const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const { parse: parseURL } = require('url');
-const { getURLFromFilePath } = require('internal/url');
+const { pathToFileUrl } = require('internal/url');
 const { EventEmitter } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');
@@ -174,7 +174,7 @@ class InspectorSession {
         const { scriptId, url } = message.params;
         this._scriptsIdsByUrl.set(scriptId, url);
         const fileUrl = url.startsWith('file:') ?
-          url : getURLFromFilePath(url).toString();
+          url : pathToFileUrl(url).toString();
         if (fileUrl === this.scriptURL().toString()) {
           this.mainScriptId = scriptId;
         }
@@ -309,7 +309,7 @@ class InspectorSession {
   }
 
   scriptURL() {
-    return getURLFromFilePath(this.scriptPath());
+    return pathToFileUrl(this.scriptPath());
   }
 }
 

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -6,7 +6,7 @@ const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const { parse: parseURL } = require('url');
-const { pathToFileUrl } = require('internal/url');
+const { pathToFileURL } = require('internal/url');
 const { EventEmitter } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');
@@ -174,7 +174,7 @@ class InspectorSession {
         const { scriptId, url } = message.params;
         this._scriptsIdsByUrl.set(scriptId, url);
         const fileUrl = url.startsWith('file:') ?
-          url : pathToFileUrl(url).toString();
+          url : pathToFileURL(url).toString();
         if (fileUrl === this.scriptURL().toString()) {
           this.mainScriptId = scriptId;
         }
@@ -309,7 +309,7 @@ class InspectorSession {
   }
 
   scriptURL() {
-    return pathToFileUrl(this.scriptPath());
+    return pathToFileURL(this.scriptPath());
   }
 }
 

--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const { isWindows } = require('../common');
 const assert = require('assert');
 const url = require('url');
 
@@ -12,7 +12,10 @@ const url = require('url');
 {
   const fileURL = url.pathToFileURL('test\\').href;
   assert.ok(fileURL.startsWith('file:///'));
-  assert.ok(fileURL.endsWith('/'));
+  if (isWindows)
+    assert.ok(fileURL.endsWith('/'));
+  else
+    assert.ok(fileURL.endsWith('%5C'));
 }
 
 {

--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -1,0 +1,21 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const url = require('url');
+
+{
+  const fileURL = url.pathToFileURL('test/').href;
+  assert.ok(fileURL.startsWith('file:///'));
+  assert.ok(fileURL.endsWith('/'));
+}
+
+{
+  const fileURL = url.pathToFileURL('test\\').href;
+  assert.ok(fileURL.startsWith('file:///'));
+  assert.ok(fileURL.endsWith('/'));
+}
+
+{
+  const fileURL = url.pathToFileURL('test/%').href;
+  assert.ok(fileURL.includes('%25'));
+}


### PR DESCRIPTION
As discussed in https://github.com/nodejs/node/issues/22502 this exposes and documents `url.pathToFileURL` and `url.fileURLToPath` in order to assist with cross platform support and encoding consistency.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
