### PR TITLE
doc: add blurb about implications of ABI stability

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -367,6 +367,10 @@ set of APIs that are used by the native code. Instead of using the V8
 or [Native Abstractions for Node.js][] APIs, the functions available
 in the N-API are used.
 
+Creating and maintaining an add-on that benefits from the ABI stability
+provided by N-API carries with it certain
+[implementation considerations](n-api.html#n_api_implications_of_abi_stability).
+
 To use N-API in the above "Hello world" example, replace the content of
 `hello.cc` with the following. All other instructions remain the same.
 

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -367,7 +367,7 @@ set of APIs that are used by the native code. Instead of using the V8
 or [Native Abstractions for Node.js][] APIs, the functions available
 in the N-API are used.
 
-Creating and maintaining an add-on that benefits from the ABI stability
+Creating and maintaining an addon that benefits from the ABI stability
 provided by N-API carries with it certain
 [implementation considerations](n-api.html#n_api_implications_of_abi_stability).
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -46,17 +46,14 @@ example is: [node-addon-api](https://github.com/nodejs/node-addon-api).
 
 Although N-API provides an ABI stability guarantee, other parts of Node.js do
 not, and any external libraries used from the addon may not. In particular,
-neither of the following Node.js APIs provides an ABI stability guarantee:
+none of the following APIs provide an ABI stability guarantee across major
+versions:
 * the Node.js C++ APIs available via any of
     ```C++
+    #include <node.h>
     #include <node_buffer.h>
-    #include <node_context_data.h>
-    #include <node_contextify.h>
-    #include <node_mutex.h>
-    #include <node_object_wrap.h>
-    #include <node_perf_common.h>
-    #include <node_platform.h>
     #include <node_version.h>
+    #include <node_object_wrap.h>
     ```
 * the libuv APIs which are also included with Node.js and available via
     ```C++
@@ -72,7 +69,7 @@ must make use exclusively of N-API by restricting itself to using
 ```C
 #include <node_api.h>
 ```
-and by checking, for all external library that it uses, that the external
+and by checking, for all external libraries that it uses, that the external
 library makes ABI stability guarantees similar to N-API.
 
 ## Usage

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -42,6 +42,39 @@ for the N-API C based functions exported by Node.js. These wrappers are not
 part of N-API, nor will they be maintained as part of Node.js. One such
 example is: [node-addon-api](https://github.com/nodejs/node-addon-api).
 
+## Implications of ABI Stability
+
+Although N-API provides an ABI stability guarantee, other parts of Node.js do
+not, and any external libraries used from the addon may not. In particular,
+neither of the following Node.js APIs provides an ABI stability guarantee:
+* the Node.js C++ APIs available via any of
+    ```C++
+    #include <node_buffer.h>
+    #include <node_context_data.h>
+    #include <node_contextify.h>
+    #include <node_mutex.h>
+    #include <node_object_wrap.h>
+    #include <node_perf_common.h>
+    #include <node_platform.h>
+    #include <node_version.h>
+    ```
+* the libuv APIs which are also included with Node.js and available via
+    ```C++
+    #include <uv.h>
+    ```
+* the V8 API available via
+    ```C++
+    #include <v8.h>
+    ```
+
+Thus, for an addon to remain ABI-compatible across Node.js major versions, it
+must make use exclusively of N-API by restricting itself to using
+```C
+#include <node_api.h>
+```
+and by checking, for all external library that it uses, that the external
+library makes ABI stability guarantees similar to N-API.
+
 ## Usage
 
 In order to use the N-API functions, include the file


### PR DESCRIPTION
Mention that ABI stability can be achieved only by linking to ABI-
stable parts of Node.js and to other libraries which are ABI-stable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
