### PR TITLE
src: add missing `NODE_WANT_INTERNALS` guards

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -1,6 +1,7 @@
-
 #ifndef SRC_ALIASED_BUFFER_H_
 #define SRC_ALIASED_BUFFER_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "v8.h"
 #include "util-inl.h"
@@ -234,5 +235,7 @@ class AliasedBuffer {
   bool free_buffer_;
 };
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_ALIASED_BUFFER_H_

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -1,6 +1,8 @@
 #ifndef SRC_INSPECTOR_AGENT_H_
 #define SRC_INSPECTOR_AGENT_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include <memory>
 
 #include <stddef.h>
@@ -119,5 +121,7 @@ class Agent {
 
 }  // namespace inspector
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_INSPECTOR_AGENT_H_

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -1,6 +1,8 @@
 #ifndef SRC_INSPECTOR_IO_H_
 #define SRC_INSPECTOR_IO_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "inspector_socket_server.h"
 #include "node_mutex.h"
 #include "uv.h"
@@ -89,5 +91,7 @@ class InspectorIo {
 
 }  // namespace inspector
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_INSPECTOR_IO_H_

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -1,6 +1,8 @@
 #ifndef SRC_INSPECTOR_SOCKET_H_
 #define SRC_INSPECTOR_SOCKET_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "util-inl.h"
 #include "uv.h"
 
@@ -52,5 +54,6 @@ class InspectorSocket {
 }  // namespace inspector
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_INSPECTOR_SOCKET_H_

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -1,6 +1,8 @@
 #ifndef SRC_INSPECTOR_SOCKET_SERVER_H_
 #define SRC_INSPECTOR_SOCKET_SERVER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "inspector_agent.h"
 #include "inspector_socket.h"
 #include "uv.h"
@@ -97,5 +99,7 @@ class InspectorSocketServer {
 
 }  // namespace inspector
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_INSPECTOR_SOCKET_SERVER_H_

--- a/src/node_context_data.h
+++ b/src/node_context_data.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CONTEXT_DATA_H_
 #define SRC_NODE_CONTEXT_DATA_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 namespace node {
 
 // Pick an index that's hopefully out of the way when we're embedded inside
@@ -36,5 +38,7 @@ enum ContextEmbedderIndex {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CONTEXT_DATA_H_

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CONTEXTIFY_H_
 #define SRC_NODE_CONTEXTIFY_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node_internals.h"
 #include "node_context_data.h"
 
@@ -106,5 +108,7 @@ class ContextifyContext {
 
 }  // namespace contextify
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CONTEXTIFY_H_

--- a/src/node_mutex.h
+++ b/src/node_mutex.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_MUTEX_H_
 #define SRC_NODE_MUTEX_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "util.h"
 #include "uv.h"
 
@@ -183,5 +185,7 @@ MutexBase<Traits>::ScopedUnlock::~ScopedUnlock() {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_MUTEX_H_

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_PERF_COMMON_H_
 #define SRC_NODE_PERF_COMMON_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "v8.h"
 
@@ -86,5 +88,7 @@ class performance_state {
 
 }  // namespace performance
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_PERF_COMMON_H_

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_PLATFORM_H_
 #define SRC_NODE_PLATFORM_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include <queue>
 #include <unordered_map>
 #include <vector>
@@ -157,5 +159,7 @@ class NodePlatform : public MultiIsolatePlatform {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_PLATFORM_H_


### PR DESCRIPTION
We generally add these to all headers that are considered
internal to Node.

These aren’t distributed as part of the headers tarball,
so I think this does not have to be semver-major
(and we have been changing the APIs in these headers
freely anyway).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
