### PR TITLE
src: deprecate option variables in public API

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -199,14 +199,17 @@ typedef intptr_t ssize_t;
 
 namespace node {
 
-// TODO(addaleax): Deprecate and remove all of these ASAP. They have been
-// made effectively non-functional anyway.
-NODE_EXTERN extern bool no_deprecation;
+// TODO(addaleax): Remove all of these.
+NODE_DEPRECATED("use command-line flags",
+                NODE_EXTERN extern bool no_deprecation);
 #if HAVE_OPENSSL
-NODE_EXTERN extern bool ssl_openssl_cert_store;
+NODE_DEPRECATED("use command-line flags",
+                NODE_EXTERN extern bool ssl_openssl_cert_store);
 # if NODE_FIPS_MODE
-NODE_EXTERN extern bool enable_fips_crypto;
-NODE_EXTERN extern bool force_fips_crypto;
+NODE_DEPRECATED("use command-line flags",
+                NODE_EXTERN extern bool enable_fips_crypto);
+NODE_DEPRECATED("user command-line flags",
+                NODE_EXTERN extern bool force_fips_crypto);
 # endif
 #endif
 

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -27,8 +27,9 @@
 
 namespace node {
 
-// TODO(addaleax): Deprecate and remove this ASAP.
-extern bool zero_fill_all_buffers;
+// TODO(addaleax): Remove this.
+NODE_DEPRECATED("use command-line flags",
+                extern bool zero_fill_all_buffers);
 
 namespace Buffer {
 


### PR DESCRIPTION
These variables should never have been exposed as part of the
public API, and certainly not as variables. Using CLI options
parser is the right thing to do here, at least until we expose
some part of the options parser API publicly (which should be
possible to do now).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
