### PR TITLE
test: move test that depends on dns query to internet

### DIFF
--- a/test/internet/test-dns-lookup.js
+++ b/test/internet/test-dns-lookup.js
@@ -1,0 +1,30 @@
+'use strict';
+
+require('../common');
+const dnsPromises = require('dns').promises;
+const { addresses } = require('../common/internet');
+const assert = require('assert');
+
+assert.rejects(
+  dnsPromises.lookup(addresses.INVALID_HOST, {
+    hints: 0,
+    family: 0,
+    all: false
+  }),
+  {
+    code: 'ENOTFOUND',
+    message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+  }
+);
+
+assert.rejects(
+  dnsPromises.lookup(addresses.INVALID_HOST, {
+    hints: 0,
+    family: 0,
+    all: true
+  }),
+  {
+    code: 'ENOTFOUND',
+    message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+  }
+);

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -1,7 +1,6 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
-const { addresses } = require('../common/internet');
 const assert = require('assert');
 const cares = process.binding('cares_wrap');
 const dns = require('dns');
@@ -96,30 +95,6 @@ common.expectsError(() => {
     all: false
   });
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
-
-  assert.rejects(
-    dnsPromises.lookup(addresses.INVALID_HOST, {
-      hints: 0,
-      family: 0,
-      all: false
-    }),
-    {
-      code: 'ENOTFOUND',
-      message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
-    }
-  );
-
-  assert.rejects(
-    dnsPromises.lookup(addresses.INVALID_HOST, {
-      hints: 0,
-      family: 0,
-      all: true
-    }),
-    {
-      code: 'ENOTFOUND',
-      message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
-    }
-  );
 })();
 
 dns.lookup(false, {


### PR DESCRIPTION
These test cases in `test/parallel/test-dns-lookup.js` send
dns requests and depend on the results, which could fail
if the DNS service for invalid hosts is hijacked by the ISP.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
