### PR TITLE
src: fix NODE_OPTIONS parsing bug

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2922,7 +2922,8 @@ void Init(std::vector<std::string>* argv,
       index = node_options.find(' ', index + 1);
       if (index - prev_index == 1) continue;
 
-      const std::string option = node_options.substr(prev_index + 1, index);
+      const std::string option = node_options.substr(
+          prev_index + 1, index - prev_index - 1);
       if (!option.empty())
         env_argv.emplace_back(std::move(option));
     } while (index != std::string::npos);

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -14,7 +14,9 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 process.chdir(tmpdir.path);
 
-expect(`-r ${require.resolve('../fixtures/printA.js')}`, 'A\nB\n');
+const printA = require.resolve('../fixtures/printA.js');
+expect(`-r ${printA}`, 'A\nB\n');
+expect(`-r ${printA} -r ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');
 expect('--trace-warnings', 'B\n');
@@ -29,6 +31,9 @@ expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
 // eslint-disable-next-line no-template-curly-in-string
 expect('--trace-event-file-pattern {pid}-${rotation}.trace_events', 'B\n');
+// eslint-disable-next-line no-template-curly-in-string
+expect('--trace-event-file-pattern {pid}-${rotation}.trace_events ' +
+       '--trace-event-categories node.async_hooks', 'B\n');
 
 if (!common.isWindows) {
   expect('--perf-basic-prof', 'B\n');


### PR DESCRIPTION
I, uhm, might have messed up by using a `substr(start, end)` signature when `std::string` actually uses `substr(start, len)`. Fix that.

Fixes: https://github.com/nodejs/node/issues/22526
Refs: https://github.com/nodejs/node/pull/22392

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
