### PR TITLE
build: use `0o` octal notation in configure

### DIFF
--- a/configure
+++ b/configure
@@ -1575,7 +1575,7 @@ write('config.gypi', do_not_edit +
 
 write('config.status', '#!/bin/sh\nset -x\nexec ./configure ' +
       ' '.join([pipes.quote(arg) for arg in original_argv]) + '\n')
-os.chmod('config.status', 0775)
+os.chmod('config.status', 0o775)
 
 config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',


### PR DESCRIPTION
This un-‘breaks’ the error message we print when using
Python 3 to run `configure`.

Refs: https://github.com/nodejs/help/issues/1457

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
