### PR TITLE
doc: remove redundant 'Example:' and similar notes

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -675,7 +675,7 @@ changes:
 Throws `value` if `value` is not `undefined` or `null`. This is useful when
 testing the `error` argument in callbacks. The stack trace contains all frames
 from the error passed to `ifError()` including the potential new frames for
-`ifError()` itself. See below for an example.
+`ifError()` itself.
 
 ```js
 const assert = require('assert').strict;

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -534,8 +534,6 @@ expensive nature of the [promise introspection API][PromiseHooks] provided by
 V8. This means that programs using promises or `async`/`await` will not get
 correct execution and trigger ids for promise callback contexts by default.
 
-Here's an example:
-
 ```js
 const ah = require('async_hooks');
 Promise.resolve(1729).then(() => {
@@ -551,7 +549,7 @@ the `triggerAsyncId` value is `0`, which means that we are missing context about
 the resource that caused (triggered) the `then()` callback to be executed.
 
 Installing async hooks via `async_hooks.createHook` enables promise execution
-tracking. Example:
+tracking:
 
 ```js
 const ah = require('async_hooks');

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -642,8 +642,6 @@ pipes between the parent and child. The value is one of the following:
    words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the
    default is `'ignore'`.
 
-Example:
-
 ```js
 const { spawn } = require('child_process');
 
@@ -1045,8 +1043,7 @@ See kill(2) for reference.
 
 Also note: on Linux, child processes of child processes will not be terminated
 when attempting to kill their parent. This is likely to happen when running a
-new process in a shell or with use of the `shell` option of `ChildProcess`, such
-as in this example:
+new process in a shell or with use of the `shell` option of `ChildProcess`:
 
 ```js
 'use strict';
@@ -1089,8 +1086,6 @@ added: v0.1.90
 * {integer}
 
 Returns the process identifier (PID) of the child process.
-
-Example:
 
 ```js
 const { spawn } = require('child_process');

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -765,8 +765,6 @@ Note that:
 * The defaults above apply to the first call only, the defaults for later
   calls is the current value at the time of `cluster.setupMaster()` is called.
 
-Example:
-
 ```js
 const cluster = require('cluster');
 cluster.setupMaster({

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1678,8 +1678,6 @@ added: v0.9.3
 * Returns: {string[]} An array with the names of the supported cipher
   algorithms.
 
-Example:
-
 ```js
 const ciphers = crypto.getCiphers();
 console.log(ciphers); // ['aes-128-cbc', 'aes-128-ccm', ...]
@@ -1690,8 +1688,6 @@ console.log(ciphers); // ['aes-128-cbc', 'aes-128-ccm', ...]
 added: v2.3.0
 -->
 * Returns: {string[]} An array with the names of the supported elliptic curves.
-
-Example:
 
 ```js
 const curves = crypto.getCurves();
@@ -1711,7 +1707,7 @@ supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in
 `'modp16'`, `'modp17'`, `'modp18'` (defined in [RFC 3526][]). The
 returned object mimics the interface of objects created by
 [`crypto.createDiffieHellman()`][], but will not allow changing
-the keys (with [`diffieHellman.setPublicKey()`][] for example). The
+the keys (with [`diffieHellman.setPublicKey()`][], for example). The
 advantage of using this method is that the parties do not have to
 generate nor exchange a group modulus beforehand, saving both processor
 and communication time.
@@ -1746,8 +1742,6 @@ added: v0.9.3
 -->
 * Returns: {string[]} An array of the names of the supported hash algorithms,
   such as `'RSA-SHA256'`.
-
-Example:
 
 ```js
 const hashes = crypto.getHashes();
@@ -1796,8 +1790,6 @@ but will take a longer amount of time to complete.
 
 The `salt` should be as unique as possible. It is recommended that a salt is
 random and at least 16 bytes long. See [NIST SP 800-132][] for details.
-
-Example:
 
 ```js
 const crypto = require('crypto');
@@ -1861,8 +1853,6 @@ but will take a longer amount of time to complete.
 
 The `salt` should be as unique as possible. It is recommended that a salt is
 random and at least 16 bytes long. See [NIST SP 800-132][] for details.
-
-Example:
 
 ```js
 const crypto = require('crypto');

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -561,7 +561,7 @@ s.bind(1234);
 s.addMembership('224.0.0.114');
 ```
 
-Must be changed to pass a callback function to the [`dgram.Socket#bind()`][]
+must be changed to pass a callback function to the [`dgram.Socket#bind()`][]
 function:
 
 ```js

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -552,8 +552,7 @@ chained.
 ### Change to asynchronous `socket.bind()` behavior
 
 As of Node.js v0.10, [`dgram.Socket#bind()`][] changed to an asynchronous
-execution model. Legacy code that assumes synchronous behavior, as in the
-following example:
+execution model. Legacy code would use syncrhronous behavior:
 
 ```js
 const s = dgram.createSocket('udp4');
@@ -561,8 +560,8 @@ s.bind(1234);
 s.addMembership('224.0.0.114');
 ```
 
-must be changed to pass a callback function to the [`dgram.Socket#bind()`][]
-function:
+Such legacy code would need to be changed to pass a callback function to the
+[`dgram.Socket#bind()`][] function:
 
 ```js
 const s = dgram.createSocket('udp4');

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -552,7 +552,7 @@ chained.
 ### Change to asynchronous `socket.bind()` behavior
 
 As of Node.js v0.10, [`dgram.Socket#bind()`][] changed to an asynchronous
-execution model. Legacy code would use syncrhronous behavior:
+execution model. Legacy code would use synchronous behavior:
 
 ```js
 const s = dgram.createSocket('udp4');

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -311,8 +311,6 @@ The returned function will be a wrapper around the supplied callback
 function. When the returned function is called, any errors that are
 thrown will be routed to the domain's `'error'` event.
 
-#### Example
-
 ```js
 const d = domain.create();
 
@@ -370,8 +368,6 @@ objects sent as the first argument to the function.
 In this way, the common `if (err) return callback(err);` pattern can be replaced
 with a single error handler in a single place.
 
-#### Example
-
 ```js
 const d = domain.create();
 
@@ -414,8 +410,6 @@ created in that context. Optionally, arguments can be passed to
 the function.
 
 This is the most basic way to use a domain.
-
-Example:
 
 ```js
 const domain = require('domain');

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1235,8 +1235,7 @@ type for one of its returned object properties on execution.
 ### ERR_INVALID_RETURN_VALUE
 
 Thrown in case a function option does not return an expected value
-type on execution.
-For example when a function is expected to return a promise.
+type on execution. For example, when a function is expected to return a promise.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
@@ -1249,8 +1248,6 @@ for more information.
 ### ERR_INVALID_THIS
 
 A Node.js API function was called with an incompatible `this` value.
-
-Example:
 
 ```js
 const urlSearchParams = new URLSearchParams('foo=bar&baz=new');
@@ -1582,7 +1579,6 @@ emitted.
 Prevents an abort if a string decoder was set on the Socket or if the decoder
 is in `objectMode`.
 
-Example
 ```js
 const Socket = require('net').Socket;
 const instance = new Socket();

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1235,7 +1235,7 @@ type for one of its returned object properties on execution.
 ### ERR_INVALID_RETURN_VALUE
 
 Thrown in case a function option does not return an expected value
-type on execution. For example, when a function is expected to return a promise.
+type on execution, such as when a function is expected to return a promise.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1044,8 +1044,6 @@ changes:
 Asynchronously append data to a file, creating the file if it does not yet
 exist. `data` can be a string or a [`Buffer`][].
 
-Example:
-
 ```js
 fs.appendFile('message.txt', 'data to append', (err) => {
   if (err) throw err;
@@ -1053,7 +1051,7 @@ fs.appendFile('message.txt', 'data to append', (err) => {
 });
 ```
 
-If `options` is a string, then it specifies the encoding. Example:
+If `options` is a string, then it specifies the encoding:
 
 ```js
 fs.appendFile('message.txt', 'data to append', 'utf8', callback);
@@ -1097,8 +1095,6 @@ changes:
 Synchronously append data to a file, creating the file if it does not yet
 exist. `data` can be a string or a [`Buffer`][].
 
-Example:
-
 ```js
 try {
   fs.appendFileSync('message.txt', 'data to append');
@@ -1108,7 +1104,7 @@ try {
 }
 ```
 
-If `options` is a string, then it specifies the encoding. Example:
+If `options` is a string, then it specifies the encoding:
 
 ```js
 fs.appendFileSync('message.txt', 'data to append', 'utf8');
@@ -1344,8 +1340,6 @@ fallback copy mechanism is used.
 create a copy-on-write reflink. If the platform does not support copy-on-write,
 then the operation will fail.
 
-Example:
-
 ```js
 const fs = require('fs');
 
@@ -1356,8 +1350,7 @@ fs.copyFile('source.txt', 'destination.txt', (err) => {
 });
 ```
 
-If the third argument is a number, then it specifies `flags`, as shown in the
-following example.
+If the third argument is a number, then it specifies `flags`:
 
 ```js
 const fs = require('fs');
@@ -1395,8 +1388,6 @@ fallback copy mechanism is used.
 create a copy-on-write reflink. If the platform does not support copy-on-write,
 then the operation will fail.
 
-Example:
-
 ```js
 const fs = require('fs');
 
@@ -1405,8 +1396,7 @@ fs.copyFileSync('source.txt', 'destination.txt');
 console.log('source.txt was copied to destination.txt');
 ```
 
-If the third argument is a number, then it specifies `flags`, as shown in the
-following example.
+If the third argument is a number, then it specifies `flags`:
 
 ```js
 const fs = require('fs');
@@ -1548,7 +1538,7 @@ deprecated: v1.0.0
   * `exists` {boolean}
 
 Test whether or not the given path exists by checking with the file system.
-Then call the `callback` argument with either true or false. Example:
+Then call the `callback` argument with either true or false:
 
 ```js
 fs.exists('/etc/passwd', (exists) => {
@@ -1881,7 +1871,7 @@ fs.ftruncate(fd, 4, (err) => {
 ```
 
 If the file previously was shorter than `len` bytes, it is extended, and the
-extended part is filled with null bytes (`'\0'`). For example,
+extended part is filled with null bytes (`'\0'`):
 
 ```js
 console.log(fs.readFileSync('temp.txt', 'utf8'));
@@ -2485,7 +2475,7 @@ changes:
   * `err` {Error}
   * `data` {string|Buffer}
 
-Asynchronously reads the entire contents of a file. Example:
+Asynchronously reads the entire contents of a file.
 
 ```js
 fs.readFile('/etc/passwd', (err, data) => {
@@ -2499,7 +2489,7 @@ contents of the file.
 
 If no encoding is specified, then the raw buffer is returned.
 
-If `options` is a string, then it specifies the encoding. Example:
+If `options` is a string, then it specifies the encoding:
 
 ```js
 fs.readFile('/etc/passwd', 'utf8', callback);
@@ -3499,8 +3489,6 @@ Asynchronously writes data to a file, replacing the file if it already exists.
 
 The `encoding` option is ignored if `data` is a buffer.
 
-Example:
-
 ```js
 const data = new Uint8Array(Buffer.from('Hello Node.js'));
 fs.writeFile('message.txt', data, (err) => {
@@ -3509,7 +3497,7 @@ fs.writeFile('message.txt', data, (err) => {
 });
 ```
 
-If `options` is a string, then it specifies the encoding. Example:
+If `options` is a string, then it specifies the encoding:
 
 ```js
 fs.writeFile('message.txt', 'Hello Node.js', 'utf8', callback);
@@ -3820,7 +3808,7 @@ doTruncate().catch(console.error);
 ```
 
 If the file previously was shorter than `len` bytes, it is extended, and the
-extended part is filled with null bytes (`'\0'`). For example,
+extended part is filled with null bytes (`'\0'`):
 
 ```js
 const fs = require('fs');
@@ -4030,8 +4018,6 @@ fallback copy mechanism is used.
 create a copy-on-write reflink. If the platform does not support copy-on-write,
 then the operation will fail.
 
-Example:
-
 ```js
 const fsPromises = require('fs').promises;
 
@@ -4041,8 +4027,7 @@ fsPromises.copyFile('source.txt', 'destination.txt')
   .catch(() => console.log('The file could not be copied'));
 ```
 
-If the third argument is a number, then it specifies `flags`, as shown in the
-following example.
+If the third argument is a number, then it specifies `flags`:
 
 ```js
 const fs = require('fs');

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -602,7 +602,6 @@ Reads out a header on the request. Note that the name is case insensitive.
 The type of the return value depends on the arguments provided to
 [`request.setHeader()`][].
 
-Example:
 ```js
 request.setHeader('content-type', 'text/html');
 request.setHeader('Content-Length', Buffer.byteLength(body));
@@ -630,7 +629,6 @@ added: v1.6.0
 
 Removes a header that's already defined into headers object.
 
-Example:
 ```js
 request.removeHeader('Content-Type');
 ```
@@ -650,7 +648,6 @@ stored without modification. Therefore, [`request.getHeader()`][] may return
 non-string values. However, the non-string values will be converted to strings
 for network transmission.
 
-Example:
 ```js
 request.setHeader('Content-Type', 'application/json');
 ```
@@ -706,8 +703,6 @@ Reference to the underlying socket. Usually users will not want to access
 this property. In particular, the socket will not emit `'readable'` events
 because of how the protocol parser attaches to the socket. The `socket`
 may also be accessed via `request.connection`.
-
-Example:
 
 ```js
 const http = require('http');
@@ -1119,8 +1114,6 @@ Reads out a header that's already been queued but not sent to the client.
 Note that the name is case insensitive. The type of the return value depends
 on the arguments provided to [`response.setHeader()`][].
 
-Example:
-
 ```js
 response.setHeader('Content-Type', 'text/html');
 response.setHeader('Content-Length', Buffer.byteLength(body));
@@ -1142,8 +1135,6 @@ added: v7.7.0
 
 Returns an array containing the unique names of the current outgoing headers.
 All header names are lowercase.
-
-Example:
 
 ```js
 response.setHeader('Foo', 'bar');
@@ -1171,8 +1162,6 @@ prototypically inherit from the JavaScript `Object`. This means that typical
 `Object` methods such as `obj.toString()`, `obj.hasOwnProperty()`, and others
 are not defined and *will not work*.
 
-Example:
-
 ```js
 response.setHeader('Foo', 'bar');
 response.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
@@ -1191,8 +1180,6 @@ added: v7.7.0
 
 Returns `true` if the header identified by `name` is currently set in the
 outgoing headers. Note that the header name matching is case-insensitive.
-
-Example:
 
 ```js
 const hasContentType = response.hasHeader('content-type');
@@ -1215,8 +1202,6 @@ added: v0.4.0
 * `name` {string}
 
 Removes a header that's queued for implicit sending.
-
-Example:
 
 ```js
 response.removeHeader('Content-Encoding');
@@ -1249,8 +1234,6 @@ here to send multiple headers with the same name. Non-string values will be
 stored without modification. Therefore, [`response.getHeader()`][] may return
 non-string values. However, the non-string values will be converted to strings
 for network transmission.
-
-Example:
 
 ```js
 response.setHeader('Content-Type', 'text/html');
@@ -1317,8 +1300,6 @@ because of how the protocol parser attaches to the socket. After
 `response.end()`, the property is nulled. The `socket` may also be accessed
 via `response.connection`.
 
-Example:
-
 ```js
 const http = require('http');
 const server = http.createServer((req, res) => {
@@ -1339,8 +1320,6 @@ When using implicit headers (not calling [`response.writeHead()`][] explicitly),
 this property controls the status code that will be sent to the client when
 the headers get flushed.
 
-Example:
-
 ```js
 response.statusCode = 404;
 ```
@@ -1359,8 +1338,6 @@ When using implicit headers (not calling [`response.writeHead()`][] explicitly),
 this property controls the status message that will be sent to the client when
 the headers get flushed. If this is left as `undefined` then the standard
 message for the status code will be used.
-
-Example:
 
 ```js
 response.statusMessage = 'Not found';
@@ -1433,8 +1410,6 @@ Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
 Optionally one can give a human-readable `statusMessage` as the second
 argument.
-
-Example:
 
 ```js
 const body = 'hello world';
@@ -1546,7 +1521,6 @@ added: v0.1.5
 The request/response headers object.
 
 Key-value pairs of header names and values. Header names are lower-cased.
-Example:
 
 ```js
 // Prints something like:
@@ -1590,8 +1564,7 @@ added: v0.1.1
 
 **Only valid for request obtained from [`http.Server`][].**
 
-The request method as a string. Read only. Example:
-`'GET'`, `'DELETE'`.
+The request method as a string. Read only. Examples: `'GET'`, `'DELETE'`.
 
 ### message.rawHeaders
 <!-- YAML
@@ -1713,7 +1686,7 @@ Then `request.url` will be:
 ```
 
 To parse the url into its parts `require('url').parse(request.url)`
-can be used. Example:
+can be used:
 
 ```txt
 $ node
@@ -1735,8 +1708,7 @@ Url {
 
 To extract the parameters from the query string, the
 `require('querystring').parse` function can be used, or
-`true` can be passed as the second argument to `require('url').parse`.
-Example:
+`true` can be passed as the second argument to `require('url').parse`:
 
 ```txt
 $ node
@@ -1829,7 +1801,7 @@ data for reasons stated in [`http.ClientRequest`][] section.
 The `callback` is invoked with a single argument that is an instance of
 [`http.IncomingMessage`][].
 
-JSON Fetching Example:
+JSON fetching example:
 
 ```js
 http.get('http://nodejs.org/dist/index.json', (res) => {
@@ -1946,8 +1918,6 @@ the [`'response'`][] event.
 `http.request()` returns an instance of the [`http.ClientRequest`][]
 class. The `ClientRequest` instance is a writable stream. If one needs to
 upload a file with a POST request, then write to the `ClientRequest` object.
-
-Example:
 
 ```js
 const postData = querystring.stringify({

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2493,7 +2493,6 @@ added: v8.4.0
 The request/response headers object.
 
 Key-value pairs of header names and values. Header names are lower-cased.
-Example:
 
 ```js
 // Prints something like:
@@ -2538,8 +2537,7 @@ added: v8.4.0
 
 * {string}
 
-The request method as a string. Read-only. Example:
-`'GET'`, `'DELETE'`.
+The request method as a string. Read-only. Examples: `'GET'`, `'DELETE'`.
 
 #### request.rawHeaders
 <!-- YAML
@@ -2666,7 +2664,7 @@ Then `request.url` will be:
 ```
 
 To parse the url into its parts `require('url').parse(request.url)`
-can be used. Example:
+can be used:
 
 ```txt
 $ node
@@ -2689,7 +2687,6 @@ Url {
 To extract the parameters from the query string, the
 `require('querystring').parse` function can be used, or
 `true` can be passed as the second argument to `require('url').parse`.
-Example:
 
 ```txt
 $ node
@@ -2807,8 +2804,6 @@ added: v8.4.0
 Reads out a header that has already been queued but not sent to the client.
 Note that the name is case insensitive.
 
-Example:
-
 ```js
 const contentType = response.getHeader('content-type');
 ```
@@ -2822,8 +2817,6 @@ added: v8.4.0
 
 Returns an array containing the unique names of the current outgoing headers.
 All header names are lowercase.
-
-Example:
 
 ```js
 response.setHeader('Foo', 'bar');
@@ -2851,8 +2844,6 @@ prototypically inherit from the JavaScript `Object`. This means that typical
 `Object` methods such as `obj.toString()`, `obj.hasOwnProperty()`, and others
 are not defined and *will not work*.
 
-Example:
-
 ```js
 response.setHeader('Foo', 'bar');
 response.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
@@ -2871,8 +2862,6 @@ added: v8.4.0
 
 Returns `true` if the header identified by `name` is currently set in the
 outgoing headers. Note that the header name matching is case-insensitive.
-
-Example:
 
 ```js
 const hasContentType = response.hasHeader('content-type');
@@ -2895,8 +2884,6 @@ added: v8.4.0
 * `name` {string}
 
 Removes a header that has been queued for implicit sending.
-
-Example:
 
 ```js
 response.removeHeader('Content-Encoding');
@@ -2926,8 +2913,6 @@ added: v8.4.0
 Sets a single header value for implicit headers. If this header already exists
 in the to-be-sent headers, its value will be replaced. Use an array of strings
 here to send multiple headers with the same name.
-
-Example:
 
 ```js
 response.setHeader('Content-Type', 'text/html');
@@ -2998,8 +2983,6 @@ more information.
 
 All other interactions will be routed directly to the socket.
 
-Example:
-
 ```js
 const http2 = require('http2');
 const server = http2.createServer((req, res) => {
@@ -3019,8 +3002,6 @@ added: v8.4.0
 When using implicit headers (not calling [`response.writeHead()`][] explicitly),
 this property controls the status code that will be sent to the client when
 the headers get flushed.
-
-Example:
 
 ```js
 response.statusCode = 404;
@@ -3111,8 +3092,6 @@ For compatibility with [HTTP/1][], a human-readable `statusMessage` may be
 passed as the second argument. However, because the `statusMessage` has no
 meaning within HTTP/2, the argument will have no effect and a process warning
 will be emitted.
-
-Example:
 
 ```js
 const body = 'hello world';

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -76,8 +76,6 @@ added: v0.3.4
  [`tls.createSecureContext()`][] and [`http.createServer()`][].
 * `requestListener` {Function} A listener to be added to the `'request'` event.
 
-Example:
-
 ```js
 // curl -k https://localhost:8000/
 const https = require('https');
@@ -133,8 +131,6 @@ Like [`http.get()`][] but for HTTPS.
 `options` can be an object, a string, or a [`URL`][] object. If `options` is a
 string, it is automatically parsed with [`new URL()`][]. If it is a [`URL`][]
 object, it will be automatically converted to an ordinary `options` object.
-
-Example:
 
 ```js
 const https = require('https');
@@ -193,8 +189,6 @@ The following additional `options` from [`tls.connect()`][] are also accepted:
 string, it is automatically parsed with [`new URL()`][]. If it is a [`URL`][]
 object, it will be automatically converted to an ordinary `options` object.
 
-Example:
-
 ```js
 const https = require('https');
 
@@ -238,8 +232,6 @@ const req = https.request(options, (res) => {
 ```
 
 Alternatively, opt out of connection pooling by not using an [`Agent`][].
-
-Example:
 
 ```js
 const options = {

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -708,7 +708,7 @@ this, assign the desired export object to `module.exports`. Note that assigning
 the desired object to `exports` will simply rebind the local `exports` variable,
 which is probably not what is desired.
 
-For example suppose we were making a module called `a.js`:
+For example, suppose we were making a module called `a.js`:
 
 ```js
 const EventEmitter = require('events');

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -451,7 +451,7 @@ originalName [code]
 ```
 
 where `originalName` is the original name associated with the error
-and `code` is the code that was provided. For example if the code
+and `code` is the code that was provided. For example, if the code
 is `'ERR_ERROR_1'` and a `TypeError` is being created the name will be:
 
 ```text
@@ -3478,8 +3478,6 @@ called on a class prototype and a function called on an instance of a class.
 A common pattern used to address this problem is to save a persistent
 reference to the class constructor for later `instanceof` checks.
 
-As an example:
-
 ```C
 napi_value MyClass_constructor = NULL;
 status = napi_get_reference_value(env, MyClass::es_constructor, &MyClass_constructor);
@@ -3931,7 +3929,7 @@ invoking the callback. This should be a value previously obtained
 from [`napi_async_init`][].
 - `[out] result`: The newly created scope.
 
-There are cases (for example resolving promises) where it is
+There are cases (for example, resolving promises) where it is
 necessary to have the equivalent of the scope associated with a callback
 in place when making certain N-API calls. If there is no other script on
 the stack the [`napi_open_callback_scope`][] and

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -124,8 +124,6 @@ as reported by the operating system if listening on an IP socket
 For a server listening on a pipe or UNIX domain socket, the name is returned
 as a string.
 
-Example:
-
 ```js
 const server = net.createServer((socket) => {
   socket.end('goodbye\n');
@@ -716,8 +714,7 @@ connects on `'192.168.1.1'`, the value of `socket.localAddress` would be
 added: v0.9.6
 -->
 
-The numeric representation of the local port. For example,
-`80` or `21`.
+The numeric representation of the local port. For example, `80` or `21`.
 
 ### socket.pause()
 
@@ -758,8 +755,7 @@ The string representation of the remote IP family. `'IPv4'` or `'IPv6'`.
 added: v0.5.10
 -->
 
-The numeric representation of the remote port. For example,
-`80` or `21`.
+The numeric representation of the remote port. For example, `80` or `21`.
 
 ### socket.resume()
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -404,8 +404,8 @@ added: v0.3.3
 * Returns: {string}
 
 The `os.type()` method returns a string identifying the operating system name
-as returned by [uname(3)][]. For example `'Linux'` on Linux, `'Darwin'` on macOS
-and `'Windows_NT'` on Windows.
+as returned by [uname(3)][]. For example, `'Linux'` on Linux, `'Darwin'` on
+macOS, and `'Windows_NT'` on Windows.
 
 Please see https://en.wikipedia.org/wiki/Uname#Examples for additional
 information about the output of running [uname(3)][] on various operating

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -58,7 +58,7 @@ path.posix.basename('/tmp/myfile.html');
 
 *Note:* On Windows Node.js follows the concept of per-drive working directory.
 This behavior can be observed when using a drive path without a backslash. For
-example `path.resolve('c:\\')` can potentially return a different result than
+example, `path.resolve('c:\\')` can potentially return a different result than
 `path.resolve('c:')`. For more information, see
 [this MSDN page][MSDN-Rel-Path].
 
@@ -258,7 +258,7 @@ The `path.isAbsolute()` method determines if `path` is an absolute path.
 
 If the given `path` is a zero-length string, `false` will be returned.
 
-For example on POSIX:
+For example, on POSIX:
 
 ```js
 path.isAbsolute('/foo/bar'); // true
@@ -325,7 +325,7 @@ instance of the platform specific path segment separator (`/` on POSIX and
 If the `path` is a zero-length string, `'.'` is returned, representing the
 current working directory.
 
-For example on POSIX:
+For example, on POSIX:
 
 ```js
 path.normalize('/foo/bar//baz/asdf/quux/..');
@@ -369,7 +369,7 @@ The returned object will have the following properties:
 * `name` {string}
 * `ext` {string}
 
-For example on POSIX:
+For example, on POSIX:
 
 ```js
 path.parse('/home/user/dir/file.txt');
@@ -446,7 +446,7 @@ path (after calling `path.resolve()` on each), a zero-length string is returned.
 If a zero-length string is passed as `from` or `to`, the current working
 directory will be used instead of the zero-length strings.
 
-For example on POSIX:
+For example, on POSIX:
 
 ```js
 path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb');
@@ -515,7 +515,7 @@ Provides the platform-specific path segment separator:
 * `\` on Windows
 * `/` on POSIX
 
-For example on POSIX:
+For example, on POSIX:
 
 ```js
 'foo/bar/baz'.split(path.sep);

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -943,8 +943,6 @@ Assigning a property on `process.env` will implicitly convert the value
 to a string. **This behavior is deprecated.** Future versions of Node.js may
 throw an error when the value is not a string, number, or boolean.
 
-Example:
-
 ```js
 process.env.test = null;
 console.log(process.env.test);
@@ -956,8 +954,6 @@ console.log(process.env.test);
 
 Use `delete` to delete a property from `process.env`.
 
-Example:
-
 ```js
 process.env.TEST = 1;
 delete process.env.TEST;
@@ -966,8 +962,6 @@ console.log(process.env.TEST);
 ```
 
 On Windows operating systems, environment variables are case-insensitive.
-
-Example:
 
 ```js
 process.env.TEST = 1;
@@ -1283,7 +1277,7 @@ the group access list, using all groups of which the user is a member. This is
 a privileged operation that requires that the Node.js process either have `root`
 access or the `CAP_SETGID` capability.
 
-Note that care must be taken when dropping privileges. Example:
+Note that care must be taken when dropping privileges:
 
 ```js
 console.log(process.getgroups());         // [ 0 ]

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -76,8 +76,7 @@ are not defined and *will not work*.
 
 By default, percent-encoded characters within the query string will be assumed
 to use UTF-8 encoding. If an alternative character encoding is used, then an
-alternative `decodeURIComponent` option will need to be specified as illustrated
-in the following example:
+alternative `decodeURIComponent` option will need to be specified:
 
 ```js
 // Assuming gbkDecodeURIComponent function already exists...
@@ -118,8 +117,7 @@ querystring.stringify({ foo: 'bar', baz: 'qux' }, ';', ':');
 
 By default, characters requiring percent-encoding within the query string will
 be encoded as UTF-8. If an alternative encoding is required, then an alternative
-`encodeURIComponent` option will need to be specified as illustrated in the
-following example:
+`encodeURIComponent` option will need to be specified:
 
 ```js
 // Assuming gbkEncodeURIComponent function already exists,

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -510,8 +510,7 @@ rl.on('line', (line) => {
 ## Example: Read File Stream Line-by-Line
 
 A common use case for `readline` is to consume input from a filesystem
-[Readable][] stream one line at a time, as illustrated in the following
-example:
+[Readable][] stream one line at a time:
 
 ```js
 const readline = require('readline');

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -323,7 +323,7 @@ the default evaluator and the `repl.REPLServer` instance was created with the
 reference to the `context` object as the only argument.
 
 This can be used primarily to re-initialize REPL context to some pre-defined
-state as illustrated in the following simple example:
+state:
 
 ```js
 const repl = require('repl');

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -37,14 +37,14 @@ the elements of the API that are required to *implement* new types of streams.
 
 There are four fundamental stream types within Node.js:
 
-* [`Writable`][] - streams to which data can be written (for example
+* [`Writable`][] - streams to which data can be written (for example,
   [`fs.createWriteStream()`][]).
-* [`Readable`][] - streams from which data can be read (for example
+* [`Readable`][] - streams from which data can be read (for example,
   [`fs.createReadStream()`][]).
-* [`Duplex`][] - streams that are both `Readable` and `Writable` (for example
+* [`Duplex`][] - streams that are both `Readable` and `Writable` (for example,
   [`net.Socket`][]).
 * [`Transform`][] - `Duplex` streams that can modify or transform the data as it
-  is written and read (for example [`zlib.createDeflate()`][]).
+  is written and read (for example, [`zlib.createDeflate()`][]).
 
 Additionally this module includes the utility functions [pipeline][] and
 [finished][].
@@ -947,8 +947,7 @@ r.pipe(z).pipe(w);
 By default, [`stream.end()`][stream-end] is called on the destination `Writable`
 stream when the source `Readable` stream emits [`'end'`][], so that the
 destination is no longer writable. To disable this default behavior, the `end`
-option can be passed as `false`, causing the destination stream to remain open,
-as illustrated in the following example:
+option can be passed as `false`, causing the destination stream to remain open:
 
 ```js
 reader.pipe(writer, { end: false });
@@ -1048,8 +1047,7 @@ The `readable.resume()` method causes an explicitly paused `Readable` stream to
 resume emitting [`'data'`][] events, switching the stream into flowing mode.
 
 The `readable.resume()` method can be used to fully consume the data from a
-stream without actually processing any of that data as illustrated in the
-following example:
+stream without actually processing any of that data:
 
 ```js
 getReadableStreamSomehow()
@@ -1890,7 +1888,7 @@ When the `Readable` is operating in flowing mode, the data added with
 The `readable.push()` method is designed to be as flexible as possible. For
 example, when wrapping a lower-level source that provides some form of
 pause/resume mechanism, and a data callback, the low-level source can be wrapped
-by the custom `Readable` instance as illustrated in the following example:
+by the custom `Readable` instance:
 
 ```js
 // source is an object with readStop() and readStart() methods,

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -618,8 +618,6 @@ If the full certificate chain was requested, each certificate will include an
 `issuerCertificate` property containing an object representing its issuer's
 certificate.
 
-For example:
-
 ```text
 { subject:
    { C: 'UK',
@@ -1244,8 +1242,6 @@ added: v0.10.2
 * Returns: {string[]}
 
 Returns an array with the names of the supported SSL ciphers.
-
-For example:
 
 ```js
 console.log(tls.getCiphers()); // ['AES128-SHA', 'AES256-SHA', ...]

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -68,7 +68,7 @@ tab of Chrome.
 The logging file is by default called `node_trace.${rotation}.log`, where
 `${rotation}` is an incrementing log-rotation id. The filepath pattern can
 be specified with `--trace-event-file-pattern` that accepts a template
-string that supports `${rotation}` and `${pid}`. For example:
+string that supports `${rotation}` and `${pid}`:
 
 ```txt
 node --trace-event-categories v8 --trace-event-file-pattern '${pid}-${rotation}.log' server.js

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -906,8 +906,6 @@ string serializations of the URL. These are not, however, customizable in
 any way. The `url.format(URL[, options])` method allows for basic customization
 of the output.
 
-For example:
-
 ```js
 const myURL = new URL('https://a:b@你好你好?abc#foo');
 
@@ -982,7 +980,7 @@ is everything following the `host` (including the `port`) and before the start
 of the `query` or `hash` components, delimited by either the ASCII question
 mark (`?`) or hash (`#`) characters.
 
-For example `'/p/a/t/h'`.
+For example: `'/p/a/t/h'`.
 
 No decoding of the path string is performed.
 
@@ -1164,8 +1162,6 @@ changes:
 The `url.resolve()` method resolves a target URL relative to a base URL in a
 manner similar to that of a Web browser resolving an anchor tag HREF.
 
-For example:
-
 ```js
 const url = require('url');
 url.resolve('/one/two/three', 'four');         // '/one/two/four'
@@ -1223,7 +1219,7 @@ specific conditions, in addition to all other cases.
 
 When non-ASCII characters appear within a hostname, the hostname is encoded
 using the [Punycode][] algorithm. Note, however, that a hostname *may* contain
-*both* Punycode encoded and percent-encoded characters. For example:
+*both* Punycode encoded and percent-encoded characters:
 
 ```js
 const myURL = new URL('https://%CF%80.com/foo');

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -948,8 +948,6 @@ Returns `true` if the value is a built-in [`ArrayBuffer`][] or
 See also [`util.types.isArrayBuffer()`][] and
 [`util.types.isSharedArrayBuffer()`][].
 
-For example:
-
 ```js
 util.types.isAnyArrayBuffer(new ArrayBuffer());  // Returns true
 util.types.isAnyArrayBuffer(new SharedArrayBuffer());  // Returns true
@@ -964,8 +962,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is an `arguments` object.
-
-For example:
 
 <!-- eslint-disable prefer-rest-params -->
 ```js
@@ -986,8 +982,6 @@ Returns `true` if the value is a built-in [`ArrayBuffer`][] instance.
 This does *not* include [`SharedArrayBuffer`][] instances. Usually, it is
 desirable to test for both; See [`util.types.isAnyArrayBuffer()`][] for that.
 
-For example:
-
 ```js
 util.types.isArrayBuffer(new ArrayBuffer());  // Returns true
 util.types.isArrayBuffer(new SharedArrayBuffer());  // Returns false
@@ -1006,8 +1000,6 @@ Note that this only reports back what the JavaScript engine is seeing;
 in particular, the return value may not match the original source code if
 a transpilation tool was used.
 
-For example:
-
 ```js
 util.types.isAsyncFunction(function foo() {});  // Returns false
 util.types.isAsyncFunction(async function foo() {});  // Returns true
@@ -1022,8 +1014,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a `BigInt64Array` instance.
-
-For example:
 
 ```js
 util.types.isBigInt64Array(new BigInt64Array());   // Returns true
@@ -1040,8 +1030,6 @@ added: v10.0.0
 
 Returns `true` if the value is a `BigUint64Array` instance.
 
-For example:
-
 ```js
 util.types.isBigUint64Array(new BigInt64Array());   // Returns false
 util.types.isBigUint64Array(new BigUint64Array());  // Returns true
@@ -1057,8 +1045,6 @@ added: v10.0.0
 
 Returns `true` if the value is a boolean object, e.g. created
 by `new Boolean()`.
-
-For example:
 
 ```js
 util.types.isBooleanObject(false);  // Returns false
@@ -1079,8 +1065,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`DataView`][] instance.
 
-For example:
-
 ```js
 const ab = new ArrayBuffer(20);
 util.types.isDataView(new DataView(ab));  // Returns true
@@ -1098,8 +1082,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Date`][] instance.
-
-For example:
 
 ```js
 util.types.isDate(new Date());  // Returns true
@@ -1125,8 +1107,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Float32Array`][] instance.
 
-For example:
-
 ```js
 util.types.isFloat32Array(new ArrayBuffer());  // Returns false
 util.types.isFloat32Array(new Float32Array());  // Returns true
@@ -1142,8 +1122,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Float64Array`][] instance.
-
-For example:
 
 ```js
 util.types.isFloat64Array(new ArrayBuffer());  // Returns false
@@ -1164,8 +1142,6 @@ Note that this only reports back what the JavaScript engine is seeing;
 in particular, the return value may not match the original source code if
 a transpilation tool was used.
 
-For example:
-
 ```js
 util.types.isGeneratorFunction(function foo() {});  // Returns false
 util.types.isGeneratorFunction(function* foo() {});  // Returns true
@@ -1185,8 +1161,6 @@ Note that this only reports back what the JavaScript engine is seeing;
 in particular, the return value may not match the original source code if
 a transpilation tool was used.
 
-For example:
-
 ```js
 function* foo() {}
 const generator = foo();
@@ -1202,8 +1176,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Int8Array`][] instance.
-
-For example:
 
 ```js
 util.types.isInt8Array(new ArrayBuffer());  // Returns false
@@ -1221,8 +1193,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Int16Array`][] instance.
 
-For example:
-
 ```js
 util.types.isInt16Array(new ArrayBuffer());  // Returns false
 util.types.isInt16Array(new Int16Array());  // Returns true
@@ -1238,8 +1208,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Int32Array`][] instance.
-
-For example:
 
 ```js
 util.types.isInt32Array(new ArrayBuffer());  // Returns false
@@ -1257,8 +1225,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Map`][] instance.
 
-For example:
-
 ```js
 util.types.isMap(new Map());  // Returns true
 ```
@@ -1273,8 +1239,6 @@ added: v10.0.0
 
 Returns `true` if the value is an iterator returned for a built-in
 [`Map`][] instance.
-
-For example:
 
 ```js
 const map = new Map();
@@ -1294,8 +1258,6 @@ added: v10.0.0
 
 Returns `true` if the value is an instance of a [Module Namespace Object][].
 
-For example:
-
 <!-- eslint-skip -->
 ```js
 import * as ns from './a.js';
@@ -1312,8 +1274,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is an instance of a built-in [`Error`][] type.
-
-For example:
 
 ```js
 util.types.isNativeError(new Error());  // Returns true
@@ -1332,8 +1292,6 @@ added: v10.0.0
 Returns `true` if the value is a number object, e.g. created
 by `new Number()`.
 
-For example:
-
 ```js
 util.types.isNumberObject(0);  // Returns false
 util.types.isNumberObject(new Number(0));   // Returns true
@@ -1349,8 +1307,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Promise`][].
 
-For example:
-
 ```js
 util.types.isPromise(Promise.resolve(42));  // Returns true
 ```
@@ -1364,8 +1320,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a [`Proxy`][] instance.
-
-For example:
 
 ```js
 const target = {};
@@ -1384,8 +1338,6 @@ added: v10.0.0
 
 Returns `true` if the value is a regular expression object.
 
-For example:
-
 ```js
 util.types.isRegExp(/abc/);  // Returns true
 util.types.isRegExp(new RegExp('abc'));  // Returns true
@@ -1401,8 +1353,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Set`][] instance.
 
-For example:
-
 ```js
 util.types.isSet(new Set());  // Returns true
 ```
@@ -1417,8 +1367,6 @@ added: v10.0.0
 
 Returns `true` if the value is an iterator returned for a built-in
 [`Set`][] instance.
-
-For example:
 
 ```js
 const set = new Set();
@@ -1440,8 +1388,6 @@ Returns `true` if the value is a built-in [`SharedArrayBuffer`][] instance.
 This does *not* include [`ArrayBuffer`][] instances. Usually, it is
 desirable to test for both; See [`util.types.isAnyArrayBuffer()`][] for that.
 
-For example:
-
 ```js
 util.types.isSharedArrayBuffer(new ArrayBuffer());  // Returns false
 util.types.isSharedArrayBuffer(new SharedArrayBuffer());  // Returns true
@@ -1457,8 +1403,6 @@ added: v10.0.0
 
 Returns `true` if the value is a string object, e.g. created
 by `new String()`.
-
-For example:
 
 ```js
 util.types.isStringObject('foo');  // Returns false
@@ -1476,8 +1420,6 @@ added: v10.0.0
 Returns `true` if the value is a symbol object, created
 by calling `Object()` on a `Symbol` primitive.
 
-For example:
-
 ```js
 const symbol = Symbol('foo');
 util.types.isSymbolObject(symbol);  // Returns false
@@ -1493,8 +1435,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`TypedArray`][] instance.
-
-For example:
 
 ```js
 util.types.isTypedArray(new ArrayBuffer());  // Returns false
@@ -1514,8 +1454,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Uint8Array`][] instance.
 
-For example:
-
 ```js
 util.types.isUint8Array(new ArrayBuffer());  // Returns false
 util.types.isUint8Array(new Uint8Array());  // Returns true
@@ -1531,8 +1469,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Uint8ClampedArray`][] instance.
-
-For example:
 
 ```js
 util.types.isUint8ClampedArray(new ArrayBuffer());  // Returns false
@@ -1550,8 +1486,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`Uint16Array`][] instance.
 
-For example:
-
 ```js
 util.types.isUint16Array(new ArrayBuffer());  // Returns false
 util.types.isUint16Array(new Uint16Array());  // Returns true
@@ -1567,8 +1501,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`Uint32Array`][] instance.
-
-For example:
 
 ```js
 util.types.isUint32Array(new ArrayBuffer());  // Returns false
@@ -1586,8 +1518,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`WeakMap`][] instance.
 
-For example:
-
 ```js
 util.types.isWeakMap(new WeakMap());  // Returns true
 ```
@@ -1602,8 +1532,6 @@ added: v10.0.0
 
 Returns `true` if the value is a built-in [`WeakSet`][] instance.
 
-For example:
-
 ```js
 util.types.isWeakSet(new WeakSet());  // Returns true
 ```
@@ -1617,8 +1545,6 @@ added: v10.0.0
 * Returns: {boolean}
 
 Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
-
-For example:
 
 ```js
 const module = new WebAssembly.Module(wasmBuffer);

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -20,8 +20,6 @@ Workers, unlike child processes or when using the `cluster` module, can also
 share memory efficiently by transferring `ArrayBuffer` instances or sharing
 `SharedArrayBuffer` instances between them.
 
-## Example
-
 ```js
 const {
   Worker, isMainThread, parentPort, workerData
@@ -280,8 +278,6 @@ pre-existing channel, such as the global one.
 See [`port.postMessage()`][] for more information on how messages are passed,
 and what kind of JavaScript values can be successfully transported through
 the thread barrier.
-
-For example:
 
 ```js
 const assert = require('assert');


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Some nits were also fixed in passing.

cc @nodejs/documentation, @Trott 
