### PR TITLE
Fix Python detection when depot_tools are in PATH in Windows

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -2,7 +2,7 @@
 echo Looking for Python 2.x
 SETLOCAL
 :: If python.exe is in %Path%, just validate
-FOR /F "delims=" %%a IN ('where python 2^> NUL') DO (
+FOR /F "delims=" %%a IN ('where python.exe 2^> NUL') DO (
   SET need_path=0
   SET p=%%~dpa
   IF NOT ERRORLEVEL 1 GOTO :validate


### PR DESCRIPTION
This fixes the detection of Python for me in Windows.

The issue is I've installed "depot_tools" in path for building v8, and as a result "depot_tools/python.bat" is being found instead and that then causes Node to say it can't find Python.

It's probably only affecting my case, but that is good enough for a PR for me :)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
