### PR TITLE
test: remove skip of OS X bug

### DIFF
--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -2,9 +2,6 @@
 
 const common = require('../common');
 
-if (common.isOSX)
-  common.skip('because of 17894467 Apple bug');
-
 const assert = require('assert');
 const dgram = require('dgram');
 

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -21,8 +21,6 @@
 
 'use strict';
 const common = require('../common');
-if (common.isOSX)
-  common.skip('because of 17894467 Apple bug');
 
 const assert = require('assert');
 const dgram = require('dgram');

--- a/test/parallel/test-dgram-send-empty-packet.js
+++ b/test/parallel/test-dgram-send-empty-packet.js
@@ -1,7 +1,5 @@
 'use strict';
 const common = require('../common');
-if (common.isOSX)
-  common.skip('because of 17894467 Apple bug');
 
 const assert = require('assert');
 const dgram = require('dgram');


### PR DESCRIPTION
Three tests are skipped because of Apple bug 17894467. That bug exists
in OS X 10.10, but we no longer support 10.10 (and neither does Apple).
Remove the test-skipping.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
