### PR TITLE
build: use arm64 as DESTCPU for aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -726,7 +726,7 @@ ifeq ($(findstring arm,$(UNAME_M)),arm)
 DESTCPU ?= arm
 else
 ifeq ($(findstring aarch64,$(UNAME_M)),aarch64)
-DESTCPU ?= aarch64
+DESTCPU ?= arm64
 else
 ifeq ($(findstring powerpc,$(shell uname -p)),powerpc)
 DESTCPU ?= ppc64

--- a/Makefile
+++ b/Makefile
@@ -746,7 +746,7 @@ else
 ifeq ($(DESTCPU),arm)
 ARCH=arm
 else
-ifeq ($(DESTCPU),aarch64)
+ifeq ($(DESTCPU),arm64)
 ARCH=arm64
 else
 ifeq ($(DESTCPU),ppc64)


### PR DESCRIPTION
On a `aarch64` system I can run the complete build with tests without
specifying the Makefile variable `DESTCPU`.

But when running the `tar-headers` target `DESTCPU` is passed to configure:
```shell
    $(PYTHON) ./configure \
               --prefix=/ \
               --dest-cpu=$(DESTCPU) \
               ...
```
The value of `DESTCPU` in this case will be 'aarch64' which will cause
configure to fail:
```shell
configure: error: option --dest-cpu: invalid choice: 'aarch64'
(choose from 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
'ppc64', 'x32', 'x64', 'x86', 'x86_64', 's390', 's390x')
```

In the configure script there is a matching of `__aarch64__` to `arm64`:
```shell
$ python -c 'from configure import host_arch_cc; print host_arch_cc()'
arm64
```

In our case it would be nice to have consitent behaviour for both of
these cases on `aarch64`.

This commit changes `DESTCPU` to `arm64` to be consistent with the
configure script. `DESTCPU` is used in `$(TARBALL)-headers` and in
`$(BINARYTAR)` but I'm not sure about the implications of making the
change purposed and hope others might chime in and provide some
guidance.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
