### PR TITLE
lib: make DOMException attributes configurable and enumerable

### DIFF
--- a/lib/internal/domexception.js
+++ b/lib/internal/domexception.js
@@ -43,6 +43,12 @@ class DOMException extends Error {
   }
 }
 
+Object.defineProperties(DOMException.prototype, {
+  name: { enumerable: true, configurable: true },
+  message: { enumerable: true, configurable: true },
+  code: { enumerable: true, configurable: true }
+});
+
 for (const [name, codeName, value] of [
   ['IndexSizeError', 'INDEX_SIZE_ERR', 1],
   ['DOMStringSizeError', 'DOMSTRING_SIZE_ERR', 2],


### PR DESCRIPTION
The `name`, `message` and `code` attributes of the DOMException
interface should be enumerable and configurable. Aligning
the definition with the Web allows us to use it when
running the Web Platform Tests.

Refs: https://heycam.github.io/webidl/#idl-DOMException
Refs: https://github.com/web-platform-tests/wpt/commit/125950d10a346482075c55d27f61a1021ca68d68

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
