### PR TITLE
crypto: make _toBuf non-enumerable

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -137,7 +137,6 @@ function createVerify(algorithm, options) {
 
 module.exports = exports = {
   // Methods
-  _toBuf: deprecate(toBuf, 'crypto._toBuf is deprecated.', 'DEP0114'),
   createCipheriv,
   createDecipheriv,
   createDiffieHellman,
@@ -205,6 +204,10 @@ function getFipsForced() {
 }
 
 Object.defineProperties(exports, {
+  _toBuf: {
+    enumerable: false,
+    value: deprecate(toBuf, 'crypto._toBuf is deprecated.', 'DEP0114')
+  },
   createCipher: {
     enumerable: false,
     value: deprecate(createCipher,


### PR DESCRIPTION
After landing https://github.com/nodejs/node/pull/22501, I noticed that I did not make `_toBuf` non-enumerable. Following the discussion in https://github.com/nodejs/node/pull/22519, I believe it should be, so here is that. Partially also for consistency with the rest of `crypto.js`.

cc @nodejs/crypto

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
