### PR TITLE
doc: unify deprecation wording

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -998,7 +998,7 @@ deprecated and support will be removed in the future.
 
 Type: Documentation-only
 
-The option `produceCachedData` has been deprecated. Use
+The option `produceCachedData` is deprecated. Use
 [`script.createCachedData()`][] instead.
 
 <a id="DEP0111"></a>

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -998,7 +998,7 @@ deprecated and support will be removed in the future.
 
 Type: Documentation-only
 
-The option `produceCachedData` is deprecated. Use
+The `produceCachedData` option is deprecated. Use
 [`script.createCachedData()`][] instead.
 
 <a id="DEP0111"></a>


### PR DESCRIPTION
As suggested by @Trott in https://github.com/nodejs/node/pull/22519#discussion_r212799151: This is the only occurrence of `has been deprecated`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
