### PR TITLE
errors: add useOriginalName to internal/errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -151,6 +151,8 @@ function makeSystemErrorWithCode(key) {
   };
 }
 
+let useOriginalName = false;
+
 function makeNodeErrorWithCode(Base, key) {
   return class NodeError extends Base {
     constructor(...args) {
@@ -158,6 +160,9 @@ function makeNodeErrorWithCode(Base, key) {
     }
 
     get name() {
+      if (useOriginalName) {
+        return super.name;
+      }
       return `${super.name} [${key}]`;
     }
 
@@ -437,7 +442,10 @@ module.exports = {
   getMessage,
   SystemError,
   codes,
-  E // This is exported only to facilitate testing.
+  // These are exported only to facilitate testing.
+  E,
+  get useOriginalName() { return useOriginalName; },
+  set useOriginalName(value) { useOriginalName = value; }
 };
 
 // To declare an error message, use the E(sym, val, def) function above. The sym

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -442,8 +442,10 @@ module.exports = {
   getMessage,
   SystemError,
   codes,
-  // These are exported only to facilitate testing.
+  // This is exported only to facilitate testing.
   E,
+  // This allows us to tell the type of the errors without using
+  // instanceof, which is necessary in WPT harness.
   get useOriginalName() { return useOriginalName; },
   set useOriginalName(value) { useOriginalName = value; }
 };

--- a/test/parallel/test-internal-error-original-names.js
+++ b/test/parallel/test-internal-error-original-names.js
@@ -1,0 +1,30 @@
+// Flags: --expose-internals
+
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const errors = require('internal/errors');
+
+
+errors.E('TEST_ERROR_1', 'Error for testing purposes: %s',
+         Error);
+{
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+}
+
+{
+  errors.useOriginalName = true;
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error');
+}
+
+{
+  errors.useOriginalName = false;
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+}

--- a/test/parallel/test-internal-error-original-names.js
+++ b/test/parallel/test-internal-error-original-names.js
@@ -2,6 +2,11 @@
 
 'use strict';
 
+// This tests `internal/errors.useOriginalName`
+// This testing feature is needed to allows us to assert the types of
+// errors without using instanceof, which is necessary in WPT harness.
+// Refs: https://github.com/nodejs/node/pull/22556
+
 require('../common');
 const assert = require('assert');
 const errors = require('internal/errors');


### PR DESCRIPTION
This allows us to tell the type of the errors without using
instanceof, which is necessary in WPT harness.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
