### PR TITLE
test: use module.exports consistently

### DIFF
--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -2,10 +2,14 @@
 const common = require('../common');
 const path = require('path');
 
+const kNodeShared = Boolean(process.config.variables.node_shared);
+const kShlibSuffix = process.config.variables.shlib_suffix;
+const kExecPath = path.dirname(process.execPath);
+
 // If node executable is linked to shared lib, need to take care about the
 // shared lib path.
-exports.addLibraryPath = function(env) {
-  if (!process.config.variables.node_shared) {
+function addLibraryPath(env) {
+  if (!kNodeShared) {
     return;
   }
 
@@ -13,37 +17,37 @@ exports.addLibraryPath = function(env) {
 
   env.LD_LIBRARY_PATH =
     (env.LD_LIBRARY_PATH ? env.LD_LIBRARY_PATH + path.delimiter : '') +
-    path.join(path.dirname(process.execPath), 'lib.target');
+    path.join(kExecPath, 'lib.target');
   // For AIX.
   env.LIBPATH =
     (env.LIBPATH ? env.LIBPATH + path.delimiter : '') +
-    path.join(path.dirname(process.execPath), 'lib.target');
+    path.join(kExecPath, 'lib.target');
   // For Mac OSX.
   env.DYLD_LIBRARY_PATH =
     (env.DYLD_LIBRARY_PATH ? env.DYLD_LIBRARY_PATH + path.delimiter : '') +
-    path.dirname(process.execPath);
+    kExecPath;
   // For Windows.
-  env.PATH =
-    (env.PATH ? env.PATH + path.delimiter : '') +
-    path.dirname(process.execPath);
-};
+  env.PATH = (env.PATH ? env.PATH + path.delimiter : '') + kExecPath;
+}
 
 // Get the full path of shared lib.
-exports.getSharedLibPath = function() {
+function getSharedLibPath() {
   if (common.isWindows) {
-    return path.join(path.dirname(process.execPath), 'node.dll');
+    return path.join(kExecPath, 'node.dll');
   } else if (common.isOSX) {
-    return path.join(path.dirname(process.execPath),
-                     `libnode.${process.config.variables.shlib_suffix}`);
+    return path.join(kExecPath, `libnode.${kShlibSuffix}`);
   } else {
-    return path.join(path.dirname(process.execPath),
-                     'lib.target',
-                     `libnode.${process.config.variables.shlib_suffix}`);
+    return path.join(kExecPath, 'lib.target', `libnode.${kShlibSuffix}`);
   }
-};
+}
 
 // Get the binary path of stack frames.
-exports.getBinaryPath = function() {
-  return process.config.variables.node_shared ?
-    exports.getSharedLibPath() : process.execPath;
+function getBinaryPath() {
+  return kNodeShared ? getSharedLibPath() : process.execPath;
+}
+
+module.exports = {
+  addLibraryPath,
+  getBinaryPath,
+  getSharedLibPath
 };

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -59,9 +59,15 @@ let tmpdirName = '.tmp';
 if (process.env.TEST_THREAD_ID) {
   tmpdirName += `.${process.env.TEST_THREAD_ID}`;
 }
-exports.path = path.join(testRoot, tmpdirName);
 
-exports.refresh = () => {
-  rimrafSync(exports.path);
-  fs.mkdirSync(exports.path);
+const tmpPath = path.join(testRoot, tmpdirName);
+
+function refresh() {
+  rimrafSync(this.path);
+  fs.mkdirSync(this.path);
+}
+
+module.exports = {
+  path: tmpPath,
+  refresh
 };


### PR DESCRIPTION
Minor style consistency updates

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
