### PR TITLE
string_decoder : support typed array or data view

### DIFF
--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -59,7 +59,8 @@ Creates a new `StringDecoder` instance.
 added: v0.9.3
 -->
 
-* `buffer` {Buffer} A `Buffer` containing the bytes to decode.
+* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, or `TypedArray`, or
+ `DataView` containing the bytes to decode.
 * Returns: {string}
 
 Returns any remaining input stored in the internal buffer as a string. Bytes
@@ -79,10 +80,11 @@ changes:
                  character instead of one for each individual byte.
 -->
 
-* `buffer` {Buffer} A `Buffer` containing the bytes to decode.
+* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, or `TypedArray`, or
+ `DataView` containing the bytes to decode.
 * Returns: {string}
 
 Returns a decoded string, ensuring that any incomplete multibyte characters at
-the end of the `Buffer` are omitted from the returned string and stored in an
-internal buffer for the next call to `stringDecoder.write()` or
-`stringDecoder.end()`.
+ the end of the `Buffer`, or `TypedArray`, or `DataView` are omitted from the
+ returned string and stored in an internal buffer for the next call to
+ `stringDecoder.write()` or `stringDecoder.end()`.

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -73,7 +73,12 @@ StringDecoder.prototype.write = function write(buf) {
     return buf;
   if (!ArrayBuffer.isView(buf))
     throw new ERR_INVALID_ARG_TYPE('buf',
-                                   ['Buffer', 'Uint8Array', 'ArrayBufferView'],
+                                   [
+                                     'Buffer',
+                                     'TypedArray',
+                                     'DataView',
+                                     'ArrayBufferView'
+                                   ],
                                    buf);
   return decode(this[kNativeDecoder], buf);
 };

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -72,11 +72,9 @@ StringDecoder.prototype.write = function write(buf) {
   if (typeof buf === 'string')
     return buf;
   if (!ArrayBuffer.isView(buf))
-    throw new ERR_INVALID_ARG_TYPE(
-      'buf',
-      ['Buffer', 'TypedArray', 'DataView', 'ArrayBufferView'],
-      buf
-    );
+    throw new ERR_INVALID_ARG_TYPE('buf',
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   buf);
   return decode(this[kNativeDecoder], buf);
 };
 

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -72,14 +72,11 @@ StringDecoder.prototype.write = function write(buf) {
   if (typeof buf === 'string')
     return buf;
   if (!ArrayBuffer.isView(buf))
-    throw new ERR_INVALID_ARG_TYPE('buf',
-                                   [
-                                     'Buffer',
-                                     'TypedArray',
-                                     'DataView',
-                                     'ArrayBufferView'
-                                   ],
-                                   buf);
+    throw new ERR_INVALID_ARG_TYPE(
+      'buf',
+      ['Buffer', 'TypedArray', 'DataView', 'ArrayBufferView'],
+      buf
+    );
   return decode(this[kNativeDecoder], buf);
 };
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -91,11 +91,26 @@ decoder = new StringDecoder('utf8');
 assert.strictEqual(decoder.write(Buffer.from('E1', 'hex')), '');
 
 // A quick test for lastChar, lastNeed & lastTotal which are undocumented.
-assert(decoder.lastChar.equals(Buffer.from([0xe1, 0, 0, 0])));
+assert(decoder.lastChar.equals(new Uint8Array([0xe1, 0, 0, 0])));
 assert.strictEqual(decoder.lastNeed, 2);
 assert.strictEqual(decoder.lastTotal, 3);
 
 assert.strictEqual(decoder.end(), '\ufffd');
+
+// TypedArray with Int8Array test
+decoder = new StringDecoder('utf8');
+assert.strictEqual(decoder.write(new Int8Array([1, 2])), '\u0001\u0002');
+assert.strictEqual(decoder.end(), '');
+
+// DataView
+const buffer = new ArrayBuffer(16);
+const dv = new DataView(buffer, 0);
+dv.setInt16(1, 42);
+
+decoder = new StringDecoder('utf8');
+assert.strictEqual(decoder.write(dv), '\u0000\u0000*\u0000\u0000\u0000\u0000' +
+  '\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000');
+assert.strictEqual(decoder.end(), '');
 
 decoder = new StringDecoder('utf8');
 assert.strictEqual(decoder.write(Buffer.from('E18B', 'hex')), '');
@@ -175,7 +190,7 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "buf" argument must be one of type Buffer, TypedArray,' +
-      ' DataView, or ArrayBufferView. Received type object'
+      ' or DataView. Received type object'
   }
 );
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -102,7 +102,7 @@ const arrayBufferViewStr = 'String for ArrayBufferView tests\n';
 const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
 for (const expectView of common.getArrayBufferViews(inputBuffer)) {
   console.log(
-    'string-decoder test with TypedArray for',
+    'string-decoder test for',
     expectView[Symbol.toStringTag]
   );
   assert.strictEqual(

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -101,10 +101,6 @@ assert.strictEqual(decoder.end(), '\ufffd');
 const arrayBufferViewStr = 'String for ArrayBufferView tests\n';
 const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
 for (const expectView of common.getArrayBufferViews(inputBuffer)) {
-  console.log(
-    'string-decoder test for',
-    expectView[Symbol.toStringTag]
-  );
   assert.strictEqual(
     decoder.write(expectView),
     inputBuffer.toString('utf8')

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -97,20 +97,20 @@ assert.strictEqual(decoder.lastTotal, 3);
 
 assert.strictEqual(decoder.end(), '\ufffd');
 
-// TypedArray with Int8Array test
-decoder = new StringDecoder('utf8');
-assert.strictEqual(decoder.write(new Int8Array([1, 2])), '\u0001\u0002');
-assert.strictEqual(decoder.end(), '');
-
-// DataView
-const buffer = new ArrayBuffer(16);
-const dv = new DataView(buffer, 0);
-dv.setInt16(1, 42);
-
-decoder = new StringDecoder('utf8');
-assert.strictEqual(decoder.write(dv), '\u0000\u0000*\u0000\u0000\u0000\u0000' +
-  '\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000');
-assert.strictEqual(decoder.end(), '');
+// ArrayBufferView tests
+const arrayBufferViewStr = 'String for ArrayBufferView tests\n';
+const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
+for (const expectView of common.getArrayBufferViews(inputBuffer)) {
+  console.log(
+    'string-decoder test with TypedArray for',
+    expectView[Symbol.toStringTag]
+  );
+  assert.strictEqual(
+    decoder.write(expectView),
+    inputBuffer.toString('utf8')
+  );
+  assert.strictEqual(decoder.end(), '');
+}
 
 decoder = new StringDecoder('utf8');
 assert.strictEqual(decoder.write(Buffer.from('E18B', 'hex')), '');

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -91,7 +91,7 @@ decoder = new StringDecoder('utf8');
 assert.strictEqual(decoder.write(Buffer.from('E1', 'hex')), '');
 
 // A quick test for lastChar, lastNeed & lastTotal which are undocumented.
-assert(decoder.lastChar.equals(new Uint8Array([0xe1, 0, 0, 0])));
+assert(decoder.lastChar.equals(Buffer.from([0xe1, 0, 0, 0])));
 assert.strictEqual(decoder.lastNeed, 2);
 assert.strictEqual(decoder.lastTotal, 3);
 
@@ -174,8 +174,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "buf" argument must be one of type Buffer, Uint8Array, or' +
-      ' ArrayBufferView. Received type object'
+    message: 'The "buf" argument must be one of type Buffer, TypedArray,' +
+      ' DataView, or ArrayBufferView. Received type object'
   }
 );
 


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: #1826 
Per [this comment with the checklist](https://github.com/nodejs/node/issues/1826#issuecomment-410487110), this PR attempts to help out the `string_decoder` scope from the check list. The PR supports explicitly `TypedArray` or `DataView`, insead of the original `Uint8Array`.
