### PR TITLE
tools: specify ESLint rules being disabled in two files

### DIFF
--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -39,7 +39,7 @@ function readDomainFromPacket(buffer, offset) {
   } else {
     // Pointer to another part of the packet.
     assert.strictEqual(length & 0xC0, 0xC0);
-    // eslint-disable-next-line
+    // eslint-disable-next-line space-infix-ops, space-unary-ops
     const pointeeOffset = buffer.readUInt16BE(offset) &~ 0xC000;
     return {
       nread: 2,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -692,7 +692,7 @@ common.expectsError(
   () => {
     a(
       (() => 'string')()
-      // eslint-disable-next-line
+      // eslint-disable-next-line operator-linebreak
       ===
       123 instanceof
           Buffer
@@ -704,7 +704,7 @@ common.expectsError(
     message: 'The expression evaluated to a falsy value:\n\n' +
              '  a(\n' +
              '    (() => \'string\')()\n' +
-             '    // eslint-disable-next-line\n' +
+             '    // eslint-disable-next-line operator-linebreak\n' +
              '    ===\n' +
              '    123 instanceof\n' +
              '        Buffer\n' +
@@ -716,7 +716,7 @@ common.expectsError(
   () => {
     a(
       (() => 'string')()
-      // eslint-disable-next-line
+      // eslint-disable-next-line operator-linebreak
       ===
   123 instanceof
           Buffer
@@ -728,7 +728,7 @@ common.expectsError(
     message: 'The expression evaluated to a falsy value:\n\n' +
              '  a(\n' +
              '    (() => \'string\')()\n' +
-             '    // eslint-disable-next-line\n' +
+             '    // eslint-disable-next-line operator-linebreak\n' +
              '    ===\n' +
              '  123 instanceof\n' +
              '        Buffer\n' +


### PR DESCRIPTION
Instead of disabling all ESLint rules, just disable the rules necessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
