### PR TITLE
docs: replace `1` by `process.stdout.fd`

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -150,9 +150,9 @@ Because printing to the console is an asynchronous operation, `console.log()`
 will cause the AsyncHooks callbacks to be called. Using `console.log()` or
 similar asynchronous operations inside an AsyncHooks callback function will thus
 cause an infinite recursion. An easy solution to this when debugging is to use a
-synchronous logging operation such as `fs.writeSync(1, msg)`. This will print to
-stdout because `1` is the file descriptor for stdout and will not invoke
-AsyncHooks recursively because it is synchronous.
+synchronous logging operation such as `fs.writeSync(process.stdout.fd, msg)`.
+This will print to stdout and will not invoke AsyncHooks recursively because it
+is synchronous.
 
 ```js
 const fs = require('fs');
@@ -160,7 +160,7 @@ const util = require('util');
 
 function debug(...args) {
   // use a function like this one when debugging inside an AsyncHooks callback
-  fs.writeSync(1, `${util.format(...args)}\n`);
+  fs.writeSync(process.stdout.fd, `${util.format(...args)}\n`);
 }
 ```
 
@@ -330,17 +330,17 @@ async_hooks.createHook({
   },
   before(asyncId) {
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(1, `${indentStr}before:  ${asyncId}\n`);
+    fs.writeSync(process.stdout.fd, `${indentStr}before:  ${asyncId}\n`);
     indent += 2;
   },
   after(asyncId) {
     indent -= 2;
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(1, `${indentStr}after:   ${asyncId}\n`);
+    fs.writeSync(process.stdout.fd, `${indentStr}after:   ${asyncId}\n`);
   },
   destroy(asyncId) {
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(1, `${indentStr}destroy: ${asyncId}\n`);
+    fs.writeSync(process.stdout.fd, `${indentStr}destroy: ${asyncId}\n`);
   },
 }).enable();
 


### PR DESCRIPTION
Using `fs.writeSync(1, ...)` is a little bit confusing in our docs, especially for those users who are not familiar with Unix File System. Replace the  number `1` it by a constant `process.stdout.fd` seems more clear.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
