### PR TITLE
lib/util.js: make formatValue function shorter and more extensible

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -134,110 +134,84 @@ const noIteratorTypeMap = new Map([
 // A strategy object, preserving functions which deal with different type;
 // The keys are data's type and values are format function;
 const typeFormatStrategy = {
-  'ARRAY'(value, constructor, keyLength, tag, ctx, keys) {
+  'ARRAY'(braces, value, constructor, keyLength, tag, ctx, keys) {
     // Only set the constructor for non ordinary ("Array [...]") arrays.
     const prefix = getPrefix(constructor, tag);
-    const braces = [`${prefix === 'Array ' ? '' : prefix}[`, ']'];
+    braces[0] = `${prefix === 'Array ' ? '' : prefix}[`;
+    braces[1] = ']';
     if (value.length === 0 && keyLength === 0)
       return { result: `${braces[0]}]` };
-    const formatter = formatArray;
-    return { braces, formatter };
+    return { formatter: formatArray };
   },
-  'SET'(value, constructor, keyLength, tag, ctx, keys) {
+  'SET'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const prefix = getPrefix(constructor, tag);
     if (value.size === 0 && keyLength === 0)
       return { result: `${prefix}{}` };
-    const braces = [`${prefix}{`, '}'];
-    const formatter = formatSet;
-    return { braces, formatter };
+    braces[0] = `${prefix}{`;
+    return { formatter: formatSet };
   },
-  'MAP'(value, constructor, keyLength, tag, ctx, keys) {
+  'MAP'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const prefix = getPrefix(constructor, tag);
     if (value.size === 0 && keyLength === 0)
       return { result: `${prefix}{}` };
-    const braces = [`${prefix}{`, '}'];
-    const formatter = formatMap;
-    return { braces, formatter };
+    braces[0] = `${prefix}{`;
+    return { formatter: formatMap };
   },
-  'TYPED_ARRAY'(value, constructor, keyLength, tag, ctx, keys) {
-    let result, formatter;
-    const braces = [`${getPrefix(constructor, tag)}[`, ']'];
-    if (value.length === 0 && keyLength === 0 && !ctx.showHidden) {
-      result = `${braces[0]}]`;
-    } else {
-      formatter = formatTypedArray;
-    }
-    return { braces, formatter, result };
+  'TYPED_ARRAY'(braces, value, constructor, keyLength, tag, ctx, keys) {
+    braces[0] = `${getPrefix(constructor, tag)}[`;
+    braces[1] = ']';
+    if (value.length === 0 && keyLength === 0 && !ctx.showHidden)
+      return { result: `${braces[0]}]` };
+    return { formatter: formatTypedArray };
   },
-  'MAP_ITERATOR'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = [`[${tag}] {`, '}'];
-    const formatter = formatMapIterator;
-    return { braces, formatter };
+  'MAP_ITERATOR'(braces, value, constructor, keyLength, tag, ctx, keys) {
+    braces[0] = `[${tag}] {`;
+    return { formatter: formatMapIterator };
   },
-  'SET_ITERATOR'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = [`[${tag}] {`, '}'];
-    const formatter = formatSetIterator;
-    return { braces, formatter };
+  'SET_ITERATOR'(braces, value, constructor, keyLength, tag, ctx, keys) {
+    braces[0] = `[${tag}] {`;
+    return { formatter: formatSetIterator };
   },
-  'PURE_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    let result;
-    const braces = ['{', '}'];
+  'PURE_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     if (isArgumentsObject(value)) {
-      if (keyLength === 0) {
-        result = '[Arguments] {}';
-      } else {
-        braces[0] = '[Arguments] {';
-      }
+      if (keyLength === 0)
+        return { result: '[Arguments] {}' };
+      braces[0] = '[Arguments] {';
     } else if (tag !== '') {
       braces[0] = `${getPrefix(constructor, tag)}{`;
-      if (keyLength === 0) {
-        result = `${braces[0]}}`;
-      }
+      if (keyLength === 0)
+        return { result: `${braces[0]}}` };
     } else if (keyLength === 0) {
-      result = '{}';
+      return { result: '{}' };
     }
-    return { braces, result };
+    return {};
   },
-  'FUNCTION'(value, constructor, keyLength, tag, ctx, keys) {
-    let result, base;
-    const braces = ['{', '}'];
+  'FUNCTION'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const type = constructor || tag || 'Function';
     const name = `${type}${value.name ? `: ${value.name}` : ''}`;
-    if (keyLength === 0) {
-      result = ctx.stylize(`[${name}]`, 'special');
-    } else {
-      base = `[${name}]`;
-    }
-    return { base, result, braces };
+    if (keyLength === 0)
+      return { result: ctx.stylize(`[${name}]`, 'special') };
+    return { base: `[${name}]` };
   },
-  'REGEXP'(value, constructor, keyLength, tag, ctx, keys, recurseTimes) {
+  'REGEXP'(
+    braces, value, constructor, keyLength, tag, ctx, keys, recurseTimes) {
     // Make RegExps say that they are RegExps
-    let result, base;
-    const braces = ['{', '}'];
-    if (keyLength === 0 || recurseTimes < 0) {
-      result = ctx.stylize(regExpToString(value), 'regexp');
-    } else {
-      base = `${regExpToString(value)}`;
-    }
-    return { base, result, braces };
+    if (keyLength === 0 || recurseTimes < 0)
+      return { result: ctx.stylize(regExpToString(value), 'regexp') };
+    return { base: `${regExpToString(value)}` };
   },
-  'DATE'(value, constructor, keyLength, tag, ctx, keys) {
+  'DATE'(braces, value, constructor, keyLength, tag, ctx, keys) {
     // Make dates with properties first say the date
-    let result, base;
-    const braces = ['{', '}'];
     if (keyLength === 0) {
       if (Number.isNaN(dateGetTime(value))) {
-        result = ctx.stylize(String(value), 'date');
+        return { result: ctx.stylize(String(value), 'date') };
       } else {
-        result = ctx.stylize(dateToISOString(value), 'date');
+        return { result: ctx.stylize(dateToISOString(value), 'date') };
       }
-    } else {
-      base = dateToISOString(value);
     }
-    return { base, result, braces };
+    return { base: dateToISOString(value) };
   },
-  'ERROR'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = ['{', '}'];
+  'ERROR'(braces, value, constructor, keyLength, tag, ctx, keys) {
     // Make error with message first say the error
     let base = formatError(value);
     // Wrap the error in brackets in case it has no stack trace.
@@ -257,103 +231,82 @@ const typeFormatStrategy = {
       braces[0] += `${base.slice(stackStart)}`;
       base = `[${base.slice(0, stackStart)}]`;
     }
-    return { braces, base };
+    return { base };
   },
-  'ANY_ARRAY_BUFFER'(value, constructor, keyLength, tag, ctx, keys) {
+  'ANY_ARRAY_BUFFER'(braces, value, constructor, keyLength, tag, ctx, keys) {
     // Fast path for ArrayBuffer and SharedArrayBuffer.
     // Can't do the same for DataView because it has a non-primitive
     // .buffer property that we need to recurse for.
-    let result;
-    const braces = ['{', '}'];
     let prefix = getPrefix(constructor, tag);
     if (prefix === '') {
       prefix = isArrayBuffer(value) ? 'ArrayBuffer ' : 'SharedArrayBuffer ';
     }
     if (keyLength === 0) {
-      result = prefix +
-      `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
+      return { result: prefix +
+        `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`
+      };
     } else {
       braces[0] = `${prefix}{`;
       keys.unshift('byteLength');
     }
-    return { result, braces };
+    return { };
   },
-  'DATA_VIEW'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = ['{', '}'];
+  'DATA_VIEW'(braces, value, constructor, keyLength, tag, ctx, keys) {
     braces[0] = `${getPrefix(constructor, tag, 'DataView')}{`;
     // .buffer goes last, it's not a primitive like the others.
     keys.unshift('byteLength', 'byteOffset', 'buffer');
-    return { braces };
+    return { };
   },
-  'PROMISE'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = ['{', '}'];
+  'PROMISE'(braces, value, constructor, keyLength, tag, ctx, keys) {
     braces[0] = `${getPrefix(constructor, tag, 'Promise')}{`;
-    const formatter = formatPromise;
-    return { braces, formatter };
+    return { formatter: formatPromise };
   },
-  'WEAK_SET'(value, constructor, keyLength, tag, ctx, keys) {
-    let extra;
-    const braces = ['{', '}'];
-    let formatter;
+  'WEAK_SET'(braces, value, constructor, keyLength, tag, ctx, keys) {
     braces[0] = `${getPrefix(constructor, tag, 'WeakSet')}{`;
     if (ctx.showHidden) {
-      formatter = formatWeakSet;
+      return { formatter: formatWeakSet };
     } else {
-      extra = ctx.stylize('<items unknown>', 'special');
+      return { extra: ctx.stylize('<items unknown>', 'special') };
     }
-    return { braces, formatter, extra };
   },
-  'WEAK_MAP'(value, constructor, keyLength, tag, ctx, keys) {
-    let extra;
-    let formatter;
-    const braces = ['{', '}'];
+  'WEAK_MAP'(braces, value, constructor, keyLength, tag, ctx, keys) {
     braces[0] = `${getPrefix(constructor, tag, 'WeakMap')}{`;
     if (ctx.showHidden) {
-      formatter = formatWeakMap;
+      return { formatter: formatWeakMap };
     } else {
-      extra = ctx.stylize('<items unknown>', 'special');
+      return { extra: ctx.stylize('<items unknown>', 'special') };
     }
-    return { braces, formatter, extra };
   },
-  'MODULE_NAME_SPACE_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    const braces = ['{', '}'];
+  'MODULE_NAME_SPACE_OBJECT'(
+    braces, value, constructor, keyLength, tag, ctx, keys) {
     braces[0] = `[${tag}] {`;
-    const formatter = formatNamespaceObject;
-    return { braces, formatter };
+    return { formatter: formatNamespaceObject };
   },
-  'NUMBER_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    let result;
-    const braces = ['{', '}'];
+  'NUMBER_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const base = `[Number: ${getBoxedValue(numberValueOf(value))}]`;
     if (keyLength === 0)
-      result = ctx.stylize(base, 'number');
-    return { result, base, braces };
+      return { result: ctx.stylize(base, 'number') };
+    return { base };
   },
-  'BOOLEAN_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    let result;
-    const braces = ['{', '}'];
+  'BOOLEAN_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const base = `[Boolean: ${getBoxedValue(booleanValueOf(value))}]`;
     if (keyLength === 0)
-      result = ctx.stylize(base, 'boolean');
-    return { result, base, braces };
+      return { result: ctx.stylize(base, 'boolean') };
+    return { base };
   },
-  'BIG_INT_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    let result;
-    const braces = ['{', '}'];
+  'BIG_INT_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const base = `[BigInt: ${getBoxedValue(bigIntValueOf(value))}]`;
     if (keyLength === 0)
-      result = ctx.stylize(base, 'bigint');
-    return { base, result, braces };
+      return { result: ctx.stylize(base, 'bigint') };
+    return { base };
   },
-  'SYMBOL_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
-    let result;
-    const braces = ['{', '}'];
+  'SYMBOL_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const base = `[Symbol: ${getBoxedValue(symbolValueOf(value))}]`;
     if (keyLength === 0)
-      result = ctx.stylize(base, 'symbol');
-    return { base, result, braces };
+      return { result: ctx.stylize(base, 'symbol') };
+    return { base };
   },
-  'STRING_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+  'STRING_OBJECT'(braces, value, constructor, keyLength, tag, ctx, keys) {
     const raw = stringValueOf(value);
     const base = `[String: ${getBoxedValue(raw, ctx)}]`;
     if (keyLength === raw.length)
@@ -362,8 +315,7 @@ const typeFormatStrategy = {
     // since they just noisy up the output and are redundant
     // Make boxed primitive Strings look like such
     keys.splice(0, value.length);
-    const braces = ['{', '}'];
-    return { base, braces };
+    return { base };
   }
 };
 
@@ -444,7 +396,7 @@ const escapeFn = (str) => meta[str.charCodeAt(0)];
 
 
 // Get data's type;
-function getType(value) {
+function getType(value, constructor) {
   if (value[Symbol.iterator]) {
     for (const key of iteratorTypeMap.keys()) {
       if (key(value)) {
@@ -454,7 +406,7 @@ function getType(value) {
   }
 
   for (const key of noIteratorTypeMap.keys()) {
-    if (key(value)) {
+    if (key(value, constructor)) {
       return noIteratorTypeMap.get(key);
     }
   }
@@ -938,27 +890,33 @@ function formatValue(ctx, value, recurseTimes) {
     tag = '';
   let base = '';
   let formatter = formatObject;
-  let braces;
+  let braces = ['{', '}'];
   let extra;
   let i = 0;
 
   // Get value's type;
-  const type = getType(value);
+  const type = getType(value, constructor);
 
   if (type) {
     // Get value's format function;
     const typeFormat = typeFormatStrategy[type];
-    const typeFormatResult =
-      typeFormat(value, constructor, keyLength, tag, ctx, keys, recurseTimes);
+    const typeFormatResult = typeFormat(
+      braces,
+      value,
+      constructor,
+      keyLength,
+      tag,
+      ctx,
+      keys,
+      recurseTimes
+    );
 
     if (typeFormatResult.result) return typeFormatResult.result;
-    braces = typeFormatResult.braces;
     if (typeFormatResult.formatter) formatter = typeFormatResult.formatter;
     if (typeFormatResult.value) value = typeFormatResult.value;
     if (typeFormatResult.base) base = typeFormatResult.base;
     if (typeFormatResult.extra) extra = typeFormatResult.extra;
   } else {
-    braces = ['{', '}'];
     const specialIterator = noPrototypeIterator(ctx, value, recurseTimes);
     if (specialIterator) {
       return specialIterator;
@@ -1493,8 +1451,7 @@ function isPrimitive(arg) {
          typeof arg !== 'object' && typeof arg !== 'function';
 }
 
-function isPureObject(value) {
-  const constructor = getConstructorName(value);
+function isPureObject(value, constructor) {
   return constructor === 'Object';
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -99,6 +99,274 @@ const inspectDefaultOptions = Object.seal({
 
 const ReflectApply = Reflect.apply;
 
+// A map preserving iterator type data's judgement function.
+// The keys are judgement functions, and values are type;
+const iteratorTypeMap = new Map([
+  [Array.isArray, 'ARRAY'],
+  [isSet, 'SET'],
+  [isMap, 'MAP'],
+  [isTypedArray, 'TYPED_ARRAY'],
+  [isMapIterator, 'MAP_ITERATOR'],
+  [isSetIterator, 'SET_ITERATOR']
+]);
+
+// A map preserving no-iterator type data's judgement function.
+// The keys are judgement functions, and values are type;
+const noIteratorTypeMap = new Map([
+  [isPureObject, 'PURE_OBJECT'],
+  [isFunction, 'FUNCTION'],
+  [isRegExp, 'REGEXP'],
+  [isDate, 'DATE'],
+  [isError, 'ERROR'],
+  [isAnyArrayBuffer, 'ANY_ARRAY_BUFFER'],
+  [isDataView, 'DATA_VIEW'],
+  [isPromise, 'PROMISE'],
+  [isWeakSet, 'WEAK_SET'],
+  [isWeakMap, 'WEAK_MAP'],
+  [types.isModuleNamespaceObject, 'MODULE_NAME_SPACE_OBJECT'],
+  [isNumberObject, 'NUMBER_OBJECT'],
+  [isBooleanObject, 'BOOLEAN_OBJECT'],
+  [isBigIntObject, 'BIG_INT_OBJECT'],
+  [isSymbolObject, 'SYMBOL_OBJECT'],
+  [isStringObject, 'STRING_OBJECT']
+]);
+
+// A strategy object, preserving functions which deal with different type;
+// The keys are data's type and values are format function;
+const typeFormatStrategy = {
+  'ARRAY'(value, constructor, keyLength, tag, ctx, keys) {
+    // Only set the constructor for non ordinary ("Array [...]") arrays.
+    const prefix = getPrefix(constructor, tag);
+    const braces = [`${prefix === 'Array ' ? '' : prefix}[`, ']'];
+    if (value.length === 0 && keyLength === 0)
+      return { result: `${braces[0]}]` };
+    const formatter = formatArray;
+    return { braces, formatter };
+  },
+  'SET'(value, constructor, keyLength, tag, ctx, keys) {
+    const prefix = getPrefix(constructor, tag);
+    if (value.size === 0 && keyLength === 0)
+      return { result: `${prefix}{}` };
+    const braces = [`${prefix}{`, '}'];
+    const formatter = formatSet;
+    return { braces, formatter };
+  },
+  'MAP'(value, constructor, keyLength, tag, ctx, keys) {
+    const prefix = getPrefix(constructor, tag);
+    if (value.size === 0 && keyLength === 0)
+      return { result: `${prefix}{}` };
+    const braces = [`${prefix}{`, '}'];
+    const formatter = formatMap;
+    return { braces, formatter };
+  },
+  'TYPED_ARRAY'(value, constructor, keyLength, tag, ctx, keys) {
+    let result, formatter;
+    const braces = [`${getPrefix(constructor, tag)}[`, ']'];
+    if (value.length === 0 && keyLength === 0 && !ctx.showHidden) {
+      result = `${braces[0]}]`;
+    } else {
+      formatter = formatTypedArray;
+    }
+    return { braces, formatter, result };
+  },
+  'MAP_ITERATOR'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = [`[${tag}] {`, '}'];
+    const formatter = formatMapIterator;
+    return { braces, formatter };
+  },
+  'SET_ITERATOR'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = [`[${tag}] {`, '}'];
+    const formatter = formatSetIterator;
+    return { braces, formatter };
+  },
+  'PURE_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    let result;
+    const braces = ['{', '}'];
+    if (isArgumentsObject(value)) {
+      if (keyLength === 0) {
+        result = '[Arguments] {}';
+      } else {
+        braces[0] = '[Arguments] {';
+      }
+    } else if (tag !== '') {
+      braces[0] = `${getPrefix(constructor, tag)}{`;
+      if (keyLength === 0) {
+        result = `${braces[0]}}`;
+      }
+    } else if (keyLength === 0) {
+      result = '{}';
+    }
+    return { braces, result };
+  },
+  'FUNCTION'(value, constructor, keyLength, tag, ctx, keys) {
+    let result, base;
+    const braces = ['{', '}'];
+    const type = constructor || tag || 'Function';
+    const name = `${type}${value.name ? `: ${value.name}` : ''}`;
+    if (keyLength === 0) {
+      result = ctx.stylize(`[${name}]`, 'special');
+    } else {
+      base = `[${name}]`;
+    }
+    return { base, result, braces };
+  },
+  'REGEXP'(value, constructor, keyLength, tag, ctx, keys, recurseTimes) {
+    // Make RegExps say that they are RegExps
+    let result, base;
+    const braces = ['{', '}'];
+    if (keyLength === 0 || recurseTimes < 0) {
+      result = ctx.stylize(regExpToString(value), 'regexp');
+    } else {
+      base = `${regExpToString(value)}`;
+    }
+    return { base, result, braces };
+  },
+  'DATE'(value, constructor, keyLength, tag, ctx, keys) {
+    // Make dates with properties first say the date
+    let result, base;
+    const braces = ['{', '}'];
+    if (keyLength === 0) {
+      if (Number.isNaN(dateGetTime(value))) {
+        result = ctx.stylize(String(value), 'date');
+      } else {
+        result = ctx.stylize(dateToISOString(value), 'date');
+      }
+    } else {
+      base = dateToISOString(value);
+    }
+    return { base, result, braces };
+  },
+  'ERROR'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = ['{', '}'];
+    // Make error with message first say the error
+    let base = formatError(value);
+    // Wrap the error in brackets in case it has no stack trace.
+    const stackStart = base.indexOf('\n    at');
+    if (stackStart === -1) {
+      base = `[${base}]`;
+    }
+    // The message and the stack have to be indented as well!
+    if (ctx.indentationLvl !== 0) {
+      const indentation = ' '.repeat(ctx.indentationLvl);
+      base = formatError(value).replace(/\n/g, `\n${indentation}`);
+    }
+    if (keyLength === 0)
+      return { result: base };
+
+    if (ctx.compact === false && stackStart !== -1) {
+      braces[0] += `${base.slice(stackStart)}`;
+      base = `[${base.slice(0, stackStart)}]`;
+    }
+    return { braces, base };
+  },
+  'ANY_ARRAY_BUFFER'(value, constructor, keyLength, tag, ctx, keys) {
+    // Fast path for ArrayBuffer and SharedArrayBuffer.
+    // Can't do the same for DataView because it has a non-primitive
+    // .buffer property that we need to recurse for.
+    let result;
+    const braces = ['{', '}'];
+    let prefix = getPrefix(constructor, tag);
+    if (prefix === '') {
+      prefix = isArrayBuffer(value) ? 'ArrayBuffer ' : 'SharedArrayBuffer ';
+    }
+    if (keyLength === 0) {
+      result = prefix +
+      `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
+    } else {
+      braces[0] = `${prefix}{`;
+      keys.unshift('byteLength');
+    }
+    return { result, braces };
+  },
+  'DATA_VIEW'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = ['{', '}'];
+    braces[0] = `${getPrefix(constructor, tag, 'DataView')}{`;
+    // .buffer goes last, it's not a primitive like the others.
+    keys.unshift('byteLength', 'byteOffset', 'buffer');
+    return { braces };
+  },
+  'PROMISE'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = ['{', '}'];
+    braces[0] = `${getPrefix(constructor, tag, 'Promise')}{`;
+    const formatter = formatPromise;
+    return { braces, formatter };
+  },
+  'WEAK_SET'(value, constructor, keyLength, tag, ctx, keys) {
+    let extra;
+    const braces = ['{', '}'];
+    let formatter;
+    braces[0] = `${getPrefix(constructor, tag, 'WeakSet')}{`;
+    if (ctx.showHidden) {
+      formatter = formatWeakSet;
+    } else {
+      extra = ctx.stylize('<items unknown>', 'special');
+    }
+    return { braces, formatter, extra };
+  },
+  'WEAK_MAP'(value, constructor, keyLength, tag, ctx, keys) {
+    let extra;
+    let formatter;
+    const braces = ['{', '}'];
+    braces[0] = `${getPrefix(constructor, tag, 'WeakMap')}{`;
+    if (ctx.showHidden) {
+      formatter = formatWeakMap;
+    } else {
+      extra = ctx.stylize('<items unknown>', 'special');
+    }
+    return { braces, formatter, extra };
+  },
+  'MODULE_NAME_SPACE_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    const braces = ['{', '}'];
+    braces[0] = `[${tag}] {`;
+    const formatter = formatNamespaceObject;
+    return { braces, formatter };
+  },
+  'NUMBER_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    let result;
+    const braces = ['{', '}'];
+    const base = `[Number: ${getBoxedValue(numberValueOf(value))}]`;
+    if (keyLength === 0)
+      result = ctx.stylize(base, 'number');
+    return { result, base, braces };
+  },
+  'BOOLEAN_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    let result;
+    const braces = ['{', '}'];
+    const base = `[Boolean: ${getBoxedValue(booleanValueOf(value))}]`;
+    if (keyLength === 0)
+      result = ctx.stylize(base, 'boolean');
+    return { result, base, braces };
+  },
+  'BIG_INT_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    let result;
+    const braces = ['{', '}'];
+    const base = `[BigInt: ${getBoxedValue(bigIntValueOf(value))}]`;
+    if (keyLength === 0)
+      result = ctx.stylize(base, 'bigint');
+    return { base, result, braces };
+  },
+  'SYMBOL_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    let result;
+    const braces = ['{', '}'];
+    const base = `[Symbol: ${getBoxedValue(symbolValueOf(value))}]`;
+    if (keyLength === 0)
+      result = ctx.stylize(base, 'symbol');
+    return { base, result, braces };
+  },
+  'STRING_OBJECT'(value, constructor, keyLength, tag, ctx, keys) {
+    const raw = stringValueOf(value);
+    const base = `[String: ${getBoxedValue(raw, ctx)}]`;
+    if (keyLength === raw.length)
+      return { result: ctx.stylize(base, 'string') };
+    // For boxed Strings, we have to remove the 0-n indexed entries,
+    // since they just noisy up the output and are redundant
+    // Make boxed primitive Strings look like such
+    keys.splice(0, value.length);
+    const braces = ['{', '}'];
+    return { base, braces };
+  }
+};
+
 // This function is borrowed from the function with the same name on V8 Extras'
 // `utils` object. V8 implements Reflect.apply very efficiently in conjunction
 // with the spread syntax, such that no additional special case is needed for
@@ -173,6 +441,24 @@ function addQuotes(str, quotes) {
 }
 
 const escapeFn = (str) => meta[str.charCodeAt(0)];
+
+
+// Get data's type;
+function getType(value) {
+  if (value[Symbol.iterator]) {
+    for (const key of iteratorTypeMap.keys()) {
+      if (key(value)) {
+        return iteratorTypeMap.get(key);
+      }
+    }
+  }
+
+  for (const key of noIteratorTypeMap.keys()) {
+    if (key(value)) {
+      return noIteratorTypeMap.get(key);
+    }
+  }
+}
 
 // Escape control characters, single quotes and the backslash.
 // This is similar to JSON stringify escaping.
@@ -653,185 +939,43 @@ function formatValue(ctx, value, recurseTimes) {
   let base = '';
   let formatter = formatObject;
   let braces;
-  let noIterator = true;
   let extra;
   let i = 0;
 
-  // Iterators and the rest are split to reduce checks
-  if (value[Symbol.iterator]) {
-    noIterator = false;
-    if (Array.isArray(value)) {
-      // Only set the constructor for non ordinary ("Array [...]") arrays.
-      const prefix = getPrefix(constructor, tag);
-      braces = [`${prefix === 'Array ' ? '' : prefix}[`, ']'];
-      if (value.length === 0 && keyLength === 0)
-        return `${braces[0]}]`;
-      formatter = formatArray;
-    } else if (isSet(value)) {
-      const prefix = getPrefix(constructor, tag);
-      if (value.size === 0 && keyLength === 0)
-        return `${prefix}{}`;
-      braces = [`${prefix}{`, '}'];
-      formatter = formatSet;
-    } else if (isMap(value)) {
-      const prefix = getPrefix(constructor, tag);
-      if (value.size === 0 && keyLength === 0)
-        return `${prefix}{}`;
-      braces = [`${prefix}{`, '}'];
-      formatter = formatMap;
-    } else if (isTypedArray(value)) {
-      braces = [`${getPrefix(constructor, tag)}[`, ']'];
-      if (value.length === 0 && keyLength === 0 && !ctx.showHidden)
-        return `${braces[0]}]`;
-      formatter = formatTypedArray;
-    } else if (isMapIterator(value)) {
-      braces = [`[${tag}] {`, '}'];
+  // Get value's type;
+  const type = getType(value);
+
+  if (type) {
+    // Get value's format function;
+    const typeFormat = typeFormatStrategy[type];
+    const typeFormatResult =
+      typeFormat(value, constructor, keyLength, tag, ctx, keys, recurseTimes);
+
+    if (typeFormatResult.result) return typeFormatResult.result;
+    braces = typeFormatResult.braces;
+    if (typeFormatResult.formatter) formatter = typeFormatResult.formatter;
+    if (typeFormatResult.value) value = typeFormatResult.value;
+    if (typeFormatResult.base) base = typeFormatResult.base;
+    if (typeFormatResult.extra) extra = typeFormatResult.extra;
+  } else {
+    braces = ['{', '}'];
+    const specialIterator = noPrototypeIterator(ctx, value, recurseTimes);
+    if (specialIterator) {
+      return specialIterator;
+    }
+    if (isMapIterator(value)) {
+      braces = [`[${tag || 'Map Iterator'}] {`, '}'];
       formatter = formatMapIterator;
     } else if (isSetIterator(value)) {
-      braces = [`[${tag}] {`, '}'];
+      braces = [`[${tag || 'Set Iterator'}] {`, '}'];
       formatter = formatSetIterator;
+    // Handle other regular objects again.
+    } else if (keyLength === 0) {
+      if (isExternal(value))
+        return ctx.stylize('[External]', 'special');
+      return `${getPrefix(constructor, tag)}{}`;
     } else {
-      noIterator = true;
-    }
-  }
-  if (noIterator) {
-    braces = ['{', '}'];
-    if (constructor === 'Object') {
-      if (isArgumentsObject(value)) {
-        if (keyLength === 0)
-          return '[Arguments] {}';
-        braces[0] = '[Arguments] {';
-      } else if (tag !== '') {
-        braces[0] = `${getPrefix(constructor, tag)}{`;
-        if (keyLength === 0) {
-          return `${braces[0]}}`;
-        }
-      } else if (keyLength === 0) {
-        return '{}';
-      }
-    } else if (typeof value === 'function') {
-      const type = constructor || tag || 'Function';
-      const name = `${type}${value.name ? `: ${value.name}` : ''}`;
-      if (keyLength === 0)
-        return ctx.stylize(`[${name}]`, 'special');
-      base = `[${name}]`;
-    } else if (isRegExp(value)) {
-      // Make RegExps say that they are RegExps
-      if (keyLength === 0 || recurseTimes < 0)
-        return ctx.stylize(regExpToString(value), 'regexp');
-      base = `${regExpToString(value)}`;
-    } else if (isDate(value)) {
-      // Make dates with properties first say the date
-      if (keyLength === 0) {
-        if (Number.isNaN(dateGetTime(value)))
-          return ctx.stylize(String(value), 'date');
-        return ctx.stylize(dateToISOString(value), 'date');
-      }
-      base = dateToISOString(value);
-    } else if (isError(value)) {
-      // Make error with message first say the error
-      base = formatError(value);
-      // Wrap the error in brackets in case it has no stack trace.
-      const stackStart = base.indexOf('\n    at');
-      if (stackStart === -1) {
-        base = `[${base}]`;
-      }
-      // The message and the stack have to be indented as well!
-      if (ctx.indentationLvl !== 0) {
-        const indentation = ' '.repeat(ctx.indentationLvl);
-        base = formatError(value).replace(/\n/g, `\n${indentation}`);
-      }
-      if (keyLength === 0)
-        return base;
-
-      if (ctx.compact === false && stackStart !== -1) {
-        braces[0] += `${base.slice(stackStart)}`;
-        base = `[${base.slice(0, stackStart)}]`;
-      }
-    } else if (isAnyArrayBuffer(value)) {
-      // Fast path for ArrayBuffer and SharedArrayBuffer.
-      // Can't do the same for DataView because it has a non-primitive
-      // .buffer property that we need to recurse for.
-      let prefix = getPrefix(constructor, tag);
-      if (prefix === '') {
-        prefix = isArrayBuffer(value) ? 'ArrayBuffer ' : 'SharedArrayBuffer ';
-      }
-      if (keyLength === 0)
-        return prefix +
-              `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
-      braces[0] = `${prefix}{`;
-      keys.unshift('byteLength');
-    } else if (isDataView(value)) {
-      braces[0] = `${getPrefix(constructor, tag, 'DataView')}{`;
-      // .buffer goes last, it's not a primitive like the others.
-      keys.unshift('byteLength', 'byteOffset', 'buffer');
-    } else if (isPromise(value)) {
-      braces[0] = `${getPrefix(constructor, tag, 'Promise')}{`;
-      formatter = formatPromise;
-    } else if (isWeakSet(value)) {
-      braces[0] = `${getPrefix(constructor, tag, 'WeakSet')}{`;
-      if (ctx.showHidden) {
-        formatter = formatWeakSet;
-      } else {
-        extra = ctx.stylize('<items unknown>', 'special');
-      }
-    } else if (isWeakMap(value)) {
-      braces[0] = `${getPrefix(constructor, tag, 'WeakMap')}{`;
-      if (ctx.showHidden) {
-        formatter = formatWeakMap;
-      } else {
-        extra = ctx.stylize('<items unknown>', 'special');
-      }
-    } else if (types.isModuleNamespaceObject(value)) {
-      braces[0] = `[${tag}] {`;
-      formatter = formatNamespaceObject;
-    } else if (isNumberObject(value)) {
-      base = `[Number: ${getBoxedValue(numberValueOf(value))}]`;
-      if (keyLength === 0)
-        return ctx.stylize(base, 'number');
-    } else if (isBooleanObject(value)) {
-      base = `[Boolean: ${getBoxedValue(booleanValueOf(value))}]`;
-      if (keyLength === 0)
-        return ctx.stylize(base, 'boolean');
-    } else if (isBigIntObject(value)) {
-      base = `[BigInt: ${getBoxedValue(bigIntValueOf(value))}]`;
-      if (keyLength === 0)
-        return ctx.stylize(base, 'bigint');
-    } else if (isSymbolObject(value)) {
-      base = `[Symbol: ${getBoxedValue(symbolValueOf(value))}]`;
-      if (keyLength === 0)
-        return ctx.stylize(base, 'symbol');
-    } else if (isStringObject(value)) {
-      const raw = stringValueOf(value);
-      base = `[String: ${getBoxedValue(raw, ctx)}]`;
-      if (keyLength === raw.length)
-        return ctx.stylize(base, 'string');
-      // For boxed Strings, we have to remove the 0-n indexed entries,
-      // since they just noisy up the output and are redundant
-      // Make boxed primitive Strings look like such
-      keys = keys.slice(value.length);
-      braces = ['{', '}'];
-    // The input prototype got manipulated. Special handle these.
-    // We have to rebuild the information so we are able to display everything.
-    } else {
-      const specialIterator = noPrototypeIterator(ctx, value, recurseTimes);
-      if (specialIterator) {
-        return specialIterator;
-      }
-      if (isMapIterator(value)) {
-        braces = [`[${tag || 'Map Iterator'}] {`, '}'];
-        formatter = formatMapIterator;
-      } else if (isSetIterator(value)) {
-        braces = [`[${tag || 'Set Iterator'}] {`, '}'];
-        formatter = formatSetIterator;
-      // Handle other regular objects again.
-      } else if (keyLength === 0) {
-        if (isExternal(value))
-          return ctx.stylize('[External]', 'special');
-        return `${getPrefix(constructor, tag)}{}`;
-      } else {
-        braces[0] = `${getPrefix(constructor, tag)}{`;
-      }
+      braces[0] = `${getPrefix(constructor, tag)}{`;
     }
   }
 
@@ -1347,6 +1491,11 @@ function isFunction(arg) {
 function isPrimitive(arg) {
   return arg === null ||
          typeof arg !== 'object' && typeof arg !== 'function';
+}
+
+function isPureObject(value) {
+  const constructor = getConstructorName(value);
+  return constructor === 'Object';
 }
 
 function pad(n) {


### PR DESCRIPTION
The formatValue function is more than 300 lines, it's very huge and hard to read.
This commit use  a strategy object to replace the huge "if else" statement in the formatValue function.
So that, it's easier to read and add new data types.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
