### PR TITLE
[v10.x backport] src: implement v8::Platform::CallDelayedOnWorkerThread

### DIFF
--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -110,6 +110,10 @@ class BackgroundTaskRunner : public v8::TaskRunner {
   size_t NumberOfAvailableBackgroundThreads() const;
  private:
   TaskQueue<v8::Task> background_tasks_;
+
+  class DelayedTaskScheduler;
+  std::unique_ptr<DelayedTaskScheduler> delayed_task_scheduler_;
+
   std::vector<std::unique_ptr<uv_thread_t>> threads_;
 };
 

--- a/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
+++ b/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
@@ -1,0 +1,21 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+(async function test() {
+  const { strictEqual } = require('assert');
+  const { Session } = require('inspector');
+  const { promisify } = require('util');
+
+  const session = new Session();
+  session.connect();
+  session.post = promisify(session.post);
+  const result = await session.post('Runtime.evaluate', {
+    expression: 'for(;;);',
+    timeout: 0
+  }).catch((e) => e);
+  strictEqual(result.message, 'Execution was terminated');
+  session.disconnect();
+})();


### PR DESCRIPTION
This method is crucial for Runtime.evaluate protocol command with
timeout flag. At least Chrome DevTools frontend uses this method for
every execution in console.

Fixes: #22157
Original PR: https://github.com/nodejs/node/pull/22383

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
