### PR TITLE
pseudo-tty tests: assert on no TTY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.editorconfig
 !.eslintignore
 !.eslintrc.js
+!.eslintrc.yaml
 !.gitattributes
 !.github
 !.gitignore

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -14,6 +14,7 @@ This directory contains modules used to test the Node.js implementation.
 * [HTTP2 module](#http2-module)
 * [Internet module](#internet-module)
 * [tmpdir module](#tmpdir-module)
+* [tty module](#tty-module)
 * [WPT module](#wpt-module)
 
 ## Benchmark Module
@@ -136,12 +137,6 @@ consisting of all `ArrayBufferView` and an `ArrayBuffer`.
 * return [&lt;string>]
 
 Returns the file name and line number for the provided Function.
-
-### getTTYfd()
-
-Attempts to get a valid TTY file descriptor. Returns `-1` if it fails.
-
-The TTY file descriptor is assumed to be capable of being writable.
 
 ### hasCrypto
 * [&lt;boolean>]
@@ -779,6 +774,21 @@ The realpath of the testing temporary directory.
 ### refresh()
 
 Deletes and recreates the testing temporary directory.
+
+## tty Module
+
+This module must be `require()`'d in all TTY tests (those is the `test/pseudo-tty`
+directory).
+
+On load, this module checks if stdin, stdout, and stderr are connected to a TTY,
+and asserts with a detailed message if they are not.
+
+### getTTYfd()
+
+Attempts to get a valid TTY file descriptor. Returns `-1` if it fails.
+
+The TTY file descriptor is assumed to be capable of being writable.
+
 
 ## WPT Module
 

--- a/test/common/common-tty.js
+++ b/test/common/common-tty.js
@@ -1,0 +1,52 @@
+/* eslint-disable node-core/required-modules */
+'use strict';
+
+// Named this way for use with the required-modules eslint rule.
+
+// Utilities for TTY related tests.
+
+const assert = require('assert');
+
+// Check TTY status on module load.
+checkIsTTY();
+
+function checkIsTTY(filename) {
+  let results = '';
+
+  for (const handle of ['stdin', 'stdout', 'stderr']) {
+    if (!process[handle].isTTY) {
+      results += `> '${handle}' was not a TTY, had an FD of ` +
+                 `'${process[handle].fd}',` +
+                 ` and was a '${process[handle].constructor.name}'.\n`;
+    }
+  }
+
+  if (results !== '') {
+    console.error('This test must be run connected to a TTY.\n' +
+                  results +
+                  'Please run this test via the \'tools/test.py\' test runner.');
+    process.exit(1);
+  }
+}
+
+function getTTYfd() {
+  // Do our best to grab a tty fd.
+  const tty = require('tty');
+  const fs = require('fs');
+  // Don't attempt fd 0 as it is not writable on Windows.
+  // Ref: ef2861961c3d9e9ed6972e1e84d969683b25cf95
+  const ttyFd = [1, 2, 4, 5].find(tty.isatty);
+  if (ttyFd === undefined) {
+    try {
+      return fs.openSync('/dev/tty');
+    } catch (e) {
+      // There aren't any tty fd's available to use.
+      return -1;
+    }
+  }
+  return ttyFd;
+}
+
+module.exports = {
+  getTTYfd
+};

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -775,23 +775,6 @@ exports.disableCrashOnUnhandledRejection = function() {
   process.removeListener('unhandledRejection', crashOnUnhandledRejection);
 };
 
-exports.getTTYfd = function getTTYfd() {
-  // Do our best to grab a tty fd.
-  const tty = require('tty');
-  // Don't attempt fd 0 as it is not writable on Windows.
-  // Ref: ef2861961c3d9e9ed6972e1e84d969683b25cf95
-  const ttyFd = [1, 2, 4, 5].find(tty.isatty);
-  if (ttyFd === undefined) {
-    try {
-      return fs.openSync('/dev/tty');
-    } catch (e) {
-      // There aren't any tty fd's available to use.
-      return -1;
-    }
-  }
-  return ttyFd;
-};
-
 exports.runWithInvalidFD = function(func) {
   let fd = 1 << 30;
   // Get first known bad file descriptor. 1 << 30 is usually unlikely to

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -50,7 +50,6 @@ const {
   getArrayBufferViews,
   getBufferSources,
   disableCrashOnUnhandledRejection,
-  getTTYfd,
   runWithInvalidFD
 } = common;
 
@@ -102,6 +101,5 @@ export {
   getArrayBufferViews,
   getBufferSources,
   disableCrashOnUnhandledRejection,
-  getTTYfd,
   runWithInvalidFD
 };

--- a/test/pseudo-tty/.eslintrc.yaml
+++ b/test/pseudo-tty/.eslintrc.yaml
@@ -1,0 +1,8 @@
+## TTY Test-specific linter rules
+
+rules:
+
+  # Custom rules in tools/eslint-rules
+  ## common module is mandatory in tests
+  ## common/tty module is mandatory in TTY tests
+  node-core/required-modules: [error, common, common-tty]

--- a/test/pseudo-tty/console_colors.js
+++ b/test/pseudo-tty/console_colors.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 // Make this test OS-independent by overriding stdio getColorDepth().
 process.stdout.getColorDepth = () => 8;
 process.stderr.getColorDepth = () => 8;

--- a/test/pseudo-tty/no_dropped_stdio.js
+++ b/test/pseudo-tty/no_dropped_stdio.js
@@ -2,6 +2,7 @@
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character

--- a/test/pseudo-tty/no_interleaved_stdio.js
+++ b/test/pseudo-tty/no_interleaved_stdio.js
@@ -2,6 +2,7 @@
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('../common');
+require('../common/common-tty');
 
 const { TTY, isTTY } = process.binding('tty_wrap');
 const strictEqual = require('assert').strictEqual;

--- a/test/pseudo-tty/stdin-setrawmode.js
+++ b/test/pseudo-tty/stdin-setrawmode.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 const assert = require('assert');
 
 process.stdin.setRawMode(true);

--- a/test/pseudo-tty/test-assert-colors.js
+++ b/test/pseudo-tty/test-assert-colors.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 const assert = require('assert').strict;
 
 try {

--- a/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
+++ b/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
@@ -4,6 +4,7 @@
 // see also test/sequential/test-async-wrap-getasyncid.js
 
 const common = require('../common');
+const { getTTYfd } = require('../common/common-tty');
 const assert = require('assert');
 const tty_wrap = process.binding('tty_wrap');
 const { internalBinding } = require('internal/test/binding');
@@ -38,7 +39,7 @@ function testInitialized(req, ctor_name) {
 }
 
 {
-  const ttyFd = common.getTTYfd();
+  const ttyFd = getTTYfd();
 
   const handle = new tty_wrap.TTY(ttyFd, false);
   testInitialized(handle, 'TTY');

--- a/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+++ b/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
@@ -3,6 +3,7 @@
 // see also test/parallel/test-handle-wrap-isrefed.js
 
 const common = require('../common');
+require('../common/common-tty');
 const strictEqual = require('assert').strictEqual;
 const ReadStream = require('tty').ReadStream;
 const tty = new ReadStream(0);

--- a/test/pseudo-tty/test-readable-tty-keepalive.js
+++ b/test/pseudo-tty/test-readable-tty-keepalive.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+require('../common/common-tty');
 const assert = require('assert');
 
 // This test ensures that Node.js will not ignore tty 'readable' subscribers

--- a/test/pseudo-tty/test-set-raw-mode-reset-process-exit.js
+++ b/test/pseudo-tty/test-set-raw-mode-reset-process-exit.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 const child_process = require('child_process');
 
 // Tests that exiting through process.exit() resets the TTY mode.

--- a/test/pseudo-tty/test-set-raw-mode-reset-signal.js
+++ b/test/pseudo-tty/test-set-raw-mode-reset-signal.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 const child_process = require('child_process');
 
 // Tests that exiting through a catchable signal resets the TTY mode.

--- a/test/pseudo-tty/test-set-raw-mode-reset.js
+++ b/test/pseudo-tty/test-set-raw-mode-reset.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 const child_process = require('child_process');
 
 // Tests that exiting through normal means resets the TTY mode.

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 
 const originalRefreshSizeStderr = process.stderr._refreshSize;
 const originalRefreshSizeStdout = process.stdout._refreshSize;

--- a/test/pseudo-tty/test-tty-get-color-depth.js
+++ b/test/pseudo-tty/test-tty-get-color-depth.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
+const { getTTYfd } = require('../common/common-tty');
 const assert = require('assert').strict;
 /* eslint-disable no-restricted-properties */
 const { WriteStream } = require('tty');
 
-const fd = common.getTTYfd();
+const fd = getTTYfd();
 const writeStream = new WriteStream(fd);
 
 {

--- a/test/pseudo-tty/test-tty-isatty.js
+++ b/test/pseudo-tty/test-tty-isatty.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('../common');
+require('../common/common-tty');
 const { strictEqual } = require('assert');
 const { isatty } = require('tty');
 

--- a/test/pseudo-tty/test-tty-stdin-end.js
+++ b/test/pseudo-tty/test-tty-stdin-end.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 
 // This test ensures that Node.js doesn't crash on `process.stdin.emit("end")`.
 // https://github.com/nodejs/node/issues/1068

--- a/test/pseudo-tty/test-tty-stdout-end.js
+++ b/test/pseudo-tty/test-tty-stdout-end.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 
 process.on('uncaughtException', common.expectsError({
   code: 'ERR_STDOUT_CLOSE',

--- a/test/pseudo-tty/test-tty-stdout-resize.js
+++ b/test/pseudo-tty/test-tty-stdout-resize.js
@@ -1,5 +1,6 @@
 'use strict';
 const { mustCall } = require('../common');
+require('../common/common-tty');
 const { notStrictEqual } = require('assert');
 
 // tty.WriteStream#_refreshSize() only emits the 'resize' event when the

--- a/test/pseudo-tty/test-tty-stream-constructors.js
+++ b/test/pseudo-tty/test-tty-stream-constructors.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+require('../common/common-tty');
 const assert = require('assert');
 const { ReadStream, WriteStream } = require('tty');
 

--- a/test/pseudo-tty/test-tty-window-size.js
+++ b/test/pseudo-tty/test-tty-window-size.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+require('../common/common-tty');
 const assert = require('assert');
 const { WriteStream } = require('tty');
 const { TTY } = process.binding('tty_wrap');

--- a/test/pseudo-tty/test-tty-wrap.js
+++ b/test/pseudo-tty/test-tty-wrap.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals --no-warnings
 'use strict';
 require('../common');
+require('../common/common-tty');
 
 const { internalBinding } = require('internal/test/binding');
 const { TTY } = process.binding('tty_wrap');

--- a/test/pseudo-tty/test-tty-write-stream-resume-crash.js
+++ b/test/pseudo-tty/test-tty-write-stream-resume-crash.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const common = require('../common');
+const { getTTYfd } = require('../common/common-tty');
 const { WriteStream } = require('tty');
-const fd = common.getTTYfd();
+const fd = getTTYfd();
 
 // Calling resume on a tty.WriteStream should be a no-op
 // Ref: https://github.com/nodejs/node/issues/21203


### PR DESCRIPTION
This should ensure that these tests are never ever run connected to anything other than a TTY. Also adds it to the linter rules for the pseudo-tty tests.

Also refactors some common TTY test code into `test/common/common-tty.js`.

Can someone verify that the new eslint file is correct? Parent directory eslints are inherited, right?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
