### PR TITLE
[v10.x] deps: sync V8 embedder string with master branch

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,


### PR DESCRIPTION
To avoid conflicts while cherry-picking future V8 backports, increment
the embedder string by one so it has the same value as in the master
branch. The value was off by one because of an ABI-breaking backport
that could not be taken in v10.x.

Refs: https://github.com/nodejs/node/pull/22106
