### PR TITLE
child_process: fix handling of incorrect uid/gid in spawn

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -37,7 +37,7 @@ const {
   ERR_INVALID_OPT_VALUE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateString, isUint32 } = require('internal/validators');
 const child_process = require('internal/child_process');
 const {
   _validateStdio,
@@ -425,13 +425,15 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Validate the uid, if present.
-  if (options.uid != null && !Number.isInteger(options.uid)) {
-    throw new ERR_INVALID_ARG_TYPE('options.uid', 'integer', options.uid);
+  if (options.uid != null &&
+      (!Number.isInteger(options.uid) || !isUint32(options.uid))) {
+    throw new ERR_INVALID_ARG_TYPE('options.uid', 'uint32', options.uid);
   }
 
   // Validate the gid, if present.
-  if (options.gid != null && !Number.isInteger(options.gid)) {
-    throw new ERR_INVALID_ARG_TYPE('options.gid', 'integer', options.gid);
+  if (options.gid != null &&
+      (!Number.isInteger(options.gid) || !isUint32(options.gid))) {
+    throw new ERR_INVALID_ARG_TYPE('options.gid', 'uint32', options.gid);
   }
 
   // Validate the shell, if present.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -37,7 +37,7 @@ const {
   ERR_INVALID_OPT_VALUE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
-const { validateString, isUint32 } = require('internal/validators');
+const { validateString, isInt32 } = require('internal/validators');
 const child_process = require('internal/child_process');
 const {
   _validateStdio,
@@ -425,15 +425,13 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Validate the uid, if present.
-  if (options.uid != null &&
-      (!Number.isInteger(options.uid) || !isUint32(options.uid))) {
-    throw new ERR_INVALID_ARG_TYPE('options.uid', 'uint32', options.uid);
+  if (options.uid != null && !isInt32(options.uid)) {
+    throw new ERR_INVALID_ARG_TYPE('options.uid', 'int32', options.uid);
   }
 
   // Validate the gid, if present.
-  if (options.gid != null &&
-      (!Number.isInteger(options.gid) || !isUint32(options.gid))) {
-    throw new ERR_INVALID_ARG_TYPE('options.gid', 'uint32', options.gid);
+  if (options.gid != null && !isInt32(options.gid)) {
+    throw new ERR_INVALID_ARG_TYPE('options.gid', 'int32', options.gid);
   }
 
   // Validate the shell, if present.

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -33,7 +33,7 @@ const invalidArgValueError =
   common.expectsError({ code: 'ERR_INVALID_ARG_VALUE', type: TypeError }, 14);
 
 const invalidArgTypeError =
-  common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 10);
+  common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }, 12);
 
 assert.throws(function() {
   const child = spawn(invalidcmd, 'this is not an array');
@@ -74,6 +74,14 @@ assert.throws(function() {
 
 assert.throws(function() {
   spawn(cmd, [], 1);
+}, invalidArgTypeError);
+
+assert.throws(function() {
+  spawn(cmd, [], { uid: 2 ** 63 });
+}, invalidArgTypeError);
+
+assert.throws(function() {
+  spawn(cmd, [], { gid: 2 ** 63 });
 }, invalidArgTypeError);
 
 // Argument types for combinatorics.


### PR DESCRIPTION
uid/gid must be int32, which is asserted on a c++ side but wasn't
checked on a JS side and therefore resulted in a process crash.

Refs: https://github.com/nodejs/node/issues/22570

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Also, I'm not sure about the 'correct type' in TypeError, is 'int32' okay?