### PR TITLE
win, build: remove superfluous error message

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -274,13 +274,13 @@ fc .gyp_configure_stamp .tmp_gyp_configure_stamp >NUL 2>&1
 if errorlevel 1 goto run-configure
 
 :skip-configure
-del .tmp_gyp_configure_stamp
+del .tmp_gyp_configure_stamp 2> NUL
 echo Reusing solution generated with %configure_flags%
 goto msbuild
 
 :run-configure
-del .tmp_gyp_configure_stamp
-del .gyp_configure_stamp
+del .tmp_gyp_configure_stamp 2> NUL
+del .gyp_configure_stamp 2> NUL
 @rem Generate the VS project.
 echo configure %configure_flags%
 echo %configure_flags%> .used_configure_flags


### PR DESCRIPTION
When building from clean checkout, `vcbuild` will produce superfluous error message about missing `.tmp_gyp_configure_stamp` and  `.gyp_configure_stamp`:

```
[vcvarsall.bat] Environment initialized for: 'x64'
Found MSVS version 15.0
Could Not Find (...)\node\.tmp_gyp_configure_stamp
Could Not Find (...)\node\.gyp_configure_stamp
configure  --with-pch --dest-cpu=x64
creating icu_config.gypi
```

 This removes both those messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
