### PR TITLE
win,build: build N-API addons in parallel

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -497,11 +497,11 @@ for /d %%F in (test\addons-napi\??_*) do (
   rd /s /q %%F
 )
 :: building addons-napi
-for /d %%F in (test\addons-napi\*) do (
-  %node_gyp_exe% rebuild ^
-    --directory="%%F" ^
-    --nodedir="%cd%"
-)
+setlocal
+set npm_config_nodedir=%~dp0
+"%node_exe%" "%~dp0tools\build-addons.js" "%~dp0deps\npm\node_modules\node-gyp\bin\node-gyp.js" "%~dp0test\addons-napi"
+if errorlevel 1 exit /b 1
+endlocal
 endlocal
 goto run-tests
 


### PR DESCRIPTION
Similar to https://github.com/nodejs/node/pull/21403, build N-API modules in parallel.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
