### PR TITLE
[WiP] buffer: runtime-deprecate buffer constructor in sync mode

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -147,6 +147,7 @@ function showFlaggedDeprecation() {
   if (bufferWarningAlreadyEmitted ||
       ++nodeModulesCheckCounter > 10000 ||
       (!pendingDeprecation &&
+       !process.stillSynchronous &&
        isInsideNodeModules())) {
     // We don't emit a warning, because we either:
     // - Already did so, or

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -116,4 +116,7 @@ function setupNextTick(_setupNextTick, _setupPromises) {
       tickInfo[kHasScheduled] = 1;
     queue.push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
   }
+
+  process.stillSynchronous = true;
+  process.nextTick(() => { process.stillSynchronous = false; });
 }


### PR DESCRIPTION
This is a work in progress, temporarily alternative for #21351 for now.
Judging by the current situation, I think that #21351 would almost certainly not land in v11.0, but I hope _this_ approach can (if ecosystem tests show that is ok, see below).

The idea is to reduce the number of warnings users see and make them reproducable, while still printing warnings for code inside of `node_modules`, long-term plan being to land #21351 (or alternative) once it becomes viable in a sense that benefits outweight potential user disturbance (see refs below).

The reasoning why we need this is that the current warnings for code outside of `node_modules` do not help much in reducing the usage of unsafe buffer constructor — they do help by downloads/month metrics, but it that did not stop the number of modules using unsafe Buffer API from growing.
See https://github.com/nodejs/node/pull/21351#issuecomment-408618137 and https://github.com/nodejs/node/pull/21351#issuecomment-399684481 for more info and reasoning.

This has to go through CITGM to check how this affects popular modules.

This is currently more like a proof-of-concept to test things around and not near being completed, so what we need now is to understand how would this affect user modules, and if we want something like this in 11.0. For that, I think that this should be enough and such things could be already tested given this code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/tsc, @targos @seishun @fhinkel @danbev @addaleax 
