### PR TITLE
test: skip fs.watch on Travis

### DIFF
--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -10,6 +10,9 @@ const fs = require('fs');
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
 
+if (process.env.TRAVIS)
+  common.skip('Skip fs.watch-intensive test because of Travis limitation.');
+
 const hooks = initHooks();
 
 hooks.enable();

--- a/test/parallel/test-fs-watch-close-when-destroyed.js
+++ b/test/parallel/test-fs-watch-close-when-destroyed.js
@@ -8,6 +8,9 @@ const tmpdir = require('../common/tmpdir');
 const fs = require('fs');
 const path = require('path');
 
+if (process.env.TRAVIS)
+  common.skip('Skip fs.watch-intensive test because of Travis limitation.');
+
 tmpdir.refresh();
 const root = path.join(tmpdir.path, 'watched-directory');
 fs.mkdirSync(root);

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -31,6 +31,9 @@ const tmpdir = require('../common/tmpdir');
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 
+if (process.env.TRAVIS)
+  common.skip('Skip fs.watch-intensive test because of Travis limitation.');
+
 const expectFilePath = common.isWindows ||
                        common.isLinux ||
                        common.isOSX ||


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/21310
Refs: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

- Refs: https://travis-ci.com/nodejs/node/jobs/142234998
  - test/async-hooks/test-fseventwrap.js
  - test/parallel/test-fs-watch-close-when-destroyed.js

- Ref: https://travis-ci.com/nodejs/node/jobs/142716959
  - test/sequential/test-fs-watch.js

Refs: https://github.com/nodejs/node/pull/24198#issuecomment-436460289
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
