### PR TITLE
src: fix external memory usage going negative

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -198,7 +198,9 @@ class SecureContext : public BaseObject {
   }
 
   inline void Reset() {
-    env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+    if (ctx_.get() != nullptr) {
+      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+    }
     ctx_.reset();
     cert_.reset();
     issuer_.reset();

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -198,7 +198,7 @@ class SecureContext : public BaseObject {
   }
 
   inline void Reset() {
-    if (ctx_.get() != nullptr) {
+    if (ctx_ != nullptr) {
       env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
     }
     ctx_.reset();

--- a/test/parallel/test-gc-tls-external-memory.js
+++ b/test/parallel/test-gc-tls-external-memory.js
@@ -1,0 +1,35 @@
+'use strict';
+// Flags: --expose-gc
+
+// Tests that memoryUsage().external doesn't go negative
+// when a lot tls connections are opened and closed
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+// Payload doesn't matter. We just need to have the tls
+// connection try and connect somewhere.
+const yolo = Buffer.alloc(10000).fill('yolo');
+const server = net.createServer(function(socket) {
+  socket.write(yolo);
+});
+
+server.listen(0, function() {
+  const { port } = server.address();
+  let runs = 0;
+  connect();
+
+  function connect() {
+    global.gc();
+    assert(process.memoryUsage().external >= 0);
+    if (runs++ < 512)
+      tls.connect(port).on('error', connect);
+    else
+      server.close();
+  }
+});

--- a/test/parallel/test-gc-tls-external-memory.js
+++ b/test/parallel/test-gc-tls-external-memory.js
@@ -19,7 +19,7 @@ const server = net.createServer(function(socket) {
   socket.write(yolo);
 });
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   const { port } = server.address();
   let runs = 0;
   connect();
@@ -32,4 +32,4 @@ server.listen(0, function() {
     else
       server.close();
   }
-});
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes a bug introduced in https://github.com/nodejs/node/commit/d7cba76856e80108edb47b2e4c50a2c5fe5e1427 that decrements the external memory twice when using SSL connections ([Reset](https://github.com/nodejs/node/blob/d7cba76856e80108edb47b2e4c50a2c5fe5e1427/src/node_crypto.h#L205) is called both during [destructuring](https://github.com/nodejs/node/blob/d7cba76856e80108edb47b2e4c50a2c5fe5e1427/src/node_crypto.h#L116) and in [Close](https://github.com/nodejs/node/blob/d7cba76856e80108edb47b2e4c50a2c5fe5e1427/src/node_crypto.cc#L1030)).
This in turn made `process.memoryUsage().external` report negative numbers.

Added a test as well.
Fixes https://github.com/nodejs/node/issues/21570
