### PR TITLE
src: do not pass code to ScriptCompiler::CreateCodeCacheForFunction

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1103,8 +1103,8 @@ void ContextifyContext::CompileFunction(
   }
 
   if (produce_cached_data) {
-    const std::unique_ptr<ScriptCompiler::CachedData>
-        cached_data(ScriptCompiler::CreateCodeCacheForFunction(fun, code));
+    const std::unique_ptr<ScriptCompiler::CachedData> cached_data(
+        ScriptCompiler::CreateCodeCacheForFunction(fun));
     bool cached_data_produced = cached_data != nullptr;
     if (cached_data_produced) {
       MaybeLocal<Object> buf = Buffer::Copy(


### PR DESCRIPTION
This is unnecessary, deprecated, and removed in V8 7.0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
