### PR TITLE
tools: add [src] links to assert.html

### DIFF
--- a/test/fixtures/apilinks/reverse.js
+++ b/test/fixtures/apilinks/reverse.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Parallel assignment to the exported variable and module.exports.
+
+function ok() {
+}
+
+const asserts = module.exports = ok;
+
+asserts.ok = ok;

--- a/test/fixtures/apilinks/reverse.js
+++ b/test/fixtures/apilinks/reverse.js
@@ -8,3 +8,6 @@ function ok() {
 const asserts = module.exports = ok;
 
 asserts.ok = ok;
+
+asserts.strictEqual = function() {
+}

--- a/test/fixtures/apilinks/reverse.json
+++ b/test/fixtures/apilinks/reverse.json
@@ -1,0 +1,3 @@
+{
+  "asserts.ok": "reverse.js#L10"
+}

--- a/test/fixtures/apilinks/reverse.json
+++ b/test/fixtures/apilinks/reverse.json
@@ -1,3 +1,5 @@
 {
-  "asserts.ok": "reverse.js#L10"
+  "asserts": "reverse.js#L8",
+  "asserts.ok": "reverse.js#L5",
+  "asserts.strictEqual": "reverse.js#L12"
 }


### PR DESCRIPTION
Parse `const assert = module.exports = ok;` as exporting a constructor
named `assert`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
