### PR TITLE
test: fix flaky test-trace-events-perf

### DIFF
--- a/test/parallel/test-trace-events-perf.js
+++ b/test/parallel/test-trace-events-perf.js
@@ -51,37 +51,36 @@ if (process.argv[2] === 'child') {
     const file = path.join(tmpdir.path, 'node_trace.1.log');
 
     assert(fs.existsSync(file));
-    fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents
-        .filter((trace) => trace.cat !== '__metadata');
-      assert.strictEqual(traces.length,
-                         expectedMarks.length +
-                         expectedBegins.length +
-                         expectedEnds.length);
+    const data = fs.readFileSync(file);
+    const traces = JSON.parse(data).traceEvents
+      .filter((trace) => trace.cat !== '__metadata');
+    assert.strictEqual(traces.length,
+                       expectedMarks.length +
+                       expectedBegins.length +
+                       expectedEnds.length);
 
-      traces.forEach((trace) => {
-        assert.strictEqual(trace.pid, proc.pid);
-        switch (trace.ph) {
-          case 'R':
-            assert.strictEqual(trace.cat,
-                               'node,node.perf,node.perf.usertiming');
-            assert.strictEqual(trace.name,
-                               expectedMarks.shift());
-            break;
-          case 'b':
-            const expectedBegin = expectedBegins.shift();
-            assert.strictEqual(trace.cat, expectedBegin.cat);
-            assert.strictEqual(trace.name, expectedBegin.name);
-            break;
-          case 'e':
-            const expectedEnd = expectedEnds.shift();
-            assert.strictEqual(trace.cat, expectedEnd.cat);
-            assert.strictEqual(trace.name, expectedEnd.name);
-            break;
-          default:
-            assert.fail('Unexpected trace event phase');
-        }
-      });
-    }));
+    traces.forEach((trace) => {
+      assert.strictEqual(trace.pid, proc.pid);
+      switch (trace.ph) {
+        case 'R':
+          assert.strictEqual(trace.cat,
+                             'node,node.perf,node.perf.usertiming');
+          assert.strictEqual(trace.name,
+                             expectedMarks.shift());
+          break;
+        case 'b':
+          const expectedBegin = expectedBegins.shift();
+          assert.strictEqual(trace.cat, expectedBegin.cat);
+          assert.strictEqual(trace.name, expectedBegin.name);
+          break;
+        case 'e':
+          const expectedEnd = expectedEnds.shift();
+          assert.strictEqual(trace.cat, expectedEnd.cat);
+          assert.strictEqual(trace.name, expectedEnd.name);
+          break;
+        default:
+          assert.fail('Unexpected trace event phase');
+      }
+    });
   }));
 }


### PR DESCRIPTION
~~test-trace-events-perf requires a `data` event on a file read to return
the complete contents of the file. This is not guaranteed. Use
synchronous file read instead as it is more appropriate in this case.~~

Fixes: https://github.com/nodejs/node/issues/22604

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
