### PR TITLE
os: don't use getCheckedFunction() in userInfo()

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -40,7 +40,7 @@ const {
   getOSType: _getOSType,
   getPriority: _getPriority,
   getTotalMem,
-  getUserInfo: _getUserInfo,
+  getUserInfo,
   getUptime,
   isBigEndian,
   setPriority: _setPriority
@@ -64,7 +64,6 @@ const getHostname = getCheckedFunction(_getHostname);
 const getInterfaceAddresses = getCheckedFunction(_getInterfaceAddresses);
 const getOSRelease = getCheckedFunction(_getOSRelease);
 const getOSType = getCheckedFunction(_getOSType);
-const getUserInfo = getCheckedFunction(_getUserInfo);
 
 getFreeMem[Symbol.toPrimitive] = () => getFreeMem();
 getHostname[Symbol.toPrimitive] = () => getHostname();
@@ -239,6 +238,19 @@ function getPriority(pid) {
   return priority;
 }
 
+function userInfo(options) {
+  if (typeof options !== 'object')
+    options = null;
+
+  const ctx = {};
+  const user = getUserInfo(options, ctx);
+
+  if (user === undefined)
+    throw new ERR_SYSTEM_ERROR(ctx);
+
+  return user;
+}
+
 module.exports = {
   arch,
   cpus,
@@ -255,7 +267,7 @@ module.exports = {
   tmpdir,
   totalmem: getTotalMem,
   type: getOSType,
-  userInfo: getUserInfo,
+  userInfo,
   uptime: getUptime,
 
   // Deprecated APIs


### PR DESCRIPTION
`os.userInfo()` takes an optional object as its first argument. `getCheckedFunction()` adds a context object to the argument list passed to the binding layer. The context object has the potential to confuse the binding layer, particularly if an error occurs. This commit makes `userInfo()` explicitly call into the binding layer with two arguments.

Refs: https://github.com/nodejs/node/pull/22599

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
