### PR TITLE
test: check parameter type of fs.mkdir()

### DIFF
--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -181,23 +181,23 @@ if (common.isMainThread && (common.isLinux || common.isOSX)) {
 // Anything else generates an error.
 {
   const pathname = path.join(tmpdir.path, nextdir());
-  ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((i) => {
+  ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((recursive) => {
     common.expectsError(
-      () => fs.mkdir(pathname, { recursive: i }, common.mustNotCall()),
+      () => fs.mkdir(pathname, { recursive }, common.mustNotCall()),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "recursive" argument must be of type boolean. Received ' +
-          `type ${typeof i}`
+          `type ${typeof recursive}`
       }
     );
     common.expectsError(
-      () => fs.mkdirSync(pathname, { recursive: i }),
+      () => fs.mkdirSync(pathname, { recursive }),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "recursive" argument must be of type boolean. Received ' +
-          `type ${typeof i}`
+          `type ${typeof recursive}`
       }
     );
   });

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -177,6 +177,32 @@ if (common.isMainThread && (common.isLinux || common.isOSX)) {
   });
 }
 
+// mkdirSync and mkdir require options.recursive to be a boolean.
+// Anything else generates an error.
+{
+  const pathname = path.join(tmpdir.path, nextdir());
+  ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((i) => {
+    common.expectsError(
+      () => fs.mkdir(pathname, { recursive: i }, common.mustNotCall()),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "recursive" argument must be of type boolean. Received ' +
+          `type ${typeof i}`
+      }
+    );
+    common.expectsError(
+      () => fs.mkdirSync(pathname, { recursive: i }),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "recursive" argument must be of type boolean. Received ' +
+          `type ${typeof i}`
+      }
+    );
+  });
+}
+
 // Keep the event loop alive so the async mkdir() requests
 // have a chance to run (since they don't ref the event loop).
 process.nextTick(() => {});

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -270,7 +270,7 @@ function verifyStatObject(stat) {
     // Anything else generates an error.
     {
       const dir = path.join(tmpDir, nextdir(), nextdir());
-      ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((i) => {
+      ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((recursive) => {
         assert.rejects(
           // mkdtemp() expects to get a string prefix.
           async () => mkdir(dir, { recursive: i }),
@@ -278,7 +278,7 @@ function verifyStatObject(stat) {
             code: 'ERR_INVALID_ARG_TYPE',
             name: 'TypeError [ERR_INVALID_ARG_TYPE]',
             message: 'The "recursive" argument must be of type boolean. ' +
-              `Received type ${typeof i}`
+              `Received type ${typeof recursive}`
           }
         );
       });

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -211,6 +211,22 @@ function verifyStatObject(stat) {
     assert.deepStrictEqual(list, ['baz2.js', 'dir']);
     await rmdir(newdir);
 
+    // mkdir when options is number.
+    {
+      const dir = path.join(tmpDir, nextdir());
+      await mkdir(dir, 777);
+      stats = await stat(dir);
+      assert(stats.isDirectory());
+    }
+
+    // mkdir when options is string.
+    {
+      const dir = path.join(tmpDir, nextdir());
+      await mkdir(dir, '777');
+      stats = await stat(dir);
+      assert(stats.isDirectory());
+    }
+
     // mkdirp when folder does not yet exist.
     {
       const dir = path.join(tmpDir, nextdir(), nextdir());
@@ -248,6 +264,24 @@ function verifyStatObject(stat) {
       await mkdir(dir, { recursive: true });
       stats = await stat(dir);
       assert(stats.isDirectory());
+    }
+
+    // mkdirp require recursive option to be a boolean.
+    // Anything else generates an error.
+    {
+      const dir = path.join(tmpDir, nextdir(), nextdir());
+      ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((i) => {
+        assert.rejects(
+          // mkdtemp() expects to get a string prefix.
+          async () => mkdir(dir, { recursive: i }),
+          {
+            code: 'ERR_INVALID_ARG_TYPE',
+            name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+            message: 'The "recursive" argument must be of type boolean. ' +
+              `Received type ${typeof i}`
+          }
+        );
+      });
     }
 
     await mkdtemp(path.resolve(tmpDir, 'FOO'));

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -272,7 +272,7 @@ function verifyStatObject(stat) {
       const dir = path.join(tmpDir, nextdir(), nextdir());
       ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((recursive) => {
         assert.rejects(
-          // mkdtemp() expects to get a string prefix.
+          // mkdir() expects to get a boolean value for options.recursive.
           async () => mkdir(dir, { recursive: i }),
           {
             code: 'ERR_INVALID_ARG_TYPE',

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -273,7 +273,7 @@ function verifyStatObject(stat) {
       ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((recursive) => {
         assert.rejects(
           // mkdir() expects to get a boolean value for options.recursive.
-          async () => mkdir(dir, { recursive: i }),
+          async () => mkdir(dir, { recursive }),
           {
             code: 'ERR_INVALID_ARG_TYPE',
             name: 'TypeError [ERR_INVALID_ARG_TYPE]',


### PR DESCRIPTION
Added tests to check parameter type of fs.mkdir(), fs.mkdirSync()
and fsPromises.mkdir() to increase coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
