### PR TITLE
build: stop supporting FreeBSD 10

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,7 +44,7 @@ platforms in production.
 | macOS/OS X   | Tier 1       | >= 10.11                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7/2008 R2/2012 R2     | x86, x64             | [2](#fn2),[3](#fn3),[4](#fn4) |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | [1](#fn1) |
-| FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
+| FreeBSD      | Tier 2       | >= 11                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
 | AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be >=power7     |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |

--- a/common.gypi
+++ b/common.gypi
@@ -490,15 +490,6 @@
         'libraries': [ '-lelf' ],
       }],
       ['OS=="freebsd"', {
-        'conditions': [
-          ['"0" < llvm_version < "4.0"', {
-            # Use this flag because on FreeBSD std::pairs copy constructor is non-trivial.
-            # Doesn't apply to llvm 4.0 (FreeBSD 11.1) or later.
-            # Refs: https://lists.freebsd.org/pipermail/freebsd-toolchain/2016-March/002094.html
-            # Refs: https://svnweb.freebsd.org/ports/head/www/node/Makefile?revision=444555&view=markup
-            'cflags': [ '-D_LIBCPP_TRIVIAL_PAIR_COPY_CTOR=1' ],
-          }],
-        ],
         'ldflags': [
           '-Wl,--export-dynamic',
         ],


### PR DESCRIPTION
FreeBSD 10 is considered a Legacy Release by the FreeBSD project.
Its latest version 10.4 was released in October 2017 and support for it is
expected to EoL on October 31, 2018.

Refs: https://www.freebsd.org/security/security.html#sup

/cc @nodejs/tsc @nodejs/build 
