### PR TITLE
util: add util.types.isBoxedPrimitive

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1049,10 +1049,31 @@ by `new Boolean()`.
 ```js
 util.types.isBooleanObject(false);  // Returns false
 util.types.isBooleanObject(true);   // Returns false
-util.types.isBooleanObject(new Boolean(false));   // Returns true
-util.types.isBooleanObject(new Boolean(true));    // Returns true
+util.types.isBooleanObject(new Boolean(false)); // Returns true
+util.types.isBooleanObject(new Boolean(true));  // Returns true
 util.types.isBooleanObject(Boolean(false)); // Returns false
-util.types.isBooleanObject(Boolean(true)); // Returns false
+util.types.isBooleanObject(Boolean(true));  // Returns false
+```
+
+### util.types.isBoxedPrimitive(value)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `value` {any}
+* Returns: {boolean}
+
+Returns `true` if the value is any boxed primitive object, e.g. created
+by `new Boolean()`, `new String()` or `Object(Symbol())`.
+
+For example:
+
+```js
+util.types.isBoxedPrimitive(false); // Returns false
+util.types.isBoxedPrimitive(new Boolean(false)); // Returns true
+util.types.isBoxedPrimitive(Symbol('foo')); // Returns false
+util.types.isBoxedPrimitive(Object(Symbol('foo'))); // Returns true
+util.types.isBoxedPrimitive(Object(BigInt(5))); // Returns true
 ```
 
 ### util.types.isDataView(value)

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -51,6 +51,15 @@ static void IsAnyArrayBuffer(const FunctionCallbackInfo<Value>& args) {
     args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer());
 }
 
+static void IsBoxedPrimitive(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(
+    args[0]->IsNumberObject() ||
+    args[0]->IsStringObject() ||
+    args[0]->IsBooleanObject() ||
+    args[0]->IsBigIntObject() ||
+    args[0]->IsSymbolObject());
+}
+
 void InitializeTypes(Local<Object> target,
                      Local<Value> unused,
                      Local<Context> context) {
@@ -63,6 +72,7 @@ void InitializeTypes(Local<Object> target,
 #undef V
 
   env->SetMethodNoSideEffect(target, "isAnyArrayBuffer", IsAnyArrayBuffer);
+  env->SetMethodNoSideEffect(target, "isBoxedPrimitive", IsBoxedPrimitive);
 }
 
 }  // anonymous namespace

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -57,7 +57,8 @@ for (const [ value, _method ] of [
 
   for (const key of Object.keys(types)) {
     if ((types.isArrayBufferView(value) ||
-         types.isAnyArrayBuffer(value)) && key.includes('Array')) {
+         types.isAnyArrayBuffer(value)) && key.includes('Array') ||
+         key === 'isBoxedPrimitive') {
       continue;
     }
 
@@ -67,6 +68,15 @@ for (const [ value, _method ] of [
                        `${method}, ${types[key](value)}`);
   }
 }
+
+// Check boxed primitives.
+[
+  new Boolean(),
+  new Number(),
+  new String(),
+  Object(Symbol()),
+  Object(BigInt(0))
+].forEach((entry) => assert(types.isBoxedPrimitive(entry)));
 
 {
   assert(!types.isUint8Array({ [Symbol.toStringTag]: 'Uint8Array' }));


### PR DESCRIPTION
Checking all boxed primitives individually requires to cross the C++
barrier multiple times besides being more complicated than just a
single check.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
