### PR TITLE
src: warn about odd UTF-16 decoding function signature

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -413,7 +413,8 @@ NODE_EXTERN v8::Local<v8::Value> Encode(v8::Isolate* isolate,
                                         size_t len,
                                         enum encoding encoding = LATIN1);
 
-// The input buffer should be in host endianness.
+// Warning: This reverses endianness on Big Endian platforms, even though the
+// signature using uint16_t implies that it should not.
 NODE_EXTERN v8::Local<v8::Value> Encode(v8::Isolate* isolate,
                                         const uint16_t* buf,
                                         size_t len);

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -100,7 +100,10 @@ class StringBytes {
                                           enum encoding encoding,
                                           v8::Local<v8::Value>* error);
 
-  // The input buffer should be in host endianness.
+  // Warning: This reverses endianness on BE platforms, even though the
+  // signature using uint16_t implies that it should not.
+  // However, the brokenness is already public API and can't therefore
+  // be changed easily.
   static v8::MaybeLocal<v8::Value> Encode(v8::Isolate* isolate,
                                           const uint16_t* buf,
                                           size_t buflen,


### PR DESCRIPTION
Using a `uint16_t` sequence for UTF-16 processing would typically
imply that the sequence already contains the correct 16-bit
code units.

However, our API does not account for that. The previous comments
were somewhat misleading, since endianness is typically applied to
sequences of bytes, which is not something that this API works with.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
