### PR TITLE
build,win: remove unmatched `endlocal` statement

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -502,7 +502,6 @@ set npm_config_nodedir=%~dp0
 "%node_exe%" "%~dp0tools\build-addons.js" "%~dp0deps\npm\node_modules\node-gyp\bin\node-gyp.js" "%~dp0test\addons-napi"
 if errorlevel 1 exit /b 1
 endlocal
-endlocal
 goto run-tests
 
 :run-tests


### PR DESCRIPTION
Seems like it's a leftover from c403eeb7fdf8c1033422b6ea8bf025667892f867

Refs: https://github.com/nodejs/node/pull/22582#pullrequestreview-150655222

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
