### PR TITLE
src: remove editing leftovers from options help text

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -201,8 +201,7 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--trace-event-file-pattern",
             "Template string specifying the filepath for the trace-events "
-            "data, it supports ${rotation} and ${pid} log-rotation id. %2$u "
-            "is the pid.",
+            "data, it supports ${rotation} and ${pid} log-rotation id.",
             &PerProcessOptions::trace_event_file_pattern,
             kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/commit/85212bb182f555f6d09e0b2f5f78d2d8e19bcef1#r30265305

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
