### PR TITLE
http2: don't expose the original socket through the socket proxy

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -675,7 +675,9 @@ const proxySocketHandler = {
   get(session, prop) {
     switch (prop) {
       case 'setTimeout':
-        return session.setTimeout.bind(session);
+      case 'ref':
+      case 'unref':
+        return session[prop].bind(session);
       case 'destroy':
       case 'emit':
       case 'end':
@@ -683,6 +685,9 @@ const proxySocketHandler = {
       case 'read':
       case 'resume':
       case 'write':
+      case 'setEncoding':
+      case 'setKeepAlive':
+      case 'setNoDelay':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default:
         const socket = session[kSocket];
@@ -701,7 +706,9 @@ const proxySocketHandler = {
   set(session, prop, value) {
     switch (prop) {
       case 'setTimeout':
-        session.setTimeout = value;
+      case 'ref':
+      case 'unref':
+        session[prop] = value;
         return true;
       case 'destroy':
       case 'emit':
@@ -710,6 +717,9 @@ const proxySocketHandler = {
       case 'read':
       case 'resume':
       case 'write':
+      case 'setEncoding':
+      case 'setKeepAlive':
+      case 'setNoDelay':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default:
         const socket = session[kSocket];

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -42,6 +42,9 @@ server.on('stream', common.mustCall(function(stream, headers) {
   common.expectsError(() => socket.read, errMsg);
   common.expectsError(() => socket.resume, errMsg);
   common.expectsError(() => socket.write, errMsg);
+  common.expectsError(() => socket.setEncoding, errMsg);
+  common.expectsError(() => socket.setKeepAlive, errMsg);
+  common.expectsError(() => socket.setNoDelay, errMsg);
 
   common.expectsError(() => (socket.destroy = undefined), errMsg);
   common.expectsError(() => (socket.emit = undefined), errMsg);
@@ -50,10 +53,18 @@ server.on('stream', common.mustCall(function(stream, headers) {
   common.expectsError(() => (socket.read = undefined), errMsg);
   common.expectsError(() => (socket.resume = undefined), errMsg);
   common.expectsError(() => (socket.write = undefined), errMsg);
+  common.expectsError(() => (socket.setEncoding = undefined), errMsg);
+  common.expectsError(() => (socket.setKeepAlive = undefined), errMsg);
+  common.expectsError(() => (socket.setNoDelay = undefined), errMsg);
 
   // Resetting the socket listeners to their own value should not throw.
   socket.on = socket.on;  // eslint-disable-line no-self-assign
   socket.once = socket.once;  // eslint-disable-line no-self-assign
+
+  socket.unref();
+  assert.strictEqual(socket._handle.hasRef(), false);
+  socket.ref();
+  assert.strictEqual(socket._handle.hasRef(), true);
 
   stream.respond();
 

--- a/test/parallel/test-http2-unbound-socket-proxy.js
+++ b/test/parallel/test-http2-unbound-socket-proxy.js
@@ -39,31 +39,6 @@ server.listen(0, common.mustCall(() => {
       }, {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });
-      common.expectsError(() => {
-        socket.ref();
-      }, {
-        code: 'ERR_HTTP2_SOCKET_UNBOUND'
-      });
-      common.expectsError(() => {
-        socket.unref();
-      }, {
-        code: 'ERR_HTTP2_SOCKET_UNBOUND'
-      });
-      common.expectsError(() => {
-        socket.setEncoding();
-      }, {
-        code: 'ERR_HTTP2_SOCKET_UNBOUND'
-      });
-      common.expectsError(() => {
-        socket.setKeepAlive();
-      }, {
-        code: 'ERR_HTTP2_SOCKET_UNBOUND'
-      });
-      common.expectsError(() => {
-        socket.setNoDelay();
-      }, {
-        code: 'ERR_HTTP2_SOCKET_UNBOUND'
-      });
     }));
   }));
 }));


### PR DESCRIPTION
These functions expose the original socket:

```js
session.socket.ref()
session.socket.unref()
session.socket.setEncoding()
session.socket.setKeepAlive()
session.socket.setNoDelay()
```

To avoid that, forward `session.socket.ref` to `session.ref`, `session.socket.unref` to `session.unref` and throw `ERR_HTTP2_NO_SOCKET_MANIPULATION` when accessing `setEncoding`, `setKeepAlive` or `setNoDelay`.

Refs: https://github.com/nodejs/node/pull/22486

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
