### PR TITLE
src: fix node::FatalException

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1485,8 +1485,8 @@ void FatalException(Isolate* isolate,
   Environment* env = Environment::GetCurrent(isolate);
   Local<Object> process_object = env->process_object();
   Local<String> fatal_exception_string = env->fatal_exception_string();
-  Local<Function> fatal_exception_function =
-      process_object->Get(fatal_exception_string).As<Function>();
+  Local<Value> fatal_exception_function =
+      process_object->Get(fatal_exception_string);
 
   if (!fatal_exception_function->IsFunction()) {
     // Failed before the process._fatalException function was added!
@@ -1501,7 +1501,8 @@ void FatalException(Isolate* isolate,
 
     // This will return true if the JS layer handled it, false otherwise
     Local<Value> caught =
-        fatal_exception_function->Call(process_object, 1, &error);
+        fatal_exception_function.As<Function>()
+            ->Call(process_object, 1, &error);
 
     if (fatal_try_catch.HasTerminated())
       return;


### PR DESCRIPTION
If a fatal exception occurs before node had a chance to setup the handler in JS properly, `node::FatalException` crashes with

```
FATAL ERROR: v8::Function::Cast Could not convert to function
```

This fixes the function to display the JS error instead of crashing.

cc @addaleax

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
