### PR TITLE
tools: add [src] links to async_hooks.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -653,10 +653,12 @@ out/apilinks.json: $(wildcard lib/*.js) tools/doc/apilinks.js
 	$(call available-node, $(gen-apilink))
 
 out/doc/api/%.json out/doc/api/%.html: doc/api/%.md tools/doc/generate.js \
-	tools/doc/html.js tools/doc/json.js | out/apilinks.json
+	tools/doc/html.js tools/doc/json.js tools/doc/apilinks.js | \
+	out/apilinks.json
 	$(call available-node, $(gen-api))
 
-out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js
+out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \
+	tools/doc/apilinks.js
 	$(call available-node, tools/doc/allhtml.js)
 
 out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js

--- a/test/fixtures/apilinks/class.js
+++ b/test/fixtures/apilinks/class.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// An exported class using ES2015 class syntax.
+
+class Class {
+  constructor() {};
+  method() {};
+}
+
+module.exports = {
+  Class
+};

--- a/test/fixtures/apilinks/class.json
+++ b/test/fixtures/apilinks/class.json
@@ -1,0 +1,5 @@
+{
+  "Class": "class.js#L5",
+  "new Class": "class.js#L6",
+  "class.method": "class.js#L7"
+}


### PR DESCRIPTION
handle ES2015 Class, constructor, and instance methods

unrelated: update Makefile so that generated HTML is out of date whenever
tools/doc/apilinks.js is updated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
