### PR TITLE
src: disable debug options when inspector is unavailable

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -23,6 +23,7 @@ namespace options_parser {
 // TODO(addaleax): Make that unnecessary.
 
 DebugOptionsParser::DebugOptionsParser() {
+#if HAVE_INSPECTOR
   AddOption("--inspect-port",
             "set host:port for inspector",
             &DebugOptions::host_port,
@@ -52,6 +53,7 @@ DebugOptionsParser::DebugOptionsParser() {
   AddOption("--debug-brk", "", &DebugOptions::break_first_line);
   Implies("--debug-brk", "--debug");
   AddAlias("--debug-brk=", { "--inspect-port", "--debug-brk" });
+#endif
 }
 
 DebugOptionsParser DebugOptionsParser::instance;

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -1,16 +1,17 @@
 'use strict';
 const common = require('../common');
-common.skipIfInspectorDisabled();
 
 // Tests that node exits consistently on bad option syntax.
 
 const assert = require('assert');
 const spawn = require('child_process').spawnSync;
 
-requiresArgument('--inspect-port');
-requiresArgument('--inspect-port=');
-requiresArgument('--debug-port');
-requiresArgument('--debug-port=');
+if (process.config.variables.v8_enable_inspector === 1) {
+  requiresArgument('--inspect-port');
+  requiresArgument('--inspect-port=');
+  requiresArgument('--debug-port');
+  requiresArgument('--debug-port=');
+}
 requiresArgument('--eval');
 
 function requiresArgument(option) {

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 // Tests that node exits consistently on bad option syntax.
 

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
+common.skipIfInspectorDisabled();
 
 // Tests that node exits consistently on bad option syntax.
 


### PR DESCRIPTION
This fixes `parallel/test-cli-node-print-help` when Node.js is compiled without the inspector.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
