### PR TITLE
worker: display MessagePort status in util.inspect() 

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -128,7 +128,7 @@ delete MessagePort.prototype.drain;
 Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
   enumerable: false,
   writable: false,
-  value: function inspect() {
+  value: function inspect() {  // eslint-disable-line func-name-matching
     let ref;
     try {
       // This may throw when `this` does not refer to a native object,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -125,6 +125,26 @@ MessagePort.prototype.close = function(cb) {
 const drainMessagePort = MessagePort.prototype.drain;
 delete MessagePort.prototype.drain;
 
+Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
+  enumerable: false,
+  writable: false,
+  value: function inspect() {
+    let ref;
+    try {
+      // This may throw when `this` does not refer to a native object,
+      // e.g. when accessing the prototype directly.
+      ref = this.hasRef();
+    } catch { return this; }
+    return Object.assign(Object.create(MessagePort.prototype),
+                         ref === undefined ? {
+                           active: false,
+                         } : {
+                           active: true,
+                           refed: ref
+                         }, this);
+  }
+});
+
 function setupPortReferencing(port, eventEmitter, eventName) {
   // Keep track of whether there are any workerMessage listeners:
   // If there are some, ref() the channel so it keeps the event loop alive.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -141,7 +141,8 @@ Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
                          } : {
                            active: true,
                            refed: ref
-                         }, this);
+                         },
+                         this);
   }
 });
 

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -40,8 +40,8 @@ port2.onmessage = common.mustCall((message) => {
 port1.postMessage(2);
 
 function tick(n, cb) {
-  if (--n > 0)
-    return setImmediate(() => tick(n - 1, cb));
+  if (n > 0)
+    setImmediate(() => tick(n - 1, cb));
   else
     cb();
 }

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -41,7 +41,7 @@ port1.postMessage(2);
 
 function tick(n, cb) {
   if (--n > 0)
-    return setImmediate(() => tick(n-1, cb));
+    return setImmediate(() => tick(n - 1, cb));
   else
     cb();
 }

--- a/test/parallel/test-worker-message-port-transfer-self.js
+++ b/test/parallel/test-worker-message-port-transfer-self.js
@@ -3,6 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+const util = require('util');
 const { MessageChannel } = require('worker_threads');
 
 const { port1, port2 } = new MessageChannel();
@@ -25,9 +26,22 @@ assert.throws(common.mustCall(() => {
 // The failed transfer should not affect the ports in anyway.
 port2.onmessage = common.mustCall((message) => {
   assert.strictEqual(message, 2);
+
+  assert(util.inspect(port1).includes('active: true'), util.inspect(port1));
+  assert(util.inspect(port2).includes('active: true'), util.inspect(port2));
+
   port1.close();
 
-  setTimeout(common.mustNotCall('The communication channel is still open'),
-             common.platformTimeout(1000)).unref();
+  tick(10, () => {
+    assert(util.inspect(port1).includes('active: false'), util.inspect(port1));
+    assert(util.inspect(port2).includes('active: false'), util.inspect(port2));
+  });
 });
 port1.postMessage(2);
+
+function tick(n, cb) {
+  if (--n > 0)
+    return setImmediate(() => tick(n-1, cb));
+  else
+    cb();
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
