### PR TITLE
Remove /MP from default additonal options

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -150,7 +150,6 @@
             'BasicRuntimeChecks': 3, # /RTC1
             'AdditionalOptions': [
               '/bigobj', # prevent error C1128 in VS2015
-              '/MP', # compile across multiple CPUs
             ],
           },
           'VCLinkerTool': {

--- a/common.gypi
+++ b/common.gypi
@@ -245,7 +245,6 @@
             'EnableIntrinsicFunctions': 'true',
             'RuntimeTypeInfo': 'false',
             'AdditionalOptions': [
-              '/MP', # compile across multiple CPUs
             ],
           }
         }

--- a/common.gypi
+++ b/common.gypi
@@ -148,6 +148,7 @@
             'MinimalRebuild': 'false',
             'OmitFramePointers': 'false',
             'BasicRuntimeChecks': 3, # /RTC1
+            'MultiProcessorCompilation': 'true',
             'AdditionalOptions': [
               '/bigobj', # prevent error C1128 in VS2015
             ],
@@ -244,6 +245,7 @@
             'EnableFunctionLevelLinking': 'true',
             'EnableIntrinsicFunctions': 'true',
             'RuntimeTypeInfo': 'false',
+            'MultiProcessorCompilation': 'true',
             'AdditionalOptions': [
             ],
           }


### PR DESCRIPTION
Forcing this option means that the user-provided option ```MultiProcessorCompilation``` in ```msvs_settings``` (from, for example, binding.gyp) is useless.  It also means that one cannot use ```#import``` in their source code or they will be faced with this error when trying to build:

```
error C2813: #import is not supported with /MP (compiling source file...)
```

Please see additional discussion of this here:  https://github.com/nodejs/node-gyp/issues/1087
and here: https://github.com/nodejs/node-gyp/issues/26
