### PR TITLE
src: remove calls to deprecated V8 functions (Int32Value)

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -61,6 +61,7 @@ using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Integer;
 using v8::Local;
 using v8::Null;
@@ -1959,23 +1960,23 @@ void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
 
   int32_t flags = 0;
   if (args[3]->IsInt32()) {
-    flags = args[3]->Int32Value(env->context()).FromJust();
+    flags = args[3].As<Int32>()->Value();
   }
 
   int family;
 
-  switch (args[2]->Int32Value(env->context()).FromJust()) {
-  case 0:
-    family = AF_UNSPEC;
-    break;
-  case 4:
-    family = AF_INET;
-    break;
-  case 6:
-    family = AF_INET6;
-    break;
-  default:
-    CHECK(0 && "bad address family");
+  switch (args[2].As<Int32>()->Value()) {
+    case 0:
+      family = AF_UNSPEC;
+      break;
+    case 4:
+      family = AF_INET;
+      break;
+    case 6:
+      family = AF_INET6;
+      break;
+    default:
+      CHECK(0 && "bad address family");
   }
 
   auto req_wrap = new GetAddrInfoReqWrap(env, req_wrap_obj, args[4]->IsTrue());

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -14,6 +14,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Local;
 using v8::Object;
 using v8::String;
@@ -154,7 +155,8 @@ void JSStream::Finish(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsObject());
   Wrap* w = static_cast<Wrap*>(StreamReq::FromObject(args[0].As<Object>()));
 
-  w->Done(args[1]->Int32Value());
+  CHECK(args[1]->IsInt32());
+  w->Done(args[1].As<Int32>()->Value());
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1198,7 +1198,8 @@ static void Exit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   WaitForInspectorDisconnect(env);
   v8_platform.StopTracingAgent();
-  env->Exit(args[0]->Int32Value());
+  int code = args[0]->Int32Value(env->context()).FromMaybe(0);
+  env->Exit(code);
 }
 
 extern "C" void node_module_register(void* m) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1045,7 +1045,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
         sc->env(), "Session timeout must be a 32-bit integer");
   }
 
-  int32_t sessionTimeout = args[0]->Int32Value();
+  int32_t sessionTimeout = args[0].As<Int32>()->Value();
   SSL_CTX_set_timeout(sc->ctx_.get(), sessionTimeout);
 }
 
@@ -1267,7 +1267,8 @@ int SecureContext::TicketKeyCallback(SSL* ssl,
                                         {0, 0}).ToLocalChecked();
   Local<Array> arr = ret.As<Array>();
 
-  int r = arr->Get(kTicketKeyReturnIndex)->Int32Value();
+  int r =
+      arr->Get(kTicketKeyReturnIndex)->Int32Value(env->context()).FromJust();
   if (r < 0)
     return r;
 
@@ -3629,14 +3630,10 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
   char* buf = Buffer::Data(args[0]);
 
   CHECK(args[2]->IsInt32());
-  Maybe<int32_t> maybe_padding = args[2]->Int32Value(env->context());
-  CHECK(maybe_padding.IsJust());
-  int padding = maybe_padding.ToChecked();
+  int padding = args[2].As<Int32>()->Value();
 
   CHECK(args[3]->IsInt32());
-  Maybe<int32_t> maybe_salt_len = args[3]->Int32Value(env->context());
-  CHECK(maybe_salt_len.IsJust());
-  int salt_len = maybe_salt_len.ToChecked();
+  int salt_len = args[3].As<Int32>()->Value();
 
   ClearErrorOnReturn clear_error_on_return;
   unsigned char md_value[8192];
@@ -3783,8 +3780,6 @@ SignBase::Error Verify::VerifyFinal(const char* key_pem,
 
 
 void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   ClearErrorOnReturn clear_error_on_return;
 
   Verify* verify;
@@ -3797,14 +3792,10 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   ssize_t hlen = Buffer::Length(args[1]);
 
   CHECK(args[2]->IsInt32());
-  Maybe<int32_t> maybe_padding = args[2]->Int32Value(env->context());
-  CHECK(maybe_padding.IsJust());
-  int padding = maybe_padding.ToChecked();
+  int padding = args[2].As<Int32>()->Value();
 
   CHECK(args[3]->IsInt32());
-  Maybe<int32_t> maybe_salt_len = args[3]->Int32Value(env->context());
-  CHECK(maybe_salt_len.IsJust());
-  int salt_len = maybe_salt_len.ToChecked();
+  int salt_len = args[3].As<Int32>()->Value();
 
   bool verify_result;
   Error err = verify->VerifyFinal(kbuf, klen, hbuf, hlen, padding, salt_len,
@@ -4076,14 +4067,14 @@ void DiffieHellman::New(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() == 2) {
     if (args[0]->IsInt32()) {
       if (args[1]->IsInt32()) {
-        initialized = diffieHellman->Init(args[0]->Int32Value(),
-                                          args[1]->Int32Value());
+        initialized = diffieHellman->Init(args[0].As<Int32>()->Value(),
+                                          args[1].As<Int32>()->Value());
       }
     } else {
       if (args[1]->IsInt32()) {
         initialized = diffieHellman->Init(Buffer::Data(args[0]),
                                           Buffer::Length(args[0]),
-                                          args[1]->Int32Value());
+                                          args[1].As<Int32>()->Value());
       } else {
         initialized = diffieHellman->Init(Buffer::Data(args[0]),
                                           Buffer::Length(args[0]),

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -69,13 +69,15 @@ using v8::Value;
   if ((*(const char **)valp = *_##member) == nullptr)                      \
     *(const char **)valp = "<unknown>";
 
-#define SLURP_INT(obj, member, valp)                                       \
-  if (!(obj)->IsObject()) {                                                \
-    return node::THROW_ERR_INVALID_ARG_TYPE(env,                           \
-        "expected object for " #obj " to contain integer member " #member);\
-  }                                                                        \
-  *valp = obj->Get(OneByteString(env->isolate(), #member))                 \
-      ->Int32Value();
+#define SLURP_INT(obj, member, valp)                                           \
+  if (!(obj)->IsObject()) {                                                    \
+    return node::THROW_ERR_INVALID_ARG_TYPE(                                   \
+        env,                                                                   \
+        "expected object for " #obj " to contain integer member " #member);    \
+  }                                                                            \
+  *valp = obj->Get(OneByteString(env->isolate(), #member))                     \
+              ->Int32Value(env->context())                                     \
+              .FromJust();
 
 #define SLURP_OBJECT(obj, member, valp)                                    \
   if (!(obj)->IsObject()) {                                                \

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -57,6 +57,7 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Integer;
 using v8::Local;
 using v8::MaybeLocal;
@@ -361,8 +362,9 @@ class Parser : public AsyncWrap, public StreamListener {
 
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
+    CHECK(args[0]->IsInt32());
     http_parser_type type =
-        static_cast<http_parser_type>(args[0]->Int32Value());
+        static_cast<http_parser_type>(args[0].As<Int32>()->Value());
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     new Parser(env, args.This(), type);
   }
@@ -458,8 +460,9 @@ class Parser : public AsyncWrap, public StreamListener {
   static void Reinitialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
 
+    CHECK(args[0]->IsInt32());
     http_parser_type type =
-        static_cast<http_parser_type>(args[0]->Int32Value());
+        static_cast<http_parser_type>(args[0].As<Int32>()->Value());
 
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     Parser* parser;

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -87,6 +87,7 @@ namespace node {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
@@ -502,7 +503,8 @@ void Transcode(const FunctionCallbackInfo<Value>&args) {
 
 void ICUErrorName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  UErrorCode status = static_cast<UErrorCode>(args[0]->Int32Value());
+  CHECK(args[0]->IsInt32());
+  UErrorCode status = static_cast<UErrorCode>(args[0].As<Int32>()->Value());
   args.GetReturnValue().Set(
       String::NewFromUtf8(env->isolate(),
                           u_errorName(status),

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -165,12 +165,15 @@ void HrtimeBigInt(const FunctionCallbackInfo<Value>& args) {
 
 void Kill(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  Local<Context> context = env->context();
 
   if (args.Length() != 2)
     return env->ThrowError("Bad argument.");
 
-  int pid = args[0]->Int32Value();
-  int sig = args[1]->Int32Value();
+  int pid;
+  if (!args[0]->Int32Value(context).To(&pid)) return;
+  int sig;
+  if (!args[1]->Int32Value(context).To(&sig)) return;
   int err = uv_kill(pid, sig);
   args.GetReturnValue().Set(err);
 }

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -45,6 +45,7 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Local;
 using v8::Number;
 using v8::Object;
@@ -419,7 +420,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    node_zlib_mode mode = static_cast<node_zlib_mode>(args[0]->Int32Value());
+    node_zlib_mode mode =
+        static_cast<node_zlib_mode>(args[0].As<Int32>()->Value());
     new ZCtx(env, args.This(), mode);
   }
 
@@ -459,7 +461,8 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
           "invalid windowBits");
     }
 
-    int level = args[1]->Int32Value();
+    int level;
+    if (!args[1]->Int32Value(context).To(&level)) return;
     CHECK((level >= Z_MIN_LEVEL && level <= Z_MAX_LEVEL) &&
       "invalid compression level");
 
@@ -506,7 +509,12 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     CHECK(args.Length() == 2 && "params(level, strategy)");
     ZCtx* ctx;
     ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
-    ctx->Params(args[0]->Int32Value(), args[1]->Int32Value());
+    Environment* env = ctx->env();
+    int level;
+    if (!args[0]->Int32Value(env->context()).To(&level)) return;
+    int strategy;
+    if (!args[1]->Int32Value(env->context()).To(&strategy)) return;
+    ctx->Params(level, strategy);
   }
 
   static void Reset(const FunctionCallbackInfo<Value> &args) {

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -36,6 +36,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Integer;
 using v8::Local;
 using v8::Number;
@@ -158,7 +159,7 @@ class ProcessWrap : public HandleWrap {
         js_options->Get(context, env->uid_string()).ToLocalChecked();
     if (!uid_v->IsUndefined() && !uid_v->IsNull()) {
       CHECK(uid_v->IsInt32());
-      const int32_t uid = uid_v->Int32Value(context).FromJust();
+      const int32_t uid = uid_v.As<Int32>()->Value();
       options.flags |= UV_PROCESS_SETUID;
       options.uid = static_cast<uv_uid_t>(uid);
     }
@@ -168,7 +169,7 @@ class ProcessWrap : public HandleWrap {
         js_options->Get(context, env->gid_string()).ToLocalChecked();
     if (!gid_v->IsUndefined() && !gid_v->IsNull()) {
       CHECK(gid_v->IsInt32());
-      const int32_t gid = gid_v->Int32Value(context).FromJust();
+      const int32_t gid = gid_v.As<Int32>()->Value();
       options.flags |= UV_PROCESS_SETGID;
       options.gid = static_cast<uv_gid_t>(gid);
     }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -88,7 +88,9 @@ class SignalWrap : public HandleWrap {
   static void Start(const FunctionCallbackInfo<Value>& args) {
     SignalWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-    int signum = args[0]->Int32Value();
+    Environment* env = wrap->env();
+    int signum;
+    if (!args[0]->Int32Value(env->context()).To(&signum)) return;
 #if defined(__POSIX__) && HAVE_INSPECTOR
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -35,6 +35,7 @@ using v8::Context;
 using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
+using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Just;
@@ -783,7 +784,7 @@ Maybe<int> SyncProcessRunner::ParseOptions(Local<Value> js_value) {
       js_options->Get(context, env()->uid_string()).ToLocalChecked();
   if (IsSet(js_uid)) {
     CHECK(js_uid->IsInt32());
-    const int32_t uid = js_uid->Int32Value(context).FromJust();
+    const int32_t uid = js_uid.As<Int32>()->Value();
     uv_process_options_.uid = static_cast<uv_uid_t>(uid);
     uv_process_options_.flags |= UV_PROCESS_SETUID;
   }
@@ -792,7 +793,7 @@ Maybe<int> SyncProcessRunner::ParseOptions(Local<Value> js_value) {
       js_options->Get(context, env()->gid_string()).ToLocalChecked();
   if (IsSet(js_gid)) {
     CHECK(js_gid->IsInt32());
-    const int32_t gid = js_gid->Int32Value(context).FromJust();
+    const int32_t gid = js_gid.As<Int32>()->Value();
     uv_process_options_.gid = static_cast<uv_gid_t>(gid);
     uv_process_options_.flags |= UV_PROCESS_SETGID;
   }
@@ -833,7 +834,7 @@ Maybe<int> SyncProcessRunner::ParseOptions(Local<Value> js_value) {
       js_options->Get(context, env()->kill_signal_string()).ToLocalChecked();
   if (IsSet(js_kill_signal)) {
     CHECK(js_kill_signal->IsInt32());
-    kill_signal_ = js_kill_signal->Int32Value(context).FromJust();
+    kill_signal_ = js_kill_signal.As<Int32>()->Value();
   }
 
   Local<Value> js_stdio =

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -180,7 +180,9 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int enable = args[0]->Int32Value();
+  Environment* env = wrap->env();
+  int enable;
+  if (!args[0]->Int32Value(env->context()).To(&enable)) return;
   unsigned int delay = args[1].As<Uint32>()->Value();
   int err = uv_tcp_keepalive(&wrap->handle_, enable, delay);
   args.GetReturnValue().Set(err);
@@ -220,8 +222,10 @@ void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  node::Utf8Value ip_address(args.GetIsolate(), args[0]);
-  int port = args[1]->Int32Value();
+  Environment* env = wrap->env();
+  node::Utf8Value ip_address(env->isolate(), args[0]);
+  int port;
+  if (!args[1]->Int32Value(env->context()).To(&port)) return;
   sockaddr_in addr;
   int err = uv_ip4_addr(*ip_address, port, &addr);
   if (err == 0) {
@@ -238,8 +242,10 @@ void TCPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  node::Utf8Value ip6_address(args.GetIsolate(), args[0]);
-  int port = args[1]->Int32Value();
+  Environment* env = wrap->env();
+  node::Utf8Value ip6_address(env->isolate(), args[0]);
+  int port;
+  if (!args[1]->Int32Value(env->context()).To(&port)) return;
   sockaddr_in6 addr;
   int err = uv_ip6_addr(*ip6_address, port, &addr);
   if (err == 0) {
@@ -256,7 +262,9 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int backlog = args[0]->Int32Value();
+  Environment* env = wrap->env();
+  int backlog;
+  if (!args[0]->Int32Value(env->context()).To(&backlog)) return;
   int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
                       backlog,
                       OnConnection);
@@ -300,12 +308,11 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 
 void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+  Environment* env = wrap->env();
 
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());
@@ -313,7 +320,8 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(env->isolate(), args[1]);
-  int port = args[2]->Int32Value();
+  int port;
+  if (!args[2]->Int32Value(env->context()).To(&port)) return;
 
   sockaddr_in6 addr;
   int err = uv_ip6_addr(*ip_address, port, &addr);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -75,7 +75,8 @@ uv_tty_t* TTYWrap::UVHandle() {
 
 void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  int fd = args[0]->Int32Value();
+  int fd;
+  if (!args[0]->Int32Value(env->context()).To(&fd)) return;
   CHECK_GE(fd, 0);
 
   uv_handle_type t = uv_guess_handle(fd);
@@ -97,7 +98,9 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
 
 
 void TTYWrap::IsTTY(const FunctionCallbackInfo<Value>& args) {
-  int fd = args[0]->Int32Value();
+  Environment* env = Environment::GetCurrent(args);
+  int fd;
+  if (!args[0]->Int32Value(env->context()).To(&fd)) return;
   CHECK_GE(fd, 0);
   bool rc = uv_guess_handle(fd) == UV_TTY;
   args.GetReturnValue().Set(rc);
@@ -144,7 +147,8 @@ void TTYWrap::New(const FunctionCallbackInfo<Value>& args) {
   // normal function.
   CHECK(args.IsConstructCall());
 
-  int fd = args[0]->Int32Value();
+  int fd;
+  if (!args[0]->Int32Value(env->context()).To(&fd)) return;
   CHECK_GE(fd, 0);
 
   int err = 0;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -267,14 +267,17 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(size);
 }
 
-
-#define X(name, fn)                                                           \
-  void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {               \
-    UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                           \
-    CHECK_EQ(args.Length(), 1);                                               \
-    int flag = args[0]->Int32Value();                                         \
-    int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);          \
-    args.GetReturnValue().Set(err);                                           \
+#define X(name, fn)                                                            \
+  void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {                \
+    UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                            \
+    Environment* env = wrap->env();                                            \
+    CHECK_EQ(args.Length(), 1);                                                \
+    int flag;                                                                  \
+    if (!args[0]->Int32Value(env->context()).To(&flag)) {                      \
+      return;                                                                  \
+    }                                                                          \
+    int err = wrap == nullptr ? UV_EBADF : fn(&wrap->handle_, flag);           \
+    args.GetReturnValue().Set(err);                                            \
   }
 
 X(SetTTL, uv_udp_set_ttl)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -43,7 +43,8 @@ using v8::Value;
 // lib/util.getSystemErrorName()
 void ErrName(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  int err = args[0]->Int32Value();
+  int err;
+  if (!args[0]->Int32Value(env->context()).To(&err)) return;
   CHECK_LT(err, 0);
   const char* name = uv_err_name(err);
   args.GetReturnValue().Set(OneByteString(env->isolate(), name));

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -25,7 +25,7 @@ function flushPool() {
 function demoBug(part1, part2) {
   flushPool();
 
-  const parser = new HTTPParser('REQUEST');
+  const parser = new HTTPParser(0);
 
   parser.headers = [];
   parser.url = '';

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -148,7 +148,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
 
 {
   const { HTTPParser } = internalBinding('http_parser');
-  testInitialized(new HTTPParser(), 'HTTPParser');
+  testInitialized(new HTTPParser(0), 'HTTPParser');
 }
 
 


### PR DESCRIPTION
Remove all calls to deprecated V8 functions (here: Value::Int32Value)
inside the code.

/cc @ryzokuken @addaleax @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
