### PR TITLE
Fixed OpenBSD node executable generation.

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -88,7 +88,7 @@
     // get the full path before process.execPath is used.
     if (process.platform === 'openbsd') {
       const { realpathSync } = NativeModule.require('fs');
-      process.execPath = realpathSync.native(process.execPath);
+      process.execPath = realpathSync(process.execPath);
     }
 
     Object.defineProperty(process, 'argv0', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
There is a bug in the realpathSync object calling to the 'native' method which doesn't exist in this version of FS module.
Just removing that method is working well in OpenBSD.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] tests and/or benchmarks are included
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
