### PR TITLE
src: remove calls to deprecated V8 functions (Equals)

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -108,9 +108,9 @@ class ProcessWrap : public HandleWrap {
       Local<Value> type =
           stdio->Get(context, env->type_string()).ToLocalChecked();
 
-      if (type->Equals(env->ignore_string())) {
+      if (type->StrictEquals(env->ignore_string())) {
         options->stdio[i].flags = UV_IGNORE;
-      } else if (type->Equals(env->pipe_string())) {
+      } else if (type->StrictEquals(env->pipe_string())) {
         options->stdio[i].flags = static_cast<uv_stdio_flags>(
             UV_CREATE_PIPE | UV_READABLE_PIPE | UV_WRITABLE_PIPE);
         Local<String> handle_key = env->handle_string();
@@ -120,7 +120,7 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream =
             reinterpret_cast<uv_stream_t*>(
                 Unwrap<PipeWrap>(handle)->UVHandle());
-      } else if (type->Equals(env->wrap_string())) {
+      } else if (type->StrictEquals(env->wrap_string())) {
         Local<String> handle_key = env->handle_string();
         Local<Object> handle =
             stdio->Get(context, handle_key).ToLocalChecked().As<Object>();


### PR DESCRIPTION
Remove all calls to deprecated V8 functions (here: String::Equals)
inside the code.

@addaleax @ryzokuken @jasnell

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
