### PR TITLE
config: support default user on IBM i

### DIFF
--- a/deps/npm/lib/config/defaults.js
+++ b/deps/npm/lib/config/defaults.js
@@ -239,7 +239,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
                      process.getuid() !== 0,
     'update-notifier': true,
     usage: false,
-    user: process.platform === 'win32' ? 0 : 'nobody',
+    user: (process.platform === 'win32' || os.type() === 'OS400') ? 0 : 'nobody',
     userconfig: path.resolve(home, '.npmrc'),
     umask: process.umask ? process.umask() : umask.fromString('022'),
     version: false,


### PR DESCRIPTION
setuid() can not accept a 'nobody' parameter on IBM i.
The default user (QSECOFR) on IBM i has user id 0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
