### PR TITLE
test: fix test-trace-events-dns

### DIFF
--- a/test/internet/test-trace-events-dns.js
+++ b/test/internet/test-trace-events-dns.js
@@ -53,8 +53,6 @@ for (const tr in tests) {
 
   const file = path.join(tmpdir.path, traceFile);
 
-  // Confirm that trace log file is created.
-  assert(common.fileExists(file));
   const data = fs.readFileSync(file);
   const traces = JSON.parse(data.toString()).traceEvents
         .filter((trace) => trace.cat !== '__metadata');


### PR DESCRIPTION
Test is using `common.fileExists()` which has been removed. There is no
need to check that the file exists as the attempt to read the file in
the next line will fail if the file does not exist. Remove existence
check.

This has broken node-daily-master (as that's where internet tests are run). Please 👍 to fast-track to get it fixed.

@nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
