### PR TITLE
deps: fix V8 test regression

### DIFF
--- a/deps/v8/test/cctest/test-log.cc
+++ b/deps/v8/test/cctest/test-log.cc
@@ -738,7 +738,7 @@ TEST(LogVersion) {
 TEST(Issue539892) {
   class : public i::CodeEventLogger {
    public:
-    void CodeMoveEvent(i::AbstractCode* from, Address to) override {}
+    void CodeMoveEvent(i::AbstractCode* from, i::AbstractCode* to) override {}
     void CodeDisableOptEvent(i::AbstractCode* code,
                              i::SharedFunctionInfo* shared) override {}
 


### PR DESCRIPTION
Fixes a regression introduced in a V8 backport PR.
A small change in cctest/test-log.cc was forgotten.

Refs: https://github.com/nodejs/node/pull/22028
Refs: https://github.com/v8/v8/commit/ba752ea4c50713dff1e94f45a79db3ba968a8d66

