### PR TITLE
doc: add warning to readline's close() method

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -195,6 +195,9 @@ The `rl.close()` method closes the `readline.Interface` instance and
 relinquishes control over the `input` and `output` streams. When called,
 the `'close'` event will be emitted.
 
+Calling `rl.close()` does not immediately stop other events (including `'line'`)
+from being emitted by the `readline.Interface` instance.
+
 ### rl.pause()
 <!-- YAML
 added: v0.3.4


### PR DESCRIPTION
When `close()` is called on a `readline` instance, it is possible that data is already buffered, and will trigger `'line'` events. This commit adds a warning to the corresponding docs. Note that
a similar warning already exists for the `pause()` method.

Fixes: https://github.com/nodejs/node/issues/22615

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
