### PR TITLE
src: fix trace-event-file-pattern description

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -203,8 +203,7 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--trace-event-file-pattern",
             "Template string specifying the filepath for the trace-events "
-            "data, it supports ${rotation} and ${pid} log-rotation id. %2$u "
-            "is the pid.",
+            "data, it supports ${rotation} and ${pid}.",
             &PerProcessOptions::trace_event_file_pattern,
             kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {


### PR DESCRIPTION
Fix description for `--trace-event-file-pattern` in `node --help`. The `%2$u` option was from an old version that never got into master.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
