### PR TITLE
deps: V8: backport detailed line information for the CPU profiler

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.26',
+    'v8_embedder_string': '-node.27',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -1211,6 +1211,9 @@ DEFINE_BOOL(log_function_events, false,
 DEFINE_BOOL(prof, false,
             "Log statistical profiling information (implies --log-code).")
 
+DEFINE_BOOL(detailed_line_info, true,
+            "Always generate detailed line information for CPU profiling.")
+
 #if defined(ANDROID)
 // Phones and tablets have processors that are much slower than desktop
 // and laptop computers for which current heuristics are tuned.

--- a/deps/v8/src/isolate.cc
+++ b/deps/v8/src/isolate.cc
@@ -3285,6 +3285,10 @@ bool Isolate::use_optimizer() {
          !is_precise_count_code_coverage() && !is_block_count_code_coverage();
 }
 
+bool Isolate::NeedsDetailedOptimizedCodeLineInfo() const {
+  return NeedsSourcePositionsForProfiling() || FLAG_detailed_line_info;
+}
+
 bool Isolate::NeedsSourcePositionsForProfiling() const {
   return FLAG_trace_deopt || FLAG_trace_turbo || FLAG_trace_turbo_graph ||
          FLAG_turbo_profiling || FLAG_perf_prof || is_profiling() ||

--- a/deps/v8/src/isolate.h
+++ b/deps/v8/src/isolate.h
@@ -1022,6 +1022,8 @@ class Isolate : private HiddenFactory {
 
   bool NeedsSourcePositionsForProfiling() const;
 
+  bool NeedsDetailedOptimizedCodeLineInfo() const;
+
   bool is_best_effort_code_coverage() const {
     return code_coverage_mode() == debug::Coverage::kBestEffort;
   }

--- a/deps/v8/src/optimized-compilation-info.cc
+++ b/deps/v8/src/optimized-compilation-info.cc
@@ -39,7 +39,7 @@ OptimizedCompilationInfo::OptimizedCompilationInfo(
   // Collect source positions for optimized code when profiling or if debugger
   // is active, to be able to get more precise source positions at the price of
   // more memory consumption.
-  if (isolate->NeedsSourcePositionsForProfiling()) {
+  if (isolate->NeedsDetailedOptimizedCodeLineInfo()) {
     MarkAsSourcePositionsEnabled();
   }
 


### PR DESCRIPTION
[cpu-profiler] Add flag to always generate accurate line info.
https://chromium.googlesource.com/v8/v8/+/56baf56790de439b3f69e887e94beb3b301ed77c

[cpu-profiler] Turn on detailed line info for optimized code
https://chromium.googlesource.com/v8/v8/+/84894ce6d2af7feb9e1f5574409355120887326c

[cpu-profiler] Separate the flags for generating extra line information
https://chromium.googlesource.com/v8/v8/+/30ff6719db441cc7ef220d449970cc169067e256

@ofrobots 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
