### PR TITLE
test: replaces assert.throws() with common.expectsError()

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -75,16 +75,40 @@ new Buffer('', 'binary');
 Buffer(0);
 
 // try to write a 0-length string beyond the end of b
-assert.throws(() => b.write('', 2048), RangeError);
+common.expectsError(
+  () => b.write('', 2048),
+  {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError
+  }
+);
 
 // throw when writing to negative offset
-assert.throws(() => b.write('a', -1), RangeError);
+common.expectsError(
+  () => b.write('a', -1),
+  {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError
+  }
+);
 
 // throw when writing past bounds from the pool
-assert.throws(() => b.write('a', 2048), RangeError);
+common.expectsError(
+  () => b.write('a', 2048),
+  {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError
+  }
+);
 
 // throw when writing to negative offset
-assert.throws(() => b.write('a', -1), RangeError);
+common.expectsError(
+  () => b.write('a', -1),
+  {
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError
+  }
+);
 
 // try to copy 0 bytes worth of data into an empty buffer
 b.copy(Buffer.alloc(0), 0, 0, 0);


### PR DESCRIPTION
replaces assert.throws() with common.expectsError() to check error code
and error type in parallel/test-buffer-alloc.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
