### PR TITLE
src: fix trace-event-file-pattern description

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -203,7 +203,7 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--trace-event-file-pattern",
             "Template string specifying the filepath for the trace-events "
-            "data, it supports ${rotation} and ${pid} log-rotation id.",
+            "data, it supports ${rotation} and ${pid}.",
             &PerProcessOptions::trace_event_file_pattern,
             kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {


### PR DESCRIPTION
Fix `--trace-event-file-pattern` description under `node --help`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
