### PR TITLE
assert: add `assert.propertyNotSet`

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1251,7 +1251,8 @@ added: REPLACEME
 
 This property can be used in combination with `assert.throws()` and
 `assert.rejects()` when using the object notation to validate the actual error.
-Passing it along makes sure the property is not set on the error object.
+Using it causes `assert.throws()` to check that the property is not set on the
+error object.
 
 ```js
 assert.throws(

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1249,6 +1249,8 @@ second argument. This might lead to difficult-to-spot errors.
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 This property can be used in combination with `assert.throws()` and
 `assert.rejects()` when using the object notation to validate the actual error.
 Using it causes `assert.throws()` to check that the property is not set on the

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1244,7 +1244,7 @@ assert.throws(throwingFirst, /Second$/);
 Due to the confusing notation, it is recommended not to use a string as the
 second argument. This might lead to difficult-to-spot errors.
 
-## assert.undefinedProperty
+## assert.propertyNotSet
 <!-- YAML
 added: REPLACEME
 -->
@@ -1258,7 +1258,7 @@ error object.
 assert.throws(
   () => { throw new Error('foo'); },
   {
-    undefinedProperty: assert.undefinedProperty,
+    nonExistingProperty: assert.propertyNotSet,
     message: 'foo'
   }
 );

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1244,6 +1244,25 @@ assert.throws(throwingFirst, /Second$/);
 Due to the confusing notation, it is recommended not to use a string as the
 second argument. This might lead to difficult-to-spot errors.
 
+## assert.undefinedProperty
+<!-- YAML
+added: REPLACEME
+-->
+
+This property can be used in combination with `assert.throws()` and
+`assert.rejects()` when using the object notation to validate the actual error.
+Passing it along makes sure the property is not set on the error object.
+
+```js
+assert.throws(
+  () => { throw new Error('foo'); },
+  {
+    undefinedProperty: assert.undefinedProperty,
+    message: 'foo'
+  }
+);
+```
+
 [`ERR_INVALID_RETURN_VALUE`]: errors.html#errors_err_invalid_return_value
 [`Class`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
 [`Error.captureStackTrace`]: errors.html#errors_error_capturestacktrace_targetobject_constructoropt

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -33,6 +33,8 @@ const { inspect, types: { isPromise, isRegExp } } = require('util');
 const { EOL } = require('internal/constants');
 const { NativeModule } = require('internal/bootstrap/loaders');
 
+const { hasOwnProperty } = Object.prototype;
+
 let isDeepEqual;
 let isDeepStrictEqual;
 let parseExpressionAt;
@@ -459,7 +461,7 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
 class Comparison {
   constructor(obj, keys, actual) {
     for (const key of keys) {
-      if (key in obj) {
+      if (hasOwnProperty.call(obj, key)) {
         if (actual !== undefined &&
             typeof actual[key] === 'string' &&
             isRegExp(obj[key]) &&
@@ -475,7 +477,7 @@ class Comparison {
 
 function compareExceptionKey(actual, expected, key, message, keys) {
   let failed;
-  if (key in actual) {
+  if (hasOwnProperty.call(actual, key)) {
     failed = !isDeepStrictEqual(actual[key], expected[key]);
   } else {
     failed = expected[key] !== assert.propertyNotSet;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -465,7 +465,7 @@ class Comparison {
             isRegExp(obj[key]) &&
             obj[key].test(actual[key])) {
           this[key] = actual[key];
-        } else if (obj[key] !== assert.undefinedProperty) {
+        } else if (obj[key] !== assert.propertyNotSet) {
           this[key] = obj[key];
         }
       }
@@ -478,7 +478,7 @@ function compareExceptionKey(actual, expected, key, message, keys) {
   if (key in actual) {
     failed = !isDeepStrictEqual(actual[key], expected[key]);
   } else {
-    failed = expected[key] !== assert.undefinedProperty;
+    failed = expected[key] !== assert.propertyNotSet;
   }
   if (failed) {
     if (!message) {
@@ -757,12 +757,12 @@ assert.strict = Object.assign(strict, assert, {
   notDeepEqual: assert.notDeepStrictEqual
 });
 
-Object.defineProperty(assert, 'undefinedProperty', {
-  value: Symbol('node.assert.undefined-property'),
+Object.defineProperty(assert, 'propertyNotSet', {
+  value: Symbol('assert.propertyNotSet'),
   enumerable: true
 });
-Object.defineProperty(assert.strict, 'undefinedProperty', {
-  value: assert.undefinedProperty,
+Object.defineProperty(assert.strict, 'propertyNotSet', {
+  value: assert.propertyNotSet,
   enumerable: true
 });
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -465,7 +465,7 @@ class Comparison {
             isRegExp(obj[key]) &&
             obj[key].test(actual[key])) {
           this[key] = actual[key];
-        } else {
+        } else if (obj[key] !== assert.undefinedProperty) {
           this[key] = obj[key];
         }
       }
@@ -474,7 +474,13 @@ class Comparison {
 }
 
 function compareExceptionKey(actual, expected, key, message, keys) {
-  if (!(key in actual) || !isDeepStrictEqual(actual[key], expected[key])) {
+  let failed;
+  if (key in actual) {
+    failed = !isDeepStrictEqual(actual[key], expected[key]);
+  } else {
+    failed = expected[key] !== assert.undefinedProperty;
+  }
+  if (failed) {
     if (!message) {
       // Create placeholder objects to create a nice output.
       const a = new Comparison(actual, keys);
@@ -750,4 +756,14 @@ assert.strict = Object.assign(strict, assert, {
   notEqual: assert.notStrictEqual,
   notDeepEqual: assert.notDeepStrictEqual
 });
+
+Object.defineProperty(assert, 'undefinedProperty', {
+  value: Symbol('node.assert.undefined-property'),
+  enumerable: true
+});
+Object.defineProperty(assert.strict, 'undefinedProperty', {
+  value: assert.undefinedProperty,
+  enumerable: true
+});
+
 assert.strict.strict = assert.strict;

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -19,7 +19,9 @@ assert.throws(() => {
   message: '\'first\' != \'second\'',
   operator: '!=',
   actual: 'first',
-  expected: 'second'
+  expected: 'second',
+  generatedMessage: true,
+  userMessage: assert.undefinedProperty
 });
 
 // Three args

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -21,7 +21,7 @@ assert.throws(() => {
   actual: 'first',
   expected: 'second',
   generatedMessage: true,
-  userMessage: assert.undefinedProperty
+  userMessage: assert.propertyNotSet
 });
 
 // Three args

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1029,11 +1029,11 @@ assert.throws(
     {
       message: /fooa/,
       name: /^TypeError$/,
-      generatedMessage: assert.undefinedProperty,
-      actual: assert.undefinedProperty,
-      expected: assert.undefinedProperty,
-      userMessage: assert.undefinedProperty,
-      operator: assert.undefinedProperty
+      generatedMessage: assert.propertyNotSet,
+      actual: assert.propertyNotSet,
+      expected: assert.propertyNotSet,
+      userMessage: assert.propertyNotSet,
+      operator: assert.propertyNotSet
     }
   ),
   {
@@ -1059,7 +1059,7 @@ assert.throws(
       actual,
       expected,
       generatedMessage: true,
-      userMessage: assert.undefinedProperty,
+      userMessage: assert.propertyNotSet,
       message: `${start}\n${actExp}\n\n` +
               '+ null\n' +
               '- {\n' +
@@ -1088,7 +1088,7 @@ assert.throws(
 assert.throws(
   () => assert.throws(
     () => { throw new TypeError('foobar'); },
-    { name: assert.undefinedProperty }
+    { name: assert.propertyNotSet }
   ),
   {
     message: `${start}\n${actExp}\n\n` +

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1028,7 +1028,12 @@ assert.throws(
     () => { throw new TypeError('foobar'); },
     {
       message: /fooa/,
-      name: /^TypeError$/
+      name: /^TypeError$/,
+      generatedMessage: assert.undefinedProperty,
+      actual: assert.undefinedProperty,
+      expected: assert.undefinedProperty,
+      userMessage: assert.undefinedProperty,
+      operator: assert.undefinedProperty
     }
   ),
   {
@@ -1054,6 +1059,7 @@ assert.throws(
       actual,
       expected,
       generatedMessage: true,
+      userMessage: assert.undefinedProperty,
       message: `${start}\n${actExp}\n\n` +
               '+ null\n' +
               '- {\n' +
@@ -1078,3 +1084,15 @@ assert.throws(
     }
   );
 }
+
+assert.throws(
+  () => assert.throws(
+    () => { throw new TypeError('foobar'); },
+    { name: assert.undefinedProperty }
+  ),
+  {
+    message: `${start}\n${actExp}\n\n` +
+             "+ Comparison {\n+   name: 'TypeError'\n+ }\n" +
+             '- Comparison {}'
+  }
+);


### PR DESCRIPTION
This allows to test that a property is not set on an error object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
