### PR TITLE
assert: add default operator to `assert.fail()`

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -87,8 +87,9 @@ function innerFail(obj) {
 function fail(actual, expected, message, operator, stackStartFn) {
   const argsLen = arguments.length;
 
+  let internalMessage;
   if (argsLen === 0) {
-    message = 'Failed';
+    internalMessage = 'Failed';
   } else if (argsLen === 1) {
     message = actual;
     actual = undefined;
@@ -106,13 +107,23 @@ function fail(actual, expected, message, operator, stackStartFn) {
       operator = '!=';
   }
 
-  innerFail({
+  if (message instanceof Error) throw message;
+
+  const errArgs = {
     actual,
     expected,
-    message,
-    operator,
+    operator: operator || 'fail',
     stackStartFn: stackStartFn || fail
-  });
+  };
+  if (message !== undefined) {
+    errArgs.message = message;
+  }
+  const err = new AssertionError(errArgs);
+  if (internalMessage) {
+    err.message = internalMessage;
+    err.generatedMessage = true;
+  }
+  throw err;
 }
 
 assert.fail = fail;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -112,7 +112,7 @@ function fail(actual, expected, message, operator, stackStartFn) {
   const errArgs = {
     actual,
     expected,
-    operator: operator || 'fail',
+    operator: operator === undefined ? 'fail' : operator,
     stackStartFn: stackStartFn || fail
   };
   if (message !== undefined) {

--- a/test/parallel/test-assert-fail-deprecation.js
+++ b/test/parallel/test-assert-fail-deprecation.js
@@ -19,7 +19,8 @@ assert.throws(() => {
   message: '\'first\' != \'second\'',
   operator: '!=',
   actual: 'first',
-  expected: 'second'
+  expected: 'second',
+  generatedMessage: true
 });
 
 // Three args
@@ -29,9 +30,10 @@ assert.throws(() => {
   code: 'ERR_ASSERTION',
   name: 'AssertionError [ERR_ASSERTION]',
   message: 'another custom message',
-  operator: undefined,
+  operator: 'fail',
   actual: 'ignored',
-  expected: 'ignored'
+  expected: 'ignored',
+  generatedMessage: false
 });
 
 // Three args with custom Error

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -10,9 +10,10 @@ assert.throws(
     code: 'ERR_ASSERTION',
     name: 'AssertionError [ERR_ASSERTION]',
     message: 'Failed',
-    operator: undefined,
+    operator: 'fail',
     actual: undefined,
-    expected: undefined
+    expected: undefined,
+    generatedMessage: true
   }
 );
 
@@ -23,9 +24,10 @@ assert.throws(() => {
   code: 'ERR_ASSERTION',
   name: 'AssertionError [ERR_ASSERTION]',
   message: 'custom message',
-  operator: undefined,
+  operator: 'fail',
   actual: undefined,
-  expected: undefined
+  expected: undefined,
+  generatedMessage: false
 });
 
 // One arg = Error


### PR DESCRIPTION
This makes sure `assert.fail()` contains an operator instead of being
undefined.

On top of that it also fixes the `err.generatedMessage` property.
Before, it was not always set correct.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
