### PR TITLE
assert: accept undefined as message input

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -33,11 +33,11 @@ changes:
     description: The `generatedMessage` property is now deprecated.
 -->
 * `options` {Object}
-  * `message` {any} If provided and not `undefined`, it is going to be
-    appended to auto-generated message and the `userMessage` will be set to this
-    value. If the `message` is not of type string, `util.inspect()` is called
-    upon that value before being appended. If no message is auto-generated, the
-    error message will be set to this value.
+  * `message` {any} If provided, it is going to be appended to auto-generated
+    message and the `userMessage` will be set to this value. If the `message` is
+    not of type string, `util.inspect()` is called upon that value before being
+    appended. If no message is auto-generated, the error message will be set to
+    this value.
   * `actual` {any} The `actual` property on the error instance is going to
     contain this value. Internally used for the `actual` error input in case
     e.g., [`assert.strictEqual()`] is used.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -21,10 +21,23 @@ thrown by the `assert` module will be instances of the `AssertionError` class.
 ### new assert.AssertionError(options)
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` is now going to be appended to the error message.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Added the `userMessage` property.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `generatedMessage` property is now deprecated.
 -->
 * `options` {Object}
-  * `message` {string} If provided, the error message is going to be set to this
-    value.
+  * `message` {any} If provided and not `undefined`, it is going to be
+    appended to auto-generated message and the `userMessage` will be set to this
+    value. If the `message` is not of type string, `util.inspect()` is called
+    upon that value before being appended. If no message is auto-generated, the
+    error message will be set to this value.
   * `actual` {any} The `actual` property on the error instance is going to
     contain this value. Internally used for the `actual` error input in case
     e.g., [`assert.strictEqual()`] is used.
@@ -46,11 +59,17 @@ and:
   [`assert.strictEqual()`] is used.
 * `expected` {any} Set to the expected value in case e.g.,
   [`assert.strictEqual()`] is used.
-* `generatedMessage` {boolean} Indicates if the message was auto-generated
-  (`true`) or not.
 * `code` {string} This is always set to the string `ERR_ASSERTION` to indicate
   that the error is actually an assertion error.
+* `generatedMessage` {boolean} Deprecated. Indicates if the message was
+  auto-generated (`true`) or not.
 * `operator` {string} Set to the passed in operator value.
+* `userMessage` {any} Contains the actual passed through message by the user.
+  It will not be set in case the user does not provide a error message.
+
+All error messages thrown by the `assert` module are auto-generated. If the user
+provides an individual error message, it will be added to the auto-generated one
+to provide extra feedback to the user.
 
 ```js
 const assert = require('assert');
@@ -74,6 +93,7 @@ try {
   assert.strictEqual(err.code, 'ERR_ASSERTION');
   assert.strictEqual(err.operator, 'strictEqual');
   assert.strictEqual(err.generatedMessage, true);
+  assert.strictEuqal('userMessage' in err, false);
 }
 ```
 
@@ -155,7 +175,7 @@ assert.deepEqual(/a/gi, new Date());
 added: v0.5.9
 -->
 * `value` {any} The input that is checked for being truthy.
-* `message` {string|Error}
+* `message` {any}
 
 An alias of [`assert.ok()`][].
 
@@ -163,6 +183,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15001
     description: The `Error` names and messages are now properly compared
@@ -181,7 +204,7 @@ changes:
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 **Strict mode**
 
@@ -249,16 +272,17 @@ assert.deepEqual(obj1, obj4);
 // AssertionError: { a: { b: 1 } } deepEqual {}
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are not deep-equal and the `message` parameter is set to an
+instance of an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.deepStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15169
     description: Enumerable symbol properties are now compared.
@@ -285,7 +309,7 @@ changes:
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 Tests for deep equality between the `actual` and `expected` parameters.
 "Deep" equality means that the enumerable "own" properties of child objects
@@ -402,11 +426,9 @@ assert.deepStrictEqual(weakMap1, weakMap3);
 //   }
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are not strictly deep-equal and the `message` parameter is set to
+an instance of an [`Error`][] then that error will be thrown. In all other cases
+an `AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.doesNotReject(block[, error][, message])
 <!-- YAML
@@ -533,10 +555,14 @@ assert.doesNotThrow(
 ## assert.equal(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 **Strict mode**
 
@@ -563,11 +589,9 @@ assert.equal({ a: { b: 1 } }, { a: { b: 1 } });
 // AssertionError: { a: { b: 1 } } == { a: { b: 1 } }
 ```
 
-If the values are not equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are not equal and the `message` parameter is set to an instance of
+an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.fail([message])
 <!-- YAML
@@ -707,6 +731,9 @@ let err;
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15001
     description: The `Error` names and messages are now properly compared
@@ -725,7 +752,7 @@ changes:
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 **Strict mode**
 
@@ -770,16 +797,17 @@ assert.notDeepEqual(obj1, obj4);
 // OK
 ```
 
-If the values are deeply equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are deeply equal and the `message` parameter is set to an instance
+of an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.notDeepStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15398
     description: The `-0` and `+0` are not considered equal anymore.
@@ -806,7 +834,7 @@ changes:
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 Tests for deep strict inequality. Opposite of [`assert.deepStrictEqual()`][].
 
@@ -817,19 +845,21 @@ assert.notDeepStrictEqual({ a: 1 }, { a: '1' });
 // OK
 ```
 
-If the values are deeply and strictly equal, an `AssertionError` is thrown with
-a `message` property set equal to the value of the `message` parameter. If the
-`message` parameter is undefined, a default error message is assigned. If the
-`message` parameter is an instance of an [`Error`][] then it will be thrown
-instead of the `AssertionError`.
+If the values are strictly deep-equal and the `message` parameter is set to an
+instance of an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.notEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 **Strict mode**
 
@@ -855,23 +885,24 @@ assert.notEqual(1, '1');
 // AssertionError: 1 != '1'
 ```
 
-If the values are equal, an `AssertionError` is thrown with a `message` property
-set equal to the value of the `message` parameter. If the `message` parameter is
-undefined, a default error message is assigned. If the `message` parameter is an
-instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are equal and the `message` parameter is set to an instance of an
+[`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.notStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/17003
     description: Used comparison changed from Strict Equality to `Object.is()`
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 Tests strict inequality between the `actual` and `expected` parameters as
 determined by the [SameValue Comparison][].
@@ -891,32 +922,32 @@ assert.notStrictEqual(1, '1');
 // OK
 ```
 
-If the values are strictly equal, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is undefined, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If the values are strictly equal and the `message` parameter is set to an
+instance of an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.ok(value[, message])
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18319
     description: The `assert.ok()` (no arguments) will now use a predefined
                  error message.
 -->
 * `value` {any}
-* `message` {string|Error}
+* `message` {any}
 
 Tests if `value` is truthy. It is equivalent to
 `assert.equal(!!value, true, message)`.
 
-If `value` is not truthy, an `AssertionError` is thrown with a `message`
-property set equal to the value of the `message` parameter. If the `message`
-parameter is `undefined`, a default error message is assigned. If the `message`
-parameter is an instance of an [`Error`][] then it will be thrown instead of the
-`AssertionError`.
+If `value` is not truthy and the `message` parameter is set to an instance of an
+[`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
+
 If no arguments are passed in at all `message` will be set to the string:
 ``'No value argument passed to `assert.ok()`'``.
 
@@ -990,8 +1021,9 @@ an object where each property will be tested for, or an instance of error where
 each property will be tested for including the non-enumerable `message` and
 `name` properties.
 
-If specified, `message` will be the message provided by the `AssertionError` if
-the block fails to reject.
+If specified, `message` will be appended to the message provided by the
+`AssertionError`, if the block call fails to reject or in case the error
+validation fails.
 
 ```js
 (async () => {
@@ -1026,13 +1058,16 @@ argument gets considered.
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `message` may now be any value.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/17003
     description: Used comparison changed from Strict Equality to `Object.is()`
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {string|Error}
+* `message` {any}
 
 Tests strict equality between the `actual` and `expected` parameters as
 determined by the [SameValue Comparison][].
@@ -1057,11 +1092,9 @@ assert.strictEqual('Hello foobar', 'Hello World!');
 //          ^
 ```
 
-If the values are not strictly equal, an `AssertionError` is thrown with a
-`message` property set equal to the value of the `message` parameter. If the
-`message` parameter is undefined, a default error message is assigned. If the
-`message` parameter is an instance of an [`Error`][] then it will be thrown
-instead of the `AssertionError`.
+If the values are not strictly equal and the `message` parameter is set to an
+instance of an [`Error`][] then that error will be thrown. In all other cases an
+`AssertionError` is thrown, passing through the `message` parameter.
 
 ## assert.throws(block[, error][, message])
 <!-- YAML

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1050,6 +1050,16 @@ deprecated along with the undocumented aliases `crypto.prng()` and
 `crypto.rng()` in favor of [`crypto.randomBytes()`][] and will be removed in a
 future release.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: AssertionError#generatedMessage
+
+Type: Runtime
+
+Instead of accessing the generatedMessage property of `AssertionErrors`, please
+check for `AssertionError#userMessage` existence instead. It contains the actual
+user message without any modification and allows to detect if the user passed
+through a message or not.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -218,7 +218,7 @@ function parseCode(code, offset) {
   ];
 }
 
-function getErrMessage(message, fn) {
+function getErrMessage(fn) {
   const tmpLimit = Error.stackTraceLimit;
   // Make sure the limit is set to 1. Otherwise it could fail (<= 0) or it
   // does to much work.
@@ -237,7 +237,7 @@ function getErrMessage(message, fn) {
   const filename = call.getFileName();
 
   if (!filename) {
-    return message;
+    return;
   }
 
   const line = call.getLineNumber() - 1;
@@ -278,6 +278,7 @@ function getErrMessage(message, fn) {
 
     fd = openSync(filename, 'r', 0o666);
     // Reset column and message.
+    let message;
     [column, message] = getCode(fd, line, column);
     // Flush unfinished multi byte characters.
     decoder.end();
@@ -317,14 +318,26 @@ function innerOk(fn, argLen, value, message) {
   if (!value) {
     let generatedMessage = false;
 
-    if (argLen === 0) {
+    let newMessage;
+    if (message === undefined) {
       generatedMessage = true;
-      message = 'No value argument passed to `assert.ok()`';
-    } else if (message == null) {
-      generatedMessage = true;
-      message = getErrMessage(message, fn);
+      if (argLen === 0) {
+        newMessage = 'No value argument passed to `assert.ok()`';
+      } else {
+        newMessage = getErrMessage(fn);
+      }
     } else if (message instanceof Error) {
       throw message;
+    } else {
+      const tmp = getErrMessage(fn);
+      if (tmp) {
+        if (typeof message !== 'string') {
+          const extra = 'Value passed through as message';
+          newMessage = `${tmp}\n${extra}:\n\n${inspect(message)}`;
+        } else {
+          newMessage = `${tmp}\nUser provided message:\n\n${message}`;
+        }
+      }
     }
 
     const err = new AssertionError({
@@ -335,6 +348,9 @@ function innerOk(fn, argLen, value, message) {
       stackStartFn: fn
     });
     err.generatedMessage = generatedMessage;
+    if (newMessage) {
+      err.message = newMessage;
+    }
     throw err;
   }
 }
@@ -475,33 +491,25 @@ class Comparison {
 
 function compareExceptionKey(actual, expected, key, message, keys) {
   if (!(key in actual) || !isDeepStrictEqual(actual[key], expected[key])) {
-    if (!message) {
-      // Create placeholder objects to create a nice output.
-      const a = new Comparison(actual, keys);
-      const b = new Comparison(expected, keys, actual);
+    // Create placeholder objects to create a nice output.
+    const a = new Comparison(actual, keys);
+    const b = new Comparison(expected, keys, actual);
 
-      const err = new AssertionError({
-        actual: a,
-        expected: b,
-        operator: 'deepStrictEqual',
-        stackStartFn: assert.throws
-      });
-      err.actual = actual;
-      err.expected = expected;
-      err.operator = 'throws';
-      throw err;
-    }
-    innerFail({
-      actual,
-      expected,
+    const err = new AssertionError({
+      actual: a,
+      expected: b,
       message,
-      operator: 'throws',
+      operator: 'deepStrictEqual',
       stackStartFn: assert.throws
     });
+    err.actual = actual;
+    err.expected = expected;
+    err.operator = 'throws';
+    throw err;
   }
 }
 
-function expectedException(actual, expected, msg) {
+function expectedException(actual, expected, message) {
   if (typeof expected !== 'function') {
     if (isRegExp(expected))
       return expected.test(actual);
@@ -517,7 +525,7 @@ function expectedException(actual, expected, msg) {
       const err = new AssertionError({
         actual,
         expected,
-        message: msg,
+        message,
         operator: 'deepStrictEqual',
         stackStartFn: assert.throws
       });
@@ -541,7 +549,7 @@ function expectedException(actual, expected, msg) {
           expected[key].test(actual[key])) {
         continue;
       }
-      compareExceptionKey(actual, expected, key, msg, keys);
+      compareExceptionKey(actual, expected, key, message, keys);
     }
     return true;
   }
@@ -632,11 +640,9 @@ function expectsError(stackStartFn, actual, error, message) {
   }
 
   if (actual === NO_EXCEPTION_SENTINEL) {
-    let details = '';
-    if (error && error.name) {
-      details += ` (${error.name})`;
-    }
-    details += message ? `: ${message}` : '.';
+    let details = error && error.name ? ` (${error.name})` : '';
+    const strMessage = typeof message === 'string' ? message : inspect(message);
+    details += message ? `: ${strMessage}` : '.';
     const fnType = stackStartFn.name === 'rejects' ? 'rejection' : 'exception';
     innerFail({
       actual: undefined,
@@ -661,7 +667,8 @@ function expectsNoError(stackStartFn, actual, error, message) {
   }
 
   if (!error || expectedException(actual, error)) {
-    const details = message ? `: ${message}` : '.';
+    const strMessage = typeof message === 'string' ? message : inspect(message);
+    const details = message ? `: ${strMessage}` : '.';
     const fnType = stackStartFn.name === 'doesNotReject' ?
       'rejection' : 'exception';
     innerFail({
@@ -709,9 +716,10 @@ assert.ifError = function ifError(err) {
       actual: err,
       expected: null,
       operator: 'ifError',
-      message,
       stackStartFn: ifError
     });
+    newErr.message = message;
+    newErr.generatedMessage = false;
 
     // Make sure we actually have a stack trace!
     const origStack = err.stack;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -340,13 +340,16 @@ function innerOk(fn, argLen, value, message) {
       }
     }
 
-    const err = new AssertionError({
+    const errArgs = {
       actual: value,
       expected: true,
-      message,
       operator: '==',
       stackStartFn: fn
-    });
+    };
+    if (argLen >= 2) {
+      errArgs.message = message;
+    }
+    const err = new AssertionError(errArgs);
     err.generatedMessage = generatedMessage;
     if (newMessage) {
       err.message = newMessage;
@@ -367,13 +370,16 @@ assert.ok = ok;
 assert.equal = function equal(actual, expected, message) {
   // eslint-disable-next-line eqeqeq
   if (actual != expected) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: '==',
       stackStartFn: equal
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
@@ -382,13 +388,16 @@ assert.equal = function equal(actual, expected, message) {
 assert.notEqual = function notEqual(actual, expected, message) {
   // eslint-disable-next-line eqeqeq
   if (actual == expected) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: '!=',
       stackStartFn: notEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
@@ -396,13 +405,16 @@ assert.notEqual = function notEqual(actual, expected, message) {
 assert.deepEqual = function deepEqual(actual, expected, message) {
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (!isDeepEqual(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'deepEqual',
       stackStartFn: deepEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
@@ -410,13 +422,16 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (isDeepEqual(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'notDeepEqual',
       stackStartFn: notDeepEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 /* eslint-enable */
@@ -424,13 +439,16 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (!isDeepStrictEqual(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'deepStrictEqual',
       stackStartFn: deepStrictEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
@@ -438,37 +456,46 @@ assert.notDeepStrictEqual = notDeepStrictEqual;
 function notDeepStrictEqual(actual, expected, message) {
   if (isDeepEqual === undefined) lazyLoadComparison();
   if (isDeepStrictEqual(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'notDeepStrictEqual',
       stackStartFn: notDeepStrictEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 }
 
 assert.strictEqual = function strictEqual(actual, expected, message) {
   if (!Object.is(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'strictEqual',
       stackStartFn: strictEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   if (Object.is(actual, expected)) {
-    innerFail({
+    const errArgs = {
       actual,
       expected,
-      message,
       operator: 'notStrictEqual',
       stackStartFn: notStrictEqual
-    });
+    };
+    if (arguments.length >= 3) {
+      errArgs.message = message;
+    }
+    innerFail(errArgs);
   }
 };
 
@@ -495,13 +522,16 @@ function compareExceptionKey(actual, expected, key, message, keys) {
     const a = new Comparison(actual, keys);
     const b = new Comparison(expected, keys, actual);
 
-    const err = new AssertionError({
+    const errArgs = {
       actual: a,
       expected: b,
-      message,
       operator: 'deepStrictEqual',
       stackStartFn: assert.throws
-    });
+    };
+    if (message !== undefined) {
+      errArgs.message = message;
+    }
+    const err = new AssertionError(errArgs);
     err.actual = actual;
     err.expected = expected;
     err.operator = 'throws';
@@ -522,13 +552,16 @@ function expectedException(actual, expected, message) {
 
     // Handle primitives properly.
     if (typeof actual !== 'object' || actual === null) {
-      const err = new AssertionError({
+      const errArgs = {
         actual,
         expected,
-        message,
         operator: 'deepStrictEqual',
         stackStartFn: assert.throws
-      });
+      };
+      if (message !== undefined) {
+        errArgs.message = message;
+      }
+      const err = new AssertionError(errArgs);
       err.operator = 'throws';
       throw err;
     }

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { inspect } = require('util');
+const { deprecate } = require('internal/util');
 const { codes: {
   ERR_INVALID_ARG_TYPE
 } } = require('internal/errors');
@@ -36,24 +37,26 @@ function copyError(source) {
   return target;
 }
 
+const inspectOptions = {
+  compact: false,
+  customInspect: false,
+  depth: 1000,
+  maxArrayLength: Infinity,
+  // Assert compares only enumerable properties (with a few exceptions).
+  showHidden: false,
+  // Having a long line as error is better than wrapping the line for
+  // comparison.
+  breakLength: Infinity,
+  // Assert does not detect proxies currently.
+  showProxy: false
+};
+
 function inspectValue(val) {
   // The util.inspect default values could be changed. This makes sure the
   // error messages contain the necessary information nevertheless.
   return inspect(
     val,
-    {
-      compact: false,
-      customInspect: false,
-      depth: 1000,
-      maxArrayLength: Infinity,
-      // Assert compares only enumerable properties (with a few exceptions).
-      showHidden: false,
-      // Having a long line as error is better than wrapping the line for
-      // comparison.
-      breakLength: Infinity,
-      // Assert does not detect proxies currently.
-      showProxy: false
-    }
+    inspectOptions
   );
 }
 
@@ -225,12 +228,93 @@ function createErrDiff(actual, expected, operator) {
   return `${msg}${skipped ? skippedMsg : ''}\n${res}${other}${end}${indicator}`;
 }
 
+function generateMessage(actual, expected, operator) {
+  let internalMessage;
+
+  if (process.stderr.isTTY) {
+    // Reset on each call to make sure we handle dynamically set environment
+    // variables correct.
+    if (process.stderr.getColorDepth() !== 1) {
+      blue = '\u001b[34m';
+      green = '\u001b[32m';
+      white = '\u001b[39m';
+      red = '\u001b[31m';
+    } else {
+      blue = '';
+      green = '';
+      white = '';
+      red = '';
+    }
+  }
+  // Prevent the error stack from being visible by duplicating the error
+  // in a very close way to the original in case both sides are actually
+  // instances of Error.
+  if (typeof actual === 'object' && actual !== null &&
+      typeof expected === 'object' && expected !== null &&
+      'stack' in actual && actual instanceof Error &&
+      'stack' in expected && expected instanceof Error) {
+    actual = copyError(actual);
+    expected = copyError(expected);
+  }
+
+  if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
+    internalMessage = createErrDiff(actual, expected, operator);
+  } else if (operator === 'notDeepStrictEqual' ||
+    operator === 'notStrictEqual') {
+    // In case the objects are equal but the operator requires unequal, show
+    // the first object and say A equals B
+    const res = inspectValue(actual).split('\n');
+    const base = kReadableOperator[operator];
+
+    // Only remove lines in case it makes sense to collapse those.
+    // TODO: Accept env to always show the full error.
+    if (res.length > 30) {
+      res[26] = `${blue}...${white}`;
+      while (res.length > 27) {
+        res.pop();
+      }
+    }
+
+    // Only print a single input.
+    if (res.length === 1) {
+      internalMessage = `${base} ${res[0]}`;
+    } else {
+      internalMessage = `${base}\n\n${res.join('\n')}\n`;
+    }
+  } else {
+    let res = inspectValue(actual);
+    let other = '';
+    const knownOperators = kReadableOperator[operator];
+    if (operator === 'notDeepEqual' || operator === 'notEqual') {
+      res = `${kReadableOperator[operator]}\n\n${res}`;
+      if (res.length > 1024) {
+        res = `${res.slice(0, 1021)}...`;
+      }
+    } else {
+      other = `${inspectValue(expected)}`;
+      if (res.length > 512) {
+        res = `${res.slice(0, 509)}...`;
+      }
+      if (other.length > 512) {
+        other = `${other.slice(0, 509)}...`;
+      }
+      if (operator === 'deepEqual' || operator === 'equal') {
+        res = `${knownOperators}\n\n${res}\n\nshould equal\n\n`;
+      } else {
+        other = ` ${operator} ${other}`;
+      }
+    }
+    internalMessage = `${res}${other}`;
+  }
+  return internalMessage;
+}
+
 class AssertionError extends Error {
   constructor(options) {
     if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
-    var {
+    const {
       actual,
       expected,
       message,
@@ -238,87 +322,55 @@ class AssertionError extends Error {
       stackStartFn
     } = options;
 
-    if (message != null) {
-      super(String(message));
-    } else {
-      if (process.stderr.isTTY) {
-        // Reset on each call to make sure we handle dynamically set environment
-        // variables correct.
-        if (process.stderr.getColorDepth() !== 1) {
-          blue = '\u001b[34m';
-          green = '\u001b[32m';
-          white = '\u001b[39m';
-          red = '\u001b[31m';
-        } else {
-          blue = '';
-          green = '';
-          white = '';
-          red = '';
-        }
-      }
-      // Prevent the error stack from being visible by duplicating the error
-      // in a very close way to the original in case both sides are actually
-      // instances of Error.
-      if (typeof actual === 'object' && actual !== null &&
-          typeof expected === 'object' && expected !== null &&
-          'stack' in actual && actual instanceof Error &&
-          'stack' in expected && expected instanceof Error) {
-        actual = copyError(actual);
-        expected = copyError(expected);
-      }
+    let userMessage = false;
 
-      if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
-        super(createErrDiff(actual, expected, operator));
-      } else if (operator === 'notDeepStrictEqual' ||
-        operator === 'notStrictEqual') {
-        // In case the objects are equal but the operator requires unequal, show
-        // the first object and say A equals B
-        const res = inspectValue(actual).split('\n');
-        const base = kReadableOperator[operator];
+    if (message !== undefined) {
+      userMessage = true;
 
-        // Only remove lines in case it makes sense to collapse those.
-        // TODO: Accept env to always show the full error.
-        if (res.length > 30) {
-          res[26] = `${blue}...${white}`;
-          while (res.length > 27) {
-            res.pop();
-          }
-        }
-
-        // Only print a single input.
-        if (res.length === 1) {
-          super(`${base} ${res[0]}`);
-        } else {
-          super(`${base}\n\n${res.join('\n')}\n`);
-        }
+      let isStringMessage = true;
+      let internalMessage;
+      if (typeof message === 'string') {
+        internalMessage = message;
       } else {
-        let res = inspectValue(actual);
-        let other = '';
-        const knownOperators = kReadableOperator[operator];
-        if (operator === 'notDeepEqual' || operator === 'notEqual') {
-          res = `${kReadableOperator[operator]}\n\n${res}`;
-          if (res.length > 1024) {
-            res = `${res.slice(0, 1021)}...`;
-          }
-        } else {
-          other = `${inspectValue(expected)}`;
-          if (res.length > 512) {
-            res = `${res.slice(0, 509)}...`;
-          }
-          if (other.length > 512) {
-            other = `${other.slice(0, 509)}...`;
-          }
-          if (operator === 'deepEqual' || operator === 'equal') {
-            res = `${knownOperators}\n\n${res}\n\nshould equal\n\n`;
-          } else {
-            other = ` ${operator} ${other}`;
-          }
-        }
-        super(`${res}${other}`);
+        isStringMessage = false;
+        internalMessage = inspectValue(message);
       }
+
+      if (operator && operator.endsWith('qual')) {
+        const tmp = generateMessage(actual, expected, operator);
+        const ln = tmp[tmp.length - 1] === '\n' ? '' : '\n';
+        const extra = isStringMessage ?
+          'User provided message' : 'Value passed through as message';
+        super(`${tmp}${ln}\n${extra}:\n\n${internalMessage}`);
+      } else {
+        super(internalMessage);
+      }
+    } else {
+      super(generateMessage(actual, expected, operator));
     }
 
-    this.generatedMessage = !message;
+    if (userMessage) {
+      this.userMessage = message;
+    }
+    Object.defineProperty(this, 'generatedMessage', {
+      get: deprecate(
+        () => {
+          return !message;
+        },
+        "The 'generatedMessage' property is deprecated. Please check for the " +
+          "'userMessage' existence instead.",
+        'DEP0XXX'),
+      set(value) {
+        Object.defineProperty(this, 'generatedMessage', {
+          value,
+          enumerable: true,
+          configurable: true,
+          writable: true
+        });
+      },
+      enumerable: true,
+      configurable: true
+    });
     this.name = 'AssertionError [ERR_ASSERTION]';
     this.code = 'ERR_ASSERTION';
     this.actual = actual;

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -324,7 +324,7 @@ class AssertionError extends Error {
 
     let userMessage = false;
 
-    if (message !== undefined) {
+    if ('message' in options) {
       userMessage = true;
 
       let isStringMessage = true;

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -1,6 +1,6 @@
 assert.js:*
-      throw err;
-      ^
+    throw err;
+    ^
 
 AssertionError [ERR_ASSERTION]: Expected inputs to be strictly deep-equal:
 + actual - expected

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -871,10 +871,11 @@ assert.deepStrictEqual(obj1, obj2);
   b.foo = 'baz';
 
   assert.throws(
-    () => assert.deepStrictEqual(a, b),
+    () => assert.deepStrictEqual(a, b, undefined),
     {
       message: `${defaultMsgStartFull}\n\n` +
-               '  [TypeError: foo] {\n+   foo: \'bar\'\n-   foo: \'baz\'\n  }'
+               '  [TypeError: foo] {\n+   foo: \'bar\'\n-   foo: \'baz\'\n  }' +
+               '\n\nValue passed through as message:\n\nundefined'
     }
   );
 }

--- a/test/parallel/test-assert-if-error.js
+++ b/test/parallel/test-assert-if-error.js
@@ -32,6 +32,8 @@ const stack = err.stack;
         assert.equal(e.actual.stack, stack);
         assert.equal(e.expected, null);
         assert.equal(e.operator, 'ifError');
+        assert.equal(e.generatedMessage, false);
+        assert(!('userMessage' in e));
         threw = true;
       }
       assert(threw);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -266,6 +266,7 @@ function testAssertionMessage(actual, expected, msg) {
              `+ actual - expected\n\n+ ${expected}\n- ''`
     );
     assert.ok(e.generatedMessage, 'Message not marked as generated');
+    assert.ok(!('userMessage' in e));
   }
 }
 
@@ -313,9 +314,13 @@ try {
 try {
   assert.strictEqual(1, 2, 'oh no');
 } catch (e) {
-  assert.strictEqual(e.message, 'oh no');
+  assert.strictEqual(
+    e.message,
+    `${strictEqualMessageStart}\n1 !== 2\n\nUser provided message:\n\noh no`
+  );
   assert.strictEqual(e.generatedMessage, false,
                      'Message incorrectly marked as generated');
+  assert.strictEqual(e.userMessage, 'oh no');
 }
 
 {
@@ -652,7 +657,9 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     generatedMessage: false,
-    message: 'Symbol(foo)'
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             "assert(false, Symbol('foo'))\n\n" +
+             'Value passed through as message:\n\nSymbol(foo)'
   }
 );
 
@@ -820,8 +827,11 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: 'test',
-    generatedMessage: false
+    message: 'The expression evaluated to a falsy value:\n\n  ' +
+             "assert.ok.call(null, 0, 'test')\n\n" +
+             'User provided message:\n\ntest',
+    generatedMessage: false,
+    userMessage: 'test'
   }
 );
 
@@ -905,12 +915,20 @@ common.expectsError(
     }
   );
 
+  const userMsg = { message: 'foobar' };
   common.expectsError(
-    () => assert.throws(() => { throw new Error(); }, { foo: 'bar' }, 'foobar'),
+    () => assert.throws(() => { throw new Error(); }, { foo: 'bar' }, userMsg),
     {
       type: assert.AssertionError,
       code: 'ERR_ASSERTION',
-      message: 'foobar'
+      message: `${start}\n${actExp}\n\n` +
+               '+ Comparison {}\n' +
+               '- Comparison {\n' +
+               "-   foo: 'bar'\n" +
+               '- }\n\n' +
+               'Value passed through as message:\n\n' +
+               inspect(userMsg, { compact: false }),
+      userMessage: userMsg
     }
   );
 
@@ -1062,6 +1080,13 @@ assert.throws(
     }
   );
 
+  common.expectWarning(
+    'DeprecationWarning',
+    "The 'generatedMessage' property is deprecated. Please check for the " +
+      "'userMessage' existence instead.",
+    'DEP0XXX'
+  );
+
   actual = 'foobar';
   const message = 'message';
   assert.throws(
@@ -1072,9 +1097,15 @@ assert.throws(
     ),
     {
       actual,
-      message,
+      message: `${start}\n${actExp}\n\n` +
+               "+ 'foobar'\n" +
+               '- {\n' +
+               "-   message: 'foobar'\n" +
+               '- }\n\n' +
+               `User provided message:\n\n${message}`,
       operator: 'throws',
-      generatedMessage: false
+      generatedMessage: false,
+      userMessage: message
     }
   );
 }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -301,15 +301,14 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
                      '{\n+   a: NaN,\n+   b: Infinity,\n+   c: -Infinity\n+ }');
 
 // https://github.com/nodejs/node-v0.x-archive/issues/5292
-try {
-  assert.strictEqual(1, 2);
-} catch (e) {
-  assert.strictEqual(
-    e.message,
-    `${strictEqualMessageStart}\n1 !== 2\n`
-  );
-  assert.ok(e.generatedMessage, 'Message not marked as generated');
-}
+assert.throws(
+  () => assert.strictEqual(1, 2, undefined),
+  {
+    message: `${strictEqualMessageStart}\n1 !== 2\n\n` +
+             'Value passed through as message:\n\nundefined',
+    generatedMessage: true
+  }
+);
 
 try {
   assert.strictEqual(1, 2, 'oh no');

--- a/test/parallel/test-stream-inheritance.js
+++ b/test/parallel/test-stream-inheritance.js
@@ -53,7 +53,14 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: 'undefined does not inherit from CustomWritable'
+    message: 'The expression evaluated to a falsy value:\n\n' +
+              '  assert.ok(\n' +
+              '    this instanceof CustomWritable,\n' +
+              // eslint-disable-next-line no-template-curly-in-string
+              '    `${this} does not inherit from CustomWritable`\n' +
+              '  )\n\n' +
+              'User provided message:\n\n' +
+              'undefined does not inherit from CustomWritable'
   }
 );
 


### PR DESCRIPTION
This is a follow up PR for #22695 but this is currently blocked by #22694. I'll remove the first commit as soon as #22695 lands.

This is important to allow any input value to be visible to the users
in case the message is used to highlight the failing passed through
input.

E.g., `assert(/abc/.test(input), input)` should highlight, that `input`
is set to `undefined`.

Refs: #22695, #22694

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
