### PR TITLE
test: remove usage of deprecated V8 APIs in addons

### DIFF
--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -73,7 +73,7 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   async_req* req = new async_req;
   req->req.data = req;
 
-  req->input = args[0]->IntegerValue();
+  req->input = args[0].As<v8::Integer>()->Value();
   req->output = 0;
   req->isolate = isolate;
   req->context = node::EmitAsyncInit(isolate, v8::Object::New(isolate), "test");

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -15,8 +15,8 @@ void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   alive++;
 
-  uintptr_t alignment = args[1]->IntegerValue();
-  uintptr_t offset = args[2]->IntegerValue();
+  uintptr_t alignment = args[1].As<v8::Integer>()->Value();
+  uintptr_t offset = args[2].As<v8::Integer>()->Value();
 
   uintptr_t static_offset = reinterpret_cast<uintptr_t>(buf) % alignment;
   char* aligned = buf + (alignment - static_offset) + offset;
@@ -24,7 +24,7 @@ void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(node::Buffer::New(
         isolate,
         aligned,
-        args[0]->IntegerValue(),
+        args[0].As<v8::Integer>()->Value(),
         FreeCallback,
         nullptr).ToLocalChecked());
 }

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -4,7 +4,7 @@
 
 void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
   v8::Isolate* isolate = args.GetIsolate();
-  uintptr_t size = args[0]->IntegerValue();
+  uintptr_t size = args[0].As<v8::Integer>()->Value();
   v8::Local<v8::Boolean> success;
 
   void* buffer = malloc(size);


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
