### PR TITLE
string_decoder: fix number of replacement chars

### DIFF
--- a/test/parallel/test-string-decoder-fuzz.js
+++ b/test/parallel/test-string-decoder-fuzz.js
@@ -1,0 +1,48 @@
+'use strict';
+require('../common');
+const { StringDecoder } = require('string_decoder');
+const util = require('util');
+const assert = require('assert');
+
+// Tests that, for random sequences of bytes, our StringDecoder gives the
+// same result as a direction conversion using Buffer.toString().
+// In particular, it checks that StringDecoder aligns with V8’s own output.
+
+function rand(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function randBuf(maxLen) {
+  const buf = Buffer.allocUnsafe(rand(maxLen));
+  for (let i = 0; i < buf.length; i++)
+    buf[i] = rand(256);
+  return buf;
+}
+
+const encodings = [
+  'utf16le', 'utf8', 'ascii', 'hex', 'base64', 'latin1'
+];
+
+function runSingleFuzzTest() {
+  const enc = encodings[rand(encodings.length)];
+  const sd = new StringDecoder(enc);
+  const bufs = [];
+  const strings = [];
+
+  const N = rand(10);
+  for (let i = 0; i < N; ++i) {
+    const buf = randBuf(50);
+    bufs.push(buf);
+    strings.push(sd.write(buf));
+  }
+  strings.push(sd.end());
+
+  assert.strictEqual(strings.join(''), Buffer.concat(bufs).toString(enc),
+                     `Mismatch:\n${util.inspect(strings)}\n` +
+                     util.inspect(bufs.map((buf) => buf.toString('hex'))) +
+                     `\nfor encoding ${enc}`);
+}
+
+const start = Date.now();
+while (Date.now() - start < 100)
+  runSingleFuzzTest();

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -151,6 +151,17 @@ assert.strictEqual(decoder.write(Buffer.alloc(20)), '\0'.repeat(10));
 assert.strictEqual(decoder.write(Buffer.alloc(48)), '\0'.repeat(24));
 assert.strictEqual(decoder.end(), '');
 
+// Regression tests for https://github.com/nodejs/node/issues/22626
+// (not enough replacement chars when having seen more than one byte of an
+// incomplete multibyte characters).
+decoder = new StringDecoder('utf8');
+assert.strictEqual(decoder.write(Buffer.from('f69b', 'hex')), '');
+assert.strictEqual(decoder.write(Buffer.from('d1', 'hex')), '\ufffd\ufffd');
+assert.strictEqual(decoder.end(), '\ufffd');
+assert.strictEqual(decoder.write(Buffer.from('f4', 'hex')), '');
+assert.strictEqual(decoder.write(Buffer.from('bde5', 'hex')), '\ufffd\ufffd');
+assert.strictEqual(decoder.end(), '\ufffd');
+
 common.expectsError(
   () => new StringDecoder(1),
   {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/22626

Tentatively labeling as semver-major.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
