### PR TITLE
zlib: fix memory leak for invalid input

### DIFF
--- a/test/parallel/test-zlib-invalid-input-memory.js
+++ b/test/parallel/test-zlib-invalid-input-memory.js
@@ -1,0 +1,21 @@
+// Flags: --expose-gc
+'use strict';
+const common = require('../common');
+const onGC = require('../common/ongc');
+const assert = require('assert');
+const zlib = require('zlib');
+
+// Checks that, if a zlib context fails with an error, it can still be GC'ed:
+// Refs: https://github.com/nodejs/node/issues/22705
+
+const ongc = common.mustCall();
+
+{
+  const input = Buffer.from('foobar');
+  const strm = zlib.createInflate();
+  strm.end(input);
+  strm.once('error', common.mustCall((err) => assert(err)));
+  onGC(strm, { ongc });
+}
+
+setImmediate(() => global.gc());

--- a/test/parallel/test-zlib-invalid-input-memory.js
+++ b/test/parallel/test-zlib-invalid-input-memory.js
@@ -16,7 +16,13 @@ const ongc = common.mustCall();
   strm.end(input);
   strm.once('error', common.mustCall((err) => {
     assert(err);
-    setImmediate(global.gc);
+    setImmediate(() => {
+      global.gc();
+      // Keep the event loop alive for seeing the async_hooks destroy hook
+      // we use for GC tracking...
+      // TODO(addaleax): This should maybe not be necessary?
+      setImmediate(() => {});
+    });
   }));
   onGC(strm, { ongc });
 }

--- a/test/parallel/test-zlib-invalid-input-memory.js
+++ b/test/parallel/test-zlib-invalid-input-memory.js
@@ -14,8 +14,9 @@ const ongc = common.mustCall();
   const input = Buffer.from('foobar');
   const strm = zlib.createInflate();
   strm.end(input);
-  strm.once('error', common.mustCall((err) => assert(err)));
+  strm.once('error', common.mustCall((err) => {
+    assert(err);
+    setImmediate(global.gc);
+  }));
   onGC(strm, { ongc });
 }
-
-setImmediate(() => global.gc());


### PR DESCRIPTION
Don’t toggle the weak/strong reference flag from the error
handler, that’s too confusing. Instead, always do it in the
code that handles the write call.

Fixes: https://github.com/nodejs/node/issues/22705

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
