### PR TITLE
test: Remove string argument from strict.Equal()

### DIFF
--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -6,16 +6,16 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
+// 'should consider equal strings to be equal'
 assert.strictEqual(
   crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('foo')),
-  true,
-  'should consider equal strings to be equal'
+  true
 );
 
+// 'should consider unequal strings to be unequal'
 assert.strictEqual(
   crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('bar')),
-  false,
-  'should consider unequal strings to be unequal'
+  false
 );
 
 common.expectsError(


### PR DESCRIPTION
Removing string literal passed as argument to assert.strictEqual() in order to print the expected value instead of the string. (First issue assigned through Email by Rich Trott)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
