### PR TITLE
src: remove abort_on_uncaught_exception node.cc

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -420,11 +420,11 @@ inline void Environment::set_trace_sync_io(bool value) {
 }
 
 inline bool Environment::abort_on_uncaught_exception() const {
-  return abort_on_uncaught_exception_;
+  return options_->abort_on_uncaught_exception;
 }
 
 inline void Environment::set_abort_on_uncaught_exception(bool value) {
-  abort_on_uncaught_exception_ = value;
+  options_->abort_on_uncaught_exception = value;
 }
 
 inline AliasedBuffer<uint32_t, v8::Uint32Array>&

--- a/src/node.cc
+++ b/src/node.cc
@@ -2667,7 +2667,7 @@ void ProcessArgv(std::vector<std::string>* args,
                 "--abort-on-uncaught-exception") != v8_args.end() ||
       std::find(v8_args.begin(), v8_args.end(),
                 "--abort_on_uncaught_exception") != v8_args.end()) {
-    per_process_opts->per_isolate->per_env->abort_on_uncaught_exception = true;
+    env_opts->abort_on_uncaught_exception = true;
   }
 
   // TODO(bnoordhuis) Intercept --prof arguments and start the CPU profiler

--- a/src/node.cc
+++ b/src/node.cc
@@ -183,9 +183,6 @@ static node_module* modlist_internal;
 static node_module* modlist_linked;
 static node_module* modlist_addon;
 
-// TODO(addaleax): This should not be global.
-static bool abort_on_uncaught_exception = false;
-
 // Bit flag used to track security reverts (see node_revert.h)
 unsigned int reverted = 0;
 
@@ -2670,7 +2667,7 @@ void ProcessArgv(std::vector<std::string>* args,
                 "--abort-on-uncaught-exception") != v8_args.end() ||
       std::find(v8_args.begin(), v8_args.end(),
                 "--abort_on_uncaught_exception") != v8_args.end()) {
-    abort_on_uncaught_exception = true;
+    per_process_opts->per_isolate->per_env->abort_on_uncaught_exception = true;
   }
 
   // TODO(bnoordhuis) Intercept --prof arguments and start the CPU profiler
@@ -3035,8 +3032,6 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
       !v8_platform.InspectorStarted(&env)) {
     return 12;  // Signal internal error.
   }
-
-  env.set_abort_on_uncaught_exception(abort_on_uncaught_exception);
 
   // TODO(addaleax): Maybe access this option directly instead of setting
   // a boolean member of Environment. Ditto below for trace_sync_io.

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -60,6 +60,7 @@ class DebugOptions {
 class EnvironmentOptions {
  public:
   std::shared_ptr<DebugOptions> debug_options { new DebugOptions() };
+  bool abort_on_uncaught_exception = false;
   bool experimental_modules = false;
   bool experimental_repl_await = false;
   bool experimental_vm_modules = false;


### PR DESCRIPTION
This commit removes the static variable abort_on_uncaught_exception and
adds it to the environment options.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
