### PR TITLE
src: make `FIXED_ONE_BYTE_STRING` an inline fn

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2173,11 +2173,11 @@ static napi_status set_error_code(napi_env env,
       }
     }
     name_string = v8::String::Concat(
-        isolate, name_string, FIXED_ONE_BYTE_STRING(isolate, " ["));
+        isolate, name_string, node::FIXED_ONE_BYTE_STRING(isolate, " ["));
     name_string =
         v8::String::Concat(isolate, name_string, code_value.As<v8::String>());
     name_string = v8::String::Concat(
-        isolate, name_string, FIXED_ONE_BYTE_STRING(isolate, "]"));
+        isolate, name_string, node::FIXED_ONE_BYTE_STRING(isolate, "]"));
 
     set_maybe = err_object->Set(context, name_key, name_string);
     RETURN_STATUS_IF_FALSE(env,

--- a/src/util.h
+++ b/src/util.h
@@ -89,9 +89,6 @@ NO_RETURN void Abort();
 NO_RETURN void Assert(const char* const (*args)[4]);
 void DumpBacktrace(FILE* fp);
 
-#define FIXED_ONE_BYTE_STRING(isolate, string)                                \
-  (node::OneByteString((isolate), (string), sizeof(string) - 1))
-
 #define DISALLOW_COPY_AND_ASSIGN(TypeName)                                    \
   void operator=(const TypeName&) = delete;                                   \
   void operator=(TypeName&&) = delete;                                        \
@@ -247,6 +244,15 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const unsigned char* data,
                                            int length = -1);
+
+// Used to be a macro, hence the uppercase name.
+template <int N>
+inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(
+    v8::Isolate* isolate,
+    const char(&data)[N]) {
+  return OneByteString(isolate, data, N - 1);
+}
+
 
 // Swaps bytes in place. nbytes is the number of bytes to swap and must be a
 // multiple of the word size (checked by function).


### PR DESCRIPTION
This prevents accidental usage on non-fixed strings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
