### PR TITLE
src: remove trace_sync_io_ from env

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -416,7 +416,7 @@ inline void Environment::set_printed_error(bool value) {
 }
 
 inline void Environment::set_trace_sync_io(bool value) {
-  trace_sync_io_ = value;
+  options_->trace_sync_io = value;
 }
 
 inline bool Environment::abort_on_uncaught_exception() const {

--- a/src/env.cc
+++ b/src/env.cc
@@ -132,7 +132,6 @@ Environment::Environment(IsolateData* isolate_data,
       tick_info_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
       printed_error_(false),
-      trace_sync_io_(false),
       abort_on_uncaught_exception_(false),
       emit_env_nonstring_warning_(true),
       makecallback_cntr_(0),
@@ -351,7 +350,7 @@ void Environment::StopProfilerIdleNotifier() {
 }
 
 void Environment::PrintSyncTrace() const {
-  if (!trace_sync_io_)
+  if (!options_->trace_sync_io)
     return;
 
   HandleScope handle_scope(isolate());

--- a/src/env.h
+++ b/src/env.h
@@ -913,7 +913,6 @@ class Environment {
   TickInfo tick_info_;
   const uint64_t timer_base_;
   bool printed_error_;
-  bool trace_sync_io_;
   bool abort_on_uncaught_exception_;
   bool emit_env_nonstring_warning_;
   size_t makecallback_cntr_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3051,8 +3051,6 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
     env.async_hooks()->pop_async_id(1);
   }
 
-  env.set_trace_sync_io(env.options()->trace_sync_io);
-
   {
     SealHandleScope seal(isolate);
     bool more;


### PR DESCRIPTION
This commit removes trace_sync_io_ and instead uses the options value
directly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
