### PR TITLE
n-api: add napi_get_value_int64() unsafe version

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2250,6 +2250,42 @@ This API returns the C `int64` primitive equivalent of the given JavaScript
 Non-finite number values (`NaN`, `+Infinity`, or `-Infinity`) set the
 result to zero.
 
+#### napi_get_value_int64_unsafe
+
+> Stability: 1 - Experimental
+
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_get_value_int64_unsafe(napi_env env,
+                                        napi_value value,
+                                        int64_t* result)
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] value`: `napi_value` representing JavaScript `Number`.
+- `[out] result`: C `int64` primitive equivalent of the given JavaScript
+  `Number`.
+
+Returns `napi_ok` if the API succeeded. If a non-number `napi_value`
+is passed in it returns `napi_number_expected`.
+
+This API returns the C `int64` primitive equivalent of the given JavaScript
+`Number`.
+
+`Number` values outside the range of
+[`Number.MIN_SAFE_INTEGER`](https://tc39.github.io/ecma262/#sec-number.min_safe_integer)
+-(2^53 - 1) -
+[`Number.MAX_SAFE_INTEGER`](https://tc39.github.io/ecma262/#sec-number.max_safe_integer)
+(2^53 - 1) will lose precision.
+
+Non-finite number values (`NaN`, `+Infinity`, or `-Infinity`) result in
+undefined and potentially engine-specific behavior.
+
+This API is a faster but less consistent version of [`napi_get_value_int64`][].
+
 #### napi_get_value_string_latin1
 <!-- YAML
 added: v8.0.0
@@ -4579,6 +4615,7 @@ This API may only be called from the main thread.
 [`napi_get_array_length`]: #n_api_napi_get_array_length
 [`napi_get_element`]: #n_api_napi_get_element
 [`napi_get_property`]: #n_api_napi_get_property
+[`napi_get_value_int64`]: #n_api_napi_get_value_int64
 [`napi_has_property`]: #n_api_napi_has_property
 [`napi_has_own_property`]: #n_api_napi_has_own_property
 [`napi_set_property`]: #n_api_napi_set_property

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -695,6 +695,9 @@ NAPI_EXTERN napi_status napi_get_value_bigint_words(napi_env env,
                                                     int* sign_bit,
                                                     size_t* word_count,
                                                     uint64_t* words);
+NAPI_EXTERN napi_status napi_get_value_int64_unsafe(napi_env env,
+                                                    napi_value value,
+                                                    int64_t* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END


### PR DESCRIPTION
Adds `napi_get_value_int64_unsafe()` which skips the correction
whereby non-finite values are rendered as zero, exposing instead
the engine-specific behavior.

This tradeoff favors performance-intensive applications where
guarantees of finiteness can be made a priori.

This modification is further motivated by the fact that there is
currently no typed array support for `int64_t`.

Fixes: https://github.com/nodejs/abi-stable-node/issues/327

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
