### PR TITLE
test: remove string literal from deepStrictEqual

### DIFF
--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -55,8 +55,8 @@ fs.createReadStream(pmmFileGz)
   })
   .on('data', (data) => pmmResultBuffers.push(data))
   .on('finish', common.mustCall(() => {
-    assert.deepStrictEqual(Buffer.concat(pmmResultBuffers), pmmExpected,
-                           'result should match original random garbage');
+    // Result should match original random garbage
+    assert.deepStrictEqual(Buffer.concat(pmmResultBuffers), pmmExpected);
   }));
 
 // test that the next gzip member can wrap around the input buffer boundary


### PR DESCRIPTION
test: remove string literal from deepStrictEqual

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
