### PR TITLE
lib: destructuring assignment instead of require whole module

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -21,11 +21,11 @@
 
 'use strict';
 
-const net = require('net');
-const util = require('util');
+const { createConnection } = require('net');
+const { debuglog } = require('util');
 const EventEmitter = require('events');
-const debug = util.debuglog('http');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
+const debug = debuglog('http');
 
 // New Agent code.
 
@@ -110,7 +110,7 @@ Object.setPrototypeOf(Agent, EventEmitter);
 
 Agent.defaultMaxSockets = Infinity;
 
-Agent.prototype.createConnection = net.createConnection;
+Agent.prototype.createConnection = createConnection;
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function getName(options) {


### PR DESCRIPTION
Minor refactor: Use `destructuring assignment` instead of require the whole module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)