### PR TITLE
build: make doc generation work on Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -459,7 +459,7 @@ robocopy /e doc\api %config%\doc\api
 robocopy /e doc\api_assets %config%\doc\api\assets
 
 for %%F in (%config%\doc\api\*.md) do (
-  %node_exe% tools\doc\generate.js --node-version=v%FULLVERSION% --analytics=%DOCS_ANALYTICS% %%F --output-dir=%%~dF%%~pF
+  %node_exe% tools\doc\generate.js --node-version=v%FULLVERSION% --analytics=%DOCS_ANALYTICS% %%F --output-directory=%%~dF%%~pF
 )
 
 :run


### PR DESCRIPTION
https://github.com/nodejs/node/pull/21697 broke doc generation on Windows since the option name for the output directory was incorrect.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
