### PR TITLE
util: inspect - remove very old legacy args

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -378,10 +378,9 @@ function debuglog(set) {
  * in the best way possible given the different types.
  *
  * @param {any} value The value to print out.
- * @param {Object} opts Optional options object that alters the output.
+ * @param {Object} options Optional options object that alters the output.
  */
-/* Legacy: value, showHidden, depth, colors */
-function inspect(value, opts) {
+function inspect(value, options) {
   // Default options
   const ctx = {
     seen: [],
@@ -398,22 +397,15 @@ function inspect(value, opts) {
     indentationLvl: 0,
     compact: inspectDefaultOptions.compact
   };
-  // Legacy...
-  if (arguments.length > 2) {
-    if (arguments[2] !== undefined) {
-      ctx.depth = arguments[2];
-    }
-    if (arguments.length > 3 && arguments[3] !== undefined) {
-      ctx.colors = arguments[3];
-    }
-  }
   // Set user-specified options
-  if (typeof opts === 'boolean') {
-    ctx.showHidden = opts;
-  } else if (opts) {
-    const optKeys = Object.keys(opts);
-    for (var i = 0; i < optKeys.length; i++) {
-      ctx[optKeys[i]] = opts[optKeys[i]];
+  if (options !== undefined) {
+    if (typeof options !== 'object') {
+      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+    } else {
+      const optKeys = Object.keys(options);
+      for (var i = 0; i < optKeys.length; i++) {
+        ctx[optKeys[i]] = options[optKeys[i]];
+      }
     }
   }
   if (ctx.colors) ctx.stylize = stylizeWithColor;


### PR DESCRIPTION
Undocumented, and refactored 6 years ago
Refs: https://github.com/nodejs/node/commit/07774e6b9570f90166a54fa87af74b8a7cf9926a

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
