### PR TITLE
src: more process moving

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1105,61 +1105,6 @@ static MaybeLocal<Value> ExecuteString(Environment* env,
 }
 
 
-static void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  Local<Array> ary = Array::New(args.GetIsolate());
-  Local<Context> ctx = env->context();
-  Local<Function> fn = env->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  size_t idx = 0;
-
-  for (auto w : *env->req_wrap_queue()) {
-    if (w->persistent().IsEmpty())
-      continue;
-    argv[idx] = w->GetOwner();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
-  }
-
-  if (idx > 0) {
-    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-  }
-
-  args.GetReturnValue().Set(ary);
-}
-
-
-// Non-static, friend of HandleWrap. Could have been a HandleWrap method but
-// implemented here for consistency with GetActiveRequests().
-void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  Local<Array> ary = Array::New(env->isolate());
-  Local<Context> ctx = env->context();
-  Local<Function> fn = env->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  size_t idx = 0;
-
-  for (auto w : *env->handle_wrap_queue()) {
-    if (!HandleWrap::HasRef(w))
-      continue;
-    argv[idx] = w->GetOwner();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
-  }
-  if (idx > 0) {
-    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-  }
-
-  args.GetReturnValue().Set(ary);
-}
-
-
 NO_RETURN void Abort() {
   DumpBacktrace(stderr);
   fflush(stderr);

--- a/src/node.cc
+++ b/src/node.cc
@@ -160,7 +160,6 @@ using v8::Object;
 using v8::ObjectTemplate;
 using v8::Promise;
 using v8::PropertyAttribute;
-using v8::PropertyCallbackInfo;
 using v8::ReadOnly;
 using v8::Script;
 using v8::ScriptCompiler;
@@ -1736,32 +1735,6 @@ static Local<Object> GetFeatures(Environment* env) {
 
   return scope.Escape(obj);
 }
-
-
-static void DebugPortGetter(Local<Name> property,
-                            const PropertyCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  Mutex::ScopedLock lock(process_mutex);
-  int port = env->options()->debug_options->port();
-#if HAVE_INSPECTOR
-  if (port == 0) {
-    if (auto io = env->inspector_agent()->io())
-      port = io->port();
-  }
-#endif  // HAVE_INSPECTOR
-  info.GetReturnValue().Set(port);
-}
-
-
-static void DebugPortSetter(Local<Name> property,
-                            Local<Value> value,
-                            const PropertyCallbackInfo<void>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  Mutex::ScopedLock lock(process_mutex);
-  env->options()->debug_options->host_port.port =
-      value->Int32Value(env->context()).FromMaybe(0);
-}
-
 
 static void DebugProcess(const FunctionCallbackInfo<Value>& args);
 static void DebugEnd(const FunctionCallbackInfo<Value>& args);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -888,6 +888,8 @@ void Abort(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Chdir(const v8::FunctionCallbackInfo<v8::Value>& args);
 void CPUUsage(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Cwd(const v8::FunctionCallbackInfo<v8::Value>& args);
+void GetActiveHandles(const v8::FunctionCallbackInfo<v8::Value>& args);
+void GetActiveRequests(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Hrtime(const v8::FunctionCallbackInfo<v8::Value>& args);
 void HrtimeBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Kill(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -910,6 +910,11 @@ void EnvSetter(v8::Local<v8::Name> property,
 void EnvQuery(v8::Local<v8::Name> property,
               const v8::PropertyCallbackInfo<v8::Integer>& info);
 void EnvEnumerator(const v8::PropertyCallbackInfo<v8::Array>& info);
+void DebugPortGetter(v8::Local<v8::Name> property,
+                     const v8::PropertyCallbackInfo<v8::Value>& info);
+void DebugPortSetter(v8::Local<v8::Name> property,
+                     v8::Local<v8::Value> value,
+                     const v8::PropertyCallbackInfo<void>& info);
 
 void GetParentProcessId(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value>& info);

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -7,6 +7,10 @@
 #include "uv.h"
 #include "v8.h"
 
+#if HAVE_INSPECTOR
+#include "inspector_io.h"
+#endif
+
 #include <limits.h>  // PATH_MAX
 #include <stdio.h>
 
@@ -841,5 +845,30 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(ary);
 }
+
+void DebugPortGetter(Local<Name> property,
+                     const PropertyCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  Mutex::ScopedLock lock(process_mutex);
+  int port = env->options()->debug_options->port();
+#if HAVE_INSPECTOR
+  if (port == 0) {
+    if (auto io = env->inspector_agent()->io())
+      port = io->port();
+  }
+#endif  // HAVE_INSPECTOR
+  info.GetReturnValue().Set(port);
+}
+
+
+void DebugPortSetter(Local<Name> property,
+                     Local<Value> value,
+                     const PropertyCallbackInfo<void>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  Mutex::ScopedLock lock(process_mutex);
+  env->options()->debug_options->host_port.port =
+      value->Int32Value(env->context()).FromMaybe(0);
+}
+
 
 }  // namespace node

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -1,5 +1,7 @@
 #include "node.h"
 #include "node_internals.h"
+#include "base_object.h"
+#include "base_object-inl.h"
 #include "env-inl.h"
 #include "util-inl.h"
 #include "uv.h"
@@ -786,5 +788,58 @@ void GetParentProcessId(Local<Name> property,
   info.GetReturnValue().Set(Integer::New(info.GetIsolate(), uv_os_getppid()));
 }
 
+void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  Local<Array> ary = Array::New(args.GetIsolate());
+  Local<Context> ctx = env->context();
+  Local<Function> fn = env->push_values_to_array_function();
+  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
+  size_t idx = 0;
+
+  for (auto w : *env->req_wrap_queue()) {
+    if (w->persistent().IsEmpty())
+      continue;
+    argv[idx] = w->GetOwner();
+    if (++idx >= arraysize(argv)) {
+      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
+      idx = 0;
+    }
+  }
+
+  if (idx > 0) {
+    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
+  }
+
+  args.GetReturnValue().Set(ary);
+}
+
+
+// Non-static, friend of HandleWrap. Could have been a HandleWrap method but
+// implemented here for consistency with GetActiveRequests().
+void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  Local<Array> ary = Array::New(env->isolate());
+  Local<Context> ctx = env->context();
+  Local<Function> fn = env->push_values_to_array_function();
+  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
+  size_t idx = 0;
+
+  for (auto w : *env->handle_wrap_queue()) {
+    if (!HandleWrap::HasRef(w))
+      continue;
+    argv[idx] = w->GetOwner();
+    if (++idx >= arraysize(argv)) {
+      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
+      idx = 0;
+    }
+  }
+  if (idx > 0) {
+    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
+  }
+
+  args.GetReturnValue().Set(ary);
+}
 
 }  // namespace node


### PR DESCRIPTION
Move `GetActiveResources`, `GetActiveHandles`, and the `DebugPortGetter|Setter` to `node_process.cc`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
