### PR TITLE
doc: clarify assigning issues to the TSC

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -473,15 +473,19 @@ level.
 
 ### Involving the TSC
 
-Collaborators may opt to elevate pull requests or issues to the [TSC][] for
-discussion by assigning the `tsc-review` label or @-mentioning the
-`@nodejs/tsc` GitHub team. This should be done where a pull request:
+Collaborators may opt to elevate pull requests or issues to the [TSC][].
+This should be done where a pull request:
 
 - is labeled `semver-major`, or
 - has a significant impact on the codebase, or
 - is inherently controversial, or
 - has failed to reach consensus amongst the Collaborators who are
   actively participating in the discussion.
+
+Assign the `tsc-review` label or @-mention the
+`@nodejs/tsc` GitHub team if you want to elevate an issue to the [TSC][].
+Do not use the GitHub UI on the right hand side to assign to
+`@nodejs/tsc` or request a review from `@nodejs/tsc`.
 
 The TSC should serve as the final arbiter where required.
 


### PR DESCRIPTION
Using the right hand side to assign `@nodejs/tsc` or to request reviews from `@nodejs/tsc` breaks all kinds of workflows and filter rules. Please use the appropriate `tsc-review` label or mention `@nodejs/tsc` in a comment instead. 