### PR TITLE
doc: add full deprecation history

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -870,6 +870,7 @@ The [`tls.CryptoStream`][] class was removed. Please use
 <a id="DEP0043"></a>
 ### DEP0043: tls.SecurePair
 <!-- YAML
+changes:
   - version:
     - v4.8.6
     - v6.12.0
@@ -1838,7 +1839,7 @@ Type: Runtime
 
 <a id="DEP0097"></a>
 ### DEP0097: MakeCallback with domain property
-<!--
+<!-- YAML
 changes:
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/17417
@@ -2206,6 +2207,8 @@ use the [WHATWG URL API][] instead.
 [`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
 [`fs.lchmod(path, mode, callback)`]: fs.html#fs_fs_lchmod_path_mode_callback
 [`fs.lchmodSync(path, mode)`]: fs.html#fs_fs_lchmodsync_path_mode
+[`fs.lchown(path, uid, gid, callback)`]: fs.html#fs_fs_lchown_path_uid_gid_callback
+[`fs.lchownSync(path, uid, gid)`]: fs.html#fs_fs_lchownsync_path_uid_gid
 [`fs.read()`]: fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readSync()`]: fs.html#fs_fs_readsync_fd_buffer_offset_length_position
 [`fs.stat()`]: fs.html#fs_fs_stat_path_options_callback

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -40,6 +40,17 @@ However, the deprecation identifier will not be modified.
 
 <a id="DEP0001"></a>
 ### DEP0001: http.OutgoingMessage.prototype.flush
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.6.0
+    pr-url: https://github.com/nodejs/node/pull/1156
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -48,6 +59,18 @@ The `OutgoingMessage.prototype.flush()` method is deprecated. Use
 
 <a id="DEP0002"></a>
 ### DEP0002: require('\_linklist')
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12113
+    description: End-of-Life.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3078
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -55,6 +78,17 @@ The `_linklist` module is deprecated. Please use a userland alternative.
 
 <a id="DEP0003"></a>
 ### DEP0003: \_writableState.buffer
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.15
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/8826
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -63,6 +97,20 @@ The `_writableState.buffer` property is deprecated. Use the
 
 <a id="DEP0004"></a>
 ### DEP0004: CryptoStream.prototype.readyState
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17882
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: 0.4.0
+    commit: 9c7f89bf56abd37a796fea621ad2e47dd33d2b82
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -70,6 +118,18 @@ The `CryptoStream.prototype.readyState` property was removed.
 
 <a id="DEP0005"></a>
 ### DEP0005: Buffer() constructor
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19524
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4682
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime (supports [`--pending-deprecation`][])
 
@@ -98,6 +158,18 @@ outside `node_modules` in order to better target developers, rather than users.
 
 <a id="DEP0006"></a>
 ### DEP0006: child\_process options.customFds
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.14
+    description: Runtime deprecation.
+  - version: v0.5.11
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -107,6 +179,21 @@ option should be used instead.
 
 <a id="DEP0007"></a>
 ### DEP0007: Replace cluster worker.suicide with worker.exitedAfterDisconnect
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13702
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/3747
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/3743
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -119,6 +206,15 @@ precisely describe the actual semantics and was unnecessarily emotion-laden.
 
 <a id="DEP0008"></a>
 ### DEP0008: require('constants')
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.3.0
+    pr-url: https://github.com/nodejs/node/pull/6534
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -129,6 +225,18 @@ to the `constants` property exposed by the relevant module. For instance,
 
 <a id="DEP0009"></a>
 ### DEP0009: crypto.pbkdf2 without digest
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11305
+    description: End-of-Life.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4047
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -140,6 +248,20 @@ undefined `digest` will throw a `TypeError`.
 
 <a id="DEP0010"></a>
 ### DEP0010: crypto.createCredentials
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/21153
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.13
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/7265
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -148,6 +270,20 @@ The `crypto.createCredentials()` API was removed. Please use
 
 <a id="DEP0011"></a>
 ### DEP0011: crypto.Credentials
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/21153
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.13
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/7265
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -156,6 +292,20 @@ instead.
 
 <a id="DEP0012"></a>
 ### DEP0012: Domain.dispose
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15412
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.7
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/5021
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -164,6 +314,15 @@ explicitly via error event handlers set on the domain instead.
 
 <a id="DEP0013"></a>
 ### DEP0013: fs asynchronous function without callback
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18668
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -172,6 +331,23 @@ in Node.js 10.0.0 onwards. (See https://github.com/nodejs/node/pull/12562.)
 
 <a id="DEP0014"></a>
 ### DEP0014: fs.read legacy String interface
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/9683
+    description: End-of-Life.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4525
+    description: Runtime deprecation.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.1.96
+    commit: c93e0aaf062081db3ec40ac45b3e2c979d5759d6
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -180,6 +356,23 @@ API as mentioned in the documentation instead.
 
 <a id="DEP0015"></a>
 ### DEP0015: fs.readSync legacy String interface
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/9683
+    description: End-of-Life.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4525
+    description: Runtime deprecation.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.1.96
+    commit: c93e0aaf062081db3ec40ac45b3e2c979d5759d6
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -188,6 +381,15 @@ The [`fs.readSync()`][] legacy `String` interface is deprecated. Use the
 
 <a id="DEP0016"></a>
 ### DEP0016: GLOBAL/root
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/1838
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -196,6 +398,15 @@ and should no longer be used.
 
 <a id="DEP0017"></a>
 ### DEP0017: Intl.v8BreakIterator
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15238
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8908
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -204,6 +415,12 @@ See [`Intl.Segmenter`](https://github.com/tc39/proposal-intl-segmenter).
 
 <a id="DEP0018"></a>
 ### DEP0018: Unhandled promise rejections
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8217
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -213,6 +430,17 @@ code.
 
 <a id="DEP0019"></a>
 ### DEP0019: require('.') resolved outside directory
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.8.1
+    pr-url: https://github.com/nodejs/node/pull/1363
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -222,6 +450,17 @@ release.
 
 <a id="DEP0020"></a>
 ### DEP0020: Server.connections
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.9.7
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/4595
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -230,6 +469,17 @@ The [`Server.connections`][] property is deprecated. Please use the
 
 <a id="DEP0021"></a>
 ### DEP0021: Server.listenFD
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.7.12
+    commit: 41421ff9da1288aa241a5e9dcf915b685ade1c23
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -238,6 +488,12 @@ The `Server.listenFD()` method is deprecated. Please use
 
 <a id="DEP0022"></a>
 ### DEP0022: os.tmpDir()
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/6739
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -245,6 +501,17 @@ The `os.tmpDir()` API is deprecated. Please use [`os.tmpdir()`][] instead.
 
 <a id="DEP0023"></a>
 ### DEP0023: os.getNetworkInterfaces()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.6.0
+    commit: 37bb37d151fb6ee4696730e63ff28bb7a4924f97
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -253,6 +520,15 @@ The `os.getNetworkInterfaces()` method is deprecated. Please use the
 
 <a id="DEP0024"></a>
 ### DEP0024: REPLServer.prototype.convertToContext()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13434
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7829
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -260,6 +536,17 @@ The `REPLServer.prototype.convertToContext()` API has been removed.
 
 <a id="DEP0025"></a>
 ### DEP0025: require('sys')
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.0.0
+    pr-url: https://github.com/nodejs/node/pull/317
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -267,6 +554,17 @@ The `sys` module is deprecated. Please use the [`util`][] module instead.
 
 <a id="DEP0026"></a>
 ### DEP0026: util.print()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -275,6 +573,17 @@ instead.
 
 <a id="DEP0027"></a>
 ### DEP0027: util.puts()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -282,6 +591,17 @@ The [`util.puts()`][] API is deprecated. Please use [`console.log()`][] instead.
 
 <a id="DEP0028"></a>
 ### DEP0028: util.debug()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -290,6 +610,17 @@ instead.
 
 <a id="DEP0029"></a>
 ### DEP0029: util.error()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -298,6 +629,15 @@ instead.
 
 <a id="DEP0030"></a>
 ### DEP0030: SlowBuffer
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5833
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -306,6 +646,15 @@ The [`SlowBuffer`][] class is deprecated. Please use
 
 <a id="DEP0031"></a>
 ### DEP0031: ecdh.setPublicKey()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v5.2.0
+    pr-url: https://github.com/nodejs/node/pull/3511
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -314,6 +663,17 @@ API is not useful.
 
 <a id="DEP0032"></a>
 ### DEP0032: domain module
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.4.2
+    pr-url: https://github.com/nodejs/node/pull/943
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -321,6 +681,17 @@ The [`domain`][] module is deprecated and should not be used.
 
 <a id="DEP0033"></a>
 ### DEP0033: EventEmitter.listenerCount()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v3.2.0
+    pr-url: https://github.com/nodejs/node/pull/2349
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -329,6 +700,17 @@ deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
 
 <a id="DEP0034"></a>
 ### DEP0034: fs.exists(path, callback)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.0.0
+    pr-url: https://github.com/iojs/io.js/pull/166
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -337,6 +719,16 @@ The [`fs.exists(path, callback)`][] API is deprecated. Please use
 
 <a id="DEP0035"></a>
 ### DEP0035: fs.lchmod(path, mode, callback)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -344,13 +736,74 @@ The [`fs.lchmod(path, mode, callback)`][] API is deprecated.
 
 <a id="DEP0036"></a>
 ### DEP0036: fs.lchmodSync(path, mode)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
 The [`fs.lchmodSync(path, mode)`][] API is deprecated.
 
+<a id="DEP0037"></a>
+### DEP0037: fs.lchown(path, uid, gid, callback)
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/21498
+    description: Deprecation revoked.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
+
+Type: Deprecation revoked
+
+The [`fs.lchown(path, uid, gid, callback)`][] API is deprecated.
+
+<a id="DEP0038"></a>
+### DEP0038: fs.lchownSync(path, uid, gid)
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/21498
+    description: Deprecation revoked.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
+
+Type: Deprecation revoked
+
+The [`fs.lchownSync(path, uid, gid)`][] API is deprecated.
+
 <a id="DEP0039"></a>
 ### DEP0039: require.extensions
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.10.6
+    commit: 7bd8a5a2a60b75266f89f9a32877d55294a3881c
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -358,6 +811,12 @@ The [`require.extensions`][] property is deprecated.
 
 <a id="DEP0040"></a>
 ### DEP0040: punycode module
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -366,6 +825,20 @@ instead.
 
 <a id="DEP0041"></a>
 ### DEP0041: NODE\_REPL\_HISTORY\_FILE environment variable
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/13876
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v3.0.0
+    pr-url: https://github.com/nodejs/node/pull/2224
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -374,6 +847,20 @@ The `NODE_REPL_HISTORY_FILE` environment variable was removed. Please use
 
 <a id="DEP0042"></a>
 ### DEP0042: tls.CryptoStream
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17882
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -382,6 +869,16 @@ The [`tls.CryptoStream`][] class was removed. Please use
 
 <a id="DEP0043"></a>
 ### DEP0043: tls.SecurePair
+<!-- YAML
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    pr-url:
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -390,6 +887,19 @@ The [`tls.SecurePair`][] class is deprecated. Please use
 
 <a id="DEP0044"></a>
 ### DEP0044: util.isArray()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -398,6 +908,19 @@ instead.
 
 <a id="DEP0045"></a>
 ### DEP0045: util.isBoolean()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -405,6 +928,19 @@ The [`util.isBoolean()`][] API is deprecated.
 
 <a id="DEP0046"></a>
 ### DEP0046: util.isBuffer()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -413,6 +949,19 @@ The [`util.isBuffer()`][] API is deprecated. Please use
 
 <a id="DEP0047"></a>
 ### DEP0047: util.isDate()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -420,6 +969,19 @@ The [`util.isDate()`][] API is deprecated.
 
 <a id="DEP0048"></a>
 ### DEP0048: util.isError()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -427,6 +989,19 @@ The [`util.isError()`][] API is deprecated.
 
 <a id="DEP0049"></a>
 ### DEP0049: util.isFunction()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -434,6 +1009,19 @@ The [`util.isFunction()`][] API is deprecated.
 
 <a id="DEP0050"></a>
 ### DEP0050: util.isNull()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -441,6 +1029,19 @@ The [`util.isNull()`][] API is deprecated.
 
 <a id="DEP0051"></a>
 ### DEP0051: util.isNullOrUndefined()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -448,6 +1049,19 @@ The [`util.isNullOrUndefined()`][] API is deprecated.
 
 <a id="DEP0052"></a>
 ### DEP0052: util.isNumber()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -455,6 +1069,19 @@ The [`util.isNumber()`][] API is deprecated.
 
 <a id="DEP0053"></a>
 ### DEP0053 util.isObject()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -462,6 +1089,19 @@ The [`util.isObject()`][] API is deprecated.
 
 <a id="DEP0054"></a>
 ### DEP0054: util.isPrimitive()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -469,6 +1109,19 @@ The [`util.isPrimitive()`][] API is deprecated.
 
 <a id="DEP0055"></a>
 ### DEP0055: util.isRegExp()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -476,6 +1129,19 @@ The [`util.isRegExp()`][] API is deprecated.
 
 <a id="DEP0056"></a>
 ### DEP0056: util.isString()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -483,6 +1149,19 @@ The [`util.isString()`][] API is deprecated.
 
 <a id="DEP0057"></a>
 ### DEP0057: util.isSymbol()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -490,6 +1169,19 @@ The [`util.isSymbol()`][] API is deprecated.
 
 <a id="DEP0058"></a>
 ### DEP0058: util.isUndefined()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -497,6 +1189,15 @@ The [`util.isUndefined()`][] API is deprecated.
 
 <a id="DEP0059"></a>
 ### DEP0059: util.log()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6161
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -504,6 +1205,15 @@ The [`util.log()`][] API is deprecated.
 
 <a id="DEP0060"></a>
 ### DEP0060: util.\_extend()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4903
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -511,6 +1221,18 @@ The [`util._extend()`][] API is deprecated.
 
 <a id="DEP0061"></a>
 ### DEP0061: fs.SyncWriteStream
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/20735
+    description: End-of-Life.
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10467
+    description: Runtime deprecation.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/6749
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -520,6 +1242,12 @@ alternative.
 
 <a id="DEP0062"></a>
 ### DEP0062: node --debug
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10970
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -529,6 +1257,12 @@ instead.
 
 <a id="DEP0063"></a>
 ### DEP0063: ServerResponse.prototype.writeHeader()
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11355
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -540,6 +1274,20 @@ officially supported API.
 
 <a id="DEP0064"></a>
 ### DEP0064: tls.createSecurePair()
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11349
+    description: Runtime deprecation.
+  - version: v0.11.15
+    pr-url:
+      - https://github.com/nodejs/node-v0.x-archive/pull/8695
+      - https://github.com/nodejs/node-v0.x-archive/pull/8700
+    description: Deprecation revoked.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -548,6 +1296,15 @@ The `tls.createSecurePair()` API was deprecated in documentation in Node.js
 
 <a id="DEP0065"></a>
 ### DEP0065: repl.REPL_MODE_MAGIC and NODE_REPL_MODE=magic
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19187
+    description: End-of-Life.
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11599
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -562,6 +1319,12 @@ removed. Please use `sloppy` instead.
 
 <a id="DEP0066"></a>
 ### DEP0066: outgoingMessage.\_headers, outgoingMessage.\_headerNames
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -577,6 +1340,12 @@ were never documented as officially supported properties.
 
 <a id="DEP0067"></a>
 ### DEP0067: OutgoingMessage.prototype.\_renderHeaders
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -588,6 +1357,12 @@ an officially supported API.
 
 <a id="DEP0068"></a>
 ### DEP0068: node debug
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11441
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -596,6 +1371,18 @@ a V8-inspector based CLI debugger available through `node inspect`.
 
 <a id="DEP0069"></a>
 ### DEP0069: vm.runInDebugContext(string)
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/13295
+    description: End-of-Life.
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/12815
+    description: Runtime deprecation.
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12243
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -605,6 +1392,15 @@ DebugContext was an experimental API.
 
 <a id="DEP0070"></a>
 ### DEP0070: async_hooks.currentId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -615,6 +1411,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0071"></a>
 ### DEP0071: async_hooks.triggerId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -625,6 +1430,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0072"></a>
 ### DEP0072: async_hooks.AsyncResource.triggerId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -635,6 +1449,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0073"></a>
 ### DEP0073: Several internal properties of net.Server
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17141
+    description: End-of-Life.
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14449
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -646,6 +1469,12 @@ code, no replacement API is provided.
 
 <a id="DEP0074"></a>
 ### DEP0074: REPLServer.bufferedCommand
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13687
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -654,6 +1483,12 @@ The `REPLServer.bufferedCommand` property was deprecated in favor of
 
 <a id="DEP0075"></a>
 ### DEP0075: REPLServer.parseREPLKeyword()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14223
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -661,6 +1496,15 @@ Type: Runtime
 
 <a id="DEP0076"></a>
 ### DEP0076: tls.parseCertString()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14249
+    description: Runtime deprecation.
+  - version: v8.6.0
+    pr-url: https://github.com/nodejs/node/pull/14245
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -684,6 +1528,12 @@ difference is that `querystring.parse()` does url decoding:
 
 <a id="DEP0077"></a>
 ### DEP0077: Module.\_debug()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13948
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -694,6 +1544,12 @@ supported API.
 
 <a id="DEP0078"></a>
 ### DEP0078: REPLServer.turnOffEditorMode()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15136
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -701,6 +1557,18 @@ Type: Runtime
 
 <a id="DEP0079"></a>
 ### DEP0079: Custom inspection function on Objects via .inspect()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/20722
+    description: End-of-Life.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16393
+    description: Runtime deprecation.
+  - version: v8.7.0
+    pr-url: https://github.com/nodejs/node/pull/15631
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -711,6 +1579,12 @@ may be specified.
 
 <a id="DEP0080"></a>
 ### DEP0080: path.\_makeLong()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14956
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -720,6 +1594,12 @@ and replaced with an identical, public `path.toNamespacedPath()` method.
 
 <a id="DEP0081"></a>
 ### DEP0081: fs.truncate() using a file descriptor
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15990
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -729,6 +1609,12 @@ file descriptors.
 
 <a id="DEP0082"></a>
 ### DEP0082: REPLServer.prototype.memory()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/16242
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -737,6 +1623,12 @@ the `REPLServer` itself. Do not use this function.
 
 <a id="DEP0083"></a>
 ### DEP0083: Disabling ECDH by setting ecdhCurve to false
+<!-- YAML
+changes:
+  - version: v9.2.0
+    pr-url: https://github.com/nodejs/node/pull/16130
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -747,6 +1639,12 @@ the client. Use the `ciphers` parameter instead.
 
 <a id="DEP0084"></a>
 ### DEP0084: requiring bundled internal dependencies
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16392
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -778,6 +1676,17 @@ code modification is necessary if that is done.
 
 <a id="DEP0085"></a>
 ### DEP0085: AsyncHooks Sensitive API
+<!-- YAML
+changes:
+  - version: 10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17147
+    description: End-of-Life.
+  - version:
+    - v8.10.0
+    - v9.4.0
+    pr-url: https://github.com/nodejs/node/pull/16972
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -787,6 +1696,17 @@ API instead.
 
 <a id="DEP0086"></a>
 ### DEP0086: Remove runInAsyncIdScope
+<!-- YAML
+changes:
+  - version: 10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17147
+    description: End-of-Life.
+  - version:
+    - v8.10.0
+    - v9.4.0
+    pr-url: https://github.com/nodejs/node/pull/16972
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -796,6 +1716,14 @@ details.
 
 <a id="DEP0089"></a>
 ### DEP0089: require('assert')
+<!-- YAML
+changes:
+  - version:
+      - v9.9.0
+      - v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17002
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -805,6 +1733,15 @@ same as the legacy assert but it will always use strict equality checks.
 
 <a id="DEP0090"></a>
 ### DEP0090: Invalid GCM authentication tag lengths
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17825
+    description: End-of-Life.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18017
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -816,6 +1753,12 @@ considered invalid in compliance with [NIST SP 800-38D][].
 
 <a id="DEP0091"></a>
 ### DEP0091: crypto.DEFAULT_ENCODING
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18333
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -823,6 +1766,12 @@ The [`crypto.DEFAULT_ENCODING`][] property is deprecated.
 
 <a id="DEP0092"></a>
 ### DEP0092: Top-level `this` bound to `module.exports`
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16878
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -832,6 +1781,12 @@ or `module.exports` instead.
 
 <a id="DEP0093"></a>
 ### DEP0093: crypto.fips is deprecated and replaced.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18335
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -840,6 +1795,12 @@ and `crypto.getFips()` instead.
 
 <a id="DEP0094"></a>
 ### DEP0094: Using `assert.fail()` with more than one argument.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18418
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -849,6 +1810,12 @@ method.
 
 <a id="DEP0095"></a>
 ### DEP0095: timers.enroll()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18066
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -857,6 +1824,12 @@ Type: Runtime
 
 <a id="DEP0096"></a>
 ### DEP0096: timers.unenroll()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18066
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -865,6 +1838,12 @@ Type: Runtime
 
 <a id="DEP0097"></a>
 ### DEP0097: MakeCallback with domain property
+<!--
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17417
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -874,6 +1853,15 @@ should start using the `async_context` variant of `MakeCallback` or
 
 <a id="DEP0098"></a>
 ### DEP0098: AsyncHooks Embedder AsyncResource.emitBefore and AsyncResource.emitAfter APIs
+<!-- YAML
+changes:
+  - version:
+    - v8.12.0
+    - v9.6.0
+    - v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18632
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -887,6 +1875,12 @@ https://github.com/nodejs/node/pull/18513 for more details.
 
 <a id="DEP0099"></a>
 ### DEP0099: async context-unaware node::MakeCallback C++ APIs
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18632
+    description: Compile-time deprecation.
+-->
 
 Type: Compile-time
 
@@ -896,6 +1890,14 @@ parameter.
 
 <a id="DEP0100"></a>
 ### DEP0100: process.assert()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18666
+    description: Runtime deprecation.
+  - version: v0.3.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -905,6 +1907,12 @@ This was never a documented feature.
 
 <a id="DEP0101"></a>
 ### DEP0101: --with-lttng
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18982
+    description: End-of-Life.
+-->
 
 Type: End-of-Life
 
@@ -912,6 +1920,12 @@ The `--with-lttng` compile-time option has been removed.
 
 <a id="DEP0102"></a>
 ### DEP0102: Using `noAssert` in Buffer#(read|write) operations.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18395
+    description: End-of-Life.
+-->
 
 Type: End-of-Life
 
@@ -921,6 +1935,15 @@ could lead to hard to find errors and crashes.
 
 <a id="DEP0103"></a>
 ### DEP0103: process.binding('util').is[...] typechecks
+<!-- YAML
+changes:
+  - version: v10.9.0
+    pr-url: https://github.com/nodejs/node/pull/22004
+    description: Superseded by [DEP0111](#DEP0111).
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18415
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
 
@@ -932,6 +1955,12 @@ This deprecation has been superseded by the deprecation of the
 
 <a id="DEP0104"></a>
 ### DEP0104: process.env string coercion
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18990
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
 
@@ -943,6 +1972,15 @@ assigning it to `process.env`.
 
 <a id="DEP0105"></a>
 ### DEP0105: decipher.finaltol
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/19941
+    description: End-of-Life.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19353
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -952,6 +1990,15 @@ Type: End-of-Life
 
 <a id="DEP0106"></a>
 ### DEP0106: crypto.createCipher and crypto.createDecipher
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22089
+    description: Runtime deprecation.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19343
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -964,6 +2011,15 @@ initialization vectors. It is recommended to derive a key using
 
 <a id="DEP0107"></a>
 ### DEP0107: tls.convertNPNProtocols()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/20736
+    description: End-of-Life.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19403
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -972,6 +2028,12 @@ core and obsoleted by the removal of NPN (Next Protocol Negotiation) support.
 
 <a id="DEP0108"></a>
 ### DEP0108: zlib.bytesRead
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19414
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -982,6 +2044,12 @@ expose values under these names.
 
 <a id="DEP0109"></a>
 ### DEP0109: http, https, and tls support for invalid URLs
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/20270
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -994,6 +2062,12 @@ deprecated and support will be removed in the future.
 
 <a id="DEP0110"></a>
 ### DEP0110: vm.Script cached data
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/20300
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -1002,6 +2076,12 @@ The `produceCachedData` option is deprecated. Use
 
 <a id="DEP0111"></a>
 ### DEP0111: process.binding()
+<!-- YAML
+changes:
+  - version: v10.9.0
+    pr-url: https://github.com/nodejs/node/pull/22004
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -1010,6 +2090,12 @@ only. Use of `process.binding()` by userland code is unsupported.
 
 <a id="DEP0112"></a>
 ### DEP0112: dgram private APIs
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22011
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -1022,6 +2108,12 @@ accessed outside of Node.js core: `Socket.prototype._handle`,
 
 <a id="DEP0113"></a>
 ### DEP0113: Cipher.setAuthTag(), Decipher.getAuthTag()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22126
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -1032,6 +2124,12 @@ release.
 
 <a id="DEP0114"></a>
 ### DEP0114: crypto._toBuf()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22501
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -1040,6 +2138,12 @@ of Node.js core and will be removed in the future.
 
 <a id="DEP0115"></a>
 ### DEP0115: crypto.prng(), crypto.pseudoRandomBytes(), crypto.rng()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22519
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -1051,6 +2155,12 @@ future release.
 
 <a id="DEP0116"></a>
 ### DEP0116: Legacy URL API
+<!-- YAML
+changes:
+  - version: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/22715
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -871,14 +871,23 @@ The [`tls.CryptoStream`][] class was removed. Please use
 ### DEP0043: tls.SecurePair
 <!-- YAML
 changes:
-  - version:
-    - v4.8.6
-    - v6.12.0
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11349
+    description: Runtime deprecation.
+  - version: v6.12.0
     pr-url: https://github.com/nodejs/node/pull/10116
     description: A deprecation code has been assigned.
-  - version:
-    pr-url:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6063
     description: Documentation-only deprecation.
+  - version: v0.11.15
+    pr-url:
+      - https://github.com/nodejs/node-v0.x-archive/pull/8695
+      - https://github.com/nodejs/node-v0.x-archive/pull/8700
+    description: Deprecation revoked.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Runtime deprecation.
 -->
 
 Type: Documentation-only
@@ -1280,6 +1289,12 @@ changes:
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11349
     description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6063
+    description: Documentation-only deprecation.
   - version: v0.11.15
     pr-url:
       - https://github.com/nodejs/node-v0.x-archive/pull/8695

--- a/tools/doc/common.js
+++ b/tools/doc/common.js
@@ -43,4 +43,4 @@ function extractAndParseYAML(text) {
   return meta;
 }
 
-module.exports = { isYAMLBlock, extractAndParseYAML };
+module.exports = { arrify, isYAMLBlock, extractAndParseYAML };

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -308,7 +308,9 @@ function parseYAML(text) {
         .use(htmlStringify)
         .processSync(change.description).toString();
 
-      result += `<tr><td>${change.version}</td>\n` +
+      const version = common.arrify(change.version).join(', ');
+
+      result += `<tr><td>${version}</td>\n` +
                   `<td>${description}</td></tr>\n`;
     });
 
@@ -326,10 +328,16 @@ function parseYAML(text) {
   return result;
 }
 
+function minVersion(a) {
+  if (!Array.isArray(a))
+    return a;
+  return a.reduce((min, e) => !min || versionSort(min, e) < 0 ? e : min);
+}
+
 const numberRe = /^\d*/;
 function versionSort(a, b) {
-  a = a.trim();
-  b = b.trim();
+  a = minVersion(a).trim();
+  b = minVersion(b).trim();
   let i = 0; // Common prefix length.
   while (i < a.length && i < b.length && a[i] === b[i]) i++;
   a = a.substr(i);

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -329,9 +329,9 @@ function parseYAML(text) {
 }
 
 function minVersion(a) {
-  if (!Array.isArray(a))
-    return a;
-  return a.reduce((min, e) => !min || versionSort(min, e) < 0 ? e : min);
+  return common.arrify(a).reduce((min, e) => {
+    return !min || versionSort(min, e) < 0 ? e : min;
+  });
 }
 
 const numberRe = /^\d*/;


### PR DESCRIPTION
I've had a hard time working with the deprecation documentation since it is currently lacking a history. Finding out when a deprecation was introduced or changed is difficult via Git and often impossible using our documentation alone. I think it is crucial to make the deprecation history transparent to users, so I tried to manually reconstruct the history of deprecations and to track them down to their origins. Having these documented publicly makes it much easier for users to find out when deprecations were introduced or changed, and it also helps us in maintaining Node.js.

The diff itself is large but will be low-maintenance once we start properly documenting these things. I also had to slightly fix the documentation tool to accept multiple versions for a single change. Note that some ancient versions might be slightly imprecise, tracking down deprecations from pre-io.js releases turned out to be difficult from time to time.

(This partially reverts https://github.com/nodejs/node/pull/21498 in that it adds the removed documentation sections again and updates them to properly represent the history of these deprecations.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
