### PR TITLE
crypto: rename symbols to match guidelines

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -23,8 +23,8 @@ const { inherits } = require('util');
 const { normalizeEncoding } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const LazyTransform = require('internal/streams/lazy_transform');
-const kState = Symbol('state');
-const kFinalized = Symbol('finalized');
+const kState = Symbol('kState');
+const kFinalized = Symbol('kFinalized');
 
 function Hash(algorithm, options) {
   if (!(this instanceof Hash))


### PR DESCRIPTION
As suggested by @addaleax in https://github.com/nodejs/node/pull/22684, rename symbols to match the variable name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
