### PR TITLE
Revert "build: enabling pgo at configure"

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -179,19 +179,9 @@
           }],
           ['OS=="linux"', {
             'variables': {
-              'pgo_generate': ' -fprofile-generate ',
-              'pgo_use': ' -fprofile-use -fprofile-correction ',
               'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ',
             },
             'conditions': [
-              ['enable_pgo_generate=="true"', {
-                'cflags': ['<(pgo_generate)'],
-                'ldflags': ['<(pgo_generate)'],
-              },],
-              ['enable_pgo_use=="true"', {
-                'cflags': ['<(pgo_use)'],
-                'ldflags': ['<(pgo_use)'],
-              },],
               ['enable_lto=="true"', {
                 'cflags': ['<(lto)'],
                 'ldflags': ['<(lto)'],

--- a/configure.py
+++ b/configure.py
@@ -132,23 +132,11 @@ parser.add_option("--enable-vtune-profiling",
          "JavaScript code executed in nodejs. This feature is only available "
          "for x32, x86, and x64 architectures.")
 
-parser.add_option("--enable-pgo-generate",
-    action="store_true",
-    dest="enable_pgo_generate",
-    help="Enable profiling with pgo of a binary. This feature is only available "
-         "on linux with gcc and g++ 5.4.1 or newer.")
-
-parser.add_option("--enable-pgo-use",
-    action="store_true",
-    dest="enable_pgo_use",
-    help="Enable use of the profile generated with --enable-pgo-generate. This "
-         "feature is only available on linux with gcc and g++ 5.4.1 or newer.")
-
 parser.add_option("--enable-lto",
     action="store_true",
     dest="enable_lto",
     help="Enable compiling with lto of a binary. This feature is only available "
-         "on linux with gcc and g++ 5.4.1 or newer.")
+         "on linux with gcc and g++.")
 
 parser.add_option("--link-module",
     action="append",
@@ -899,16 +887,6 @@ def configure_mips(o):
   o['variables']['mips_fpu_mode'] = options.mips_fpu_mode
 
 
-def gcc_version_ge(version_checked):
-  for compiler in [(CC, 'c'), (CXX, 'c++')]:
-    ok, is_clang, clang_version, compiler_version = \
-      try_check_compiler(compiler[0], compiler[1])
-    compiler_version_num = tuple(map(int, compiler_version))
-    if is_clang or compiler_version_num < version_checked:
-      return False
-  return True
-
-
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
@@ -953,29 +931,6 @@ def configure_node(o):
   else:
     o['variables']['node_enable_v8_vtunejit'] = 'false'
 
-  if flavor != 'linux' and (options.enable_pgo_generate or options.enable_pgo_use):
-    raise Exception(
-      'The pgo option is supported only on linux.')
-
-  if flavor == 'linux':
-    if options.enable_pgo_generate or options.enable_pgo_use:
-      version_checked = (5, 4, 1)
-      if not gcc_version_ge(version_checked):
-        version_checked_str = ".".join(map(str, version_checked))
-        raise Exception(
-          'The options --enable-pgo-generate and --enable-pgo-use '
-          'are supported for gcc and gxx %s or newer only.' % (version_checked_str))
-
-    if options.enable_pgo_generate and options.enable_pgo_use:
-      raise Exception(
-        'Only one of the --enable-pgo-generate or --enable-pgo-use options '
-        'can be specified at a time. You would like to use '
-        '--enable-pgo-generate first, profile node, and then recompile '
-        'with --enable-pgo-use')
-
-  o['variables']['enable_pgo_generate'] = b(options.enable_pgo_generate)
-  o['variables']['enable_pgo_use']      = b(options.enable_pgo_use)
-
   if flavor != 'linux' and (options.enable_lto):
     raise Exception(
       'The lto option is supported only on linux.')
@@ -983,11 +938,15 @@ def configure_node(o):
   if flavor == 'linux':
     if options.enable_lto:
       version_checked = (5, 4, 1)
-      if not gcc_version_ge(version_checked):
-        version_checked_str = ".".join(map(str, version_checked))
-        raise Exception(
-          'The option --enable-lto is supported for gcc and gxx %s'
-          ' or newer only.' % (version_checked_str))
+      for compiler in [(CC, 'c'), (CXX, 'c++')]:
+        ok, is_clang, clang_version, compiler_version = \
+          try_check_compiler(compiler[0], compiler[1])
+        compiler_version_num = tuple(map(int, compiler_version))
+        if is_clang or compiler_version_num < version_checked:
+          version_checked_str = ".".join(map(str, version_checked))
+          raise Exception(
+            'The option --enable-lto is supported for gcc and gxx %s'
+            ' or newer only.' % (version_checked_str))
 
   o['variables']['enable_lto'] = b(options.enable_lto)
 


### PR DESCRIPTION
This reverts commit 9be15559cc0bfe506d9cdfba4ad0f4beacf5ce17.

This commit broke native addon compilation by adding
variables to `common.gypi` that are not available
to builds outside of Node.js core.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
