### PR TITLE
worker: correct (de)initialization order

### DIFF
--- a/test/parallel/test-worker-invalid-workerdata.js
+++ b/test/parallel/test-worker-invalid-workerdata.js
@@ -1,0 +1,15 @@
+// Flags: --experimental-worker
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// This tests verifies that failing to serialize workerData does not keep
+// the process alive.
+// Refs: https://github.com/nodejs/node/issues/22736
+
+assert.throws(() => {
+  new Worker('./worker.js', {
+    workerData: { fn: () => {} }
+  });
+}, /DataCloneError/);


### PR DESCRIPTION
- Initialize `thread_exit_async_` only once the thread has been
  started. This is done since it is only triggered from the
  thread when it is exiting.
- Move the final `uv_run` to the `Worker` destructor.
  This makes sure that it is always run, regardless of whether
  the thread is actually started or not.
- Always dispose the `Isolate` before cleaning up the libuv event
  loop. This now matches the reverse order of initialization.

Fixes: https://github.com/nodejs/node/issues/22736

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @nodejs/workers 