### PR TITLE
crypto: fix public key encryption internals

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3887,7 +3887,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   bool r = Cipher<operation, EVP_PKEY_cipher_init, EVP_PKEY_cipher>(
       kbuf,
       klen,
-      args.Length() >= 3 && !args[2]->IsNull() ? *passphrase : nullptr,
+      args.Length() >= 4 && !args[3]->IsNull() ? *passphrase : nullptr,
       padding,
       reinterpret_cast<const unsigned char*>(buf),
       len,


### PR DESCRIPTION
This should have been updated in 6adf3ecebb42c05662f7c6a792953589ffdfd4dc. Coincidentally, the old version works as well since the `padding` parameter is never `null`, but it is semantically incorrect.

cc @nodejs/crypto

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
