### PR TITLE
src: move no_async_hooks_checks to env

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -189,6 +189,9 @@ Environment::Environment(IsolateData* isolate_data,
 
   isolate()->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
       BuildEmbedderGraph, this);
+  if (options_->no_force_async_hooks_checks) {
+    async_hooks_.no_force_checks();
+  }
 }
 
 Environment::~Environment() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2977,12 +2977,6 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
     return 12;  // Signal internal error.
   }
 
-  // TODO(addaleax): Maybe access this option directly instead of setting
-  // a boolean member of Environment. Ditto below for trace_sync_io.
-  if (env.options()->no_force_async_hooks_checks) {
-    env.async_hooks()->no_force_checks();
-  }
-
   {
     Environment::AsyncCallbackScope callback_scope(&env);
     env.async_hooks()->push_async_ids(1, 0);


### PR DESCRIPTION
This commit moves the setting of AsyncHooks no_force_checks to the
Environment constructor instead of from the Start function in node.cc.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
