### PR TITLE
util: fix indentationLvl when exceeding max call stack size

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -872,6 +872,7 @@ function formatRaw(ctx, value, recurseTimes) {
 
   ctx.seen.push(value);
   let output;
+  const indentationLvl = ctx.indentationLvl;
   try {
     output = formatter(ctx, value, recurseTimes, keys);
     if (skip === false) {
@@ -881,16 +882,17 @@ function formatRaw(ctx, value, recurseTimes) {
       }
     }
   } catch (err) {
-    return handleMaxCallStackSize(ctx, err, constructor, tag);
+    return handleMaxCallStackSize(ctx, err, constructor, tag, indentationLvl);
   }
   ctx.seen.pop();
 
   return reduceToSingleString(ctx, output, base, braces);
 }
 
-function handleMaxCallStackSize(ctx, err, constructor, tag) {
+function handleMaxCallStackSize(ctx, err, constructor, tag, indentationLvl) {
   if (errors.isStackOverflowError(err)) {
     ctx.seen.pop();
+    ctx.indentationLvl = indentationLvl;
     return ctx.stylize(
       `[${constructor || tag || 'Object'}: Inspection interrupted ` +
         'prematurely. Maximum call stack size exceeded.]',


### PR DESCRIPTION
The inspection indentation level was not always reset to it's former
value in case the maximum call stack size was exceeded.

It did not seem to be critical to add a test case for this as it's a pretty
special case that has no completely reliable output anyway (the stack
limit is not going to be identical on each run).
Please let me know if you feel I should add a test nevertheless.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
