### PR TITLE
src: fix `--prof-process` CLI argument handling

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -693,9 +693,11 @@
       for (const [ from, expansion ] of aliases) {
         let isAccepted = true;
         for (const to of expansion) {
-          if (!to.startsWith('-')) continue;
+          if (!to.startsWith('-') || to === '--') continue;
           const recursiveExpansion = aliases.get(to);
           if (recursiveExpansion) {
+            if (recursiveExpansion[0] === to)
+              recursiveExpansion.splice(0, 1);
             expansion.push(...recursiveExpansion);
             continue;
           }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -108,6 +108,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--prof-process",
             "process V8 profiler output generated using --prof",
             &EnvironmentOptions::prof_process);
+  // Options after --prof-process are passed through to the prof processor.
+  AddAlias("--prof-process", { "--prof-process", "--" });
   AddOption("--redirect-warnings",
             "write warnings to file instead of stderr",
             &EnvironmentOptions::redirect_warnings,

--- a/test/parallel/test-tick-processor-arguments.js
+++ b/test/parallel/test-tick-processor-arguments.js
@@ -7,6 +7,8 @@ const { spawnSync } = require('child_process');
 
 if (!common.isMainThread)
   common.skip('chdir not available in workers');
+if (!common.enoughTestMem)
+  common.skip('skipped due to memory requirements');
 
 tmpdir.refresh();
 process.chdir(tmpdir.path);

--- a/test/parallel/test-tick-processor-arguments.js
+++ b/test/parallel/test-tick-processor-arguments.js
@@ -1,9 +1,12 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const fs = require('fs');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
+
+if (!common.isMainThread)
+  common.skip('chdir not available in workers');
 
 tmpdir.refresh();
 process.chdir(tmpdir.path);
@@ -14,7 +17,10 @@ spawnSync(process.execPath, [ '--prof', '-p', '42' ]);
 const logfile = fs.readdirSync('.').filter((name) => name.endsWith('.log'))[0];
 assert(logfile);
 
-// Make sure that the --preprocess argument is passed through correctly.
+// Make sure that the --preprocess argument is passed through correctly,
+// as an example flag listed in deps/v8/tools/tickprocessor.js.
+// Any of the other flags there should work for this test too, if --preprocess
+// is ever removed.
 const { stdout } = spawnSync(
   process.execPath,
   [ '--prof-process', '--preprocess', logfile ],

--- a/test/parallel/test-tick-processor-arguments.js
+++ b/test/parallel/test-tick-processor-arguments.js
@@ -9,6 +9,8 @@ if (!common.isMainThread)
   common.skip('chdir not available in workers');
 if (!common.enoughTestMem)
   common.skip('skipped due to memory requirements');
+if (common.isAIX)
+  common.skip('does not work on AIX');
 
 tmpdir.refresh();
 process.chdir(tmpdir.path);

--- a/test/parallel/test-tick-processor-arguments.js
+++ b/test/parallel/test-tick-processor-arguments.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+tmpdir.refresh();
+process.chdir(tmpdir.path);
+
+// Generate log file.
+spawnSync(process.execPath, [ '--prof', '-p', '42' ]);
+
+const logfile = fs.readdirSync('.').filter((name) => name.endsWith('.log'))[0];
+assert(logfile);
+
+// Make sure that the --preprocess argument is passed through correctly.
+const { stdout } = spawnSync(
+  process.execPath,
+  [ '--prof-process', '--preprocess', logfile ],
+  { encoding: 'utf8' });
+
+// Make sure that the result is valid JSON.
+JSON.parse(stdout);


### PR DESCRIPTION
Make sure that options after `--prof-process` are not treated
as Node.js options.

Fixes: https://github.com/nodejs/node/issues/22786

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
