### PR TITLE
fs: ensure readdir() callback is only called once

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -10,6 +10,7 @@ const {
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { isUint8Array, isArrayBufferView } = require('internal/util/types');
+const { once } = require('internal/util');
 const pathModule = require('path');
 const util = require('util');
 const kType = Symbol('type');
@@ -123,6 +124,7 @@ function getDirents(path, [names, types], callback) {
   if (typeof callback == 'function') {
     const len = names.length;
     let toFinish = 0;
+    callback = once(callback);
     for (i = 0; i < len; i++) {
       const type = types[i];
       if (type === UV_DIRENT_UNKNOWN) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -5,20 +5,12 @@
 
 let eos;
 
+const { once } = require('internal/util');
 const {
   ERR_INVALID_CALLBACK,
   ERR_MISSING_ARGS,
   ERR_STREAM_DESTROYED
 } = require('internal/errors').codes;
-
-function once(callback) {
-  let called = false;
-  return function(err) {
-    if (called) return;
-    called = true;
-    callback(err);
-  };
-}
 
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -365,6 +365,15 @@ function isInsideNodeModules() {
   return false;
 }
 
+function once(callback) {
+  let called = false;
+  return function(...args) {
+    if (called) return;
+    called = true;
+    callback(...args);
+  };
+}
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -381,6 +390,7 @@ module.exports = {
   join,
   normalizeEncoding,
   objectToString,
+  once,
   promisify,
   spliceOne,
   removeColors,


### PR DESCRIPTION
This commit ensures that the `readdir()` callback can only be called once when the `withFileTypes` parameter is supplied.

Fixes: https://github.com/nodejs/node/issues/22778

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
