### PR TITLE
Http2 timeout documentation

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1617,6 +1617,23 @@ The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 **Default:** 2 minutes.
 
+#### server.setTimeout([msecs][, callback])
+<!-- YAML
+added: v8.4.0
+-->
+
+* `msecs` {number} **Default:** `120000` (2 minutes)
+* `callback` {Function}
+* Returns: {Http2SecureServer}
+
+Sets the timeout value for http2 secure server requests, and emits a `'timeout'` event on
+the Server object if a timeout occurs.
+
+By default, the Server's timeout value is 2 minutes, if a callback is assigned
+to the Server's `'timeout'` event, timeouts must be handled explicitly.
+
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throwen.
+
 #### server.close([callback])
 <!-- YAML
 added: v8.4.0
@@ -1740,6 +1757,23 @@ The `'unknownProtocol'` event is emitted when a connecting client fails to
 negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
 receives the socket for handling. If no listener is registered for this event,
 the connection is terminated. See the [Compatibility API][].
+
+#### server.setTimeout([msecs][, callback])
+<!-- YAML
+added: v8.4.0
+-->
+
+* `msecs` {number} **Default:** `120000` (2 minutes)
+* `callback` {Function}
+* Returns: {Http2SecureServer}
+
+Sets the timeout value for http2 secure server requests, and emits a `'timeout'` event on
+the Server object if a timeout occurs.
+
+By default, the Server's timeout value is 2 minutes, if a callback is assigned
+to the Server's `'timeout'` event, timeouts must be handled explicitly.
+
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throwen.
 
 #### server.close([callback])
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1615,7 +1615,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
-**Default:** `2 Minutes`.
+**Default:** 2 Minutes.
 
 #### server.close([callback])
 <!-- YAML
@@ -1729,7 +1729,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2secureServer.setTimeout()`.
-**Default:** `2 Minutes`.
+**Default:** 2 Minutes.
 
 #### Event: 'unknownProtocol'
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1624,15 +1624,13 @@ added: v8.4.0
 
 * `msecs` {number} **Default:** `120000` (2 minutes)
 * `callback` {Function}
-* Returns: {Http2SecureServer}
+* Returns: {Http2Server}
 
-Sets the timeout value for http2 secure server requests, and emits a `'timeout'` event on
-the Server object if a timeout occurs.
+Used to set the timeout value for http2 secure server requests, and sets a callback function that is called when there is no activity on the Http2Server after `msecs` milliseconds. 
 
-By default, the Server's timeout value is 2 minutes, if a callback is assigned
-to the Server's `'timeout'` event, timeouts must be handled explicitly.
+The given callback is registered as a listener on the 'timeout' event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throwen.
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throw.
 
 #### server.close([callback])
 <!-- YAML
@@ -1767,13 +1765,11 @@ added: v8.4.0
 * `callback` {Function}
 * Returns: {Http2SecureServer}
 
-Sets the timeout value for http2 secure server requests, and emits a `'timeout'` event on
-the Server object if a timeout occurs.
+Used to set the timeout value for http2 secure server requests, and sets a callback function that is called when there is no activity on the Http2SecureServer after `msecs` milliseconds. 
 
-By default, the Server's timeout value is 2 minutes, if a callback is assigned
-to the Server's `'timeout'` event, timeouts must be handled explicitly.
+The given callback is registered as a listener on the 'timeout' event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throwen.
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throw.
 
 #### server.close([callback])
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1626,11 +1626,14 @@ added: v8.4.0
 * `callback` {Function}
 * Returns: {Http2Server}
 
-Used to set the timeout value for http2 secure server requests, and sets a callback function that is called when there is no activity on the Http2Server after `msecs` milliseconds. 
+Used to set the timeout value for http2 secure server requests, 
+and sets a callback function that is called when there is no activity 
+on the Http2Server after `msecs` milliseconds. 
 
 The given callback is registered as a listener on the 'timeout' event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throw.
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+error will be throw.
 
 #### server.close([callback])
 <!-- YAML
@@ -1763,13 +1766,16 @@ added: v8.4.0
 
 * `msecs` {number} **Default:** `120000` (2 minutes)
 * `callback` {Function}
-* Returns: {Http2SecureServer}
+* Returns: {Http2Server}
 
-Used to set the timeout value for http2 secure server requests, and sets a callback function that is called when there is no activity on the Http2SecureServer after `msecs` milliseconds. 
+Used to set the timeout value for http2 secure server requests, 
+and sets a callback function that is called when there is no activity 
+on the Http2Server after `msecs` milliseconds. 
 
 The given callback is registered as a listener on the 'timeout' event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` error will be throw.
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+error will be throw.
 
 #### server.close([callback])
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1615,6 +1615,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
+**Default:** `2 Minutes`.
 
 #### server.close([callback])
 <!-- YAML
@@ -1728,6 +1729,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2secureServer.setTimeout()`.
+**Default:** `2 Minutes`.
 
 #### Event: 'unknownProtocol'
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1780,9 +1780,9 @@ added: v8.4.0
 * `callback` {Function}
 * Returns: {Http2SecureServer}
 
-Used to set the timeout value for http2 server requests, 
+Used to set the timeout value for http2 secure server requests, 
 and sets a callback function that is called when there is no activity 
-on the `Http2Server` after `msecs` milliseconds. 
+on the `Http2SecureServer` after `msecs` milliseconds. 
 
 The given callback is registered as a listener on the `'timeout'` event.
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1615,7 +1615,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
-**Default:** 2 Minutes.
+**Default:** 2 minutes.
 
 #### server.close([callback])
 <!-- YAML
@@ -1729,7 +1729,7 @@ added: v8.4.0
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2secureServer.setTimeout()`.
-**Default:** 2 Minutes.
+**Default:** 2 minutes.
 
 #### Event: 'unknownProtocol'
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1617,24 +1617,6 @@ The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 **Default:** 2 minutes.
 
-#### server.setTimeout([msecs][, callback])
-<!-- YAML
-added: v8.4.0
--->
-
-* `msecs` {number} **Default:** `120000` (2 minutes)
-* `callback` {Function}
-* Returns: {Http2Server}
-
-Used to set the timeout value for http2 secure server requests, 
-and sets a callback function that is called when there is no activity 
-on the Http2Server after `msecs` milliseconds. 
-
-The given callback is registered as a listener on the 'timeout' event.
-
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
-error will be throw.
-
 #### server.close([callback])
 <!-- YAML
 added: v8.4.0
@@ -1646,6 +1628,24 @@ Stops the server from accepting new connections.  See [`net.Server.close()`][].
 Note that this is not analogous to restricting new requests since HTTP/2
 connections are persistent. To achieve a similar graceful shutdown behavior,
 consider also using [`http2session.close()`] on active sessions.
+
+#### server.setTimeout([msecs][, callback])
+<!-- YAML
+added: v8.4.0
+-->
+
+* `msecs` {number} **Default:** `120000` (2 minutes)
+* `callback` {Function}
+* Returns: {Http2Server}
+
+Used to set the timeout value for http2 server requests, 
+and sets a callback function that is called when there is no activity 
+on the `Http2Server` after `msecs` milliseconds. 
+
+The given callback is registered as a listener on the `'timeout'` event.
+
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+error will be thrown.
 
 ### Class: Http2SecureServer
 <!-- YAML
@@ -1759,24 +1759,6 @@ negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
 receives the socket for handling. If no listener is registered for this event,
 the connection is terminated. See the [Compatibility API][].
 
-#### server.setTimeout([msecs][, callback])
-<!-- YAML
-added: v8.4.0
--->
-
-* `msecs` {number} **Default:** `120000` (2 minutes)
-* `callback` {Function}
-* Returns: {Http2Server}
-
-Used to set the timeout value for http2 secure server requests, 
-and sets a callback function that is called when there is no activity 
-on the Http2Server after `msecs` milliseconds. 
-
-The given callback is registered as a listener on the 'timeout' event.
-
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
-error will be throw.
-
 #### server.close([callback])
 <!-- YAML
 added: v8.4.0
@@ -1788,6 +1770,24 @@ Stops the server from accepting new connections.  See [`tls.Server.close()`][].
 Note that this is not analogous to restricting new requests since HTTP/2
 connections are persistent. To achieve a similar graceful shutdown behavior,
 consider also using [`http2session.close()`] on active sessions.
+
+#### server.setTimeout([msecs][, callback])
+<!-- YAML
+added: v8.4.0
+-->
+
+* `msecs` {number} **Default:** `120000` (2 minutes)
+* `callback` {Function}
+* Returns: {Http2SecureServer}
+
+Used to set the timeout value for http2 server requests, 
+and sets a callback function that is called when there is no activity 
+on the `Http2Server` after `msecs` milliseconds. 
+
+The given callback is registered as a listener on the `'timeout'` event.
+
+In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+error will be thrown.
 
 ### http2.createServer(options[, onRequestHandler])
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1644,7 +1644,7 @@ on the `Http2Server` after `msecs` milliseconds.
 
 The given callback is registered as a listener on the `'timeout'` event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+In case of no callback function were assigned, a new `ERR_INVALID_CALLBACK` 
 error will be thrown.
 
 ### Class: Http2SecureServer
@@ -1786,7 +1786,7 @@ on the `Http2Server` after `msecs` milliseconds.
 
 The given callback is registered as a listener on the `'timeout'` event.
 
-In case of no callback were assigned, a new `ERR_INVALID_CALLBACK` 
+In case of no callback function were assigned, a new `ERR_INVALID_CALLBACK` 
 error will be thrown.
 
 ### http2.createServer(options[, onRequestHandler])


### PR DESCRIPTION
Added into documentation new default timeout values of "2 minutes" under 2 classes at "Event: 'timeout'" section.

1) Class: Http2SecureServer
2) Class: Http2Server

Documentation:
https://nodejs.org/api/http2.html#http2_event_timeout_2
https://nodejs.org/api/http2.html#http2_event_timeout_3
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
