### PR TITLE
lib: Simplify 'processChunkSync'

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -527,13 +527,11 @@ function processChunkSync(self, chunk, flushFlag) {
   }
 
   self.bytesWritten = inputRead;
+  _close(self);
 
   if (nread >= kMaxLength) {
-    _close(self);
     throw new ERR_BUFFER_TOO_LARGE();
   }
-
-  _close(self);
 
   if (nread === 0)
     return Buffer.alloc(0);


### PR DESCRIPTION
According to the real logic codes, it seems no matter whether 'nread >=
kMaxLength' or not. We always close the 'self' stream first. So we can
shorten it by merging them into one.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]
