### PR TITLE
fs: consistently return symlink type from readdir

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -129,7 +129,7 @@ function getDirents(path, [names, types], callback) {
         const name = names[i];
         const idx = i;
         toFinish++;
-        lazyLoadFs().stat(pathModule.resolve(path, name), (err, stats) => {
+        lazyLoadFs().lstat(pathModule.join(path, name), (err, stats) => {
           if (err) {
             callback(err);
             return;
@@ -152,7 +152,7 @@ function getDirents(path, [names, types], callback) {
       const type = types[i];
       if (type === UV_DIRENT_UNKNOWN) {
         const name = names[i];
-        const stats = lazyLoadFs().statSync(pathModule.resolve(path, name));
+        const stats = lazyLoadFs().lstatSync(pathModule.join(path, name));
         names[i] = new DirentFromStats(name, stats);
       } else {
         names[i] = new Dirent(names[i], types[i]);


### PR DESCRIPTION
Use 'lstat' to determine type of directory entry.
This is more consistent with the type returned from the readdir binding.
Also use 'path.join' over 'path.resolve' because 'name' is not absolute.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
