### PR TITLE
tracing: Fix some race conditions

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/libplatform/tracing/tracing-controller.cc
+++ b/deps/v8/src/libplatform/tracing/tracing-controller.cc
@@ -63,13 +63,15 @@ uint64_t TracingController::AddTraceEvent(
     const uint64_t* arg_values,
     std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
     unsigned int flags) {
-  uint64_t handle;
-  TraceObject* trace_object = trace_buffer_->AddTraceEvent(&handle);
-  if (trace_object) {
-    trace_object->Initialize(
-        phase, category_enabled_flag, name, scope, id, bind_id, num_args,
-        arg_names, arg_types, arg_values, arg_convertables, flags,
-        CurrentTimestampMicroseconds(), CurrentCpuTimestampMicroseconds());
+  uint64_t handle = 0;
+  if (mode_ != DISABLED) {
+    TraceObject* trace_object = trace_buffer_->AddTraceEvent(&handle);
+    if (trace_object) {
+      trace_object->Initialize(
+          phase, category_enabled_flag, name, scope, id, bind_id, num_args,
+          arg_names, arg_types, arg_values, arg_convertables, flags,
+          CurrentTimestampMicroseconds(), CurrentCpuTimestampMicroseconds());
+    }
   }
   return handle;
 }
@@ -81,13 +83,15 @@ uint64_t TracingController::AddTraceEventWithTimestamp(
     const uint64_t* arg_values,
     std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
     unsigned int flags, int64_t timestamp) {
-  uint64_t handle;
-  TraceObject* trace_object = trace_buffer_->AddTraceEvent(&handle);
-  if (trace_object) {
-    trace_object->Initialize(phase, category_enabled_flag, name, scope, id,
-                             bind_id, num_args, arg_names, arg_types,
-                             arg_values, arg_convertables, flags, timestamp,
-                             CurrentCpuTimestampMicroseconds());
+  uint64_t handle = 0;
+  if (mode_ != DISABLED) {
+    TraceObject* trace_object = trace_buffer_->AddTraceEvent(&handle);
+    if (trace_object) {
+      trace_object->Initialize(phase, category_enabled_flag, name, scope, id,
+                               bind_id, num_args, arg_names, arg_types,
+                               arg_values, arg_convertables, flags, timestamp,
+                               CurrentCpuTimestampMicroseconds());
+    }
   }
   return handle;
 }

--- a/src/tracing/node_trace_buffer.cc
+++ b/src/tracing/node_trace_buffer.cc
@@ -59,7 +59,13 @@ void InternalTraceBuffer::Flush(bool blocking) {
       for (size_t i = 0; i < total_chunks_; ++i) {
         auto& chunk = chunks_[i];
         for (size_t j = 0; j < chunk->size(); ++j) {
-          agent_->AppendTraceEvent(chunk->GetEventAt(j));
+          TraceObject* trace_event = chunk->GetEventAt(j);
+          // Another thread may have added a trace that is yet to be
+          // initialized. Skip such traces.
+          // https://github.com/nodejs/node/issues/21038.
+          if (trace_event->name()) {
+            agent_->AppendTraceEvent(trace_event);
+          }
         }
       }
       total_chunks_ = 0;


### PR DESCRIPTION
This PR contains two commits that fix some race conditions that were causing flakiness on https://github.com/nodejs/node/issues/21038. There may yet be more races, but this is what I got right now.

One of the commits is an upstream V8 fix. I didn't bother requesting an upstream back-port as it is not particular useful for Chrome and better to float here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

