### PR TITLE
doc, win: improve os.setPriority documentation

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -371,6 +371,9 @@ priority classes, `priority` is mapped to one of six priority constants in
 mapping may cause the return value to be slightly different on Windows. To avoid
 confusion, it is recommended to set `priority` to one of the priority constants.
 
+On Windows setting priority to `PRIORITY_HIGHEST` requires elevated user,
+otherwise the set priority will be silently reduced to `PRIORITY_HIGH`.
+
 ## os.tmpdir()
 <!-- YAML
 added: v0.9.9

--- a/test/parallel/test-os-process-priority.js
+++ b/test/parallel/test-os-process-priority.js
@@ -116,8 +116,10 @@ function checkPriority(pid, expected) {
     return;
   }
 
+  // On Windows setting PRIORITY_HIGHEST will only work for elevated user,
+  // for others it will be silently reduced to PRIORITY_HIGH
   if (expected < PRIORITY_HIGH)
-    assert.strictEqual(priority, PRIORITY_HIGHEST);
+    assert.ok(priority === PRIORITY_HIGHEST || priority === PRIORITY_HIGH);
   else if (expected < PRIORITY_ABOVE_NORMAL)
     assert.strictEqual(priority, PRIORITY_HIGH);
   else if (expected < PRIORITY_NORMAL)


### PR DESCRIPTION
Also fixes the test: https://github.com/nodejs/node/issues/22799

See https://support.microsoft.com/en-us/help/110853/prb-can-t-increase-process-priority

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
