### PR TITLE
(v10.x backport) doc: add full deprecation history

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -40,6 +40,17 @@ However, the deprecation identifier will not be modified.
 
 <a id="DEP0001"></a>
 ### DEP0001: http.OutgoingMessage.prototype.flush
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.6.0
+    pr-url: https://github.com/nodejs/node/pull/1156
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -48,6 +59,18 @@ The `OutgoingMessage.prototype.flush()` method is deprecated. Use
 
 <a id="DEP0002"></a>
 ### DEP0002: require('\_linklist')
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12113
+    description: End-of-Life.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3078
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -55,6 +78,17 @@ The `_linklist` module is deprecated. Please use a userland alternative.
 
 <a id="DEP0003"></a>
 ### DEP0003: \_writableState.buffer
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.15
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/8826
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -63,6 +97,20 @@ The `_writableState.buffer` property is deprecated. Use the
 
 <a id="DEP0004"></a>
 ### DEP0004: CryptoStream.prototype.readyState
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17882
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: 0.4.0
+    commit: 9c7f89bf56abd37a796fea621ad2e47dd33d2b82
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -70,6 +118,18 @@ The `CryptoStream.prototype.readyState` property was removed.
 
 <a id="DEP0005"></a>
 ### DEP0005: Buffer() constructor
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19524
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4682
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime (supports [`--pending-deprecation`][])
 
@@ -98,6 +158,18 @@ outside `node_modules` in order to better target developers, rather than users.
 
 <a id="DEP0006"></a>
 ### DEP0006: child\_process options.customFds
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.14
+    description: Runtime deprecation.
+  - version: v0.5.11
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -107,6 +179,21 @@ option should be used instead.
 
 <a id="DEP0007"></a>
 ### DEP0007: Replace cluster worker.suicide with worker.exitedAfterDisconnect
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13702
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/3747
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/3743
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -119,6 +206,15 @@ precisely describe the actual semantics and was unnecessarily emotion-laden.
 
 <a id="DEP0008"></a>
 ### DEP0008: require('constants')
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.3.0
+    pr-url: https://github.com/nodejs/node/pull/6534
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -129,6 +225,18 @@ to the `constants` property exposed by the relevant module. For instance,
 
 <a id="DEP0009"></a>
 ### DEP0009: crypto.pbkdf2 without digest
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11305
+    description: End-of-Life.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4047
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -140,6 +248,17 @@ undefined `digest` will throw a `TypeError`.
 
 <a id="DEP0010"></a>
 ### DEP0010: crypto.createCredentials
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.13
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/7265
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -148,6 +267,17 @@ The [`crypto.createCredentials()`][] API is deprecated. Please use
 
 <a id="DEP0011"></a>
 ### DEP0011: crypto.Credentials
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.13
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/7265
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -156,6 +286,20 @@ instead.
 
 <a id="DEP0012"></a>
 ### DEP0012: Domain.dispose
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15412
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.7
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/5021
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -164,6 +308,15 @@ explicitly via error event handlers set on the domain instead.
 
 <a id="DEP0013"></a>
 ### DEP0013: fs asynchronous function without callback
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18668
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -172,6 +325,23 @@ in Node.js 10.0.0 onwards. (See https://github.com/nodejs/node/pull/12562.)
 
 <a id="DEP0014"></a>
 ### DEP0014: fs.read legacy String interface
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/9683
+    description: End-of-Life.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4525
+    description: Runtime deprecation.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.1.96
+    commit: c93e0aaf062081db3ec40ac45b3e2c979d5759d6
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -180,6 +350,23 @@ API as mentioned in the documentation instead.
 
 <a id="DEP0015"></a>
 ### DEP0015: fs.readSync legacy String interface
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/9683
+    description: End-of-Life.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4525
+    description: Runtime deprecation.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.1.96
+    commit: c93e0aaf062081db3ec40ac45b3e2c979d5759d6
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -188,6 +375,15 @@ The [`fs.readSync()`][] legacy `String` interface is deprecated. Use the
 
 <a id="DEP0016"></a>
 ### DEP0016: GLOBAL/root
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/1838
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -196,6 +392,15 @@ and should no longer be used.
 
 <a id="DEP0017"></a>
 ### DEP0017: Intl.v8BreakIterator
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15238
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8908
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -204,6 +409,12 @@ See [`Intl.Segmenter`](https://github.com/tc39/proposal-intl-segmenter).
 
 <a id="DEP0018"></a>
 ### DEP0018: Unhandled promise rejections
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8217
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -213,6 +424,17 @@ code.
 
 <a id="DEP0019"></a>
 ### DEP0019: require('.') resolved outside directory
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.8.1
+    pr-url: https://github.com/nodejs/node/pull/1363
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -222,6 +444,17 @@ release.
 
 <a id="DEP0020"></a>
 ### DEP0020: Server.connections
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.9.7
+    pr-url: https://github.com/nodejs/node-v0.x-archive/pull/4595
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -230,6 +463,17 @@ The [`Server.connections`][] property is deprecated. Please use the
 
 <a id="DEP0021"></a>
 ### DEP0021: Server.listenFD
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.7.12
+    commit: 41421ff9da1288aa241a5e9dcf915b685ade1c23
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -238,6 +482,12 @@ The `Server.listenFD()` method is deprecated. Please use
 
 <a id="DEP0022"></a>
 ### DEP0022: os.tmpDir()
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/6739
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -245,6 +495,17 @@ The `os.tmpDir()` API is deprecated. Please use [`os.tmpdir()`][] instead.
 
 <a id="DEP0023"></a>
 ### DEP0023: os.getNetworkInterfaces()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.6.0
+    commit: 37bb37d151fb6ee4696730e63ff28bb7a4924f97
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -253,6 +514,15 @@ The `os.getNetworkInterfaces()` method is deprecated. Please use the
 
 <a id="DEP0024"></a>
 ### DEP0024: REPLServer.prototype.convertToContext()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13434
+    description: End-of-Life.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7829
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -260,6 +530,17 @@ The `REPLServer.prototype.convertToContext()` API has been removed.
 
 <a id="DEP0025"></a>
 ### DEP0025: require('sys')
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.0.0
+    pr-url: https://github.com/nodejs/node/pull/317
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -267,6 +548,17 @@ The `sys` module is deprecated. Please use the [`util`][] module instead.
 
 <a id="DEP0026"></a>
 ### DEP0026: util.print()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -275,6 +567,17 @@ instead.
 
 <a id="DEP0027"></a>
 ### DEP0027: util.puts()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -282,6 +585,17 @@ The [`util.puts()`][] API is deprecated. Please use [`console.log()`][] instead.
 
 <a id="DEP0028"></a>
 ### DEP0028: util.debug()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -290,6 +604,17 @@ instead.
 
 <a id="DEP0029"></a>
 ### DEP0029: util.error()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: 896b2aa7074fc886efd7dd0a397d694763cac7ce
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -298,6 +623,15 @@ instead.
 
 <a id="DEP0030"></a>
 ### DEP0030: SlowBuffer
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5833
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -306,6 +640,15 @@ The [`SlowBuffer`][] class is deprecated. Please use
 
 <a id="DEP0031"></a>
 ### DEP0031: ecdh.setPublicKey()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v5.2.0
+    pr-url: https://github.com/nodejs/node/pull/3511
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -314,6 +657,17 @@ API is not useful.
 
 <a id="DEP0032"></a>
 ### DEP0032: domain module
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.4.2
+    pr-url: https://github.com/nodejs/node/pull/943
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -321,6 +675,17 @@ The [`domain`][] module is deprecated and should not be used.
 
 <a id="DEP0033"></a>
 ### DEP0033: EventEmitter.listenerCount()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v3.2.0
+    pr-url: https://github.com/nodejs/node/pull/2349
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -329,6 +694,17 @@ deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
 
 <a id="DEP0034"></a>
 ### DEP0034: fs.exists(path, callback)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v1.0.0
+    pr-url: https://github.com/iojs/io.js/pull/166
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -337,6 +713,16 @@ The [`fs.exists(path, callback)`][] API is deprecated. Please use
 
 <a id="DEP0035"></a>
 ### DEP0035: fs.lchmod(path, mode, callback)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -344,13 +730,74 @@ The [`fs.lchmod(path, mode, callback)`][] API is deprecated.
 
 <a id="DEP0036"></a>
 ### DEP0036: fs.lchmodSync(path, mode)
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
 The [`fs.lchmodSync(path, mode)`][] API is deprecated.
 
+<a id="DEP0037"></a>
+### DEP0037: fs.lchown(path, uid, gid, callback)
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/21498
+    description: Deprecation revoked.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
+
+Type: Deprecation revoked
+
+The [`fs.lchown(path, uid, gid, callback)`][] API is deprecated.
+
+<a id="DEP0038"></a>
+### DEP0038: fs.lchownSync(path, uid, gid)
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/21498
+    description: Deprecation revoked.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
+-->
+
+Type: Deprecation revoked
+
+The [`fs.lchownSync(path, uid, gid)`][] API is deprecated.
+
 <a id="DEP0039"></a>
 ### DEP0039: require.extensions
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.10.6
+    commit: 7bd8a5a2a60b75266f89f9a32877d55294a3881c
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -358,6 +805,12 @@ The [`require.extensions`][] property is deprecated.
 
 <a id="DEP0040"></a>
 ### DEP0040: punycode module
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -366,6 +819,20 @@ instead.
 
 <a id="DEP0041"></a>
 ### DEP0041: NODE\_REPL\_HISTORY\_FILE environment variable
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/13876
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v3.0.0
+    pr-url: https://github.com/nodejs/node/pull/2224
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -374,6 +841,20 @@ The `NODE_REPL_HISTORY_FILE` environment variable was removed. Please use
 
 <a id="DEP0042"></a>
 ### DEP0042: tls.CryptoStream
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17882
+    description: End-of-Life.
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -382,6 +863,26 @@ The [`tls.CryptoStream`][] class was removed. Please use
 
 <a id="DEP0043"></a>
 ### DEP0043: tls.SecurePair
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11349
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6063
+    description: Documentation-only deprecation.
+  - version: v0.11.15
+    pr-url:
+      - https://github.com/nodejs/node-v0.x-archive/pull/8695
+      - https://github.com/nodejs/node-v0.x-archive/pull/8700
+    description: Deprecation revoked.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Runtime deprecation.
+-->
 
 Type: Documentation-only
 
@@ -390,6 +891,19 @@ The [`tls.SecurePair`][] class is deprecated. Please use
 
 <a id="DEP0044"></a>
 ### DEP0044: util.isArray()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -398,6 +912,19 @@ instead.
 
 <a id="DEP0045"></a>
 ### DEP0045: util.isBoolean()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -405,6 +932,19 @@ The [`util.isBoolean()`][] API is deprecated.
 
 <a id="DEP0046"></a>
 ### DEP0046: util.isBuffer()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -413,6 +953,19 @@ The [`util.isBuffer()`][] API is deprecated. Please use
 
 <a id="DEP0047"></a>
 ### DEP0047: util.isDate()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -420,6 +973,19 @@ The [`util.isDate()`][] API is deprecated.
 
 <a id="DEP0048"></a>
 ### DEP0048: util.isError()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -427,6 +993,19 @@ The [`util.isError()`][] API is deprecated.
 
 <a id="DEP0049"></a>
 ### DEP0049: util.isFunction()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -434,6 +1013,19 @@ The [`util.isFunction()`][] API is deprecated.
 
 <a id="DEP0050"></a>
 ### DEP0050: util.isNull()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -441,6 +1033,19 @@ The [`util.isNull()`][] API is deprecated.
 
 <a id="DEP0051"></a>
 ### DEP0051: util.isNullOrUndefined()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -448,6 +1053,19 @@ The [`util.isNullOrUndefined()`][] API is deprecated.
 
 <a id="DEP0052"></a>
 ### DEP0052: util.isNumber()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -455,6 +1073,19 @@ The [`util.isNumber()`][] API is deprecated.
 
 <a id="DEP0053"></a>
 ### DEP0053 util.isObject()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -462,6 +1093,19 @@ The [`util.isObject()`][] API is deprecated.
 
 <a id="DEP0054"></a>
 ### DEP0054: util.isPrimitive()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -469,6 +1113,19 @@ The [`util.isPrimitive()`][] API is deprecated.
 
 <a id="DEP0055"></a>
 ### DEP0055: util.isRegExp()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -476,6 +1133,19 @@ The [`util.isRegExp()`][] API is deprecated.
 
 <a id="DEP0056"></a>
 ### DEP0056: util.isString()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -483,6 +1153,19 @@ The [`util.isString()`][] API is deprecated.
 
 <a id="DEP0057"></a>
 ### DEP0057: util.isSymbol()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -490,6 +1173,19 @@ The [`util.isSymbol()`][] API is deprecated.
 
 <a id="DEP0058"></a>
 ### DEP0058: util.isUndefined()
+<!-- YAML
+changes:
+  - version:
+    - v4.8.6
+    - v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version:
+    - v3.3.1
+    - v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2447
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -497,6 +1193,15 @@ The [`util.isUndefined()`][] API is deprecated.
 
 <a id="DEP0059"></a>
 ### DEP0059: util.log()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6161
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -504,6 +1209,15 @@ The [`util.log()`][] API is deprecated.
 
 <a id="DEP0060"></a>
 ### DEP0060: util.\_extend()
+<!-- YAML
+changes:
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4903
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -511,6 +1225,15 @@ The [`util._extend()`][] API is deprecated.
 
 <a id="DEP0061"></a>
 ### DEP0061: fs.SyncWriteStream
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10467
+    description: Runtime deprecation.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/6749
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -519,6 +1242,12 @@ API. No alternative API is available. Please use a userland alternative.
 
 <a id="DEP0062"></a>
 ### DEP0062: node --debug
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10970
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -528,6 +1257,12 @@ instead.
 
 <a id="DEP0063"></a>
 ### DEP0063: ServerResponse.prototype.writeHeader()
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11355
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -539,6 +1274,26 @@ officially supported API.
 
 <a id="DEP0064"></a>
 ### DEP0064: tls.createSecurePair()
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11349
+    description: Runtime deprecation.
+  - version: v6.12.0
+    pr-url: https://github.com/nodejs/node/pull/10116
+    description: A deprecation code has been assigned.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6063
+    description: Documentation-only deprecation.
+  - version: v0.11.15
+    pr-url:
+      - https://github.com/nodejs/node-v0.x-archive/pull/8695
+      - https://github.com/nodejs/node-v0.x-archive/pull/8700
+    description: Deprecation revoked.
+  - version: v0.11.3
+    commit: af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -547,6 +1302,15 @@ The `tls.createSecurePair()` API was deprecated in documentation in Node.js
 
 <a id="DEP0065"></a>
 ### DEP0065: repl.REPL_MODE_MAGIC and NODE_REPL_MODE=magic
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19187
+    description: End-of-Life.
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11599
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -561,6 +1325,12 @@ removed. Please use `sloppy` instead.
 
 <a id="DEP0066"></a>
 ### DEP0066: outgoingMessage.\_headers, outgoingMessage.\_headerNames
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -576,6 +1346,12 @@ were never documented as officially supported properties.
 
 <a id="DEP0067"></a>
 ### DEP0067: OutgoingMessage.prototype.\_renderHeaders
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/10941
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -587,6 +1363,12 @@ an officially supported API.
 
 <a id="DEP0068"></a>
 ### DEP0068: node debug
+<!-- YAML
+changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11441
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -595,6 +1377,18 @@ a V8-inspector based CLI debugger available through `node inspect`.
 
 <a id="DEP0069"></a>
 ### DEP0069: vm.runInDebugContext(string)
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/13295
+    description: End-of-Life.
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/12815
+    description: Runtime deprecation.
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12243
+    description: Documentation-only deprecation.
+-->
 
 Type: End-of-Life
 
@@ -604,6 +1398,15 @@ DebugContext was an experimental API.
 
 <a id="DEP0070"></a>
 ### DEP0070: async_hooks.currentId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -614,6 +1417,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0071"></a>
 ### DEP0071: async_hooks.triggerId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -624,6 +1436,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0072"></a>
 ### DEP0072: async_hooks.AsyncResource.triggerId()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14414
+    description: End-of-Life.
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -634,6 +1455,15 @@ This change was made while `async_hooks` was an experimental API.
 
 <a id="DEP0073"></a>
 ### DEP0073: Several internal properties of net.Server
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17141
+    description: End-of-Life.
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14449
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -645,6 +1475,12 @@ code, no replacement API is provided.
 
 <a id="DEP0074"></a>
 ### DEP0074: REPLServer.bufferedCommand
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13687
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -653,6 +1489,12 @@ The `REPLServer.bufferedCommand` property was deprecated in favor of
 
 <a id="DEP0075"></a>
 ### DEP0075: REPLServer.parseREPLKeyword()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14223
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -660,6 +1502,15 @@ Type: Runtime
 
 <a id="DEP0076"></a>
 ### DEP0076: tls.parseCertString()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14249
+    description: Runtime deprecation.
+  - version: v8.6.0
+    pr-url: https://github.com/nodejs/node/pull/14245
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -683,6 +1534,12 @@ difference is that `querystring.parse()` does url decoding:
 
 <a id="DEP0077"></a>
 ### DEP0077: Module.\_debug()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/13948
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -693,6 +1550,12 @@ supported API.
 
 <a id="DEP0078"></a>
 ### DEP0078: REPLServer.turnOffEditorMode()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15136
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -700,6 +1563,15 @@ Type: Runtime
 
 <a id="DEP0079"></a>
 ### DEP0079: Custom inspection function on Objects via .inspect()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16393
+    description: Runtime deprecation.
+  - version: v8.7.0
+    pr-url: https://github.com/nodejs/node/pull/15631
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -710,6 +1582,12 @@ may be specified.
 
 <a id="DEP0080"></a>
 ### DEP0080: path.\_makeLong()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/14956
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -719,6 +1597,12 @@ and replaced with an identical, public `path.toNamespacedPath()` method.
 
 <a id="DEP0081"></a>
 ### DEP0081: fs.truncate() using a file descriptor
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/15990
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -728,6 +1612,12 @@ file descriptors.
 
 <a id="DEP0082"></a>
 ### DEP0082: REPLServer.prototype.memory()
+<!-- YAML
+changes:
+  - version: v9.0.0
+    pr-url: https://github.com/nodejs/node/pull/16242
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -736,6 +1626,12 @@ the `REPLServer` itself. Do not use this function.
 
 <a id="DEP0083"></a>
 ### DEP0083: Disabling ECDH by setting ecdhCurve to false
+<!-- YAML
+changes:
+  - version: v9.2.0
+    pr-url: https://github.com/nodejs/node/pull/16130
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -746,6 +1642,12 @@ the client. Use the `ciphers` parameter instead.
 
 <a id="DEP0084"></a>
 ### DEP0084: requiring bundled internal dependencies
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16392
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -777,6 +1679,17 @@ code modification is necessary if that is done.
 
 <a id="DEP0085"></a>
 ### DEP0085: AsyncHooks Sensitive API
+<!-- YAML
+changes:
+  - version: 10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17147
+    description: End-of-Life.
+  - version:
+    - v8.10.0
+    - v9.4.0
+    pr-url: https://github.com/nodejs/node/pull/16972
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -786,6 +1699,17 @@ API instead.
 
 <a id="DEP0086"></a>
 ### DEP0086: Remove runInAsyncIdScope
+<!-- YAML
+changes:
+  - version: 10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17147
+    description: End-of-Life.
+  - version:
+    - v8.10.0
+    - v9.4.0
+    pr-url: https://github.com/nodejs/node/pull/16972
+    description: Runtime deprecation.
+-->
 
 Type: End-of-Life
 
@@ -795,6 +1719,14 @@ details.
 
 <a id="DEP0089"></a>
 ### DEP0089: require('assert')
+<!-- YAML
+changes:
+  - version:
+      - v9.9.0
+      - v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17002
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -804,6 +1736,12 @@ same as the legacy assert but it will always use strict equality checks.
 
 <a id="DEP0090"></a>
 ### DEP0090: Invalid GCM authentication tag lengths
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18017
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -816,6 +1754,12 @@ is not included in this list will be considered invalid in compliance with
 
 <a id="DEP0091"></a>
 ### DEP0091: crypto.DEFAULT_ENCODING
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18333
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -823,6 +1767,12 @@ The [`crypto.DEFAULT_ENCODING`][] property is deprecated.
 
 <a id="DEP0092"></a>
 ### DEP0092: Top-level `this` bound to `module.exports`
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/16878
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -832,6 +1782,12 @@ or `module.exports` instead.
 
 <a id="DEP0093"></a>
 ### DEP0093: crypto.fips is deprecated and replaced.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18335
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -840,6 +1796,12 @@ and `crypto.getFips()` instead.
 
 <a id="DEP0094"></a>
 ### DEP0094: Using `assert.fail()` with more than one argument.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18418
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -849,6 +1811,12 @@ method.
 
 <a id="DEP0095"></a>
 ### DEP0095: timers.enroll()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18066
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -857,6 +1825,12 @@ Type: Runtime
 
 <a id="DEP0096"></a>
 ### DEP0096: timers.unenroll()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18066
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -865,6 +1839,12 @@ Type: Runtime
 
 <a id="DEP0097"></a>
 ### DEP0097: MakeCallback with domain property
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/17417
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -874,6 +1854,15 @@ should start using the `async_context` variant of `MakeCallback` or
 
 <a id="DEP0098"></a>
 ### DEP0098: AsyncHooks Embedder AsyncResource.emitBefore and AsyncResource.emitAfter APIs
+<!-- YAML
+changes:
+  - version:
+    - v8.12.0
+    - v9.6.0
+    - v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18632
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -887,6 +1876,12 @@ https://github.com/nodejs/node/pull/18513 for more details.
 
 <a id="DEP0099"></a>
 ### DEP0099: async context-unaware node::MakeCallback C++ APIs
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18632
+    description: Compile-time deprecation.
+-->
 
 Type: Compile-time
 
@@ -896,6 +1891,14 @@ parameter.
 
 <a id="DEP0100"></a>
 ### DEP0100: process.assert()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18666
+    description: Runtime deprecation.
+  - version: v0.3.7
+    description: Documentation-only deprecation.
+-->
 
 Type: Runtime
 
@@ -905,6 +1908,12 @@ This was never a documented feature.
 
 <a id="DEP0101"></a>
 ### DEP0101: --with-lttng
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18982
+    description: End-of-Life.
+-->
 
 Type: End-of-Life
 
@@ -912,6 +1921,12 @@ The `--with-lttng` compile-time option has been removed.
 
 <a id="DEP0102"></a>
 ### DEP0102: Using `noAssert` in Buffer#(read|write) operations.
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18395
+    description: End-of-Life.
+-->
 
 Type: End-of-Life
 
@@ -921,6 +1936,15 @@ could lead to hard to find errors and crashes.
 
 <a id="DEP0103"></a>
 ### DEP0103: process.binding('util').is[...] typechecks
+<!-- YAML
+changes:
+  - version: v10.9.0
+    pr-url: https://github.com/nodejs/node/pull/22004
+    description: Superseded by [DEP0111](#DEP0111).
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18415
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
 
@@ -932,6 +1956,12 @@ This deprecation has been superseded by the deprecation of the
 
 <a id="DEP0104"></a>
 ### DEP0104: process.env string coercion
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/18990
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
 
@@ -943,6 +1973,12 @@ assigning it to `process.env`.
 
 <a id="DEP0105"></a>
 ### DEP0105: decipher.finaltol
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19353
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -952,6 +1988,12 @@ is recommended to use [`decipher.final()`][] instead.
 
 <a id="DEP0106"></a>
 ### DEP0106: crypto.createCipher and crypto.createDecipher
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19343
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -964,6 +2006,12 @@ initialization vectors. It is recommended to derive a key using
 
 <a id="DEP0107"></a>
 ### DEP0107: tls.convertNPNProtocols()
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19403
+    description: Runtime deprecation.
+-->
 
 Type: Runtime
 
@@ -972,6 +2020,12 @@ core and obsoleted by the removal of NPN (Next Protocol Negotiation) support.
 
 <a id="DEP0108"></a>
 ### DEP0108: zlib.bytesRead
+<!-- YAML
+changes:
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19414
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -982,6 +2036,12 @@ expose values under these names.
 
 <a id="DEP0110"></a>
 ### DEP0110: vm.Script cached data
+<!-- YAML
+changes:
+  - version: v10.6.0
+    pr-url: https://github.com/nodejs/node/pull/20300
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -990,6 +2050,12 @@ The `produceCachedData` option is deprecated. Use
 
 <a id="DEP0111"></a>
 ### DEP0111: process.binding()
+<!-- YAML
+changes:
+  - version: v10.9.0
+    pr-url: https://github.com/nodejs/node/pull/22004
+    description: Documentation-only deprecation.
+-->
 
 Type: Documentation-only
 
@@ -1033,6 +2099,8 @@ only. Use of `process.binding()` by userland code is unsupported.
 [`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
 [`fs.lchmod(path, mode, callback)`]: fs.html#fs_fs_lchmod_path_mode_callback
 [`fs.lchmodSync(path, mode)`]: fs.html#fs_fs_lchmodsync_path_mode
+[`fs.lchown(path, uid, gid, callback)`]: fs.html#fs_fs_lchown_path_uid_gid_callback
+[`fs.lchownSync(path, uid, gid)`]: fs.html#fs_fs_lchownsync_path_uid_gid
 [`fs.read()`]: fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readSync()`]: fs.html#fs_fs_readsync_fd_buffer_offset_length_position
 [`fs.stat()`]: fs.html#fs_fs_stat_path_options_callback


### PR DESCRIPTION
Manual backport of https://github.com/nodejs/node/pull/22766.