### PR TITLE
crypto: assign missing deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2184,8 +2184,8 @@ The [Legacy URL API][] is deprecated. This includes [`url.format()`][],
 [`url.parse()`][], [`url.resolve()`][], and the [legacy `urlObject`][]. Please
 use the [WHATWG URL API][] instead.
 
-<a id="DEP00XX"></a>
-### DEP00XX: Native crypto handles
+<a id="DEP0117"></a>
+### DEP0117: Native crypto handles
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -36,10 +36,10 @@ function legacyNativeHandle(obj, handle) {
   Object.defineProperty(obj, '_handle', {
     get: deprecate(() => handle,
                    `${obj.constructor.name}._handle is deprecated. Use the ` +
-                   'public API instead.', 'DEP00XX'),
+                   'public API instead.', 'DEP0117'),
     set: deprecate((h) => obj[kHandle] = handle = h,
                    `${obj.constructor.name}._handle is deprecated. Use the ` +
-                   'public API instead.', 'DEP00XX'),
+                   'public API instead.', 'DEP0117'),
     enumerable: false
   });
 }


### PR DESCRIPTION
I forgot to assign the deprecation code while landing https://github.com/nodejs/node/pull/22747, thanks to @vsemozhetbyt for noticing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
