### PR TITLE
crypto: fix edge case in authenticated encryption

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2899,6 +2899,10 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(false);
   }
 
+  // TODO(tniessen): Throw if the authentication tag has already been set.
+  if (cipher->auth_tag_state_ == kAuthTagPassedToOpenSSL)
+    return args.GetReturnValue().Set(true);
+
   unsigned int tag_len = Buffer::Length(args[0]);
   const int mode = EVP_CIPHER_CTX_mode(cipher->ctx_.get());
   bool is_valid;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2818,7 +2818,6 @@ bool CipherBase::InitAuthenticated(const char* cipher_type, int iv_len,
 
     // Remember the given authentication tag length for later.
     auth_tag_len_ = auth_tag_len;
-    auth_tag_state_ = kAuthTagLengthKnown;
 
     if (mode == EVP_CIPH_CCM_MODE) {
       // Restrict the message length to min(INT_MAX, 2^(8*(15-iv_len))-1) bytes.
@@ -2841,7 +2840,6 @@ bool CipherBase::InitAuthenticated(const char* cipher_type, int iv_len,
 
       // Remember the given authentication tag length for later.
       auth_tag_len_ = auth_tag_len;
-      auth_tag_state_ = kAuthTagLengthKnown;
     }
   }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -365,7 +365,6 @@ class CipherBase : public BaseObject {
   };
   enum AuthTagState {
     kAuthTagUnknown,
-    kAuthTagLengthKnown,
     kAuthTagKnown,
     kAuthTagPassedToOpenSSL
   };

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -363,6 +363,12 @@ class CipherBase : public BaseObject {
     kErrorMessageSize,
     kErrorState
   };
+  enum AuthTagState {
+    kAuthTagUnknown,
+    kAuthTagLengthKnown,
+    kAuthTagKnown,
+    kAuthTagPassedToOpenSSL
+  };
   static const unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
 
   void Init(const char* cipher_type,
@@ -404,7 +410,7 @@ class CipherBase : public BaseObject {
       : BaseObject(env, wrap),
         ctx_(nullptr),
         kind_(kind),
-        auth_tag_set_(false),
+        auth_tag_state_(kAuthTagUnknown),
         auth_tag_len_(kNoAuthTagLength),
         pending_auth_failed_(false) {
     MakeWeak();
@@ -413,7 +419,7 @@ class CipherBase : public BaseObject {
  private:
   DeleteFnPtr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free> ctx_;
   const CipherKind kind_;
-  bool auth_tag_set_;
+  AuthTagState auth_tag_state_;
   unsigned int auth_tag_len_;
   char auth_tag_[EVP_GCM_TLS_TAG_LEN];
   bool pending_auth_failed_;

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -557,27 +557,35 @@ for (const test of TEST_CASES) {
 }
 
 // Test that the authentication tag can be set at any point before calling
-// final() in GCM mode.
+// final() in GCM or OCB mode.
 {
   const plain = Buffer.from('Hello world', 'utf8');
   const key = Buffer.from('0123456789abcdef', 'utf8');
   const iv = Buffer.from('0123456789ab', 'utf8');
 
-  const cipher = crypto.createCipheriv('aes-128-gcm', key, iv);
-  const ciphertext = Buffer.concat([cipher.update(plain), cipher.final()]);
-  const authTag = cipher.getAuthTag();
+  for (const mode of ['gcm', 'ocb']) {
+    for (const authTagLength of mode === 'gcm' ? [undefined, 8] : [8]) {
+      const cipher = crypto.createCipheriv(`aes-128-${mode}`, key, iv, {
+        authTagLength
+      });
+      const ciphertext = Buffer.concat([cipher.update(plain), cipher.final()]);
+      const authTag = cipher.getAuthTag();
 
-  for (const authTagBeforeUpdate of [true, false]) {
-    const decipher = crypto.createDecipheriv('aes-128-gcm', key, iv);
-    if (authTagBeforeUpdate) {
-      decipher.setAuthTag(authTag);
+      for (const authTagBeforeUpdate of [true, false]) {
+        const decipher = crypto.createDecipheriv(`aes-128-${mode}`, key, iv, {
+          authTagLength
+        });
+        if (authTagBeforeUpdate) {
+          decipher.setAuthTag(authTag);
+        }
+        const resultUpdate = decipher.update(ciphertext);
+        if (!authTagBeforeUpdate) {
+          decipher.setAuthTag(authTag);
+        }
+        const resultFinal = decipher.final();
+        const result = Buffer.concat([resultUpdate, resultFinal]);
+        assert(result.equals(plain));
+      }
     }
-    const resultUpdate = decipher.update(ciphertext);
-    if (!authTagBeforeUpdate) {
-      decipher.setAuthTag(authTag);
-    }
-    const resultFinal = decipher.final();
-    const result = Buffer.concat([resultUpdate, resultFinal]);
-    assert(result.equals(plain));
   }
 }


### PR DESCRIPTION
Restricting the authentication tag length and calling `update` or `setAAD` before `setAuthTag` caused an incorrect authentication tag to be passed to OpenSSL: The `auth_tag_len_` field was already set, so the implementation assumed that the tag itself was known as well. This change allows the implementation to distinguish between knowing the tag length and the tag itself using the `auth_tag_state_` field which replaces the `auth_tag_set_` field.

This also allows https://github.com/nodejs/node/pull/22538 to work for OCB! Sadly, CCM won't work without changes within OpenSSL and they probably won't change that due to a more or less related NIST recommendation.

This should finally fix #22421.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
