### PR TITLE
fs: fix promisified fs.readdir withFileTypes

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -317,7 +317,8 @@ async function readdir(path, options) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const result = await binding.readdir(pathModule.toNamespacedPath(path),
-                                       options.encoding, !!options.withTypes,
+                                       options.encoding,
+                                       !!options.withFileTypes,
                                        kUsePromises);
   return options.withFileTypes ?
     getDirectoryEntriesPromise(path, result) :

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -57,6 +57,14 @@ fs.readdir(readdirDir, {
   assertDirents(dirents);
 }));
 
+// Check the promisified version
+assert.doesNotReject(async () => {
+  const dirents = await fs.promises.readdir(readdirDir, {
+    withFileTypes: true
+  });
+  assertDirents(dirents);
+});
+
 // Check for correct types when the binding returns unknowns
 const UNKNOWN = constants.UV_DIRENT_UNKNOWN;
 const oldReaddir = binding.readdir;


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/22829

CI: https://ci.nodejs.org/job/node-test-pull-request/17164/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
