### PR TITLE
doc: add withFileTypes option to fsPromises.readdir

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4196,11 +4196,16 @@ a colon, Node.js will open a file system stream, as described by
 ### fsPromises.readdir(path[, options])
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22020
+    description: New option `withFileTypes` was added.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {string|Object}
   * `encoding` {string} **Default:** `'utf8'`
+  * `withFileTypes` {boolean} **Default:** `false`
 * Returns: {Promise}
 
 Reads the contents of a directory then resolves the `Promise` with an array
@@ -4210,6 +4215,9 @@ The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use for
 the filenames. If the `encoding` is set to `'buffer'`, the filenames returned
 will be passed as `Buffer` objects.
+
+If `options.withFileTypes` is set to `true`, the resolved array will contain
+[`fs.Dirent`][] objects.
 
 ### fsPromises.readFile(path[, options])
 <!-- YAML


### PR DESCRIPTION
Note: I left the version as `REPLACEME` even though it was added in 10.10.0, because it's *broken* in 10.10.0, but this is fixed in https://github.com/nodejs/node/pull/22832.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
