### PR TITLE
lib: destructuring assignment `path` module in fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -234,7 +234,7 @@ function existsSync(path) {
     return false;
   }
   const ctx = { path };
-  binding.access(pathModule.toNamespacedPath(path), F_OK, undefined, ctx);
+  binding.access(toNamespacedPath(path), F_OK, undefined, ctx);
   return ctx.errno === undefined;
 }
 
@@ -916,7 +916,7 @@ function symlink(target, path, type_, callback_) {
       // if it is a directory. Ignore resolve error to keep symlink
       // errors consistent between platforms if invalid path is
       // provided.
-      absoluteTarget = pathModule.resolve(path, '..', target);
+      absoluteTarget = resolve(path, '..', target);
     } catch { }
     if (absoluteTarget !== undefined) {
       stat(absoluteTarget, (err, stat) => {
@@ -925,7 +925,7 @@ function symlink(target, path, type_, callback_) {
         binding.symlink(preprocessSymlinkDestination(target,
                                                      resolvedType,
                                                      path),
-                        pathModule.toNamespacedPath(path), resolvedFlags, req);
+                        toNamespacedPath(path), resolvedFlags, req);
       });
       return;
     }
@@ -940,7 +940,7 @@ function symlinkSync(target, path, type) {
   type = (typeof type === 'string' ? type : null);
   if (isWindows && type === null) {
     try {
-      const absoluteTarget = pathModule.resolve(path, '..', target);
+      const absoluteTarget = resolve(path, '..', target);
       if (statSync(absoluteTarget).isDirectory()) {
         type = 'dir';
       }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -40,7 +40,7 @@ const {
 } = constants;
 
 const { _extend } = require('util');
-const pathModule = require('path');
+const { _makeLong, toNamespacedPath, resolve } = require('path');
 const { isArrayBufferView } = require('internal/util/types');
 const binding = internalBinding('fs');
 const { Buffer, kMaxLength } = require('buffer');
@@ -183,7 +183,7 @@ function access(path, mode, callback) {
   mode = mode | 0;
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
-  binding.access(pathModule.toNamespacedPath(path), mode, req);
+  binding.access(toNamespacedPath(path), mode, req);
 }
 
 function accessSync(path, mode) {
@@ -196,7 +196,7 @@ function accessSync(path, mode) {
     mode = mode | 0;
 
   const ctx = { path };
-  binding.access(pathModule.toNamespacedPath(path), mode, undefined, ctx);
+  binding.access(toNamespacedPath(path), mode, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -302,7 +302,7 @@ function readFile(path, options, callback) {
 
   path = toPathIfFileURL(path);
   validatePath(path);
-  binding.open(pathModule.toNamespacedPath(path),
+  binding.open(toNamespacedPath(path),
                stringToFlags(options.flag || 'r'),
                0o666,
                req);
@@ -431,7 +431,7 @@ function open(path, flags, mode, callback) {
   const req = new FSReqCallback();
   req.oncomplete = callback;
 
-  binding.open(pathModule.toNamespacedPath(path),
+  binding.open(toNamespacedPath(path),
                flagsNumber,
                mode,
                req);
@@ -445,7 +445,7 @@ function openSync(path, flags, mode) {
   mode = validateMode(mode, 'mode', 0o666);
 
   const ctx = { path };
-  const result = binding.open(pathModule.toNamespacedPath(path),
+  const result = binding.open(toNamespacedPath(path),
                               flagsNumber, mode,
                               undefined, ctx);
   handleErrorFromBinding(ctx);
@@ -601,8 +601,8 @@ function rename(oldPath, newPath, callback) {
   validatePath(newPath, 'newPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.rename(pathModule.toNamespacedPath(oldPath),
-                 pathModule.toNamespacedPath(newPath),
+  binding.rename(toNamespacedPath(oldPath),
+                 toNamespacedPath(newPath),
                  req);
 }
 
@@ -612,8 +612,8 @@ function renameSync(oldPath, newPath) {
   newPath = toPathIfFileURL(newPath);
   validatePath(newPath, 'newPath');
   const ctx = { path: oldPath, dest: newPath };
-  binding.rename(pathModule.toNamespacedPath(oldPath),
-                 pathModule.toNamespacedPath(newPath), undefined, ctx);
+  binding.rename(toNamespacedPath(oldPath),
+                 toNamespacedPath(newPath), undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -692,14 +692,14 @@ function rmdir(path, callback) {
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.rmdir(pathModule.toNamespacedPath(path), req);
+  binding.rmdir(toNamespacedPath(path), req);
 }
 
 function rmdirSync(path) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
+  binding.rmdir(toNamespacedPath(path), undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -751,7 +751,7 @@ function mkdir(path, options, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.mkdir(pathModule.toNamespacedPath(path),
+  binding.mkdir(toNamespacedPath(path),
                 validateMode(mode, 'mode', 0o777), recursive, req);
 }
 
@@ -770,7 +770,7 @@ function mkdirSync(path, options) {
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
 
   const ctx = { path };
-  binding.mkdir(pathModule.toNamespacedPath(path),
+  binding.mkdir(toNamespacedPath(path),
                 validateMode(mode, 'mode', 0o777), recursive, undefined,
                 ctx);
   handleErrorFromBinding(ctx);
@@ -794,7 +794,7 @@ function readdir(path, options, callback) {
       getDirents(path, result, callback);
     };
   }
-  binding.readdir(pathModule.toNamespacedPath(path), options.encoding,
+  binding.readdir(toNamespacedPath(path), options.encoding,
                   !!options.withFileTypes, req);
 }
 
@@ -803,7 +803,7 @@ function readdirSync(path, options) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  const result = binding.readdir(pathModule.toNamespacedPath(path),
+  const result = binding.readdir(toNamespacedPath(path),
                                  options.encoding, !!options.withFileTypes,
                                  undefined, ctx);
   handleErrorFromBinding(ctx);
@@ -831,7 +831,7 @@ function lstat(path, options, callback) {
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
-  binding.lstat(pathModule.toNamespacedPath(path), options.bigint, req);
+  binding.lstat(toNamespacedPath(path), options.bigint, req);
 }
 
 function stat(path, options, callback) {
@@ -844,7 +844,7 @@ function stat(path, options, callback) {
   validatePath(path);
   const req = new FSReqCallback(options.bigint);
   req.oncomplete = callback;
-  binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
+  binding.stat(toNamespacedPath(path), options.bigint, req);
 }
 
 function fstatSync(fd, options = {}) {
@@ -859,7 +859,7 @@ function lstatSync(path, options = {}) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  const stats = binding.lstat(pathModule.toNamespacedPath(path),
+  const stats = binding.lstat(toNamespacedPath(path),
                               options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
@@ -869,7 +869,7 @@ function statSync(path, options = {}) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  const stats = binding.stat(pathModule.toNamespacedPath(path),
+  const stats = binding.stat(toNamespacedPath(path),
                              options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
@@ -882,7 +882,7 @@ function readlink(path, options, callback) {
   validatePath(path, 'oldPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.readlink(pathModule.toNamespacedPath(path), options.encoding, req);
+  binding.readlink(toNamespacedPath(path), options.encoding, req);
 }
 
 function readlinkSync(path, options) {
@@ -890,7 +890,7 @@ function readlinkSync(path, options) {
   path = toPathIfFileURL(path);
   validatePath(path, 'oldPath');
   const ctx = { path };
-  const result = binding.readlink(pathModule.toNamespacedPath(path),
+  const result = binding.readlink(toNamespacedPath(path),
                                   options.encoding, undefined, ctx);
   handleErrorFromBinding(ctx);
   return result;
@@ -933,7 +933,7 @@ function symlink(target, path, type_, callback_) {
 
   const flags = stringToSymlinkType(type);
   binding.symlink(preprocessSymlinkDestination(target, type, path),
-                  pathModule.toNamespacedPath(path), flags, req);
+                  toNamespacedPath(path), flags, req);
 }
 
 function symlinkSync(target, path, type) {
@@ -954,7 +954,7 @@ function symlinkSync(target, path, type) {
 
   const ctx = { path: target, dest: path };
   binding.symlink(preprocessSymlinkDestination(target, type, path),
-                  pathModule.toNamespacedPath(path), flags, undefined, ctx);
+                  toNamespacedPath(path), flags, undefined, ctx);
 
   handleErrorFromBinding(ctx);
 }
@@ -970,8 +970,8 @@ function link(existingPath, newPath, callback) {
   const req = new FSReqCallback();
   req.oncomplete = callback;
 
-  binding.link(pathModule.toNamespacedPath(existingPath),
-               pathModule.toNamespacedPath(newPath),
+  binding.link(toNamespacedPath(existingPath),
+               toNamespacedPath(newPath),
                req);
 }
 
@@ -982,8 +982,8 @@ function linkSync(existingPath, newPath) {
   validatePath(newPath, 'newPath');
 
   const ctx = { path: existingPath, dest: newPath };
-  const result = binding.link(pathModule.toNamespacedPath(existingPath),
-                              pathModule.toNamespacedPath(newPath),
+  const result = binding.link(toNamespacedPath(existingPath),
+                              toNamespacedPath(newPath),
                               undefined, ctx);
   handleErrorFromBinding(ctx);
   return result;
@@ -995,14 +995,14 @@ function unlink(path, callback) {
   validatePath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.unlink(pathModule.toNamespacedPath(path), req);
+  binding.unlink(toNamespacedPath(path), req);
 }
 
 function unlinkSync(path) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  binding.unlink(pathModule.toNamespacedPath(path), undefined, ctx);
+  binding.unlink(toNamespacedPath(path), undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -1064,7 +1064,7 @@ function chmod(path, mode, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.chmod(pathModule.toNamespacedPath(path), mode, req);
+  binding.chmod(toNamespacedPath(path), mode, req);
 }
 
 function chmodSync(path, mode) {
@@ -1073,7 +1073,7 @@ function chmodSync(path, mode) {
   mode = validateMode(mode, 'mode');
 
   const ctx = { path };
-  binding.chmod(pathModule.toNamespacedPath(path), mode, undefined, ctx);
+  binding.chmod(toNamespacedPath(path), mode, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -1085,7 +1085,7 @@ function lchown(path, uid, gid, callback) {
   validateUint32(gid, 'gid');
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.lchown(pathModule.toNamespacedPath(path), uid, gid, req);
+  binding.lchown(toNamespacedPath(path), uid, gid, req);
 }
 
 function lchownSync(path, uid, gid) {
@@ -1094,7 +1094,7 @@ function lchownSync(path, uid, gid) {
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
   const ctx = { path };
-  binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
+  binding.lchown(toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -1127,7 +1127,7 @@ function chown(path, uid, gid, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.chown(pathModule.toNamespacedPath(path), uid, gid, req);
+  binding.chown(toNamespacedPath(path), uid, gid, req);
 }
 
 function chownSync(path, uid, gid) {
@@ -1136,7 +1136,7 @@ function chownSync(path, uid, gid) {
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
   const ctx = { path };
-  binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
+  binding.chown(toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 
@@ -1147,7 +1147,7 @@ function utimes(path, atime, mtime, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.utimes(pathModule.toNamespacedPath(path),
+  binding.utimes(toNamespacedPath(path),
                  toUnixTimestamp(atime),
                  toUnixTimestamp(mtime),
                  req);
@@ -1157,7 +1157,7 @@ function utimesSync(path, atime, mtime) {
   path = toPathIfFileURL(path);
   validatePath(path);
   const ctx = { path };
-  binding.utimes(pathModule.toNamespacedPath(path),
+  binding.utimes(toNamespacedPath(path),
                  toUnixTimestamp(atime), toUnixTimestamp(mtime),
                  undefined, ctx);
   handleErrorFromBinding(ctx);
@@ -1323,7 +1323,7 @@ const statWatchers = new Map();
 function watchFile(filename, options, listener) {
   filename = toPathIfFileURL(filename);
   validatePath(filename);
-  filename = pathModule.resolve(filename);
+  filename = resolve(filename);
   let stat;
 
   const defaults = {
@@ -1362,7 +1362,7 @@ function watchFile(filename, options, listener) {
 function unwatchFile(filename, listener) {
   filename = toPathIfFileURL(filename);
   validatePath(filename);
-  filename = pathModule.resolve(filename);
+  filename = resolve(filename);
   const stat = statWatchers.get(filename);
 
   if (stat === undefined) return;
@@ -1437,7 +1437,7 @@ function realpathSync(p, options) {
     p += '';
   }
   validatePath(p);
-  p = pathModule.resolve(p);
+  p = resolve(p);
 
   const cache = options[realpathCacheKey];
   const maybeCachedResult = cache && cache.get(p);
@@ -1465,7 +1465,7 @@ function realpathSync(p, options) {
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
     const ctx = { path: base };
-    binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
+    binding.lstat(toNamespacedPath(base), false, undefined, ctx);
     handleErrorFromBinding(ctx);
     knownHard[base] = true;
   }
@@ -1505,7 +1505,7 @@ function realpathSync(p, options) {
       // Use stats array directly to avoid creating an fs.Stats instance just
       // for our internal use.
 
-      const baseLong = pathModule.toNamespacedPath(base);
+      const baseLong = toNamespacedPath(base);
       const ctx = { path: base };
       const stats = binding.lstat(baseLong, false, undefined, ctx);
       handleErrorFromBinding(ctx);
@@ -1535,14 +1535,14 @@ function realpathSync(p, options) {
         linkTarget = binding.readlink(baseLong, undefined, undefined, ctx);
         handleErrorFromBinding(ctx);
       }
-      resolvedLink = pathModule.resolve(previous, linkTarget);
+      resolvedLink = resolve(previous, linkTarget);
 
       if (cache) cache.set(base, resolvedLink);
       if (!isWindows) seenLinks[id] = linkTarget;
     }
 
     // resolve the link, then start over
-    p = pathModule.resolve(resolvedLink, p.slice(pos));
+    p = resolve(resolvedLink, p.slice(pos));
 
     // Skip over roots
     current = base = splitRoot(p);
@@ -1551,7 +1551,7 @@ function realpathSync(p, options) {
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
       const ctx = { path: base };
-      binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
+      binding.lstat(toNamespacedPath(base), false, undefined, ctx);
       handleErrorFromBinding(ctx);
       knownHard[base] = true;
     }
@@ -1584,7 +1584,7 @@ function realpath(p, options, callback) {
     p += '';
   }
   validatePath(p);
-  p = pathModule.resolve(p);
+  p = resolve(p);
 
   const seenLinks = Object.create(null);
   const knownHard = Object.create(null);
@@ -1680,12 +1680,12 @@ function realpath(p, options, callback) {
   function gotTarget(err, target, base) {
     if (err) return callback(err);
 
-    gotResolvedLink(pathModule.resolve(previous, target));
+    gotResolvedLink(resolve(previous, target));
   }
 
   function gotResolvedLink(resolvedLink) {
     // resolve the link, then start over
-    p = pathModule.resolve(resolvedLink, p.slice(pos));
+    p = resolve(resolvedLink, p.slice(pos));
     current = base = splitRoot(p);
     pos = current.length;
 
@@ -1754,8 +1754,8 @@ function copyFile(src, dest, flags, callback) {
   validatePath(src, 'src');
   validatePath(dest, 'dest');
 
-  src = pathModule._makeLong(src);
-  dest = pathModule._makeLong(dest);
+  src = _makeLong(src);
+  dest = _makeLong(dest);
   flags = flags | 0;
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
@@ -1771,8 +1771,8 @@ function copyFileSync(src, dest, flags) {
 
   const ctx = { path: src, dest };  // non-prefixed
 
-  src = pathModule._makeLong(src);
-  dest = pathModule._makeLong(dest);
+  src = _makeLong(src);
+  dest = _makeLong(dest);
   flags = flags | 0;
   binding.copyFile(src, dest, flags, undefined, ctx);
   handleErrorFromBinding(ctx);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -37,7 +37,7 @@ const {
   validateInteger,
   validateUint32
 } = require('internal/validators');
-const pathModule = require('path');
+const { toNamespacedPath } = require('path');
 const { promisify } = require('internal/util');
 
 const kHandle = Symbol('handle');
@@ -176,7 +176,7 @@ async function access(path, mode = F_OK) {
   validatePath(path);
 
   mode = mode | 0;
-  return binding.access(pathModule.toNamespacedPath(path), mode,
+  return binding.access(toNamespacedPath(path), mode,
                         kUsePromises);
 }
 
@@ -186,8 +186,8 @@ async function copyFile(src, dest, flags) {
   validatePath(src, 'src');
   validatePath(dest, 'dest');
   flags = flags | 0;
-  return binding.copyFile(pathModule.toNamespacedPath(src),
-                          pathModule.toNamespacedPath(dest),
+  return binding.copyFile(toNamespacedPath(src),
+                          toNamespacedPath(dest),
                           flags, kUsePromises);
 }
 
@@ -200,7 +200,7 @@ async function open(path, flags, mode) {
   const flagsNumber = stringToFlags(flags);
   mode = validateMode(mode, 'mode', 0o666);
   return new FileHandle(
-    await binding.openFileHandle(pathModule.toNamespacedPath(path),
+    await binding.openFileHandle(toNamespacedPath(path),
                                  flagsNumber, mode, kUsePromises));
 }
 
@@ -262,8 +262,8 @@ async function rename(oldPath, newPath) {
   newPath = toPathIfFileURL(newPath);
   validatePath(oldPath, 'oldPath');
   validatePath(newPath, 'newPath');
-  return binding.rename(pathModule.toNamespacedPath(oldPath),
-                        pathModule.toNamespacedPath(newPath),
+  return binding.rename(toNamespacedPath(oldPath),
+                        toNamespacedPath(newPath),
                         kUsePromises);
 }
 
@@ -281,7 +281,7 @@ async function ftruncate(handle, len = 0) {
 async function rmdir(path) {
   path = toPathIfFileURL(path);
   validatePath(path);
-  return binding.rmdir(pathModule.toNamespacedPath(path), kUsePromises);
+  return binding.rmdir(toNamespacedPath(path), kUsePromises);
 }
 
 async function fdatasync(handle) {
@@ -308,7 +308,7 @@ async function mkdir(path, options) {
   if (typeof recursive !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
 
-  return binding.mkdir(pathModule.toNamespacedPath(path),
+  return binding.mkdir(toNamespacedPath(path),
                        validateMode(mode, 'mode', 0o777), recursive,
                        kUsePromises);
 }
@@ -317,7 +317,7 @@ async function readdir(path, options) {
   options = getOptions(options, {});
   path = toPathIfFileURL(path);
   validatePath(path);
-  const result = await binding.readdir(pathModule.toNamespacedPath(path),
+  const result = await binding.readdir(toNamespacedPath(path),
                                        options.encoding,
                                        !!options.withFileTypes,
                                        kUsePromises);
@@ -330,7 +330,7 @@ async function readlink(path, options) {
   options = getOptions(options, {});
   path = toPathIfFileURL(path);
   validatePath(path, 'oldPath');
-  return binding.readlink(pathModule.toNamespacedPath(path),
+  return binding.readlink(toNamespacedPath(path),
                           options.encoding, kUsePromises);
 }
 
@@ -341,7 +341,7 @@ async function symlink(target, path, type_) {
   validatePath(target, 'target');
   validatePath(path);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
-                         pathModule.toNamespacedPath(path),
+                         toNamespacedPath(path),
                          stringToSymlinkType(type),
                          kUsePromises);
 }
@@ -355,7 +355,7 @@ async function fstat(handle, options = { bigint: false }) {
 async function lstat(path, options = { bigint: false }) {
   path = toPathIfFileURL(path);
   validatePath(path);
-  const result = await binding.lstat(pathModule.toNamespacedPath(path),
+  const result = await binding.lstat(toNamespacedPath(path),
                                      options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
@@ -363,7 +363,7 @@ async function lstat(path, options = { bigint: false }) {
 async function stat(path, options = { bigint: false }) {
   path = toPathIfFileURL(path);
   validatePath(path);
-  const result = await binding.stat(pathModule.toNamespacedPath(path),
+  const result = await binding.stat(toNamespacedPath(path),
                                     options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
@@ -373,15 +373,15 @@ async function link(existingPath, newPath) {
   newPath = toPathIfFileURL(newPath);
   validatePath(existingPath, 'existingPath');
   validatePath(newPath, 'newPath');
-  return binding.link(pathModule.toNamespacedPath(existingPath),
-                      pathModule.toNamespacedPath(newPath),
+  return binding.link(toNamespacedPath(existingPath),
+                      toNamespacedPath(newPath),
                       kUsePromises);
 }
 
 async function unlink(path) {
   path = toPathIfFileURL(path);
   validatePath(path);
-  return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises);
+  return binding.unlink(toNamespacedPath(path), kUsePromises);
 }
 
 async function fchmod(handle, mode) {
@@ -394,7 +394,7 @@ async function chmod(path, mode) {
   path = toPathIfFileURL(path);
   validatePath(path);
   mode = validateMode(mode, 'mode');
-  return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises);
+  return binding.chmod(toNamespacedPath(path), mode, kUsePromises);
 }
 
 async function lchmod(path, mode) {
@@ -410,7 +410,7 @@ async function lchown(path, uid, gid) {
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
-  return binding.lchown(pathModule.toNamespacedPath(path),
+  return binding.lchown(toNamespacedPath(path),
                         uid, gid, kUsePromises);
 }
 
@@ -426,14 +426,14 @@ async function chown(path, uid, gid) {
   validatePath(path);
   validateUint32(uid, 'uid');
   validateUint32(gid, 'gid');
-  return binding.chown(pathModule.toNamespacedPath(path),
+  return binding.chown(toNamespacedPath(path),
                        uid, gid, kUsePromises);
 }
 
 async function utimes(path, atime, mtime) {
   path = toPathIfFileURL(path);
   validatePath(path);
-  return binding.utimes(pathModule.toNamespacedPath(path),
+  return binding.utimes(toNamespacedPath(path),
                         toUnixTimestamp(atime),
                         toUnixTimestamp(mtime),
                         kUsePromises);

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -10,8 +10,8 @@ const {
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { isUint8Array, isArrayBufferView } = require('internal/util/types');
+const { join, resolve, toNamespacedPath } = require('path');
 const { once } = require('internal/util');
-const pathModule = require('path');
 const util = require('util');
 const kType = Symbol('type');
 const kStats = Symbol('stats');
@@ -131,7 +131,7 @@ function getDirents(path, [names, types], callback) {
         const name = names[i];
         const idx = i;
         toFinish++;
-        lazyLoadFs().lstat(pathModule.join(path, name), (err, stats) => {
+        lazyLoadFs().lstat(join(path, name), (err, stats) => {
           if (err) {
             callback(err);
             return;
@@ -154,7 +154,7 @@ function getDirents(path, [names, types], callback) {
       const type = types[i];
       if (type === UV_DIRENT_UNKNOWN) {
         const name = names[i];
-        const stats = lazyLoadFs().lstatSync(pathModule.join(path, name));
+        const stats = lazyLoadFs().lstatSync(join(path, name));
         names[i] = new DirentFromStats(name, stats);
       } else {
         names[i] = new Dirent(names[i], types[i]);
@@ -220,8 +220,8 @@ function preprocessSymlinkDestination(path, type, linkPath) {
   } else if (type === 'junction') {
     // Junctions paths need to be absolute and \\?\-prefixed.
     // A relative target is relative to the link's parent directory.
-    path = pathModule.resolve(linkPath, '..', path);
-    return pathModule.toNamespacedPath(path);
+    path = resolve(linkPath, '..', path);
+    return toNamespacedPath(path);
   } else {
     // Windows symlinks don't tolerate forward slashes.
     return ('' + path).replace(/\//g, '\\');


### PR DESCRIPTION
Minor refactor: Use `destructuring assignment` at `path` module in fs instead of require the whole module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)