### PR TITLE
src: add `globalThis`

### DIFF
--- a/lib/internal/per_context.js
+++ b/lib/internal/per_context.js
@@ -3,6 +3,16 @@
 // node::NewContext calls this script
 
 (function(global) {
+  // https://github.com/tc39/proposal-global
+  // https://github.com/nodejs/node/pull/22835
+  // TODO(devsnek,ljharb) remove when V8 71 lands
+  Object.defineProperty(global, 'globalThis', {
+    value: global,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
   // https://github.com/nodejs/node/issues/14909
   if (global.Intl) delete global.Intl.v8BreakIterator;
 

--- a/test/parallel/test-global-descriptors.js
+++ b/test/parallel/test-global-descriptors.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const actualGlobal = Function('return this')();
+
+const {
+  value,
+  configurable,
+  enumerable,
+  writable
+} = Object.getOwnPropertyDescriptor(actualGlobal, 'globalThis');
+
+assert.strictEqual(value, actualGlobal, 'globalThis should be global object');
+assert.strictEqual(configurable, true, 'globalThis should be configurable');
+assert.strictEqual(enumerable, false, 'globalThis should be non-enumerable');
+assert.strictEqual(writable, true, 'globalThis should be writable');


### PR DESCRIPTION
Per https://github.com/tc39/proposal-global, the global value `globalThis` should be configurable, writable, and non-enumerable, and be the global object.

I assume this PR is semver-minor.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This PR replaces #10405.