### PR TITLE
test: fix syntax about try catch

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -41,7 +41,7 @@ const noop = () => {};
 const isMainThread = (() => {
   try {
     return require('worker_threads').isMainThread;
-  } catch {
+  } catch (e) {
     // Worker module not enabled → only a single main thread exists.
     return true;
   }


### PR DESCRIPTION
add `(e)` for `try...catch` scope.

I think it will be better to add `(e)` for `try...catch` scope. Although it works well when I use `./output/Debug/node` to run this code.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
