### PR TITLE
util: change inspect depth

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -183,6 +183,10 @@ property take precedence over `--trace-deprecation` and
 <!-- YAML
 added: v0.5.3
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17907
+    description: The `%o` specifier's `depth` option will now fall back to the
+                 default depth.
   - version: v8.4.0
     pr-url: https://github.com/nodejs/node/pull/14558
     description: The `%o` and `%O` specifiers are supported now.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -361,6 +361,9 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22846
+    description: The `depth` default changed to `20`.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/22788
     description: The `sorted` option is supported now.
   - version: REPLACEME
@@ -401,7 +404,7 @@ changes:
   * `depth` {number} Specifies the number of times to recurse while formatting
     the `object`. This is useful for inspecting large complicated objects. To
     make it recurse up to the maximum call stack size pass `Infinity` or `null`.
-    **Default:** `2`.
+    **Default:** `20`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.
@@ -458,12 +461,23 @@ util.inspect(new Bar()); // 'Bar {}'
 util.inspect(baz);       // '[foo] {}'
 ```
 
-The following example inspects all properties of the `util` object:
+The following example limits the inspected output of the `paths` property:
 
 ```js
 const util = require('util');
 
-console.log(util.inspect(util, { showHidden: true, depth: null }));
+console.log(util.inspect(module, { depth: 0 }));
+// Instead of showing all entries in `paths` `[Array]` is used to limit the
+// output for readability:
+
+// Module {
+//   id: '<repl>',
+//   exports: {},
+//   parent: undefined,
+//   filename: null,
+//   loaded: false,
+//   children: [],
+//   paths: [Array] }
 ```
 
 The following example highlights the difference with the `compact` option:
@@ -479,7 +493,7 @@ const o = {
     'foo']], 4],
   b: new Map([['za', 1], ['zb', 'test']])
 };
-console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
+console.log(util.inspect(o, { compact: true, breakLength: 80 }));
 
 // This will print
 
@@ -493,7 +507,7 @@ console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
 //   b: Map { 'za' => 1, 'zb' => 'test' } }
 
 // Setting `compact` to false changes the output to be more reader friendly.
-console.log(util.inspect(o, { compact: false, depth: 5, breakLength: 80 }));
+console.log(util.inspect(o, { compact: false, breakLength: 80 }));
 
 // {
 //   a: [

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -94,7 +94,7 @@ const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: 2,
+  depth: 20,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -128,8 +128,9 @@ function hasOwnProperty(obj, prop) {
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options =
-    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
+writer.options = Object.assign({},
+                               util.inspect.defaultOptions,
+                               { showProxy: true, depth: 2 });
 
 exports._builtinLibs = builtinLibs;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,8 +113,7 @@ function formatWithOptions(inspectOptions, f) {
           {
             const opts = Object.assign({}, inspectOptions, {
               showHidden: true,
-              showProxy: true,
-              depth: 4
+              showProxy: true
             });
             tempStr = inspect(arguments[a++], opts);
             break;

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -3,6 +3,7 @@
 require('../common');
 const assert = require('assert');
 const BufferList = require('internal/streams/buffer_list');
+const util = require('util');
 
 // Test empty buffer list.
 const emptyList = new BufferList();
@@ -30,3 +31,10 @@ assert.strictEqual(list.join(','), 'foo');
 const shifted = list.shift();
 assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());
+
+const tmp = util.inspect.defaultOptions.colors;
+util.inspect.defaultOptions = { colors: true };
+assert.strictEqual(
+  util.inspect(list),
+  'BufferList { length: \u001b[33m0\u001b[39m }');
+util.inspect.defaultOptions = { colors: tmp };

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -50,13 +50,17 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], {} ],' +
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ],' +
                   ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
-                  ', Proxy [ Proxy [Array], {} ] ] ]';
-const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], Proxy [Array]' +
-                  ' ],\n    Proxy [ Proxy [Array], Proxy [Array] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [Array], Proxy [Array] ],\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ] ] ]';
+                  ', Proxy [ Proxy [ {}, {} ], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
+                    'Proxy [ {}, {} ] ],\n' +
+                  '    Proxy [ Proxy [ {}, {} ], ' +
+                    'Proxy [ Proxy [ {}, {} ], {} ] ] ],\n' +
+                  '  Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
+                    'Proxy [ {}, {} ] ],\n' +
+                  '    Proxy [ Proxy [ {}, {} ], ' +
+                    'Proxy [ Proxy [ {}, {} ], {} ] ] ] ]';
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: true, depth: null }),
   expected1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -71,7 +71,7 @@ assert.strictEqual(util.inspect({ a: 1, b: 2 }), '{ a: 1, b: 2 }');
 assert.strictEqual(util.inspect({ 'a': {} }), '{ a: {} }');
 assert.strictEqual(util.inspect({ 'a': { 'b': 2 } }), '{ a: { b: 2 } }');
 assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }),
-                   '{ a: { b: { c: [Object] } } }');
+                   '{ a: { b: { c: { d: 2 } } } }');
 assert.strictEqual(
   util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }, false, null),
   '{ a: { b: { c: { d: 2 } } } }');
@@ -110,7 +110,7 @@ assert.strictEqual(util.inspect((new JSStream())._externalStream),
   assert.strictEqual(util.inspect({ a: regexp }, false, 0), '{ a: /regexp/ }');
 }
 
-assert(/Object/.test(
+assert(!/Object/.test(
   util.inspect({ a: { a: { a: { a: {} } } } }, undefined, undefined, true)
 ));
 assert(!/Object/.test(
@@ -1049,15 +1049,15 @@ if (typeof Symbol !== 'undefined') {
 // Empty and circular before depth.
 {
   const arr = [[[[]]]];
-  assert.strictEqual(util.inspect(arr), '[ [ [ [] ] ] ]');
+  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [] ] ] ]');
   arr[0][0][0][0] = [];
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Array] ] ] ]');
+  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Array] ] ] ]');
   arr[0][0][0] = {};
-  assert.strictEqual(util.inspect(arr), '[ [ [ {} ] ] ]');
+  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ {} ] ] ]');
   arr[0][0][0] = { a: 2 };
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
+  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Object] ] ] ]');
   arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
+  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Circular] ] ] ]');
 }
 
 // Corner cases.
@@ -1154,10 +1154,10 @@ if (typeof Symbol !== 'undefined') {
   assert(!/1 more item/.test(util.inspect(arr)));
   util.inspect.defaultOptions.maxArrayLength = oldOptions.maxArrayLength;
   assert(/1 more item/.test(util.inspect(arr)));
-  util.inspect.defaultOptions.depth = null;
-  assert(!/Object/.test(util.inspect(obj)));
-  util.inspect.defaultOptions.depth = oldOptions.depth;
+  util.inspect.defaultOptions.depth = 2;
   assert(/Object/.test(util.inspect(obj)));
+  util.inspect.defaultOptions.depth = oldOptions.depth;
+  assert(!/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)
@@ -1169,7 +1169,7 @@ if (typeof Symbol !== 'undefined') {
   assert(/Object/.test(util.inspect(obj)));
   util.inspect.defaultOptions = oldOptions;
   assert(/1 more item/.test(util.inspect(arr)));
-  assert(/Object/.test(util.inspect(obj)));
+  assert(!/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)
@@ -1555,11 +1555,19 @@ util.inspect(process);
   let head = list;
   // A linked list of length 100k should be inspectable in some way, even though
   // the real cutoff value is much lower than 100k.
-  for (let i = 0; i < 100000; i++)
+  for (let i = 0; i < 100000; i++) {
     head = head.next = {};
+  }
+
+  const res = Array(15)
+    .fill(0)
+    .map((_, i) => `{ next:\n${'   '.repeat(i + 1)}`)
+    .join('') +
+    '{ next: { next: { next: { next: { next: { next:' +
+    ' [Object] } } } } } } } } } } } } } } } } } } } } }';
   assert.strictEqual(
     util.inspect(list),
-    '{ next: { next: { next: [Object] } } }'
+    res
   );
   const longList = util.inspect(list, { depth: Infinity });
   const match = longList.match(/next/g);


### PR DESCRIPTION
The current default is not ideal in most use cases. Therefore it is
changed to inspect objects to a maximum depth of 20 in case
util.inspect is called with it's defaults. The default is kept at 2
when using console.log() and similar in the repl.

See the commit message for further details.

This should not be an issue for e.g., npm, since the maximum output
size is limited to 128 MB of data.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
