### PR TITLE
lib: remove useless input parameters and make 'digest' clear in the doc

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1784,6 +1784,9 @@ otherwise `err` will be `null`. By default, the successfully generated
 `derivedKey` will be passed to the callback as a [`Buffer`][]. An error will be
 thrown if any of the input arguments specify invalid values or types.
 
+If `digest` is `null`, `'sha1'` will be used. This behavior will be deprecated
+in a future version of Node.js.
+
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,
 but will take a longer amount of time to complete.
@@ -1846,6 +1849,9 @@ applied to derive a key of the requested byte length (`keylen`) from the
 
 If an error occurs an `Error` will be thrown, otherwise the derived key will be
 returned as a [`Buffer`][].
+
+If `digest` is `null`, `'sha1'` will be used. This behavior will be deprecated
+in a future version of Node.js.
 
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -23,7 +23,7 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   }
 
   ({ password, salt, iterations, keylen, digest } =
-      check(password, salt, iterations, keylen, digest, callback));
+    check(password, salt, iterations, keylen, digest));
 
   if (typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK();
@@ -43,7 +43,7 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
 function pbkdf2Sync(password, salt, iterations, keylen, digest) {
   ({ password, salt, iterations, keylen, digest } =
-      check(password, salt, iterations, keylen, digest, pbkdf2Sync));
+    check(password, salt, iterations, keylen, digest));
   const keybuf = Buffer.alloc(keylen);
   handleError(keybuf, password, salt, iterations, digest);
   const encoding = getDefaultEncoding();
@@ -51,7 +51,7 @@ function pbkdf2Sync(password, salt, iterations, keylen, digest) {
   return keybuf.toString(encoding);
 }
 
-function check(password, salt, iterations, keylen, digest, callback) {
+function check(password, salt, iterations, keylen, digest) {
   if (typeof digest !== 'string') {
     if (digest !== null)
       throw new ERR_INVALID_ARG_TYPE('digest', ['string', 'null'], digest);


### PR DESCRIPTION
1) Remove 'callback' in 'check' function, because we don't check or use
that directly.

2) Adjust the orders of codes in 'pbkdf2' to have a quick check whether
the callback is a function or not instead of using it into the 'check'
method.

3) Add explainations to 'digest' in the doc.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]
