### PR TITLE
http2: do not emit 'aborted' if the stream closed locally

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1489,7 +1489,7 @@ function closeStream(stream, code, rstStreamStatus = kSubmitRstStream) {
   if (!ending) {
     // If the writable side of the Http2Stream is still open, emit the
     // 'aborted' event and set the aborted flag.
-    if (!stream.aborted) {
+    if (!stream.aborted && !stream.closed) {
       state.flags |= STREAM_FLAGS_ABORTED;
       stream.emit('aborted');
     }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1489,7 +1489,7 @@ function closeStream(stream, code, rstStreamStatus = kSubmitRstStream) {
   if (!ending) {
     // If the writable side of the Http2Stream is still open, emit the
     // 'aborted' event and set the aborted flag.
-    if (!stream.aborted && !stream.closed) {
+    if (!stream.aborted && !stream.state.localClose) {
       state.flags |= STREAM_FLAGS_ABORTED;
       stream.emit('aborted');
     }


### PR DESCRIPTION
check if the stream didn't close locally before calling `aborted`

Fixes: https://github.com/nodejs/node/issues/22851

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
