### PR TITLE
http2: do not falsely emit 'aborted' on push

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -275,6 +275,7 @@ function onSessionHeaders(handle, id, cat, flags, headers) {
       }
     } else {
       stream = new ClientHttp2Stream(session, handle, id, opts);
+      stream.end();
     }
     process.nextTick(emit, session, 'stream', stream, obj, flags, headers);
   } else {

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -54,6 +54,7 @@ server.listen(0, common.mustCall(() => {
       assert.strictEqual(headers['content-type'], 'text/html');
       assert.strictEqual(headers['x-push-data'], 'pushed by server');
     }));
+    stream.on('aborted', common.mustNotCall());
   }));
 
   let data = '';


### PR DESCRIPTION
A push stream should have its writable side closed upon receipt, to avoid emitting the 'aborted' event when the readable side is closed.

(As far as I can tell this has been an issue as long as http2 has been around.)

Fixes: https://github.com/nodejs/node/issues/22851

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
