### PR TITLE
test: expect test to fail in debug builds

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,3 +21,8 @@ test-trace-events-fs-sync: PASS,FLAKY
 [$system==freebsd]
 
 [$system==aix]
+
+# https://github.com/nodejs/node/issues/22775
+# ATM This fails with V8 6.9. Should be fixed in 7.0.
+[$mode==debug]
+test-http-same-map.js: FAIL

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -25,4 +25,4 @@ test-trace-events-fs-sync: PASS,FLAKY
 # https://github.com/nodejs/node/issues/22775
 # ATM This fails with V8 6.9. Should be fixed in 7.0.
 [$mode==debug]
-test-http-same-map.js: FAIL
+test-http-same-map: FAIL


### PR DESCRIPTION
ATM This fails with V8 6.9. Should be fixed in 7.0.
Refs: https://github.com/nodejs/node/issues/22775

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
