### PR TITLE
tools: synchronize deepStrictEqual() message rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -160,6 +160,10 @@ module.exports = {
     'no-restricted-syntax': [
       'error',
       {
+        selector: "CallExpression[callee.object.name='assert'][callee.property.name='deepStrictEqual'][arguments.2.type='Literal']",
+        message: 'Do not use a literal for the third argument of assert.deepStrictEqual()'
+      },
+      {
         selector: "CallExpression[callee.object.name='assert'][callee.property.name='doesNotThrow']",
         message: 'Please replace `assert.doesNotThrow()` and add a comment next to the code instead.'
       },


### PR DESCRIPTION
Update ESLint config to include a rule about assert.deepStrictEqual()
messages and string literals. The rule is included in lib and test, but
should be included everywhere else as well.

(Whoops! This was my mistake in b7661a8311a0bf5703a009bf35b4333c1c6e60e0.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
