### PR TITLE
[v8.x backport] tools, test: forbid string literal as third argument for assert.strictEqual() and friends

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -610,11 +610,11 @@ try {
 }
 
 try {
-  assert.strictEqual(1, 2, 'oh no');
+  assert.strictEqual(1, 2, 'oh no'); // eslint-disable-line no-restricted-syntax
 } catch (e) {
   assert.strictEqual(e.message.split('\n')[0], 'oh no');
-  assert.strictEqual(e.generatedMessage, false,
-                     'Message incorrectly marked as generated');
+  // Message should not be marked as generated.
+  assert.strictEqual(e.generatedMessage, false);
 }
 
 {

--- a/test/parallel/test-dns-resolveany-bad-ancount.js
+++ b/test/parallel/test-dns-resolveany-bad-ancount.js
@@ -31,8 +31,8 @@ server.bind(0, common.mustCall(() => {
     assert.strictEqual(err.syscall, 'queryAny');
     assert.strictEqual(err.hostname, 'example.org');
     const descriptor = Object.getOwnPropertyDescriptor(err, 'message');
-    assert.strictEqual(descriptor.enumerable,
-                       false, 'The error message should be non-enumerable');
+    // The error message should be non-enumerable.
+    assert.strictEqual(descriptor.enumerable, false);
     server.close();
   }));
 }));

--- a/test/parallel/test-next-tick-domain.js
+++ b/test/parallel/test-next-tick-domain.js
@@ -27,5 +27,5 @@ const origNextTick = process.nextTick;
 
 require('domain');
 
-assert.strictEqual(origNextTick, process.nextTick,
-                   'Requiring domain should not change nextTick');
+// Requiring domain should not change nextTick.
+assert.strictEqual(origNextTick, process.nextTick);

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -26,8 +26,8 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-assert.strictEqual(typeof global.gc, 'function',
-                   'Run this test with --expose-gc');
+if (typeof global.gc !== 'function')
+  assert.fail('Run this test with --expose-gc');
 
 common.globalCheck = false;
 

--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -48,7 +48,7 @@ server.on('stream', common.mustCall((stream) => {
 }));
 server.setTimeout(serverTimeout);
 server.on('timeout', () => {
-  assert.strictEqual(didReceiveData, false, 'Should not timeout');
+  assert.ok(!didReceiveData, 'Should not timeout');
 });
 
 server.listen(0, common.mustCall(() => {

--- a/test/sequential/test-http2-timeout-large-write.js
+++ b/test/sequential/test-http2-timeout-large-write.js
@@ -40,13 +40,13 @@ server.on('stream', common.mustCall((stream) => {
   stream.write(content);
   stream.setTimeout(serverTimeout);
   stream.on('timeout', () => {
-    assert.strictEqual(didReceiveData, false, 'Should not timeout');
+    assert.ok(!didReceiveData, 'Should not timeout');
   });
   stream.end();
 }));
 server.setTimeout(serverTimeout);
 server.on('timeout', () => {
-  assert.strictEqual(didReceiveData, false, 'Should not timeout');
+  assert.ok(!didReceiveData, 'Should not timeout');
 });
 
 server.listen(0, common.mustCall(() => {

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -33,8 +33,7 @@ function checkBadPath(err) {
 }
 
 function checkException(message) {
-  assert.strictEqual(message.exceptionDetails, undefined,
-                     'An exception occurred during execution');
+  assert.strictEqual(message.exceptionDetails, undefined);
 }
 
 function assertNoUrlsWhileConnected(response) {


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/22849.

This backport does not preserve the lint rule (because it would result in 121 lint warnings in the v8.x code base), but preserves all the relevant changes to tests due to the lint rule.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
