### PR TITLE
[v6.x backport] tools, test: forbid string literal as third argument for assert.strictEqual() and friends

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -547,11 +547,11 @@ try {
 }
 
 try {
-  assert.strictEqual(1, 2, 'oh no');
+  assert.strictEqual(1, 2, 'oh no'); // eslint-disable-line no-restricted-syntax
 } catch (e) {
   assert.strictEqual(e.toString().split('\n')[0], 'AssertionError: oh no');
-  assert.strictEqual(e.generatedMessage, false,
-                     'Message incorrectly marked as generated');
+  // Message should not be marked as generated.
+  assert.strictEqual(e.generatedMessage, false);
 }
 
 // Verify that throws() and doesNotThrow() throw on non-function block

--- a/test/parallel/test-next-tick-domain.js
+++ b/test/parallel/test-next-tick-domain.js
@@ -6,5 +6,5 @@ const origNextTick = process.nextTick;
 
 require('domain');
 
-assert.strictEqual(origNextTick, process.nextTick,
-                   'Requiring domain should not change nextTick');
+// Requiring domain should not change nextTick.
+assert.strictEqual(origNextTick, process.nextTick);

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -5,8 +5,8 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-assert.strictEqual(typeof global.gc, 'function',
-                   'Run this test with --expose-gc');
+if (typeof global.gc !== 'function')
+  assert.fail('Run this test with --expose-gc');
 
 common.globalCheck = false;
 


### PR DESCRIPTION
Backport of #22849.

This backport does not preserve the lint rule (because it would result in lint warnings in the v6.x code base), but preserves all the relevant changes to tests due to the lint rule.