### PR TITLE
test: Remove string literals for strictEquals/notStrictEquals

### DIFF
--- a/test/fixtures/not-main-module.js
+++ b/test/fixtures/not-main-module.js
@@ -20,6 +20,5 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const assert = require('assert');
-assert.notStrictEqual(module, require.main, 'require.main should not == module');
-assert.notStrictEqual(module, process.mainModule,
-                      'process.mainModule should not === module');
+assert.notStrictEqual(module, require.main);
+assert.notStrictEqual(module, process.mainModule);

--- a/test/parallel/test-async-wrap-trigger-id.js
+++ b/test/parallel/test-async-wrap-trigger-id.js
@@ -11,12 +11,16 @@ let triggerAsyncId1;
 process.nextTick(() => {
   process.nextTick(() => {
     triggerAsyncId1 = triggerAsyncId();
+    // Async resources having different causal ancestry
+    // should have different triggerAsyncIds
     assert.notStrictEqual(
       triggerAsyncId0,
       triggerAsyncId1);
   });
   process.nextTick(() => {
     const triggerAsyncId2 = triggerAsyncId();
+    // Async resources having the same causal ancestry
+    // should have the same triggerAsyncId
     assert.strictEqual(
       triggerAsyncId1,
       triggerAsyncId2);

--- a/test/parallel/test-async-wrap-trigger-id.js
+++ b/test/parallel/test-async-wrap-trigger-id.js
@@ -13,16 +13,12 @@ process.nextTick(() => {
     triggerAsyncId1 = triggerAsyncId();
     assert.notStrictEqual(
       triggerAsyncId0,
-      triggerAsyncId1,
-      'Async resources having different causal ancestry ' +
-      'should have different triggerAsyncIds');
+      triggerAsyncId1);
   });
   process.nextTick(() => {
     const triggerAsyncId2 = triggerAsyncId();
     assert.strictEqual(
       triggerAsyncId1,
-      triggerAsyncId2,
-      'Async resources having the same causal ancestry ' +
-      'should have the same triggerAsyncId');
+      triggerAsyncId2);
   });
 });


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/22849.

In short: Some unit tests are using string literals to simply tell you a
conclusion what's right/wrong BUT not tell you what actually values are.
So it's necessary to print them out in the console.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines]