### PR TITLE
child_process: fire close event from stdio

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -387,6 +387,9 @@ ChildProcess.prototype.spawn = function(options) {
     // The stream is already cloned and piped, thus close it.
     if (stream.type === 'wrap') {
       stream.handle.close();
+      if (stream._stdio && stream._stdio instanceof EventEmitter) {
+        stream._stdio.emit('close');
+      }
       continue;
     }
 
@@ -946,7 +949,8 @@ function _validateStdio(stdio, sync) {
       acc.push({
         type: 'wrap',
         wrapType: getHandleWrapType(handle),
-        handle: handle
+        handle: handle,
+        _stdio: stdio
       });
     } else if (isArrayBufferView(stdio) || typeof stdio === 'string') {
       if (!sync) {

--- a/test/parallel/test-child-process-server-close.js
+++ b/test/parallel/test-child-process-server-close.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const { spawn } = require('child_process');
+const net = require('net');
+
+const server = net.createServer((conn) => {
+  conn.on('close', common.mustCall());
+
+  spawn(process.execPath, ['-v'], {
+    stdio: ['ignore', conn, 'ignore']
+  }).on('close', common.mustCall());
+}).listen(common.PIPE, () => {
+  const client = net.connect(common.PIPE, common.mustCall());
+  client.on('data', () => {
+    client.end(() => {
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Event of close does not fire when giving for stdio option that type is wrap.
For example, if we set event listener to net.server and giving child_process, that events never fire.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
