### PR TITLE
TTY: Document WriteStream.cursorTo and others

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -164,18 +164,7 @@ to pass in an object with different settings.
 Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
 always return 1.
 
-## writeStream.getWindowSize()
-<!-- YAML
-added: v0.7.7
--->
-* Returns: {number[]}
-
-`writeStream.getWindowSize()` returns the size of the [TTY](tty.html) corresponding
-to this `WriteStream`. The array is of the type `[numColumns, numRows]`
-where `numColumns` and `numRows` represent the number of columns and rows
-in the corresponding [TTY](tty.html).
-
-## tty.isatty(fd)
+### tty.isatty(fd)
 <!-- YAML
 added: v0.5.8
 -->
@@ -185,6 +174,17 @@ added: v0.5.8
 The `tty.isatty()` method returns `true` if the given `fd` is associated with
 a TTY and `false` if it is not, including whenever `fd` is not a non-negative
 integer.
+
+### writeStream.getWindowSize()
+<!-- YAML
+added: v0.7.7
+-->
+* Returns: {number[]}
+
+`writeStream.getWindowSize()` returns the size of the [TTY](tty.html)
+corresponding to this `WriteStream`. The array is of the type
+`[numColumns, numRows]` where `numColumns` and `numRows` represent the number
+of columns and rows in the corresponding [TTY](tty.html).
 
 ### writeStream.isTTY
 <!-- YAML

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -98,6 +98,27 @@ process.stdout.on('resize', () => {
 });
 ```
 
+### writeStream.clearLine(dir)
+<!-- YAML
+added: v0.7.7
+-->
+
+* `dir` {number}
+  * `-1` - to the left from cursor
+  * `1` - to the right from cursor
+  * `0` - the entire line
+
+`writeStream.clearLine()` clears the current line of this `WriteStream` in a
+direction identified by `dir`.
+
+### writeStream.clearScreenDown()
+<!-- YAML
+added: v0.7.7
+-->
+
+`writeStream.clearScreenDown()` clears this `WriteStream` from the current
+cursor down.
+
 ### writeStream.columns
 <!-- YAML
 added: v0.7.7
@@ -114,66 +135,8 @@ added: v0.7.7
 * `x` {number}
 * `y` {number}
 
-`writeStream.cursorTo` moves this `WriteStream`'s cursor to the specified
+`writeStream.cursorTo()` moves this `WriteStream`'s cursor to the specified
 position.
-
-### writeStream.moveCursor(dx, dy)
-<!-- YAML
-added: v0.7.7
--->
-
-* `dx` {number}
-* `dy` {number}
-
-`writeStream.moveCursor` moves this `WriteStream`'s cursor *relative* to its
-current position.
-
-### writeStream.clearLine(dir)
-<!-- YAML
-added: v0.7.7
--->
-
-* `dir` {number}
-  * `-1` - to the left from cursor
-  * `1` - to the right from cursor
-  * `0` - the entire line
-
-`writeStream.clearLine` clears the current line of this `WriteStream` in a
-direction identified by `dir`.
-
-### writeStream.clearScreenDown()
-<!-- YAML
-added: v0.7.7
--->
-
-`writeStream.clearScreenDown` clears this `WriteStream` from the current
-cursor down.
-
-### writeStream.getWindowSize()
-<!-- YAML
-added: v0.7.7
--->
-* Returns: {array}
-
-`writeStream.getWindowSize` returns the size of the [TTY]() corresponding
-to this `WriteStream`. The array is of the type `[numColumns, numRows]`
-where `numColumns` and `numRows` represents the number of columns and rows
-in the corresponding [TTY]().
-
-### writeStream.isTTY
-<!-- YAML
-added: v0.5.8
--->
-
-A `boolean` that is always `true`.
-
-### writeStream.rows
-<!-- YAML
-added: v0.7.7
--->
-
-A `number` specifying the number of rows the TTY currently has. This property
-is updated whenever the `'resize'` event is emitted.
 
 ### writeStream.getColorDepth([env])
 <!-- YAML
@@ -201,6 +164,17 @@ to pass in an object with different settings.
 Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
 always return 1.
 
+## writeStream.getWindowSize()
+<!-- YAML
+added: v0.7.7
+-->
+* Returns: {number[]}
+
+`writeStream.getWindowSize()` returns the size of the [TTY](tty.html) corresponding
+to this `WriteStream`. The array is of the type `[numColumns, numRows]`
+where `numColumns` and `numRows` represent the number of columns and rows
+in the corresponding [TTY](tty.html).
+
 ## tty.isatty(fd)
 <!-- YAML
 added: v0.5.8
@@ -211,6 +185,32 @@ added: v0.5.8
 The `tty.isatty()` method returns `true` if the given `fd` is associated with
 a TTY and `false` if it is not, including whenever `fd` is not a non-negative
 integer.
+
+### writeStream.isTTY
+<!-- YAML
+added: v0.5.8
+-->
+
+A `boolean` that is always `true`.
+
+### writeStream.moveCursor(dx, dy)
+<!-- YAML
+added: v0.7.7
+-->
+
+* `dx` {number}
+* `dy` {number}
+
+`writeStream.moveCursor()` moves this `WriteStream`'s cursor *relative* to its
+current position.
+
+### writeStream.rows
+<!-- YAML
+added: v0.7.7
+-->
+
+A `number` specifying the number of rows the TTY currently has. This property
+is updated whenever the `'resize'` event is emitted.
 
 [`net.Socket`]: net.html#net_class_net_socket
 [`process.stdin`]: process.html#process_process_stdin

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -106,6 +106,60 @@ added: v0.7.7
 A `number` specifying the number of columns the TTY currently has. This property
 is updated whenever the `'resize'` event is emitted.
 
+### writeStream.cursorTo(x, y)
+<!-- YAML
+added: v0.7.7
+-->
+
+* `x` {number}
+* `y` {number}
+
+`writeStream.cursorTo` moves this `WriteStream`'s cursor to the specified
+position.
+
+### writeStream.moveCursor(dx, dy)
+<!-- YAML
+added: v0.7.7
+-->
+
+* `dx` {number}
+* `dy` {number}
+
+`writeStream.moveCursor` moves this `WriteStream`'s cursor *relative* to its
+current position.
+
+### writeStream.clearLine(dir)
+<!-- YAML
+added: v0.7.7
+-->
+
+* `dir` {number}
+  * `-1` - to the left from cursor
+  * `1` - to the right from cursor
+  * `0` - the entire line
+
+`writeStream.clearLine` clears the current line of this `WriteStream` in a
+direction identified by `dir`.
+
+### writeStream.clearScreenDown()
+<!-- YAML
+added: v0.7.7
+-->
+
+`writeStream.clearScreenDown` clears this `WriteStream` from the current
+cursor down.
+
+### writeStream.getWindowSize()
+<!-- YAML
+added: v0.7.7
+-->
+* Returns: {array}
+
+`writeStream.getWindowSize` returns the size of the [TTY]() corresponding
+to this `WriteStream`. The array is of the type `[numColumns, numRows]`
+where `numColumns` and `numRows` represents the number of columns and rows
+in the corresponding [TTY]().
+
 ### writeStream.isTTY
 <!-- YAML
 added: v0.5.8


### PR DESCRIPTION
This adds documentation for the following WriteStream instance methods:
- cursorTo
- moveCursor
- clearLine
- clearScreenDown
- getWindowSize

Fixes #9853.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
