### PR TITLE
tty: implement ReadStream._final to avoid ENOTCONN on .end()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -80,6 +80,7 @@ const {
 } = errors.codes;
 const { validateInt32, validateString } = require('internal/validators');
 const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
+const kShouldShutdown = Symbol('shouldShutdown');
 
 // Lazy loaded to improve startup performance.
 let cluster;
@@ -245,6 +246,10 @@ function Socket(options) {
   options.writable = options.writable || false;
   const { allowHalfOpen } = options;
 
+  // Needed to avoid to call uv_shutdown during _final
+  // as otherwise it would error with an ENOTCONN.
+  this[kShouldShutdown] = options.writable;
+
   // Prevent the "no-half-open enforcer" from being inherited from `Duplex`.
   options.allowHalfOpen = true;
   // For backwards compat do not emit close on destroy.
@@ -359,7 +364,7 @@ Socket.prototype._final = function(cb) {
   debug('_final: not ended, call shutdown()');
 
   // otherwise, just shutdown, or destroy() if not possible
-  if (!this._handle || !this._handle.shutdown) {
+  if (!this[kShouldShutdown] || !this._handle || !this._handle.shutdown) {
     cb();
     return this.destroy();
   }

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -66,6 +66,7 @@ function ReadStream(fd, options) {
 }
 inherits(ReadStream, net.Socket);
 
+
 ReadStream.prototype.setRawMode = function(flag) {
   flag = !!flag;
   this._handle.setRawMode(flag);

--- a/test/pseudo-tty/test-tty-stdin-call-end.js
+++ b/test/pseudo-tty/test-tty-stdin-call-end.js
@@ -1,0 +1,8 @@
+'use strict';
+
+require('../common');
+
+// This tests verifies that process.stdin.end() does not
+// crash the process with ENOTCONN
+
+process.stdin.end();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/22814.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
