### PR TITLE
lib: remove unused parameter

### DIFF
--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -71,7 +71,7 @@ function handleError(keybuf, password, salt, N, r, p, maxmem, wrap) {
   throw ex;  // Scrypt operation failed, exception object contains details.
 }
 
-function check(password, salt, keylen, options, callback) {
+function check(password, salt, keylen, options) {
   if (_scrypt === undefined)
     throw new ERR_CRYPTO_SCRYPT_NOT_SUPPORTED();
 


### PR DESCRIPTION
The parameter is neither used within the function nor passed from other functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
