### PR TITLE
 deps: backport 958b761 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -29,7 +29,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.2',
+    'v8_embedder_string': '-node.3',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -865,6 +865,8 @@ action("postmortem-metadata") {
     "src/objects/js-regexp-string-iterator.h",
     "src/objects/map.h",
     "src/objects/map-inl.h",
+    "src/objects/name.h",
+    "src/objects/name-inl.h",
     "src/objects/scope-info.h",
     "src/objects/script.h",
     "src/objects/script-inl.h",

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -2728,6 +2728,8 @@
             '../src/objects/js-regexp-string-iterator.h',
             '../src/objects/map.h',
             '../src/objects/map-inl.h',
+            '../src/objects/name.h',
+            '../src/objects/name-inl.h',
             '../src/objects/scope-info.h',
             '../src/objects/script.h',
             '../src/objects/script-inl.h',

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -418,14 +418,9 @@ def load_objects_from_file(objfilename, checktypes):
         #
         for type in types:
                 #
-                # Symbols and Strings are implemented using the same classes.
-                #
-                usetype = re.sub('SYMBOL_', 'STRING_', type);
-
-                #
                 # REGEXP behaves like REG_EXP, as in JS_REGEXP_TYPE => JSRegExp.
                 #
-                usetype = re.sub('_REGEXP_', '_REG_EXP_', usetype);
+                usetype = re.sub('_REGEXP_', '_REG_EXP_', type);
 
                 #
                 # Remove the "_TYPE" suffix and then convert to camel case,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Original commit message:

    [postmortem] add postmortem metadata for symbols

    As discussed in nodejs/llnode#156, we need
    postmortem metadata for Symbols to properly print Symbol property names
    in postmortem debugging tools. Patch suggested by Ben Noordhuis
    (nodejs/llnode#156 (comment)).

    R=bmeurer@google.com, yangguo@google.com

    Change-Id: Ied6d3c079e8b23a9c796bc632c37785ed7dbc118
    Reviewed-on: chromium-review.googlesource.com/1205052
    Reviewed-by: Benedikt Meurer <bmeurer@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Commit-Queue: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#55632}

Refs: v8/v8@958b761

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
