### PR TITLE
vm: update source, related basic & cached data tests for ArrayBuffer

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -434,10 +434,10 @@ changes:
     in stack traces produced by this script.
   * `columnOffset` {number} Specifies the column number offset that is displayed
     in stack traces produced by this script.
-  * `cachedData` {Buffer} Provides an optional `Buffer` with V8's code cache
-    data for the supplied source. When supplied, the `cachedDataRejected` value
-    will be set to either `true` or `false` depending on acceptance of the data
-    by V8.
+  * `cachedData` {Buffer|TypedArray|DataView} Provides an optional `Buffer` or
+    `TypedArray`, or `DataView` with V8's code cache data for the supplied
+     source. When supplied, the `cachedDataRejected` value will be set to
+     either `true` or `false` depending on acceptance of the data by V8.
   * `produceCachedData` {boolean} When `true` and no `cachedData` is present, V8
     will attempt to produce code cache data for `code`. Upon success, a
     `Buffer` with V8's code cache data will be produced and stored in the
@@ -669,8 +669,9 @@ added: v10.10.0
     in stack traces produced by this script. **Default:** `0`.
   * `columnOffset` {number} Specifies the column number offset that is displayed
     in stack traces produced by this script. **Default:** `0`.
-  * `cachedData` {Buffer} Provides an optional `Buffer` with V8's code cache
-    data for the supplied source.
+  * `cachedData` {Buffer|TypedArray|DataView} Provides an optional `Buffer` or
+    `TypedArray`, or `DataView` with V8's code cache data for the supplied
+     source.
   * `produceCachedData` {boolean} Specifies whether to produce new cache data.
     **Default:** `false`.
   * `parsingContext` {Object} The [contextified][] sandbox in which the said

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -32,7 +32,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
-const { isModuleNamespaceObject, isUint8Array } = require('util').types;
+const { isModuleNamespaceObject, isArrayBufferView } = require('util').types;
 const { validateInt32, validateUint32 } = require('internal/validators');
 const kParsingContext = Symbol('script parsing context');
 
@@ -64,9 +64,12 @@ class Script extends ContextifyScript {
     }
     validateInt32(lineOffset, 'options.lineOffset');
     validateInt32(columnOffset, 'options.columnOffset');
-    if (cachedData !== undefined && !isUint8Array(cachedData)) {
-      throw new ERR_INVALID_ARG_TYPE('options.cachedData',
-                                     ['Buffer', 'Uint8Array'], cachedData);
+    if (cachedData !== undefined && !isArrayBufferView(cachedData)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'options.cachedData',
+        ['Buffer', 'TypedArray', 'DataView'],
+        cachedData
+      );
     }
     if (typeof produceCachedData !== 'boolean') {
       throw new ERR_INVALID_ARG_TYPE('options.produceCachedData', 'boolean',
@@ -346,10 +349,10 @@ function compileFunction(code, params, options = {}) {
   }
   validateUint32(columnOffset, 'options.columnOffset');
   validateUint32(lineOffset, 'options.lineOffset');
-  if (cachedData !== undefined && !isUint8Array(cachedData)) {
+  if (cachedData !== undefined && !isArrayBufferView(cachedData)) {
     throw new ERR_INVALID_ARG_TYPE(
       'options.cachedData',
-      'Uint8Array',
+      ['Buffer', 'TypedArray', 'DataView'],
       cachedData
     );
   }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -33,6 +33,7 @@ namespace contextify {
 
 using v8::Array;
 using v8::ArrayBuffer;
+using v8::ArrayBufferView;
 using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -64,7 +65,6 @@ using v8::String;
 using v8::Symbol;
 using v8::TryCatch;
 using v8::Uint32;
-using v8::Uint8Array;
 using v8::UnboundScript;
 using v8::Value;
 using v8::WeakCallbackInfo;
@@ -629,7 +629,7 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
 
   Local<Integer> line_offset;
   Local<Integer> column_offset;
-  Local<Uint8Array> cached_data_buf;
+  Local<ArrayBufferView> cached_data_buf;
   bool produce_cached_data = false;
   Local<Context> parsing_context = context;
 
@@ -642,8 +642,8 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
     CHECK(args[3]->IsNumber());
     column_offset = args[3].As<Integer>();
     if (!args[4]->IsUndefined()) {
-      CHECK(args[4]->IsUint8Array());
-      cached_data_buf = args[4].As<Uint8Array>();
+      CHECK(args[4]->IsArrayBufferView());
+      cached_data_buf = args[4].As<ArrayBufferView>();
     }
     CHECK(args[5]->IsBoolean());
     produce_cached_data = args[5]->IsTrue();
@@ -994,10 +994,10 @@ void ContextifyContext::CompileFunction(
   Local<Integer> column_offset = args[3].As<Integer>();
 
   // Argument 5: cached data (optional)
-  Local<Uint8Array> cached_data_buf;
+  Local<ArrayBufferView> cached_data_buf;
   if (!args[4]->IsUndefined()) {
-    CHECK(args[4]->IsUint8Array());
-    cached_data_buf = args[4].As<Uint8Array>();
+    CHECK(args[4]->IsArrayBufferView());
+    cached_data_buf = args[4].As<ArrayBufferView>();
   }
 
   // Argument 6: produce cache data

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -178,18 +178,20 @@ const vm = require('vm');
     'filename': 'string',
     'columnOffset': 'number',
     'lineOffset': 'number',
-    'cachedData': 'Uint8Array',
+    'cachedData': 'Buffer, TypedArray, or DataView',
     'produceCachedData': 'boolean',
   };
 
   for (const option in optionTypes) {
+    const typeErrorMessage = `The "options.${option}" property must be ` +
+       `${option === 'cachedData' ? 'one of' : 'of'} type`;
     common.expectsError(() => {
       vm.compileFunction('', undefined, { [option]: null });
     }, {
       type: TypeError,
       code: 'ERR_INVALID_ARG_TYPE',
-      message: `The "options.${option}" property must be of type ` +
-        `${optionTypes[option]}. Received type object`
+      message: typeErrorMessage +
+        ` ${optionTypes[option]}. Received type object`
     });
   }
 

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -91,5 +91,5 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: /must be one of type Buffer or Uint8Array/
+  message: /must be one of type Buffer, TypedArray, or DataView/
 });

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -41,12 +41,13 @@ function testProduceConsume() {
 
   const data = produce(source);
 
-  // It should consume code cache
-  const script = new vm.Script(source, {
-    cachedData: data
-  });
-  assert(!script.cachedDataRejected);
-  assert.strictEqual(script.runInThisContext()(), 'original');
+  for (const parsedData of common.getArrayBufferViews(data)) {
+    const script = new vm.Script(source, {
+      cachedData: parsedData
+    });
+    assert(!script.cachedDataRejected);
+    assert.strictEqual(script.runInThisContext()(), 'original');
+  }
 }
 testProduceConsume();
 
@@ -61,15 +62,16 @@ function testRejectInvalid() {
   const source = getSource('invalid');
 
   const data = produce(source);
-
-  // It should reject invalid code cache
-  const script = new vm.Script(getSource('invalid_1'), {
-    cachedData: data
-  });
-  assert(script.cachedDataRejected);
-  assert.strictEqual(script.runInThisContext()(), 'invalid_1');
+ 
+  for (const parsedData of common.getArrayBufferViews(data)) {
+    // It should reject invalid code cache
+    const script = new vm.Script(getSource('invalid_1'), {
+      cachedData: parsedData
+    });
+    assert(script.cachedDataRejected);
+    assert.strictEqual(script.runInThisContext()(), 'invalid_1');
+  }
 }
-testRejectInvalid();
 
 function testRejectSlice() {
   const source = getSource('slice');
@@ -81,7 +83,7 @@ function testRejectSlice() {
   });
   assert(script.cachedDataRejected);
 }
-testRejectSlice();
+// testRejectSlice();
 
 // It should throw on non-Buffer cachedData
 common.expectsError(() => {

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -42,6 +42,7 @@ function testProduceConsume() {
   const data = produce(source);
 
   for (const parsedData of common.getArrayBufferViews(data)) {
+    // It should consume code cache
     const script = new vm.Script(source, {
       cachedData: parsedData
     });
@@ -62,16 +63,15 @@ function testRejectInvalid() {
   const source = getSource('invalid');
 
   const data = produce(source);
- 
-  for (const parsedData of common.getArrayBufferViews(data)) {
-    // It should reject invalid code cache
-    const script = new vm.Script(getSource('invalid_1'), {
-      cachedData: parsedData
-    });
-    assert(script.cachedDataRejected);
-    assert.strictEqual(script.runInThisContext()(), 'invalid_1');
-  }
+
+  // It should reject invalid code cache
+  const script = new vm.Script(getSource('invalid_1'), {
+    cachedData: data
+  });
+  assert(script.cachedDataRejected);
+  assert.strictEqual(script.runInThisContext()(), 'invalid_1');
 }
+testRejectInvalid();
 
 function testRejectSlice() {
   const source = getSource('slice');
@@ -83,7 +83,7 @@ function testRejectSlice() {
   });
   assert(script.cachedDataRejected);
 }
-// testRejectSlice();
+testRejectSlice();
 
 // It should throw on non-Buffer cachedData
 common.expectsError(() => {

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -42,7 +42,7 @@ function testProduceConsume() {
   const data = produce(source);
 
   for (const parsedData of common.getArrayBufferViews(data)) {
-    // It should consume code cache
+    // It should consume code cache 
     const script = new vm.Script(source, {
       cachedData: parsedData
     });

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -44,7 +44,7 @@ function testProduceConsume() {
   for (const cachedData of common.getArrayBufferViews(data)) {
     // It should consume code cache
     const script = new vm.Script(source, {
-      cachedData: cachedData
+      cachedData
     });
     assert(!script.cachedDataRejected);
     assert.strictEqual(script.runInThisContext()(), 'original');

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -43,7 +43,9 @@ function testProduceConsume() {
 
   for (const cachedData of common.getArrayBufferViews(data)) {
     // It should consume code cache
-    const script = new vm.Script(source, { cachedData });
+    const script = new vm.Script(source, {
+      cachedData
+    });
     assert(!script.cachedDataRejected);
     assert.strictEqual(script.runInThisContext()(), 'original');
   }

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -44,7 +44,7 @@ function testProduceConsume() {
   for (const cachedData of common.getArrayBufferViews(data)) {
     // It should consume code cache
     const script = new vm.Script(source, {
-      cachedData
+      cachedData: cachedData
     });
     assert(!script.cachedDataRejected);
     assert.strictEqual(script.runInThisContext()(), 'original');

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -41,11 +41,9 @@ function testProduceConsume() {
 
   const data = produce(source);
 
-  for (const parsedData of common.getArrayBufferViews(data)) {
-    // It should consume code cache 
-    const script = new vm.Script(source, {
-      cachedData: parsedData
-    });
+  for (const cachedData of common.getArrayBufferViews(data)) {
+    // It should consume code cache
+    const script = new vm.Script(source, { cachedData });
     assert(!script.cachedDataRejected);
     assert.strictEqual(script.runInThisContext()(), 'original');
   }


### PR DESCRIPTION
Refs: #1826 

Referring to the [comment in "mentor-available" #1826](https://github.com/nodejs/node/issues/1826#issuecomment-410487110), this PR tries out the `vm` item from the checklist of the comment:

- accept `ArrayBufferView` type(s) in place of Uint8Array in the source

- related test code in `test-vm-basic.js` & `test-vm-cached-data.js`.

(P.S.: if any potential test case(s) or `vm` doc update is missed, please advise. Thanks!)

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
