### PR TITLE
[v8.x] tls,http2: handle writes after SSL destroy more gracefully

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -601,7 +601,12 @@ int TLSWrap::DoWrite(WriteWrap* w,
                      size_t count,
                      uv_stream_t* send_handle) {
   CHECK_EQ(send_handle, nullptr);
-  CHECK_NE(ssl_, nullptr);
+
+  if (ssl_ == nullptr) {
+    ClearError();
+    error_ = "Write after DestroySSL";
+    return UV_EPROTO;
+  }
 
   bool empty = true;
 
@@ -640,12 +645,6 @@ int TLSWrap::DoWrite(WriteWrap* w,
     for (i = 0; i < count; i++)
       clear_in_->Write(bufs[i].base, bufs[i].len);
     return 0;
-  }
-
-  if (ssl_ == nullptr) {
-    ClearError();
-    error_ = "Write after DestroySSL";
-    return UV_EPROTO;
   }
 
   crypto::MarkPopErrorOnReturn mark_pop_error_on_return;


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/18987 with only neighbouring-lines conflicts.

The test part was already backported in 805347467958398973cc7e32e17ef8c849ce5b31, and passes on v8.x even without the src/ changes; however, https://github.com/nodejs/node/issues/22923 seems to be a related issue that exists on v8.x currently, so backporting the rest probably makes sense.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
