### PR TITLE
worker: only stop inspector if started

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -136,6 +136,7 @@ void Worker::Run() {
       TRACE_STR_COPY(name.c_str()));
   MultiIsolatePlatform* platform = isolate_data_->platform();
   CHECK_NE(platform, nullptr);
+  bool inspector_started = false;
 
   Debug(this, "Starting worker with id %llu", thread_id_);
   {
@@ -163,6 +164,9 @@ void Worker::Run() {
       }
 
       if (!is_stopped()) {
+        StartWorkerInspector(env_.get(), url_);
+        inspector_started = true;
+
         HandleScope handle_scope(isolate_);
         Environment::AsyncCallbackScope callback_scope(env_.get());
         env_->async_hooks()->push_async_ids(1, 0);
@@ -171,7 +175,6 @@ void Worker::Run() {
         env_->async_hooks()->pop_async_id(1);
 
         Debug(this, "Loaded environment for worker %llu", thread_id_);
-        StartWorkerInspector(env_.get(), url_);
       }
 
       {
@@ -232,7 +235,8 @@ void Worker::Run() {
       env_->stop_sub_worker_contexts();
       env_->RunCleanup();
       RunAtExit(env_.get());
-      WaitForWorkerInspectorToStop(env_.get());
+      if (inspector_started)
+        WaitForWorkerInspectorToStop(env_.get());
 
       {
         Mutex::ScopedLock stopped_lock(stopped_mutex_);


### PR DESCRIPTION
This may fix some flakiness with tests that use `worker.terminate()`.
In particular, the following failure seems like it could be related
(no consistent reproduction available, though):

```
15:30:14 not ok 187 parallel/test-heapdump-worker
15:30:14   ---
15:30:14   duration_ms: 2.499
15:30:14   severity: fail
15:30:14   exitcode: 134
15:30:14   stack: |-
15:30:14     npm[6904]: src\inspector_agent.cc:729: Assertion `(client_) != nullptr' failed.
```

From https://ci.nodejs.org/job/node-test-binary-windows/20041/COMPILED_BY=vs2017,RUNNER=win2016,RUN_SUBSET=2/console

Refs: https://github.com/nodejs/node/pull/22769

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
