### PR TITLE
doc: specify fast-tracking

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -183,9 +183,12 @@ can be fast-tracked and may be landed after a shorter delay. For example:
   * Regressions that happen right before a release, or reported soon after.
 
 When a pull request is deemed suitable to be fast-tracked, label it with
-`fast-track`. The pull request can be landed once 2 or more Collaborators
-approve both the pull request and the fast-tracking request, and the necessary
-CI testing is done.
+`fast-track` and add a comment that collaborators may upvote. Please mention the
+collaborators that gave an approval before in that comment. If someone disagrees
+with the fast-tracking request, please go ahead and remove the label and leave a
+comment why it should not be fast-tracked. The pull request can be landed once 2
+or more Collaborators approve both the pull request and the fast-tracking
+request, and the necessary CI testing is done.
 
 ### Testing and CI
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -185,10 +185,10 @@ can be fast-tracked and may be landed after a shorter delay. For example:
 When a pull request is deemed suitable to be fast-tracked, label it with
 `fast-track` and add a comment that collaborators may upvote. Please mention the
 collaborators that gave an approval before in that comment. If someone disagrees
-with the fast-tracking request, please go ahead and remove the label and leave a
-comment why it should not be fast-tracked. The pull request can be landed once 2
-or more Collaborators approve both the pull request and the fast-tracking
-request, and the necessary CI testing is done.
+with the fast-tracking request, remove the label and leave a comment why it
+should not be fast-tracked. The pull request can be landed once 2 or more
+Collaborators approve both the pull request and the fast-tracking request, and
+the necessary CI testing is done.
 
 ### Testing and CI
 


### PR DESCRIPTION
**Update**: please check the commit message as description.

<s>It is currently not clear if a PR approval also approves the
fast-tracking request. This simplifies things by explicitly asking
the collaborators to remove the label if they disagree with it and
that any PR approval is also a fast-tracking approval from as soon
as the label is attached to the PR.</s>

@nodejs/collaborators PTAL (sorry for pinging everyone but since this
is important for each one of us, it's important that everyone is on the same
page).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
