### PR TITLE
crypto: do not allow multiple calls to setAuthTag

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -445,7 +445,7 @@ is invalid according to [NIST SP 800-38D][] or does not match the value of the
 `authTagLength` option, `decipher.setAuthTag()` will throw an error.
 
 The `decipher.setAuthTag()` method must be called before
-[`decipher.final()`][].
+[`decipher.final()`][] and can only be called once.
 
 ### decipher.setAutoPadding([autoPadding])
 <!-- YAML

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2893,13 +2893,10 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
 
   if (!cipher->ctx_ ||
       !cipher->IsAuthenticatedMode() ||
-      cipher->kind_ != kDecipher) {
+      cipher->kind_ != kDecipher ||
+      cipher->auth_tag_state_ != kAuthTagUnknown) {
     return args.GetReturnValue().Set(false);
   }
-
-  // TODO(tniessen): Throw if the authentication tag has already been set.
-  if (cipher->auth_tag_state_ == kAuthTagPassedToOpenSSL)
-    return args.GetReturnValue().Set(true);
 
   unsigned int tag_len = Buffer::Length(args[0]);
   const int mode = EVP_CIPHER_CTX_mode(cipher->ctx_.get());


### PR DESCRIPTION
Calling `setAuthTag` multiple times can result in hard to detect bugs since to the user, it is unclear which invocation actually affected OpenSSL. It also doesn't make sense to call the function multiple times since `setAuthTag` / `getAuthTag` is not a getter/setter pair.

cc @addaleax due to https://github.com/nodejs/node/pull/22828#discussion_r217304564, @nodejs/crypto, @nodejs/security-wg, @nodejs/tsc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
