### PR TITLE
build: build release/CI on non-Windows with code cache

### DIFF
--- a/test/code-cache/test-code-cache.js
+++ b/test/code-cache/test-code-cache.js
@@ -4,7 +4,7 @@
 // This test verifies that the binary is compiled with code cache and the
 // cache is used when built in modules are compiled.
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const {
   types: {
@@ -17,6 +17,10 @@ const {
   compiledWithCache,
   compiledWithoutCache
 } = require('internal/bootstrap/cache');
+
+if (process.config.variables.node_code_cache_path === undefined) {
+  common.skip('Not configured with --code-cache-path');
+}
 
 assert.strictEqual(
   typeof process.config.variables.node_code_cache_path,


### PR DESCRIPTION
This is the minimal change to enable code cache in
CI/release builds on non-Windows.
(Needs another PR to vcbuild.bat to enable it on Windows).

The normal dev flow is unaltered because currently
`make test` does not run configure automatically.
To enable code cache locally (so that the tests run faster) one will
need to run `make with-code-cache` first to persist the
configure options to `./config.status`. If that target has
never been run, the build flow is the same as before except
that the code cache test will be skipped instead of being ignored.

Refs: https://github.com/nodejs/node/issues/21563

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
