### PR TITLE
test: remove common.hasSmallICU

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -158,11 +158,6 @@ Indicates `hasCrypto` and `crypto` with fips.
 
 Indicates if [internationalization] is supported.
 
-### hasSmallICU
-* [&lt;boolean>]
-
-Indicates `hasIntl` and `small-icu` are supported.
-
 ### hasIPv6
 * [&lt;boolean>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -32,8 +32,7 @@ const { fixturesDir } = require('./fixtures');
 const tmpdir = require('./tmpdir');
 const {
   bits,
-  hasIntl,
-  hasSmallICU
+  hasIntl
 } = process.binding('config');
 
 const noop = () => {};
@@ -715,7 +714,6 @@ module.exports = {
   hasIntl,
   hasCrypto,
   hasIPv6,
-  hasSmallICU,
   hasMultiLocalhost,
   isAIX,
   isAlive,

--- a/test/parallel/test-icu-data-dir.js
+++ b/test/parallel/test-icu-data-dir.js
@@ -1,7 +1,9 @@
 'use strict';
 const common = require('../common');
 const os = require('os');
-if (!(common.hasIntl && common.hasSmallICU))
+
+const { hasSmallICU } = process.binding('config');
+if (!(common.hasIntl && hasSmallICU))
   common.skip('missing Intl');
 
 const assert = require('assert');


### PR DESCRIPTION
common.hasSmallICU is used in only one test and is a one-liner. Move
into the test where it is used to chip away at the `common` monolith.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
