### PR TITLE
trace_event: destroy platform before tracing

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -297,15 +297,18 @@ static struct {
     controller->AddTraceStateObserver(new NodeTraceStateObserver(controller));
     tracing::TraceEventHelper::SetTracingController(controller);
     StartTracingAgent();
+    // Tracing must be initialized before platform threads are created.
     platform_ = new NodePlatform(thread_pool_size, controller);
     V8::InitializePlatform(platform_);
   }
 
   void Dispose() {
-    tracing_agent_.reset(nullptr);
     platform_->Shutdown();
     delete platform_;
     platform_ = nullptr;
+    // Destroy tracing after the platform (and platform threads) have been
+    // stopped.
+    tracing_agent_.reset(nullptr);
   }
 
   void DrainVMTasks(Isolate* isolate) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -250,10 +250,9 @@ int PerIsolatePlatformData::unref() {
 NodePlatform::NodePlatform(int thread_pool_size,
                            TracingController* tracing_controller) {
   if (tracing_controller) {
-    tracing_controller_.reset(tracing_controller);
+    tracing_controller_ = tracing_controller;
   } else {
-    TracingController* controller = new TracingController();
-    tracing_controller_.reset(controller);
+    tracing_controller_ = new TracingController();
   }
   worker_thread_task_runner_ =
       std::make_shared<WorkerThreadsTaskRunner>(thread_pool_size);
@@ -423,7 +422,7 @@ double NodePlatform::CurrentClockTimeMillis() {
 }
 
 TracingController* NodePlatform::GetTracingController() {
-  return tracing_controller_.get();
+  return tracing_controller_;
 }
 
 template <class T>

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -154,7 +154,7 @@ class NodePlatform : public MultiIsolatePlatform {
   std::unordered_map<v8::Isolate*,
                      std::shared_ptr<PerIsolatePlatformData>> per_isolate_;
 
-  std::unique_ptr<v8::TracingController> tracing_controller_;
+  v8::TracingController* tracing_controller_;
   std::shared_ptr<WorkerThreadsTaskRunner> worker_thread_task_runner_;
 };
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -70,7 +70,7 @@ class Agent {
   Agent();
   ~Agent();
 
-  TracingController* GetTracingController() { return tracing_controller_; }
+  TracingController* GetTracingController() { return tracing_controller_.get(); }
 
   enum UseDefaultCategoryMode {
     kUseDefaultCategories,
@@ -121,7 +121,7 @@ class Agent {
   // These maps store the original arguments to AddClient(), by id.
   std::unordered_map<int, std::multiset<std::string>> categories_;
   std::unordered_map<int, std::unique_ptr<AsyncTraceWriter>> writers_;
-  TracingController* tracing_controller_ = nullptr;
+  std::unique_ptr<TracingController> tracing_controller_;
 
   // Variables related to initializing per-event-loop properties of individual
   // writers, such as libuv handles.

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -70,7 +70,9 @@ class Agent {
   Agent();
   ~Agent();
 
-  TracingController* GetTracingController() { return tracing_controller_.get(); }
+  TracingController* GetTracingController() {
+    return tracing_controller_.get();
+  }
 
   enum UseDefaultCategoryMode {
     kUseDefaultCategories,


### PR DESCRIPTION
For safer shutdown, we should destroy the platform – and platform
threads - before the tracing infrastructure is destroyed. This change
fixes the relative order of NodePlatform disposition and the tracing
agent shutting down. This matches the nesting order for startup.

Make the tracing agent own the tracing controller instead of platform
to match the above rationale.

Fixes: https://github.com/nodejs/node/issues/22865


This should fix the thread races we have been observing with trace events. I have been running this on the FreeBSD box that was showing flakes in the CI:

```
[freebsd@test-digitalocean-freebsd11-x64-2 ~/ofrobots]$ tools/test.py -J test/parallel/test-trace-events-fs-sync.js --repeat 1000
[28:25|% 100|+ 1000|-   0]: Done
[freebsd@test-digitalocean-freebsd11-x64-2 ~/ofrobots]$ tools/test.py -J test/parallel/test-trace-events-fs-sync.js --repeat 9999
[290:38|% 100|+ 9999|-   0]: Done
```


I believe this makes https://github.com/nodejs/node/commit/92b695ed2690504b7cbc630b3f5c85e7bd87ca55 unnecessary (but harmless). I can revert that if this change sticks and the CI proves that the flakiness is gone.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: https://ci.nodejs.org/job/node-test-pull-request/17302/