### PR TITLE
test: mark some tests as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,6 +9,9 @@ prefix parallel
 test-trace-events-fs-sync: PASS,FLAKY
 
 [$system==win32]
+test-http2-pipe: PASS,FLAKY
+test-worker-syntax-error: PASS,FLAKY
+test-worker-syntax-error-file: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -10,6 +10,7 @@ prefix sequential
 test-fs-readfile-tostring-fail: PASS, FLAKY
 
 [$system==win32]
+test-http2-large-file: PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Marks as flaky 4 tests that have recently failed in CI and don't have PRs open to fix.

Please approve for fast-tracking, feel free to land when the necessary conditions are met.

Refs: https://github.com/nodejs/node/issues/20750
Refs: https://github.com/nodejs/node/issues/22327
Refs: https://github.com/nodejs/node/issues/22762
Refs: https://github.com/nodejs/reliability/issues/16

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
