### PR TITLE
test: increase coverage for worker_threads

### DIFF
--- a/test/parallel/test-worker-onmessage-not-a-function.js
+++ b/test/parallel/test-worker-onmessage-not-a-function.js
@@ -1,0 +1,26 @@
+// When MessagePort.onmessage is set to a value that is not a function, the
+// setter should call .unref() and .stop(), clearing a previous onmessage
+// listener from holding the event loop open. This test confirms that
+// functionality.
+
+// Flags: --experimental-worker
+'use strict';
+const common = require('../common');
+const { Worker, parentPort } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+  w.postMessage(2);
+} else {
+  // .onmessage uses a setter. Set .onmessage to a function that ultimately
+  // should not be called. This will call .ref() and .start() which will keep
+  // the event loop open (and prevent this from exiting) if the subsequent
+  // assignment of a value to .onmessage doesn't call .unref() and .stop().
+  parentPort.onmessage = common.mustNotCall();
+  // Setting `onmessage` to a value that is not a function should clear the
+  // previous value and also should allow the event loop to exit. (In other
+  // words, this test should exit rather than run indefinitely.)
+  parentPort.onmessage = 'fhqwhgads';
+}


### PR DESCRIPTION
Provide a test to cover adding setting `onmessage` to a non-function.

This provides previously-missing coverage for an else block in the
`onmessage` setter.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
