### PR TITLE
src: add CheckOptions to Options classes

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -270,7 +270,7 @@ void OptionsParser<Options>::Parse(
     std::vector<std::string>* const v8_args,
     Options* const options,
     OptionEnvvarSettings required_env_settings,
-    std::string* const error) {
+    std::vector<std::string>* const errors) {
   ArgsInfo args(orig_args, exec_args);
 
   // The first entry is the process name. Make sure it ends up in the V8 argv,
@@ -279,7 +279,7 @@ void OptionsParser<Options>::Parse(
   if (v8_args->empty())
     v8_args->push_back(args.program_name());
 
-  while (!args.empty() && error->empty()) {
+  while (!args.empty() && errors->empty()) {
     if (args.first().size() <= 1 || args.first()[0] != '-') break;
 
     // We know that we're either going to consume this
@@ -288,7 +288,7 @@ void OptionsParser<Options>::Parse(
 
     if (arg == "--") {
       if (required_env_settings == kAllowedInEnvironment)
-        *error = NotAllowedInEnvErr("--");
+        errors->push_back(NotAllowedInEnvErr("--"));
       break;
     }
 
@@ -357,7 +357,7 @@ void OptionsParser<Options>::Parse(
     if ((it == options_.end() ||
          it->second.env_setting == kDisallowedInEnvironment) &&
         required_env_settings == kAllowedInEnvironment) {
-      *error = NotAllowedInEnvErr(original_name);
+      errors->push_back(NotAllowedInEnvErr(original_name));
       break;
     }
 
@@ -379,7 +379,7 @@ void OptionsParser<Options>::Parse(
         value = arg.substr(equals_index + 1);
         if (value.empty()) {
         missing_argument:
-          *error = RequiresArgumentErr(original_name);
+          errors->push_back(RequiresArgumentErr(original_name));
           break;
         }
       } else {
@@ -413,7 +413,7 @@ void OptionsParser<Options>::Parse(
         break;
       case kHostPort:
         Lookup<HostPort>(info.field, options)
-            ->Update(SplitHostPort(value, error));
+            ->Update(SplitHostPort(value, errors));
         break;
       case kNoOp:
         break;
@@ -424,6 +424,7 @@ void OptionsParser<Options>::Parse(
         UNREACHABLE();
     }
   }
+  options->CheckOptions(errors);
 }
 
 }  // namespace options_parser

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -18,7 +18,6 @@ using v8::Value;
 namespace node {
 
 void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
-  // Check any per-process options here.
 #if HAVE_OPENSSL
   if (use_openssl_ca && use_bundled_ca) {
     errors->push_back("either --use-openssl-ca or --use-bundled-ca can be "
@@ -26,8 +25,10 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
   }
 #endif
   per_isolate->CheckOptions(errors);
-  per_isolate->per_env->CheckOptions(errors);
-  per_isolate->per_env->debug_options->CheckOptions(errors);
+}
+
+void PerIsolateOptions::CheckOptions(std::vector<std::string>* errors) {
+  per_env->CheckOptions(errors);
 }
 
 void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
@@ -38,6 +39,7 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
   if (syntax_check_only && has_eval_string) {
     errors->push_back("either --check or --eval can be used, not both");
   }
+  debug_options->CheckOptions(errors);
 }
 
 namespace options_parser {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -16,6 +16,30 @@ using v8::Undefined;
 using v8::Value;
 
 namespace node {
+
+void PerProcessOptions::CheckOptions(std::vector<std::string>* errors) {
+  // Check any per-process options here.
+#if HAVE_OPENSSL
+  if (use_openssl_ca && use_bundled_ca) {
+    errors->push_back("either --use-openssl-ca or --use-bundled-ca can be "
+                      "used, not both");
+  }
+#endif
+  per_isolate->CheckOptions(errors);
+  per_isolate->per_env->CheckOptions(errors);
+  per_isolate->per_env->debug_options->CheckOptions(errors);
+}
+
+void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
+  if (!userland_loader.empty() && !experimental_modules) {
+    errors->push_back("--loader requires --experimental-modules be enabled");
+  }
+
+  if (syntax_check_only && has_eval_string) {
+    errors->push_back("either --check or --eval can be used, not both");
+  }
+}
+
 namespace options_parser {
 
 // XXX: If you add an option here, please also add it to doc/node.1 and
@@ -302,18 +326,20 @@ inline std::string RemoveBrackets(const std::string& host) {
     return host;
 }
 
-inline int ParseAndValidatePort(const std::string& port, std::string* error) {
+inline int ParseAndValidatePort(const std::string& port,
+                                std::vector<std::string>* errors) {
   char* endptr;
   errno = 0;
   const long result = strtol(port.c_str(), &endptr, 10);  // NOLINT(runtime/int)
   if (errno != 0 || *endptr != '\0'||
       (result != 0 && result < 1024) || result > 65535) {
-    *error = "Port must be 0 or in range 1024 to 65535.";
+    errors->push_back(" must be 0 or in range 1024 to 65535.");
   }
   return static_cast<int>(result);
 }
 
-HostPort SplitHostPort(const std::string& arg, std::string* error) {
+HostPort SplitHostPort(const std::string& arg,
+                      std::vector<std::string>* errors) {
   // remove_brackets only works if no port is specified
   // so if it has an effect only an IPv6 address was specified.
   std::string host = RemoveBrackets(arg);
@@ -329,11 +355,11 @@ HostPort SplitHostPort(const std::string& arg, std::string* error) {
         return HostPort { arg, -1 };
       }
     }
-    return HostPort { "", ParseAndValidatePort(arg, error) };
+    return HostPort { "", ParseAndValidatePort(arg, errors) };
   }
   // Host and port found:
   return HostPort { RemoveBrackets(arg.substr(0, colon)),
-                    ParseAndValidatePort(arg.substr(colon + 1), error) };
+                    ParseAndValidatePort(arg.substr(colon + 1), errors) };
 }
 
 // Usage: Either:

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -105,6 +105,7 @@ class PerIsolateOptions : public Options {
   bool track_heap_objects = false;
 
   inline EnvironmentOptions* get_per_env_options();
+  void CheckOptions(std::vector<std::string>* errors);
 };
 
 class PerProcessOptions : public Options {


### PR DESCRIPTION
This commit adds a CheckOptions function that the options classes can
optionally implement to check that options specified are correct
(dependencies between options are met or options that are mutually
exclusive).

In the process of doing this the error pointer passed to Parse was
changed to be of type vector so that potentially multiple options check
failures can be reported.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
