### PR TITLE
cluster: add new ip-hash scheduling policy

### DIFF
--- a/lib/internal/cluster/iphash_handle.js
+++ b/lib/internal/cluster/iphash_handle.js
@@ -1,0 +1,204 @@
+'use strict';
+
+const assert = require('assert');
+const net = require('net');
+const { sendHelper } = require('internal/cluster/utils');
+const { internalBinding } = require('internal/bootstrap/loaders');
+const uv = internalBinding('uv');
+
+const relocate = Symbol('relocate');
+const distribute = Symbol('distribute');
+const handoff = Symbol('handoff');
+const free = Symbol('free');
+
+const kState = Symbol('state');
+const kHash = Symbol('hash');
+const kQueues = Symbol('queues');
+const kWorkers = Symbol('workers');
+const kHandle = Symbol('handle');
+const kKey = Symbol('key');
+const kServer = Symbol('server');
+
+const STATE_PENDING = 0;
+const STATE_CALLING = 1;
+
+const hash = (ip) => {
+  // Times33 string hashing function.
+  // Support ipv4 and ipv6
+  let hash = 5381;
+  let i = ip.length;
+  while (i) {
+    hash = (hash * 33) ^ ip.charCodeAt(--i);
+  }
+  return hash >>> 0;
+};
+
+class IPHashHandle {
+  constructor(key, address, port, addressType, fd) {
+    this[kKey] = key;
+    this[kWorkers] = [];
+    this[kQueues] = [];
+    this[kHandle] = null;
+    this[kServer] = net.createServer(assert.fail);
+
+    if (fd >= 0)
+      this[kServer].listen({ fd });
+    else if (port >= 0)
+      this[kServer].listen(port, address);
+    else
+      assert.fail('not support UNIX domain socket');
+
+    this[kServer].once('listening', () => {
+      if (this[kWorkers].length === 0) { // All workers removed.
+        return;
+      }
+
+      this[kHandle] = this[kServer]._handle;
+      this[kHandle].onconnection = (err, handle) => {
+        this[distribute](err, handle);
+      };
+      this[kServer]._handle = null;
+      this[kServer] = null;
+    });
+  }
+
+  add(worker, send) {
+    assert(this[kWorkers].indexOf(worker) === -1);
+    worker[kState] = STATE_PENDING;
+    this[kWorkers].push(worker);
+    this[relocate](); // Relocate handle.
+
+    const done = () => {
+      if (this[kWorkers].indexOf(worker) === -1) { // Already removed.
+        return;
+      }
+
+      const out = {};
+      const errno = this[kHandle].getsockname(out);
+      if (errno === 0) {
+        send(0, { sockname: out }, null);
+      } else {
+        send(errno, null);
+        this.remove(worker);
+        return;
+      }
+
+      this[handoff](worker);  // In case there are connections pending.
+    };
+
+    if (this[kServer] === null) {
+      return done();
+    }
+
+    // Still busy binding.
+    this[kServer].once('listening', done);
+    this[kServer].once('error', (err) => {
+      if (this[kWorkers].indexOf(worker) === -1) { // Already removed.
+        return;
+      }
+
+      // Hack: translate 'EADDRINUSE' error string back to numeric error code.
+      // It works but ideally we'd have some backchannel between the net and
+      // cluster modules for stuff like this.
+      send(uv[`UV_${err.errno}`], null);
+    });
+  }
+
+  remove(worker) {
+    const index = this[kWorkers].indexOf(worker);
+
+    if (index >= 0) {
+      this[kWorkers].splice(index, 1);
+    } else {
+      return false;
+    }
+
+    if (this[kWorkers].length > 0) {
+      this[relocate](); // Relocate handle.
+      return false;
+    } else {
+      this[free]();
+      return true;
+    }
+  }
+
+  [free]() {
+    this[kQueues].forEach((queue) => queue.forEach((handle) => handle.close()));
+    this[kQueues] = [];
+
+    if (this[kHandle] !== null) { // Maybe still busy binding.
+      this[kHandle].close();
+      this[kHandle] = null;
+    }
+  }
+
+  [relocate]() {
+    const queues = [];
+    for (var i = 0; i < this[kWorkers].length; i += 1) {
+      queues.push([]);
+    }
+
+    for (const queue of this[kQueues]) {
+      for (const handle of queue) {
+        queues[handle[kHash] % this[kWorkers].length].push(handle);
+      }
+    }
+
+    this[kQueues] = queues;
+  }
+
+  [distribute](err, handle) {
+    if (err !== 0) {
+      return;
+    }
+
+    const out = {};
+    if (handle.getpeername(out) !== 0) {
+      handle.close();
+      return;
+    }
+    handle[kHash] = hash(out.address);
+
+    const index = handle[kHash] % this[kWorkers].length;
+
+    this[kQueues][index].push(handle);
+
+    const worker = this[kWorkers][index];
+    if (worker[kState] === STATE_PENDING) {
+      this[handoff](worker);
+    }
+  }
+
+  [handoff](worker) {
+    const index = this[kWorkers].indexOf(worker);
+
+    if (index === -1) {
+      return; // Worker is closing (or has closed) the server.
+    }
+
+    const handle = this[kQueues][index].shift();
+
+    if (handle === undefined) {
+      worker[kState] = STATE_PENDING;
+      return;
+    } else {
+      worker[kState] = STATE_CALLING;
+    }
+
+    const message = { act: 'newconn', key: this[kKey] };
+
+    sendHelper(worker.process, message, handle, (reply) => {
+      if (reply.accepted) {
+        handle.close();
+      } else {
+        // Worker is shutting down, Add to queue again.
+        this[kQueues][index].push(handle);
+      }
+
+      worker[kState] = STATE_PENDING;
+      this[handoff](worker);
+    });
+  }
+}
+
+module.exports = IPHashHandle;

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -6,6 +6,7 @@ const path = require('path');
 const EventEmitter = require('events');
 const RoundRobinHandle = require('internal/cluster/round_robin_handle');
 const SharedHandle = require('internal/cluster/shared_handle');
+const IPHashHandle = require('internal/cluster/iphash_handle');
 const Worker = require('internal/cluster/worker');
 const { internal, sendHelper, handles } = require('internal/cluster/utils');
 const { ERR_SOCKET_BAD_PORT } = require('internal/errors').codes;
@@ -14,6 +15,7 @@ const cluster = new EventEmitter();
 const intercom = new EventEmitter();
 const SCHED_NONE = 1;
 const SCHED_RR = 2;
+const SCHED_IP = 3;
 const { isLegalPort } = require('internal/net');
 const [ minPort, maxPort ] = [ 1024, 65535 ];
 
@@ -26,6 +28,7 @@ cluster.workers = {};
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
 cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
+cluster.SCHED_IP = SCHED_IP;      // IP Hash distributes connections.
 
 var ids = 0;
 var debugPortOffset = 1;
@@ -34,7 +37,8 @@ var initialized = false;
 // XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
 var schedulingPolicy = {
   'none': SCHED_NONE,
-  'rr': SCHED_RR
+  'rr': SCHED_RR,
+  'ip': SCHED_IP
 }[process.env.NODE_CLUSTER_SCHED_POLICY];
 
 if (schedulingPolicy === undefined) {
@@ -71,7 +75,9 @@ cluster.setupMaster = function(options) {
 
   initialized = true;
   schedulingPolicy = cluster.schedulingPolicy;  // Freeze policy.
-  assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
+  assert(schedulingPolicy === SCHED_NONE ||
+         schedulingPolicy === SCHED_RR ||
+         schedulingPolicy === SCHED_IP,
          `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
 
   process.nextTick(setupSettingsNT, settings);
@@ -292,14 +298,33 @@ function queryServer(worker, message) {
         address = message.address;
     }
 
-    var constructor = RoundRobinHandle;
+    let constructor = null;
+
     // UDP is exempt from round-robin connection balancing for what should
     // be obvious reasons: it's connectionless. There is nothing to send to
     // the workers except raw datagrams and that's pointless.
-    if (schedulingPolicy !== SCHED_RR ||
-        message.addressType === 'udp4' ||
-        message.addressType === 'udp6') {
+    if (message.addressType === 'udp4' || message.addressType === 'udp6') {
       constructor = SharedHandle;
+    } else {
+      switch (schedulingPolicy) {
+        case SCHED_IP: {
+          // UNIX domain socket not supported by IP hash schedulingPolicy.
+          if (message.fd >= 0 || message.port >= 0) {
+            constructor = IPHashHandle;
+          } else {
+            constructor = SharedHandle;
+          }
+          break;
+        }
+        case SCHED_RR: {
+          constructor = RoundRobinHandle;
+          break;
+        }
+        default: {
+          constructor = SharedHandle;
+          break;
+        }
+      }
     }
 
     handles[key] = handle = new constructor(key,

--- a/node.gyp
+++ b/node.gyp
@@ -89,6 +89,7 @@
       'lib/internal/child_process.js',
       'lib/internal/cluster/child.js',
       'lib/internal/cluster/master.js',
+      'lib/internal/cluster/iphash_handle.js',
       'lib/internal/cluster/round_robin_handle.js',
       'lib/internal/cluster/shared_handle.js',
       'lib/internal/cluster/utils.js',

--- a/test/parallel/test-cluster-iphash-dispatch.js
+++ b/test/parallel/test-cluster-iphash-dispatch.js
@@ -1,0 +1,97 @@
+'use strict';
+const common = require('../common');
+
+// This test checks if clients with the same remote address
+// can be distributed to the same worker server by using
+// the cluster scheduling policy `ip`
+
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+const os = require('os');
+
+cluster.schedulingPolicy = cluster.SCHED_IP;
+
+if (cluster.isMaster) {
+  const freeport = (callback) => {
+    const server = net.createServer(common.mustNotCall());
+    server.listen(0, common.mustCall(() => {
+      const { port } = server.address();
+      server.close();
+      callback(port);
+    }));
+  };
+
+  const request = (port, callback) => {
+    const interfaces = [].concat(...Object.values(os.networkInterfaces()));
+    const result = {};
+    let count = 0;
+
+    // Using all IPv4 interfaces to request, simulate different ip sources.
+    for (const { address, family } of interfaces) {
+      let client = null;
+
+      if (family !== 'IPv4') {
+        continue;
+      }
+
+      count += 1;
+
+      client = net.connect(port, address);
+      client.setEncoding('ascii');
+      client.on('data', common.mustCall((data) => {
+        const [ip, id] = data.split('|');
+
+        assert.strictEqual(typeof ip, 'string');
+        assert.notStrictEqual(ip, '');
+        assert(parseInt(id) >= 0, 'id must be large than 0');
+
+        result[ip] = id;
+        count -= 1;
+
+        if (count === 0) {
+          callback(result);
+        }
+      }));
+    }
+  };
+
+  const test = (count) => {
+    freeport(common.mustCall((port) => { // Get free port.
+      let listenCount = 0;
+
+      for (let i = 0; i < count; i += 1) {
+        const worker = cluster.fork({
+          _TEST_IPHASH_PORT_: port,
+          _TEST_IPHASH_ID_: i
+        });
+        worker.on('listening', common.mustCall(() => {
+          listenCount += 1;
+
+          if (listenCount === count) {
+            request(port, common.mustCall((first) => {
+              request(port, common.mustCall((second) => {
+                assert.deepStrictEqual(first, second);
+                process.exit(0);
+              }));
+            }));
+          }
+        }));
+      }
+    }));
+  };
+
+  test(3); // fork 3 workers.
+} else {
+  const server = net.createServer((client) => {
+    client.write(`${client.address().address}|${process.env._TEST_IPHASH_ID_}`);
+    client.end();
+  });
+
+  const port = parseInt(process.env._TEST_IPHASH_PORT_);
+  if (port > 0) {
+    server.listen(port);
+  } else {
+    common.mustNotCall();
+  }
+}


### PR DESCRIPTION
Clients with the same remote address can be distributed to the
same worker by using the new cluster scheduling policy `SCHED_IP` :

```js
const cluster = require('cluster');
cluster.schedulingPolicy = cluster.SCHED_IP;
```
or
```bash
export NODE_CLUSTER_SCHED_POLICY=ip
```

Thus like WebSocket will work as expected, on cluster.

It can works correctly with IPv4 and IPv6.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
