### PR TITLE
crypto: extract throwInvalidArgType function

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -86,15 +86,19 @@ function createCipherBase(cipher, credential, options, decipher, iv) {
   LazyTransform.call(this, options);
 }
 
+function invalidArrayBufferView(name, value) {
+  return new ERR_INVALID_ARG_TYPE(
+    name,
+    ['string', 'Buffer', 'TypedArray', 'DataView'],
+    value
+  );
+}
+
 function createCipher(cipher, password, options, decipher) {
   validateString(cipher, 'cipher');
   password = toBuf(password);
   if (!isArrayBufferView(password)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'password',
-      ['string', 'Buffer', 'TypedArray', 'DataView'],
-      password
-    );
+    throw invalidArrayBufferView('password', password);
   }
 
   createCipherBase.call(this, cipher, password, options, decipher);
@@ -104,20 +108,12 @@ function createCipherWithIV(cipher, key, options, decipher, iv) {
   validateString(cipher, 'cipher');
   key = toBuf(key);
   if (!isArrayBufferView(key)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'key',
-      ['string', 'Buffer', 'TypedArray', 'DataView'],
-      key
-    );
+    throw invalidArrayBufferView('key', key);
   }
 
   iv = toBuf(iv);
   if (iv !== null && !isArrayBufferView(iv)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'iv',
-      ['string', 'Buffer', 'TypedArray', 'DataView'],
-      iv
-    );
+    throw invalidArrayBufferView('iv', iv);
   }
   createCipherBase.call(this, cipher, key, options, decipher, iv);
 }
@@ -152,11 +148,7 @@ Cipher.prototype.update = function update(data, inputEncoding, outputEncoding) {
   outputEncoding = outputEncoding || encoding;
 
   if (typeof data !== 'string' && !isArrayBufferView(data)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'data',
-      ['string', 'Buffer', 'TypedArray', 'DataView'],
-      data
-    );
+    throw invalidArrayBufferView('data', data);
   }
 
   const ret = this[kHandle].update(data, inputEncoding);


### PR DESCRIPTION
This commit extracts the throwing of ERR_INVALID_ARG_TYPE which is done
in identical ways in a few places in cipher.js.

The motivation for this is that I think it improves readability enough to
warrant a commit even though I'm aware that we should avoid commits with
only these sort of refactoring.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
