### PR TITLE
src: initialize pid variable before goto

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2271,6 +2271,7 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   HANDLE mapping = nullptr;
   wchar_t mapping_name[32];
   LPTHREAD_START_ROUTINE* handler = nullptr;
+  DWORD pid = 0;
 
   if (args.Length() != 1) {
     env->ThrowError("Invalid number of arguments.");
@@ -2278,7 +2279,7 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   }
 
   CHECK(args[0]->IsNumber());
-  DWORD pid = args[0].As<Integer>()->Value();
+  pid = args[0].As<Integer>()->Value();
 
   process = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
                             PROCESS_VM_OPERATION | PROCESS_VM_WRITE |


### PR DESCRIPTION
This fixes an error when compiling with clang-cl on Windows:

```
src/node.cc(2437,5):  error: jump from this goto statement to its label is a Microsoft extension [-Werror,-Wmicrosoft-goto]
    goto out;
    ^
src/node.cc(2441,9):  note: jump bypasses variable initialization
  DWORD pid = args[0].As<Integer>()->Value();
        ^
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
