### PR TITLE
deps: Use '===' instead of '=='

### DIFF
--- a/deps/v8/test/mjsunit/asm/embenchen/box2d.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/box2d.js
@@ -1121,7 +1121,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/copy.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/copy.js
@@ -1120,7 +1120,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/corrections.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/corrections.js
@@ -1120,7 +1120,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/fannkuch.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/fannkuch.js
@@ -1151,7 +1151,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/fasta.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/fasta.js
@@ -1130,7 +1130,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/lua_binarytrees.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/lua_binarytrees.js
@@ -1152,7 +1152,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/memops.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/memops.js
@@ -1120,7 +1120,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/primes.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/primes.js
@@ -1120,7 +1120,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/embenchen/zlib.js
+++ b/deps/v8/test/mjsunit/asm/embenchen/zlib.js
@@ -1120,7 +1120,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/asm/poppler/poppler.js
+++ b/deps/v8/test/mjsunit/asm/poppler/poppler.js
@@ -1132,7 +1132,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/box2d.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/box2d.js
@@ -1124,7 +1124,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/copy.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/copy.js
@@ -1123,7 +1123,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/corrections.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/corrections.js
@@ -1123,7 +1123,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/fannkuch.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/fannkuch.js
@@ -1154,7 +1154,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/fasta.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/fasta.js
@@ -1133,7 +1133,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/lua_binarytrees.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/lua_binarytrees.js
@@ -1155,7 +1155,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/memops.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/memops.js
@@ -1123,7 +1123,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/primes.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/primes.js
@@ -1123,7 +1123,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/test/mjsunit/wasm/embenchen/zlib.js
+++ b/deps/v8/test/mjsunit/wasm/embenchen/zlib.js
@@ -1123,7 +1123,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }

--- a/deps/v8/tools/profviz/gnuplot-4.6.3-emscripten.js
+++ b/deps/v8/tools/profviz/gnuplot-4.6.3-emscripten.js
@@ -757,7 +757,7 @@ Module['HEAPF64'] = HEAPF64;
 function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback === 'function') {
       callback();
       continue;
     }


### PR DESCRIPTION
To use '===' instead of '==' in union, because all the other js files are using '===' for the strict equal comparation.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
