### PR TITLE
windows installation shouldn't add current version in beginning of path

### DIFF
--- a/tools/msvs/nodevars.bat
+++ b/tools/msvs/nodevars.bat
@@ -1,6 +1,6 @@
 @echo off
 
-rem Ensure this Node.js and npm are first in the PATH
+rem Ensure this Node.js and npm are last in the PATH
 set "PATH=%PATH%;%APPDATA%\npm;%~dp0"
 
 setlocal enabledelayedexpansion

--- a/tools/msvs/nodevars.bat
+++ b/tools/msvs/nodevars.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem Ensure this Node.js and npm are first in the PATH
-set "PATH=%APPDATA%\npm;%~dp0;%PATH%"
+set "PATH=%PATH%;%APPDATA%\npm;%~dp0"
 
 setlocal enabledelayedexpansion
 pushd "%~dp0"


### PR DESCRIPTION
fixes  Installation problem with search path #22939 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
