### PR TITLE
src: remove calls to SetWrapperClassId()

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -556,9 +556,6 @@ AsyncWrap::AsyncWrap(Environment* env,
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
-  // Shift provider value over to prevent id collision.
-  persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider_type_);
-
   // Use AsyncReset() call to execute the init() callbacks.
   AsyncReset(execution_async_id, silent);
 }

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -31,8 +31,6 @@
 
 namespace node {
 
-#define NODE_ASYNC_ID_OFFSET 0xA1C
-
 #define NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                               \
   V(NONE)                                                                     \
   V(DNSCHANNEL)                                                               \

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -144,7 +144,6 @@ CallbackInfo::CallbackInfo(Isolate* isolate,
     CHECK_NOT_NULL(data_);
 
   persistent_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
-  persistent_.SetWrapperClassId(BUFFER_ID);
   isolate->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
 }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -33,8 +33,6 @@
 #include <string.h>
 #include <limits.h>
 
-#define BUFFER_ID 0xB0E4
-
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 #define THROW_AND_RETURN_UNLESS_BUFFER(env, obj)                            \


### PR DESCRIPTION
We have migrated from the deprecated RetainedObjectInfo API to
the new EmbedderGraph API, so there is no need to take care
of wrapper class ids anymore since they are dedicated to the
deprecated API (the new API uses a graph insted of ids to retrieve
info about nodes).

Refs: https://github.com/nodejs/node/pull/21741
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
