### PR TITLE
test: fix flaky key pair generation test

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -169,7 +169,7 @@ function convertDERToPEM(label, der) {
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => {
       testSignVerify(publicKey, privateKey);
-    }, /bad decrypt/);
+    }, /bad decrypt|asn1 encoding routines/);
 
     // Signing should work with the correct password.
     testSignVerify(publicKey, {
@@ -232,7 +232,7 @@ function convertDERToPEM(label, der) {
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => {
       testSignVerify(publicKey, privateKey);
-    }, /bad decrypt/);
+    }, /bad decrypt|asn1 encoding routines/);
 
     testSignVerify(publicKey, {
       key: privateKey,


### PR DESCRIPTION
There is a very small chance (about 0.4%) that OpenSSL will successfully decrypt a key without the correct passphrase and will then fail while parsing its ASN.1 structure. In those rare cases, the error message will be different.

Fixes: https://github.com/nodejs/node/issues/22978

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
