### PR TITLE
Improving error messages description

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -287,6 +287,42 @@ function uvException(ctx) {
 }
 
 /**
+ * This creates an error compatible with errors produced in the C++
+ * This function should replace the deprecated `uvException(ctx)` function.
+ *
+ * @param {number} err - A libuv error number
+ * @param {string} syscall
+ * @param {string} address
+ * @param {number} [port]
+ * @param {string} [additional]
+ * @returns {Error}
+ */
+function uvExceptionWithHostPort(err, syscall, address, port, additional) {
+  const [ code, uvmsg ] = errmap.get(err);
+  const message = `${code}: ${uvmsg}, ${syscall}`;
+  let details = '';
+  if (port && port > 0) {
+    details = ` ${address}:${port}`;
+  } else if (address) {
+    details = ` ${address}`;
+  }
+  if (additional) {
+    details += ` - Local (${additional})`;
+  }
+
+  const ex = new Error(`${message} ${details}`);
+  ex.code = code;
+  ex.syscall = syscall;
+  ex.address = address;
+  if (port) {
+    ex.port = port;
+  }
+
+  Error.captureStackTrace(ex, uvExceptionWithHostPort);
+  return ex;
+}
+
+/**
  * This used to be util._errnoException().
  *
  * @param {number} err - A libuv error number
@@ -315,8 +351,6 @@ function errnoException(err, syscall, original) {
 }
 
 /**
- * This used to be util._exceptionWithHostPort().
- *
  * @param {number} err - A libuv error number
  * @param {string} syscall
  * @param {string} address
@@ -438,6 +472,7 @@ module.exports = {
   errnoException,
   exceptionWithHostPort,
   uvException,
+  uvExceptionWithHostPort,
   isStackOverflowError,
   getMessage,
   SystemError,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -310,6 +310,7 @@ function uvExceptionWithHostPort(err, syscall, address, port, additional) {
     details += ` - Local (${additional})`;
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   const ex = new Error(`${message} ${details}`);
   ex.code = code;
   ex.syscall = syscall;

--- a/lib/net.js
+++ b/lib/net.js
@@ -85,7 +85,11 @@ const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 let cluster;
 let dns;
 
-const { errnoException, exceptionWithHostPort } = errors;
+const {
+  errnoException,
+  exceptionWithHostPort,
+  uvExceptionWithHostPort
+} = errors;
 
 const {
   kTimeout,
@@ -1267,7 +1271,7 @@ function setupListenHandle(address, port, addressType, backlog, fd) {
       rval = createServerHandle(address, port, addressType, fd);
 
     if (typeof rval === 'number') {
-      var error = exceptionWithHostPort(rval, 'listen', address, port);
+      var error = uvExceptionWithHostPort(rval, 'listen', address, port);
       process.nextTick(emitErrorNT, this, error);
       return;
     }
@@ -1284,7 +1288,7 @@ function setupListenHandle(address, port, addressType, backlog, fd) {
   var err = this._handle.listen(backlog || 511);
 
   if (err) {
-    var ex = exceptionWithHostPort(err, 'listen', address, port);
+    var ex = uvExceptionWithHostPort(err, 'listen', address, port);
     this._handle.close();
     this._handle = null;
     defaultTriggerAsyncIdScope(this[async_id_symbol],

--- a/lib/util.js
+++ b/lib/util.js
@@ -1505,7 +1505,6 @@ function getSystemErrorName(err) {
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = exports = {
   _errnoException: errors.errnoException,
-  _exceptionWithHostPort: errors.exceptionWithHostPort,
   _extend,
   callbackify,
   debuglog,


### PR DESCRIPTION
lib: improved error message description for the http server binding errors.

changed in `setupListenHandle`, but needs to be change all over.

Added new `uvExceptionWithHostPort` function (+export) in `lib/internal/error.js` that extracts the error message defined by libuv, using the error code, and returns an error object with the full error description:  'address already in use' for example.

Removed exportable function `_exceptionWithHostPort` from `lib/util.js` - exported by accident

Replaced `exceptionWithHostPort` to the new function `uvExceptionWithHostPort` for a more detailed error.

Fixes: https://github.com/nodejs/node/issues/22936

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
