### PR TITLE
test: add  dns.onlookupall() error test to increase coverage

### DIFF
--- a/test/internet/test-dns-lookup.js
+++ b/test/internet/test-dns-lookup.js
@@ -1,7 +1,9 @@
 'use strict';
 
 require('../common');
-const dnsPromises = require('dns').promises;
+const common = require('../common');
+const dns = require('dns');
+const dnsPromises = dns.promises;
 const { addresses } = require('../common/internet');
 const assert = require('assert');
 
@@ -28,3 +30,17 @@ assert.rejects(
     message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
   }
 );
+
+dns.lookup(addresses.INVALID_HOST, {
+  hints: 0,
+  family: 0,
+  all: true
+}, common.mustCall((error) => {
+  assert.strictEqual(error.code, 'ENOTFOUND');
+  assert.strictEqual(
+    error.message,
+    `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+  );
+  assert.strictEqual(error.syscall, 'getaddrinfo');
+  assert.strictEqual(error.hostname, addresses.INVALID_HOST);
+}));


### PR DESCRIPTION
Added test that callback should be called when error occurs in dns.lookupall().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
