### PR TITLE
win,msi: install Boxstarter from elevated shell

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -22,4 +22,4 @@ echo available at https://github.com/nodejs/node-gyp#on-windows
 echo.
 pause
 
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName '%~dp0\install_tools.txt'"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://boxstarter.org/bootstrapper.ps1'')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName ''%~dp0\install_tools.txt''; Read-Host ''Type ENTER to exit'' ' -Verb RunAs


### PR DESCRIPTION
This fixes the issue described in https://github.com/nodejs/node/pull/22645#issuecomment-422696809 (cc @targos).

Boxstarter asks for elevation to install packages, but not to install Boxstarter itself. If Boxstarter is already installed, the command succeeds with or without elevation. This PR changes the batch file to run all the commands from an elevated PowerShell.

LTS and semver: This is a bug fix for https://github.com/nodejs/node/pull/22645, which is currently only in master. That PR is `semver-minor` without a strong case for backporting, so this one should not be backported as well even if this is `semver-patch`.

cc @nodejs/platform-windows @richardlau 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
