### PR TITLE
build,doc: remove outdated `lint-md-build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       node_js: "latest"
       env: 
         - NODE=$(which node)
-      install:
-        - make lint-md-build
       script:
         - make lint
     - name: "Test Suite"

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -455,8 +455,8 @@ Cherry-pick the release commit to `master`. After cherry-picking, edit
 previously on `master`. `NODE_VERSION_IS_RELEASE` should be `0`. **Do not**
 cherry-pick the "Working on vx.y.z" commit to `master`.
 
-Run `make lint-md-build; make lint` before pushing to `master`, to make sure the
-Changelog formatting passes the lint rules on `master`.
+Run `make lint` before pushing to `master`, to make sure the Changelog
+formatting passes the lint rules on `master`.
 
 ### 13. Promote and Sign the Release Builds
 


### PR DESCRIPTION
- In release guide
- In Travis config

Refs: https://github.com/nodejs/node/pull/20109