### PR TITLE
doc,test: fix inspect's sorted compare function

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -556,7 +556,7 @@ const o1 = {
 };
 console.log(inspect(o1, { sorted: true }));
 // { a: '`a` comes before `b`', b: [ 2, 3, 1 ], c: Set { 1, 2, 3 } }
-console.log(inspect(o1, { sorted: (a, b) => a < b }));
+console.log(inspect(o1, { sorted: (a, b) => b.localeCompare(a) }));
 // { c: Set { 3, 2, 1 }, b: [ 2, 3, 1 ], a: '`a` comes before `b`' }
 
 const o2 = {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1688,7 +1688,7 @@ assert.strictEqual(
 assert.strictEqual(
   inspect(
     { a200: 4, a100: 1, a102: 3, a101: 2 },
-    { sorted(a, b) { return a < b; } }
+    { sorted(a, b) { return b.localeCompare(a); } }
   ),
   '{ a200: 4, a102: 3, a101: 2, a100: 1 }'
 );


### PR DESCRIPTION
In V8 7.0, the array sorting algorithm was changed to Timsort, which
is stable. A compare function returning only `true` or `false`
(converted to 0 and 1) cannot work properly.

