### PR TITLE
src: replace deprecated uses of FunctionTemplate::GetFunction

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -635,6 +635,7 @@ functions and returning those back to JavaScript:
 
 namespace demo {
 
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -652,8 +653,9 @@ void MyFunction(const FunctionCallbackInfo<Value>& args) {
 void CreateFunction(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
+  Local<Context> context = isolate->GetCurrentContext();
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, MyFunction);
-  Local<Function> fn = tpl->GetFunction();
+  Local<Function> fn = tpl->GetFunction(context).ToLocalChecked();
 
   // omit this to make it anonymous
   fn->SetName(String::NewFromUtf8(isolate, "theFunction"));
@@ -777,9 +779,10 @@ void MyObject::Init(Local<Object> exports) {
   // Prototype
   NODE_SET_PROTOTYPE_METHOD(tpl, "plusOne", PlusOne);
 
-  constructor.Reset(isolate, tpl->GetFunction());
+  Local<Context> context = isolate->GetCurrentContext();
+  constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
   exports->Set(String::NewFromUtf8(isolate, "MyObject"),
-               tpl->GetFunction());
+               tpl->GetFunction(context).ToLocalChecked());
 }
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
@@ -969,7 +972,8 @@ void MyObject::Init(Isolate* isolate) {
   // Prototype
   NODE_SET_PROTOTYPE_METHOD(tpl, "plusOne", PlusOne);
 
-  constructor.Reset(isolate, tpl->GetFunction());
+  Local<Context> context = isolate->GetCurrentContext();
+  constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
 }
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
@@ -1177,7 +1181,8 @@ void MyObject::Init(Isolate* isolate) {
   tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  constructor.Reset(isolate, tpl->GetFunction());
+  Local<Context> context = isolate->GetCurrentContext();
+  constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
 }
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2224,7 +2224,7 @@ void Initialize(Local<Object> target,
   Local<String> addrInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap");
   aiw->SetClassName(addrInfoWrapString);
-  target->Set(addrInfoWrapString, aiw->GetFunction());
+  target->Set(addrInfoWrapString, aiw->GetFunction(context).ToLocalChecked());
 
   Local<FunctionTemplate> niw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2232,7 +2232,7 @@ void Initialize(Local<Object> target,
   Local<String> nameInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap");
   niw->SetClassName(nameInfoWrapString);
-  target->Set(nameInfoWrapString, niw->GetFunction());
+  target->Set(nameInfoWrapString, niw->GetFunction(context).ToLocalChecked());
 
   Local<FunctionTemplate> qrw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2240,7 +2240,7 @@ void Initialize(Local<Object> target,
   Local<String> queryWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap");
   qrw->SetClassName(queryWrapString);
-  target->Set(queryWrapString, qrw->GetFunction());
+  target->Set(queryWrapString, qrw->GetFunction(context).ToLocalChecked());
 
   Local<FunctionTemplate> channel_wrap =
       env->NewFunctionTemplate(ChannelWrap::New);
@@ -2267,7 +2267,8 @@ void Initialize(Local<Object> target,
   Local<String> channelWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap");
   channel_wrap->SetClassName(channelWrapString);
-  target->Set(channelWrapString, channel_wrap->GetFunction());
+  target->Set(channelWrapString,
+              channel_wrap->GetFunction(context).ToLocalChecked());
 }
 
 }  // anonymous namespace

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -715,13 +715,15 @@ inline v8::Local<v8::FunctionTemplate>
 inline void Environment::SetMethod(v8::Local<v8::Object> that,
                                    const char* name,
                                    v8::FunctionCallback callback) {
+  v8::Local<v8::Context> context = isolate()->GetCurrentContext();
   v8::Local<v8::Function> function =
-      NewFunctionTemplate(callback,
-                          v8::Local<v8::Signature>(),
+      NewFunctionTemplate(callback, v8::Local<v8::Signature>(),
                           // TODO(TimothyGu): Investigate if SetMethod is ever
                           // used for constructors.
                           v8::ConstructorBehavior::kAllow,
-                          v8::SideEffectType::kHasSideEffect)->GetFunction();
+                          v8::SideEffectType::kHasSideEffect)
+          ->GetFunction(context)
+          .ToLocalChecked();
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
@@ -733,13 +735,15 @@ inline void Environment::SetMethod(v8::Local<v8::Object> that,
 inline void Environment::SetMethodNoSideEffect(v8::Local<v8::Object> that,
                                                const char* name,
                                                v8::FunctionCallback callback) {
+  v8::Local<v8::Context> context = isolate()->GetCurrentContext();
   v8::Local<v8::Function> function =
-      NewFunctionTemplate(callback,
-                          v8::Local<v8::Signature>(),
+      NewFunctionTemplate(callback, v8::Local<v8::Signature>(),
                           // TODO(TimothyGu): Investigate if SetMethod is ever
                           // used for constructors.
                           v8::ConstructorBehavior::kAllow,
-                          v8::SideEffectType::kHasNoSideEffect)->GetFunction();
+                          v8::SideEffectType::kHasNoSideEffect)
+          ->GetFunction(context)
+          .ToLocalChecked();
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =

--- a/src/env.cc
+++ b/src/env.cc
@@ -268,8 +268,10 @@ void Environment::Start(const std::vector<std::string>& args,
   auto process_template = FunctionTemplate::New(isolate());
   process_template->SetClassName(FIXED_ONE_BYTE_STRING(isolate(), "process"));
 
-  auto process_object =
-      process_template->GetFunction()->NewInstance(context()).ToLocalChecked();
+  auto process_object = process_template->GetFunction(context())
+                            .ToLocalChecked()
+                            ->NewInstance(context())
+                            .ToLocalChecked();
   set_process_object(process_object);
 
   SetupProcessObject(this, args, exec_args);

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -121,7 +121,7 @@ void FSEventWrap::Initialize(Local<Object> target,
       Local<FunctionTemplate>(),
       static_cast<PropertyAttribute>(ReadOnly | DontDelete | v8::DontEnum));
 
-  target->Set(fsevent_string, t->GetFunction());
+  target->Set(fsevent_string, t->GetFunction(context).ToLocalChecked());
 }
 
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -310,7 +310,10 @@ void Initialize(Local<Object> target, Local<Value> unused,
   AsyncWrap::AddWrapMethods(env, tmpl);
   env->SetProtoMethod(tmpl, "dispatch", JSBindingsConnection::Dispatch);
   env->SetProtoMethod(tmpl, "disconnect", JSBindingsConnection::Disconnect);
-  target->Set(env->context(), conn_str, tmpl->GetFunction()).ToChecked();
+  target
+      ->Set(env->context(), conn_str,
+            tmpl->GetFunction(env->context()).ToLocalChecked())
+      .ToChecked();
 }
 
 }  // namespace

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -211,7 +211,7 @@ void JSStream::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "emitEOF", EmitEOF);
 
   StreamBase::AddMethods<JSStream>(env, t);
-  target->Set(jsStreamString, t->GetFunction());
+  target->Set(jsStreamString, t->GetFunction(context).ToLocalChecked());
 }
 
 }  // namespace node

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -801,7 +801,8 @@ void ModuleWrap::Initialize(Local<Object> target,
   env->SetProtoMethodNoSideEffect(tpl, "getStaticDependencySpecifiers",
                                   GetStaticDependencySpecifiers);
 
-  target->Set(FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"), tpl->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"),
+              tpl->GetFunction(context).ToLocalChecked());
   env->SetMethod(target, "resolve", Resolve);
   env->SetMethod(target,
                  "setImportModuleDynamicallyCallback",

--- a/src/node.h
+++ b/src/node.h
@@ -366,9 +366,10 @@ inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
                             v8::FunctionCallback callback) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
                                                                 callback);
-  v8::Local<v8::Function> fn = t->GetFunction();
+  v8::Local<v8::Function> fn = t->GetFunction(context).ToLocalChecked();
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
       v8::NewStringType::kInternalized).ToLocalChecked();
   fn->SetName(fn_name);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1518,7 +1518,9 @@ napi_status napi_define_class(napi_env env,
     }
   }
 
-  *result = v8impl::JsValueFromV8LocalValue(scope.Escape(tpl->GetFunction()));
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  *result = v8impl::JsValueFromV8LocalValue(
+      scope.Escape(tpl->GetFunction(context).ToLocalChecked()));
 
   if (static_property_count > 0) {
     std::vector<napi_property_descriptor> static_descriptors;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -203,7 +203,8 @@ void ContextifyContext::Init(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> function_template =
       FunctionTemplate::New(env->isolate());
   function_template->InstanceTemplate()->SetInternalFieldCount(1);
-  env->set_script_data_constructor_function(function_template->GetFunction());
+  env->set_script_data_constructor_function(
+      function_template->GetFunction(env->context()).ToLocalChecked());
 
   env->SetMethod(target, "makeContext", MakeContext);
   env->SetMethod(target, "isContext", IsContext);
@@ -608,7 +609,8 @@ class ContextifyScript : public BaseObject {
     env->SetProtoMethod(script_tmpl, "runInContext", RunInContext);
     env->SetProtoMethod(script_tmpl, "runInThisContext", RunInThisContext);
 
-    target->Set(class_name, script_tmpl->GetFunction());
+    target->Set(class_name,
+                script_tmpl->GetFunction(env->context()).ToLocalChecked());
     env->set_script_context_constructor_template(script_tmpl);
   }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -366,7 +366,8 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kTicketKeyIVIndex"),
          Integer::NewFromUnsigned(env->isolate(), kTicketKeyIVIndex));
 
-  target->Set(secureContextString, t->GetFunction());
+  target->Set(secureContextString,
+              t->GetFunction(env->context()).ToLocalChecked());
   env->set_secure_context_constructor_template(t);
 }
 
@@ -2561,7 +2562,7 @@ void CipherBase::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethod(t, "setAAD", SetAAD);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "CipherBase"),
-              t->GetFunction());
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -3195,7 +3196,8 @@ void Hmac::Initialize(Environment* env, v8::Local<Object> target) {
   env->SetProtoMethod(t, "update", HmacUpdate);
   env->SetProtoMethod(t, "digest", HmacDigest);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hmac"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hmac"),
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -3314,7 +3316,8 @@ void Hash::Initialize(Environment* env, v8::Local<Object> target) {
   env->SetProtoMethod(t, "update", HashUpdate);
   env->SetProtoMethod(t, "digest", HashDigest);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hash"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Hash"),
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -3508,7 +3511,8 @@ void Sign::Initialize(Environment* env, v8::Local<Object> target) {
   env->SetProtoMethod(t, "update", SignUpdate);
   env->SetProtoMethod(t, "sign", SignFinal);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Sign"), t->GetFunction());
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Sign"),
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -3710,7 +3714,7 @@ void Verify::Initialize(Environment* env, v8::Local<Object> target) {
   env->SetProtoMethod(t, "verify", VerifyFinal);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Verify"),
-              t->GetFunction());
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -3948,7 +3952,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
       attributes);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DiffieHellman"),
-              t->GetFunction());
+              t->GetFunction(env->context()).ToLocalChecked());
 
   Local<FunctionTemplate> t2 = env->NewFunctionTemplate(DiffieHellmanGroup);
   t2->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3977,7 +3981,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
       attributes);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "DiffieHellmanGroup"),
-              t2->GetFunction());
+              t2->GetFunction(env->context()).ToLocalChecked());
 }
 
 
@@ -4326,7 +4330,7 @@ void ECDH::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethod(t, "setPrivateKey", SetPrivateKey);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ECDH"),
-              t->GetFunction());
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -276,7 +276,9 @@ void InitDTrace(Environment* env, Local<Object> target) {
 
   for (size_t i = 0; i < arraysize(tab); i++) {
     Local<String> key = OneByteString(env->isolate(), tab[i].name);
-    Local<Value> val = env->NewFunctionTemplate(tab[i].func)->GetFunction();
+    Local<Value> val = env->NewFunctionTemplate(tab[i].func)
+                           ->GetFunction(env->context())
+                           .ToLocalChecked();
     target->Set(key, val);
   }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2240,7 +2240,10 @@ void Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqCallback");
   fst->SetClassName(wrapString);
-  target->Set(context, wrapString, fst->GetFunction()).FromJust();
+  target
+      ->Set(context, wrapString,
+            fst->GetFunction(env->context()).ToLocalChecked())
+      .FromJust();
 
   // Create FunctionTemplate for FileHandleReadWrap. There’s no need
   // to do anything in the constructor, so we only store the instance template.
@@ -2274,7 +2277,10 @@ void Initialize(Local<Object> target,
        FIXED_ONE_BYTE_STRING(env->isolate(), "FileHandle");
   fd->SetClassName(handleString);
   StreamBase::AddMethods<FileHandle>(env, fd);
-  target->Set(context, handleString, fd->GetFunction()).FromJust();
+  target
+      ->Set(context, handleString,
+            fd->GetFunction(env->context()).ToLocalChecked())
+      .FromJust();
   env->set_fd_constructor_template(fdt);
 
   // Create FunctionTemplate for FileHandle::CloseReq

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2867,7 +2867,7 @@ void Initialize(Local<Object> target,
   env->set_http2stream_constructor_template(streamt);
   target->Set(context,
               FIXED_ONE_BYTE_STRING(env->isolate(), "Http2Stream"),
-              stream->GetFunction()).FromJust();
+              stream->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
   Local<FunctionTemplate> session =
       env->NewFunctionTemplate(Http2Session::New);
@@ -2894,7 +2894,7 @@ void Initialize(Local<Object> target,
       Http2Session::RefreshSettings<nghttp2_session_get_remote_settings>);
   target->Set(context,
               http2SessionClassName,
-              session->GetFunction()).FromJust();
+              session->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
   Local<Object> constants = Object::New(isolate);
   Local<Array> name_for_error_code = Array::New(isolate);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -776,7 +776,7 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(t, "getCurrentBuffer", Parser::GetCurrentBuffer);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "HTTPParser"),
-              t->GetFunction());
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 }  // anonymous namespace

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -405,7 +405,7 @@ void Initialize(Local<Object> target,
 
   Local<FunctionTemplate> pe = FunctionTemplate::New(isolate);
   pe->SetClassName(performanceEntryString);
-  Local<Function> fn = pe->GetFunction();
+  Local<Function> fn = pe->GetFunction(context).ToLocalChecked();
   target->Set(context, performanceEntryString, fn).FromJust();
   env->set_performance_entry_template(fn);
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -56,7 +56,8 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
 
   env->SetProtoMethod(t, "start", StatWatcher::Start);
 
-  target->Set(statWatcherString, t->GetFunction());
+  target->Set(statWatcherString,
+              t->GetFunction(env->context()).ToLocalChecked());
 }
 
 

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -113,7 +113,7 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(category_set, "disable", NodeCategorySet::Disable);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "CategorySet"),
-              category_set->GetFunction());
+              category_set->GetFunction(env->context()).ToLocalChecked());
 
   Local<String> isTraceCategoryEnabled =
       FIXED_ONE_BYTE_STRING(env->isolate(), "isTraceCategoryEnabled");

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -492,7 +492,7 @@ void InitWorker(Local<Object> target,
     Local<String> workerString =
         FIXED_ONE_BYTE_STRING(env->isolate(), "Worker");
     w->SetClassName(workerString);
-    target->Set(workerString, w->GetFunction());
+    target->Set(workerString, w->GetFunction(env->context()).ToLocalChecked());
   }
 
   env->SetMethod(target, "getEnvMessagePort", GetEnvMessagePort);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -773,7 +773,7 @@ void Initialize(Local<Object> target,
 
   Local<String> zlibString = FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib");
   z->SetClassName(zlibString);
-  target->Set(zlibString, z->GetFunction());
+  target->Set(zlibString, z->GetFunction(env->context()).ToLocalChecked());
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
               FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -57,7 +57,9 @@ Local<Object> PipeWrap::Instantiate(Environment* env,
   EscapableHandleScope handle_scope(env->isolate());
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(parent);
   CHECK_EQ(false, env->pipe_constructor_template().IsEmpty());
-  Local<Function> constructor = env->pipe_constructor_template()->GetFunction();
+  Local<Function> constructor = env->pipe_constructor_template()
+                                    ->GetFunction(env->context())
+                                    .ToLocalChecked();
   CHECK_EQ(false, constructor.IsEmpty());
   Local<Value> type_value = Int32::New(env->isolate(), type);
   Local<Object> instance =
@@ -91,7 +93,7 @@ void PipeWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "fchmod", Fchmod);
 
-  target->Set(pipeString, t->GetFunction());
+  target->Set(pipeString, t->GetFunction(env->context()).ToLocalChecked());
   env->set_pipe_constructor_template(t);
 
   // Create FunctionTemplate for PipeConnectWrap.
@@ -100,7 +102,7 @@ void PipeWrap::Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap");
   cwt->SetClassName(wrapString);
-  target->Set(wrapString, cwt->GetFunction());
+  target->Set(wrapString, cwt->GetFunction(env->context()).ToLocalChecked());
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -64,7 +64,8 @@ class ProcessWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "spawn", Spawn);
     env->SetProtoMethod(constructor, "kill", Kill);
 
-    target->Set(processString, constructor->GetFunction());
+    target->Set(processString,
+                constructor->GetFunction(context).ToLocalChecked());
   }
 
   void MemoryInfo(MemoryTracker* tracker) const override {

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -57,7 +57,8 @@ class SignalWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 
-    target->Set(signalString, constructor->GetFunction());
+    target->Set(signalString,
+                constructor->GetFunction(env->context()).ToLocalChecked());
   }
 
   void MemoryInfo(MemoryTracker* tracker) const override {

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -260,7 +260,10 @@ void InitializeStreamPipe(Local<Object> target,
   AsyncWrap::AddWrapMethods(env, pipe);
   pipe->SetClassName(stream_pipe_string);
   pipe->InstanceTemplate()->SetInternalFieldCount(1);
-  target->Set(context, stream_pipe_string, pipe->GetFunction()).FromJust();
+  target
+      ->Set(context, stream_pipe_string,
+            pipe->GetFunction(context).ToLocalChecked())
+      .FromJust();
 }
 
 }  // anonymous namespace

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -67,7 +67,7 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
       FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap");
   sw->SetClassName(wrapString);
   AsyncWrap::AddWrapMethods(env, sw);
-  target->Set(wrapString, sw->GetFunction());
+  target->Set(wrapString, sw->GetFunction(env->context()).ToLocalChecked());
   env->set_shutdown_wrap_template(sw->InstanceTemplate());
 
   Local<FunctionTemplate> ww =
@@ -77,7 +77,8 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
       FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap");
   ww->SetClassName(writeWrapString);
   AsyncWrap::AddWrapMethods(env, ww);
-  target->Set(writeWrapString, ww->GetFunction());
+  target->Set(writeWrapString,
+              ww->GetFunction(env->context()).ToLocalChecked());
   env->set_write_wrap_template(ww->InstanceTemplate());
 }
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -60,7 +60,9 @@ Local<Object> TCPWrap::Instantiate(Environment* env,
   EscapableHandleScope handle_scope(env->isolate());
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(parent);
   CHECK_EQ(env->tcp_constructor_template().IsEmpty(), false);
-  Local<Function> constructor = env->tcp_constructor_template()->GetFunction();
+  Local<Function> constructor = env->tcp_constructor_template()
+                                    ->GetFunction(env->context())
+                                    .ToLocalChecked();
   CHECK_EQ(constructor.IsEmpty(), false);
   Local<Value> type_value = Int32::New(env->isolate(), type);
   Local<Object> instance =
@@ -107,7 +109,7 @@ void TCPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
 
-  target->Set(tcpString, t->GetFunction());
+  target->Set(tcpString, t->GetFunction(env->context()).ToLocalChecked());
   env->set_tcp_constructor_template(t);
 
   // Create FunctionTemplate for TCPConnectWrap.
@@ -117,7 +119,7 @@ void TCPWrap::Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap");
   cwt->SetClassName(wrapString);
-  target->Set(wrapString, cwt->GetFunction());
+  target->Set(wrapString, cwt->GetFunction(env->context()).ToLocalChecked());
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -905,9 +905,10 @@ void TLSWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "getServername", GetServername);
   env->SetProtoMethod(t, "setServername", SetServername);
 
-  env->set_tls_wrap_constructor_function(t->GetFunction());
+  env->set_tls_wrap_constructor_function(
+      t->GetFunction(env->context()).ToLocalChecked());
 
-  target->Set(tlsWrapString, t->GetFunction());
+  target->Set(tlsWrapString, t->GetFunction(env->context()).ToLocalChecked());
 }
 
 }  // namespace node

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -63,7 +63,7 @@ void TTYWrap::Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "isTTY", IsTTY);
   env->SetMethodNoSideEffect(target, "guessHandleType", GuessHandleType);
 
-  target->Set(ttyString, t->GetFunction());
+  target->Set(ttyString, t->GetFunction(env->context()).ToLocalChecked());
   env->set_tty_constructor_template(t);
 }
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -138,8 +138,9 @@ void UDPWrap::Initialize(Local<Object> target,
   AsyncWrap::AddWrapMethods(env, t);
   HandleWrap::AddWrapMethods(env, t);
 
-  target->Set(udpString, t->GetFunction());
-  env->set_udp_constructor_function(t->GetFunction());
+  target->Set(udpString, t->GetFunction(env->context()).ToLocalChecked());
+  env->set_udp_constructor_function(
+      t->GetFunction(env->context()).ToLocalChecked());
 
   // Create FunctionTemplate for SendWrap
   Local<FunctionTemplate> swt =
@@ -148,7 +149,8 @@ void UDPWrap::Initialize(Local<Object> target,
   Local<String> sendWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap");
   swt->SetClassName(sendWrapString);
-  target->Set(sendWrapString, swt->GetFunction());
+  target->Set(sendWrapString,
+              swt->GetFunction(env->context()).ToLocalChecked());
 }
 
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -57,7 +57,9 @@ void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   target->Set(FIXED_ONE_BYTE_STRING(isolate, "errname"),
-              env->NewFunctionTemplate(ErrName)->GetFunction());
+              env->NewFunctionTemplate(ErrName)
+                  ->GetFunction(env->context())
+                  .ToLocalChecked());
 
 #define V(name, _) NODE_DEFINE_CONSTANT(target, UV_##name);
   UV_ERRNO_MAP(V)

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -18,8 +18,11 @@ inline void Test(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 inline void Initialize(v8::Local<v8::Object> binding) {
   v8::Isolate* const isolate = binding->GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   binding->Set(v8::String::NewFromUtf8(isolate, "test"),
-               v8::FunctionTemplate::New(isolate, Test)->GetFunction());
+               v8::FunctionTemplate::New(isolate, Test)
+                   ->GetFunction(context)
+                   .ToLocalChecked());
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -11,8 +11,11 @@ inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 inline void Initialize(v8::Local<v8::Object> binding) {
   auto isolate = binding->GetIsolate();
+  auto context = isolate->GetCurrentContext();
   binding->Set(v8::String::NewFromUtf8(isolate, "Class"),
-               v8::FunctionTemplate::New(isolate, NewClass)->GetFunction());
+               v8::FunctionTemplate::New(isolate, NewClass)
+                   ->GetFunction(context)
+                   .ToLocalChecked());
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -23,7 +23,9 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
   auto key = v8::String::NewFromUtf8(isolate, "randomBytes");
-  auto value = v8::FunctionTemplate::New(isolate, RandomBytes)->GetFunction();
+  auto value = v8::FunctionTemplate::New(isolate, RandomBytes)
+                   ->GetFunction(context)
+                   .ToLocalChecked();
   assert(exports->Set(context, key, value).IsJust());
 }
 

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -46,7 +46,9 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
   auto key = v8::String::NewFromUtf8(isolate, "compressBytes");
-  auto value = v8::FunctionTemplate::New(isolate, CompressBytes)->GetFunction();
+  auto value = v8::FunctionTemplate::New(isolate, CompressBytes)
+                   ->GetFunction(context)
+                   .ToLocalChecked();
   assert(exports->Set(context, key, value).IsJust());
 }
 

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -134,8 +134,10 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
   auto obj_template = v8::FunctionTemplate::New(isolate_);
   obj_template->InstanceTemplate()->SetInternalFieldCount(1);
 
-  v8::Local<v8::Object> object =
-      obj_template->GetFunction()->NewInstance(env.context()).ToLocalChecked();
+  v8::Local<v8::Object> object = obj_template->GetFunction(env.context())
+                                     .ToLocalChecked()
+                                     ->NewInstance(env.context())
+                                     .ToLocalChecked();
   TestHandleWrap obj(*env, object, &handle);
 
   auto queue = reinterpret_cast<uintptr_t>((*env)->handle_wrap_queue());
@@ -161,8 +163,10 @@ TEST_F(DebugSymbolsTest, ReqWrapList) {
   auto obj_template = v8::FunctionTemplate::New(isolate_);
   obj_template->InstanceTemplate()->SetInternalFieldCount(1);
 
-  v8::Local<v8::Object> object =
-      obj_template->GetFunction()->NewInstance(env.context()).ToLocalChecked();
+  v8::Local<v8::Object> object = obj_template->GetFunction(env.context())
+                                     .ToLocalChecked()
+                                     ->NewInstance(env.context())
+                                     .ToLocalChecked();
   TestReqWrap obj(*env, object);
 
   // NOTE (mmarchini): Workaround to fix failing tests on ARM64 machines with


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Refs: https://github.com/v8/node/commit/70d60c4d4fb78ee87b379973b7e4e11f4ef997bb

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
