### PR TITLE
test: use a valid comparefn for sort

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1688,7 +1688,7 @@ assert.strictEqual(
 assert.strictEqual(
   inspect(
     { a200: 4, a100: 1, a102: 3, a101: 2 },
-    { sorted(a, b) { return a < b; } }
+    { sorted(a, b) { return a === b ? 0 : (a < b ? 1 : -1); } }
   ),
   '{ a200: 4, a102: 3, a101: 2, a100: 1 }'
 );


### PR DESCRIPTION
According the the ES spec a valid comparefn returns a negative number,
zero, or a positive number. The behavior of returning a boolean is also
not consistent among JS engines.

For example:

```console
$ eshost -ise "Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a < b; })"
## Source
print(Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a < b; }))

#### Chakra, V8, V8 --harmony
a200,a100,a102,a101

#### JavaScriptCore, SpiderMonkey, XS
a200,a102,a101,a100

```

Interestingly D8 and node-v8 disagree (**EDIT:** this is because of the Timsort introduction in V8 7.0):

```console
$ ~/.jsvu/v8 -e "console.log(Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a < b; }))"
a200,a100,a102,a101
$ node -e "console.log(Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a < b; }))"
[ 'a200', 'a102', 'a101', 'a100' ]
```

With the updated compare function everyone agrees:

```console
$ eshost -ise "Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a === b ? 0 : (a < b ? 1 : -1); })"
## Source
print(Object.keys({ a200: 4, a100: 1, a102: 3, a101: 2 }).sort(function (a, b) { return a === b ? 0 : (a < b ? 1 : -1); }))

#### Chakra, JavaScriptCore, SpiderMonkey, V8, V8 --harmony, XS
a200,a102,a101,a100

```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
