### PR TITLE
win,msi: highlight installation of 3rd-party tools

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -5,8 +5,8 @@ echo Tools for Node.js Native Modules Installation Script
 echo ====================================================
 echo.
 echo This Boxstarter script will install Python and the Visual Studio Build Tools,
-echo necessary to compile Node.js native modules. All necessary Windows updates
-echo will also be installed.
+echo necessary to compile Node.js native modules. Note that Boxstarter,
+echo Chocolatey and required Windows updates will also be installed.
 echo.
 echo This will require about 3 Gb of free disk space, plus any space necessary to
 echo install Windows updates.

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -14,7 +14,7 @@
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
     <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
     <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. The script will pop-up in a new window after the installation completes.</String>
-    <String Id="NativeToolsDlgManualDetails">Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
+    <String Id="NativeToolsDlgManualDetails">Note that this will also install Boxstarter and Chocolatey. Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
 
     <!-- References like [ProductName] or $(var.ProductName) don't seem to work in Title attributes -->
     <String Id="NodeRuntime_Title">Node.js runtime</String>

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -13,8 +13,8 @@
     <String Id="NativeToolsDlgDescription">Optionally install the tools necessary to compile native modules.</String>
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
     <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
-    <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. The script will pop-up in a new window after the installation completes.</String>
-    <String Id="NativeToolsDlgManualDetails">Note that this will also install Boxstarter and Chocolatey. Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
+    <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. Note that this will also install Boxstarter and Chocolatey. The script will pop-up in a new window after the installation completes.</String>
+    <String Id="NativeToolsDlgManualDetails">Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
 
     <!-- References like [ProductName] or $(var.ProductName) don't seem to work in Title attributes -->
     <String Id="NodeRuntime_Title">Node.js runtime</String>


### PR DESCRIPTION
Currently, the installation wizard more or less silently installs third-party software (Boxstarter + Chocolatey). This adds some text to the MSI installation dialog and to the Boxstarter installation script.

Refs: https://github.com/nodejs/node/pull/22645
Refs: https://github.com/nodejs/node/pull/22988

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
