### PR TITLE
repl: do not swallow errors in nested REPLs

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1002,6 +1002,7 @@ function complete(line, callback) {
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
     if (!magic[kBufferedCommandSymbol]) {
+      magic._domain.on('error', (err) => { throw err; });
       return magic.complete(line, callback);
     }
   }

--- a/test/fixtures/repl-tab-completion-nested-repls.js
+++ b/test/fixtures/repl-tab-completion-nested-repls.js
@@ -1,0 +1,50 @@
+// Tab completion sometimes uses a separate REPL instance under the hood.
+// That REPL instance has its own domain. Make sure domain errors trickle back
+// up to the main REPL.
+//
+// Ref: https://github.com/nodejs/node/issues/21586
+
+'use strict';
+
+const { Stream } = require('stream');
+const { inherits } = require('util');
+function noop() {}
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    data.forEach((line) => {
+      this.emit('data', `${line}\n`);
+    });
+  };
+}
+
+inherits(ArrayStream, Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.pause = noop;
+ArrayStream.prototype.resume = noop;
+ArrayStream.prototype.write = noop;
+
+const repl = require('repl');
+
+const putIn = new ArrayStream();
+const testMe = repl.start('', putIn);
+
+// Some errors are passed to the domain, but do not callback
+testMe._domain.on('error', function(err) {
+  throw err;
+});
+
+// Nesting of structures causes REPL to use a nested REPL for completion.
+putIn.run([
+  'var top = function() {',
+  'r = function test (',
+  ' one, two) {',
+  'var inner = {',
+  ' one:1',
+  '};'
+]);
+
+// In Node.js 10.11.0, this next line will terminate the repl silently...
+testMe.complete('inner.o', () => { throw new Error('fhqwhgads'); });

--- a/test/parallel/test-repl-tab-complete-nested-repls.js
+++ b/test/parallel/test-repl-tab-complete-nested-repls.js
@@ -1,0 +1,21 @@
+// Tab completion sometimes uses a separate REPL instance under the hood.
+// That REPL instance has its own domain. Make sure domain errors trickle back
+// up to the main REPL.
+//
+// Ref: https://github.com/nodejs/node/issues/21586
+
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const testFile = fixtures.path('repl-tab-completion-nested-repls.js');
+const result = spawnSync(process.execPath, [testFile]);
+
+// The spawned process will fail. In Node.js 10.11.0, it will fail silently. The
+// test here is to make sure that the error information bubbles up to the
+// calling process.
+assert.ok(result.status, 'testFile swallowed its error');

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -158,7 +158,6 @@ testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
-
 putIn.run(['.clear']);
 
 // currently does not work, but should not break, not the {

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -154,10 +154,10 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-// See: https://github.com/nodejs/node/issues/21586
-// testMe.complete('inner.o', getNoResultsFunction());
 testMe.complete('inner.o', common.mustCall(function(error, data) {
+  assert.deepStrictEqual(data, works);
 }));
+
 
 putIn.run(['.clear']);
 


### PR DESCRIPTION
For tab completion, a REPLServer instance will sometimes create another
REPLServer instance. If a callback is sent to the `.complete()` function
and that callback throws an error, it will be swallowed by the nested
REPLs domain. Re-throw the error so that processes don't silently exit
without any indication of an error (including a status code).

Fixes: https://github.com/nodejs/node/issues/21586

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
