### PR TITLE
http2: add Http2Session.lastReceivedTime

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -416,7 +416,7 @@ Transmits a `GOAWAY` frame to the connected peer *without* shutting down the
 added: REPLACEME
 -->
 
-* { double }
+* {number}
 
 A timestamp indicating the moment the most recently received communication of
 any kind was received from the connected peer. A value of `0` indicates that

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -411,6 +411,17 @@ added: v9.4.0
 Transmits a `GOAWAY` frame to the connected peer *without* shutting down the
 `Http2Session`.
 
+#### http2session.lastReceivedTime
+<!-- YAML
+added: REPLACEME
+-->
+
+* { double }
+
+A timestamp indicating the moment the most recently received communication of
+any kind was received from the connected peer. A value of `0` indicates that
+the session is still open but no data has yet been received.
+
 #### http2session.localSettings
 <!-- YAML
 added: v8.4.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -411,16 +411,17 @@ added: v9.4.0
 Transmits a `GOAWAY` frame to the connected peer *without* shutting down the
 `Http2Session`.
 
-#### http2session.lastReceivedTime
+#### http2session.getLastReceivedTime()
 <!-- YAML
 added: REPLACEME
 -->
 
-* {number}
+* Returns: {number}
 
-A timestamp indicating the moment the most recently received communication of
-any kind was received from the connected peer. A value of `0` indicates that
-the session is still open but no data has yet been received.
+Returns a timestamp indicating the moment the most recently received
+communication of any kind was received from the connected peer. A value of `0`
+indicates that the session is still open but no data has yet been received.
+A value of `undefined` indicates that the session is no longer valid.
 
 #### http2session.localSettings
 <!-- YAML

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1015,7 +1015,7 @@ class Http2Session extends EventEmitter {
     return !!(this[kState].flags & SESSION_FLAGS_DESTROYED);
   }
 
-  get lastReceivedTime() {
+  getLastReceivedTime() {
     return !this.destroyed ? this[kHandle].getLastReceivedTime() : undefined;
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1015,6 +1015,10 @@ class Http2Session extends EventEmitter {
     return !!(this[kState].flags & SESSION_FLAGS_DESTROYED);
   }
 
+  get lastReceivedTime() {
+    return !this.destroyed ? this[kHandle].getLastReceivedTime() : undefined;
+  }
+
   // Resets the timeout counter
   [kUpdateTimer]() {
     if (this.destroyed)

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -799,6 +799,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   static void Ping(const FunctionCallbackInfo<Value>& args);
   static void AltSvc(const FunctionCallbackInfo<Value>& args);
   static void Origin(const FunctionCallbackInfo<Value>& args);
+  static void GetLastReceivedTime(const FunctionCallbackInfo<Value>& args);
 
   template <get_setting fn>
   static void RefreshSettings(const FunctionCallbackInfo<Value>& args);
@@ -827,6 +828,8 @@ class Http2Session : public AsyncWrap, public StreamListener {
   // Tell our custom memory allocator that this rcbuf is independent of
   // this session now, and may outlive it.
   void StopTrackingRcbuf(nghttp2_rcbuf* buf);
+
+  double LastReceivedTime() { return last_received_ts_ / 1e6; }
 
   // Returns the current session memory including memory allocated by nghttp2,
   // the current outbound storage queue, and pending writes.
@@ -991,6 +994,8 @@ class Http2Session : public AsyncWrap, public StreamListener {
   std::vector<nghttp2_stream_write> outgoing_buffers_;
   std::vector<uint8_t> outgoing_storage_;
   std::vector<int32_t> pending_rst_streams_;
+
+  uint64_t last_received_ts_ = 0;
 
   void CopyDataIntoOutgoing(const uint8_t* src, size_t src_length);
   void ClearOutgoing(int status);

--- a/test/parallel/test-http2-session-lastreceivedtime.js
+++ b/test/parallel/test-http2-session-lastreceivedtime.js
@@ -15,7 +15,7 @@ const assert = require('assert');
 
 const server = createServer();
 server.on('stream', mustCall((stream) => {
-  assert(stream.session.lastReceivedTime > 0);
+  assert(stream.session.getLastReceivedTime() > 0);
   stream.respond();
   stream.end('ok');
 }));
@@ -25,7 +25,7 @@ server.listen(0, mustCall(() => {
 
   const req = client.request();
   req.on('response', mustCall(() => {
-    assert(client.lastReceivedTime > 0);
+    assert(client.getLastReceivedTime() > 0);
   }));
   req.resume();
   req.on('close', mustCall(() => {

--- a/test/parallel/test-http2-session-lastreceivedtime.js
+++ b/test/parallel/test-http2-session-lastreceivedtime.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const {
+  hasCrypto,
+  mustCall,
+  skip
+} = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
+const {
+  createServer,
+  connect
+} = require('http2');
+const assert = require('assert');
+
+const server = createServer();
+server.on('stream', mustCall((stream) => {
+  assert(stream.session.lastReceivedTime > 0);
+  stream.respond();
+  stream.end('ok');
+}));
+
+server.listen(0, mustCall(() => {
+  const client = connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request();
+  req.on('response', mustCall(() => {
+    assert(client.lastReceivedTime > 0);
+  }));
+  req.resume();
+  req.on('close', mustCall(() => {
+    server.close();
+    client.close();
+  }));
+}));


### PR DESCRIPTION
Adds a time stamp indicating the last time data was received from
the connected peer.

Fixes: https://github.com/nodejs/node/issues/21730

/cc @murgatroid99 who requested the feature
/cc @nodejs/http2

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
