### PR TITLE
Feature: directoriesNames method in path.js

### DIFF
--- a/benchmark/path/directoriesNames-posix.js
+++ b/benchmark/path/directoriesNames-posix.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common.js');
+const { posix } = require('path');
+
+const bench = common.createBenchmark(main, {
+  pathext: [
+    '/',
+    'D:/DDL/EBOOK/whatEverFile.pub',
+    '/foo'
+  ],
+  n: [1e6]
+});
+
+function main({ n, pathext }) {
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    posix.directoriesNames(pathext);
+  }
+  bench.end(n);
+}

--- a/benchmark/path/directoriesNames-win32.js
+++ b/benchmark/path/directoriesNames-win32.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common.js');
+const { win32 } = require('path');
+
+const bench = common.createBenchmark(main, {
+  pathext: [
+    'C:\\',
+    'D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi'
+  ],
+  n: [1e6]
+});
+
+function main({ n, pathext }) {
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    win32.directoriesNames(pathext);
+  }
+  bench.end(n);
+}

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -122,6 +122,26 @@ process.env.PATH.split(path.delimiter);
 // Returns ['C:\\Windows\\system32', 'C:\\Windows', 'C:\\Program Files\\node\\']
 ```
 
+## path.directoriesNames(path)
+<!-- YAML
+added: v10.11.1
+-->
+
+* `path` {string}
+* Returns: {string[]}
+
+The `path.directoriesNames()` method returns an array that contains
+all directories names contained in a `path`
+
+```js
+// Windows path - gives [ 'D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques' ]
+path.directoriesNames("D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi");
+// POSIX path - gives [ '/' ]
+path.directoriesNames("/foo");
+```
+
+A [`TypeError`][] is thrown if `path` is not a string.
+
 ## path.dirname(path)
 <!-- YAML
 added: v0.1.16

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -135,9 +135,9 @@ all directories names contained in a `path`
 
 ```js
 // Windows path - gives [ 'D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques' ]
-path.directoriesNames("D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi");
+path.directoriesNames('D:\\DDL\\ANIME\\les chevaliers du zodiaques\\aFile.avi');
 // POSIX path - gives [ '/' ]
-path.directoriesNames("/foo");
+path.directoriesNames('/foo');
 ```
 
 A [`TypeError`][] is thrown if `path` is not a string.

--- a/lib/path.js
+++ b/lib/path.js
@@ -1065,7 +1065,7 @@ const win32 = {
   delimiter: ';',
   win32: null,
   posix: null,
-  directories: null
+  directoriesNames: null
 };
 
 
@@ -1524,7 +1524,7 @@ const posix = {
   delimiter: ':',
   win32: null,
   posix: null,
-  directories: null
+  directoriesNames: null
 };
 
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1533,6 +1533,7 @@ posix.posix = win32.posix = posix;
 
 // Cross-platform function to extract each folder name contained in a path
 function parseDirectories(path) {
+  assertPath(path);
   const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args)));
   const isWindowsPath = (path.indexOf('\\') !== -1);
   const pathModule = (isWindowsPath) ? win32 : posix;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1534,10 +1534,10 @@ posix.posix = win32.posix = posix;
 // Cross-platform function to extract each folder name contained in a path
 function parseDirectories(path) {
   assertPath(path);
-  const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args)));
+  const pipe = (...fns) => (x) => fns.reduce((v, f) => f(v), x);
   const isWindowsPath = (path.indexOf('\\') !== -1);
   const pathModule = (isWindowsPath) ? win32 : posix;
-  return compose(
+  return pipe(
     // could help with some ref linux path ^^
     (path) => pathModule.normalize(path),
     // get only the directories
@@ -1556,8 +1556,7 @@ function parseDirectories(path) {
           accumulator.push(currentValue);
         }
         return accumulator;
-      }
-      , [])
+      }, [])
   )(path);
 }
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1560,7 +1560,7 @@ function parseDirectories(path) {
   )(path);
 }
 
-posix.directories = win32.directories = parseDirectories;
+posix.directoriesNames = win32.directoriesNames = parseDirectories;
 
 // Legacy internal API, docs-only deprecated: DEP0080
 win32._makeLong = win32.toNamespacedPath;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1064,7 +1064,8 @@ const win32 = {
   sep: '\\',
   delimiter: ';',
   win32: null,
-  posix: null
+  posix: null,
+  directories: null
 };
 
 
@@ -1522,12 +1523,44 @@ const posix = {
   sep: '/',
   delimiter: ':',
   win32: null,
-  posix: null
+  posix: null,
+  directories: null
 };
 
 
 posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
+
+// Cross-platform function to extract each folder name contained in a path
+function parseDirectories(path) {
+  const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args)));
+  const isWindowsPath = (path.indexOf('\\') !== -1);
+  const pathModule = (isWindowsPath) ? win32 : posix;
+  return compose(
+    // could help with some ref linux path ^^
+    (path) => pathModule.normalize(path),
+    // get only the directories
+    (path) => pathModule.parse(path).dir,
+    (path) => path.split(pathModule.sep).reduce(
+      (accumulator, currentValue, currentIndex) => {
+        // cases when a empty string occurs
+        // if it is on linux and at first position ,
+        // default set to pathModule Root (for example /foo )
+        if (currentValue.length === 0) {
+          if (currentIndex === 0) {
+            accumulator.push(pathModule.sep);
+          }
+          // else ignore it
+        } else {
+          accumulator.push(currentValue);
+        }
+        return accumulator;
+      }
+      , [])
+  )(path);
+}
+
+posix.directories = win32.directories = parseDirectories;
 
 // Legacy internal API, docs-only deprecated: DEP0080
 win32._makeLong = win32.toNamespacedPath;

--- a/test/parallel/test-path-directories.js
+++ b/test/parallel/test-path-directories.js
@@ -1,0 +1,35 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const path = require('path');
+
+// A windows path
+assert.strictEqual(
+  path.directories(
+    'D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi'
+  ),
+  ['D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques']
+);
+
+// A Linux path
+assert.strictEqual(
+  path.directories(
+    'D:/DDL/EBOOK/whatEverFile.pub'
+  ),
+  [ 'D:', 'DDL', 'EBOOK' ]
+);
+
+// Path near root (Windows / Linux)
+assert.strictEqual(
+  path.directories(
+    '/foo'
+  ),
+  ['/']
+);
+
+assert.strictEqual(
+  path.directories(
+    'D:\\test.avi'
+  ),
+  ['D:']
+);

--- a/test/parallel/test-path-directoriesNames.js
+++ b/test/parallel/test-path-directoriesNames.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 // A windows path
 assert.strictEqual(
-  path.directories(
+  path.directoriesNames(
     'D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi'
   ),
   ['D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques']
@@ -13,7 +13,7 @@ assert.strictEqual(
 
 // A Linux path
 assert.strictEqual(
-  path.directories(
+  path.directoriesNames(
     'D:/DDL/EBOOK/whatEverFile.pub'
   ),
   [ 'D:', 'DDL', 'EBOOK' ]
@@ -21,14 +21,14 @@ assert.strictEqual(
 
 // Path near root (Windows / Linux)
 assert.strictEqual(
-  path.directories(
+  path.directoriesNames(
     '/foo'
   ),
   ['/']
 );
 
 assert.strictEqual(
-  path.directories(
+  path.directoriesNames(
     'D:\\test.avi'
   ),
   ['D:']

--- a/test/parallel/test-path-directoriesNames.js
+++ b/test/parallel/test-path-directoriesNames.js
@@ -5,31 +5,27 @@ const path = require('path');
 
 // A windows path
 assert.strictEqual(
-  path.directoriesNames(
-    'D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi'
+  JSON.stringify(
+    path.directoriesNames(
+      'D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi'
+    )
   ),
-  ['D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques']
+  JSON.stringify(['D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques'])
 );
 
 // A Linux path
 assert.strictEqual(
-  path.directoriesNames(
-    'D:/DDL/EBOOK/whatEverFile.pub'
-  ),
-  [ 'D:', 'DDL', 'EBOOK' ]
+  JSON.stringify(path.directoriesNames('D:/DDL/EBOOK/whatEverFile.pub')),
+  JSON.stringify(['D:', 'DDL', 'EBOOK'])
 );
 
 // Path near root (Windows / Linux)
 assert.strictEqual(
-  path.directoriesNames(
-    '/foo'
-  ),
-  ['/']
+  JSON.stringify(path.directoriesNames('/foo')),
+  JSON.stringify(['/'])
 );
 
 assert.strictEqual(
-  path.directoriesNames(
-    'D:\\test.avi'
-  ),
-  ['D:']
+  JSON.stringify(path.directoriesNames('D:\\test.avi')),
+  JSON.stringify(['D:'])
 );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Description

I find out a random behaviour when testing the dirname method of lib/path.js with a windows path : 

```js
const path = require("path")
path.dirname("D:\\DDL\\ANIME\\les chevaliers du zodiaques\\whateverFile.avi");
// it gives "." at least on https://npm.runkit.com ^^
```

Since this method seems to work with no Windows path(s), I thought about a cross-platform version.

Here is my suggestion : 

> The path.directoriesNames() method returns an array that contains all directories names contained in a path

```js
const path = require('path');
// Windows path - gives [ 'D:', 'DDL', 'ANIME', 'les chevaliers du zodiaques' ]
path.directoriesNames('D:\\DDL\\ANIME\\les chevaliers du zodiaques\\aFile.avi');
// POSIX path - gives [ '/' ]
path.directoriesNames('/foo');
```

For what it would useful ? Kind of dirname + ^^ 

Edit : sorry for the duplicate history - I wrote a wrong message . Commit squashing should be ok.