### PR TITLE
errors: fix ERR_SOCKET_BAD_PORT message

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1521,7 +1521,7 @@ An invalid (negative) size was passed for either the `recvBufferSize` or
 <a id="ERR_SOCKET_BAD_PORT"></a>
 ### ERR_SOCKET_BAD_PORT
 
-An API function expecting a port > 0 and < 65536 received an invalid value.
+An API function expecting a port >= 0 and < 65536 received an invalid value.
 
 <a id="ERR_SOCKET_BAD_TYPE"></a>
 ### ERR_SOCKET_BAD_TYPE

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -801,7 +801,7 @@ E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound', Error);
 E('ERR_SOCKET_BAD_BUFFER_SIZE',
   'Buffer size must be a positive integer', TypeError);
 E('ERR_SOCKET_BAD_PORT',
-  'Port should be > 0 and < 65536. Received %s.', RangeError);
+  'Port should be >= 0 and < 65536. Received %s.', RangeError);
 E('ERR_SOCKET_BAD_TYPE',
   'Bad socket type specified. Valid types are: udp4, udp6', TypeError);
 E('ERR_SOCKET_BUFFER_SIZE',

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -290,7 +290,7 @@ const portErr = (port) => {
   const err = {
     code: 'ERR_SOCKET_BAD_PORT',
     message:
-      `Port should be > 0 and < 65536. Received ${port}.`,
+      `Port should be >= 0 and < 65536. Received ${port}.`,
     type: RangeError
   };
 

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -129,7 +129,7 @@ assert.strictEqual(errors.getMessage('ERR_MISSING_ARGS', ['a', 'b', 'c']),
 // Test ERR_SOCKET_BAD_PORT
 assert.strictEqual(
   errors.getMessage('ERR_SOCKET_BAD_PORT', [0]),
-  'Port should be > 0 and < 65536. Received 0.');
+  'Port should be >= 0 and < 65536. Received 0.');
 
 // Test ERR_TLS_CERT_ALTNAME_INVALID
 assert.strictEqual(


### PR DESCRIPTION
The current message says 'Port should be > 0' meaning '0' is an invalid value. You can pass '0' to get a random port from the system. The correct message for this error is 'Port should be >= 0'.

A correct message for this type of error is being shown in the docs already: https://nodejs.org/api/errors.html#errors_class_rangeerror

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
