### PR TITLE
crypto: downgrade DEP0115 to `--pending-deprecation` only

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2168,7 +2168,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime (supports [`--pending-deprecation`][])
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 In recent versions of Node.js, there is no difference between
 [`crypto.randomBytes()`][] and `crypto.pseudoRandomBytes()`. The latter is

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2168,12 +2168,12 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: Runtime (supports [`--pending-deprecation`][])
 
 In recent versions of Node.js, there is no difference between
 [`crypto.randomBytes()`][] and `crypto.pseudoRandomBytes()`. The latter is
 deprecated along with the undocumented aliases `crypto.prng()` and
-`crypto.rng()` in favor of [`crypto.randomBytes()`][] and will be removed in a
+`crypto.rng()` in favor of [`crypto.randomBytes()`][] and may be removed in a
 future release.
 
 <a id="DEP0116"></a>

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2164,8 +2164,11 @@ of Node.js core and will be removed in the future.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/22519
-    description: Runtime deprecation.
+    pr-url:
+      - https://github.com/nodejs/node/pull/22519
+      - https://github.com/nodejs/node/pull/23017
+    description: Added documentation-only deprecation
+                 with `--pending-deprecation` support.
 -->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -36,6 +36,7 @@ const {
   ERR_CRYPTO_FIPS_UNAVAILABLE
 } = require('internal/errors').codes;
 const constants = process.binding('constants').crypto;
+const { pendingDeprecation } = process.binding('config');
 const {
   fipsMode,
   fipsForced
@@ -243,19 +244,24 @@ Object.defineProperties(exports, {
   },
 
   // Aliases for randomBytes are deprecated.
-  // The ecosystem needs those to exist for backwards compatibility with
-  // ancient Node.js runtimes (0.10, 0.12).
+  // The ecosystem needs those to exist for backwards compatibility.
   prng: {
     enumerable: false,
-    value: deprecate(randomBytes, 'crypto.prng is deprecated.', 'DEP0115')
+    value: pendingDeprecation ?
+      deprecate(randomBytes, 'crypto.prng is deprecated.', 'DEP0115') :
+      randomBytes
   },
   pseudoRandomBytes: {
     enumerable: false,
-    value: deprecate(randomBytes,
-                     'crypto.pseudoRandomBytes is deprecated.', 'DEP0115')
+    value: pendingDeprecation ?
+      deprecate(randomBytes,
+                'crypto.pseudoRandomBytes is deprecated.', 'DEP0115') :
+      randomBytes
   },
   rng: {
     enumerable: false,
-    value: deprecate(randomBytes, 'crypto.rng is deprecated.', 'DEP0115')
+    value: pendingDeprecation ?
+      deprecate(randomBytes, 'crypto.rng is deprecated.', 'DEP0115') :
+      randomBytes
   }
 });

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --pending-deprecation
 'use strict';
 const common = require('../common');
 


### PR DESCRIPTION
Aliases are very cheap to maintain, so an unconditional runtime
deprecation that affects existing ecosystem code is not
a good idea. This commit turns the runtime deprecation into
a `--pending-deprecation` one.

Fixes: https://github.com/nodejs/node/issues/23013

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
