### PR TITLE
assert: stringMatching method

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1063,6 +1063,31 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 `message` parameter is an instance of an [`Error`][] then it will be thrown
 instead of the `AssertionError`.
 
+## assert.stringMatching(input, match)
+<!-- YAML
+added: v10.11.1
+-->
+* `input` {string|String|(string|String)[]}
+* `match` {(RegExp|String|string)[]}
+
+Verify that requested constraints match the provided input :
+
+```js
+const assert = require("assert");
+
+// default case : check if string(s) match criterias
+// should be false
+assert.stringMatching('blublu', ['blublu', 'blu']),
+
+// advanced case : check that strings matches regex
+// should be true
+assert.stringMatching(['blublu','blu'], /blu\.*/),
+
+// or to mix both of them ^^
+// should be false
+assert.stringMatching(['blublu', 'lol'], ['blublu', /blu\.*/])
+```
+
 ## assert.throws(fn[, error][, message])
 <!-- YAML
 added: v0.1.21

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1073,19 +1073,19 @@ added: v10.11.1
 Verify that requested constraints match the provided input :
 
 ```js
-const assert = require("assert");
+const assert = require('assert');
 
 // default case : check if string(s) match criterias
 // should be false
-assert.stringMatching('blublu', ['blublu', 'blu']),
+assert.stringMatching('blublu', ['blublu', 'blu']);
 
 // advanced case : check that strings matches regex
 // should be true
-assert.stringMatching(['blublu','blu'], /blu\.*/),
+assert.stringMatching(['blublu', 'blu'], /blu\.*/);
 
 // or to mix both of them ^^
 // should be false
-assert.stringMatching(['blublu', 'lol'], ['blublu', /blu\.*/])
+assert.stringMatching(['blublu', 'lol'], ['blublu', /blu\.*/]);
 ```
 
 ## assert.throws(fn[, error][, message])

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1068,7 +1068,7 @@ instead of the `AssertionError`.
 added: v10.11.1
 -->
 * `input` {string|string[]}
-* `match` {(RegExp|string)[]}
+* `match` {RegExp|RegExp[]|string|string[]}
 
 Verify that requested constraints match the provided input :
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1067,8 +1067,8 @@ instead of the `AssertionError`.
 <!-- YAML
 added: v10.11.1
 -->
-* `input` {string|String|(string|String)[]}
-* `match` {(RegExp|String|string)[]}
+* `input` {string|string[]}
+* `match` {(RegExp|string)[]}
 
 Verify that requested constraints match the provided input :
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,7 +29,10 @@ const { codes: {
 } } = require('internal/errors');
 const { AssertionError, errorCache } = require('internal/assert');
 const { openSync, closeSync, readSync } = require('fs');
-const { inspect, types: { isPromise, isRegExp } } = require('util');
+const {
+  inspect,
+  types: { isPromise, isRegExp, isStringObject }
+} = require('util');
 const { EOL } = require('internal/constants');
 const { NativeModule } = require('internal/bootstrap/loaders');
 
@@ -103,8 +106,7 @@ function fail(actual, expected, message, operator, stackStartFn) {
         'DEP0094'
       );
     }
-    if (argsLen === 2)
-      operator = '!=';
+    if (argsLen === 2) operator = '!=';
   }
 
   if (message instanceof Error) throw message;
@@ -750,6 +752,50 @@ assert.ifError = function ifError(err) {
 
     throw newErr;
   }
+};
+
+// String Matching
+assert.stringMatching = function stringMatching(...[input, match]) {
+  // check parameters
+  const search =
+    typeof input === 'string' || isStringObject(input) ?
+      [input] :
+      Array.isArray(input) &&
+      input.every((str) => typeof str === 'string' || isStringObject(str)) ?
+        input :
+        undefined;
+  if (search === undefined) {
+    innerFail({
+      actual: input,
+      expected: 'string[] || String[]',
+      message: 'Wrong type of argument',
+      operator: 'stringMatching',
+      stackStartFn: stringMatching
+    });
+  }
+  const expectedMatch =
+    typeof match === 'string' || isStringObject(match) || isRegExp(match) ?
+      [match] :
+      Array.isArray(match) &&
+      match.every(
+        (ex) => typeof ex === 'string' || isStringObject(ex) || isRegExp(ex)
+      ) ?
+        match :
+        undefined;
+  if (expectedMatch === undefined) {
+    innerFail({
+      actual: match,
+      expected: 'string[] || String[] || Regex[]',
+      message: 'Wrong type of argument',
+      operator: 'stringMatching',
+      stackStartFn: stringMatching
+    });
+  }
+  const guardCheck = (ex) => (param) => {
+    return isRegExp(ex) ? ex.test(param) : param.valueOf() === ex.valueOf();
+  };
+
+  return expectedMatch.every((ex) => search.every(guardCheck(ex)));
 };
 
 // Expose a strict only variant of assert

--- a/test/parallel/test-assert-stringMatching.js
+++ b/test/parallel/test-assert-stringMatching.js
@@ -1,0 +1,31 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+
+// TODO add a test that throws something (example wrong type of args)
+
+// trivial case
+assert.deepStrictEqual(
+  assert.stringMatching([], []),
+  true
+);
+
+// case with only string
+assert.deepStrictEqual(
+  assert.stringMatching('blublu', ['blublu', 'blu']),
+  false
+);
+
+// case with regex
+assert.deepStrictEqual(
+  assert.stringMatching('blublu', ['blublu', /blu\.*/]),
+  true
+);
+
+// case with regex and string
+assert.deepStrictEqual(
+  assert.stringMatching(['blublu', 'lol'], ['blublu', /blu\.*/]),
+  false
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description

Verify that requested constraints match the provided input :

```js
const assert = require('assert');

// default case : check if string(s) match criterias
// should be false
assert.stringMatching('blublu', ['blublu', 'blu']);

// advanced case : check that strings matches regex
// should be true
assert.stringMatching(['blublu', 'blu'], /blu\.*/);

// or to mix both of them ^^
// should be false
assert.stringMatching(['blublu', 'lol'], ['blublu', /blu\.*/]);
```