### PR TITLE
src: simplify `MessagePort` construction code a bit

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -483,14 +483,14 @@ MessagePort* MessagePort::New(
   Local<Function> ctor;
   if (!GetMessagePortConstructor(env, context).ToLocal(&ctor))
     return nullptr;
-  MessagePort* port = nullptr;
 
   // Construct a new instance, then assign the listener instance and possibly
   // the MessagePortData to it.
   Local<Object> instance;
   if (!ctor->NewInstance(context).ToLocal(&instance))
     return nullptr;
-  ASSIGN_OR_RETURN_UNWRAP(&port, instance, nullptr);
+  MessagePort* port = Unwrap<MessagePort>(instance);
+  CHECK_NOT_NULL(port);
   if (data) {
     port->Detach();
     port->data_ = std::move(data);


### PR DESCRIPTION
Using `ASSIGN_OR_RETURN_UNWRAP` would return if the
created `MessagePort` object had no internal fields.
That would be a bug, so switch to a checked conversion instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
