### PR TITLE
worker: reduce `MessagePort` prototype to documented API

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -24,7 +24,8 @@ util.inherits(MessagePort, EventEmitter);
 const {
   Worker: WorkerImpl,
   getEnvMessagePort,
-  threadId
+  threadId,
+  oninit: oninit_symbol
 } = internalBinding('worker');
 
 const isMainThread = threadId === 0;
@@ -93,7 +94,7 @@ function oninit() {
   setupPortReferencing(this, this, 'message');
 }
 
-Object.defineProperty(MessagePort.prototype, 'oninit', {
+Object.defineProperty(MessagePort.prototype, oninit_symbol, {
   enumerable: true,
   writable: false,
   value: oninit

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -19,8 +19,6 @@ const { clearAsyncIdStack } = require('internal/async_hooks');
 const { serializeError, deserializeError } = require('internal/error-serdes');
 const { pathToFileURL } = require('url');
 
-util.inherits(MessagePort, EventEmitter);
-
 const {
   Worker: WorkerImpl,
   getEnvMessagePort,
@@ -58,6 +56,22 @@ const messageTypes = {
   LOAD_SCRIPT: 'loadScript'
 };
 
+// We have to mess with the MessagePort prototype a bit, so that a) we can make
+// it inherit from EventEmitter, even though it is a C++ class, and b) we do
+// not provide methods that are not present in the Browser and not documented
+// on our side (e.g. hasRef).
+// Save a copy of the original set of methods as a shallow clone.
+const MessagePortPrototype = Object.create(
+  Object.getPrototypeOf(MessagePort.prototype),
+  Object.getOwnPropertyDescriptors(MessagePort.prototype));
+// Set up the new inheritance chain.
+Object.setPrototypeOf(MessagePort, EventEmitter);
+Object.setPrototypeOf(MessagePort.prototype, EventEmitter.prototype);
+// Finally, purge methods we don't want to be public.
+delete MessagePort.prototype.stop;
+delete MessagePort.prototype.drain;
+delete MessagePort.prototype.hasRef;
+
 // A communication channel consisting of a handle (that wraps around an
 // uv_async_t) which can receive information from other threads and emits
 // .onmessage events, and a function used for sending data to a MessagePort
@@ -81,10 +95,10 @@ Object.defineProperty(MessagePort.prototype, 'onmessage', {
     this[kOnMessageListener] = value;
     if (typeof value === 'function') {
       this.ref();
-      this.start();
+      MessagePortPrototype.start.call(this);
     } else {
       this.unref();
-      this.stop();
+      MessagePortPrototype.stop.call(this);
     }
   }
 });
@@ -117,15 +131,11 @@ Object.defineProperty(MessagePort.prototype, handle_onclose, {
   value: onclose
 });
 
-const originalClose = MessagePort.prototype.close;
 MessagePort.prototype.close = function(cb) {
   if (typeof cb === 'function')
     this.once('close', cb);
-  originalClose.call(this);
+  MessagePortPrototype.close.call(this);
 };
-
-const drainMessagePort = MessagePort.prototype.drain;
-delete MessagePort.prototype.drain;
 
 Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
   enumerable: false,
@@ -135,7 +145,7 @@ Object.defineProperty(MessagePort.prototype, util.inspect.custom, {
     try {
       // This may throw when `this` does not refer to a native object,
       // e.g. when accessing the prototype directly.
-      ref = this.hasRef();
+      ref = MessagePortPrototype.hasRef.call(this);
     } catch { return this; }
     return Object.assign(Object.create(MessagePort.prototype),
                          ref === undefined ? {
@@ -157,12 +167,12 @@ function setupPortReferencing(port, eventEmitter, eventName) {
   eventEmitter.on('newListener', (name) => {
     if (name === eventName && eventEmitter.listenerCount(eventName) === 0) {
       port.ref();
-      port.start();
+      MessagePortPrototype.start.call(port);
     }
   });
   eventEmitter.on('removeListener', (name) => {
     if (name === eventName && eventEmitter.listenerCount(eventName) === 0) {
-      port.stop();
+      MessagePortPrototype.stop.call(port);
       port.unref();
     }
   });
@@ -304,7 +314,7 @@ class Worker extends EventEmitter {
 
   [kOnExit](code) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
-    drainMessagePort.call(this[kPublicPort]);
+    MessagePortPrototype.drain.call(this[kPublicPort]);
     this[kDispose]();
     this.emit('exit', code);
     this.removeAllListeners();

--- a/src/env.h
+++ b/src/env.h
@@ -113,6 +113,7 @@ struct PackageConfig {
 #define PER_ISOLATE_SYMBOL_PROPERTIES(V)                                      \
   V(handle_onclose_symbol, "handle_onclose")                                  \
   V(owner_symbol, "owner")                                                    \
+  V(oninit_symbol, "oninit")                                                  \
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.
@@ -219,7 +220,6 @@ struct PackageConfig {
   V(onhandshakedone_string, "onhandshakedone")                                \
   V(onhandshakestart_string, "onhandshakestart")                              \
   V(onheaders_string, "onheaders")                                            \
-  V(oninit_string, "oninit")                                                  \
   V(onmessage_string, "onmessage")                                            \
   V(onnewsession_string, "onnewsession")                                      \
   V(onocspresponse_string, "onocspresponse")                                  \

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -421,7 +421,7 @@ MessagePort::MessagePort(Environment* env,
   async()->data = static_cast<void*>(this);
 
   Local<Value> fn;
-  if (!wrap->Get(context, env->oninit_string()).ToLocal(&fn))
+  if (!wrap->Get(context, env->oninit_symbol()).ToLocal(&fn))
     return;
 
   if (fn->IsFunction()) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -502,6 +502,10 @@ void InitWorker(Local<Object> target,
               thread_id_string,
               Number::New(env->isolate(),
                           static_cast<double>(env->thread_id()))).FromJust();
+  Local<String> oninit_string = FIXED_ONE_BYTE_STRING(env->isolate(), "oninit");
+  target->Set(env->context(),
+              oninit_string,
+              env->oninit_symbol()).FromJust();
 }
 
 }  // anonymous namespace

--- a/test/parallel/test-heapdump-worker.js
+++ b/test/parallel/test-heapdump-worker.js
@@ -19,8 +19,7 @@ validateSnapshotNodes('Worker', [
 validateSnapshotNodes('MessagePort', [
   {
     children: [
-      { name: 'MessagePortData' },
-      { name: 'MessagePort' }
+      { name: 'MessagePortData' }
     ]
   }
 ], { loose: true });

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -69,3 +69,12 @@ const { MessageChannel, MessagePort } = require('worker_threads');
     });
   });
 }
+
+{
+  assert.deepStrictEqual(
+    Object.getOwnPropertyNames(MessagePort.prototype).sort(),
+    [
+      'ref', 'unref', 'start', 'close', 'postMessage', 'onmessage',
+      'constructor'
+    ].sort());
+}


### PR DESCRIPTION
* worker: hide MessagePort init function behind symbol

  This reduces unintended exposure of internals.

* worker: reduce `MessagePort` prototype to documented API

  `MessagePort` is special because it has to be a C++ API
that is exposed to userland. Therefore, there is a number
of internal methods on its native prototype; this commit
reduces this set of methods to only what is documented in
the API.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
