### PR TITLE
test: fix flaky sequential/test-fs-watch-system-limit

### DIFF
--- a/test/sequential/test-fs-watch-system-limit.js
+++ b/test/sequential/test-fs-watch-system-limit.js
@@ -42,7 +42,8 @@ gatherStderr.on('data', common.mustCallAtLeast((chunk) => {
   if (accumulated.includes('Error:') && !finished) {
     assert(
       accumulated.includes('ENOSPC: System limit for number ' +
-                           'of file watchers reached'),
+                           'of file watchers reached') ||
+      accumulated.includes('EMFILE: '),
       accumulated);
     console.log(`done after ${processes.length} processes, cleaning up`);
     finished = true;


### PR DESCRIPTION
This test has at least once locally received `EMFILE` rather
than `ENOSPC`, which also seems to provide a reasonable error
message (which is what the test ultimately checks).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
