### PR TITLE
test: remove unnecessary assertions

### DIFF
--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -10,8 +10,6 @@ const { internalBinding } = require('internal/test/binding');
   const spawn = require('child_process').spawn;
   const cmd = common.isWindows ? 'rundll32' : 'ls';
   const cp = spawn(cmd);
-  strictEqual(Object.getPrototypeOf(cp._handle).hasOwnProperty('hasRef'),
-              true, 'process_wrap: hasRef() missing');
   strictEqual(cp._handle.hasRef(),
               true, 'process_wrap: not initially refed');
   cp.unref();
@@ -34,8 +32,6 @@ const { kStateSymbol } = require('internal/dgram');
   const sock4 = dgram.createSocket('udp4');
   const handle = sock4[kStateSymbol].handle;
 
-  strictEqual(Object.getPrototypeOf(handle).hasOwnProperty('hasRef'),
-              true, 'udp_wrap: ipv4: hasRef() missing');
   strictEqual(handle.hasRef(),
               true, 'udp_wrap: ipv4: not initially refed');
   sock4.unref();
@@ -55,8 +51,6 @@ const { kStateSymbol } = require('internal/dgram');
   const sock6 = dgram.createSocket('udp6');
   const handle = sock6[kStateSymbol].handle;
 
-  strictEqual(Object.getPrototypeOf(handle).hasOwnProperty('hasRef'),
-              true, 'udp_wrap: ipv6: hasRef() missing');
   strictEqual(handle.hasRef(),
               true, 'udp_wrap: ipv6: not initially refed');
   sock6.unref();
@@ -75,8 +69,6 @@ const { kStateSymbol } = require('internal/dgram');
 {
   const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
   const handle = new Pipe(PipeConstants.SOCKET);
-  strictEqual(Object.getPrototypeOf(handle).hasOwnProperty('hasRef'),
-              true, 'pipe_wrap: hasRef() missing');
   strictEqual(handle.hasRef(),
               true, 'pipe_wrap: not initially refed');
   handle.unref();
@@ -95,8 +87,6 @@ const { kStateSymbol } = require('internal/dgram');
 {
   const net = require('net');
   const server = net.createServer(() => {}).listen(0);
-  strictEqual(Object.getPrototypeOf(server._handle).hasOwnProperty('hasRef'),
-              true, 'tcp_wrap: hasRef() missing');
   strictEqual(server._handle.hasRef(),
               true, 'tcp_wrap: not initially refed');
   strictEqual(server._unref,

--- a/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+++ b/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
@@ -10,8 +10,6 @@ const tty = new ReadStream(0);
 const { internalBinding } = require('internal/test/binding');
 const isTTY = internalBinding('tty_wrap').isTTY;
 strictEqual(isTTY(0), true, 'tty_wrap: stdin is not a TTY');
-strictEqual(Object.getPrototypeOf(tty._handle).hasOwnProperty('hasRef'),
-            true, 'tty_wrap: hasRef() missing');
 strictEqual(tty._handle.hasRef(),
             true, 'tty_wrap: not initially refed');
 tty.unref();


### PR DESCRIPTION
It’s not necessary to assert that the internal `hasRef()`
method exists, since it is always called directly afterwards
in these tests. Furthermore, the test is overly specific,
in that it expects them on a specific position in the prototype
chain.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
