### PR TITLE
http2: close fd in doSendFileFD()

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2149,6 +2149,7 @@ function doSendFileFD(session, options, fd, headers, streamOptions, err, stat) {
         isDirectory) {
       const err = isDirectory ?
         new ERR_HTTP2_SEND_FILE() : new ERR_HTTP2_SEND_FILE_NOSEEK();
+      tryClose(fd);
       if (onError)
         onError(err);
       else
@@ -2179,6 +2180,7 @@ function doSendFileFD(session, options, fd, headers, streamOptions, err, stat) {
   if ((typeof options.statCheck === 'function' &&
        options.statCheck.call(this, stat, headers) === false) ||
        (this[kState].flags & STREAM_FLAGS_HEADERS_SENT)) {
+    tryClose(fd);
     return;
   }
 


### PR DESCRIPTION
This commit closes the file descriptor in two code paths that
return from doSendFileFD().

Fixes: https://github.com/nodejs/node/issues/23029

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
