### PR TITLE
assert: reduce diff noise

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -253,8 +253,8 @@ function createErrDiff(actual, expected, operator) {
         // and reset the cache.
         res += other;
         other = '';
-        // If the last diverging line is not more than two lines above, print
-        // that line as well.
+        // If the last diverging line is exactly one line above or if it is the
+        // very first line, add the line to the result.
         if (cur === 1 || i === 0) {
           res += `\n  ${actualLine}`;
           printedLines++;

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -191,29 +191,42 @@ function createErrDiff(actual, expected, operator) {
       res += `\n${green}+${white} ${actualLines[i]}`;
       printedLines++;
     // Lines diverge
-    } else if (actualLines[i] !== expectedLines[i]) {
-      if (cur > 1 && i > 2) {
-        if (cur > 4) {
-          res += `\n${blue}...${white}`;
-          skipped = true;
-        } else if (cur > 3) {
-          res += `\n  ${actualLines[i - 2]}`;
+    } else {
+      const expectedLine = expectedLines[i];
+      let actualLine = actualLines[i];
+      let divergingLines = actualLine !== expectedLine &&
+                           (!actualLine.endsWith(',') ||
+                            actualLine.slice(0, -1) !== expectedLine);
+      if (divergingLines &&
+          expectedLine.endsWith(',') &&
+          expectedLine.slice(0, -1) === actualLine) {
+        divergingLines = false;
+        actualLine += ',';
+      }
+      if (divergingLines) {
+        if (cur > 1 && i > 2) {
+          if (cur > 4) {
+            res += `\n${blue}...${white}`;
+            skipped = true;
+          } else if (cur > 3) {
+            res += `\n  ${actualLines[i - 2]}`;
+            printedLines++;
+          }
+          res += `\n  ${actualLines[i - 1]}`;
           printedLines++;
         }
-        res += `\n  ${actualLines[i - 1]}`;
-        printedLines++;
-      }
-      lastPos = i;
-      res += `\n${green}+${white} ${actualLines[i]}`;
-      other += `\n${red}-${white} ${expectedLines[i]}`;
-      printedLines += 2;
-    // Lines are identical
-    } else {
-      res += other;
-      other = '';
-      if (cur === 1 || i === 0) {
-        res += `\n  ${actualLines[i]}`;
-        printedLines++;
+        lastPos = i;
+        res += `\n${green}+${white} ${actualLine}`;
+        other += `\n${red}-${white} ${expectedLine}`;
+        printedLines += 2;
+      // Lines are identical
+      } else {
+        res += other;
+        other = '';
+        if (cur === 1 || i === 0) {
+          res += `\n  ${actualLine}`;
+          printedLines++;
+        }
       }
     }
     // Inspected object to big (Show ~20 rows max)

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -160,6 +160,9 @@ function createErrDiff(actual, expected, operator) {
     // Only extra expected lines exist
     const cur = i - lastPos;
     if (actualLines.length < i + 1) {
+      // If the last diverging line is more than one line above and the
+      // current line is at least line three, add some of the former lines and
+      // also add dots to indicate skipped entries.
       if (cur > 1 && i > 2) {
         if (cur > 4) {
           res += `\n${blue}...${white}`;
@@ -171,11 +174,16 @@ function createErrDiff(actual, expected, operator) {
         res += `\n  ${expectedLines[i - 1]}`;
         printedLines++;
       }
+      // Mark the current line as the last diverging one.
       lastPos = i;
+      // Add the expected line to the cache.
       other += `\n${red}-${white} ${expectedLines[i]}`;
       printedLines++;
     // Only extra actual lines exist
     } else if (expectedLines.length < i + 1) {
+      // If the last diverging line is more than one line above and the
+      // current line is at least line three, add some of the former lines and
+      // also add dots to indicate skipped entries.
       if (cur > 1 && i > 2) {
         if (cur > 4) {
           res += `\n${blue}...${white}`;
@@ -187,16 +195,30 @@ function createErrDiff(actual, expected, operator) {
         res += `\n  ${actualLines[i - 1]}`;
         printedLines++;
       }
+      // Mark the current line as the last diverging one.
       lastPos = i;
+      // Add the actual line to the result.
       res += `\n${green}+${white} ${actualLines[i]}`;
       printedLines++;
     // Lines diverge
     } else {
       const expectedLine = expectedLines[i];
       let actualLine = actualLines[i];
+      // If the lines diverge, specifically check for lines that only diverge by
+      // a trailing comma. In that case it is actually identical and we should
+      // mark it as such.
       let divergingLines = actualLine !== expectedLine &&
                            (!actualLine.endsWith(',') ||
                             actualLine.slice(0, -1) !== expectedLine);
+      // If the expected line has a trailing comma but is otherwise identical,
+      // add a comma at the end of the actual line. Otherwise the output could
+      // look weird as in:
+      //
+      //   [
+      //     1         // No comma at the end!
+      // +   2
+      //   ]
+      //
       if (divergingLines &&
           expectedLine.endsWith(',') &&
           expectedLine.slice(0, -1) === actualLine) {
@@ -204,6 +226,9 @@ function createErrDiff(actual, expected, operator) {
         actualLine += ',';
       }
       if (divergingLines) {
+        // If the last diverging line is more than one line above and the
+        // current line is at least line three, add some of the former lines and
+        // also add dots to indicate skipped entries.
         if (cur > 1 && i > 2) {
           if (cur > 4) {
             res += `\n${blue}...${white}`;
@@ -215,14 +240,21 @@ function createErrDiff(actual, expected, operator) {
           res += `\n  ${actualLines[i - 1]}`;
           printedLines++;
         }
+        // Mark the current line as the last diverging one.
         lastPos = i;
+        // Add the actual line to the result and cache the expected diverging
+        // line so consecutive diverging lines show up as +++--- and not +-+-+-.
         res += `\n${green}+${white} ${actualLine}`;
         other += `\n${red}-${white} ${expectedLine}`;
         printedLines += 2;
       // Lines are identical
       } else {
+        // Add all cached information to the result before adding other things
+        // and reset the cache.
         res += other;
         other = '';
+        // If the last diverging line is not more than two lines above, print
+        // that line as well.
         if (cur === 1 || i === 0) {
           res += `\n  ${actualLine}`;
           printedLines++;
@@ -232,7 +264,7 @@ function createErrDiff(actual, expected, operator) {
     // Inspected object to big (Show ~20 rows max)
     if (printedLines > 20 && i < maxLines - 2) {
       return `${msg}${skippedMsg}\n${res}\n${blue}...${white}${other}\n` +
-        `${blue}...${white}`;
+             `${blue}...${white}`;
     }
   }
 

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -65,9 +65,13 @@ assert.deepEqual(arr, buf);
     () => assert.deepStrictEqual(buf2, buf),
     {
       code: 'ERR_ASSERTION',
-      message: `${defaultMsgStartFull}\n\n` +
-               '  Buffer [Uint8Array] [\n    120,\n    121,\n    122,\n' +
-               '+   10,\n+   prop: 1\n-   10\n  ]'
+      message: `${defaultMsgStartFull} ... Lines skipped\n\n` +
+               '  Buffer [Uint8Array] [\n' +
+               '    120,\n' +
+               '...\n' +
+               '    10,\n' +
+               '+   prop: 1\n' +
+               '  ]'
     }
   );
   assert.deepEqual(buf2, buf);
@@ -80,9 +84,13 @@ assert.deepEqual(arr, buf);
     () => assert.deepStrictEqual(arr, arr2),
     {
       code: 'ERR_ASSERTION',
-      message: `${defaultMsgStartFull}\n\n` +
-               '  Uint8Array [\n    120,\n    121,\n    122,\n' +
-               '+   10\n-   10,\n-   prop: 5\n  ]'
+      message: `${defaultMsgStartFull} ... Lines skipped\n\n` +
+               '  Uint8Array [\n' +
+               '    120,\n' +
+               '...\n' +
+               '    10,\n' +
+               '-   prop: 5\n' +
+               '  ]'
     }
   );
   assert.deepEqual(arr, arr2);
@@ -822,7 +830,7 @@ assert.throws(
     code: 'ERR_ASSERTION',
     name: 'AssertionError [ERR_ASSERTION]',
     message: `${defaultMsgStartFull}\n\n  ` +
-             '{\n+   a: 4\n-   a: 4,\n-   b: true\n  }'
+             '{\n    a: 4,\n-   b: true\n  }'
   });
 assert.throws(
   () => assert.deepStrictEqual(['a'], { 0: 'a' }),
@@ -891,7 +899,7 @@ assert.deepStrictEqual(obj1, obj2);
   assert.throws(
     () => assert.deepStrictEqual(arrProxy, [1, 2, 3]),
     { message: `${defaultMsgStartFull}\n\n` +
-               '  [\n    1,\n+   2\n-   2,\n-   3\n  ]' }
+               '  [\n    1,\n    2,\n-   3\n  ]' }
   );
   util.inspect.defaultOptions = tmp;
 


### PR DESCRIPTION
Assertion errors that produce a diff show a diff for identical entries
in case one side of the comparison has more object properties than the
other one. Those lines are now taken into account and will not show up
as diverging lines anymore.

Refs: https://github.com/nodejs/node/issues/22763

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
