### PR TITLE
src: improve SSL version extraction logic

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -237,24 +237,7 @@ class NodeTraceStateObserver :
     trace_process->SetString("napi", node_napi_version);
 
 #if HAVE_OPENSSL
-    // Stupid code to slice out the version string.
-    {  // NOLINT(whitespace/braces)
-      size_t i, j, k;
-      int c;
-      for (i = j = 0, k = sizeof(OPENSSL_VERSION_TEXT) - 1; i < k; ++i) {
-        c = OPENSSL_VERSION_TEXT[i];
-        if ('0' <= c && c <= '9') {
-          for (j = i + 1; j < k; ++j) {
-            c = OPENSSL_VERSION_TEXT[j];
-            if (c == ' ')
-              break;
-          }
-          break;
-        }
-      }
-      trace_process->SetString("openssl",
-                              std::string(&OPENSSL_VERSION_TEXT[i], j - i));
-    }
+    trace_process->SetString("openssl", crypto::GetOpenSSLVersion());
 #endif
     trace_process->EndDictionary();
 
@@ -1764,26 +1747,10 @@ void SetupProcessObject(Environment* env,
       FIXED_ONE_BYTE_STRING(env->isolate(), node_napi_version));
 
 #if HAVE_OPENSSL
-  // Stupid code to slice out the version string.
-  {  // NOLINT(whitespace/braces)
-    size_t i, j, k;
-    int c;
-    for (i = j = 0, k = sizeof(OPENSSL_VERSION_TEXT) - 1; i < k; ++i) {
-      c = OPENSSL_VERSION_TEXT[i];
-      if ('0' <= c && c <= '9') {
-        for (j = i + 1; j < k; ++j) {
-          c = OPENSSL_VERSION_TEXT[j];
-          if (c == ' ')
-            break;
-        }
-        break;
-      }
-    }
-    READONLY_PROPERTY(
-        versions,
-        "openssl",
-        OneByteString(env->isolate(), &OPENSSL_VERSION_TEXT[i], j - i));
-  }
+  READONLY_PROPERTY(
+      versions,
+      "openssl",
+      OneByteString(env->isolate(), crypto::GetOpenSSLVersion().c_str()));
 #endif
 
   // process.arch

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5725,14 +5725,19 @@ void Initialize(Local<Object> target,
 #endif  // OPENSSL_NO_SCRYPT
 }
 
+constexpr int search(const char* s, int n, int c) {
+  return *s == c ? n : search(s + 1, n + 1, c);
+}
+
 std::string GetOpenSSLVersion() {
   // sample openssl version string format
-  // for reference: "OpenSSL 1.1.0i  14 Aug 2018"
-  std::string ssl(OPENSSL_VERSION_TEXT);
-  size_t first = ssl.find(" ");
-  size_t second = ssl.find(" ", first + 1);
-  CHECK_GT(second, first);
-  return ssl.substr(first + 1, second - first - 1);
+  // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
+  char buf[128];
+  const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
+  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ') + 1;
+  const int len = end - start;
+  snprintf(buf, len, "%.*s\n", len, &OPENSSL_VERSION_TEXT[start]);
+  return std::string(buf);
 }
 
 }  // namespace crypto

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5725,6 +5725,16 @@ void Initialize(Local<Object> target,
 #endif  // OPENSSL_NO_SCRYPT
 }
 
+std::string GetOpenSSLVersion() {
+  // sample openssl version string format
+  // for reference: "OpenSSL 1.1.0i  14 Aug 2018"
+  std::string ssl(OPENSSL_VERSION_TEXT);
+  size_t first = ssl.find(" ");
+  size_t second = ssl.find(" ", first + 1);
+  CHECK_GT(second, first);
+  return ssl.substr(first + 1, second - first - 1);
+}
+
 }  // namespace crypto
 }  // namespace node
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -98,6 +98,7 @@ extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 extern void UseExtraCaCerts(const std::string& file);
 
 void InitCryptoOnce();
+std::string GetOpenSSLVersion();
 
 class SecureContext : public BaseObject {
  public:


### PR DESCRIPTION
The openssl version as defined in ssl libraries is complex. The current logic to extract the major.minor.pacth format uses C semantics to loop through the text and search for specific patterns. Use C++ string to tidy it up.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
