### PR TITLE
doc: remove outdated notes on stdio in workers

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1797,8 +1797,6 @@ a [Writable][] stream.
 `process.stderr` differs from other Node.js streams in important ways, see
 [note on process I/O][] for more information.
 
-This feature is not available in [`Worker`][] threads.
-
 ## process.stdin
 
 * {Stream}
@@ -1831,8 +1829,6 @@ In "old" streams mode the `stdin` stream is paused by default, so one
 must call `process.stdin.resume()` to read from it. Note also that calling
 `process.stdin.resume()` itself would switch stream to "old" mode.
 
-This feature is not available in [`Worker`][] threads.
-
 ## process.stdout
 
 * {Stream}
@@ -1850,8 +1846,6 @@ process.stdin.pipe(process.stdout);
 
 `process.stdout` differs from other Node.js streams in important ways, see
 [note on process I/O][] for more information.
-
-This feature is not available in [`Worker`][] threads.
 
 ### A note on process I/O
 


### PR DESCRIPTION
Workers support `stdio` streams since the initial PR landed. These
lines are editing leftovers from before that and should be removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
