### PR TITLE
Minor improvements for test-http2-session-timeout

### DIFF
--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -3,10 +3,15 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const assert = require('assert');
 const http2 = require('http2');
 
 const serverTimeout = common.platformTimeout(200);
-const mustNotCall = common.mustNotCall();
+
+let requests = 0;
+const mustNotCall = () => {
+  assert.fail(`Timeout after ${requests} request(s)`);
+};
 
 const server = http2.createServer();
 server.timeout = serverTimeout;
@@ -31,6 +36,8 @@ server.listen(0, common.mustCall(() => {
     });
     request.resume();
     request.end();
+
+    requests += 1;
 
     request.on('end', () => {
       const diff = process.hrtime(startTime);

--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -36,7 +36,7 @@ server.listen(0, common.mustCall(() => {
       const diff = process.hrtime(startTime);
       const milliseconds = (diff[0] * 1e3 + diff[1] / 1e6);
       if (milliseconds < serverTimeout * 2) {
-        setImmediate(makeReq);
+        makeReq();
       } else {
         server.removeListener('timeout', mustNotCall);
         server.close();


### PR DESCRIPTION
First commit:

    test: remove setImmediate from timeout test
    
    In test-http2-session-timeout, setImmediate() is used to wrap makeReq().
    makeReq() is asynchronous and setImmediate() is not necessary.

Second commit:

    test: improve debugging information for http2 test
    
    In test-http2-session-timeout, provide the number of requests that
    occurred when the test fails.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
