### PR TITLE
util: change inspect's default depth from 2 to 4

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -361,6 +361,9 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/23062
+    description: The `depth` option now defaults to `4` instead of `2`.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/22788
     description: The `sorted` option is supported now.
   - version: REPLACEME
@@ -401,7 +404,7 @@ changes:
   * `depth` {number} Specifies the number of times to recurse while formatting
     the `object`. This is useful for inspecting large complicated objects. To
     make it recurse up to the maximum call stack size pass `Infinity` or `null`.
-    **Default:** `2`.
+    **Default:** `4`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -94,7 +94,7 @@ const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: 2,
+  depth: 4,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -50,13 +50,14 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], {} ],' +
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ],' +
                   ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
-                  ', Proxy [ Proxy [Array], {} ] ] ]';
-const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], Proxy [Array]' +
-                  ' ],\n    Proxy [ Proxy [Array], Proxy [Array] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [Array], Proxy [Array] ],\n' +
-                  '    Proxy [ Proxy [Array], Proxy [Array] ] ] ]';
+                  ', Proxy [ Proxy [ {}, {} ], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ],' +
+                  ' Proxy [ {}, {} ] ],\n    Proxy [ Proxy [ {}, {} ], Proxy' +
+                  ' [ Proxy [ {}, {} ], {} ] ] ],\n  Proxy [ Proxy [ Proxy' +
+                  ' [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ],\n    Proxy' +
+                  ' [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ] ] ]';
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: true, depth: null }),
   expected1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -70,8 +70,10 @@ assert.strictEqual(util.inspect({ a: function*() {} }),
 assert.strictEqual(util.inspect({ a: 1, b: 2 }), '{ a: 1, b: 2 }');
 assert.strictEqual(util.inspect({ 'a': {} }), '{ a: {} }');
 assert.strictEqual(util.inspect({ 'a': { 'b': 2 } }), '{ a: { b: 2 } }');
-assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }),
-                   '{ a: { b: { c: [Object] } } }');
+assert.strictEqual(util.inspect(
+  { 'a': { 'b': { 'c': { 'd': { 'e': { 'f': {} } } } } } }),
+                   '{ a: { b: { c: { d: { e: [Object] } } } } }'
+);
 assert.strictEqual(
   util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }, false, null),
   '{ a: { b: { c: { d: 2 } } } }');
@@ -111,10 +113,12 @@ assert.strictEqual(util.inspect((new JSStream())._externalStream),
 }
 
 assert(/Object/.test(
-  util.inspect({ a: { a: { a: { a: {} } } } }, undefined, undefined, true)
+  util.inspect({ a: { a: { a: { a: { a: { a: {} } } } } } },
+               undefined, undefined, true)
 ));
 assert(!/Object/.test(
-  util.inspect({ a: { a: { a: { a: {} } } } }, undefined, null, true)
+  util.inspect({ a: { a: { a: { a: { a: { a: {} } } } } } },
+               undefined, null, true)
 ));
 
 for (const showHidden of [true, false]) {
@@ -1048,16 +1052,16 @@ if (typeof Symbol !== 'undefined') {
 
 // Empty and circular before depth.
 {
-  const arr = [[[[]]]];
-  assert.strictEqual(util.inspect(arr), '[ [ [ [] ] ] ]');
-  arr[0][0][0][0] = [];
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Array] ] ] ]');
-  arr[0][0][0] = {};
-  assert.strictEqual(util.inspect(arr), '[ [ [ {} ] ] ]');
-  arr[0][0][0] = { a: 2 };
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
-  arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
+  const arr = [[[[[[]]]]]];
+  assert.strictEqual(util.inspect(arr), '[ [ [ [ [ [] ] ] ] ] ]');
+  arr[0][0][0][0][0][0] = [];
+  assert.strictEqual(util.inspect(arr), '[ [ [ [ [ [Array] ] ] ] ] ]');
+  arr[0][0][0][0][0] = {};
+  assert.strictEqual(util.inspect(arr), '[ [ [ [ [ {} ] ] ] ] ]');
+  arr[0][0][0][0][0] = { a: 2 };
+  assert.strictEqual(util.inspect(arr), '[ [ [ [ [ [Object] ] ] ] ] ]');
+  arr[0][0][0][0][0] = arr;
+  assert.strictEqual(util.inspect(arr), '[ [ [ [ [ [Circular] ] ] ] ] ]');
 }
 
 // Corner cases.
@@ -1145,7 +1149,7 @@ if (typeof Symbol !== 'undefined') {
 // util.inspect.defaultOptions tests.
 {
   const arr = new Array(101).fill();
-  const obj = { a: { a: { a: { a: 1 } } } };
+  const obj = { a: { a: { a: { a: { a: { a: 1 } } } } } };
 
   const oldOptions = Object.assign({}, util.inspect.defaultOptions);
 
@@ -1559,7 +1563,7 @@ util.inspect(process);
     head = head.next = {};
   assert.strictEqual(
     util.inspect(list),
-    '{ next: { next: { next: [Object] } } }'
+    '{ next: { next: { next: { next: { next: [Object] } } } } }'
   );
   const longList = util.inspect(list, { depth: Infinity });
   const match = longList.match(/next/g);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

When dealing with somewhat deep objects, the default depth of 2 is often a hindrance when using the console to log said objects. This changes the default depth to a more reasonable 4.