### PR TITLE
doc: shorten intro of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@
 </p>
 
 Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. For
-more information on using Node.js, see the
-[Node.js Website][].
+more information on using Node.js, see the [Node.js Website][].
 
-The Node.js project is supported by the
-[Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
-policies, and releases are managed under an
-[open governance model](./GOVERNANCE.md).
+Node.js contributions, policies, and releases are managed under an
+[open governance model](./GOVERNANCE.md). The [Node.js Foundation][] provides
+support for the project.
 
 **This project is bound by a [Code of Conduct][].**
 
@@ -643,6 +641,7 @@ Previous releases may also have been signed with one of the following GPG keys:
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Help]: https://github.com/nodejs/help
+[Node.js Foundation]: https://nodejs.org/en/foundation/
 [Node.js Website]: https://nodejs.org/en/
 [Questions tagged 'node.js' on StackOverflow]: https://stackoverflow.com/questions/tagged/node.js
 [Working Groups]: https://github.com/nodejs/TSC/blob/master/WORKING_GROUPS.md


### PR DESCRIPTION
There are many things I might want to know about if I'm reading the
introduction of the README file for Node.js: Where to get help, what the
latest release is, how to compile from source, where to report bugs, how
to contribute...

One thing I cannot imagine wondering about is, "I wonder if there is a
foundation that supports Node.js." Remove that sentence as it seems
designed to serve the project and not the end user.

Bonus: This removes a usage of passive voice.

The Linux kernel README does not mention the Linux Foundation.
https://github.com/torvalds/linux/blob/master/README

The jQuery README does not mention the JS Foundation.
https://github.com/jquery/jquery/blob/master/README.md
(It does mention the no-longer-extant jQuery Foundation but only because
the Foundation itself apparently had coding standards.)

The Python README only mentions the Python Software Foundation as the
copyright owner.

The Apache httpd README does mention the Apache Software Foundation
although it does not link to it and it is mentioned in passing rather
than being the topic of a declarative sentence.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
