### PR TITLE
doc: remove governance info in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine. For
 more information on using Node.js, see the [Node.js Website][].
 
-Node.js contributions, policies, and releases are managed under an
-[open governance model](./GOVERNANCE.md). The [Node.js Foundation][] provides
-support for the project.
+The Node.js project uses an [open governance model](./GOVERNANCE.md). The
+[Node.js Foundation][] provides support for the project.
 
 **This project is bound by a [Code of Conduct][].**
 


### PR DESCRIPTION
There are many things I might want to know about if I'm reading the
introduction of the README file for Node.js: Where to get help, what the
latest release is, how to compile from source, where to report bugs, how
to contribute...

A link to governance is not the thing I would expect in the
introduction. This link appears later in the document, so remove it from
the introduction. This allows the reader to get to what they're looking
for (support information, etc.) faster.

Bonus: This removes a usage of passive voice.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
