### PR TITLE
tools: fix cpplint --quiet option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1199,7 +1199,7 @@ lint-cpp: tools/.cpplintstamp
 
 tools/.cpplintstamp: $(LINT_CPP_FILES)
 	@echo "Running C++ linter..."
-	@$(PYTHON) tools/cpplint.py $?
+	@$(PYTHON) tools/cpplint.py --quiet $?
 	@$(PYTHON) tools/check-imports.py
 	@touch $@
 

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -6429,11 +6429,10 @@ def ParseArguments(args):
       except ValueError:
         PrintUsage('Extensions must be comma seperated list.')
     elif opt == '--recursive':
-          PrintUsage('Extensions must be comma separated list.')
-    elif opt == '--logfile':
       recursive = True
-    elif opt == '--quiet':
+    elif opt == '--logfile':
       logger.addHandler(logging.FileHandler(val, mode='wb'))
+    elif opt == '--quiet':
       global _quiet
       _quiet = True
 


### PR DESCRIPTION
Currently, the `--quiet` option for cpplint will generate the following
error:
```console
$ tools/cpplint.py  --quiet src/node.cc
Traceback (most recent call last):
  File "tools/cpplint.py", line 6529, in <module>
    main()
  File "tools/cpplint.py", line 6497, in main
    filenames = ParseArguments(sys.argv[1:])
  File "tools/cpplint.py", line 6437, in ParseArguments
    logger.addHandler(logging.FileHandler(val, mode='wb'))
  File "/python2.7/logging/__init__.py", line 911, in __init__
    StreamHandler.__init__(self, self._open())
  File "/python2.7/logging/__init__.py", line 941, in _open
    stream = open(self.baseFilename, self.mode)
IOError: [Errno 21] Is a directory: '/Users/danielbevenius/work/nodejs/node
```

This commit moves the FileHandler that currently exists in the quiet
option to the logfile clause. It looks like this issue came about when
merging in commit fee4d3ab90365aaff0d3469076c7ef8a3a91bc79 ("tools:
merge custom cpplint with cpplint v1.3.0").


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
