### PR TITLE
util: extract `uncurryThis` function for reuse

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -385,6 +385,17 @@ function once(callback) {
   };
 }
 
+const ReflectApply = Reflect.apply;
+
+// This function is borrowed from the function with the same name on V8 Extras'
+// `utils` object. V8 implements Reflect.apply very efficiently in conjunction
+// with the spread syntax, such that no additional special case is needed for
+// function calls w/o arguments.
+// Refs: https://github.com/v8/v8/blob/d6ead37d265d7215cf9c5f768f279e21bd170212/src/js/prologue.js#L152-L156
+function uncurryThis(func) {
+  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
+}
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -405,6 +416,7 @@ module.exports = {
   promisify,
   spliceOne,
   removeColors,
+  uncurryThis,
 
   // Symbol used to customize promisify conversion
   customPromisifyArgs: kCustomPromisifyArgsSymbol,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -12,9 +12,7 @@ const {
   arrow_message_private_symbol: kArrowMessagePrivateSymbolIndex,
   decorated_private_symbol: kDecoratedPrivateSymbolIndex
 } = internalBinding('util');
-const {
-  isNativeError
-} = require('internal/util/types');
+const { isNativeError } = internalBinding('types');
 
 const noCrypto = !process.versions.openssl;
 

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -24,12 +24,7 @@ const {
     ONLY_ENUMERABLE
   }
 } = internalBinding('util');
-
-const ReflectApply = Reflect.apply;
-
-function uncurryThis(func) {
-  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
-}
+const { uncurryThis } = require('internal/util');
 
 const kStrict = true;
 const kLoose = false;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -17,7 +17,8 @@ const {
   customInspectSymbol,
   isError,
   join,
-  removeColors
+  removeColors,
+  uncurryThis
 } = require('internal/util');
 
 const {
@@ -67,17 +68,6 @@ const assert = require('internal/assert');
 
 // Avoid monkey-patched built-ins.
 const { Object } = primordials;
-
-const ReflectApply = Reflect.apply;
-
-// This function is borrowed from the function with the same name on V8 Extras'
-// `utils` object. V8 implements Reflect.apply very efficiently in conjunction
-// with the spread syntax, such that no additional special case is needed for
-// function calls w/o arguments.
-// Refs: https://github.com/v8/v8/blob/d6ead37d265d7215cf9c5f768f279e21bd170212/src/js/prologue.js#L152-L156
-function uncurryThis(func) {
-  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
-}
 
 const propertyIsEnumerable = uncurryThis(Object.prototype.propertyIsEnumerable);
 const regExpToString = uncurryThis(RegExp.prototype.toString);

--- a/lib/internal/util/types.js
+++ b/lib/internal/util/types.js
@@ -1,15 +1,6 @@
 'use strict';
 
-const ReflectApply = Reflect.apply;
-
-// This function is borrowed from the function with the same name on V8 Extras'
-// `utils` object. V8 implements Reflect.apply very efficiently in conjunction
-// with the spread syntax, such that no additional special case is needed for
-// function calls w/o arguments.
-// Refs: https://github.com/v8/v8/blob/d6ead37d265d7215cf9c5f768f279e21bd170212/src/js/prologue.js#L152-L156
-function uncurryThis(func) {
-  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
-}
+const { uncurryThis } = require('internal/util');
 
 const TypedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -42,13 +42,9 @@ const {
   deprecate,
   getSystemErrorName: internalErrorName,
   promisify,
+  uncurryThis
 } = require('internal/util');
 
-const ReflectApply = Reflect.apply;
-
-function uncurryThis(func) {
-  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
-}
 const objectToString = uncurryThis(Object.prototype.toString);
 
 let internalDeepEqual;


### PR DESCRIPTION
Extracts `uncurryThis` function which is done in identical ways in a few places in `lib/internal/util` dir.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
