### PR TITLE
doc: simplify pull request wait time to 48 hours

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -171,7 +171,7 @@ agenda.
 ### Waiting for Approvals
 
 Before landing pull requests, sufficient time should be left for input
-from other Collaborators. In general, leave at least 72 hours to account for
+from other Collaborators. In general, leave at least 48 hours to account for
 international time differences and work schedules. However, certain types of
 pull requests can be fast-tracked and may be landed after a shorter delay. For
 example:

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -138,7 +138,7 @@ onboarding session.
   * There is a minimum waiting time which we try to respect for non-trivial
     changes so that people who may have important input in such a distributed
     project are able to respond.
-  * For non-trivial changes, leave the pull request open for at least 72 hours.
+  * For non-trivial changes, leave the pull request open for at least 48 hours.
   * If a pull request is abandoned, check if they'd mind if you took it over
     (especially if it just has nits left).
 * Approving a change
@@ -214,7 +214,7 @@ needs to be pointed out separately during the onboarding.
 * Run CI on the PR. Because the PR does not affect any code, use the
   `node-test-pull-request-lite-pipeline` CI task.
 * After one or two approvals, land the PR (PRs of this type do not need to wait
-  for 72 hours to land).
+  for 48 hours to land).
   * Be sure to add the `PR-URL: <full-pr-url>` and appropriate `Reviewed-By:`
     metadata.
   * [`node-core-utils`][] automates the generation of metadata and the landing


### PR DESCRIPTION
Not a change I'd want to sneak in unnoticed, so: @nodejs/collaborators 

Currently, we have a 48/72 rule for how many hours a pull request should
be left open at a minimum. Unfortunately, whether a pull request should
be left open for 48 or 72 hours is often unclear. The 72 hours is
required if it is a weekend. If I open a pull request on a Friday
morning, does it need to stay open 48 hours or 72 or something in
between? Does it matter if I'm in one time zone or another?

Pull requests used to require a single approval but now require two
approvals unless they've been open for a week. Given this, it seems like
we can simplify the wait time rule to be just 48 hours.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
