### PR TITLE
util: update definition of DISALLOW_COPY_AND_ASSIGN macro

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -90,10 +90,8 @@ NO_RETURN void Assert(const char* const (*args)[4]);
 void DumpBacktrace(FILE* fp);
 
 #define DISALLOW_COPY_AND_ASSIGN(TypeName)                                    \
-  void operator=(const TypeName&) = delete;                                   \
-  void operator=(TypeName&&) = delete;                                        \
   TypeName(const TypeName&) = delete;                                         \
-  TypeName(TypeName&&) = delete
+  TypeName& operator=(const TypeName&) = delete
 
 // Windows 8+ does not like abort() in Release mode
 #ifdef _WIN32


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR updates the `DISALLOW_COPY_AND_ASSIGN` macro.
The compiler will not define move constructor or move assignment operators when copy constructor/assignment is defined.
Hence, it's not needed to `delete` move operations.
This also makes the definition coherent with chromium's definition of the same. https://cs.chromium.org/chromium/src/base/macros.h?rcl=b209442fa2c29021b06a6dcbbd0486b440011fe2&l=33.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
