### PR TITLE
test: replace localhost with os.hostname in fs-readfilesync

### DIFF
--- a/test/parallel/test-fs-readfilesync-enoent.js
+++ b/test/parallel/test-fs-readfilesync-enoent.js
@@ -11,6 +11,7 @@ if (!common.isWindows)
 
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 function test(p) {
@@ -23,10 +24,10 @@ function test(p) {
   }));
 }
 
-test('//localhost/c$/Windows/System32');
-test('//localhost/c$/Windows');
-test('//localhost/c$/');
-test('\\\\localhost\\c$\\');
+test(`//${os.hostname()}/c$/Windows/System32`);
+test(`//${os.hostname()}/c$/Windows`);
+test(`//${os.hostname()}/c$/`);
+test(`\\\\${os.hostname()}\\c$\\`);
 test('C:\\');
 test('C:');
 test(process.env.windir);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/21501

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (waiting for CI)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

@targos could you please try this on the setup mentioned in the issue if possible?
