### PR TITLE
util: set `super_` property to non-enumerable

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -285,7 +285,11 @@ function inherits(ctor, superCtor) {
     throw new ERR_INVALID_ARG_TYPE('superCtor.prototype',
                                    'Function', superCtor.prototype);
   }
-  ctor.super_ = superCtor;
+  Object.defineProperty(ctor, 'super_', {
+    value: superCtor,
+    writable: true,
+    configurable: true
+  });
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
 }
 

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -18,7 +18,15 @@ function B(value) {
 inherits(B, A);
 B.prototype.b = function() { return this._b; };
 
-assert.strictEqual(B.super_, A);
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(B, 'super_'),
+  {
+    value: A,
+    enumerable: false,
+    configurable: true,
+    writable: true
+  }
+);
 
 const b = new B('b');
 assert.strictEqual(b.a(), 'a');


### PR DESCRIPTION
Using `util.inherits()` adds a `super_` property to the constructor
and inspecting that constructor is going to show that property even
though it's not useful for the user.

Therefore the property is now set as non-enumerable and such entries
are not visible by default when using `console.log()` or
`util.inspect()`.

This significantly reduces the amount of data shown when inspecting streams.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
