### PR TITLE
timers: use custom inspection for linked lists

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -17,6 +17,8 @@ const {
 } = require('internal/errors').codes;
 const { validateNumber } = require('internal/validators');
 
+const { inspect } = require('util');
+
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2 ** 31 - 1;
 
@@ -81,6 +83,17 @@ function Timeout(callback, after, args, isRepeat) {
 
   initAsyncResource(this, 'Timeout');
 }
+
+// Make sure the linked list only shows the minimal necessary information.
+Timeout.prototype[inspect.custom] = function(_, options) {
+  return inspect(this, {
+    ...options,
+    // Only inspect one level.
+    depth: 0,
+    // It should not recurse.
+    customInspect: false
+  });
+};
 
 Timeout.prototype.refresh = function() {
   if (this[kRefed])

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -239,6 +239,17 @@ function TimersList(expiry, msecs) {
   this.priorityQueuePosition = null;
 }
 
+// Make sure the linked list only shows the minimal necessary information.
+TimersList.prototype[util.inspect.custom] = function(_, options) {
+  return util.inspect(this, {
+    ...options,
+    // Only inspect one level.
+    depth: 0,
+    // It should not recurse.
+    customInspect: false
+  });
+};
+
 const { _tickCallback: runNextTicks } = process;
 function processTimers(now) {
   debug('process timer lists %d', now);

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -8,6 +8,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const h2 = require('http2');
 const net = require('net');
+const util = require('util');
 
 const { kTimeout } = require('internal/timers');
 
@@ -34,6 +35,22 @@ server.on('stream', common.mustCall(function(stream, headers) {
 
   socket.setTimeout(987);
   assert.strictEqual(session[kTimeout]._idleTimeout, 987);
+
+  // The indentation is corrected depending on the depth.
+  let inspectedTimeout = util.inspect(session[kTimeout]);
+  assert(inspectedTimeout.includes('  _idlePrev: [TimersList]'));
+  assert(inspectedTimeout.includes('  _idleNext: [TimersList]'));
+  assert(!inspectedTimeout.includes('   _idleNext: [TimersList]'));
+
+  inspectedTimeout = util.inspect([ session[kTimeout] ]);
+  assert(inspectedTimeout.includes('    _idlePrev: [TimersList]'));
+  assert(inspectedTimeout.includes('    _idleNext: [TimersList]'));
+  assert(!inspectedTimeout.includes('     _idleNext: [TimersList]'));
+
+  const inspectedTimersList = util.inspect([[ session[kTimeout]._idlePrev ]]);
+  assert(inspectedTimersList.includes('      _idlePrev: [Timeout]'));
+  assert(inspectedTimersList.includes('      _idleNext: [Timeout]'));
+  assert(!inspectedTimersList.includes('       _idleNext: [Timeout]'));
 
   common.expectsError(() => socket.destroy, errMsg);
   common.expectsError(() => socket.emit, errMsg);


### PR DESCRIPTION
Inspecting linked lists is something that is not really useful.
Instead, just use a custom inspection function and hide everything
besides the first level.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
