### PR TITLE
deps: add no-strict-aliasing to ICU cflags

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -51,7 +51,7 @@
       'direct_dependent_settings': {
         'conditions': [
           [ 'os_posix == 1 and OS != "mac" and OS != "ios"', {
-            'cflags': [ '-Wno-deprecated-declarations' ],
+            'cflags': [ '-Wno-deprecated-declarations', '-Wno-strict-aliasing' ],
             'cflags_cc': [ '-frtti' ],
             'cflags_cc!': [ '-fno-rtti' ],
           }],


### PR DESCRIPTION
This commit adds -Wno-strict-aliasing to the icu_implementation target.
The motivation for this is that this flags is enabled when building with
macosx, and will make the output a little cleaner when building on
other operating systems.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
