### PR TITLE
build: move addons message in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,9 +278,9 @@ jstest: build-addons build-addons-napi ## Runs addon tests and JS tests
 .PHONY: test
 # This does not run tests of third-party libraries inside deps.
 test: all ## Runs default tests, linters, and builds docs.
+	$(MAKE) -s test-doc
 	@echo "Build the addons before running the tests so the test results"
 	@echo "can be displayed together"
-	$(MAKE) -s test-doc
 	$(MAKE) -s build-addons
 	$(MAKE) -s build-addons-napi
 	$(MAKE) -s cctest


### PR DESCRIPTION
Displaying a message about building addons before building docs can be
confusing when troubleshooting. (This just happened to me.) Move the
message about building addons to just before the step for building
addons.

👍 here to fast-track.

@nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
