### PR TITLE
build: remove unnecessary Makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,6 @@ jstest: build-addons build-addons-napi ## Runs addon tests and JS tests
 # This does not run tests of third-party libraries inside deps.
 test: all ## Runs default tests, linters, and builds docs.
 	$(MAKE) -s test-doc
-	@echo "Build the addons before running the tests so the test results"
-	@echo "can be displayed together"
 	$(MAKE) -s build-addons
 	$(MAKE) -s build-addons-napi
 	$(MAKE) -s cctest
@@ -288,8 +286,6 @@ test: all ## Runs default tests, linters, and builds docs.
 
 .PHONY: test-only
 test-only: all  ## For a quick test, does not run linter or build docs.
-	@echo "Build the addons before running the tests so the test results"
-	@echo "can be displayed together"
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
 	$(MAKE) cctest
@@ -297,8 +293,6 @@ test-only: all  ## For a quick test, does not run linter or build docs.
 
 # Used by `make coverage-test`
 test-cov: all
-	@echo "Build the addons before running the tests so the test results"
-	@echo "can be displayed together"
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
 	# $(MAKE) cctest


### PR DESCRIPTION
Remove unnecessary @echo commands from Makefile.

These were originally comments but were changed to @echo in 6bc43aeea79.
They aren't terribly useful so let's remove them.

👍 here to fast-track.

@nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
