### PR TITLE
cluster: move handle tracking out of utils

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -7,7 +7,7 @@ const EventEmitter = require('events');
 const RoundRobinHandle = require('internal/cluster/round_robin_handle');
 const SharedHandle = require('internal/cluster/shared_handle');
 const Worker = require('internal/cluster/worker');
-const { internal, sendHelper, handles } = require('internal/cluster/utils');
+const { internal, sendHelper } = require('internal/cluster/utils');
 const { ERR_SOCKET_BAD_PORT } = require('internal/errors').codes;
 const keys = Object.keys;
 const cluster = new EventEmitter();
@@ -19,6 +19,7 @@ const [ minPort, maxPort ] = [ 1024, 65535 ];
 
 module.exports = cluster;
 
+const handles = new Map();
 cluster.isWorker = false;
 cluster.isMaster = true;
 cluster.Worker = Worker;

--- a/lib/internal/cluster/utils.js
+++ b/lib/internal/cluster/utils.js
@@ -3,8 +3,7 @@ const util = require('util');
 
 module.exports = {
   sendHelper,
-  internal,
-  handles: new Map() // Used in tests.
+  internal
 };
 
 const callbacks = new Map();


### PR DESCRIPTION
`internal/cluster/utils.js` exported a `handles` object, which was used in a test. That test, `test-cluster-disconnect-handles.js`, was removed in https://github.com/nodejs/node/pull/12495. This commit moves the handles object to the only file in the codebase that still uses it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
