### PR TITLE
crypto: replace gotos

### DIFF
--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -74,12 +74,6 @@ bool ClientHelloParser::ParseRecordHeader(const uint8_t* data, size_t avail) {
 
 void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
   ClientHello hello;
-  bool failed = true;
-
-  OnScopeLeave cleanup([&]() {
-    if (failed)
-      End();
-  });
 
   // >= 5 + frame size bytes for frame parsing
   if (body_offset_ + frame_len_ > avail)
@@ -94,23 +88,23 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
   if (data[body_offset_ + 4] != 0x03 ||
       data[body_offset_ + 5] < 0x01 ||
       data[body_offset_ + 5] > 0x03) {
-    return;
+    return End();
   }
 
   if (data[body_offset_] == kClientHello) {
     if (state_ == kTLSHeader) {
       if (!ParseTLSClientHello(data, avail))
-        return;
+        return End();
     } else {
       // We couldn't get here, but whatever
-      return;
+      return End();
     }
 
     // Check if we overflowed (do not reply with any private data)
     if (session_id_ == nullptr ||
         session_size_ > 32 ||
         session_id_ + session_size_ > data + avail) {
-      return;
+      return End();
     }
   }
 
@@ -122,8 +116,6 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
   hello.servername_ = servername_;
   hello.servername_size_ = static_cast<uint8_t>(servername_size_);
   onhello_cb_(cb_arg_, hello);
-  failed = false;
-  return;
 }
 
 


### PR DESCRIPTION
These occurrences of `goto` are almost trivial and only end up calling `End()`. I personally don't think it makes the code less expressive, but I'd like to know if someone feels different.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
