### PR TITLE
fs: track file offset in writeFile of fs/promises

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -121,12 +121,19 @@ async function writeFileHandle(filehandle, data, options) {
     data : Buffer.from('' + data, options.encoding || 'utf8');
   let remaining = buffer.length;
   if (remaining === 0) return;
+  // If the file is opened in APPEND mode set position as null, so that the
+  // data will be always written at the end of the file, otherwise start at 0.
+  let position = (options.flag || '').includes('a') ? null : 0;
+
   do {
     const { bytesWritten } =
       await write(filehandle, buffer, 0,
-                  Math.min(16384, buffer.length));
+                  Math.min(16384, buffer.length), position);
     remaining -= bytesWritten;
     buffer = buffer.slice(bytesWritten);
+    if (typeof position === 'number') {
+      position += bytesWritten;
+    }
   } while (remaining > 0);
 }
 

--- a/test/parallel/test-fs-promises-file-handle-writeFile-after-truncate.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile-after-truncate.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// This tests if the writeFile automatically adjusts the file offset even if
+// the file is truncated.
+
+const common = require('../common');
+const fsPromises = require('fs').promises;
+const path = require('path');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const tmpDir = tmpdir.path;
+const Data = 'FS Promises';
+
+tmpdir.refresh();
+
+(async function() {
+  assert(!/A/.test(Data));
+  const fileName = path.resolve(tmpDir, 'temp.txt');
+  const fileHandle = await fsPromises.open(fileName, 'w');
+  await fileHandle.writeFile('A'.repeat(Data.length * 2));
+  await fileHandle.truncate();
+  await fileHandle.writeFile(Data);
+  await fileHandle.close();
+  assert.deepStrictEqual(await fsPromises.readFile(fileName, 'UTF-8'), Data);
+})().then(common.mustCall());
+
+(async function() {
+  // In this case there is no truncate call, but still the contents of the file
+  // should be truncated before the new string is written.
+  assert(!/A/.test(Data));
+  const fileName = path.resolve(tmpDir, 'temp.txt');
+  const fileHandle = await fsPromises.open(fileName, 'w');
+  await fileHandle.writeFile('A'.repeat(Data.length * 2));
+  await fileHandle.writeFile(Data);
+  await fileHandle.close();
+  assert.deepStrictEqual(await fsPromises.readFile(fileName, 'UTF-8'), Data);
+})().then(common.mustCall());
+
+(async function() {
+  // This tests appendFile as well, as appendFile internally uses writeFile
+  const fileName = path.resolve(tmpDir, 'temp-1.txt');
+  const fileHandle = await fsPromises.open(fileName, 'w');
+  await fileHandle.writeFile('A'.repeat(Data.length * 2));
+  await fileHandle.truncate();
+  await fileHandle.appendFile(Data);
+  await fileHandle.close();
+  assert.deepStrictEqual(await fsPromises.readFile(fileName, 'UTF-8'), Data);
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -24,5 +24,23 @@ async function validateWriteFile() {
   assert.deepStrictEqual(buffer, readFileData);
 }
 
+async function validateLargeWriteFile() {
+  const fileName = path.resolve(tmpDir, 'large.txt');
+  const handle = await open(fileName, 'w');
+  // 16385 is written as (16384 + 1) because, 16384 is the max chunk size used
+  // in the writeFile, the max chunk size is searchable, and the boundary
+  // testing is also done.
+  const buffer = Buffer.from(
+    Array.apply(null, { length: (16384 + 1) * 3 })
+      .map(Math.random)
+      .map((number) => (number * (1 << 8)))
+  );
+
+  await handle.writeFile(buffer);
+  await handle.close();
+  assert.deepStrictEqual(fs.readFileSync(fileName), buffer);
+}
+
 validateWriteFile()
+  .then(validateLargeWriteFile)
   .then(common.mustCall());

--- a/test/parallel/test-fs-promises-writefile.js
+++ b/test/parallel/test-fs-promises-writefile.js
@@ -20,6 +20,22 @@ async function doWrite() {
   assert.deepStrictEqual(data, buffer);
 }
 
+async function doLargeWrite() {
+  // 16385 is written as (16384 + 1) because, 16384 is the max chunk size used
+  // in the writeFile, the max chunk size is searchable, and the boundary
+  // testing is also done.
+  const buffer = Buffer.from(
+    Array.apply(null, { length: (16384 + 1) * 3 })
+      .map(Math.random)
+      .map((number) => (number * (1 << 8)))
+  );
+  const dest = path.resolve(tmpDir, 'large.txt');
+
+  await fsPromises.writeFile(dest, buffer);
+  const data = fs.readFileSync(dest);
+  assert.deepStrictEqual(data, buffer);
+}
+
 async function doAppend() {
   await fsPromises.appendFile(dest, buffer2);
   const data = fs.readFileSync(dest);
@@ -41,6 +57,7 @@ async function doReadWithEncoding() {
 }
 
 doWrite()
+  .then(doLargeWrite)
   .then(doAppend)
   .then(doRead)
   .then(doReadWithEncoding)


### PR DESCRIPTION
If the file offset is not tracked with `position` in the `write` calls
all the data will be always written at the end of the file.

This is problematic when we pass file descriptors to `writeFile` because
the the file offset will not be updated. So, if some string is written
to the FD with `writeFile` and if some other string is written to the
same FD with `writeFile` without closing and reopening the file, the
contents will be appended instead of writing from the beginning.

----

**Simple Reproduction of the Bug**

```js
'use strict';
const assert = require('assert');
const fs = require('fs').promises;

(async function() {
    const h = await fs.open('/tmp/test', 'w');
    await h.writeFile('AAAA');
    await h.truncate();
    await h.writeFile('BBB');
    await h.close();
    assert.deepStrictEqual(await fs.readFile('/tmp/test', 'utf8'), 'BBB');
})();
```

```console
(node:51030) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

+ '\u0000\u0000\u0000\u0000BBB'
- 'BBB'
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
