### PR TITLE
test: fix flaky test-gc-net-timeout

### DIFF
--- a/test/sequential/test-gc-net-timeout.js
+++ b/test/sequential/test-gc-net-timeout.js
@@ -41,7 +41,6 @@ function getall() {
   req.setTimeout(10, function() {
     req.destroy();
     done++;
-    global.gc();
   });
 
   count++;


### PR DESCRIPTION
There's a global.gc() invoked in an interval, and a second one in a
req.setTimeout() callback. Remove the one in the callback. I'm not sure
how competing global.gc() calls might result in a deadlock, but it seems
plausible and empirical testing confirms that it makes the test
reliable.

Fixes: https://github.com/nodejs/node/issues/23067

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
