### PR TITLE
doc: add contents table to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ small and all contributions are valued.
 This guide explains the process for contributing to the Node.js project's core
 `nodejs/node` GitHub Repository and describes what to expect at each step.
 
+## Contents
+
+* [Code of Conduct](#code-of-conduct)
+* [Issues](#issues)
+* [Pull Requests](#pull-requests)
+* [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin-11)
+
 ## [Code of Conduct](./doc/guides/contributing/coc.md)
 
 The Node.js project has a


### PR DESCRIPTION
Add contents table to CONTRIBUTING.md so that user can index to the wanted contents,
such as the [COLLABORATOR_GUIDE.md](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#contents) did.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)