### PR TITLE
test: error when empty buffer is passed to fs.read()

### DIFF
--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
@@ -10,6 +11,15 @@ const buffer = new Uint8Array();
 
 assert.throws(
   () => fs.readSync(fd, buffer, 0, 10, 0),
+  {
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: 'The argument \'buffer\' is empty and cannot be written. ' +
+    'Received Uint8Array []'
+  }
+);
+
+assert.throws(
+  () => fs.read(fd, buffer, 0, 1, 0, common.mustNotCall()),
   {
     code: 'ERR_INVALID_ARG_VALUE',
     message: 'The argument \'buffer\' is empty and cannot be written. ' +


### PR DESCRIPTION
Added tests to occur error when empty buffer is passed to `fs.read()`
to increase coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
