### PR TITLE
Replace vague 'may not' with definitive 'will not'

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -200,7 +200,7 @@ Modules are cached after the first time they are loaded. This means
 (among other things) that every call to `require('foo')` will get
 exactly the same object returned, if it would resolve to the same file.
 
-Multiple calls to `require('foo')` may not cause the module code to be
+Multiple calls to `require('foo')` will not cause the module code to be
 executed multiple times.  This is an important feature. With it,
 "partially done" objects can be returned, thus allowing transitive
 dependencies to be loaded even when they would cause cycles.


### PR DESCRIPTION
This vagueness of 'may' has caused a great deal of confusion. See https://stackoverflow.com/questions/8887318/understanding-node-js-modules-multiple-requires-return-the-same-object

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
