### PR TITLE
test: fix unreliable test-gc-http-client

### DIFF
--- a/test/sequential/test-gc-http-client.js
+++ b/test/sequential/test-gc-http-client.js
@@ -43,7 +43,6 @@ function getall() {
 function cb(res) {
   res.resume();
   done += 1;
-  res.on('end', global.gc);
 }
 
 function ongc() {


### PR DESCRIPTION
Calling `global.gc()` in multiple places leads to unreliability. Call it
in the interval only.

Fixes: https://github.com/nodejs/node/issues/22336

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
