### PR TITLE
http2: don't send trailers on a closed connection

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -330,7 +330,7 @@ function tryClose(fd) {
 function onStreamTrailers() {
   const stream = this[kOwner];
   stream[kState].trailersReady = true;
-  if (stream.destroyed)
+  if (stream.destroyed || stream.closed)
     return;
   if (!stream.emit('wantTrailers')) {
     // There are no listeners, send empty trailing HEADERS frame and close.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Addresses https://github.com/koajs/koa/issues/1229 and https://github.com/nodejs/node/issues/22135.