### PR TITLE
crypto: add support for PEM-level encryption

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -140,7 +140,9 @@ function parseKeyEncoding(keyType, options) {
   if (cipher != null) {
     if (typeof cipher !== 'string')
       throw new ERR_INVALID_OPT_VALUE('privateKeyEncoding.cipher', cipher);
-    if (privateType !== PK_ENCODING_PKCS8) {
+    if (privateFormat === PK_FORMAT_DER &&
+        (privateType === PK_ENCODING_PKCS1 ||
+         privateType === PK_ENCODING_SEC1)) {
       throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
         strPrivateType, 'does not support encryption');
     }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5060,20 +5060,24 @@ class GenerateKeyPairJob : public CryptoJob {
 
     // Now do the same for the private key (which is a bit more difficult).
     if (private_key_encoding_.type_ == PK_ENCODING_PKCS1) {
-      // PKCS#1 is only permitted for RSA keys and without encryption.
+      // PKCS#1 is only permitted for RSA keys.
       CHECK_EQ(EVP_PKEY_id(pkey), EVP_PKEY_RSA);
-      CHECK_NULL(private_key_encoding_.cipher_);
 
       RSAPointer rsa(EVP_PKEY_get1_RSA(pkey));
       if (private_key_encoding_.format_ == PK_FORMAT_PEM) {
         // Encode PKCS#1 as PEM.
-        if (PEM_write_bio_RSAPrivateKey(bio.get(), rsa.get(),
-                                        nullptr, nullptr, 0,
-                                        nullptr, nullptr) != 1)
+        char* pass = private_key_encoding_.passphrase_.get();
+        if (PEM_write_bio_RSAPrivateKey(
+                bio.get(), rsa.get(),
+                private_key_encoding_.cipher_,
+                reinterpret_cast<unsigned char*>(pass),
+                private_key_encoding_.passphrase_length_,
+                nullptr, nullptr) != 1)
           return false;
       } else {
-        // Encode PKCS#1 as DER.
+        // Encode PKCS#1 as DER. This does not permit encryption.
         CHECK_EQ(private_key_encoding_.format_, PK_FORMAT_DER);
+        CHECK_NULL(private_key_encoding_.cipher_);
         if (i2d_RSAPrivateKey_bio(bio.get(), rsa.get()) != 1)
           return false;
       }
@@ -5101,20 +5105,24 @@ class GenerateKeyPairJob : public CryptoJob {
     } else {
       CHECK_EQ(private_key_encoding_.type_, PK_ENCODING_SEC1);
 
-      // SEC1 is only permitted for EC keys and without encryption.
+      // SEC1 is only permitted for EC keys.
       CHECK_EQ(EVP_PKEY_id(pkey), EVP_PKEY_EC);
-      CHECK_NULL(private_key_encoding_.cipher_);
 
       ECKeyPointer ec_key(EVP_PKEY_get1_EC_KEY(pkey));
       if (private_key_encoding_.format_ == PK_FORMAT_PEM) {
         // Encode SEC1 as PEM.
-        if (PEM_write_bio_ECPrivateKey(bio.get(), ec_key.get(),
-                                       nullptr, nullptr, 0,
-                                       nullptr, nullptr) != 1)
+        char* pass = private_key_encoding_.passphrase_.get();
+        if (PEM_write_bio_ECPrivateKey(
+                bio.get(), ec_key.get(),
+                private_key_encoding_.cipher_,
+                reinterpret_cast<unsigned char*>(pass),
+                private_key_encoding_.passphrase_length_,
+                nullptr, nullptr) != 1)
           return false;
       } else {
-        // Encode SEC1 as DER.
+        // Encode SEC1 as DER. This does not permit encryption.
         CHECK_EQ(private_key_encoding_.format_, PK_FORMAT_DER);
+        CHECK_NULL(private_key_encoding_.cipher_);
         if (i2d_ECPrivateKey_bio(bio.get(), ec_key.get()) != 1)
           return false;
       }


### PR DESCRIPTION
This adds support for PEM-level encryption as defined in RFC 1421. PEM-level encryption is intentionally unsupported for PKCS#8 private keys since PKCS#8 defines a newer encryption format.

/cc @bnoordhuis who suggested this feature in https://github.com/nodejs/node/pull/22660#discussion_r218948141.

Refs: https://github.com/nodejs/node/pull/22660

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
