### PR TITLE
doc: formalize non-const reference usage in C++ style guide

### DIFF
--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -230,8 +230,8 @@ class ExampleClass {
 
  private:
   std::string foo_string_;
-  // Pointer instead of reference. If this objects 'owns' the other object,
-  // this should be be a `std::unique_ptr<OtherClass>`; a
+  // Pointer instead of reference. If this object 'owns' the other object,
+  // this should be a `std::unique_ptr<OtherClass>`; a
   // `std::shared_ptr<OtherClass>` can also be a better choice.
   OtherClass* pointer_to_other_;
 };

--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -206,6 +206,34 @@ Never use `std::auto_ptr`. Instead, use `std::unique_ptr`.
 Using non-const references often obscures which values are changed by an
 assignment. A pointer is almost always a better choice.
 
+```c++
+class ExampleClass {
+ public:
+  explicit ExampleClass(int* int_ptr) : pointer_to_integer_(int_ptr) {}
+
+  void SomeMethod(const std::string& input_param,
+                  std::string* in_out_param);  // Pointer instead of reference
+
+  const std::string& get_foo() const { return foo_string_; }
+  void set_foo(const std::string& new_value) { foo_string_ = new_value; }
+
+  void ReplaceCharacterInFoo(char from, char to) {
+    // A non-const reference is okay here, because the method name already tells
+    // users that this modifies 'foo_string_' -- if that is not the case,
+    // it can still be better to use an indexed for loop, or leave appropriate
+    // comments.
+    for (char& character : foo_string_) {
+      if (character == from)
+        character = to;
+    }
+  }
+
+ private:
+  std::string foo_string_;
+  int* pointer_to_integer_;  // Pointer instead of reference.
+};
+```
+
 ## Others
 
 ### Type casting

--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -204,7 +204,8 @@ Never use `std::auto_ptr`. Instead, use `std::unique_ptr`.
 ### Avoid non-const references
 
 Using non-const references often obscures which values are changed by an
-assignment. A pointer is almost always a better choice.
+assignment. Consider using a pointer instead, which requires more explicit
+syntax to indicate that modifications take place.
 
 ```c++
 class ExampleClass {

--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -209,7 +209,7 @@ assignment. A pointer is almost always a better choice.
 ```c++
 class ExampleClass {
  public:
-  explicit ExampleClass(int* int_ptr) : pointer_to_integer_(int_ptr) {}
+  explicit ExampleClass(OtherClass* other_ptr) : pointer_to_other_(other_ptr) {}
 
   void SomeMethod(const std::string& input_param,
                   std::string* in_out_param);  // Pointer instead of reference
@@ -230,7 +230,10 @@ class ExampleClass {
 
  private:
   std::string foo_string_;
-  int* pointer_to_integer_;  // Pointer instead of reference.
+  // Pointer instead of reference. If this objects 'owns' the other object,
+  // this should be be a `std::unique_ptr<OtherClass>`; a
+  // `std::shared_ptr<OtherClass>` can also be a better choice.
+  OtherClass* pointer_to_other_;
 };
 ```
 

--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -18,6 +18,7 @@
   * [Memory allocation](#memory-allocation)
   * [Use `nullptr` instead of `NULL` or `0`](#use-nullptr-instead-of-null-or-0)
   * [Ownership and Smart Pointers](#ownership-and-smart-pointers)
+  * [Avoid non-const references](#avoid-non-const-references)
 * [Others](#others)
   * [Type casting](#type-casting)
   * [Do not include `*.h` if `*-inl.h` has already been included](#do-not-include-h-if--inlh-has-already-been-included)
@@ -199,6 +200,11 @@ void FooConsumer(std::unique_ptr<Foo> ptr);
 ```
 
 Never use `std::auto_ptr`. Instead, use `std::unique_ptr`.
+
+### Avoid non-const references
+
+Using non-const references often obscures which values are changed by an
+assignment. A pointer is almost always a better choice.
 
 ## Others
 


### PR DESCRIPTION
Split out from #23028 by request from @refack. I’ve added people who approved the other PR as reviewers on the commit. I’m also moving the `tsc-agenda` label over here, assuming @refack’s objection stands.

---

We generally avoid using non-const references if not necessary. This
formalizes this rules by writing them down in the C++ style guide.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
