### PR TITLE
deps: provide more V8 backwards compatibility

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 7
 #define V8_MINOR_VERSION 0
 #define V8_BUILD_NUMBER 276
-#define V8_PATCH_LEVEL 22
+#define V8_PATCH_LEVEL 24
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1123,6 +1123,10 @@ class V8_EXPORT PrimitiveArray {
  public:
   static Local<PrimitiveArray> New(Isolate* isolate, int length);
   int Length() const;
+  V8_DEPRECATED("Use Isolate* version",
+      void Set(int index, Local<Primitive> item));
+  V8_DEPRECATED("Use Isolate* version",
+      Local<Primitive> Get(int index));
   void Set(Isolate* isolate, int index, Local<Primitive> item);
   Local<Primitive> Get(Isolate* isolate, int index);
 };
@@ -1829,6 +1833,8 @@ class V8_EXPORT StackTrace {
   /**
    * Returns a StackFrame at a particular index.
    */
+  V8_DEPRECATED("Use Isolate version",
+                Local<StackFrame> GetFrame(uint32_t index) const);
   Local<StackFrame> GetFrame(Isolate* isolate, uint32_t index) const;
 
   /**
@@ -2524,18 +2530,25 @@ class V8_EXPORT Value : public Data {
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT MaybeLocal<Int32> ToInt32(Local<Context> context) const;
 
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<Boolean> ToBoolean(Isolate* isolate) const);
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<Number> ToNumber(Isolate* isolate) const);
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<String> ToString(Isolate* isolate) const);
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<Object> ToObject(Isolate* isolate) const);
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<Integer> ToInteger(Isolate* isolate) const);
-  V8_DEPRECATE_SOON("Use maybe version",
-                    Local<Int32> ToInt32(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<Boolean> ToBoolean(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<Number> ToNumber(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<String> ToString(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<Object> ToObject(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<Integer> ToInteger(Isolate* isolate) const);
+  V8_DEPRECATED("Use maybe version",
+                Local<Int32> ToInt32(Isolate* isolate) const);
+
+  inline V8_DEPRECATED("Use maybe version",
+                       Local<Boolean> ToBoolean() const);
+  inline V8_DEPRECATED("Use maybe version", Local<String> ToString() const);
+  inline V8_DEPRECATED("Use maybe version", Local<Object> ToObject() const);
+  inline V8_DEPRECATED("Use maybe version",
+                       Local<Integer> ToInteger() const);
 
   /**
    * Attempts to convert a string to an array index.
@@ -2552,7 +2565,14 @@ class V8_EXPORT Value : public Data {
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
 
+  V8_DEPRECATED("Use maybe version", bool BooleanValue() const);
+  V8_DEPRECATED("Use maybe version", double NumberValue() const);
+  V8_DEPRECATED("Use maybe version", int64_t IntegerValue() const);
+  V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
+  V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
+
   /** JS == */
+  V8_DEPRECATED("Use maybe version", bool Equals(Local<Value> that) const);
   V8_WARN_UNUSED_RESULT Maybe<bool> Equals(Local<Context> context,
                                            Local<Value> that) const;
   bool StrictEquals(Local<Value> that) const;
@@ -2659,6 +2679,8 @@ class V8_EXPORT String : public Name {
    * Returns the number of bytes in the UTF-8 encoded
    * representation of this string.
    */
+  V8_DEPRECATED("Use Isolate version instead", int Utf8Length() const);
+
   int Utf8Length(Isolate* isolate) const;
 
   /**
@@ -2715,12 +2737,23 @@ class V8_EXPORT String : public Name {
   // 16-bit character codes.
   int Write(Isolate* isolate, uint16_t* buffer, int start = 0, int length = -1,
             int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int Write(uint16_t* buffer, int start = 0, int length = -1,
+                          int options = NO_OPTIONS) const);
   // One byte characters.
   int WriteOneByte(Isolate* isolate, uint8_t* buffer, int start = 0,
                    int length = -1, int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int WriteOneByte(uint8_t* buffer, int start = 0,
+                                 int length = -1, int options = NO_OPTIONS)
+                    const);
   // UTF-8 encoded characters.
   int WriteUtf8(Isolate* isolate, char* buffer, int length = -1,
                 int* nchars_ref = NULL, int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int WriteUtf8(char* buffer, int length = -1,
+                              int* nchars_ref = NULL,
+                              int options = NO_OPTIONS) const);
 
   /**
    * A zero length string.
@@ -2884,6 +2917,9 @@ class V8_EXPORT String : public Name {
    */
   static Local<String> Concat(Isolate* isolate, Local<String> left,
                               Local<String> right);
+  static V8_DEPRECATED("Use Isolate* version",
+                       Local<String> Concat(Local<String> left,
+                                            Local<String> right));
 
   /**
    * Creates a new external string using the data defined in the given
@@ -2952,6 +2988,8 @@ class V8_EXPORT String : public Name {
    */
   class V8_EXPORT Utf8Value {
    public:
+    V8_DEPRECATED("Use Isolate version",
+                  explicit Utf8Value(Local<v8::Value> obj));
     Utf8Value(Isolate* isolate, Local<v8::Value> obj);
     ~Utf8Value();
     char* operator*() { return str_; }
@@ -2975,6 +3013,7 @@ class V8_EXPORT String : public Name {
    */
   class V8_EXPORT Value {
    public:
+    V8_DEPRECATED("Use Isolate version", explicit Value(Local<v8::Value> obj));
     Value(Isolate* isolate, Local<v8::Value> obj);
     ~Value();
     uint16_t* operator*() { return str_; }
@@ -5217,6 +5256,8 @@ class V8_EXPORT BooleanObject : public Object {
 class V8_EXPORT StringObject : public Object {
  public:
   static Local<Value> New(Isolate* isolate, Local<String> value);
+  V8_DEPRECATED("Use Isolate* version",
+                static Local<Value> New(Local<String> value));
 
   Local<String> ValueOf() const;
 
@@ -10213,6 +10254,30 @@ bool Value::QuickIsString() const {
 
 template <class T> Value* Value::Cast(T* value) {
   return static_cast<Value*>(value);
+}
+
+
+Local<Boolean> Value::ToBoolean() const {
+  return ToBoolean(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Boolean>());
+}
+
+
+Local<String> Value::ToString() const {
+  return ToString(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<String>());
+}
+
+
+Local<Object> Value::ToObject() const {
+  return ToObject(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Object>());
+}
+
+
+Local<Integer> Value::ToInteger() const {
+  return ToInteger(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Integer>());
 }
 
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1125,10 +1125,6 @@ class V8_EXPORT PrimitiveArray {
   int Length() const;
   void Set(Isolate* isolate, int index, Local<Primitive> item);
   Local<Primitive> Get(Isolate* isolate, int index);
-
-  V8_DEPRECATED("Use Isolate version",
-                void Set(int index, Local<Primitive> item));
-  V8_DEPRECATED("Use Isolate version", Local<Primitive> Get(int index));
 };
 
 /**
@@ -1833,8 +1829,6 @@ class V8_EXPORT StackTrace {
   /**
    * Returns a StackFrame at a particular index.
    */
-  V8_DEPRECATED("Use Isolate version",
-                Local<StackFrame> GetFrame(uint32_t index) const);
   Local<StackFrame> GetFrame(Isolate* isolate, uint32_t index) const;
 
   /**
@@ -2543,11 +2537,6 @@ class V8_EXPORT Value : public Data {
   V8_DEPRECATE_SOON("Use maybe version",
                     Local<Int32> ToInt32(Isolate* isolate) const);
 
-  inline V8_DEPRECATED("Use maybe version", Local<Boolean> ToBoolean() const);
-  inline V8_DEPRECATED("Use maybe version", Local<String> ToString() const);
-  inline V8_DEPRECATED("Use maybe version", Local<Object> ToObject() const);
-  inline V8_DEPRECATED("Use maybe version", Local<Integer> ToInteger() const);
-
   /**
    * Attempts to convert a string to an array index.
    * Returns an empty handle if the conversion fails.
@@ -2563,14 +2552,7 @@ class V8_EXPORT Value : public Data {
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
 
-  V8_DEPRECATED("Use maybe version", bool BooleanValue() const);
-  V8_DEPRECATED("Use maybe version", double NumberValue() const);
-  V8_DEPRECATED("Use maybe version", int64_t IntegerValue() const);
-  V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
-  V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
-
   /** JS == */
-  V8_DEPRECATED("Use maybe version", bool Equals(Local<Value> that) const);
   V8_WARN_UNUSED_RESULT Maybe<bool> Equals(Local<Context> context,
                                            Local<Value> that) const;
   bool StrictEquals(Local<Value> that) const;
@@ -2677,8 +2659,6 @@ class V8_EXPORT String : public Name {
    * Returns the number of bytes in the UTF-8 encoded
    * representation of this string.
    */
-  V8_DEPRECATED("Use Isolate version instead", int Utf8Length() const);
-
   int Utf8Length(Isolate* isolate) const;
 
   /**
@@ -2735,23 +2715,12 @@ class V8_EXPORT String : public Name {
   // 16-bit character codes.
   int Write(Isolate* isolate, uint16_t* buffer, int start = 0, int length = -1,
             int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int Write(uint16_t* buffer, int start = 0, int length = -1,
-                          int options = NO_OPTIONS) const);
   // One byte characters.
   int WriteOneByte(Isolate* isolate, uint8_t* buffer, int start = 0,
                    int length = -1, int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int WriteOneByte(uint8_t* buffer, int start = 0,
-                                 int length = -1, int options = NO_OPTIONS)
-                    const);
   // UTF-8 encoded characters.
   int WriteUtf8(Isolate* isolate, char* buffer, int length = -1,
                 int* nchars_ref = NULL, int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int WriteUtf8(char* buffer, int length = -1,
-                              int* nchars_ref = NULL, int options = NO_OPTIONS)
-                    const);
 
   /**
    * A zero length string.
@@ -2915,9 +2884,6 @@ class V8_EXPORT String : public Name {
    */
   static Local<String> Concat(Isolate* isolate, Local<String> left,
                               Local<String> right);
-  static V8_DEPRECATED("Use Isolate* version",
-                       Local<String> Concat(Local<String> left,
-                                            Local<String> right));
 
   /**
    * Creates a new external string using the data defined in the given
@@ -5251,8 +5217,6 @@ class V8_EXPORT BooleanObject : public Object {
 class V8_EXPORT StringObject : public Object {
  public:
   static Local<Value> New(Isolate* isolate, Local<String> value);
-  static V8_DEPRECATED("Use Isolate* version",
-                       Local<Value> New(Local<String> value));
 
   Local<String> ValueOf() const;
 
@@ -10251,25 +10215,6 @@ template <class T> Value* Value::Cast(T* value) {
   return static_cast<Value*>(value);
 }
 
-Local<Boolean> Value::ToBoolean() const {
-  return ToBoolean(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(Local<Boolean>());
-}
-
-Local<String> Value::ToString() const {
-  return ToString(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(Local<String>());
-}
-
-Local<Object> Value::ToObject() const {
-  return ToObject(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(Local<Object>());
-}
-
-Local<Integer> Value::ToInteger() const {
-  return ToInteger(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(Local<Integer>());
-}
 
 Boolean* Boolean::Cast(v8::Value* value) {
 #ifdef V8_ENABLE_CHECKS

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1125,6 +1125,10 @@ class V8_EXPORT PrimitiveArray {
   int Length() const;
   void Set(Isolate* isolate, int index, Local<Primitive> item);
   Local<Primitive> Get(Isolate* isolate, int index);
+
+  V8_DEPRECATED("Use Isolate version",
+                void Set(int index, Local<Primitive> item));
+  V8_DEPRECATED("Use Isolate version", Local<Primitive> Get(int index));
 };
 
 /**
@@ -1829,6 +1833,8 @@ class V8_EXPORT StackTrace {
   /**
    * Returns a StackFrame at a particular index.
    */
+  V8_DEPRECATED("Use Isolate version",
+                Local<StackFrame> GetFrame(uint32_t index) const);
   Local<StackFrame> GetFrame(Isolate* isolate, uint32_t index) const;
 
   /**
@@ -2537,6 +2543,11 @@ class V8_EXPORT Value : public Data {
   V8_DEPRECATE_SOON("Use maybe version",
                     Local<Int32> ToInt32(Isolate* isolate) const);
 
+  inline V8_DEPRECATED("Use maybe version", Local<Boolean> ToBoolean() const);
+  inline V8_DEPRECATED("Use maybe version", Local<String> ToString() const);
+  inline V8_DEPRECATED("Use maybe version", Local<Object> ToObject() const);
+  inline V8_DEPRECATED("Use maybe version", Local<Integer> ToInteger() const);
+
   /**
    * Attempts to convert a string to an array index.
    * Returns an empty handle if the conversion fails.
@@ -2552,7 +2563,14 @@ class V8_EXPORT Value : public Data {
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
 
+  V8_DEPRECATED("Use maybe version", bool BooleanValue() const);
+  V8_DEPRECATED("Use maybe version", double NumberValue() const);
+  V8_DEPRECATED("Use maybe version", int64_t IntegerValue() const);
+  V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
+  V8_DEPRECATED("Use maybe version", int32_t Int32Value() const);
+
   /** JS == */
+  V8_DEPRECATED("Use maybe version", bool Equals(Local<Value> that) const);
   V8_WARN_UNUSED_RESULT Maybe<bool> Equals(Local<Context> context,
                                            Local<Value> that) const;
   bool StrictEquals(Local<Value> that) const;
@@ -2659,6 +2677,8 @@ class V8_EXPORT String : public Name {
    * Returns the number of bytes in the UTF-8 encoded
    * representation of this string.
    */
+  V8_DEPRECATED("Use Isolate version instead", int Utf8Length() const);
+
   int Utf8Length(Isolate* isolate) const;
 
   /**
@@ -2715,12 +2735,23 @@ class V8_EXPORT String : public Name {
   // 16-bit character codes.
   int Write(Isolate* isolate, uint16_t* buffer, int start = 0, int length = -1,
             int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int Write(uint16_t* buffer, int start = 0, int length = -1,
+                          int options = NO_OPTIONS) const);
   // One byte characters.
   int WriteOneByte(Isolate* isolate, uint8_t* buffer, int start = 0,
                    int length = -1, int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int WriteOneByte(uint8_t* buffer, int start = 0,
+                                 int length = -1, int options = NO_OPTIONS)
+                    const);
   // UTF-8 encoded characters.
   int WriteUtf8(Isolate* isolate, char* buffer, int length = -1,
                 int* nchars_ref = NULL, int options = NO_OPTIONS) const;
+  V8_DEPRECATED("Use Isolate* version",
+                int WriteUtf8(char* buffer, int length = -1,
+                              int* nchars_ref = NULL, int options = NO_OPTIONS)
+                    const);
 
   /**
    * A zero length string.
@@ -2884,6 +2915,9 @@ class V8_EXPORT String : public Name {
    */
   static Local<String> Concat(Isolate* isolate, Local<String> left,
                               Local<String> right);
+  static V8_DEPRECATED("Use Isolate* version",
+                       Local<String> Concat(Local<String> left,
+                                            Local<String> right));
 
   /**
    * Creates a new external string using the data defined in the given
@@ -5217,6 +5251,8 @@ class V8_EXPORT BooleanObject : public Object {
 class V8_EXPORT StringObject : public Object {
  public:
   static Local<Value> New(Isolate* isolate, Local<String> value);
+  static V8_DEPRECATED("Use Isolate* version",
+                       Local<Value> New(Local<String> value));
 
   Local<String> ValueOf() const;
 
@@ -10215,6 +10251,25 @@ template <class T> Value* Value::Cast(T* value) {
   return static_cast<Value*>(value);
 }
 
+Local<Boolean> Value::ToBoolean() const {
+  return ToBoolean(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Boolean>());
+}
+
+Local<String> Value::ToString() const {
+  return ToString(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<String>());
+}
+
+Local<Object> Value::ToObject() const {
+  return ToObject(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Object>());
+}
+
+Local<Integer> Value::ToInteger() const {
+  return ToInteger(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(Local<Integer>());
+}
 
 Boolean* Boolean::Cast(v8::Value* value) {
 #ifdef V8_ENABLE_CHECKS

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -219,6 +219,28 @@ Local<Context> ContextFromNeverReadOnlySpaceObject(
   return reinterpret_cast<v8::Isolate*>(obj->GetIsolate())->GetCurrentContext();
 }
 
+// TODO(delphick): Remove this completely when the deprecated functions that use
+// it are removed.
+// DO NOT USE THIS IN NEW CODE!
+i::Isolate* UnsafeIsolateFromHeapObject(i::Handle<i::HeapObject> obj) {
+  // Use MemoryChunk directly instead of Isolate::FromWritableHeapObject to
+  // temporarily allow isolate access from read-only space objects.
+  i::MemoryChunk* chunk = i::MemoryChunk::FromHeapObject(*obj);
+  return chunk->heap()->isolate();
+}
+
+// TODO(delphick): Remove this completely when the deprecated functions that use
+// it are removed.
+// DO NOT USE THIS IN NEW CODE!
+Local<Context> UnsafeContextFromHeapObject(i::Handle<i::Object> obj) {
+  // Use MemoryChunk directly instead of Isolate::FromWritableHeapObject to
+  // temporarily allow isolate access from read-only space objects.
+  i::MemoryChunk* chunk =
+      i::MemoryChunk::FromHeapObject(i::HeapObject::cast(*obj));
+  return reinterpret_cast<Isolate*>(chunk->heap()->isolate())
+      ->GetCurrentContext();
+}
+
 class InternalEscapableScope : public v8::EscapableHandleScope {
  public:
   explicit inline InternalEscapableScope(i::Isolate* isolate)
@@ -2170,6 +2192,12 @@ void PrimitiveArray::Set(Isolate* v8_isolate, int index,
   array->set(index, *i_item);
 }
 
+void PrimitiveArray::Set(int index, Local<Primitive> item) {
+  i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(array);
+  Set(reinterpret_cast<Isolate*>(isolate), index, item);
+}
+
 Local<Primitive> PrimitiveArray::Get(Isolate* v8_isolate, int index) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
@@ -2180,6 +2208,12 @@ Local<Primitive> PrimitiveArray::Get(Isolate* v8_isolate, int index) {
                   "array length");
   i::Handle<i::Object> i_item(array->get(index), isolate);
   return ToApiHandle<Primitive>(i_item);
+}
+
+Local<Primitive> PrimitiveArray::Get(int index) {
+  i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(array);
+  return Get(reinterpret_cast<Isolate*>(isolate), index);
 }
 
 Module::Status Module::GetStatus() const {
@@ -2908,6 +2942,11 @@ Local<StackFrame> StackTrace::GetFrame(Isolate* v8_isolate,
   auto obj = handle(Utils::OpenHandle(this)->get(index), isolate);
   auto info = i::Handle<i::StackFrameInfo>::cast(obj);
   return scope.Escape(Utils::StackFrameToLocal(info));
+}
+
+Local<StackFrame> StackTrace::GetFrame(uint32_t index) const {
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
+  return GetFrame(reinterpret_cast<Isolate*>(isolate), index);
 }
 
 int StackTrace::GetFrameCount() const {
@@ -3881,6 +3920,14 @@ Maybe<bool> Value::BooleanValue(Local<Context> context) const {
   return Just(Utils::OpenHandle(this)->BooleanValue(isolate));
 }
 
+bool Value::BooleanValue() const {
+  auto obj = Utils::OpenHandle(this);
+  if (obj->IsSmi()) return *obj != i::Smi::kZero;
+  DCHECK(obj->IsHeapObject());
+  i::Isolate* isolate =
+      UnsafeIsolateFromHeapObject(i::Handle<i::HeapObject>::cast(obj));
+  return obj->BooleanValue(isolate);
+}
 
 Maybe<double> Value::NumberValue(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3894,6 +3941,12 @@ Maybe<double> Value::NumberValue(Local<Context> context) const {
   return Just(num->Number());
 }
 
+double Value::NumberValue() const {
+  auto obj = Utils::OpenHandle(this);
+  if (obj->IsNumber()) return obj->Number();
+  return NumberValue(UnsafeContextFromHeapObject(obj))
+      .FromMaybe(std::numeric_limits<double>::quiet_NaN());
+}
 
 Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3909,6 +3962,17 @@ Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
   return Just(NumberToInt64(*num));
 }
 
+int64_t Value::IntegerValue() const {
+  auto obj = Utils::OpenHandle(this);
+  if (obj->IsNumber()) {
+    if (obj->IsSmi()) {
+      return i::Smi::ToInt(*obj);
+    } else {
+      return static_cast<int64_t>(obj->Number());
+    }
+  }
+  return IntegerValue(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
+}
 
 Maybe<int32_t> Value::Int32Value(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3923,6 +3987,11 @@ Maybe<int32_t> Value::Int32Value(Local<Context> context) const {
                            : static_cast<int32_t>(num->Number()));
 }
 
+int32_t Value::Int32Value() const {
+  auto obj = Utils::OpenHandle(this);
+  if (obj->IsNumber()) return NumberToInt32(*obj);
+  return Int32Value(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
+}
 
 Maybe<uint32_t> Value::Uint32Value(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3937,6 +4006,11 @@ Maybe<uint32_t> Value::Uint32Value(Local<Context> context) const {
                            : static_cast<uint32_t>(num->Number()));
 }
 
+uint32_t Value::Uint32Value() const {
+  auto obj = Utils::OpenHandle(this);
+  if (obj->IsNumber()) return NumberToUint32(*obj);
+  return Uint32Value(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
+}
 
 MaybeLocal<Uint32> Value::ToArrayIndex(Local<Context> context) const {
   auto self = Utils::OpenHandle(this);
@@ -3971,6 +4045,19 @@ Maybe<bool> Value::Equals(Local<Context> context, Local<Value> that) const {
   return i::Object::Equals(isolate, self, other);
 }
 
+bool Value::Equals(Local<Value> that) const {
+  auto self = Utils::OpenHandle(this);
+  auto other = Utils::OpenHandle(*that);
+  if (self->IsSmi() && other->IsSmi()) {
+    return self->Number() == other->Number();
+  }
+  if (self->IsJSObject() && other->IsJSObject()) {
+    return *self == *other;
+  }
+  auto heap_object = self->IsSmi() ? other : self;
+  auto context = UnsafeContextFromHeapObject(heap_object);
+  return Equals(context, that).FromMaybe(false);
+}
 
 bool Value::StrictEquals(Local<Value> that) const {
   auto self = Utils::OpenHandle(this);
@@ -5295,6 +5382,11 @@ bool String::ContainsOnlyOneByte() const {
   return helper.Check(*str);
 }
 
+int String::Utf8Length() const {
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
+  return Utf8Length(reinterpret_cast<Isolate*>(isolate));
+}
+
 int String::Utf8Length(Isolate* isolate) const {
   i::Handle<i::String> str = Utils::OpenHandle(this);
   str = i::String::Flatten(reinterpret_cast<i::Isolate*>(isolate), str);
@@ -5563,6 +5655,14 @@ int String::WriteUtf8(Isolate* v8_isolate, char* buffer, int capacity,
   return writer.CompleteWrite(write_null, nchars_ref);
 }
 
+int String::WriteUtf8(char* buffer, int capacity, int* nchars_ref,
+                      int options) const {
+  i::Handle<i::String> str = Utils::OpenHandle(this);
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(str);
+  return WriteUtf8(reinterpret_cast<Isolate*>(isolate), buffer, capacity,
+                   nchars_ref, options);
+}
+
 template <typename CharType>
 static inline int WriteHelper(i::Isolate* isolate, const String* string,
                               CharType* buffer, int start, int length,
@@ -5584,6 +5684,11 @@ static inline int WriteHelper(i::Isolate* isolate, const String* string,
   return end - start;
 }
 
+int String::WriteOneByte(uint8_t* buffer, int start, int length,
+                         int options) const {
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
+  return WriteHelper(isolate, this, buffer, start, length, options);
+}
 
 int String::WriteOneByte(Isolate* isolate, uint8_t* buffer, int start,
                          int length, int options) const {
@@ -5591,6 +5696,10 @@ int String::WriteOneByte(Isolate* isolate, uint8_t* buffer, int start,
                      start, length, options);
 }
 
+int String::Write(uint16_t* buffer, int start, int length, int options) const {
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
+  return WriteHelper(isolate, this, buffer, start, length, options);
+}
 
 int String::Write(Isolate* isolate, uint16_t* buffer, int start, int length,
                   int options) const {
@@ -6549,6 +6658,12 @@ Local<String> v8::String::Concat(Isolate* v8_isolate, Local<String> left,
   return Utils::ToLocal(result);
 }
 
+Local<String> v8::String::Concat(Local<String> left, Local<String> right) {
+  i::Handle<i::String> left_string = Utils::OpenHandle(*left);
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(left_string);
+  return Concat(reinterpret_cast<Isolate*>(isolate), left, right);
+}
+
 MaybeLocal<String> v8::String::NewExternalTwoByte(
     Isolate* isolate, v8::String::ExternalStringResource* resource) {
   CHECK(resource && resource->data());
@@ -6757,6 +6872,11 @@ bool v8::BooleanObject::ValueOf() const {
   return jsvalue->value()->IsTrue(isolate);
 }
 
+Local<v8::Value> v8::StringObject::New(Local<String> value) {
+  i::Handle<i::String> string = Utils::OpenHandle(*value);
+  i::Isolate* isolate = UnsafeIsolateFromHeapObject(string);
+  return New(reinterpret_cast<Isolate*>(isolate), value);
+}
 
 Local<v8::Value> v8::StringObject::New(Isolate* v8_isolate,
                                        Local<String> value) {

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -219,28 +219,6 @@ Local<Context> ContextFromNeverReadOnlySpaceObject(
   return reinterpret_cast<v8::Isolate*>(obj->GetIsolate())->GetCurrentContext();
 }
 
-// TODO(delphick): Remove this completely when the deprecated functions that use
-// it are removed.
-// DO NOT USE THIS IN NEW CODE!
-i::Isolate* UnsafeIsolateFromHeapObject(i::Handle<i::HeapObject> obj) {
-  // Use MemoryChunk directly instead of Isolate::FromWritableHeapObject to
-  // temporarily allow isolate access from read-only space objects.
-  i::MemoryChunk* chunk = i::MemoryChunk::FromHeapObject(*obj);
-  return chunk->heap()->isolate();
-}
-
-// TODO(delphick): Remove this completely when the deprecated functions that use
-// it are removed.
-// DO NOT USE THIS IN NEW CODE!
-Local<Context> UnsafeContextFromHeapObject(i::Handle<i::Object> obj) {
-  // Use MemoryChunk directly instead of Isolate::FromWritableHeapObject to
-  // temporarily allow isolate access from read-only space objects.
-  i::MemoryChunk* chunk =
-      i::MemoryChunk::FromHeapObject(i::HeapObject::cast(*obj));
-  return reinterpret_cast<Isolate*>(chunk->heap()->isolate())
-      ->GetCurrentContext();
-}
-
 class InternalEscapableScope : public v8::EscapableHandleScope {
  public:
   explicit inline InternalEscapableScope(i::Isolate* isolate)
@@ -2192,12 +2170,6 @@ void PrimitiveArray::Set(Isolate* v8_isolate, int index,
   array->set(index, *i_item);
 }
 
-void PrimitiveArray::Set(int index, Local<Primitive> item) {
-  i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(array);
-  Set(reinterpret_cast<Isolate*>(isolate), index, item);
-}
-
 Local<Primitive> PrimitiveArray::Get(Isolate* v8_isolate, int index) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
@@ -2208,12 +2180,6 @@ Local<Primitive> PrimitiveArray::Get(Isolate* v8_isolate, int index) {
                   "array length");
   i::Handle<i::Object> i_item(array->get(index), isolate);
   return ToApiHandle<Primitive>(i_item);
-}
-
-Local<Primitive> PrimitiveArray::Get(int index) {
-  i::Handle<i::FixedArray> array = Utils::OpenHandle(this);
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(array);
-  return Get(reinterpret_cast<Isolate*>(isolate), index);
 }
 
 Module::Status Module::GetStatus() const {
@@ -2942,11 +2908,6 @@ Local<StackFrame> StackTrace::GetFrame(Isolate* v8_isolate,
   auto obj = handle(Utils::OpenHandle(this)->get(index), isolate);
   auto info = i::Handle<i::StackFrameInfo>::cast(obj);
   return scope.Escape(Utils::StackFrameToLocal(info));
-}
-
-Local<StackFrame> StackTrace::GetFrame(uint32_t index) const {
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
-  return GetFrame(reinterpret_cast<Isolate*>(isolate), index);
 }
 
 int StackTrace::GetFrameCount() const {
@@ -3920,14 +3881,6 @@ Maybe<bool> Value::BooleanValue(Local<Context> context) const {
   return Just(Utils::OpenHandle(this)->BooleanValue(isolate));
 }
 
-bool Value::BooleanValue() const {
-  auto obj = Utils::OpenHandle(this);
-  if (obj->IsSmi()) return *obj != i::Smi::kZero;
-  DCHECK(obj->IsHeapObject());
-  i::Isolate* isolate =
-      UnsafeIsolateFromHeapObject(i::Handle<i::HeapObject>::cast(obj));
-  return obj->BooleanValue(isolate);
-}
 
 Maybe<double> Value::NumberValue(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3941,12 +3894,6 @@ Maybe<double> Value::NumberValue(Local<Context> context) const {
   return Just(num->Number());
 }
 
-double Value::NumberValue() const {
-  auto obj = Utils::OpenHandle(this);
-  if (obj->IsNumber()) return obj->Number();
-  return NumberValue(UnsafeContextFromHeapObject(obj))
-      .FromMaybe(std::numeric_limits<double>::quiet_NaN());
-}
 
 Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3962,17 +3909,6 @@ Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
   return Just(NumberToInt64(*num));
 }
 
-int64_t Value::IntegerValue() const {
-  auto obj = Utils::OpenHandle(this);
-  if (obj->IsNumber()) {
-    if (obj->IsSmi()) {
-      return i::Smi::ToInt(*obj);
-    } else {
-      return static_cast<int64_t>(obj->Number());
-    }
-  }
-  return IntegerValue(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
-}
 
 Maybe<int32_t> Value::Int32Value(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -3987,11 +3923,6 @@ Maybe<int32_t> Value::Int32Value(Local<Context> context) const {
                            : static_cast<int32_t>(num->Number()));
 }
 
-int32_t Value::Int32Value() const {
-  auto obj = Utils::OpenHandle(this);
-  if (obj->IsNumber()) return NumberToInt32(*obj);
-  return Int32Value(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
-}
 
 Maybe<uint32_t> Value::Uint32Value(Local<Context> context) const {
   auto obj = Utils::OpenHandle(this);
@@ -4006,11 +3937,6 @@ Maybe<uint32_t> Value::Uint32Value(Local<Context> context) const {
                            : static_cast<uint32_t>(num->Number()));
 }
 
-uint32_t Value::Uint32Value() const {
-  auto obj = Utils::OpenHandle(this);
-  if (obj->IsNumber()) return NumberToUint32(*obj);
-  return Uint32Value(UnsafeContextFromHeapObject(obj)).FromMaybe(0);
-}
 
 MaybeLocal<Uint32> Value::ToArrayIndex(Local<Context> context) const {
   auto self = Utils::OpenHandle(this);
@@ -4045,19 +3971,6 @@ Maybe<bool> Value::Equals(Local<Context> context, Local<Value> that) const {
   return i::Object::Equals(isolate, self, other);
 }
 
-bool Value::Equals(Local<Value> that) const {
-  auto self = Utils::OpenHandle(this);
-  auto other = Utils::OpenHandle(*that);
-  if (self->IsSmi() && other->IsSmi()) {
-    return self->Number() == other->Number();
-  }
-  if (self->IsJSObject() && other->IsJSObject()) {
-    return *self == *other;
-  }
-  auto heap_object = self->IsSmi() ? other : self;
-  auto context = UnsafeContextFromHeapObject(heap_object);
-  return Equals(context, that).FromMaybe(false);
-}
 
 bool Value::StrictEquals(Local<Value> that) const {
   auto self = Utils::OpenHandle(this);
@@ -5382,11 +5295,6 @@ bool String::ContainsOnlyOneByte() const {
   return helper.Check(*str);
 }
 
-int String::Utf8Length() const {
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
-  return Utf8Length(reinterpret_cast<Isolate*>(isolate));
-}
-
 int String::Utf8Length(Isolate* isolate) const {
   i::Handle<i::String> str = Utils::OpenHandle(this);
   str = i::String::Flatten(reinterpret_cast<i::Isolate*>(isolate), str);
@@ -5655,14 +5563,6 @@ int String::WriteUtf8(Isolate* v8_isolate, char* buffer, int capacity,
   return writer.CompleteWrite(write_null, nchars_ref);
 }
 
-int String::WriteUtf8(char* buffer, int capacity, int* nchars_ref,
-                      int options) const {
-  i::Handle<i::String> str = Utils::OpenHandle(this);
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(str);
-  return WriteUtf8(reinterpret_cast<Isolate*>(isolate), buffer, capacity,
-                   nchars_ref, options);
-}
-
 template <typename CharType>
 static inline int WriteHelper(i::Isolate* isolate, const String* string,
                               CharType* buffer, int start, int length,
@@ -5684,11 +5584,6 @@ static inline int WriteHelper(i::Isolate* isolate, const String* string,
   return end - start;
 }
 
-int String::WriteOneByte(uint8_t* buffer, int start, int length,
-                         int options) const {
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
-  return WriteHelper(isolate, this, buffer, start, length, options);
-}
 
 int String::WriteOneByte(Isolate* isolate, uint8_t* buffer, int start,
                          int length, int options) const {
@@ -5696,10 +5591,6 @@ int String::WriteOneByte(Isolate* isolate, uint8_t* buffer, int start,
                      start, length, options);
 }
 
-int String::Write(uint16_t* buffer, int start, int length, int options) const {
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(Utils::OpenHandle(this));
-  return WriteHelper(isolate, this, buffer, start, length, options);
-}
 
 int String::Write(Isolate* isolate, uint16_t* buffer, int start, int length,
                   int options) const {
@@ -6658,12 +6549,6 @@ Local<String> v8::String::Concat(Isolate* v8_isolate, Local<String> left,
   return Utils::ToLocal(result);
 }
 
-Local<String> v8::String::Concat(Local<String> left, Local<String> right) {
-  i::Handle<i::String> left_string = Utils::OpenHandle(*left);
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(left_string);
-  return Concat(reinterpret_cast<Isolate*>(isolate), left, right);
-}
-
 MaybeLocal<String> v8::String::NewExternalTwoByte(
     Isolate* isolate, v8::String::ExternalStringResource* resource) {
   CHECK(resource && resource->data());
@@ -6872,11 +6757,6 @@ bool v8::BooleanObject::ValueOf() const {
   return jsvalue->value()->IsTrue(isolate);
 }
 
-Local<v8::Value> v8::StringObject::New(Local<String> value) {
-  i::Handle<i::String> string = Utils::OpenHandle(*value);
-  i::Isolate* isolate = UnsafeIsolateFromHeapObject(string);
-  return New(reinterpret_cast<Isolate*>(isolate), value);
-}
 
 Local<v8::Value> v8::StringObject::New(Isolate* v8_isolate,
                                        Local<String> value) {

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -2157,6 +2157,10 @@ int PrimitiveArray::Length() const {
   return array->length();
 }
 
+void PrimitiveArray::Set(int index, Local<Primitive> item) {
+  return Set(Isolate::GetCurrent(), index, item);
+}
+
 void PrimitiveArray::Set(Isolate* v8_isolate, int index,
                          Local<Primitive> item) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
@@ -2168,6 +2172,10 @@ void PrimitiveArray::Set(Isolate* v8_isolate, int index,
                   "array length");
   i::Handle<i::Object> i_item = Utils::OpenHandle(*item);
   array->set(index, *i_item);
+}
+
+Local<Primitive> PrimitiveArray::Get(int index) {
+  return Get(Isolate::GetCurrent(), index);
 }
 
 Local<Primitive> PrimitiveArray::Get(Isolate* v8_isolate, int index) {
@@ -2899,6 +2907,10 @@ void Message::PrintCurrentStackTrace(Isolate* isolate, FILE* out) {
 
 
 // --- S t a c k T r a c e ---
+
+Local<StackFrame> StackTrace::GetFrame(uint32_t index) const {
+  return GetFrame(Isolate::GetCurrent(), index);
+}
 
 Local<StackFrame> StackTrace::GetFrame(Isolate* v8_isolate,
                                        uint32_t index) const {
@@ -3876,6 +3888,36 @@ void v8::RegExp::CheckCast(v8::Value* that) {
 }
 
 
+bool Value::BooleanValue() const {
+  return BooleanValue(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(false);
+}
+
+
+double Value::NumberValue() const {
+  return NumberValue(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(0.0);
+}
+
+
+int64_t Value::IntegerValue() const {
+  return NumberValue(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(0);
+}
+
+
+uint32_t Value::Uint32Value() const {
+  return Uint32Value(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(0);
+}
+
+
+int32_t Value::Int32Value() const {
+  return Int32Value(Isolate::GetCurrent()->GetCurrentContext())
+      .FromMaybe(0);
+}
+
+
 Maybe<bool> Value::BooleanValue(Local<Context> context) const {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
   return Just(Utils::OpenHandle(this)->BooleanValue(isolate));
@@ -3961,6 +4003,12 @@ MaybeLocal<Uint32> Value::ToArrayIndex(Local<Context> context) const {
     RETURN_ESCAPED(Utils::Uint32ToLocal(value));
   }
   return Local<Uint32>();
+}
+
+
+bool Value::Equals(Local<Value> that) const {
+  return Equals(Isolate::GetCurrent()->GetCurrentContext(), that)
+      .FromMaybe(false);
 }
 
 
@@ -5295,6 +5343,10 @@ bool String::ContainsOnlyOneByte() const {
   return helper.Check(*str);
 }
 
+int String::Utf8Length() const {
+  return Utf8Length(Isolate::GetCurrent());
+}
+
 int String::Utf8Length(Isolate* isolate) const {
   i::Handle<i::String> str = Utils::OpenHandle(this);
   str = i::String::Flatten(reinterpret_cast<i::Isolate*>(isolate), str);
@@ -5518,6 +5570,14 @@ static bool RecursivelySerializeToUtf8(i::String* current,
   return true;
 }
 
+
+int String::WriteUtf8(char* buffer, int capacity,
+                      int* nchars_ref, int options) const {
+  return WriteUtf8(Isolate::GetCurrent(),
+                   buffer, capacity, nchars_ref, options);
+}
+
+
 int String::WriteUtf8(Isolate* v8_isolate, char* buffer, int capacity,
                       int* nchars_ref, int options) const {
   i::Handle<i::String> str = Utils::OpenHandle(this);
@@ -5582,6 +5642,18 @@ static inline int WriteHelper(i::Isolate* isolate, const String* string,
     buffer[end - start] = '\0';
   }
   return end - start;
+}
+
+
+int String::WriteOneByte(uint8_t* buffer, int start,
+                         int length, int options) const {
+  return WriteOneByte(Isolate::GetCurrent(), buffer, start, length, options);
+}
+
+
+int String::Write(uint16_t* buffer, int start, int length,
+                  int options) const {
+  return Write(Isolate::GetCurrent(), buffer, start, length, options);
 }
 
 
@@ -6532,6 +6604,11 @@ MaybeLocal<String> String::NewFromTwoByte(Isolate* isolate,
   return result;
 }
 
+Local<String> v8::String::Concat(Local<String> left,
+                                 Local<String> right) {
+  return Concat(Isolate::GetCurrent(), left, right);
+}
+
 Local<String> v8::String::Concat(Isolate* v8_isolate, Local<String> left,
                                  Local<String> right) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
@@ -6755,6 +6832,11 @@ bool v8::BooleanObject::ValueOf() const {
   i::Isolate* isolate = jsvalue->GetIsolate();
   LOG_API(isolate, BooleanObject, BooleanValue);
   return jsvalue->value()->IsTrue(isolate);
+}
+
+
+Local<v8::Value> v8::StringObject::New(Local<String> value) {
+  return New(Isolate::GetCurrent(), value);
 }
 
 
@@ -8893,6 +8975,9 @@ bool MicrotasksScope::IsRunningMicrotasks(Isolate* v8Isolate) {
   return isolate->IsRunningMicrotasks();
 }
 
+String::Utf8Value::Utf8Value(v8::Local<v8::Value> obj)
+  : Utf8Value(Isolate::GetCurrent(), obj) {}
+
 String::Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> obj)
     : str_(nullptr), length_(0) {
   if (obj.IsEmpty()) return;
@@ -8911,6 +8996,9 @@ String::Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> obj)
 String::Utf8Value::~Utf8Value() {
   i::DeleteArray(str_);
 }
+
+String::Value::Value(v8::Local<v8::Value> obj)
+  : Value(Isolate::GetCurrent(), obj) {}
 
 String::Value::Value(v8::Isolate* isolate, v8::Local<v8::Value> obj)
     : str_(nullptr), length_(0) {

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -3890,13 +3890,13 @@ void v8::RegExp::CheckCast(v8::Value* that) {
 
 bool Value::BooleanValue() const {
   return BooleanValue(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(false);
+      .FromJust();
 }
 
 
 double Value::NumberValue() const {
   return NumberValue(Isolate::GetCurrent()->GetCurrentContext())
-      .FromMaybe(0.0);
+      .FromMaybe(std::numeric_limits<double>::quiet_NaN());
 }
 
 

--- a/deps/v8/src/wasm/streaming-decoder.h
+++ b/deps/v8/src/wasm/streaming-decoder.h
@@ -65,8 +65,13 @@ class V8_EXPORT_PRIVATE StreamingDecoder {
 
   void Abort();
 
-  // Notify the StreamingDecoder that there has been an compilation error.
-  void NotifyError() { ok_ = false; }
+  // Notify the StreamingDecoder that compilation ended and the
+  // StreamingProcessor should not be called anymore.
+  void NotifyCompilationEnded() {
+    // We set {ok_} to false to turn all future calls to the StreamingDecoder
+    // into no-ops.
+    ok_ = false;
+  }
 
  private:
   // TODO(ahaas): Put the whole private state of the StreamingDecoder into the


### PR DESCRIPTION
Add back a number deprecated APIs, using shims that
should work well enough at least for the duration of Node 11
and do not come with significant maintenance overhead.

Refs: https://github.com/nodejs/node/issues/23122

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
