### PR TITLE
tools: unify .editorconfig rules for 2-space

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,40 +1,26 @@
 root = true
 
 [*]
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+end_of_line = lf
+indent_size = 2
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [vcbuild.bat]
 end_of_line = crlf
 
-[{lib,test,tools}/**.js]
-indent_style = space
-indent_size = 2
-
-[src/**.{h,cc}]
-indent_style = space
-indent_size = 2
-
-[test/*.py]
-indent_style = space
-indent_size = 2
-
-[configure]
-indent_style = space
-indent_size = 2
-
 [Makefile]
-indent_style = tab
 indent_size = 8
+indent_style = tab
 
 [{deps}/**]
-indent_style = ignore
-indent_size = ignore
-end_of_line = ignore
-trim_trailing_whitespace = ignore
 charset = ignore
+end_of_line = ignore
+indent_size = ignore
+indent_style = ignore
+trim_trailing_whitespace = ignore
 
 [{test/fixtures,deps,tools/node_modules,tools/gyp,tools/icu,tools/msvs}/**]
 insert_final_newline = false


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

The `doc` directory had not had any editorconfig rules applied which can lead to tab indentation in editors. This unifies the rules to use 2-space as the default. Additionally, all rules are now sorted alphabetically.