### PR TITLE
build: add loader path to rpath for cctest

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -956,6 +956,11 @@
         [ 'OS=="win" and node_shared=="true"', {
           'type': 'none',
         }],
+        [ 'node_shared=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
+          },
+        }],
       ],
     }
   ], # end targets


### PR DESCRIPTION
Building on Mac OS/X as follows:

```
./configure --shared
make -j4 test
```

Results in:

```
dyld: Library not loaded: @rpath/libnode.67.dylib
  Referenced from: /Users/rubys/git/node-shared/out/Release/cctest
  Reason: image not found
make: *** [cctest] Abort trap: 6
```

This change adds the loader path to the runtime path for the `cctest` executable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
