### PR TITLE
dns: deprecate passing falsy hostname to dns.lookup

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2215,7 +2215,7 @@ Using the `_handle` property to access the native object is deprecated because
 improper use of the native object can lead to crashing the application.
 
 <a id="DEP0XXX"></a>
-### DEP0XXX: dns.lookup() supports for a falsy hostname
+### DEP0XXX: dns.lookup() support for a falsy hostname
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2226,9 +2226,9 @@ changes:
 Type: Runtime
 
 Previous versions of Node.js supported `dns.lookup()` with a falsy hostname
-like `dns.lookup(false)` due to backward compatibility long before.
-This behavior is undocumented and seems useless in real world apps. We
-might make passing invalid hostname throw in the future.
+like `dns.lookup(false)` due to backward compatibility.
+This behavior is undocumented and is thought to be unused in real world apps.
+It will become an error in future versions of Node.js.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2215,7 +2215,7 @@ Using the `_handle` property to access the native object is deprecated because
 improper use of the native object can lead to crashing the application.
 
 <a id="DEP0XXX"></a>
-### DEP0XXX: dns.lookup() supports for falsy hostname
+### DEP0XXX: dns.lookup() supports for a falsy hostname
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2225,8 +2225,8 @@ changes:
 
 Type: Runtime
 
-Previous versions of Node.js support `dns.lookup()` a falsy hostname like
-`dns.lookup(false)` for the reason of backward compatibility long before.
+Previous versions of Node.js supported `dns.lookup()` with a falsy hostname
+like `dns.lookup(false)` due to backward compatibility long before.
 This behavior is undocumented and seems useless in real world apps. We
 might make invalid hostname throw in the future.
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2228,7 +2228,7 @@ Type: Runtime
 Previous versions of Node.js supported `dns.lookup()` with a falsy hostname
 like `dns.lookup(false)` due to backward compatibility long before.
 This behavior is undocumented and seems useless in real world apps. We
-might make invalid hostname throw in the future.
+might make passing invalid hostname throw in the future.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2214,6 +2214,22 @@ the `_handle` property of the `Cipher`, `Decipher`, `DiffieHellman`,
 Using the `_handle` property to access the native object is deprecated because
 improper use of the native object can lead to crashing the application.
 
+<a id="DEP0118"></a>
+### DEP0118: dns.lookup supports for falsy hostname
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/23173
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Previous versions of Node.js support `dns.lookup` a falsy hostname like
+`dns.lookup(false)` for the reason of backward compatibility long before.
+This behavior is undocumented and seems useless in real world apps. We
+might make invalid hostname throw in the future.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2214,8 +2214,8 @@ the `_handle` property of the `Cipher`, `Decipher`, `DiffieHellman`,
 Using the `_handle` property to access the native object is deprecated because
 improper use of the native object can lead to crashing the application.
 
-<a id="DEP0118"></a>
-### DEP0118: dns.lookup supports for falsy hostname
+<a id="DEP0XXX"></a>
+### DEP0XXX: dns.lookup() supports for falsy hostname
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2225,7 +2225,7 @@ changes:
 
 Type: Runtime
 
-Previous versions of Node.js support `dns.lookup` a falsy hostname like
+Previous versions of Node.js support `dns.lookup()` a falsy hostname like
 `dns.lookup(false)` for the reason of backward compatibility long before.
 This behavior is undocumented and seems useless in real world apps. We
 might make invalid hostname throw in the future.

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -31,7 +31,8 @@ const {
   getDefaultResolver,
   setDefaultResolver,
   Resolver,
-  validateHints
+  validateHints,
+  emitInvalidHostnameWarning,
 } = require('internal/dns/utils');
 const {
   ERR_INVALID_ARG_TYPE,
@@ -93,7 +94,7 @@ function lookup(hostname, options, callback) {
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('hostname', ['string', 'falsy'], hostname);
+    throw new ERR_INVALID_ARG_TYPE('hostname', 'string', hostname);
   } else if (typeof options === 'function') {
     callback = options;
     family = 0;
@@ -114,6 +115,7 @@ function lookup(hostname, options, callback) {
     throw new ERR_INVALID_OPT_VALUE('family', family);
 
   if (!hostname) {
+    emitInvalidHostnameWarning(hostname);
     if (all) {
       process.nextTick(callback, null, []);
     } else {

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -2,7 +2,8 @@
 const {
   bindDefaultResolver,
   Resolver: CallbackResolver,
-  validateHints
+  validateHints,
+  emitInvalidHostnameWarning,
 } = require('internal/dns/utils');
 const { codes, dnsException } = require('internal/errors');
 const { isIP, isIPv4, isLegalPort } = require('internal/net');
@@ -56,6 +57,7 @@ function onlookupall(err, addresses) {
 function createLookupPromise(family, hostname, all, hints, verbatim) {
   return new Promise((resolve, reject) => {
     if (!hostname) {
+      emitInvalidHostnameWarning(hostname);
       if (all)
         resolve([]);
       else
@@ -100,7 +102,7 @@ function lookup(hostname, options) {
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('hostname', ['string', 'falsy'], hostname);
+    throw new ERR_INVALID_ARG_TYPE('hostname', 'string', hostname);
   } else if (options !== null && typeof options === 'object') {
     hints = options.hints >>> 0;
     family = options.family >>> 0;

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -141,10 +141,19 @@ function validateHints(hints) {
   }
 }
 
+function emitInvalidHostnameWarning(hostname) {
+  process.emitWarning(
+    `The provided hostname "${hostname}" is not a valid ` +
+    'hostname, and is supported in the dns module solely for compatibility.',
+    'DeprecationWarning',
+  );
+}
+
 module.exports = {
   bindDefaultResolver,
   getDefaultResolver,
   setDefaultResolver,
   validateHints,
-  Resolver
+  Resolver,
+  emitInvalidHostnameWarning,
 };

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -146,7 +146,7 @@ function emitInvalidHostnameWarning(hostname) {
     `The provided hostname "${hostname}" is not a valid ` +
     'hostname, and is supported in the dns module solely for compatibility.',
     'DeprecationWarning',
-    'DEP0118'
+    'DEP0XXX'
   );
 }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -141,7 +141,13 @@ function validateHints(hints) {
   }
 }
 
+let invalidHostnameWarningEmitted = false;
+
 function emitInvalidHostnameWarning(hostname) {
+  if (invalidHostnameWarningEmitted) {
+    return;
+  }
+  invalidHostnameWarningEmitted = true;
   process.emitWarning(
     `The provided hostname "${hostname}" is not a valid ` +
     'hostname, and is supported in the dns module solely for compatibility.',

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -146,6 +146,7 @@ function emitInvalidHostnameWarning(hostname) {
     `The provided hostname "${hostname}" is not a valid ` +
     'hostname, and is supported in the dns module solely for compatibility.',
     'DeprecationWarning',
+    'DEP0118'
   );
 }
 

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -36,10 +36,12 @@ common.expectWarning({
     [
       'The provided hostname "false" is not a valid ' +
       'hostname, and is supported in the dns module solely for compatibility.',
+      'DEP0118',
     ],
     [
       'The provided hostname "false" is not a valid ' +
       'hostname, and is supported in the dns module solely for compatibility.',
+      'DEP0118',
     ]
   ],
 });

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -14,12 +14,35 @@ cares.getaddrinfo = () => internalBinding('uv').UV_ENOENT;
   const err = {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "hostname" argument must be one of type string or falsy/
+    message: /^The "hostname" argument must be of type string\. Received type number/
   };
 
   common.expectsError(() => dns.lookup(1, {}), err);
   common.expectsError(() => dnsPromises.lookup(1, {}), err);
 }
+
+common.expectWarning({
+  // For 'internal/test/binding' module.
+  'internal/test/binding': [
+    'These APIs are exposed only for testing and are not ' +
+    'tracked by any versioning system or deprecation process.'
+  ],
+  // For dns.promises.
+  'ExperimentalWarning': [
+    'The dns.promises API is experimental'
+  ],
+  // For call `dns.lookup` with falsy `hostname`, twice.
+  'DeprecationWarning': [
+    [
+      'The provided hostname "false" is not a valid ' +
+      'hostname, and is supported in the dns module solely for compatibility.',
+    ],
+    [
+      'The provided hostname "false" is not a valid ' +
+      'hostname, and is supported in the dns module solely for compatibility.',
+    ]
+  ],
+});
 
 common.expectsError(() => {
   dns.lookup(false, 'cb');

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -31,18 +31,11 @@ common.expectWarning({
   'ExperimentalWarning': [
     'The dns.promises API is experimental'
   ],
-  // For call `dns.lookup` with falsy `hostname`, twice.
+  // For calling `dns.lookup` with falsy `hostname`.
   'DeprecationWarning': [
-    [
-      'The provided hostname "false" is not a valid ' +
-      'hostname, and is supported in the dns module solely for compatibility.',
-      'DEP0XXX',
-    ],
-    [
-      'The provided hostname "false" is not a valid ' +
-      'hostname, and is supported in the dns module solely for compatibility.',
-      'DEP0XXX',
-    ]
+    'The provided hostname "false" is not a valid ' +
+    'hostname, and is supported in the dns module solely for compatibility.',
+    'DEP0XXX',
   ],
 });
 

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -36,12 +36,12 @@ common.expectWarning({
     [
       'The provided hostname "false" is not a valid ' +
       'hostname, and is supported in the dns module solely for compatibility.',
-      'DEP0118',
+      'DEP0XXX',
     ],
     [
       'The provided hostname "false" is not a valid ' +
       'hostname, and is supported in the dns module solely for compatibility.',
-      'DEP0118',
+      'DEP0XXX',
     ]
   ],
 });

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -166,7 +166,7 @@ assert.deepStrictEqual(dns.getServers(), []);
   const errorReg = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "hostname" argument must be one of type string or falsy/
+    message: /^The "hostname" argument must be of type string\. Received type .*/
   }, 10);
 
   assert.throws(() => dns.lookup({}, common.mustNotCall()), errorReg);


### PR DESCRIPTION
We can `dns.lookup` a falsy `hostname` like `dns.lookup(false)`
for the reason of backwards compatibility long before(see #13119
for detail). This behavior is undocumented and seems useless in
real world apps.

We could also make invalid `hostname` throw in the future and the
change might be semver-major.

Fixes: #13119

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
