### PR TITLE
src: use default parameters for `UVException()`

### DIFF
--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -88,15 +88,6 @@ Local<Value> UVException(Isolate* isolate,
                          int errorno,
                          const char* syscall,
                          const char* msg,
-                         const char* path) {
-  return UVException(isolate, errorno, syscall, msg, path, nullptr);
-}
-
-
-Local<Value> UVException(Isolate* isolate,
-                         int errorno,
-                         const char* syscall,
-                         const char* msg,
                          const char* path,
                          const char* dest) {
   Environment* env = Environment::GetCurrent(isolate);

--- a/src/node.h
+++ b/src/node.h
@@ -118,13 +118,8 @@ NODE_EXTERN v8::Local<v8::Value> UVException(v8::Isolate* isolate,
                                              int errorno,
                                              const char* syscall = nullptr,
                                              const char* message = nullptr,
-                                             const char* path = nullptr);
-NODE_EXTERN v8::Local<v8::Value> UVException(v8::Isolate* isolate,
-                                             int errorno,
-                                             const char* syscall,
-                                             const char* message,
-                                             const char* path,
-                                             const char* dest);
+                                             const char* path = nullptr,
+                                             const char* dest = nullptr);
 
 NODE_DEPRECATED("Use ErrnoException(isolate, ...)",
                 inline v8::Local<v8::Value> ErrnoException(


### PR DESCRIPTION
(dont-land-on-v10.x because of the ABI change.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
