### PR TITLE
build: cleanup in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !.mailmap
 !.nycrc
 !.travis.yml
+!.eslintrc.yaml
 
 core
 vgcore.*
@@ -38,14 +39,15 @@ icu_config.gypi
 .eslintcache
 node_trace.*.log
 coverage/
+!**/node_modules/**/coverage
 
 /out
 
 # various stuff that VC++ produces/uses
 Debug/
 !**/node_modules/debug/
-!deps/v8/src/debug/
 Release/
+!**/node_modules/**/release
 !doc/blog/**
 *.sln
 !nodemsi.sln
@@ -64,7 +66,6 @@ ipch/
 *.VC.opendb
 .vs/
 .vscode/
-/deps/v8/src/debug/obj
 /*.exe
 
 /config.mk
@@ -98,6 +99,7 @@ deps/openssl/openssl.xml
 deps/openssl/openssl.target.mk
 deps/zlib/zlib.target.mk
 
+!deps/npm/node_modules
 # not needed and causes issues for distro packagers
 deps/npm/node_modules/.bin/
 
@@ -130,8 +132,4 @@ deps/uv/docs/src/guide/
 # ignore VS compiler output unhandled by V8's .gitignore
 deps/v8/gypfiles/Debug/
 deps/v8/gypfiles/Release/
-deps/v8/src/Debug/
-deps/v8/src/Release/
-deps/v8/src/inspector/Debug/
-deps/v8/src/inspector/Release/
 deps/v8/third_party/eu-strip/


### PR DESCRIPTION
* explicitly unignore files that we track.

The following are not created anymore (only as subdirs of v8/gypfiles)
/deps/v8/src/debug/obj
deps/v8/src/Debug/
deps/v8/src/Release/
deps/v8/src/inspector/Debug/
deps/v8/src/inspector/Release/

Refs: https://github.com/nodejs/node/pull/23156

/CC @nodejs/build-files 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
