### PR TITLE
src: clean up zlib write code

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -138,24 +138,15 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
   // write(flush, in, in_off, in_len, out, out_off, out_len)
   template <bool async>
   static void Write(const FunctionCallbackInfo<Value>& args) {
+    Environment* env = Environment::GetCurrent(args);
+    Local<Context> context = env->context();
     CHECK_EQ(args.Length(), 7);
 
-    ZCtx* ctx;
-    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
-    CHECK(ctx->init_done_ && "write before init");
-    CHECK(ctx->mode_ != NONE && "already finalized");
-
-    CHECK_EQ(false, ctx->write_in_progress_ && "write already in progress");
-    CHECK_EQ(false, ctx->pending_close_ && "close is pending");
-    ctx->write_in_progress_ = true;
-    ctx->Ref();
+    uint32_t in_off, in_len, out_off, out_len, flush;
+    Bytef* in;
+    Bytef* out;
 
     CHECK_EQ(false, args[0]->IsUndefined() && "must provide flush value");
-
-    Environment* env = ctx->env();
-    Local<Context> context = env->context();
-
-    unsigned int flush;
     if (!args[0]->Uint32Value(context).To(&flush)) return;
 
     if (flush != Z_NO_FLUSH &&
@@ -167,12 +158,6 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
       CHECK(0 && "Invalid flush value");
     }
 
-    AllocScope alloc_scope(ctx);
-
-    Bytef* in;
-    Bytef* out;
-    uint32_t in_off, in_len, out_off, out_len;
-
     if (args[1]->IsNull()) {
       // just a flush
       in = nullptr;
@@ -180,43 +165,62 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
       in_off = 0;
     } else {
       CHECK(Buffer::HasInstance(args[1]));
-      Local<Object> in_buf;
-      in_buf = args[1]->ToObject(context).ToLocalChecked();
+      Local<Object> in_buf = args[1].As<Object>();
       if (!args[2]->Uint32Value(context).To(&in_off)) return;
       if (!args[3]->Uint32Value(context).To(&in_len)) return;
 
       CHECK(Buffer::IsWithinBounds(in_off, in_len, Buffer::Length(in_buf)));
-      in = reinterpret_cast<Bytef *>(Buffer::Data(in_buf) + in_off);
+      in = reinterpret_cast<Bytef*>(Buffer::Data(in_buf) + in_off);
     }
 
     CHECK(Buffer::HasInstance(args[4]));
-    Local<Object> out_buf = args[4]->ToObject(context).ToLocalChecked();
+    Local<Object> out_buf = args[4].As<Object>();
     if (!args[5]->Uint32Value(context).To(&out_off)) return;
     if (!args[6]->Uint32Value(context).To(&out_len)) return;
     CHECK(Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf)));
-    out = reinterpret_cast<Bytef *>(Buffer::Data(out_buf) + out_off);
+    out = reinterpret_cast<Bytef*>(Buffer::Data(out_buf) + out_off);
 
-    ctx->strm_.avail_in = in_len;
-    ctx->strm_.next_in = in;
-    ctx->strm_.avail_out = out_len;
-    ctx->strm_.next_out = out;
-    ctx->flush_ = flush;
+    ZCtx* ctx;
+    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
+
+    ctx->Write<async>(flush, in, in_off, in_len, out, out_off, out_len);
+  }
+
+  template <bool async>
+  void Write(uint32_t flush,
+             Bytef* in, uint32_t in_off, uint32_t in_len,
+             Bytef* out, uint32_t out_off, uint32_t out_len) {
+    AllocScope alloc_scope(this);
+
+    CHECK(init_done_ && "write before init");
+    CHECK(mode_ != NONE && "already finalized");
+
+    CHECK_EQ(false, write_in_progress_);
+    CHECK_EQ(false, pending_close_);
+    write_in_progress_ = true;
+    Ref();
+
+    strm_.avail_in = in_len;
+    strm_.next_in = in;
+    strm_.avail_out = out_len;
+    strm_.next_out = out;
+    flush_ = flush;
 
     if (!async) {
       // sync version
-      env->PrintSyncTrace();
-      ctx->DoThreadPoolWork();
-      if (ctx->CheckError()) {
-        ctx->write_result_[0] = ctx->strm_.avail_out;
-        ctx->write_result_[1] = ctx->strm_.avail_in;
-        ctx->write_in_progress_ = false;
+      env()->PrintSyncTrace();
+      DoThreadPoolWork();
+      if (CheckError()) {
+        write_result_[0] = strm_.avail_out;
+        write_result_[1] = strm_.avail_in;
+        write_in_progress_ = false;
       }
-      ctx->Unref();
+      Unref();
       return;
     }
 
     // async version
-    ctx->ScheduleWork();
+    ScheduleWork();
   }
 
   // thread pool!

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -183,13 +183,13 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     ZCtx* ctx;
     ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
 
-    ctx->Write<async>(flush, in, in_off, in_len, out, out_off, out_len);
+    ctx->Write<async>(flush, in, in_len, out, out_len);
   }
 
   template <bool async>
   void Write(uint32_t flush,
-             Bytef* in, uint32_t in_off, uint32_t in_len,
-             Bytef* out, uint32_t out_off, uint32_t out_len) {
+             Bytef* in, uint32_t in_len,
+             Bytef* out, uint32_t out_len) {
     AllocScope alloc_scope(this);
 
     CHECK(init_done_ && "write before init");


### PR DESCRIPTION
Split the existing `Write()` method into one that takes care
of translating the arguments from JS to C++, and a non-static
method for the actual write operations, as well as some minor
stylistic drive-by fixes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
