### PR TITLE
zlib: move, rename, document internal `params()` cb

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -156,17 +156,6 @@ function zlibOnError(message, errno) {
   self.emit('error', error);
 }
 
-function flushCallback(level, strategy, callback) {
-  if (!this._handle)
-    assert(false, 'zlib binding closed');
-  this._handle.params(level, strategy);
-  if (!this._hadError) {
-    this._level = level;
-    this._strategy = strategy;
-    if (callback) callback();
-  }
-}
-
 // 1. Returns false for undefined and NaN
 // 2. Returns true for finite numbers
 // 3. Throws ERR_INVALID_ARG_TYPE for non-numbers
@@ -352,13 +341,28 @@ Object.defineProperty(Zlib.prototype, 'bytesRead', {
   }
 });
 
+// This callback is used by `.params()` to wait until a full flush happened
+// before adjusting the parameters. In particular, the call to the native
+// `params()` function should not happen while a write is currently in progress
+// on the threadpool.
+function paramsAfterFlushCallback(level, strategy, callback) {
+  if (!this._handle)
+    assert(false, 'zlib binding closed');
+  this._handle.params(level, strategy);
+  if (!this._hadError) {
+    this._level = level;
+    this._strategy = strategy;
+    if (callback) callback();
+  }
+}
+
 Zlib.prototype.params = function params(level, strategy, callback) {
   checkRangesOrGetDefault(level, 'level', Z_MIN_LEVEL, Z_MAX_LEVEL);
   checkRangesOrGetDefault(strategy, 'strategy', Z_DEFAULT_STRATEGY, Z_FIXED);
 
   if (this._level !== level || this._strategy !== strategy) {
     this.flush(Z_SYNC_FLUSH,
-               flushCallback.bind(this, level, strategy, callback));
+               paramsAfterFlushCallback.bind(this, level, strategy, callback));
   } else {
     process.nextTick(callback);
   }


### PR DESCRIPTION
Give the callback a more specific name, explain what it does
and why it is necessary, and move it to a location much closer
to its use site.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
