### PR TITLE
zlib: use common owner symbol to access JS wrapper

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -42,6 +42,7 @@ const {
   Buffer,
   kMaxLength
 } = require('buffer');
+const { owner_symbol } = require('internal/async_hooks').symbols;
 
 const constants = process.binding('constants').zlib;
 const {
@@ -143,7 +144,7 @@ function zlibBufferSync(engine, buffer) {
 }
 
 function zlibOnError(message, errno) {
-  var self = this.jsref;
+  var self = this[owner_symbol];
   // there is no way to cleanly recover.
   // continuing only obscures problems.
   _close(self);
@@ -300,7 +301,8 @@ function Zlib(opts, mode) {
   Transform.call(this, opts);
   this.bytesWritten = 0;
   this._handle = new binding.Zlib(mode);
-  this._handle.jsref = this; // Used by processCallback() and zlibOnError()
+  // Used by processCallback() and zlibOnError()
+  this._handle[owner_symbol] = this;
   this._handle.onerror = zlibOnError;
   this._hadError = false;
   this._writeState = new Uint32Array(2);
@@ -712,6 +714,13 @@ function createProperty(ctor) {
     }
   };
 }
+
+// Legacy alias on the C++ wrapper object. This is not public API, so we may
+// want to runtime-deprecate it at some point. There's no hurry, though.
+Object.defineProperty(binding.Zlib.prototype, 'jsref', {
+  get() { return this[owner_symbol]; },
+  set(v) { return this[owner_symbol] = v; }
+});
 
 module.exports = {
   Deflate,


### PR DESCRIPTION
Use the same symbol that other `AsyncWrap` instances also use
for accessing the JS wrapper.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
