### PR TITLE
build,deps: enable building V8 as shared library

### DIFF
--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -97,13 +97,14 @@
     'v8_untrusted_code_mitigations%': 'true',
 
     'v8_dynamic%': "false",
-
-    'conditions': [
-      [ 'v8_dynamic=="true"', {
-        'component': 'shared_library',
-      }],
-    ],
   },
+  'conditions': [
+    [ 'v8_dynamic=="true"', {
+      'variables': {
+        'component': 'shared_library',
+      },
+    }],
+  ],
   'target_defaults': {
     'conditions': [
       ['v8_embedder_string!=""', {

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -95,6 +95,14 @@
 
     # Enable mitigations for executing untrusted code.
     'v8_untrusted_code_mitigations%': 'true',
+
+    'v8_dynamic%': "false",
+
+    'conditions': [
+      [ 'v8_dynamic=="true"', {
+        'component': 'shared_library',
+      }],
+    ],
   },
   'target_defaults': {
     'conditions': [
@@ -154,6 +162,9 @@
       }],
       ['v8_untrusted_code_mitigations=="false"', {
         'defines': ['DISABLE_UNTRUSTED_CODE_MITIGATIONS',],
+      }],
+      [ 'v8_dynamic=="true"', {
+        'cflags': [ '-fPIC', ],
       }],
     ],  # conditions
     'configurations': {

--- a/node.gyp
+++ b/node.gyp
@@ -23,6 +23,7 @@
     'node_core_target_name%': 'node',
     'node_lib_target_name%': 'node_lib',
     'node_intermediate_lib_type%': 'static_library',
+    'v8_dynamic%': "false",
     'library_files': [
       'lib/internal/per_context.js',
       'lib/internal/bootstrap/cache.js',

--- a/node.gypi
+++ b/node.gypi
@@ -259,7 +259,7 @@
       ],
     }],
     [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
-        ' and force_load=="true"', {
+        ' and force_load=="true" and v8_dynamic!="true"', {
       'ldflags': [ '-Wl,-z,noexecstack',
                    '-Wl,--whole-archive <(v8_base)',
                    '-Wl,--no-whole-archive' ]


### PR DESCRIPTION
Motivation: Makes linking the `node` binary faster, which is especially significant when doing a debug build.

The incantation is `./configure ... -- -Dv8_dynamic=true`
Files will be in `out/[Release\Debug]/lib.target/libv8*.so`

/CC @nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
