### PR TITLE
vm: pass correct context to CompileFunctionInContext in CompileFunction

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -673,8 +673,8 @@ added: v10.10.0
     data for the supplied source.
   * `produceCachedData` {boolean} Specifies whether to produce new cache data.
     **Default:** `false`.
-  * `parsingContext` {Object} The sandbox/context in which the said function
-    should be compiled in.
+  * `parsingContext` {Object} The [contextified][] sandbox in which the said
+    function should be compiled in.
   * `contextExtensions` {Object[]} An array containing a collection of context
     extensions (objects wrapping the current scope) to be applied while
     compiling. **Default:** `[]`.

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1070,7 +1070,7 @@ void ContextifyContext::CompileFunction(
   }
 
   MaybeLocal<Function> maybe_fun = ScriptCompiler::CompileFunctionInContext(
-      context, &source, params.size(), params.data(),
+      parsing_context, &source, params.size(), params.data(),
       context_extensions.size(), context_extensions.data(), options);
 
   Local<Function> fun;

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -267,6 +267,46 @@ const vm = require('vm');
     stack: 'Error: Sample Error\n    at <anonymous>:1:10'
   });
 
+  assert.strictEqual(
+    vm.compileFunction(
+      'return varInContext',
+      [],
+      {
+        parsingContext: vm.createContext({ varInContext: 'abc' })
+      }
+    )(),
+    'abc'
+  );
+
+  common.expectsError(() => {
+    vm.compileFunction(
+      'return varInContext',
+      []
+    )();
+  }, {
+    message: 'varInContext is not defined',
+    stack: 'ReferenceError: varInContext is not defined\n    at <anonymous>:1:1'
+  });
+
+  assert.notDeepStrictEqual(
+    vm.compileFunction(
+      'return global',
+      [],
+      {
+        parsingContext: vm.createContext({ global: {} })
+      }
+    )(),
+    global
+  );
+
+  assert.deepStrictEqual(
+    vm.compileFunction(
+      'return global',
+      []
+    )(),
+    global
+  );
+
   // Resetting value
   Error.stackTraceLimit = oldLimit;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/nodejs/node/issues/23194

The `ContextifyContext::CompileFunction` function was accidentally passing the wrong context variable into `ScriptCompiler::CompileFunctionInContext` this resulted in the incorrect context being passed to the compiled function.

You can quickly test this with the following code:

```js
const vm = require('vm')

const name = 'world'
const parsingContext = vm.createContext({ name: 'world' })

const code = `return 'hello ' + name`

const fn = vm.compileFunction(code, [], { parsingContext })

console.log(fn())
```

With Node v10.10.0 I get the following output:

```
:1
return 'hello ' + name
                  ^

ReferenceError: name is not defined
    at <anonymous>:1:19
    at Object.<anonymous> (/Users/dara/mydev/vmtest/index.js:10:13)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:696:3)
```

With the proposed changes, the output is `hello world`.

I also edited the description of the `parsingContext` option in the docs to explicitly use the word `contextified`. The docs use this word everywhere else when referring to a context object.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
