### PR TITLE
tls: update source, related test & doc for ArrayBuffer/DataView

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -886,7 +886,7 @@ changes:
     verification fails; `err.code` contains the OpenSSL error code. **Default:**
     `true`.
   * `ALPNProtocols`: {string[]|Buffer[]|TypedArray[]|DataView[]|Buffer|
-  TypedArray|DataView}
+    TypedArray|DataView}
     An array of strings, `Buffer`s or `TypedArray`s or `DataView`s, or a 
     single `Buffer` or `TypedArray` or `DataView` containing the supported ALPN 
     protocols. `Buffer`s should have the format `[len][name][len][name]...` 
@@ -1141,7 +1141,7 @@ changes:
 
 * `options` {Object}
   * `ALPNProtocols`: {string[]|Buffer[]|TypedArray[]|DataView[]|Buffer| 
-  TypedArray|DataView}
+    TypedArray|DataView}
     An array of strings, `Buffer`s or `TypedArray`s or `DataView`s, or a single 
     `Buffer` or `TypedArray` or `DataView` containing the supported ALPN 
     protocols. `Buffer`s should have the format `[len][name][len][name]...` 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -856,7 +856,8 @@ changes:
     description: The `lookup` option is supported now.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11984
-    description: The `ALPNProtocols` option can be a `Uint8Array` now.
+    description: The `ALPNProtocols` option can be a `TypedArray` or 
+     `DataView` now.
   - version: v5.3.0, v4.7.0
     pr-url: https://github.com/nodejs/node/pull/4246
     description: The `secureContext` option is supported now.
@@ -884,12 +885,14 @@ changes:
     verified against the list of supplied CAs. An `'error'` event is emitted if
     verification fails; `err.code` contains the OpenSSL error code. **Default:**
     `true`.
-  * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
-    An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
-    `Uint8Array` containing the supported ALPN protocols. `Buffer`s should have
-    the format `[len][name][len][name]...` e.g. `0x05hello0x05world`, where the
-    first byte is the length of the next protocol name. Passing an array is
-    usually much simpler, e.g. `['hello', 'world']`.
+  * `ALPNProtocols`: {string[]|Buffer[]|TypedArray[]|DataView[]|Buffer|
+  TypedArray|DataView}
+    An array of strings, `Buffer`s or `TypedArray`s or `DataView`s, or a 
+    single `Buffer` or `TypedArray` or `DataView` containing the supported ALPN 
+    protocols. `Buffer`s should have the format `[len][name][len][name]...` 
+    e.g. `0x05hello0x05world`, where the first byte is the length of the next 
+    protocol name. Passing an array is usually much simpler, e.g. 
+    `['hello', 'world']`.
   * `servername`: {string} Server name for the SNI (Server Name Indication) TLS
     extension.
   * `checkServerIdentity(servername, cert)` {Function} A callback function
@@ -1129,20 +1132,22 @@ changes:
     description: The `options` parameter can now include `clientCertEngine`.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11984
-    description: The `ALPNProtocols` option can be a `Uint8Array` now.
+    description: The `ALPNProtocols` option can be a `TypedArray` or 
+     `DataView` now.
   - version: v5.0.0
     pr-url: https://github.com/nodejs/node/pull/2564
     description: ALPN options are supported now.
 -->
 
 * `options` {Object}
-  * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
-    An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
-    `Uint8Array` containing the supported ALPN protocols. `Buffer`s should have
-    the format `[len][name][len][name]...` e.g. `0x05hello0x05world`, where the
-    first byte is the length of the next protocol name. Passing an array is
-    usually much simpler, e.g. `['hello', 'world']`.
-    (Protocols should be ordered by their priority.)
+  * `ALPNProtocols`: {string[]|Buffer[]|TypedArray[]|DataView[]|Buffer| 
+  TypedArray|DataView}
+    An array of strings, `Buffer`s or `TypedArray`s or `DataView`s, or a single 
+    `Buffer` or `TypedArray` or `DataView` containing the supported ALPN 
+    protocols. `Buffer`s should have the format `[len][name][len][name]...` 
+    e.g. `0x05hello0x05world`, where the first byte is the length of the next 
+    protocol name. Passing an array is usually much simpler, e.g. 
+    `['hello', 'world']`. (Protocols should be ordered by their priority.)
   * `clientCertEngine` {string} Name of an OpenSSL engine which can provide the
     client certificate.
   * `handshakeTimeout` {number} Abort the connection if the SSL/TLS handshake

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -25,7 +25,7 @@ const { ERR_TLS_CERT_ALTNAME_INVALID } = require('internal/errors').codes;
 const internalUtil = require('internal/util');
 const internalTLS = require('internal/tls');
 internalUtil.assertCrypto();
-const { isUint8Array } = require('internal/util/types');
+const { isArrayBufferView } = require('internal/util/types');
 
 const net = require('net');
 const url = require('url');
@@ -79,7 +79,7 @@ exports.convertALPNProtocols = function convertALPNProtocols(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
     out.ALPNProtocols = convertProtocols(protocols);
-  } else if (isUint8Array(protocols)) {
+  } else if (isArrayBufferView(protocols)) {
     // Copy new buffer not to be modified by user.
     out.ALPNProtocols = Buffer.from(protocols);
   }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -94,8 +94,11 @@ common.expectsError(
 }
 
 {
-  const buffer = new Uint8Array(Buffer.from('abcd'));
-  const out = {};
-  tls.convertALPNProtocols(buffer, out);
-  assert(out.ALPNProtocols.equals(Buffer.from('abcd')));
+  const arrayBufferViewStr = 'abcd';
+  const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
+  for (const expectView of common.getArrayBufferViews(inputBuffer)) {
+    const out = {};
+    tls.convertALPNProtocols(expectView, out);
+    assert(out.ALPNProtocols.equals(Buffer.from(expectView)));
+  }
 }


### PR DESCRIPTION
Refs: #1826

Referring to [the comment in "mentor-available" #1826](https://github.com/nodejs/node/issues/1826#issuecomment-410487110), this PR tries out the `tls` item from the checklist of the comment: (Thanks for your review!)

* use `isArrayBufferView` in place of `isUint8Array`
* update test code in "test-tls-basic-validations.js"
* update `tls.md` doc.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
