### PR TITLE
Fixed minor typo (to early -> too early)

### DIFF
--- a/doc/guides/diagnostic-tooling-support-tiers.md
+++ b/doc/guides/diagnostic-tooling-support-tiers.md
@@ -143,6 +143,6 @@ The tools are currently assigned to Tiers as follows:
  | Profiling | DTrace                    | No                            | Partial                 |     3       |
  | Profiling | Windows Xperf             | No                            | ?                       |     ?       |
  | Profiling | 0x                        | No                            | No                      |     4       |
- | Profiling | node-clinic               | No                            | No                      | to early    |
+ | Profiling | node-clinic               | No                            | No                      | too early   |
  | F/P/T     | appmetrics                | No                            | No                      |     ?       |
  | M/T       | eBPF tracing tool         | No                            | No                      |     ?       |

--- a/doc/guides/maintaining-the-build-files.md
+++ b/doc/guides/maintaining-the-build-files.md
@@ -17,7 +17,7 @@ There are three main build files that may be directly run when building Node.js:
 - `vcbuild.bat`: A Windows Batch Script that locates build tools, provides a
   subset of the targets available in the [Makefile](#makefile), and a few
   targets of its own. For a detailed guide on this script, see
-  [vcbuild.bat](#vcbuild.bat).
+  [vcbuild.bat](#vcbuildbat).
 - `Makefile`: A Makefile that can be run with GNU Make. It provides a set of
   targets that build and test the Node.js binary, produce releases and
   documentation, and interact with the CI to run benchmarks or tests. For a
@@ -41,7 +41,7 @@ need to update the configuration process.
 
 To see the help text, run `make help`. This file is not generated, it is
 maintained by humans. Note that this is not usually run on Windows, where
-[vcbuild.bat](#vcbuild.bat) is used instead.
+[vcbuild.bat](#vcbuildbat) is used instead.
 
 ### Options
 


### PR DESCRIPTION
Small change, fixed a typo from 'to early' to 'too early'.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
