### PR TITLE
crypto: set `DEFAULT_ENCODING` property to non-enumerable

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -230,7 +230,7 @@ Object.defineProperties(exports, {
       fipsForced ? setFipsForced : setFipsCrypto
   },
   DEFAULT_ENCODING: {
-    enumerable: true,
+    enumerable: false,
     configurable: true,
     get: deprecate(getDefaultEncoding,
                    'crypto.DEFAULT_ENCODING is deprecated.', 'DEP0091'),


### PR DESCRIPTION
Since it is a deprecated API, a deprecation warning is printed when
loading crypto module from ESM. Making it non enumerable removes the
deprecation warning and makes the API non-available to named imports.

Fixes: https://github.com/nodejs/node/issues/23203

The `Credentials` API was already removed by https://github.com/nodejs/node/pull/21153.

It is a breaking change, but IMHO it should be integrated to Node 11 before it's released as it is a minor semver change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
