### PR TITLE
[v8.x] backport some assert commits

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -635,18 +635,21 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `error` parameter can now be an object as well.
   - version: v4.2.0
     pr-url: https://github.com/nodejs/node/pull/3276
     description: The `error` parameter can now be an arrow function.
 -->
 * `block` {Function}
-* `error` {RegExp|Function}
+* `error` {RegExp|Function|object}
 * `message` {any}
 
 Expects the function `block` to throw an error.
 
-If specified, `error` can be a constructor, [`RegExp`][], or validation
-function.
+If specified, `error` can be a constructor, [`RegExp`][], a validation
+function, or an object where each property will be tested for.
 
 If specified, `message` will be the message provided by the `AssertionError` if
 the block fails to throw.
@@ -686,6 +689,23 @@ assert.throws(
     }
   },
   'unexpected error'
+);
+```
+
+Custom error object / error instance:
+
+```js
+assert.throws(
+  () => {
+    const err = new TypeError('Wrong value');
+    err.code = 404;
+    throw err;
+  },
+  {
+    name: 'TypeError',
+    message: 'Wrong value'
+    // Note that only properties on the error object will be tested!
+  }
 );
 ```
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -691,16 +691,41 @@ assert.throws(
 
 Note that `error` can not be a string. If a string is provided as the second
 argument, then `error` is assumed to be omitted and the string will be used for
-`message` instead. This can lead to easy-to-miss mistakes:
+`message` instead. This can lead to easy-to-miss mistakes. Please read the
+example below carefully if using a string as the second argument gets
+considered:
 
 <!-- eslint-disable no-restricted-syntax -->
 ```js
-// THIS IS A MISTAKE! DO NOT DO THIS!
-assert.throws(myFunction, 'missing foo', 'did not throw with expected message');
+function throwingFirst() {
+  throw new Error('First');
+}
+function throwingSecond() {
+  throw new Error('Second');
+}
+function notThrowing() {}
 
-// Do this instead.
-assert.throws(myFunction, /missing foo/, 'did not throw with expected message');
+// The second argument is a string and the input function threw an Error.
+// In that case both cases do not throw as neither is going to try to
+// match for the error message thrown by the input function!
+assert.throws(throwingFirst, 'Second');
+assert.throws(throwingSecond, 'Second');
+
+// The string is only used (as message) in case the function does not throw:
+assert.throws(notThrowing, 'Second');
+// AssertionError [ERR_ASSERTION]: Missing expected exception: Second
+
+// If it was intended to match for the error message do this instead:
+assert.throws(throwingSecond, /Second$/);
+// Does not throw because the error messages match.
+assert.throws(throwingFirst, /Second$/);
+// Throws a error:
+// Error: First
+//     at throwingFirst (repl:2:9)
 ```
+
+Due to the confusing notation, it is recommended not to use a string as the
+second argument. This might lead to difficult-to-spot errors.
 
 ## Caveats
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -7,6 +7,57 @@
 The `assert` module provides a simple set of assertion tests that can be used to
 test invariants.
 
+A `strict` and a `legacy` mode exist, while it is recommended to only use
+[`strict mode`][].
+
+For more information about the used equality comparisons see
+[MDN's guide on equality comparisons and sameness][mdn-equality-guide].
+
+## Strict mode
+<!-- YAML
+added: REPLACEME
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17002
+    description: Added strict mode to the assert module.
+-->
+
+When using the `strict mode`, any `assert` function will use the equality used in
+the strict function mode. So [`assert.deepEqual()`][] will, for example, work the
+same as [`assert.deepStrictEqual()`][].
+
+It can be accessed using:
+
+```js
+const assert = require('assert').strict;
+```
+
+## Legacy mode
+
+> Stability: 0 - Deprecated: Use strict mode instead.
+
+When accessing `assert` directly instead of using the `strict` property, the
+[Abstract Equality Comparison][] will be used for any function without a
+"strict" in its name (e.g. [`assert.deepEqual()`][]).
+
+It can be accessed using:
+
+```js
+const assert = require('assert');
+```
+
+It is recommended to use the [`strict mode`][] instead as the
+[Abstract Equality Comparison][] can often have surprising results. Especially
+in case of [`assert.deepEqual()`][] as the used comparison rules there are very
+lax.
+
+E.g.
+
+```js
+// WARNING: This does not throw an AssertionError!
+assert.deepEqual(/a/gi, new Date());
+```
+
 ## assert(value[, message])
 <!-- YAML
 added: v0.5.9
@@ -36,6 +87,14 @@ changes:
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
+
+**Strict mode**
+
+An alias of [`assert.deepStrictEqual()`][].
+
+**Legacy mode**
+
+> Stability: 0 - Deprecated: Use [`assert.deepStrictEqual()`][] instead.
 
 Tests for deep equality between the `actual` and `expected` parameters.
 Primitive values are compared with the [Abstract Equality Comparison][]
@@ -126,16 +185,26 @@ changes:
 
 Generally identical to `assert.deepEqual()` with a few exceptions:
 
-1. Primitive values are compared using the [Strict Equality Comparison][]
-  ( `===` ). Set values and Map keys are compared using the [SameValueZero][]
+### Comparison details
+
+* Primitive values are compared using the [Strict Equality Comparison][]
+  ( `===` ).
+* Set values and Map keys are compared using the [SameValueZero][]
   comparison. (Which means they are free of the [caveats][]).
-2. [`[[Prototype]]`][prototype-spec] of objects are compared using
-  the [Strict Equality Comparison][] too.
-3. [Type tags][Object.prototype.toString()] of objects should be the same.
-4. [Object wrappers][] are compared both as objects and unwrapped values.
+* [Type tags][Object.prototype.toString()] of objects should be the same.
+* [`[[Prototype]]`][prototype-spec] of objects are compared using
+  the [Strict Equality Comparison][].
+* Only [enumerable "own" properties][] are considered.
+* [`Error`][] messages are always compared, even though this property is
+  non-enumerable.
+* [Object wrappers][] are compared both as objects and unwrapped values.
+* Object properties are compared unordered.
+* Map keys and Set items are compared unordered.
+* Recursion stops when both sides differ or both sides encounter a circular
+  reference.
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.deepEqual({ a: 1 }, { a: '1' });
 // OK, because 1 == '1'
@@ -251,6 +320,14 @@ added: v0.1.21
 * `expected` {any}
 * `message` {any}
 
+**Strict mode**
+
+An alias of [`assert.strictEqual()`][].
+
+**Legacy mode**
+
+> Stability: 0 - Deprecated: Use [`assert.strictEqual()`][] instead.
+
 Tests shallow, coercive equality between the `actual` and `expected` parameters
 using the [Abstract Equality Comparison][] ( `==` ).
 
@@ -292,7 +369,7 @@ If `stackStartFunction` is provided, all stack frames above that function will
 be removed from stacktrace (see [`Error.captureStackTrace`]).
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.fail(1, 2, undefined, '>');
 // AssertionError [ERR_ASSERTION]: 1 > 2
@@ -340,7 +417,7 @@ Throws `value` if `value` is truthy. This is useful when testing the `error`
 argument in callbacks.
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.ifError(null);
 // OK
@@ -361,6 +438,14 @@ added: v0.1.21
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
+
+**Strict mode**
+
+An alias of [`assert.notDeepStrictEqual()`][].
+
+**Legacy mode**
+
+> Stability: 0 - Deprecated: Use [`assert.notDeepStrictEqual()`][] instead.
 
 Tests for any deep inequality. Opposite of [`assert.deepEqual()`][].
 
@@ -412,7 +497,7 @@ added: v1.2.0
 Tests for deep strict inequality. Opposite of [`assert.deepStrictEqual()`][].
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.notDeepEqual({ a: 1 }, { a: '1' });
 // AssertionError: { a: 1 } notDeepEqual { a: '1' }
@@ -432,6 +517,14 @@ added: v0.1.21
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
+
+**Strict mode**
+
+An alias of [`assert.notStrictEqual()`][].
+
+**Legacy mode**
+
+> Stability: 0 - Deprecated: Use [`assert.notStrictEqual()`][] instead.
 
 Tests shallow, coercive inequality with the [Abstract Equality Comparison][]
 ( `!=` ).
@@ -465,7 +558,7 @@ Tests strict inequality as determined by the [Strict Equality Comparison][]
 ( `!==` ).
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.notStrictEqual(1, 2);
 // OK
@@ -496,7 +589,7 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is `undefined`, a default error message is assigned.
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.ok(true);
 // OK
@@ -522,7 +615,7 @@ Tests strict equality as determined by the [Strict Equality Comparison][]
 ( `===` ).
 
 ```js
-const assert = require('assert');
+const assert = require('assert').strict;
 
 assert.strictEqual(1, 2);
 // AssertionError: 1 === 2
@@ -643,8 +736,12 @@ For more information, see
 [`TypeError`]: errors.html#errors_class_typeerror
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
 [`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message
+[`assert.notDeepStrictEqual()`]: #assert_assert_notdeepstrictequal_actual_expected_message
+[`assert.notStrictEqual()`]: #assert_assert_notstrictequal_actual_expected_message
 [`assert.ok()`]: #assert_assert_ok_value_message
+[`assert.strictEqual()`]: #assert_assert_strictequal_actual_expected_message
 [`assert.throws()`]: #assert_assert_throws_block_error_message
+[`strict mode`]: #assert_strict_mode
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
 [Object.prototype.toString()]: https://tc39.github.io/ecma262/#sec-object.prototype.tostring
 [SameValueZero]: https://tc39.github.io/ecma262/#sec-samevaluezero

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -684,6 +684,15 @@ Type: Runtime
 cause a lot of issues. See https://github.com/nodejs/node/issues/14328 for more
 details.
 
+<a id="DEP0089"></a>
+### DEP0089: require('assert')
+
+Type: Documentation-only
+
+Importing assert directly is not recommended as the exposed functions will use
+loose equality checks. Use `require('assert').strict` instead. The API is the
+same as the legacy assert but it will always use strict equality checks.
+
 <a id="DEP0098"></a>
 ### DEP0098: AsyncHooks Embedder AsyncResource.emit{Before,After} APIs
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,6 +25,7 @@ const { isSet, isMap, isDate, isRegExp } = process.binding('util');
 const { objectToString } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const errors = require('internal/errors');
+const { inspect } = require('util');
 
 // The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
@@ -660,10 +661,44 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function expectedException(actual, expected) {
+function createMsg(msg, key, actual, expected) {
+  if (msg)
+    return msg;
+  return `${key}: expected ${inspect(expected[key])}, ` +
+    `not ${inspect(actual[key])}`;
+}
+
+function expectedException(actual, expected, msg) {
   if (typeof expected !== 'function') {
-    // Should be a RegExp, if not fail hard
-    return expected.test(actual);
+    if (expected instanceof RegExp)
+      return expected.test(actual);
+    // assert.doesNotThrow does not accept objects.
+    if (arguments.length === 2) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'expected',
+                                 ['Function', 'RegExp'], expected);
+    }
+    // The name and message could be non enumerable. Therefore test them
+    // explicitly.
+    if ('name' in expected) {
+      assert.strictEqual(
+        actual.name,
+        expected.name,
+        createMsg(msg, 'name', actual, expected));
+    }
+    if ('message' in expected) {
+      assert.strictEqual(
+        actual.message,
+        expected.message,
+        createMsg(msg, 'message', actual, expected));
+    }
+    const keys = Object.keys(expected);
+    for (const key of keys) {
+      assert.deepStrictEqual(
+        actual[key],
+        expected[key],
+        createMsg(msg, key, actual, expected));
+    }
+    return true;
   }
   // Guard instanceof against arrow functions as they don't have a prototype.
   if (expected.prototype !== undefined && actual instanceof expected) {
@@ -716,7 +751,7 @@ assert.throws = function throws(block, error, message) {
       stackStartFn: throws
     });
   }
-  if (error && expectedException(actual, error) === false) {
+  if (error && expectedException(actual, error, message) === false) {
     throw actual;
   }
 };

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -661,11 +661,17 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function createMsg(msg, key, actual, expected) {
-  if (msg)
-    return msg;
-  return `${key}: expected ${inspect(expected[key])}, ` +
-    `not ${inspect(actual[key])}`;
+function compareExceptionKey(actual, expected, key, msg) {
+  if (!innerDeepEqual(actual[key], expected[key], true)) {
+    innerFail({
+      actual: actual[key],
+      expected: expected[key],
+      message: msg || `${key}: expected ${inspect(expected[key])}, ` +
+                      `not ${inspect(actual[key])}`,
+      operator: 'throws',
+      stackStartFn: assert.throws
+    });
+  }
 }
 
 function expectedException(actual, expected, msg) {
@@ -680,23 +686,13 @@ function expectedException(actual, expected, msg) {
     // The name and message could be non enumerable. Therefore test them
     // explicitly.
     if ('name' in expected) {
-      assert.strictEqual(
-        actual.name,
-        expected.name,
-        createMsg(msg, 'name', actual, expected));
+      compareExceptionKey(actual, expected, 'name', msg);
     }
     if ('message' in expected) {
-      assert.strictEqual(
-        actual.message,
-        expected.message,
-        createMsg(msg, 'message', actual, expected));
+      compareExceptionKey(actual, expected, 'message', msg);
     }
-    const keys = Object.keys(expected);
-    for (const key of keys) {
-      assert.deepStrictEqual(
-        actual[key],
-        expected[key],
-        createMsg(msg, key, actual, expected));
+    for (const key of Object.keys(expected)) {
+      compareExceptionKey(actual, expected, key, msg);
     }
     return true;
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -643,7 +643,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         details += ` (${expected.name})`;
       }
       details += message ? `: ${message}` : '.';
-      fail(actual, expected, `Missing expected exception${details}`, fail);
+      fail(actual, expected, `Missing expected exception${details}`, 'throws');
     }
     if (expected && expectedException(actual, expected) === false) {
       throw actual;
@@ -651,7 +651,10 @@ function innerThrows(shouldThrow, block, expected, message) {
   } else if (actual !== undefined) {
     if (!expected || expectedException(actual, expected)) {
       details = message ? `: ${message}` : '.';
-      fail(actual, expected, `Got unwanted exception${details}`, fail);
+      fail(actual,
+           expected,
+           `Got unwanted exception${details}`,
+           'doesNotThrow');
     }
     throw actual;
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -709,7 +709,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         expected,
         operator: 'throws',
         message: `Missing expected exception${details}`,
-        stackStartFn: innerThrows
+        stackStartFn: assert.throws
       });
     }
     if (expected && expectedException(actual, expected) === false) {
@@ -723,7 +723,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         expected,
         operator: 'doesNotThrow',
         message: `Got unwanted exception${details}`,
-        stackStartFn: innerThrows
+        stackStartFn: assert.doesNotThrow
       });
     }
     throw actual;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -675,7 +675,11 @@ function expectedException(actual, expected) {
   return expected.call({}, actual) === true;
 }
 
-function tryBlock(block) {
+function getActual(block) {
+  if (typeof block !== 'function') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
+                               block);
+  }
   try {
     block();
   } catch (e) {
@@ -683,60 +687,61 @@ function tryBlock(block) {
   }
 }
 
-function innerThrows(shouldThrow, block, expected, message) {
-  var details = '';
-
-  if (typeof block !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'function',
-                               block);
-  }
-
-  if (typeof expected === 'string') {
-    message = expected;
-    expected = null;
-  }
-
-  const actual = tryBlock(block);
-
-  if (shouldThrow === true) {
-    if (actual === undefined) {
-      if (expected && expected.name) {
-        details += ` (${expected.name})`;
-      }
-      details += message ? `: ${message}` : '.';
-      innerFail({
-        actual,
-        expected,
-        operator: 'throws',
-        message: `Missing expected exception${details}`,
-        stackStartFn: assert.throws
-      });
-    }
-    if (expected && expectedException(actual, expected) === false) {
-      throw actual;
-    }
-  } else if (actual !== undefined) {
-    if (!expected || expectedException(actual, expected)) {
-      details = message ? `: ${message}` : '.';
-      innerFail({
-        actual,
-        expected,
-        operator: 'doesNotThrow',
-        message: `Got unwanted exception${details}`,
-        stackStartFn: assert.doesNotThrow
-      });
-    }
-    throw actual;
-  }
-}
-
 // Expected to throw an error.
 assert.throws = function throws(block, error, message) {
-  innerThrows(true, block, error, message);
+  const actual = getActual(block);
+
+  if (typeof error === 'string') {
+    if (arguments.length === 3)
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'error',
+                                 ['Function', 'RegExp'],
+                                 error);
+
+    message = error;
+    error = null;
+  }
+
+  if (actual === undefined) {
+    let details = '';
+    if (error && error.name) {
+      details += ` (${error.name})`;
+    }
+    details += message ? `: ${message}` : '.';
+    innerFail({
+      actual,
+      expected: error,
+      operator: 'throws',
+      message: `Missing expected exception${details}`,
+      stackStartFn: throws
+    });
+  }
+  if (error && expectedException(actual, error) === false) {
+    throw actual;
+  }
 };
 
 assert.doesNotThrow = function doesNotThrow(block, error, message) {
-  innerThrows(false, block, error, message);
+  const actual = getActual(block);
+  if (actual === undefined)
+    return;
+
+  if (typeof error === 'string') {
+    message = error;
+    error = null;
+  }
+
+  if (!error || expectedException(actual, error)) {
+    const details = message ? `: ${message}` : '.';
+    innerFail({
+      actual,
+      expected: error,
+      operator: 'doesNotThrow',
+      message: `Got unwanted exception${details}\n${actual.message}`,
+      stackStartFn: doesNotThrow
+    });
+  }
+  throw actual;
 };
 
 assert.ifError = function ifError(err) { if (err) throw err; };

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -783,7 +783,15 @@ assert.ifError = function ifError(err) { if (err) throw err; };
 
 // Expose a strict only variant of assert
 function strict(value, message) {
-  if (!value) innerFail(value, true, message, '==', strict);
+  if (!value) {
+    innerFail({
+      actual: value,
+      expected: true,
+      message,
+      operator: '==',
+      stackStartFn: strict
+    });
+  }
 }
 assert.strict = Object.assign(strict, assert, {
   equal: assert.strictEqual,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -667,3 +667,15 @@ assert.doesNotThrow = function doesNotThrow(block, error, message) {
 };
 
 assert.ifError = function ifError(err) { if (err) throw err; };
+
+// Expose a strict only variant of assert
+function strict(value, message) {
+  if (!value) innerFail(value, true, message, '==', strict);
+}
+assert.strict = Object.assign(strict, assert, {
+  equal: assert.strictEqual,
+  deepEqual: assert.deepStrictEqual,
+  notEqual: assert.notStrictEqual,
+  notDeepEqual: assert.notDeepStrictEqual
+});
+assert.strict.strict = assert.strict;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -38,22 +38,26 @@ const assert = module.exports = ok;
 // both the actual and expected values to the assertion error for
 // display purposes.
 
-function innerFail(actual, expected, message, operator, stackStartFunction) {
-  throw new errors.AssertionError({
-    message,
-    actual,
-    expected,
-    operator,
-    stackStartFunction
-  });
+function innerFail(obj) {
+  throw new errors.AssertionError(obj);
 }
 
-function fail(actual, expected, message, operator, stackStartFunction) {
-  if (arguments.length === 1)
+function fail(actual, expected, message, operator, stackStartFn) {
+  const argsLen = arguments.length;
+
+  if (argsLen === 1) {
     message = actual;
-  if (arguments.length === 2)
+  } else if (argsLen === 2) {
     operator = '!=';
-  innerFail(actual, expected, message, operator, stackStartFunction || fail);
+  }
+
+  innerFail({
+    actual,
+    expected,
+    message,
+    operator,
+    stackStartFn: stackStartFn || fail
+  });
 }
 assert.fail = fail;
 
@@ -67,7 +71,15 @@ assert.AssertionError = errors.AssertionError;
 // Pure assertion tests whether a value is truthy, as determined
 // by !!value.
 function ok(value, message) {
-  if (!value) innerFail(value, true, message, '==', ok);
+  if (!value) {
+    innerFail({
+      actual: value,
+      expected: true,
+      message,
+      operator: '==',
+      stackStartFn: ok
+    });
+  }
 }
 assert.ok = ok;
 
@@ -75,7 +87,15 @@ assert.ok = ok;
 /* eslint-disable no-restricted-properties */
 assert.equal = function equal(actual, expected, message) {
   // eslint-disable-next-line eqeqeq
-  if (actual != expected) innerFail(actual, expected, message, '==', equal);
+  if (actual != expected) {
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '==',
+      stackStartFn: equal
+    });
+  }
 };
 
 // The non-equality assertion tests for whether two objects are not
@@ -83,21 +103,39 @@ assert.equal = function equal(actual, expected, message) {
 assert.notEqual = function notEqual(actual, expected, message) {
   // eslint-disable-next-line eqeqeq
   if (actual == expected) {
-    innerFail(actual, expected, message, '!=', notEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '!=',
+      stackStartFn: notEqual
+    });
   }
 };
 
 // The equivalence assertion tests a deep equality relation.
 assert.deepEqual = function deepEqual(actual, expected, message) {
   if (!innerDeepEqual(actual, expected, false)) {
-    innerFail(actual, expected, message, 'deepEqual', deepEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: 'deepEqual',
+      stackStartFn: deepEqual
+    });
   }
 };
 /* eslint-enable */
 
 assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
   if (!innerDeepEqual(actual, expected, true)) {
-    innerFail(actual, expected, message, 'deepStrictEqual', deepStrictEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: 'deepStrictEqual',
+      stackStartFn: deepStrictEqual
+    });
   }
 };
 
@@ -572,22 +610,39 @@ function objEquiv(a, b, strict, keys, memos) {
 // The non-equivalence assertion tests for any deep inequality.
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (innerDeepEqual(actual, expected, false)) {
-    innerFail(actual, expected, message, 'notDeepEqual', notDeepEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: 'notDeepEqual',
+      stackStartFn: notDeepEqual
+    });
   }
 };
 
 assert.notDeepStrictEqual = notDeepStrictEqual;
 function notDeepStrictEqual(actual, expected, message) {
   if (innerDeepEqual(actual, expected, true)) {
-    innerFail(actual, expected, message, 'notDeepStrictEqual',
-              notDeepStrictEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: 'notDeepStrictEqual',
+      stackStartFn: notDeepStrictEqual
+    });
   }
 }
 
 // The strict equality assertion tests strict equality, as determined by ===.
 assert.strictEqual = function strictEqual(actual, expected, message) {
   if (actual !== expected) {
-    innerFail(actual, expected, message, '===', strictEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '===',
+      stackStartFn: strictEqual
+    });
   }
 };
 
@@ -595,7 +650,13 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
 // determined by !==.
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   if (actual === expected) {
-    innerFail(actual, expected, message, '!==', notStrictEqual);
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '!==',
+      stackStartFn: notStrictEqual
+    });
   }
 };
 
@@ -643,7 +704,13 @@ function innerThrows(shouldThrow, block, expected, message) {
         details += ` (${expected.name})`;
       }
       details += message ? `: ${message}` : '.';
-      fail(actual, expected, `Missing expected exception${details}`, 'throws');
+      innerFail({
+        actual,
+        expected,
+        operator: 'throws',
+        message: `Missing expected exception${details}`,
+        stackStartFn: innerThrows
+      });
     }
     if (expected && expectedException(actual, expected) === false) {
       throw actual;
@@ -651,10 +718,13 @@ function innerThrows(shouldThrow, block, expected, message) {
   } else if (actual !== undefined) {
     if (!expected || expectedException(actual, expected)) {
       details = message ? `: ${message}` : '.';
-      fail(actual,
-           expected,
-           `Got unwanted exception${details}`,
-           'doesNotThrow');
+      innerFail({
+        actual,
+        expected,
+        operator: 'doesNotThrow',
+        message: `Got unwanted exception${details}`,
+        stackStartFn: innerThrows
+      });
     }
     throw actual;
   }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -80,7 +80,7 @@ class AssertionError extends Error {
     if (typeof options !== 'object' || options === null) {
       throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
     }
-    var { actual, expected, message, operator, stackStartFunction } = options;
+    var { actual, expected, message, operator, stackStartFn } = options;
     if (message) {
       super(message);
     } else {
@@ -99,7 +99,7 @@ class AssertionError extends Error {
     this.actual = actual;
     this.expected = expected;
     this.operator = operator;
-    Error.captureStackTrace(this, stackStartFunction);
+    Error.captureStackTrace(this, stackStartFn);
   }
 }
 

--- a/test/message/assert_throws_stack.js
+++ b/test/message/assert_throws_stack.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert').strict;
+
+assert.throws(() => { throw new Error('foo'); }, { bar: true });

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -1,0 +1,14 @@
+assert.js:*
+  throw new errors.AssertionError(obj);
+  ^
+
+AssertionError [ERR_ASSERTION]: bar: expected true, not undefined
+    at Object.<anonymous> (*assert_throws_stack.js:*:*)
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -1,6 +1,6 @@
 Exiting with code=1
 assert.js:*
-  throw new errors.AssertionError({
+  throw new errors.AssertionError(obj);
   ^
 
 AssertionError [ERR_ASSERTION]: 1 === 2

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -696,3 +696,22 @@ common.expectsError(
     message: /^'Error: foo' === 'Error: foobar'$/
   }
 );
+
+// Test strict assert
+{
+  const a = require('assert');
+  const assert = require('assert').strict;
+  /* eslint-disable no-restricted-properties */
+  assert.throws(() => assert.equal(1, true), assert.AssertionError);
+  assert.notEqual(0, false);
+  assert.throws(() => assert.deepEqual(1, true), assert.AssertionError);
+  assert.notDeepEqual(0, false);
+  assert.equal(assert.strict, assert.strict.strict);
+  assert.equal(assert.equal, assert.strictEqual);
+  assert.equal(assert.deepEqual, assert.deepStrictEqual);
+  assert.equal(assert.notEqual, assert.notStrictEqual);
+  assert.equal(assert.notDeepEqual, assert.notDeepStrictEqual);
+  assert.equal(Object.keys(assert).length, Object.keys(a).length);
+  /* eslint-enable no-restricted-properties */
+  assert(7);
+}

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -603,6 +603,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
   } catch (e) {
     threw = true;
     assert.strictEqual(e.message, 'Missing expected exception.');
+    assert.ok(!e.stack.includes('throws'), e.stack);
   }
   assert.ok(threw);
 }
@@ -619,8 +620,8 @@ try {
   assert.strictEqual(1, 2, 'oh no'); // eslint-disable-line no-restricted-syntax
 } catch (e) {
   assert.strictEqual(e.message.split('\n')[0], 'oh no');
-  // Message should not be marked as generated.
-  assert.strictEqual(e.generatedMessage, false);
+  assert.strictEqual(e.generatedMessage, false,
+                     'Message incorrectly marked as generated');
 }
 
 {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -721,3 +721,12 @@ common.expectsError(
   /* eslint-enable no-restricted-properties */
   assert(7);
 }
+
+common.expectsError(
+  () => assert.ok(null),
+  {
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'null == true'
+  }
+);

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -640,7 +640,7 @@ try {
       common.expectsError({
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "block" argument must be of type function. Received ' +
+        message: 'The "block" argument must be of type Function. Received ' +
                  `type ${typeName(block)}`
       })(e);
     }
@@ -729,5 +729,16 @@ common.expectsError(
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
     message: 'null == true'
+  }
+);
+
+common.expectsError(
+  // eslint-disable-next-line no-restricted-syntax
+  () => assert.throws(() => {}, 'Error message', 'message'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "error" argument must be one of type Function or RegExp. ' +
+             'Received type string'
   }
 );

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -711,6 +711,14 @@ common.expectsError(
   assert.equal(Object.keys(assert).length, Object.keys(a).length);
   /* eslint-enable no-restricted-properties */
   assert(7);
+  common.expectsError(
+    () => assert(),
+    {
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'undefined == true'
+    }
+  );
 }
 
 common.expectsError(

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -463,10 +463,15 @@ assert.throws(() => { assert.ifError(new Error('test error')); },
 assert.doesNotThrow(() => { assert.ifError(null); });
 assert.doesNotThrow(() => { assert.ifError(); });
 
-assert.throws(() => {
-  assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
-}, /Got unwanted exception: user message/,
-              'a.doesNotThrow ignores user message');
+common.expectsError(
+  () => assert.doesNotThrow(makeBlock(thrower, Error), 'user message'),
+  {
+    type: a.AssertionError,
+    code: 'ERR_ASSERTION',
+    operator: 'doesNotThrow',
+    message: 'Got unwanted exception: user message\n[object Object]'
+  }
+);
 
 // make sure that validating using constructor really works
 {
@@ -525,7 +530,8 @@ a.throws(makeBlock(thrower, TypeError), (err) => {
     () => { a.throws((noop)); },
     common.expectsError({
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception\.$/
+      message: /^Missing expected exception\.$/,
+      operator: 'throws'
     }));
 
   assert.throws(

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -36,16 +36,6 @@ assert.ok(a.AssertionError.prototype instanceof Error,
 
 assert.throws(makeBlock(a, false), a.AssertionError, 'ok(false)');
 
-// Using a object as second arg results in a failure
-assert.throws(
-  () => { assert.throws(() => { throw new Error(); }, { foo: 'bar' }); },
-  common.expectsError({
-    type: TypeError,
-    message: 'expected.test is not a function'
-  })
-);
-
-
 assert.doesNotThrow(makeBlock(a, true), a.AssertionError, 'ok(true)');
 
 assert.doesNotThrow(makeBlock(a, 'test', 'ok(\'test\')'));
@@ -742,3 +732,79 @@ common.expectsError(
              'Received type string'
   }
 );
+
+{
+  const errFn = () => {
+    const err = new TypeError('Wrong value');
+    err.code = 404;
+    throw err;
+  };
+  const errObj = {
+    name: 'TypeError',
+    message: 'Wrong value'
+  };
+  assert.throws(errFn, errObj);
+
+  errObj.code = 404;
+  assert.throws(errFn, errObj);
+
+  errObj.code = '404';
+  common.expectsError(
+  // eslint-disable-next-line no-restricted-syntax
+    () => assert.throws(errFn, errObj),
+    {
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'code: expected \'404\', not 404'
+    }
+  );
+
+  errObj.code = 404;
+  errObj.foo = 'bar';
+  common.expectsError(
+  // eslint-disable-next-line no-restricted-syntax
+    () => assert.throws(errFn, errObj),
+    {
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'foo: expected \'bar\', not undefined'
+    }
+  );
+
+  common.expectsError(
+    () => assert.throws(() => { throw new Error(); }, { foo: 'bar' }, 'foobar'),
+    {
+      type: assert.AssertionError,
+      code: 'ERR_ASSERTION',
+      message: 'foobar'
+    }
+  );
+
+  common.expectsError(
+    () => assert.doesNotThrow(() => { throw new Error(); }, { foo: 'bar' }),
+    {
+      type: TypeError,
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "expected" argument must be one of type Function or ' +
+               'RegExp. Received type object'
+    }
+  );
+
+  assert.throws(() => { throw new Error('e'); }, new Error('e'));
+  common.expectsError(
+    () => assert.throws(() => { throw new TypeError('e'); }, new Error('e')),
+    {
+      type: assert.AssertionError,
+      code: 'ERR_ASSERTION',
+      message: "name: expected 'Error', not 'TypeError'"
+    }
+  );
+  common.expectsError(
+    () => assert.throws(() => { throw new Error('foo'); }, new Error('')),
+    {
+      type: assert.AssertionError,
+      code: 'ERR_ASSERTION',
+      message: "message: expected '', not 'foo'"
+    }
+  );
+}


### PR DESCRIPTION
Using assert became much more friendly recently. As long as we still have the chance to get some commits into 8 I thought I go ahead and open a backport for these.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
