### PR TITLE
doc: add description for filehandle.write(string[, position[, encoding]])

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3939,6 +3939,37 @@ On Linux, positional writes do not work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
+#### filehandle.write(string[, position[, encoding]])
+<!-- YAML
+added: v10.0.0
+-->
+
+* `string` {string}
+* `position` {integer}
+* `encoding` {string} **Default:** `'utf8'`
+* Returns: {Promise}
+
+Write `string` to the file. If `string` is not a string, then
+the value will be coerced to one.
+
+The `Promise` is resolved with an object containing a `bytesWritten` property
+identifying the number of bytes written, and a `buffer` property containing
+a reference to the `string` written.
+
+`position` refers to the offset from the beginning of the file where this data
+should be written. If the type of `position` is not a `number` the data 
+will be written at the current position. See pwrite(2).
+
+`encoding` is the expected string encoding.
+
+It is unsafe to use `filehandle.write()` multiple times on the same file
+without waiting for the `Promise` to be resolved (or rejected). For this
+scenario, [`fs.createWriteStream()`][] is strongly recommended.
+
+On Linux, positional writes do not work when the file is opened in append mode.
+The kernel ignores the position argument and always appends the data to
+the end of the file.
+
 #### filehandle.writeFile(data, options)
 <!-- YAML
 added: v10.0.0


### PR DESCRIPTION
Hey folks, this PR adds missing docs for `filehandle.write(string[, position[, encoding]])` in the `fs.promises` API.

As per https://github.com/nodejs/node/issues/20406, only the buffer version of this API is documented right now.

One thing I wanted to ask. I believe the intention is to reconcile the Promise based API as much as possible with the callback based one. In the docs submitted with this PR, I described the `encoding` option has having the default value `utf8`. This is the behaviour in the callback based API. 

Based off the code [here](https://github.com/nodejs/node/blob/master/lib/internal/fs/promises.js#L252-L256). I don't think that's actually happening in the Promise based version.

I have two questions:

* Should the behaviour be modified such that a default value of `utf8` is used? I'd be delighted to provide a PR and some tests.
* Or should I just remove any mention of it from this PR?

Cheers!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
