### PR TITLE
crypto: make DEFAULT_ENCODING non-enumerable

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -230,7 +230,7 @@ Object.defineProperties(exports, {
       fipsForced ? setFipsForced : setFipsCrypto
   },
   DEFAULT_ENCODING: {
-    enumerable: true,
+    enumerable: false,
     configurable: true,
     get: deprecate(getDefaultEncoding,
                    'crypto.DEFAULT_ENCODING is deprecated.', 'DEP0091'),


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/23203.

Deprecated exports now need to always be non-enumerable - this pattern was established when we implemented named exports for Node core modules from ES Modules. Otherwise `import 'crypto'` will always give a deprecation warning for modules.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
