### PR TITLE
Revert "util: change util.inspect depth default"

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -183,10 +183,6 @@ property take precedence over `--trace-deprecation` and
 <!-- YAML
 added: v0.5.3
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17907
-    description: The `%o` specifier's `depth` option will now fall back to the
-                 default depth.
   - version: v8.4.0
     pr-url: https://github.com/nodejs/node/pull/14558
     description: The `%o` and `%O` specifiers are supported now.
@@ -365,9 +361,6 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/22846
-    description: The `depth` default changed to `20`.
-  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/22788
     description: The `sorted` option is supported now.
   - version: REPLACEME
@@ -408,7 +401,7 @@ changes:
   * `depth` {number} Specifies the number of times to recurse while formatting
     the `object`. This is useful for inspecting large complicated objects. To
     make it recurse up to the maximum call stack size pass `Infinity` or `null`.
-    **Default:** `20`.
+    **Default:** `2`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.
@@ -465,23 +458,12 @@ util.inspect(new Bar()); // 'Bar {}'
 util.inspect(baz);       // '[foo] {}'
 ```
 
-The following example limits the inspected output of the `paths` property:
+The following example inspects all properties of the `util` object:
 
 ```js
 const util = require('util');
 
-console.log(util.inspect(module, { depth: 0 }));
-// Instead of showing all entries in `paths` `[Array]` is used to limit the
-// output for readability:
-
-// Module {
-//   id: '<repl>',
-//   exports: {},
-//   parent: undefined,
-//   filename: null,
-//   loaded: false,
-//   children: [],
-//   paths: [Array] }
+console.log(util.inspect(util, { showHidden: true, depth: null }));
 ```
 
 The following example highlights the difference with the `compact` option:
@@ -497,7 +479,7 @@ const o = {
     'foo']], 4],
   b: new Map([['za', 1], ['zb', 'test']])
 };
-console.log(util.inspect(o, { compact: true, breakLength: 80 }));
+console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
 
 // This will print
 
@@ -511,7 +493,7 @@ console.log(util.inspect(o, { compact: true, breakLength: 80 }));
 //   b: Map { 'za' => 1, 'zb' => 'test' } }
 
 // Setting `compact` to false changes the output to be more reader friendly.
-console.log(util.inspect(o, { compact: false, breakLength: 80 }));
+console.log(util.inspect(o, { compact: false, depth: 5, breakLength: 80 }));
 
 // {
 //   a: [

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -94,7 +94,7 @@ const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: 20,
+  depth: 2,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -128,9 +128,8 @@ function hasOwnProperty(obj, prop) {
 // Can overridden with custom print functions, such as `probe` or `eyes.js`.
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options = Object.assign({},
-                               util.inspect.defaultOptions,
-                               { showProxy: true, depth: 2 });
+writer.options =
+    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
 
 exports._builtinLibs = builtinLibs;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,7 +113,8 @@ function formatWithOptions(inspectOptions, f) {
           {
             const opts = Object.assign({}, inspectOptions, {
               showHidden: true,
-              showProxy: true
+              showProxy: true,
+              depth: 4
             });
             tempStr = inspect(arguments[a++], opts);
             break;

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -3,7 +3,6 @@
 require('../common');
 const assert = require('assert');
 const BufferList = require('internal/streams/buffer_list');
-const util = require('util');
 
 // Test empty buffer list.
 const emptyList = new BufferList();
@@ -31,10 +30,3 @@ assert.strictEqual(list.join(','), 'foo');
 const shifted = list.shift();
 assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());
-
-const tmp = util.inspect.defaultOptions.colors;
-util.inspect.defaultOptions = { colors: true };
-assert.strictEqual(
-  util.inspect(list),
-  'BufferList { length: \u001b[33m0\u001b[39m }');
-util.inspect.defaultOptions = { colors: tmp };

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -50,17 +50,13 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ],' +
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], {} ],' +
                   ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
-                  ', Proxy [ Proxy [ {}, {} ], {} ] ] ]';
-const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
-                    'Proxy [ {}, {} ] ],\n' +
-                  '    Proxy [ Proxy [ {}, {} ], ' +
-                    'Proxy [ Proxy [ {}, {} ], {} ] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [ Proxy [ {}, {} ], {} ], ' +
-                    'Proxy [ {}, {} ] ],\n' +
-                  '    Proxy [ Proxy [ {}, {} ], ' +
-                    'Proxy [ Proxy [ {}, {} ], {} ] ] ] ]';
+                  ', Proxy [ Proxy [Array], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], Proxy [Array]' +
+                  ' ],\n    Proxy [ Proxy [Array], Proxy [Array] ] ],\n' +
+                  '  Proxy [ Proxy [ Proxy [Array], Proxy [Array] ],\n' +
+                  '    Proxy [ Proxy [Array], Proxy [Array] ] ] ]';
 assert.strictEqual(
   util.inspect(proxy1, { showProxy: true, depth: null }),
   expected1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -71,7 +71,7 @@ assert.strictEqual(util.inspect({ a: 1, b: 2 }), '{ a: 1, b: 2 }');
 assert.strictEqual(util.inspect({ 'a': {} }), '{ a: {} }');
 assert.strictEqual(util.inspect({ 'a': { 'b': 2 } }), '{ a: { b: 2 } }');
 assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }),
-                   '{ a: { b: { c: { d: 2 } } } }');
+                   '{ a: { b: { c: [Object] } } }');
 assert.strictEqual(
   util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }, false, null),
   '{ a: { b: { c: { d: 2 } } } }');
@@ -110,7 +110,7 @@ assert.strictEqual(util.inspect((new JSStream())._externalStream),
   assert.strictEqual(util.inspect({ a: regexp }, false, 0), '{ a: /regexp/ }');
 }
 
-assert(!/Object/.test(
+assert(/Object/.test(
   util.inspect({ a: { a: { a: { a: {} } } } }, undefined, undefined, true)
 ));
 assert(!/Object/.test(
@@ -1055,15 +1055,15 @@ if (typeof Symbol !== 'undefined') {
 // Empty and circular before depth.
 {
   const arr = [[[[]]]];
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [] ] ] ]');
   arr[0][0][0][0] = [];
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Array] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Array] ] ] ]');
   arr[0][0][0] = {};
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ {} ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ {} ] ] ]');
   arr[0][0][0] = { a: 2 };
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Object] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Object] ] ] ]');
   arr[0][0][0] = arr;
-  assert.strictEqual(util.inspect(arr, { depth: 2 }), '[ [ [ [Circular] ] ] ]');
+  assert.strictEqual(util.inspect(arr), '[ [ [ [Circular] ] ] ]');
 }
 
 // Corner cases.
@@ -1160,10 +1160,10 @@ if (typeof Symbol !== 'undefined') {
   assert(!/1 more item/.test(util.inspect(arr)));
   util.inspect.defaultOptions.maxArrayLength = oldOptions.maxArrayLength;
   assert(/1 more item/.test(util.inspect(arr)));
-  util.inspect.defaultOptions.depth = 2;
-  assert(/Object/.test(util.inspect(obj)));
-  util.inspect.defaultOptions.depth = oldOptions.depth;
+  util.inspect.defaultOptions.depth = null;
   assert(!/Object/.test(util.inspect(obj)));
+  util.inspect.defaultOptions.depth = oldOptions.depth;
+  assert(/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)
@@ -1175,7 +1175,7 @@ if (typeof Symbol !== 'undefined') {
   assert(/Object/.test(util.inspect(obj)));
   util.inspect.defaultOptions = oldOptions;
   assert(/1 more item/.test(util.inspect(arr)));
-  assert(!/Object/.test(util.inspect(obj)));
+  assert(/Object/.test(util.inspect(obj)));
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)
@@ -1561,19 +1561,11 @@ util.inspect(process);
   let head = list;
   // A linked list of length 100k should be inspectable in some way, even though
   // the real cutoff value is much lower than 100k.
-  for (let i = 0; i < 100000; i++) {
+  for (let i = 0; i < 100000; i++)
     head = head.next = {};
-  }
-
-  const res = Array(15)
-    .fill(0)
-    .map((_, i) => `{ next:\n${'   '.repeat(i + 1)}`)
-    .join('') +
-    '{ next: { next: { next: { next: { next: { next:' +
-    ' [Object] } } } } } } } } } } } } } } } } } } } } }';
   assert.strictEqual(
     util.inspect(list),
-    res
+    '{ next: { next: { next: [Object] } } }'
   );
   const longList = util.inspect(list, { depth: Infinity });
   const match = longList.match(/next/g);


### PR DESCRIPTION
This reverts commits:
ac7450a09a4c167cd43c14d7c88721d22f077529
1a1fe53e3dbd0042807b75caac94dcae0abe4dc1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
