### PR TITLE
src: ready background workers before bootstrap

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -37,7 +37,7 @@ static void PlatformWorkerThread(void* data) {
   // Notify the main thread that the platform worker is ready.
   {
     Mutex::ScopedLock lock(*worker_data->platform_workers_mutex);
-    *worker_data->pending_platform_workers--;
+    (*worker_data->pending_platform_workers)--;
     worker_data->platform_workers_ready->Signal(lock);
   }
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -116,6 +116,10 @@ class WorkerThreadsTaskRunner {
   std::unique_ptr<DelayedTaskScheduler> delayed_task_scheduler_;
 
   std::vector<std::unique_ptr<uv_thread_t>> threads_;
+
+  Mutex platform_workers_mutex_;
+  ConditionVariable platform_workers_ready_;
+  int pending_platform_workers_;
 };
 
 class NodePlatform : public MultiIsolatePlatform {


### PR DESCRIPTION
This is an alternative to #23110 that doesn't depend upon https://github.com/libuv/libuv/pull/2003.

Make sure background workers are ready before proceeding with the
bootstrap or post-bootstrap execution of any code that may trigger
`process.exit()`.

Fixes: https://github.com/nodejs/node/issues/23065

EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/17595/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
