### PR TITLE
doc: replace `server.close()` which don't exist in code snippets in tls.md

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -918,9 +918,12 @@ The `callback` function, if specified, will be added as a listener for the
 
 `tls.connect()` returns a [`tls.TLSSocket`][] object.
 
-The following implements a simple "echo server" example:
+Here is an example of a client of echo server as described in
+[`tls.createServer()`][]:
 
 ```js
+// This example assumes that you have created an echo server that is
+// listening on port 8000.
 const tls = require('tls');
 const fs = require('fs');
 
@@ -944,13 +947,15 @@ socket.on('data', (data) => {
   console.log(data);
 });
 socket.on('end', () => {
-  server.close();
+  console.log('client ends');
 });
 ```
 
 Or
 
 ```js
+// This example assumes that you have created an echo server that is
+// listening on port 8000.
 const tls = require('tls');
 const fs = require('fs');
 
@@ -969,7 +974,7 @@ socket.on('data', (data) => {
   console.log(data);
 });
 socket.on('end', () => {
-  server.close();
+  console.log('client ends');
 });
 ```
 


### PR DESCRIPTION
Replace `server.close()` as the `server` don't exist in the code snippets in `tls.md`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
