### PR TITLE
doc: improve `stream.Writable` ctor encoding option docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1500,9 +1500,13 @@ changes:
   * `highWaterMark` {number} Buffer level when
     [`stream.write()`][stream-write] starts returning `false`. **Default:**
     `16384` (16kb), or `16` for `objectMode` streams.
-  * `decodeStrings` {boolean} Whether or not to decode strings into
-    `Buffer`s before passing them to [`stream._write()`][stream-_write].
+  * `decodeStrings` {boolean} Whether or not to encode strings as
+    `Buffer`s before passing them to [`stream._write()`][stream-_write],
+    using the encoding specified in the [`stream.write()`][stream-write] call.
     **Default:** `true`.
+  * `defaultEncoding` {string} The default encoding that is used when no
+    encoding is specified as an argument to [`stream.write()`][stream-write].
+    **Default:** `'utf8'`.
   * `objectMode` {boolean} Whether or not the
     [`stream.write(anyObj)`][stream-write] is a valid operation. When set,
     it becomes possible to write JavaScript values other than string,


### PR DESCRIPTION
- Document `defaultEncoding`. This was previously undocumented.
- Clarify `decodeStrings`. In particular, the previous description was
  talking about decoding, which matches the unfortunate option name,
  but what actually happens is usually refererred to as encoding
  a string into a binary form.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
