### PR TITLE
doc: update author-ready label terms

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -83,10 +83,11 @@ necessary.
 ### Author ready pull requests
 
 A pull request that is still awaiting the minimum review time is considered
-_author ready_ as soon as the CI has been started, it has at least one approval,
-and it has no outstanding review comments. Please always make sure to add the
-`author ready` label to the PR in that case and remove it again as soon as that
-condition is not met anymore.
+_author ready_ as soon as the CI has been started, it has at least two approvals
+(one Collaborator approval is enough if the pull request has been open for more
+than 7 days), and it has no outstanding review comments. Please always make sure
+to add the `author ready` label to the PR in that case and remove it again as
+soon as that condition is not met anymore.
 
 ### Handling own pull requests
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -99,7 +99,8 @@ onboarding session.
   * Please add the `author-ready` label for PRs where:
     * the CI has been started (not necessarily finished),
     * no outstanding review comments exist and
-    * at least one collaborator approved the PR.
+    * at least two Collaborators approved the PR (one Collaborator approval is
+      enough if the pull request has been open for more than 7 days).
 
 * See [Who to CC in the issue tracker][who-to-cc].
   * This will come more naturally over time


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

If I understand it correctly, we need this correction after https://github.com/nodejs/node/pull/22255

cc @Trott 