### PR TITLE
test: error when empty buffer is passed to filehandle.read()

### DIFF
--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const fs = require('fs');
 const filepath = fixtures.path('x.txt');
 const fd = fs.openSync(filepath, 'r');
+const fsPromises = fs.promises;
 
 const buffer = new Uint8Array();
 
@@ -26,3 +27,14 @@ assert.throws(
     'Received Uint8Array []'
   }
 );
+
+fsPromises.open(filepath, 'r').then((filehandle) => {
+  assert.rejects(
+    () => filehandle.read(buffer, 0, 1, 0),
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: 'The argument \'buffer\' is empty and cannot be written. ' +
+        'Received Uint8Array []'
+    }
+  );
+});

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -28,7 +28,8 @@ assert.throws(
   }
 );
 
-fsPromises.open(filepath, 'r').then((filehandle) => {
+(async () => {
+  const filehandle = await fsPromises.open(filepath, 'r');
   assert.rejects(
     () => filehandle.read(buffer, 0, 1, 0),
     {
@@ -37,4 +38,4 @@ fsPromises.open(filepath, 'r').then((filehandle) => {
         'Received Uint8Array []'
     }
   );
-});
+})();

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -35,7 +35,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_VALUE',
       message: 'The argument \'buffer\' is empty and cannot be written. ' +
-        'Received Uint8Array []'
+               'Received Uint8Array []'
     }
   );
 })();


### PR DESCRIPTION
Added tests to occur error when empty buffer is passed to `filehandle.read()`
to increase coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
