### PR TITLE
Revert "tools,gyp: don't force build actions with multiple outputs"

### DIFF
--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -1758,10 +1758,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
       self.WriteLn('\t%s' % '@:')
       self.WriteLn('%s: %s' % ('.INTERMEDIATE', intermediate))
-      # Don't add `force_append` (FORCE_DO_CMD) to the intermediate sentinal.
-      # Adding it makes the action run alway, even when there are no changes.
-      # (refack): AFAICT because `*.intermediate` files don't have build rules.
-      self.WriteLn('%s: %s' % (intermediate, ' '.join(inputs)))
+      self.WriteLn('%s: %s%s' %
+                   (intermediate, ' '.join(inputs), force_append))
       actions.insert(0, '$(call do_cmd,touch)')
 
     if actions:


### PR DESCRIPTION
This reverts commit 5d8373a498a50b1387464391402ef22636439303.

Fixes: https://github.com/nodejs/node/issues/23255

---

cc @refack @devsnek @targos 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
