### PR TITLE
test: add module require tests for certain package.json errors

### DIFF
--- a/test/fixtures/packages/missing-main/index.js
+++ b/test/fixtures/packages/missing-main/index.js
@@ -1,0 +1,22 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exports.ok = 'ok';

--- a/test/fixtures/packages/missing-main/package.json
+++ b/test/fixtures/packages/missing-main/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "missingmain",
+  "main": "doesnotexist.js"
+}

--- a/test/fixtures/packages/unparseable/package.json
+++ b/test/fixtures/packages/unparseable/package.json
@@ -1,0 +1,4 @@
+{
+    "main": "therain" "inspain"
+}
+

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -104,6 +104,15 @@ const d2 = require('../fixtures/b/d');
 assert.strictEqual(require('../fixtures/packages/index').ok, 'ok');
 assert.strictEqual(require('../fixtures/packages/main').ok, 'ok');
 assert.strictEqual(require('../fixtures/packages/main-index').ok, 'ok');
+assert.strictEqual(require('../fixtures/packages/missing-main').ok, 'ok');
+
+let unparseableErrorThrown = false;
+try {
+  require('../fixtures/packages/unparseable');
+} catch (e) {
+  unparseableErrorThrown = true;
+  assert.strictEqual(/^Error parsing .*/.test(e.message), true);
+}
 
 {
   console.error('test cycles containing a .. path');
@@ -267,6 +276,7 @@ try {
     'fixtures/packages/index/index.js': {},
     'fixtures/packages/main/package-main-module.js': {},
     'fixtures/packages/main-index/package-main-module/index.js': {},
+    'fixtures/packages/missing-main/index.js': {},
     'fixtures/cycles/root.js': {
       'fixtures/cycles/folder/foo.js': {}
     },
@@ -317,6 +327,7 @@ process.on('exit', function() {
   assert.strictEqual(d2.D(), 'D done');
 
   assert.strictEqual(errorThrown, true);
+  assert.strictEqual(unparseableErrorThrown, true);
 
   console.log('exit');
 });

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -106,13 +106,10 @@ assert.strictEqual(require('../fixtures/packages/main').ok, 'ok');
 assert.strictEqual(require('../fixtures/packages/main-index').ok, 'ok');
 assert.strictEqual(require('../fixtures/packages/missing-main').ok, 'ok');
 
-let unparseableErrorThrown = false;
-try {
-  require('../fixtures/packages/unparseable');
-} catch (e) {
-  unparseableErrorThrown = true;
-  assert.strictEqual(/^Error parsing .*/.test(e.message), true);
-}
+assert.throws(
+  function() { require('../fixtures/packages/unparseable'); },
+  /^SyntaxError: Error parsing/
+);
 
 {
   console.error('test cycles containing a .. path');
@@ -327,7 +324,6 @@ process.on('exit', function() {
   assert.strictEqual(d2.D(), 'D done');
 
   assert.strictEqual(errorThrown, true);
-  assert.strictEqual(unparseableErrorThrown, true);
 
   console.log('exit');
 });


### PR DESCRIPTION
test for unusual error cases: verify that module require
falls back to index if package.json names a missing file and
throws an error if package.json is unparseable.

##### Checklist

- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
