### PR TITLE
net: use connect() instead of connect.call()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -152,7 +152,7 @@ function connect(...args) {
     socket.setTimeout(options.timeout);
   }
 
-  return Socket.prototype.connect.call(socket, normalized);
+  return socket.connect(normalized);
 }
 
 


### PR DESCRIPTION
Use socket.connect() directly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
