### PR TITLE
src: reduce scope of variables throughout codebase

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -429,7 +429,6 @@ void cares_wrap_hostent_cpy(struct hostent* dest, struct hostent* src) {
 
   /* copy `h_aliases` */
   size_t alias_count;
-  size_t cur_alias_length;
   for (alias_count = 0;
       src->h_aliases[alias_count] != nullptr;
       alias_count++) {
@@ -437,9 +436,9 @@ void cares_wrap_hostent_cpy(struct hostent* dest, struct hostent* src) {
 
   dest->h_aliases = node::Malloc<char*>(alias_count + 1);
   for (size_t i = 0; i < alias_count; i++) {
-    cur_alias_length = strlen(src->h_aliases[i]);
-    dest->h_aliases[i] = node::Malloc(cur_alias_length + 1);
-    memcpy(dest->h_aliases[i], src->h_aliases[i], cur_alias_length + 1);
+    const size_t cur_alias_size = strlen(src->h_aliases[i]) + 1;
+    dest->h_aliases[i] = node::Malloc(cur_alias_size);
+    memcpy(dest->h_aliases[i], src->h_aliases[i], cur_alias_size);
   }
   dest->h_aliases[alias_count] = nullptr;
 
@@ -1065,7 +1064,6 @@ int ParseSoaReply(Environment* env,
   /* Can't use ares_parse_soa_reply() here which can only parse single record */
   unsigned int ancount = cares_get_16bit(buf + 6);
   unsigned char* ptr = buf + NS_HFIXEDSZ;
-  int rr_type, rr_len;
   char* name;
   char* rr_name;
   long temp_len;  // NOLINT(runtime/int)
@@ -1094,8 +1092,8 @@ int ParseSoaReply(Environment* env,
       break;
     }
 
-    rr_type = cares_get_16bit(ptr);
-    rr_len = cares_get_16bit(ptr + 8);
+    const int rr_type = cares_get_16bit(ptr);
+    const int rr_len = cares_get_16bit(ptr + 8);
     ptr += NS_RRFIXEDSZ;
 
     /* only need SOA */

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -449,16 +449,15 @@ std::string ReadFile(uv_file file) {
   uv_fs_t req;
   char buffer_memory[4096];
   uv_buf_t buf = uv_buf_init(buffer_memory, sizeof(buffer_memory));
-  int r;
 
   do {
-    r = uv_fs_read(uv_default_loop(),
-                   &req,
-                   file,
-                   &buf,
-                   1,
-                   contents.length(),  // offset
-                   nullptr);
+    const int r = uv_fs_read(uv_default_loop(),
+                             &req,
+                             file,
+                             &buf,
+                             1,
+                             contents.length(),  // offset
+                             nullptr);
     uv_fs_req_cleanup(&req);
 
     if (r <= 0)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -573,17 +573,13 @@ int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
   if (ret) {
     // If we could set up our certificate, now proceed to
     // the CA certificates.
-    int r;
-
     SSL_CTX_clear_extra_chain_certs(ctx);
 
     for (int i = 0; i < sk_X509_num(extra_certs); i++) {
       X509* ca = sk_X509_value(extra_certs, i);
 
       // NOTE: Increments reference count on `ca`
-      r = SSL_CTX_add1_chain_cert(ctx, ca);
-
-      if (!r) {
+      if (!SSL_CTX_add1_chain_cert(ctx, ca)) {
         ret = 0;
         issuer = nullptr;
         break;
@@ -1580,15 +1576,11 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     if (index < 0)
       continue;
 
-    X509_EXTENSION* ext;
-    int rv;
-
-    ext = X509_get_ext(cert, index);
+    X509_EXTENSION* ext = X509_get_ext(cert, index);
     CHECK_NOT_NULL(ext);
 
     if (!SafeX509ExtPrint(bio.get(), ext)) {
-      rv = X509V3_EXT_print(bio.get(), ext, 0, 0);
-      CHECK_EQ(rv, 1);
+      CHECK_EQ(1, X509V3_EXT_print(bio.get(), ext, 0, 0));
     }
 
     BIO_get_mem_ptr(bio.get(), &mem);
@@ -3746,7 +3738,6 @@ SignBase::Error Verify::VerifyFinal(const char* key_pem,
   EVPKeyPointer pkey;
   unsigned char m[EVP_MAX_MD_SIZE];
   unsigned int m_len;
-  int r = 0;
   *verify_result = false;
   EVPMDPointer mdctx = std::move(mdctx_);
 
@@ -3762,11 +3753,11 @@ SignBase::Error Verify::VerifyFinal(const char* key_pem,
       ApplyRSAOptions(pkey, pkctx.get(), padding, saltlen) &&
       EVP_PKEY_CTX_set_signature_md(pkctx.get(),
                                     EVP_MD_CTX_md(mdctx.get())) > 0) {
-    r = EVP_PKEY_verify(pkctx.get(),
-                        reinterpret_cast<const unsigned char*>(sig),
-                        siglen,
-                        m,
-                        m_len);
+    const int r = EVP_PKEY_verify(pkctx.get(),
+                                  reinterpret_cast<const unsigned char*>(sig),
+                                  siglen,
+                                  m,
+                                  m_len);
     *verify_result = r == 1;
   }
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -792,7 +792,7 @@ void URLHost::ParseIPv6Host(const char* input, size_t length) {
   uint16_t* compress_pointer = nullptr;
   const char* pointer = input;
   const char* end = pointer + length;
-  unsigned value, len, swaps, numbers_seen;
+  unsigned value, len, numbers_seen;
   char ch = pointer < end ? pointer[0] : kEOL;
   if (ch == ':') {
     if (length < 2 || pointer[1] != ':')
@@ -881,7 +881,7 @@ void URLHost::ParseIPv6Host(const char* input, size_t length) {
   }
 
   if (compress_pointer != nullptr) {
-    swaps = piece_pointer - compress_pointer;
+    unsigned swaps = piece_pointer - compress_pointer;
     piece_pointer = buffer_end - 1;
     while (piece_pointer != &value_.ipv6[0] && swaps > 0) {
       uint16_t temp = *piece_pointer;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -150,13 +150,13 @@ void Worker::Run() {
       TRACE_STR_COPY(name.c_str()));
   MultiIsolatePlatform* platform = isolate_data_->platform();
   CHECK_NE(platform, nullptr);
-  bool inspector_started = false;
 
   Debug(this, "Starting worker with id %llu", thread_id_);
   {
     Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
     SealHandleScope outer_seal(isolate_);
+    bool inspector_started = false;
 
     {
       Context::Scope context_scope(env_->context());

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -209,8 +209,6 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
   if (args[2]->IsObject())
     send_handle_obj = args[2].As<Object>();
 
-  int err;
-
   // Compute the size of the storage that the string will be flattened into.
   // For UTF8 strings that are very long, go ahead and take the hit for
   // computing their actual size, rather than tripling the storage.
@@ -243,7 +241,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
 
     uv_buf_t* bufs = &buf;
     size_t count = 1;
-    err = DoTryWrite(&bufs, &count);
+    const int err = DoTryWrite(&bufs, &count);
     // Keep track of the bytes written here, because we're taking a shortcut
     // by using `DoTryWrite()` directly instead of using the utilities
     // provided by `Write()`.

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -49,10 +49,8 @@ void NodeTraceWriter::WriteSuffix() {
 NodeTraceWriter::~NodeTraceWriter() {
   WriteSuffix();
   uv_fs_t req;
-  int err;
   if (fd_ != -1) {
-    err = uv_fs_close(nullptr, &req, fd_, nullptr);
-    CHECK_EQ(err, 0);
+    CHECK_EQ(0, uv_fs_close(nullptr, &req, fd_, nullptr));
     uv_fs_req_cleanup(&req);
   }
   uv_async_send(&exit_signal_);


### PR DESCRIPTION
Move various variables in the C++ code to more narrow scopes where possible.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
