### PR TITLE
doc: use backticks around file names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ directory under _docs_ or at <https://nodejs.org/download/docs/>.
 
 ### Verifying Binaries
 
-Download directories contain a SHASUMS256.txt file with SHA checksums for the
+Download directories contain a `SHASUMS256.txt` file with SHA checksums for the
 files.
 
-To download SHASUMS256.txt using `curl`:
+To download `SHASUMS256.txt` using `curl`:
 
 ```console
 $ curl -O https://nodejs.org/dist/vx.y.z/SHASUMS256.txt
@@ -132,9 +132,9 @@ it through `sha256sum` with a command such as:
 $ grep node-vx.y.z.tar.gz SHASUMS256.txt | sha256sum -c -
 ```
 
-For Current and LTS, the GPG detached signature of SHASUMS256.txt is in
-SHASUMS256.txt.sig. You can use it with `gpg` to verify the integrity of
-SHASUM256.txt. You will first need to import all the GPG keys of individuals
+For Current and LTS, the GPG detached signature of `SHASUMS256.txt` is in
+`SHASUMS256.txt.sig`. You can use it with `gpg` to verify the integrity of
+`SHASUM256.txt`. You will first need to import all the GPG keys of individuals
 authorized to create releases. They are at the bottom of this README under
 [Release Team](#release-team). To import the keys:
 
@@ -144,7 +144,7 @@ $ gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C2
 
 See the bottom of this README for a full script to import active release keys.
 
-Next, download the SHASUMS256.txt.sig for the release:
+Next, download the `SHASUMS256.txt.sig` for the release:
 
 ```console
 $ curl -O https://nodejs.org/dist/vx.y.z/SHASUMS256.txt.sig


### PR DESCRIPTION
Use backticks around `SHASUM256.txt` etc. in README.md.

👍 here to fast-track.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
