### PR TITLE
benchmark: increase lint compliance

### DIFF
--- a/benchmark/napi/function_args/index.js
+++ b/benchmark/napi/function_args/index.js
@@ -12,16 +12,14 @@ let napi;
 try {
   v8 = require('./build/Release/binding');
 } catch (err) {
-  // eslint-disable-next-line no-path-concat
-  console.error(__filename + ': V8 Binding failed to load');
+  console.error(`${__filename}: V8 Binding failed to load`);
   process.exit(0);
 }
 
 try {
   napi = require('./build/Release/napi_binding');
 } catch (err) {
-  // eslint-disable-next-line no-path-concat
-  console.error(__filename + ': NAPI-Binding failed to load');
+  console.error(`${__filename}: NAPI-Binding failed to load`);
   process.exit(0);
 }
 


### PR DESCRIPTION
Remove two eslint-disable comments by replacing string concatenation
with template literals. These changes are in catch blocks that are not
part of the actual code being benchmarked.

👍 here to fast-track

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
