### PR TITLE
doc: minor text fixes to streams.md

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2327,7 +2327,7 @@ primarily for examples and testing, but there are some use cases where
 Prior to Node.js 0.10, the `Readable` stream interface was simpler, but also
 less powerful and less useful.
 
-* Rather than waiting for calls the [`stream.read()`][stream-read] method,
+* Rather than waiting for calls to the [`stream.read()`][stream-read] method,
   [`'data'`][] events would begin emitting immediately. Applications that
   would need to perform some amount of work to decide how to handle data
   were required to store read data into buffers so the data would not be lost.


### PR DESCRIPTION
    Refer to Node.js versions without a prepended `v`. This was standardized
    on previously to avoid confusion between Node.js 8 and the V8 JavaScript
    engine. (`Node.js 8` is clear. `v8` or even `Node.js v8`, not so much.)
    
    It appears that a `to` was left out in one sentence of the streams.md
    doc. Add it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
