### PR TITLE
zlib: move `bytesRead` accessors to runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2056,12 +2056,15 @@ core and obsoleted by the removal of NPN (Next Protocol Negotiation) support.
 ### DEP0108: zlib.bytesRead
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/19414
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Deprecated alias for [`zlib.bytesWritten`][]. This original name was chosen
 because it also made sense to interpret the value as the number of bytes

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2057,7 +2057,7 @@ core and obsoleted by the removal of NPN (Next Protocol Negotiation) support.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/23308
     description: Runtime deprecation.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/19414

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -29,6 +29,7 @@ const {
 } = require('internal/errors').codes;
 const Transform = require('_stream_transform');
 const {
+  deprecate,
   _extend,
   inherits,
   types: {
@@ -333,12 +334,14 @@ Object.defineProperty(Zlib.prototype, '_closed', {
 Object.defineProperty(Zlib.prototype, 'bytesRead', {
   configurable: true,
   enumerable: true,
-  get() {
+  get: deprecate(function() {
     return this.bytesWritten;
-  },
-  set(value) {
+  }, 'zlib.bytesRead is deprecated and will change its meaning in the ' +
+     'future. Use zlib.bytesWritten instead.', 'DEP0108'),
+  set: deprecate(function(value) {
     this.bytesWritten = value;
-  }
+  }, 'Setting zlib.bytesRead is deprecated. ' +
+     'This feature will be removed in the future.', 'DEP0108')
 });
 
 // This callback is used by `.params()` to wait until a full flush happened

--- a/test/parallel/test-zlib-bytes-read.js
+++ b/test/parallel/test-zlib-bytes-read.js
@@ -21,6 +21,12 @@ function createWriter(target, buffer) {
   return writer;
 }
 
+common.expectWarning(
+  'DeprecationWarning',
+  'zlib.bytesRead is deprecated and will change its meaning in the ' +
+  'future. Use zlib.bytesWritten instead.',
+  'DEP0108');
+
 for (const method of [
   ['createGzip', 'createGunzip', false],
   ['createGzip', 'createUnzip', false],


### PR DESCRIPTION
This paves way for making `bytesRead` consistent with all other
Node.js streams that provide a property with this name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
