### PR TITLE
src: fix use of deprecated ToObject()

### DIFF
--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -128,7 +128,9 @@ Local<Value> UVException(Isolate* isolate,
         String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, "'"));
   }
 
-  Local<Object> e = Exception::Error(js_msg)->ToObject(isolate);
+  Local<Object> e =
+    Exception::Error(js_msg)->ToObject(isolate->GetCurrentContext())
+      .ToLocalChecked();
 
   e->Set(env->errno_string(), Integer::New(isolate, errorno));
   e->Set(env->code_string(), js_code);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -623,7 +623,8 @@ class Parser : public AsyncWrap, public StreamListener {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser_);
 
       Local<Value> e = Exception::Error(env()->parse_error_string());
-      Local<Object> obj = e->ToObject(env()->isolate());
+      Local<Object> obj = e->ToObject(env()->isolate()->GetCurrentContext())
+        .ToLocalChecked();
       obj->Set(env()->bytes_parsed_string(), nparsed_obj);
       obj->Set(env()->code_string(),
                OneByteString(env()->isolate(), http_errno_name(err)));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
