### PR TITLE
worker: improve integration with native addons

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -232,6 +232,23 @@ NODE_MODULE_INIT(/* exports, module, context */) {
 }
 ```
 
+#### Worker support
+
+In order to support [`Worker`][] threads, addons need to clean up any resources
+they may have allocated when such a thread exists. This can be achieved through
+the usage of the `AddEnvironmentCleanupHook()` function:
+
+```c++
+void AddEnvironmentCleanupHook(v8::Isolate* isolate,
+                               void (*fun)(void* arg),
+                               void* arg);
+```
+
+This function adds a hook that will run before a given Node.js instance shuts
+down. If necessary, such hooks can be removed using
+`RemoveEnvironmentCleanupHook()` before they are run, which has the same
+signature.
+
 ### Building
 
 Once the source code has been written, it must be compiled into the binary
@@ -1316,6 +1333,7 @@ Test in JavaScript by running:
 require('./build/Release/addon');
 ```
 
+[`Worker`]: worker_threads.html#worker_threads_class_worker
 [Electron]: https://electronjs.org/
 [Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide
 [Linking to Node.js' own dependencies]: #addons_linking_to_node_js_own_dependencies

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -253,11 +253,9 @@ Notable differences inside a Worker environment are:
 - Execution may stop at any point as a result of [`worker.terminate()`][]
   being invoked.
 - IPC channels from parent processes are not accessible.
-
-Currently, the following differences also exist until they are addressed:
-
-- The [`inspector`][] module is not available yet.
-- Native addons are not supported yet.
+- Native add-ons are unloaded if they are only used inside `Worker` instances
+  when those workers shut down.
+  See the [addons documentation][] for more detials.
 
 Creating `Worker` instances inside of other `Worker`s is possible.
 
@@ -484,7 +482,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`require('worker_threads').parentPort`]: #worker_threads_worker_parentport
 [`require('worker_threads').threadId`]: #worker_threads_worker_threadid
 [`cluster` module]: cluster.html
-[`inspector`]: inspector.html
+[addons documentation]: addons.html#addons_worker_support
 [v8.serdes]: v8.html#v8_serialization_api
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 [Signals events]: process.html#process_signal_events

--- a/src/node.cc
+++ b/src/node.cc
@@ -1166,8 +1166,8 @@ class DLib : public std::enable_shared_from_this<DLib> {
   inline void* GetSymbolAddress(const char* name);
   inline void AddEnvironment(Environment* env);
 
-  std::string filename_;
-  int flags_;
+  const std::string filename_;
+  const int flags_ = 0;
   std::string errmsg_;
   void* handle_ = nullptr;
   std::unordered_set<Environment*> users_;
@@ -1334,9 +1334,7 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
       break;
     }
 
-    dlib = std::make_shared<DLib>();
-    dlib->filename_ = *filename;
-    dlib->flags_ = flags;
+    dlib = std::make_shared<DLib>(*filename, flags);
     bool is_opened = dlib->Open();
 
     if (is_opened && handle_to_dlib.count(dlib->handle_) > 0) {

--- a/test/addons/dlopen-ping-pong/test.js
+++ b/test/addons/dlopen-ping-pong/test.js
@@ -14,7 +14,5 @@ process.dlopen(module, bindingPath,
 module.exports.load(`${path.dirname(bindingPath)}/ping.so`);
 assert.strictEqual(module.exports.ping(), 'pong');
 
-// Check that after the addon is loaded with
-// process.dlopen() a require() call fails.
-const re = /^Error: Module did not self-register\.$/;
-assert.throws(() => require(`./build/${common.buildType}/binding`), re);
+// This second `require()` call should not throw an error.
+require(`./build/${common.buildType}/binding`);

--- a/test/addons/hello-world/test-worker.js
+++ b/test/addons/hello-world/test-worker.js
@@ -1,0 +1,14 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const path = require('path');
+const { Worker } = require('worker_threads');
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+
+const w = new Worker(`
+require('worker_threads').parentPort.postMessage(
+  require(${JSON.stringify(binding)}).hello());`, { eval: true });
+w.on('message', common.mustCall((message) => {
+  assert.strictEqual(message, 'world');
+}));

--- a/test/addons/worker-addon/binding.cc
+++ b/test/addons/worker-addon/binding.cc
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <node.h>
+#include <v8.h>
+
+using v8::Context;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+size_t count = 0;
+
+struct statically_allocated {
+  statically_allocated() {
+    assert(count == 0);
+    printf("ctor ");
+  }
+  ~statically_allocated() {
+    assert(count == 0);
+    printf("dtor");
+  }
+} var;
+
+void Dummy(void*) {
+  assert(0);
+}
+
+void Cleanup(void* str) {
+  printf("%s ", static_cast<const char*>(str));
+}
+
+void Initialize(Local<Object> exports,
+                Local<Value> module,
+                Local<Context> context) {
+  node::AddEnvironmentCleanupHook(
+      context->GetIsolate(), Cleanup,
+      const_cast<void*>(static_cast<const void*>("cleanup")));
+  node::AddEnvironmentCleanupHook(context->GetIsolate(), Dummy, nullptr);
+  node::RemoveEnvironmentCleanupHook(context->GetIsolate(), Dummy, nullptr);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/worker-addon/binding.gyp
+++ b/test/addons/worker-addon/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/worker-addon/test.js
+++ b/test/addons/worker-addon/test.js
@@ -1,0 +1,17 @@
+// Flags: --experimental-worker
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const path = require('path');
+const { Worker } = require('worker_threads');
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+
+if (process.argv[2] === 'child') {
+  new Worker(`require(${JSON.stringify(binding)});`, { eval: true });
+} else {
+  const proc = child_process.spawnSync(process.execPath, [__filename, 'child']);
+  assert.strictEqual(proc.stderr.toString(), '');
+  assert.strictEqual(proc.stdout.toString(), 'ctor cleanup dtor');
+  assert.strictEqual(proc.status, 0);
+}


### PR DESCRIPTION
Native addons are now unloaded if all Environments referring to it
have been cleaned up, except if it also loaded by the main Environment.

/cc @gabrielschulhof Who I remember had some suggestions for improving upon this approach

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
