### PR TITLE
util: format specifier `%d` use parseInt

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -211,7 +211,7 @@ specifiers. Each specifier is replaced with the converted value from the
 corresponding argument. Supported specifiers are:
 
 * `%s` - `String`.
-* `%d` - `Number` (integer or floating point value) or `BigInt`.
+* `%d` - Integer or `BigInt`.
 * `%i` - Integer or `BigInt`.
 * `%f` - Floating point value.
 * `%j` - JSON. Replaced with the string `'[Circular]'` if the argument

--- a/lib/util.js
+++ b/lib/util.js
@@ -109,15 +109,6 @@ function formatWithOptions(inspectOptions, ...args) {
             case 106: // 'j'
               tempStr = tryStringify(args[a++]);
               break;
-            case 100: // 'd'
-              const tempNum = args[a++];
-              // eslint-disable-next-line valid-typeof
-              if (typeof tempNum === 'bigint') {
-                tempStr = `${tempNum}n`;
-              } else {
-                tempStr = `${Number(tempNum)}`;
-              }
-              break;
             case 79: // 'O'
               tempStr = inspect(args[a++], inspectOptions);
               break;
@@ -131,6 +122,7 @@ function formatWithOptions(inspectOptions, ...args) {
               tempStr = inspect(args[a++], opts);
               break;
             }
+            case 100: // 'd'
             case 105: // 'i'
               const tempInteger = args[a++];
               // eslint-disable-next-line valid-typeof

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -70,7 +70,7 @@ assert.strictEqual(util.format('%d %d', 42, 43), '42 43');
 assert.strictEqual(util.format('%d %d', 42), '42 %d');
 assert.strictEqual(
   util.format('%d', 1180591620717411303424),
-  '1.1805916207174113e+21'
+  '1'
 );
 assert.strictEqual(
   util.format('%d', 1180591620717411303424n),

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -57,15 +57,15 @@ assert.throws(
   }
 );
 
-// Number format specifier
+// Integer format specifier
 assert.strictEqual(util.format('%d'), '%d');
 assert.strictEqual(util.format('%d', 42.0), '42');
 assert.strictEqual(util.format('%d', 42), '42');
 assert.strictEqual(util.format('%d', '42'), '42');
 assert.strictEqual(util.format('%d', '42.0'), '42');
-assert.strictEqual(util.format('%d', 1.5), '1.5');
-assert.strictEqual(util.format('%d', -0.5), '-0.5');
-assert.strictEqual(util.format('%d', ''), '0');
+assert.strictEqual(util.format('%d', 1.5), '1');
+assert.strictEqual(util.format('%d', -0.5), '0');
+assert.strictEqual(util.format('%d', ''), 'NaN');
 assert.strictEqual(util.format('%d %d', 42, 43), '42 43');
 assert.strictEqual(util.format('%d %d', 42), '42 %d');
 assert.strictEqual(
@@ -270,7 +270,7 @@ assert.strictEqual(util.format('o: %O, a: %O'), 'o: %O, a: %O');
 // Invalid format specifiers
 assert.strictEqual(util.format('a% b', 'x'), 'a% b x');
 assert.strictEqual(util.format('percent: %d%, fraction: %d', 10, 0.1),
-                   'percent: 10%, fraction: 0.1');
+                   'percent: 10%, fraction: 0');
 assert.strictEqual(util.format('abc%', 1), 'abc% 1');
 
 // Additional arguments after format specifiers


### PR DESCRIPTION
Change spec of %d specifier in util.format to follow whatwg spec
(https://console.spec.whatwg.org/#formatting-specifiers).
This is a breaking change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Fixes: #22885 