### PR TITLE
test: fix compiler warning in doc/api/addons.md

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -587,6 +587,7 @@ property `msg` that echoes the string passed to `createObject()`:
 
 namespace demo {
 
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
@@ -596,9 +597,11 @@ using v8::Value;
 
 void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   Local<Object> obj = Object::New(isolate);
-  obj->Set(String::NewFromUtf8(isolate, "msg"), args[0]->ToString(isolate));
+  obj->Set(String::NewFromUtf8(isolate, "msg"),
+                               args[0]->ToString(context).ToLocalChecked());
 
   args.GetReturnValue().Set(obj);
 }

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1081,6 +1081,7 @@ that can take two `MyObject` objects as input arguments:
 
 namespace demo {
 
+using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
@@ -1095,11 +1096,12 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
 
 void Add(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   MyObject* obj1 = node::ObjectWrap::Unwrap<MyObject>(
-      args[0]->ToObject(isolate));
+      args[0]->ToObject(context).ToLocalChecked());
   MyObject* obj2 = node::ObjectWrap::Unwrap<MyObject>(
-      args[1]->ToObject(isolate));
+      args[1]->ToObject(context).ToLocalChecked());
 
   double sum = obj1->value() + obj2->value();
   args.GetReturnValue().Set(Number::New(isolate, sum));


### PR DESCRIPTION
Currently the following compiler warning is emitted:
```console
../addon.cc:17:58: warning: 'ToString' is deprecated: Use maybe version [-Wdeprecated-declarations]
  obj->Set(String::NewFromUtf8(isolate, "msg"), args[0]->ToString(isolate));
                                                         ^
./deps/v8/include/v8.h:2537:3: note: 'ToString' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version",
  ^
```
This commit updates example to use the non-deprecated version.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
