### PR TITLE
fs: don't emit 'ready'/'open' after .destroy

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -37,6 +37,10 @@ function allocNewPool(poolSize) {
   pool.used = 0;
 }
 
+function noop() {
+
+}
+
 function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
@@ -123,6 +127,13 @@ util.inherits(ReadStream, Readable);
 
 ReadStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
+    if (this.destroyed) {
+      if (!er) {
+        fs.close(fd, noop);
+      }
+      return;
+    }
+
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -205,24 +216,25 @@ ReadStream.prototype._read = function(n) {
 
 ReadStream.prototype._destroy = function(err, cb) {
   const isOpen = typeof this.fd !== 'number';
-  if (isOpen) {
-    this.once('open', closeFsStream.bind(null, this, cb, err));
+  if (!isOpen) {
+    process.nextTick(() => {
+      cb(err);
+      if (!err) {
+        this.emit('close');
+      }
+    });
     return;
   }
-
-  closeFsStream(this, cb, err);
-  this.fd = null;
-};
-
-function closeFsStream(stream, cb, err) {
-  fs.close(stream.fd, (er) => {
+  fs.close(this.fd, (er) => {
     er = er || err;
     cb(er);
-    stream.closed = true;
-    if (!er)
-      stream.emit('close');
+    this.closed = true;
+    if (!er) {
+      this.emit('close');
+    }
   });
-}
+  this.fd = null;
+};
 
 ReadStream.prototype.close = function(cb) {
   this.destroy(null, cb);
@@ -281,6 +293,13 @@ WriteStream.prototype._final = function(callback) {
 
 WriteStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
+    if (this.destroyed) {
+      if (!er) {
+        fs.close(fd, noop);
+      }
+      return;
+    }
+
     if (er) {
       if (this.autoClose) {
         this.destroy();

--- a/test/parallel/test-fs-stream-destroy.js
+++ b/test/parallel/test-fs-stream-destroy.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+test(fs.createReadStream(__filename));
+test(fs.createWriteStream(`${tmpdir.path}/dummy`));
+
+function test(stream) {
+  stream.on('open', common.mustNotCall());
+  stream.on('ready', common.mustNotCall());
+  stream.destroy();
+}

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -20,35 +20,17 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 test1(fs.createReadStream(__filename));
-test2(fs.createReadStream(__filename));
-test3(fs.createReadStream(__filename));
 
 test1(fs.createWriteStream(`${tmpdir.path}/dummy1`));
-test2(fs.createWriteStream(`${tmpdir.path}/dummy2`));
-test3(fs.createWriteStream(`${tmpdir.path}/dummy3`));
 
 function test1(stream) {
   stream.destroy();
   stream.destroy();
-}
-
-function test2(stream) {
-  stream.destroy();
-  stream.on('open', common.mustCall(function(fd) {
-    stream.destroy();
-  }));
-}
-
-function test3(stream) {
-  stream.on('open', common.mustCall(function(fd) {
-    stream.destroy();
-    stream.destroy();
-  }));
 }


### PR DESCRIPTION
##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
