### PR TITLE
http2: make Http2Settings constructors delegate

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -225,32 +225,27 @@ void Http2Session::Http2Settings::Init() {
   count_ = n;
 }
 
-Http2Session::Http2Settings::Http2Settings(
-    Environment* env)
+Http2Session::Http2Settings::Http2Settings(Environment* env,
+    Http2Session* session, uint64_t start_time)
         : AsyncWrap(env,
                     env->http2settings_constructor_template()
                         ->NewInstance(env->context())
                             .ToLocalChecked(),
-                    AsyncWrap::PROVIDER_HTTP2SETTINGS),
-          session_(nullptr),
-          startTime_(0) {
+                    PROVIDER_HTTP2SETTINGS),
+          session_(session),
+          startTime_(start_time) {
   Init();
 }
+
+
+Http2Session::Http2Settings::Http2Settings(Environment* env)
+  : Http2Settings(env, nullptr, 0) {}
 
 // The Http2Settings class is used to configure a SETTINGS frame that is
 // to be sent to the connected peer. The settings are set using a TypedArray
 // that is shared with the JavaScript side.
-Http2Session::Http2Settings::Http2Settings(
-    Http2Session* session)
-        : AsyncWrap(session->env(),
-                    session->env()->http2settings_constructor_template()
-                        ->NewInstance(session->env()->context())
-                            .ToLocalChecked(),
-                    AsyncWrap::PROVIDER_HTTP2SETTINGS),
-          session_(session),
-          startTime_(uv_hrtime()) {
-  Init();
-}
+Http2Session::Http2Settings::Http2Settings(Http2Session* session)
+  : Http2Settings(session->env(), session, uv_hrtime()) {}
 
 // Generates a Buffer that contains the serialized payload of a SETTINGS
 // frame. This can be used, for instance, to create the Base64-encoded

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -1135,6 +1135,7 @@ class Http2Session::Http2Settings : public AsyncWrap {
                      get_setting fn);
 
  private:
+  Http2Settings(Environment* env, Http2Session* session, uint64_t start_time);
   void Init();
   Http2Session* session_;
   uint64_t startTime_;


### PR DESCRIPTION
This commit extracts the common code in the existing Http2Settings
constructors into a private constructor, allowing the existing ones to
delegate to the private constructor it and avoid code duplication.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
