### PR TITLE
tls: emit a warning when `servername` is an IP address

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2293,6 +2293,20 @@ Type: Runtime
 Please use `Server.prototype.setSecureContext()` instead.
 
 
+<a id="DEP00XX"></a>
+### DEP00XX: setting the TLS ServerName to an IP address
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Setting the TLS ServerName to an IP address is not permitted by
+[RFC 6066][]. This will be ignored in a future version.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
@@ -2393,3 +2407,4 @@ Please use `Server.prototype.setSecureContext()` instead.
 [legacy `urlObject`]: url.html#url_legacy_urlobject
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [WHATWG URL API]: url.html#url_the_whatwg_url_api
+[RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1235,9 +1235,10 @@ exports.connect = function connect(...args) {
   if (options.servername) {
     if (!ipServernameWarned && net.isIP(options.servername)) {
       process.emitWarning(
-        'Setting the TLS ServerName to an IP address is not supported by ' +
-        'RFC6066. This will be ignored in a future version.',
-        'UnsupportedWarning'
+        'Setting the TLS ServerName to an IP address is not permitted by ' +
+        'RFC 6066. This will be ignored in a future version.',
+        'DeprecationWarning',
+        'DEP00XX'
       );
       ipServernameWarned = true;
     }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -59,6 +59,8 @@ const kSNICallback = Symbol('snicallback');
 
 const noop = () => {};
 
+let ipServernameWarned = false;
+
 function onhandshakestart(now) {
   debug('onhandshakestart');
 
@@ -1230,8 +1232,17 @@ exports.connect = function connect(...args) {
   if (options.session)
     socket.setSession(options.session);
 
-  if (options.servername)
+  if (options.servername) {
+    if (!ipServernameWarned && net.isIP(options.servername)) {
+      process.emitWarning(
+        'Setting the TLS ServerName to an IP address is not supported by ' +
+        'RFC6066. This will be ignored in a future version.',
+        'UnsupportedWarning'
+      );
+      ipServernameWarned = true;
+    }
     socket.setServername(options.servername);
+  }
 
   if (options.socket)
     socket._start();

--- a/test/parallel/test-tls-ip-servername-deprecation.js
+++ b/test/parallel/test-tls-ip-servername-deprecation.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+
+// This test expects `tls.connect()` to emit a warning when
+// `servername` of options is an IP address.
+common.expectWarning(
+  'DeprecationWarning',
+  'Setting the TLS ServerName to an IP address is not permitted by ' +
+  'RFC 6066. This will be ignored in a future version.',
+  'DEP00XX'
+);
+
+{
+  const options = {
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem')
+  };
+
+  const server = tls.createServer(options, function(s) {
+    s.end('hello');
+  }).listen(0, function() {
+    const client = tls.connect({
+      port: this.address().port,
+      rejectUnauthorized: false,
+      servername: '127.0.0.1',
+    }, function() {
+      client.end();
+    });
+  });
+
+  server.on('connection', common.mustCall(function(socket) {
+    server.close();
+  }));
+}


### PR DESCRIPTION
Setting the TLS ServerName to an IP address is not permitted by RFC6066. This will be ignored in a future version.

This PR is basing on #18127 and should be semver-major.

Fixes: #18071

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
