### PR TITLE
test: read() on dir on AIX does not return EISDIR

### DIFF
--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -25,9 +25,9 @@ const fs = require('fs');
 
 // Test that fs.readFile fails correctly on a non-existent file.
 
-// `fs.readFile('/')` does not fail on FreeBSD, because you can open and read
-// the directory there.
-if (common.isFreeBSD)
+// `fs.readFile('/')` does not fail on AIX and FreeBSD because you can open
+// and read the directory there.
+if (common.isAIX || common.isFreeBSD)
   common.skip('platform not supported.');
 
 const assert = require('assert');


### PR DESCRIPTION
An upcoming change in libuv will remove the artificial EISDIR error.
Update the test to reflect that.

Refs: https://github.com/libuv/libuv/pull/2025