### PR TITLE
build: expose more openssl categories for addons

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -586,7 +586,8 @@
               # Categories to export.
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
               'PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,STDIO,TLSEXT,'
-              'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD,SCRYPT',
+              'FP_API,TLS1_METHOD,TLS1_1_METHOD,TLS1_2_METHOD,SCRYPT,OCSP,'
+              'NEXTPROTONEG,RMD160,CAST',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.


### PR DESCRIPTION
Those categories are necessary to build addons that depends on libcurl and libssh, the following were the missing symbols:
libcurl:
```
OCSP_cert_status_str
OCSP_check_validity
OCSP_basic_verify
OCSP_RESPONSE_free
OCSP_single_get0_status
OCSP_response_get1_basic
OCSP_BASICRESP_free
OCSP_crl_reason_str
OCSP_resp_count
OCSP_response_status
OCSP_response_status_str
OCSP_resp_get0
d2i_OCSP_RESPONSE
SSL_CTX_set_next_proto_select_cb
```
libssh:
```
EVP_ripemd160
EVP_cast5_cbc
```

Fixes: https://github.com/nodejs/node/issues/23293
