### PR TITLE
doc: remove style instruction that is not followed

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -24,8 +24,6 @@
     clause — a subject, verb, and an object.
   * Outside of the wrapping element if the wrapping element contains only a
     fragment of a clause.
-* Place end-of-sentence punctuation inside wrapping elements — periods go
-  inside parentheses and quotes, not after.
 * Documents must start with a level-one heading.
 * Prefer affixing links to inlining links — prefer `[a link][]` to
   `[a link](http://example.com)`.


### PR DESCRIPTION
Remove style guide instruction to place punctuation inside parentehses
and quotation marks. Those are not universally correct and we do not
follow those rules in cases where they are not correct.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
