### PR TITLE
util: reduce inspection depth default to five

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -365,8 +365,8 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/22846
-    description: The `depth` default changed to `20`.
+    pr-url: https://github.com/nodejs/node/pull/23350
+    description: The `depth` default changed to `5`.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/22788
     description: The `sorted` option is supported now.
@@ -408,7 +408,7 @@ changes:
   * `depth` {number} Specifies the number of times to recurse while formatting
     the `object`. This is useful for inspecting large complicated objects. To
     make it recurse up to the maximum call stack size pass `Infinity` or `null`.
-    **Default:** `20`.
+    **Default:** `5`.
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Colors are customizable, see [Customizing `util.inspect` colors][].
     **Default:** `false`.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -92,7 +92,7 @@ const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
-  depth: 20,
+  depth: 5,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1565,15 +1565,9 @@ util.inspect(process);
     head = head.next = {};
   }
 
-  const res = Array(15)
-    .fill(0)
-    .map((_, i) => `{ next:\n${'   '.repeat(i + 1)}`)
-    .join('') +
-    '{ next: { next: { next: { next: { next: { next:' +
-    ' [Object] } } } } } } } } } } } } } } } } } } } } }';
   assert.strictEqual(
     util.inspect(list),
-    res
+    '{ next: { next: { next: { next: { next: { next: [Object] } } } } } }'
   );
   const longList = util.inspect(list, { depth: Infinity });
   const match = longList.match(/next/g);


### PR DESCRIPTION
To minimize potential problems with the higher `util.inspect()` depth default it is lowered to five as a intermediate step.

I added the don't-land-on labels instead of marking this as semver-major since this relies on a semver-major commit.

Refs: https://github.com/nodejs/node/pull/22846#issuecomment-427894307

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
