### PR TITLE
src: remove unused limits header from util-inl.h

### DIFF
--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -24,7 +24,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <limits.h>  // INT_MAX
 #include <cstring>
 #include "util.h"
 


### PR DESCRIPTION
This commit removes the inclusion of limits.h which was introduced in
commit e812be4a55915575fc1afce739848026a48b781e ("src: make CLI options
programatically accesible"), but as far as I can see it was not used
there either so it look like it can safely be removed.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
