### PR TITLE
build: restore js2c direct dependency on config.gypi

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -629,6 +629,7 @@
           'process_outputs_as_sources': 1,
           'inputs': [
             '<@(library_files)',
+            'config.gypi',
             'tools/check_macros.py'
           ],
           'outputs': [
@@ -648,7 +649,7 @@
           'action': [
             'python', 'tools/js2c.py',
             '<@(_outputs)',
-            '<@(_inputs)', 'config.gypi',
+            '<@(_inputs)',
           ],
         },
       ],


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/23352

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
