### PR TITLE
doc: fix deprecation warnings from ToObject() in addons.md

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -589,6 +589,7 @@ namespace demo {
 
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
+using v8::Context;
 using v8::Local;
 using v8::Object;
 using v8::String;
@@ -596,9 +597,11 @@ using v8::Value;
 
 void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   Local<Object> obj = Object::New(isolate);
-  obj->Set(String::NewFromUtf8(isolate, "msg"), args[0]->ToString(isolate));
+  obj->Set(String::NewFromUtf8(isolate, "msg"),
+    args[0]->ToString(context).ToLocalChecked());
 
   args.GetReturnValue().Set(obj);
 }
@@ -1080,6 +1083,7 @@ namespace demo {
 
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
+using v8::Context;
 using v8::Local;
 using v8::Number;
 using v8::Object;
@@ -1092,11 +1096,12 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
 
 void Add(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   MyObject* obj1 = node::ObjectWrap::Unwrap<MyObject>(
-      args[0]->ToObject(isolate));
+      args[0]->ToObject(context).ToLocalChecked());
   MyObject* obj2 = node::ObjectWrap::Unwrap<MyObject>(
-      args[1]->ToObject(isolate));
+      args[1]->ToObject(context).ToLocalChecked());
 
   double sum = obj1->value() + obj2->value();
   args.GetReturnValue().Set(Number::New(isolate, sum));


### PR DESCRIPTION
These code snippets are also used in addon tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
