### PR TITLE
doc: revise security-reporting text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,12 @@ source and a list of supported platforms.
 
 ## Security
 
-Security flaws in Node.js should be reported by emailing security@nodejs.org.
-Please do not disclose security bugs publicly until they have been handled by
-the security team.
+If you find a security vulnerability in Node.js, please report it to
+security@nodejs.org. Please withhold public disclosure until after the security
+team has addressed the vulnerability.
 
-Your email will be acknowledged within 24 hours, and you will receive a more
-detailed response to your email within 48 hours indicating the next steps in
-handling your report.
+The security team will acknowledge your email within 24 hours. You will receive
+a more detailed response within 48 hours.
 
 There are no hard and fast rules to determine if a bug is worth reporting as
 a security issue. The general rule is an issue worth reporting should allow an


### PR DESCRIPTION
Simplify and clarify the security-reporting text in the README. Now is
also probably a good time to ping the security triage folks to make sure
the text is still accurate.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
