### PR TITLE
build: make configure script verbose by default

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -562,7 +562,7 @@ parser.add_option('--build-v8-with-gn',
 parser.add_option('--verbose',
     action='store_true',
     dest='verbose',
-    default=False,
+    default=True,
     help='get more output from this script')
 
 # Create compile_commands.json in out/Debug and out/Release.


### PR DESCRIPTION
The change that added the --verbose flag was supposed to be
semver-major but already landed in a 10.x release.

Refs: https://github.com/nodejs/node/pull/22450
