### PR TITLE
test: correct isReused parameter in test-http-parser

### DIFF
--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -98,7 +98,7 @@ function expectBody(expected) {
     throw new Error('hello world');
   };
 
-  parser.reinitialize(HTTPParser.REQUEST, false);
+  parser.reinitialize(HTTPParser.REQUEST, true);
 
   assert.throws(
     () => { parser.execute(request, 0, request.length); },
@@ -558,7 +558,7 @@ function expectBody(expected) {
   parser[kOnBody] = expectBody('ping');
   parser.execute(req1, 0, req1.length);
 
-  parser.reinitialize(REQUEST, false);
+  parser.reinitialize(REQUEST, true);
   parser[kOnBody] = expectBody('pong');
   parser[kOnHeadersComplete] = onHeadersComplete2;
   parser.execute(req2, 0, req2.length);


### PR DESCRIPTION
While backporting #23272 to v10.x and v8.x I noticed that the `isReused` parameters used in the two `reinitialize` calls in this test should actually be `true` instead of `false` to better reflect the actual usage here (the parser is being reused).

This does not have any effect on the test result here (since we do not test async_hooks calls here) but for the sake of consistency the test should use the API correctly.

Refs: #23272

##### Checklist

- [x] `make -j4 test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
