### PR TITLE
zlib: generate error code names in C++

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -143,7 +143,7 @@ function zlibBufferSync(engine, buffer) {
   return buffer;
 }
 
-function zlibOnError(message, errno) {
+function zlibOnError(message, errno, code) {
   var self = this[owner_symbol];
   // there is no way to cleanly recover.
   // continuing only obscures problems.
@@ -153,7 +153,7 @@ function zlibOnError(message, errno) {
   // eslint-disable-next-line no-restricted-syntax
   const error = new Error(message);
   error.errno = errno;
-  error.code = codes[errno];
+  error.code = code;
   self.emit('error', error);
 }
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -46,8 +46,8 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Int32;
+using v8::Integer;
 using v8::Local;
-using v8::Number;
 using v8::Object;
 using v8::String;
 using v8::Uint32;
@@ -55,6 +55,24 @@ using v8::Uint32Array;
 using v8::Value;
 
 namespace {
+
+#define ZLIB_ERROR_CODES(V)      \
+  V(Z_OK)                        \
+  V(Z_STREAM_END)                \
+  V(Z_NEED_DICT)                 \
+  V(Z_ERRNO)                     \
+  V(Z_STREAM_ERROR)              \
+  V(Z_DATA_ERROR)                \
+  V(Z_MEM_ERROR)                 \
+  V(Z_BUF_ERROR)                 \
+  V(Z_VERSION_ERROR)             \
+
+inline const char* ZlibStrerror(int err) {
+#define V(code) if (err == code) return #code;
+  ZLIB_ERROR_CODES(V)
+#undef V
+  return "Z_UNKNOWN_ERROR";
+}
 
 enum node_zlib_mode {
   NONE,
@@ -404,9 +422,10 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
     }
 
     HandleScope scope(env()->isolate());
-    Local<Value> args[2] = {
+    Local<Value> args[3] = {
       OneByteString(env()->isolate(), message),
-      Number::New(env()->isolate(), err_)
+      Integer::New(env()->isolate(), err_),
+      OneByteString(env()->isolate(), ZlibStrerror(err_))
     };
     MakeCallback(env()->onerror_string(), arraysize(args), args);
 


### PR DESCRIPTION
(Splitting out from https://github.com/nodejs/node/pull/23360:)

This makes it easier to implement the lookup in a way that targets
error codes from a specific compression library, as a way towards
supporting multiple ones (e.g. brotli).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
