### PR TITLE
deps: cherry-pick b0af309 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.4',
+    'v8_embedder_string': '-node.5',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -4362,13 +4362,6 @@ class V8_EXPORT WasmCompiledModule : public Object {
  public:
   typedef std::pair<std::unique_ptr<const uint8_t[]>, size_t> SerializedModule;
 
-// The COMMA macro allows us to use ',' inside of the V8_DEPRECATED macro.
-#define COMMA ,
-  V8_DEPRECATED(
-      "Use BufferReference.",
-      typedef std::pair<const uint8_t * COMMA size_t> CallerOwnedBuffer);
-#undef COMMA
-
   /**
    * A unowned reference to a byte buffer.
    */
@@ -4377,12 +4370,6 @@ class V8_EXPORT WasmCompiledModule : public Object {
     size_t size;
     BufferReference(const uint8_t* start, size_t size)
         : start(start), size(size) {}
-    // Temporarily allow conversion to and from CallerOwnedBuffer.
-    V8_DEPRECATED(
-        "Use BufferReference directly.",
-        inline BufferReference(CallerOwnedBuffer));  // NOLINT(runtime/explicit)
-    V8_DEPRECATED("Use BufferReference directly.",
-                      inline operator CallerOwnedBuffer());
   };
 
   /**
@@ -4429,8 +4416,6 @@ class V8_EXPORT WasmCompiledModule : public Object {
    * Get the wasm-encoded bytes that were used to compile this module.
    */
   BufferReference GetWasmWireBytesRef();
-  V8_DEPRECATED("Use GetWasmWireBytesRef version.",
-                    Local<String> GetWasmWireBytes());
 
   /**
    * Serialize the compiled module. The serialized data does not include the
@@ -4462,15 +4447,6 @@ class V8_EXPORT WasmCompiledModule : public Object {
   WasmCompiledModule();
   static void CheckCast(Value* obj);
 };
-
-// TODO(clemensh): Remove after M70 branch.
-WasmCompiledModule::BufferReference::BufferReference(
-    WasmCompiledModule::CallerOwnedBuffer buf)
-    : BufferReference(buf.first, buf.second) {}
-WasmCompiledModule::BufferReference::
-operator WasmCompiledModule::CallerOwnedBuffer() {
-  return {start, size};
-}
 
 /**
  * The V8 interface for WebAssembly streaming compilation. When streaming

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -7382,14 +7382,6 @@ WasmCompiledModule::BufferReference WasmCompiledModule::GetWasmWireBytesRef() {
   return {bytes_vec.start(), bytes_vec.size()};
 }
 
-Local<String> WasmCompiledModule::GetWasmWireBytes() {
-  BufferReference ref = GetWasmWireBytesRef();
-  CHECK_LE(ref.size, String::kMaxLength);
-  return String::NewFromOneByte(GetIsolate(), ref.start, NewStringType::kNormal,
-                                static_cast<int>(ref.size))
-      .ToLocalChecked();
-}
-
 WasmCompiledModule::TransferrableModule
 WasmCompiledModule::GetTransferrableModule() {
   if (i::FLAG_wasm_shared_code) {


### PR DESCRIPTION
This fixes a compilation warning that a number of us are seeing a lot when compiling Node.js core.

(This is technically semver-major, but also almost certainly unused in userland addons, so I’d really like to get it into Node 11. @nodejs/tsc)

---

Original commit message:

    [api] Remove deprecated wasm methods

    These methods were deprecated in 7.0, now we can remove them.

    R=adamk@chromium.org

    Bug: v8:7868
    Cq-Include-Trybots: luci.chromium.try:linux_chromium_rel_ng
    Change-Id: I60badb378a055152bdd27aed67d11ddf74fce174
    Reviewed-on: https://chromium-review.googlesource.com/1209283
    Reviewed-by: Adam Klein <adamk@chromium.org>
    Commit-Queue: Clemens Hammacher <clemensh@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#55695}

Refs: https://github.com/v8/v8/commit/b0af30948505b68c843b538e109ab378d3750e37

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
