### PR TITLE
Back-port v8 changes for ppc64, Aix platform

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.35',
+    'v8_embedder_string': '-node.36',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/infra/mb/mb_config.pyl
+++ b/deps/v8/infra/mb/mb_config.pyl
@@ -30,15 +30,27 @@
       'ppc.debug': 'default_debug_ppc',
       'ppc.optdebug': 'default_optdebug_ppc',
       'ppc.release': 'default_release_ppc',
+      'ppc.debug.sim': 'default_debug_ppc_sim',
+      'ppc.optdebug.sim': 'default_optdebug_ppc_sim',
+      'ppc.release.sim': 'default_release_ppc_sim',
       'ppc64.debug': 'default_debug_ppc64',
       'ppc64.optdebug': 'default_optdebug_ppc64',
       'ppc64.release': 'default_release_ppc64',
+      'ppc64.debug.sim': 'default_debug_ppc64_sim',
+      'ppc64.optdebug.sim': 'default_optdebug_ppc64_sim',
+      'ppc64.release.sim': 'default_release_ppc64_sim',
       's390.debug': 'default_debug_s390',
       's390.optdebug': 'default_optdebug_s390',
       's390.release': 'default_release_s390',
+      's390.debug.sim': 'default_debug_s390_sim',
+      's390.optdebug.sim': 'default_optdebug_s390_sim',
+      's390.release.sim': 'default_release_s390_sim',
       's390x.debug': 'default_debug_s390x',
       's390x.optdebug': 'default_optdebug_s390x',
       's390x.release': 'default_release_s390x',
+      's390x.debug.sim': 'default_debug_s390x_sim',
+      's390x.optdebug.sim': 'default_optdebug_s390x_sim',
+      's390x.release.sim': 'default_release_s390x_sim',
       'x64.debug': 'default_debug_x64',
       'x64.optdebug': 'default_optdebug_x64',
       'x64.release': 'default_release_x64',
@@ -285,28 +297,52 @@
     'default_release_mips64el': [
       'release', 'simulate_mips64el'],
     'default_debug_ppc': [
-      'debug', 'simulate_ppc', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+      'debug', 'ppc', 'v8_enable_slow_dchecks', 'v8_full_debug'],
     'default_optdebug_ppc': [
-      'debug', 'simulate_ppc', 'v8_enable_slow_dchecks'],
+      'debug', 'ppc', 'v8_enable_slow_dchecks'],
     'default_release_ppc': [
+      'release', 'ppc'],
+    'default_debug_ppc_sim': [
+      'debug', 'simulate_ppc', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_ppc_sim': [
+      'debug', 'simulate_ppc', 'v8_enable_slow_dchecks'],
+    'default_release_ppc_sim': [
       'release', 'simulate_ppc'],
     'default_debug_ppc64': [
-      'debug', 'simulate_ppc64', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+      'debug', 'ppc64', 'v8_enable_slow_dchecks', 'v8_full_debug'],
     'default_optdebug_ppc64': [
-      'debug', 'simulate_ppc64', 'v8_enable_slow_dchecks'],
+      'debug', 'ppc64', 'v8_enable_slow_dchecks'],
     'default_release_ppc64': [
+      'release', 'ppc64'],
+    'default_debug_ppc64_sim': [
+      'debug', 'simulate_ppc64', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_ppc64_sim': [
+      'debug', 'simulate_ppc64', 'v8_enable_slow_dchecks'],
+    'default_release_ppc64_sim': [
       'release', 'simulate_ppc64'],
     'default_debug_s390': [
-      'debug', 'simulate_s390', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+      'debug', 's390', 'v8_enable_slow_dchecks', 'v8_full_debug'],
     'default_optdebug_s390': [
-      'debug', 'simulate_s390', 'v8_enable_slow_dchecks'],
+      'debug', 's390', 'v8_enable_slow_dchecks'],
     'default_release_s390': [
+      'release', 's390'],
+    'default_debug_s390_sim': [
+      'debug', 'simulate_s390', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_s390_sim': [
+      'debug', 'simulate_s390', 'v8_enable_slow_dchecks'],
+    'default_release_s390_sim': [
       'release', 'simulate_s390'],
     'default_debug_s390x': [
-      'debug', 'simulate_s390x', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+      'debug', 's390x', 'v8_enable_slow_dchecks', 'v8_full_debug'],
     'default_optdebug_s390x': [
-      'debug', 'simulate_s390x', 'v8_enable_slow_dchecks'],
+      'debug', 's390x', 'v8_enable_slow_dchecks'],
     'default_release_s390x': [
+      'release', 's390x'],
+    'default_debug_s390x_sim': [
+      'debug', 'simulate_s390x', 'v8_enable_slow_dchecks', 'v8_full_debug'],
+    'default_optdebug_s390x_sim': [
+      'debug', 'simulate_s390x', 'v8_enable_slow_dchecks'],
+    'default_release_s390x_sim': [
       'release', 'simulate_s390x'],
     'default_debug_x64': [
       'debug', 'x64', 'v8_enable_slow_dchecks', 'v8_full_debug'],
@@ -814,6 +850,22 @@
 
     'v8_verify_csa': {
       'gn_args': 'v8_enable_verify_csa=true',
+    },
+
+    's390': {
+      'gn_args': 'target_cpu="s390x" v8_target_cpu="s390"',
+    },
+
+    's390x': {
+      'gn_args': 'target_cpu="s390x" v8_target_cpu="s390x"',
+    },
+
+    'ppc': {
+      'gn_args': 'target_cpu="ppc"',
+    },
+
+    'ppc64': {
+      'gn_args': 'target_cpu="ppc64" use_custom_libcxx=false',
     },
 
     'x64': {

--- a/deps/v8/src/compiler/bytecode-graph-builder.cc
+++ b/deps/v8/src/compiler/bytecode-graph-builder.cc
@@ -514,7 +514,7 @@ Node* BytecodeGraphBuilder::Environment::Checkpoint(
 BytecodeGraphBuilder::BytecodeGraphBuilder(
     Zone* local_zone, Handle<SharedFunctionInfo> shared_info,
     Handle<FeedbackVector> feedback_vector, BailoutId osr_offset,
-    JSGraph* jsgraph, CallFrequency invocation_frequency,
+    JSGraph* jsgraph, CallFrequency& invocation_frequency,
     SourcePositionTable* source_positions, Handle<Context> native_context,
     int inlining_id, JSTypeHintLowering::Flags flags, bool stack_check,
     bool analyze_environment_liveness)

--- a/deps/v8/src/compiler/bytecode-graph-builder.h
+++ b/deps/v8/src/compiler/bytecode-graph-builder.h
@@ -31,7 +31,7 @@ class BytecodeGraphBuilder {
   BytecodeGraphBuilder(
       Zone* local_zone, Handle<SharedFunctionInfo> shared,
       Handle<FeedbackVector> feedback_vector, BailoutId osr_offset,
-      JSGraph* jsgraph, CallFrequency invocation_frequency,
+      JSGraph* jsgraph, CallFrequency& invocation_frequency,
       SourcePositionTable* source_positions, Handle<Context> native_context,
       int inlining_id = SourcePosition::kNotInlined,
       JSTypeHintLowering::Flags flags = JSTypeHintLowering::kNoFlags,

--- a/deps/v8/src/compiler/js-inlining.cc
+++ b/deps/v8/src/compiler/js-inlining.cc
@@ -484,9 +484,10 @@ Reduction JSInliner::ReduceJSCall(Node* node) {
     if (info_->is_bailout_on_uninitialized()) {
       flags |= JSTypeHintLowering::kBailoutOnUninitialized;
     }
+    CallFrequency frequency = call.frequency();
     BytecodeGraphBuilder graph_builder(
         zone(), shared_info, feedback_vector, BailoutId::None(), jsgraph(),
-        call.frequency(), source_positions_, native_context(), inlining_id,
+        frequency, source_positions_, native_context(), inlining_id,
         flags, false, info_->is_analyze_environment_liveness());
     graph_builder.CreateGraph();
 

--- a/deps/v8/src/compiler/js-operator.cc
+++ b/deps/v8/src/compiler/js-operator.cc
@@ -794,7 +794,8 @@ const Operator* JSOperatorBuilder::CallForwardVarargs(size_t arity,
       parameters);                                               // parameter
 }
 
-const Operator* JSOperatorBuilder::Call(size_t arity, CallFrequency frequency,
+const Operator* JSOperatorBuilder::Call(size_t arity,
+                                        CallFrequency const& frequency,
                                         VectorSlotPair const& feedback,
                                         ConvertReceiverMode convert_mode,
                                         SpeculationMode speculation_mode) {
@@ -818,8 +819,8 @@ const Operator* JSOperatorBuilder::CallWithArrayLike(CallFrequency frequency) {
 }
 
 const Operator* JSOperatorBuilder::CallWithSpread(
-    uint32_t arity, CallFrequency frequency, VectorSlotPair const& feedback,
-    SpeculationMode speculation_mode) {
+    uint32_t arity, CallFrequency const& frequency,
+    VectorSlotPair const& feedback, SpeculationMode speculation_mode) {
   DCHECK_IMPLIES(speculation_mode == SpeculationMode::kAllowSpeculation,
                  feedback.IsValid());
   CallParameters parameters(arity, frequency, feedback,

--- a/deps/v8/src/compiler/js-operator.h
+++ b/deps/v8/src/compiler/js-operator.h
@@ -160,7 +160,7 @@ CallForwardVarargsParameters const& CallForwardVarargsParametersOf(
 // used as a parameter by JSCall and JSCallWithSpread operators.
 class CallParameters final {
  public:
-  CallParameters(size_t arity, CallFrequency frequency,
+  CallParameters(size_t arity, CallFrequency const& frequency,
                  VectorSlotPair const& feedback,
                  ConvertReceiverMode convert_mode,
                  SpeculationMode speculation_mode)
@@ -171,7 +171,7 @@ class CallParameters final {
         feedback_(feedback) {}
 
   size_t arity() const { return ArityField::decode(bit_field_); }
-  CallFrequency frequency() const { return frequency_; }
+  CallFrequency const& frequency() const { return frequency_; }
   ConvertReceiverMode convert_mode() const {
     return ConvertReceiverModeField::decode(bit_field_);
   }
@@ -721,13 +721,13 @@ class V8_EXPORT_PRIVATE JSOperatorBuilder final
 
   const Operator* CallForwardVarargs(size_t arity, uint32_t start_index);
   const Operator* Call(
-      size_t arity, CallFrequency frequency = CallFrequency(),
+      size_t arity, CallFrequency const& frequency = CallFrequency(),
       VectorSlotPair const& feedback = VectorSlotPair(),
       ConvertReceiverMode convert_mode = ConvertReceiverMode::kAny,
       SpeculationMode speculation_mode = SpeculationMode::kDisallowSpeculation);
   const Operator* CallWithArrayLike(CallFrequency frequency);
   const Operator* CallWithSpread(
-      uint32_t arity, CallFrequency frequency = CallFrequency(),
+      uint32_t arity, CallFrequency const& frequency = CallFrequency(),
       VectorSlotPair const& feedback = VectorSlotPair(),
       SpeculationMode speculation_mode = SpeculationMode::kDisallowSpeculation);
   const Operator* CallRuntime(Runtime::FunctionId id);

--- a/deps/v8/src/compiler/pipeline.cc
+++ b/deps/v8/src/compiler/pipeline.cc
@@ -1059,10 +1059,11 @@ struct GraphBuilderPhase {
     if (data->info()->is_bailout_on_uninitialized()) {
       flags |= JSTypeHintLowering::kBailoutOnUninitialized;
     }
+    CallFrequency frequency = CallFrequency(1.0f);
     BytecodeGraphBuilder graph_builder(
         temp_zone, data->info()->shared_info(),
         handle(data->info()->closure()->feedback_vector()),
-        data->info()->osr_offset(), data->jsgraph(), CallFrequency(1.0f),
+        data->info()->osr_offset(), data->jsgraph(), frequency,
         data->source_positions(), data->native_context(),
         SourcePosition::kNotInlined, flags, true,
         data->info()->is_analyze_environment_liveness());

--- a/deps/v8/src/torque/file-visitor.h
+++ b/deps/v8/src/torque/file-visitor.h
@@ -21,6 +21,10 @@ namespace torque {
 
 class FileVisitor {
  public:
+#if defined(__GNUC__) && V8_OS_AIX
+  // prevent non-virtual-dtor gcc error on Aix
+  virtual ~FileVisitor() = default;
+#endif
   explicit FileVisitor(GlobalContext& global_context)
       : global_context_(global_context),
         declarations_(global_context.declarations()),

--- a/deps/v8/test/cctest/cctest.status
+++ b/deps/v8/test/cctest/cctest.status
@@ -390,6 +390,7 @@
   # TODO(ppc): Implement load/store reverse byte instructions
   'test-run-wasm-simd/RunWasmCompiled_SimdLoadStoreLoad': [SKIP],
   'test-run-wasm-simd/RunWasm_SimdLoadStoreLoad': [SKIP],
+  'test-run-wasm-simd/RunWasm_SimdLoadStoreLoad_turbofan': [SKIP],
 
 }],  # 'system == aix or (arch == ppc64 and byteorder == big)'
 

--- a/deps/v8/third_party/antlr4/BUILD.gn
+++ b/deps/v8/third_party/antlr4/BUILD.gn
@@ -9,6 +9,9 @@ config("antlr-compatibility") {
       "-Wno-unused-but-set-variable",
     ]
   }
+  if (current_os == "aix") {
+    cflags += [ "-fdollars-in-identifiers" ]
+  }
 }
 
 source_set("antlr4") {

--- a/deps/v8/tools/mb/mb.py
+++ b/deps/v8/tools/mb/mb.py
@@ -835,7 +835,13 @@ class MetaBuildWrapper(object):
     else:
       subdir, exe = 'win', 'gn.exe'
 
-    gn_path = self.PathJoin(self.chromium_src_dir, 'buildtools', subdir, exe)
+    arch = platform.machine()
+    if self.platform.startswith('aix') or (self.platform == 'linux2' and
+       (arch.startswith('s390') or arch.startswith('ppc'))):
+      # use gn in PATH
+      gn_path = 'gn'
+    else:
+      gn_path = self.PathJoin(self.chromium_src_dir, 'buildtools', subdir, exe)
     return [gn_path, subcommand, path] + list(args)
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->



Back-port v8 changes for ppc64, Aix platform 
Changes included:


s390, ppc64: Enable v8gen.py on Linux s390, ppc64
V8 Revision: abab9fbb643e97d1fa7ddee9bfc609e0e4a4f184
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1135540

fix gn builds on aix.
V8 Revision: d9e78322d0370543342d52d58e4d81db67bb7203
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1103533


Use gn from PATH on aix in v8gen.py
V8 Revision: e7fad930a83b5b4f1bfee6bee620f35b988d28c3
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1168087


ppc64, aix: Pass CallFrequency object by const reference to avoid value copy error.
Bug: v8:8193
GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61976
V8 Revision: d2e0166ded485df126c765b9196f7edd1ce50f82
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1228633


disable failing cctest on AIX temporarily
V8 Revision: 67b549938d9060dde5cb557865f7451392a0f004
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1174560


deps/v8/src/torque/file-visitor.h:
Add virtual dtor to avoid gcc error on Aix. (Not currently present in v8/master)

The following patch to v8/build solves this issue for v8/master:
a1a12ef3b343f9e75c630ed6dc8f1ea44a8a747b

However, the version of '/chromium/src/build.git' cannot be updated to include this
patch in v8/DEPS file. (could potentially cause issues for other platforms)

The change to deps/v8/src/torque/file-visitor.h is a workaround for origin/v10.x-staging
branch.

