### PR TITLE
build: add common `defines`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -20,12 +20,14 @@
     'node_module_version%': '',
     'node_with_ltcg%': '',
     'node_use_pch%': 'false',
+    'node_shared_openssl%': 'false',
 
     'node_tag%': '',
     'uv_library%': 'static_library',
 
     'clang%': 0,
 
+    'openssl_no_asm%': 0,
     'openssl_fips%': '',
 
     # Reset this number to 0 on major V8 upgrades.
@@ -261,6 +263,14 @@
         }
       }
     },
+
+    # Defines these mostly for node-gyp to pickup, and warn addon authors of
+    # imminent V8 deprecations, also to sync how dependencies are configured.
+    'defines': [
+      'V8_DEPRECATION_WARNINGS',
+      'V8_IMMINENT_DEPRECATION_WARNINGS',
+    ],
+
     # Forcibly disable -Werror.  We support a wide range of compilers, it's
     # simply not feasible to squelch all warnings, never mind that the
     # libraries in deps/ are not under our control.
@@ -503,7 +513,18 @@
         'ldflags': [
           '-Wl,--export-dynamic',
         ],
-      }]
+      }],
+      ['node_shared_openssl!="true"', {
+        # `OPENSSL_THREADS` is defined via GYP for openSSL for all architectures.
+        'defines': [
+          'OPENSSL_THREADS',
+        ],
+      }],
+      ['node_shared_openssl!="true" and openssl_no_asm==1', {
+        'defines': [
+          'OPENSSL_NO_ASM',
+        ],
+      }],
     ],
   }
 }


### PR DESCRIPTION
* `V8_DEPRECATION_WARNINGS` is here for explicity. It is already defined
  in `node.gypi`, and `addon.gypi`.
* `V8_IMMINENT_DEPRECATION_WARNINGS` added to warn addons authors.
* `OPENSSL_THREADS` apears in the openSSL `.h` files, and was only
  defined via GYP for the node build.

Refs: https://github.com/nodejs/node/issues/23122
Refs: https://github.com/nodejs/node/pull/23414#issuecomment-428763624
Fixes: https://github.com/nodejs/node/issues/23167
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
