### PR TITLE
crypto: reduce memory usage of SignFinal

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3631,7 +3631,7 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
     return sign->CheckThrow(err);
 
   Local<Object> rc =
-      Buffer::New(env, reinterpret_cast<char*>(sig.data), sig.size)
+      Buffer::New(env, reinterpret_cast<char*>(sig.release()), sig.size)
       .ToLocalChecked();
   args.GetReturnValue().Set(rc);
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3635,7 +3635,7 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
     return sign->CheckThrow(std::get<Error>(ret));
 
   MallocedBuffer<unsigned char> sig =
-      std::get<MallocedBuffer<unsigned char>>(std::move(ret));
+      std::move(std::get<MallocedBuffer<unsigned char>>(ret));
 
   Local<Object> rc =
       Buffer::New(env, reinterpret_cast<char*>(sig.release()), sig.size)

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -521,8 +521,7 @@ class Sign : public SignBase {
   Error SignFinal(const char* key_pem,
                   int key_pem_len,
                   const char* passphrase,
-                  unsigned char* sig,
-                  unsigned int* sig_len,
+                  MallocedBuffer<unsigned char>* sig,
                   int padding,
                   int saltlen);
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -518,12 +518,12 @@ class Sign : public SignBase {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
-  Error SignFinal(const char* key_pem,
-                  int key_pem_len,
-                  const char* passphrase,
-                  MallocedBuffer<unsigned char>* sig,
-                  int padding,
-                  int saltlen);
+  std::pair<Error, MallocedBuffer<unsigned char>> SignFinal(
+      const char* key_pem,
+      int key_pem_len,
+      const char* passphrase,
+      int padding,
+      int saltlen);
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/util.h
+++ b/src/util.h
@@ -439,6 +439,11 @@ struct MallocedBuffer {
     return ret;
   }
 
+  void Truncate(size_t new_size) {
+    CHECK(new_size <= size);
+    size = new_size;
+  }
+
   inline bool is_empty() const { return data == nullptr; }
 
   MallocedBuffer() : data(nullptr) {}

--- a/src/util.h
+++ b/src/util.h
@@ -446,7 +446,7 @@ struct MallocedBuffer {
 
   inline bool is_empty() const { return data == nullptr; }
 
-  MallocedBuffer() : data(nullptr) {}
+  MallocedBuffer() : data(nullptr), size(0) {}
   explicit MallocedBuffer(size_t size) : data(Malloc<T>(size)), size(size) {}
   MallocedBuffer(T* data, size_t size) : data(data), size(size) {}
   MallocedBuffer(MallocedBuffer&& other) : data(other.data), size(other.size) {


### PR DESCRIPTION
The fixed-size buffer on the stack is unnecessary and way too large for most applications. This change removes it and allocates the required memory directly instead of copying into heap later.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
