### PR TITLE
crypto: add a crypto.uuid() method

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -139,6 +139,15 @@ function createVerify(algorithm, options) {
   return new Verify(algorithm, options);
 }
 
+function uuid() {
+  // Generate 32 random hexadecimal characters
+  const src = randomBytes(16).toString('hex');
+
+  // The 13th random hex character is discarded and replaced with '4'
+  return `${src.substr(0, 8)}-${src.substr(8, 4)}-4${src.substr(13, 3)}` +
+    `-${src.substr(16, 4)}-${src.substr(20, 32)}`;
+}
+
 module.exports = exports = {
   // Methods
   createCipheriv,
@@ -169,6 +178,7 @@ module.exports = exports = {
   scryptSync,
   setEngine,
   timingSafeEqual,
+  uuid,
   getFips: !fipsMode ? getFipsDisabled :
     fipsForced ? getFipsForced : getFipsCrypto,
   setFips: !fipsMode ? setFipsDisabled :

--- a/test/parallel/test-crypto-uuid.js
+++ b/test/parallel/test-crypto-uuid.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const UUID_V4_REGEX =
+  /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}/;
+
+// Test crypto.randomBytes() implementation
+for (let i = 0; i < 100; i++) {
+  const uuid = crypto.uuid();
+  assert.ok(UUID_V4_REGEX.test(uuid));
+}


### PR DESCRIPTION
This PR introduces a new method called `crypto.uuid()`. This method generates a [UUID v4 string](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)). It can be used like so:

```js
const crypto = require('crypto');
const uuid = crypto.uuid();
console.log(uuid); // f933d282-560c-4464-aff2-56bf65c0a431
```

### Why introduce this into Node.js Core
The Node.js community has a great need for this method. For example, the npm package [uuid](https://www.npmjs.com/package/uuid) receives **11.4mm** downloads per week, and the deprecated [node-uuid](https://www.npmjs.com/package/node-uuid) still receives **1.6mm** downloads per week.

This same functionality is often provided by other languages/platforms such as the C#/.NET implementation [System.Guid.NewGuid()](https://docs.microsoft.com/en-us/dotnet/api/system.guid.newguid?redirectedfrom=MSDN&view=netframework-4.7.2#System_Guid_NewGuid) or Pythons [import uuid](https://docs.python.org/3/library/uuid.html).

Anecdotally, most projects I build require a UUID generator.

### What's a UUID
A UUID string is a random series of 32 hexadecimal characters separated by hyphens at well-known locations for a total length of 36 characters. The 13th character is always a `'4'`, so that leaves 31 hexadecimal characters of entropy. According to Wikipedia that means the overall string has _2^122, or 5.3x1036 (5.3 undecillion)_ possible variations.

### Why UUID v4?
This is the most popular method as far as I've seen used in the wild. It's also the easiest to generate since it's just random characters. The other versions take current time into consideration and may generate ever-increasing values. Some attempt to maintain uniqueness across different systems which also adds complexity.

This approach would be forward compatible if we did want to support different UUID versions in the future. For example `.uuid` could have further methods attached, such as `.uuid.v1()` or even `.uuid.v4()` which would be an alias for `.uuid()`.

##### Checklist

I haven't added documentation yet since this method may move around before being accepted (if it's accepted at all). I'll definitely write docs after the first round of feedback!

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
