### PR TITLE
test: fix `assert.strictEqual` arguments in test/parallel/test-c-ares.js

### DIFF
--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -46,20 +46,20 @@ const dnsPromises = dns.promises;
 
 dns.lookup(null, common.mustCall((error, result, addressType) => {
   assert.ifError(error);
-  assert.strictEqual(null, result);
-  assert.strictEqual(4, addressType);
+  assert.strictEqual(result, null);
+  assert.strictEqual(addressType, 4);
 }));
 
 dns.lookup('127.0.0.1', common.mustCall((error, result, addressType) => {
   assert.ifError(error);
-  assert.strictEqual('127.0.0.1', result);
-  assert.strictEqual(4, addressType);
+  assert.strictEqual(result, '127.0.0.1');
+  assert.strictEqual(addressType, 4);
 }));
 
 dns.lookup('::1', common.mustCall((error, result, addressType) => {
   assert.ifError(error);
-  assert.strictEqual('::1', result);
-  assert.strictEqual(6, addressType);
+  assert.strictEqual(result, '::1');
+  assert.strictEqual(addressType, 6);
 }));
 
 [


### PR DESCRIPTION
When using `assert.strictEqual`, the first argument must be the actual
value and the second argument must be the expected value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
