### PR TITLE
test: fix http local address test assertion

### DIFF
--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -30,7 +30,7 @@ const assert = require('assert');
 
 const server = http.createServer(function(req, res) {
   console.log(`Connect from: ${req.connection.remoteAddress}`);
-  assert.strictEqual('127.0.0.2', req.connection.remoteAddress);
+  assert.strictEqual(req.connection.remoteAddress, '127.0.0.2');
 
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });


### PR DESCRIPTION
Reverse the argument for assertion. The first argument should be the
actual value and the second value should be the expected value. When
there is an AssertionError, the expected and actual value will be
labeled correctly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
