### PR TITLE
src: change v8:ConstructorBehavior in stream_base-inl.h

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -275,29 +275,28 @@ void StreamBase::AddMethods(Environment* env, Local<FunctionTemplate> t) {
 
   Local<Signature> signature = Signature::New(env->isolate(), t);
 
-  // TODO(TimothyGu): None of these should have ConstructorBehavior::kAllow.
   Local<FunctionTemplate> get_fd_templ =
       env->NewFunctionTemplate(GetFD<Base>,
                                signature,
-                               v8::ConstructorBehavior::kAllow,
+                               v8::ConstructorBehavior::kThrow,
                                v8::SideEffectType::kHasNoSideEffect);
 
   Local<FunctionTemplate> get_external_templ =
       env->NewFunctionTemplate(GetExternal<Base>,
                                signature,
-                               v8::ConstructorBehavior::kAllow,
+                               v8::ConstructorBehavior::kThrow,
                                v8::SideEffectType::kHasNoSideEffect);
 
   Local<FunctionTemplate> get_bytes_read_templ =
       env->NewFunctionTemplate(GetBytesRead<Base>,
                                signature,
-                               v8::ConstructorBehavior::kAllow,
+                               v8::ConstructorBehavior::kThrow,
                                v8::SideEffectType::kHasNoSideEffect);
 
   Local<FunctionTemplate> get_bytes_written_templ =
       env->NewFunctionTemplate(GetBytesWritten<Base>,
                                signature,
-                               v8::ConstructorBehavior::kAllow,
+                               v8::ConstructorBehavior::kThrow,
                                v8::SideEffectType::kHasNoSideEffect);
 
   t->PrototypeTemplate()->SetAccessorProperty(env->fd_string(),


### PR DESCRIPTION
Throw if addMethod functions used as constructors.
Implemented TimothyGu) TODO: None of these should
have ConstructorBehavior::kAllow
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
