### PR TITLE
test: replace assert.throws w/ common.expectsError

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -804,20 +804,52 @@ assert.strictEqual(Buffer.from('13.37').length, 5);
 Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 
 // issue GH-5587
-assert.throws(() => Buffer.alloc(8).writeFloatLE(0, 5), RangeError);
-assert.throws(() => Buffer.alloc(16).writeDoubleLE(0, 9), RangeError);
+common.expectsError(
+  () => Buffer.alloc(8).writeFloatLE(0, 5),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
+common.expectsError(
+  () => Buffer.alloc(16).writeDoubleLE(0, 9),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
 
 // attempt to overflow buffers, similar to previous bug in array buffers
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
-              RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
-              RangeError);
-
+common.expectsError(
+  () => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
+common.expectsError(
+  () => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
 
 // ensure negative values can't get past offset
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
-
+common.expectsError(
+  () => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
+common.expectsError(
+  () => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError
+  }
+);
 
 // test for common write(U)IntLE/BE
 {


### PR DESCRIPTION
Converts RangeError assertions to use common.expectsError and includes
an assertion for the error code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
