### PR TITLE
test: strictEqual correct order for http-information-processing test

### DIFF
--- a/test/parallel/test-http-information-processing.js
+++ b/test/parallel/test-http-information-processing.js
@@ -38,7 +38,7 @@ server.listen(0, function() {
   req.on('response', function(res) {
     // Check that all 102 Processing received before full response received.
     assert.strictEqual(countdown.remaining, 1);
-    assert.strictEqual(200, res.statusCode,
+    assert.strictEqual(res.statusCode, 200,
                        `Final status code was ${res.statusCode}, not 200.`);
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });


### PR DESCRIPTION
for one test, inside the test/parallel/test-http-information-processing.js, the assert.strictEqual() had the wrong order

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
