### PR TITLE
test: swap assert.strictEqual args to actual, expected

### DIFF
--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -47,7 +47,7 @@ if (cluster.isMaster && process.argv.length !== 3) {
   worker.on('message', common.mustCall(function(err) {
     // disconnect first, so that we will not leave zombies
     worker.disconnect();
-    assert.strictEqual('EADDRINUSE', err.code);
+    assert.strictEqual(err.code, 'EADDRINUSE');
   }));
 } else if (process.argv.length !== 3) {
   // cluster.worker


### PR DESCRIPTION
test: swap assert.strictEqual args to actual, expected

In this test, `assert.strictEqual()` takes two arguments where the first is the expected value and the second is the actual. This is backwards from the documentation where the first value should be the actual value and the second be the expected. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
