### PR TITLE
test: fix incorrect ordering of args in assert.strictEqual()

### DIFF
--- a/test/parallel/test-http-upgrade-server2.js
+++ b/test/parallel/test-http-upgrade-server2.js
@@ -36,7 +36,7 @@ server.on('upgrade', function(req, socket, upgradeHead) {
 });
 
 process.on('uncaughtException', common.mustCall(function(e) {
-  assert.strictEqual('upgrade error', e.message);
+  assert.strictEqual(e.message, 'upgrade error');
   process.exit(0);
 }));
 


### PR DESCRIPTION
test: fix incorrect ordering of args in assert.strictEqual()
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
