### PR TITLE
test: correct assert test

### DIFF
--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -72,7 +72,7 @@ c.log('test');
 c.error('test');
 
 out.write = common.mustCall((d) => {
-  assert.strictEqual('{ foo: 1 }\n', d);
+  assert.strictEqual(d, '{ foo: 1 }\n')
 });
 
 c.dir({ foo: 1 });

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -72,7 +72,7 @@ c.log('test');
 c.error('test');
 
 out.write = common.mustCall((d) => {
-  assert.strictEqual(d, '{ foo: 1 }\n')
+  assert.strictEqual(d, '{ foo: 1 }\n');
 });
 
 c.dir({ foo: 1 });


### PR DESCRIPTION
# Description

Corrected `assert.strictEqual` on `parallel/test-console-instance.js` as the test was inverse of assert documentation
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
