### PR TITLE
lib: migrate from process.binding to internalBinding

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -415,7 +415,7 @@ module.exports = {
   compileFunction,
 };
 
-if (process.binding('config').experimentalVMModules) {
+if (internalBinding('options').getOptions('--experimental-vm-modules')) {
   const { SourceTextModule } = require('internal/vm/source_text_module');
   module.exports.SourceTextModule = SourceTextModule;
 }


### PR DESCRIPTION
We are migrating towards using internalBinding(\'options\').getOptions()
instead of process.binding(\'config\') to access the value of the
--experimental-vm-modules command line option.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
