### PR TITLE
Removed unused e variable in catch statement

### DIFF
--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -50,7 +50,7 @@ if (process.argv[2] === 'child') {
       if (process.argv.includes('useTryCatch')) {
         try {
           throw new Error(domainErrHandlerExMessage);
-        } catch () {
+        } catch {
         }
       } else {
         throw new Error(domainErrHandlerExMessage);

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -50,7 +50,7 @@ if (process.argv[2] === 'child') {
       if (process.argv.includes('useTryCatch')) {
         try {
           throw new Error(domainErrHandlerExMessage);
-        } catch (e) {
+        } catch () {
         }
       } else {
         throw new Error(domainErrHandlerExMessage);


### PR DESCRIPTION
##### Checklist
Removed an unused e variable from a catch statement. This PR was completed as part of the Node - JS Interactive 2018 Vancouver code and learn.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
