### PR TITLE
test: flip assertion arguments for make-callback/test.js

### DIFF
--- a/test/addons/make-callback/test.js
+++ b/test/addons/make-callback/test.js
@@ -6,39 +6,39 @@ const vm = require('vm');
 const binding = require(`./build/${common.buildType}/binding`);
 const makeCallback = binding.makeCallback;
 
-assert.strictEqual(42, makeCallback(process, common.mustCall(function() {
-  assert.strictEqual(0, arguments.length);
-  assert.strictEqual(this, process);
+assert.strictEqual(makeCallback(process, common.mustCall(function() {
+  assert.strictEqual(arguments.length, 0);
+  assert.strictEqual(process, this);
   return 42;
-})));
+})), 42);
 
-assert.strictEqual(42, makeCallback(process, common.mustCall(function(x) {
-  assert.strictEqual(1, arguments.length);
-  assert.strictEqual(this, process);
+assert.strictEqual(makeCallback(process, common.mustCall(function(x) {
+  assert.strictEqual(arguments.length, 1);
+  assert.strictEqual(process, this);
   assert.strictEqual(x, 1337);
   return 42;
-}), 1337));
+}), 1337), 42);
 
 const recv = {
   one: common.mustCall(function() {
-    assert.strictEqual(0, arguments.length);
-    assert.strictEqual(this, recv);
+    assert.strictEqual(arguments.length, 0);
+    assert.strictEqual(recv, this);
     return 42;
   }),
   two: common.mustCall(function(x) {
-    assert.strictEqual(1, arguments.length);
-    assert.strictEqual(this, recv);
+    assert.strictEqual(arguments.length, 1);
+    assert.strictEqual(recv, this);
     assert.strictEqual(x, 1337);
     return 42;
   }),
 };
 
-assert.strictEqual(42, makeCallback(recv, 'one'));
-assert.strictEqual(42, makeCallback(recv, 'two', 1337));
+assert.strictEqual(makeCallback(recv, 'one'), 42);
+assert.strictEqual(makeCallback(recv, 'two', 1337), 42);
 
 // Check that callbacks on a receiver from a different context works.
 const foreignObject = vm.runInNewContext('({ fortytwo() { return 42; } })');
-assert.strictEqual(42, makeCallback(foreignObject, 'fortytwo'));
+assert.strictEqual(makeCallback(foreignObject, 'fortytwo'), 42);
 
 // Check that the callback is made in the context of the receiver.
 const target = vm.runInNewContext(`
@@ -48,7 +48,7 @@ const target = vm.runInNewContext(`
       return Object;
     })
 `);
-assert.notStrictEqual(Object, makeCallback(process, target, Object));
+assert.notStrictEqual(makeCallback(process, target, Object), Object);
 
 // Runs in inner context.
 const forward = vm.runInNewContext(`
@@ -62,4 +62,4 @@ function endpoint($Object) {
     throw new Error('bad');
   return Object;
 }
-assert.strictEqual(Object, makeCallback(process, forward, endpoint));
+assert.strictEqual(makeCallback(process, forward, endpoint), Object);


### PR DESCRIPTION
Assertion arguments should have the first value be the actual value, while the second value be the expected value. This follows the documentation for `assert.strictEqual()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
