### PR TITLE
readline: remove usage of process exit event listener

### DIFF
--- a/test/parallel/test-readline-emit-keypress-events.js
+++ b/test/parallel/test-readline-emit-keypress-events.js
@@ -20,11 +20,9 @@ stream.on('keypress', (s, k) => {
 
 stream.write('foo');
 
-process.on('exit', () => {
-  assert.deepStrictEqual(sequence, ['f', 'o', 'o']);
-  assert.deepStrictEqual(keys, [
-    { sequence: 'f', name: 'f', ctrl: false, meta: false, shift: false },
-    { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false },
-    { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false }
-  ]);
-});
+assert.deepStrictEqual(sequence, ['f', 'o', 'o']);
+assert.deepStrictEqual(keys, [
+  { sequence: 'f', name: 'f', ctrl: false, meta: false, shift: false },
+  { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false },
+  { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false }
+]);


### PR DESCRIPTION
Removes the unneccesary usage of the process.exit event listener
(NodeJS code and learn)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
