### PR TITLE
Correctly order assertion arguments in test-inspector-debug-brk-flag.js

### DIFF
--- a/test/sequential/test-inspector-debug-brk-flag.js
+++ b/test/sequential/test-inspector-debug-brk-flag.js
@@ -34,7 +34,7 @@ async function runTests() {
   await testBreakpointOnStart(session);
   await session.runToCompletion();
 
-  assert.strictEqual(55, (await child.expectShutdown()).exitCode);
+  assert.strictEqual((await child.expectShutdown()).exitCode, 55);
 }
 
 runTests();


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
