### PR TITLE
swap actual and expected in assertions

### DIFF
--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -41,41 +41,41 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 {
   const expected = 'ümlaut eins';  // Must be a unique string.
   externalizeString(expected);
-  assert.strictEqual(true, isOneByteString(expected));
+  assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'latin1');
   fs.closeSync(fd);
-  assert.strictEqual(expected, fs.readFileSync(fn, 'latin1'));
+  assert.strictEqual(fs.readFileSync(fn, 'latin1'), expected);
 }
 
 {
   const expected = 'ümlaut zwei';  // Must be a unique string.
   externalizeString(expected);
-  assert.strictEqual(true, isOneByteString(expected));
+  assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'utf8');
   fs.closeSync(fd);
-  assert.strictEqual(expected, fs.readFileSync(fn, 'utf8'));
+  assert.strictEqual(fs.readFileSync(fn, 'utf8'), expected);
 }
 
 {
   const expected = '中文 1';  // Must be a unique string.
   externalizeString(expected);
-  assert.strictEqual(false, isOneByteString(expected));
+  assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'ucs2');
   fs.closeSync(fd);
-  assert.strictEqual(expected, fs.readFileSync(fn, 'ucs2'));
+  assert.strictEqual(fs.readFileSync(fn, 'ucs2'), expected);
 }
 
 {
   const expected = '中文 2';  // Must be a unique string.
   externalizeString(expected);
-  assert.strictEqual(false, isOneByteString(expected));
+  assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
   fs.writeSync(fd, expected, 0, 'utf8');
   fs.closeSync(fd);
-  assert.strictEqual(expected, fs.readFileSync(fn, 'utf8'));
+  assert.strictEqual(fs.readFileSync(fn, 'utf8'), expected);
 }
 /* eslint-enable no-undef */
 
@@ -84,16 +84,16 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
 
   const done = common.mustCall(function(err, written) {
     assert.ifError(err);
-    assert.strictEqual(Buffer.byteLength(expected), written);
+    assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
     const found = fs.readFileSync(fn, 'utf8');
     fs.unlinkSync(fn);
-    assert.strictEqual(expected, found);
+    assert.strictEqual(found, expected);
   });
 
   const written = common.mustCall(function(err, written) {
     assert.ifError(err);
-    assert.strictEqual(0, written);
+    assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
   });
 
@@ -106,16 +106,16 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
 
   const done = common.mustCall((err, written) => {
     assert.ifError(err);
-    assert.strictEqual(Buffer.byteLength(expected), written);
+    assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
     const found = fs.readFileSync(fn2, 'utf8');
     fs.unlinkSync(fn2);
-    assert.strictEqual(expected, found);
+    assert.strictEqual(found, expected);
   });
 
   const written = common.mustCall(function(err, written) {
     assert.ifError(err);
-    assert.strictEqual(0, written);
+    assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
   });
 
@@ -127,7 +127,7 @@ fs.open(fn3, 'w', 0o644, common.mustCall(function(err, fd) {
 
   const done = common.mustCall(function(err, written) {
     assert.ifError(err);
-    assert.strictEqual(Buffer.byteLength(expected), written);
+    assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
   });
 

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -79,10 +79,10 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 /* eslint-enable no-undef */
 
-fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
+fs.open(fn, 'w', 0o644, common.mustCall((err, fd) => {
   assert.ifError(err);
 
-  const done = common.mustCall(function(err, written) {
+  const done = common.mustCall((err, written) => {
     assert.ifError(err);
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
@@ -91,7 +91,7 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.strictEqual(found, expected);
   });
 
-  const written = common.mustCall(function(err, written) {
+  const written = common.mustCall((err, written) => {
     assert.ifError(err);
     assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
@@ -113,7 +113,7 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
     assert.strictEqual(found, expected);
   });
 
-  const written = common.mustCall(function(err, written) {
+  const written = common.mustCall((err, written) => {
     assert.ifError(err);
     assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
@@ -122,10 +122,10 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
   fs.write(fd, '', 0, 'utf8', written);
 }));
 
-fs.open(fn3, 'w', 0o644, common.mustCall(function(err, fd) {
+fs.open(fn3, 'w', 0o644, common.mustCall((err, fd) => {
   assert.ifError(err);
 
-  const done = common.mustCall(function(err, written) {
+  const done = common.mustCall((err, written) => {
     assert.ifError(err);
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
`test/parallel/test-fs-write.js` contains assertions where the first
argument provided is the expected value and the second value is the
actual value. This is backward from the documentation for assertions
like `assert.strictEqual()` where the first value should be the actual
value being tested and the second value is the expected value.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
