### PR TITLE
test-http2-respond-file-fd-invalid: remove unused "e" from catch

### DIFF
--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -25,7 +25,7 @@ server.on('stream', (stream) => {
   // Get first known bad file descriptor.
   try {
     while (fs.fstatSync(++fd));
-  } catch (e) {
+  } catch {
     // do nothing; we now have an invalid fd
   }
 


### PR DESCRIPTION
Removed an unused e variable from a catch statement. This PR was completed as part of the Node - JS Interactive 2018 Vancouver code and learn.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
