### PR TITLE
test: change to arrow functions in send-bad-arguments

### DIFF
--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -28,17 +28,17 @@ const buf = Buffer.from('test');
 const host = '127.0.0.1';
 const sock = dgram.createSocket('udp4');
 
-assert.throws(function() {
+assert.throws(() => {
   sock.send();
 }, TypeError);  // First argument should be a buffer.
 
 // send(buf, offset, length, port, host)
-assert.throws(function() { sock.send(buf, 1, 1, -1, host); }, RangeError);
-assert.throws(function() { sock.send(buf, 1, 1, 0, host); }, RangeError);
-assert.throws(function() { sock.send(buf, 1, 1, 65536, host); }, RangeError);
+assert.throws(() => { sock.send(buf, 1, 1, -1, host); }, RangeError);
+assert.throws(() => { sock.send(buf, 1, 1, 0, host); }, RangeError);
+assert.throws(() => { sock.send(buf, 1, 1, 65536, host); }, RangeError);
 
 // send(buf, port, host)
-assert.throws(function() { sock.send(23, 12345, host); }, TypeError);
+assert.throws(() => { sock.send(23, 12345, host); }, TypeError);
 
 // send([buf1, ..], port, host)
-assert.throws(function() { sock.send([buf, 23], 12345, host); }, TypeError);
+assert.throws(() => { sock.send([buf, 23], 12345, host); }, TypeError);


### PR DESCRIPTION
Part of Code and Learn workshop at Node + JS Interactive! 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
