### PR TITLE
test: fix argument order for assert.strictEqual

### DIFF
--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -81,7 +81,7 @@ async function runTests() {
   await session.waitForBreakOnLine(0, 'evalmachine.<anonymous>');
 
   await session.runToCompletion();
-  assert.strictEqual(0, (await instance.expectShutdown()).exitCode);
+  assert.strictEqual((await instance.expectShutdown()).exitCode, 0);
 }
 
 runTests();


### PR DESCRIPTION
# Description #
Fix the order of arguments in test assertion. The documentation for `assert.strictEqual()` says the first value should be the actual value being tested, and the second value is the expected value.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
