### PR TITLE
lib: switch to internalBinding for cjs loader

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -42,9 +42,9 @@ const {
   stripShebang
 } = require('internal/modules/cjs/helpers');
 const options = internalBinding('options');
-const preserveSymlinks = !!options.getOptions('--preserve-symlinks');
-const preserveSymlinksMain = !!options.getOptions('--preserve-symlinks-main');
-const experimentalModules = !!options.getOptions('--experimental-modules');
+const preserveSymlinks = options.getOptions('--preserve-symlinks');
+const preserveSymlinksMain = options.getOptions('--preserve-symlinks-main');
+const experimentalModules = options.getOptions('--experimental-modules');
 
 const {
   ERR_INVALID_ARG_TYPE,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -41,9 +41,10 @@ const {
   stripBOM,
   stripShebang
 } = require('internal/modules/cjs/helpers');
-const preserveSymlinks = !!process.binding('config').preserveSymlinks;
-const preserveSymlinksMain = !!process.binding('config').preserveSymlinksMain;
-const experimentalModules = !!process.binding('config').experimentalModules;
+const options = internalBinding('options');
+const preserveSymlinks = !!options.getOptions('--preserve-symlinks');
+const preserveSymlinksMain = !!options.getOptions('--preserve-symlinks-main');
+const experimentalModules = !!options.getOptions('--experimental-modules');
 
 const {
   ERR_INVALID_ARG_TYPE,


### PR DESCRIPTION
Switch the cjs loader to use internalBinding instead of
process.binding for reading command line options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
