### PR TITLE
src: move default assignment of async_id_ in async_wrap.h

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -563,7 +563,6 @@ AsyncWrap::AsyncWrap(Environment* env,
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
-  async_id_ = -1;
   // Use AsyncReset() call to execute the init() callbacks.
   AsyncReset(execution_async_id, silent);
 }

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -200,7 +200,7 @@ class AsyncWrap : public BaseObject {
   inline AsyncWrap();
   const ProviderType provider_type_;
   // Because the values may be Reset(), cannot be made const.
-  double async_id_;
+  double async_id_ = -1;
   double trigger_async_id_;
 };
 


### PR DESCRIPTION
Moving the default assignment of async_id from the constructor in
async_wrap.cc to class definition in async_wrap.h

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
