### PR TITLE
test: modernizing test-dgram-listen-after-bind with arrow functions

### DIFF
--- a/test/parallel/test-dgram-listen-after-bind.js
+++ b/test/parallel/test-dgram-listen-after-bind.js
@@ -29,16 +29,16 @@ const socket = dgram.createSocket('udp4');
 socket.bind();
 
 let fired = false;
-const timer = setTimeout(function() {
+const timer = setTimeout(() => {
   socket.close();
 }, 100);
 
-socket.on('listening', function() {
+socket.on('listening', () => {
   clearTimeout(timer);
   fired = true;
   socket.close();
 });
 
-socket.on('close', function() {
+socket.on('close', () => {
   assert(fired, 'listening should fire after bind');
 });


### PR DESCRIPTION
Replace `function () {}` with `() => {}` in `test/parallel/test-dgram-listen-after-bind.js`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
