### PR TITLE
test: properly order test assertion variables

### DIFF
--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -31,5 +31,5 @@ const cp = ch.spawn('python', ['-c', `print ${SIZE} * "C"`], {
 });
 
 cp.on('exit', common.mustCall(function(code) {
-  assert.strictEqual(0, code);
+  assert.strictEqual(code, 0);
 }));


### PR DESCRIPTION
#### Description

Reorder test assertion variable to align with documentation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
