### PR TITLE
test: put expected assert value in correct place

### DIFF
--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -28,5 +28,5 @@ fs.readdir(tmpdir.path, 'ucs2', common.mustCall((err, list) => {
   assert.strictEqual(list.length, 1);
   const fn = list[0];
   assert.deepStrictEqual(Buffer.from(fn, 'ucs2'), filebuff);
-  assert.strictEqual(filename, fn);
+  assert.strictEqual(fn, filename);
 }));

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -25,8 +25,8 @@ try {
 
 fs.readdir(tmpdir.path, 'ucs2', common.mustCall((err, list) => {
   assert.ifError(err);
-  assert.strictEqual(1, list.length);
+  assert.strictEqual(list.length, 1);
   const fn = list[0];
-  assert.deepStrictEqual(filebuff, Buffer.from(fn, 'ucs2'));
-  assert.strictEqual(fn, filename);
+  assert.deepStrictEqual(Buffer.from(fn, 'ucs2'), filebuff);
+  assert.strictEqual(filename, fn);
 }));


### PR DESCRIPTION
The order of arguments in test-fs-readdir-ucs2 was the
opposite of what is recommended in the documentation,
which is that the first value should be the value being tested,
and the second value is the expected value.
This fixes the test to make it conform to the documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
