### PR TITLE
lib: make the global console [[Prototype]] an empty object

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -60,17 +60,21 @@ let cliTable;
 
 // Track amount of indentation required via `console.group()`.
 const kGroupIndent = Symbol('kGroupIndent');
-
 const kFormatForStderr = Symbol('kFormatForStderr');
 const kFormatForStdout = Symbol('kFormatForStdout');
 const kGetInspectOptions = Symbol('kGetInspectOptions');
 const kColorMode = Symbol('kColorMode');
+const kIsConsole = Symbol('kIsConsole');
 
 function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
-  if (!(this instanceof Console)) {
+  // We have to test new.target here to see if this function is called
+  // with new, because we need to define a custom instanceof to accommodate
+  // the global console.
+  if (!new.target) {
     return new Console(...arguments);
   }
 
+  this[kIsConsole] = true;
   if (!options || typeof options.write === 'function') {
     options = {
       stdout: options,
@@ -125,7 +129,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   var keys = Object.keys(Console.prototype);
   for (var v = 0; v < keys.length; v++) {
     var k = keys[v];
-    this[k] = this[k].bind(this);
+    this[k] = Console.prototype[k].bind(this);
   }
 }
 
@@ -465,10 +469,50 @@ Console.prototype.table = function(tabularData, properties) {
   return final(keys, values);
 };
 
-module.exports = new Console({
+function noop() {}
+
+// See https://console.spec.whatwg.org/#console-namespace
+// > For historical web-compatibility reasons, the namespace object
+// > for console must have as its [[Prototype]] an empty object,
+// > created as if by ObjectCreate(%ObjectPrototype%),
+// > instead of %ObjectPrototype%.
+
+// Since in Node.js, the Console constructor has been exposed through
+// require('console'), we need to keep the Console constructor but
+// we cannot actually use `new Console` to construct the global console.
+// Therefore, the console.Console.prototype is not
+// in the global console prototype chain anymore.
+const globalConsole = Object.create({});
+const tempConsole = new Console({
   stdout: process.stdout,
   stderr: process.stderr
 });
-module.exports.Console = Console;
 
-function noop() {}
+// Since Console is not on the prototype chain of the global console,
+// the symbol properties on Console.prototype have to be looked up from
+// the global console itself.
+for (const prop of Object.getOwnPropertySymbols(Console.prototype)) {
+  globalConsole[prop] = Console.prototype[prop];
+}
+
+// Reflect.ownKeys() is used here for retrieving Symbols
+for (const prop of Reflect.ownKeys(tempConsole)) {
+  const desc = { ...(Reflect.getOwnPropertyDescriptor(tempConsole, prop)) };
+  // Since Console would bind method calls onto the instance,
+  // make sure the methods are called on globalConsole instead of
+  // tempConsole.
+  if (typeof Console.prototype[prop] === 'function') {
+    desc.value = Console.prototype[prop].bind(globalConsole);
+  }
+  Reflect.defineProperty(globalConsole, prop, desc);
+}
+
+globalConsole.Console = Console;
+
+Object.defineProperty(Console, Symbol.hasInstance, {
+  value(instance) {
+    return instance[kIsConsole];
+  }
+});
+
+module.exports = globalConsole;

--- a/test/parallel/test-whatwg-console-is-a-namespace.js
+++ b/test/parallel/test-whatwg-console-is-a-namespace.js
@@ -38,9 +38,7 @@ test(() => {
   const prototype1 = Object.getPrototypeOf(console);
   const prototype2 = Object.getPrototypeOf(prototype1);
 
-  // This got commented out from the original test because in Node.js all
-  // functions are declared on the prototype.
-  // assert_equals(Object.getOwnPropertyNames(prototype1).length, 0, "The [[Prototype]] must have no properties");
+  assert_equals(Object.getOwnPropertyNames(prototype1).length, 0, "The [[Prototype]] must have no properties");
   assert_equals(prototype2, Object.prototype, "The [[Prototype]]'s [[Prototype]] must be %ObjectPrototype%");
 }, "The prototype chain must be correct");
 


### PR DESCRIPTION
lib: make the global console [[Prototype]] an empty object

From the WHATWG console spec:

> For historical web-compatibility reasons, the namespace object for
> console must have as its [[Prototype]] an empty object, created as
> if by ObjectCreate(%ObjectPrototype%), instead of %ObjectPrototype%.

Since in Node.js, the Console constructor has been exposed through
require('console'), we need to keep the Console constructor but
we cannot actually use `new Console` to construct the global console.

This patch changes the prototype chain of the global console object,
so the console.Console.prototype is not in the global console prototype
chain anymore.

```
const proto = Object.getPrototypeOf(global.console);
// Before this patch
proto.constructor === global.console.Console
// After this patch
proto.constructor === Object
```

But, we still maintain that

```
global.console instanceof global.console.Console
```

through a custom Symbol.hasInstance function of Console that tests
for a special symbol kIsConsole for backwards compatibility.

This fixes a case in the console Web Platform Test that we commented
out.

Refs: https://console.spec.whatwg.org/#console-namespace
Refs: https://github.com/whatwg/console/issues/3

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
