### PR TITLE
doc: clarify use of timeout option in vm

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -246,9 +246,9 @@ in the ECMAScript specification.
 ### module.evaluate([options])
 
 * `options` {Object}
-  * `timeout` {number} Specifies the number of milliseconds to evaluate
+  * `timeout` {integer} Specifies the number of milliseconds to evaluate
     before terminating execution. If execution is interrupted, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
     `SIGINT` (Ctrl+C) is received. Existing handlers for the event that have
     been attached via `process.on('SIGINT')` will be disabled during script
@@ -507,9 +507,9 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint`: if `true`, the execution will be terminated when
     `SIGINT` (Ctrl+C) is received. Existing handlers for the
     event that have been attached via `process.on('SIGINT')` will be disabled
@@ -570,9 +570,9 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
   * `contextName` {string} Human-readable name of the newly created context.
     **Default:** `'VM Context i'`, where `i` is an ascending numerical index of
     the created context.
@@ -628,9 +628,9 @@ added: v0.3.1
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
 
 Runs the compiled code contained by the `vm.Script` within the context of the
 current `global` object. Running code does not have access to local scope, but
@@ -775,9 +775,9 @@ Returns `true` if the given `sandbox` object has been [contextified][] using
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
 
 The `vm.runInContext()` method compiles `code`, runs it within the context of
 the `contextifiedSandbox`, then returns the result. Running code does not have
@@ -822,9 +822,9 @@ added: v0.3.1
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
   * `contextName` {string} Human-readable name of the newly created context.
     **Default:** `'VM Context i'`, where `i` is an ascending numerical index of
     the created context.
@@ -876,9 +876,9 @@ added: v0.3.1
   * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
+  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+    will be thrown. This value must be a strictly positive integer.
 
 `vm.runInThisContext()` compiles `code`, runs it within the context of the
 current `global` and returns the result. Running code does not have access to


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


This clarifies the use of the `timeout` option in the `vm` module. This number always must be a strictly positive integer otherwise it results in a `TypeError`