### PR TITLE
test: fix test-dgram-pingpong assertion arg order

### DIFF
--- a/test/sequential/test-dgram-pingpong.js
+++ b/test/sequential/test-dgram-pingpong.js
@@ -6,7 +6,7 @@ const dgram = require('dgram');
 function pingPongTest(port, host) {
 
   const server = dgram.createSocket('udp4', common.mustCall((msg, rinfo) => {
-    assert.strictEqual('PING', msg.toString('ascii'));
+    assert.strictEqual(msg.toString('ascii'), 'PING');
     server.send('PONG', 0, 4, rinfo.port, rinfo.address);
   }));
 
@@ -20,7 +20,7 @@ function pingPongTest(port, host) {
     const client = dgram.createSocket('udp4');
 
     client.on('message', function(msg) {
-      assert.strictEqual('PONG', msg.toString('ascii'));
+      assert.strictEqual(msg.toString('ascii'), 'PONG');
 
       client.close();
       server.close();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This test file contains assertions where the argument ordering is in reverse, thus potentially giving us false positives.

This PR fixes that by reversing that ordering to the expected (actual, expected) argument ordering.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
