### PR TITLE
test: updated order of the arguments for strictequal to match documentation

### DIFF
--- a/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
+++ b/test/sequential/test-inspector-async-hook-setup-at-inspect-brk.js
@@ -44,7 +44,7 @@ async function runTests() {
   await checkAsyncStackTrace(session);
 
   await session.runToCompletion();
-  assert.strictEqual(55, (await instance.expectShutdown()).exitCode);
+  assert.strictEqual((await instance.expectShutdown()).exitCode, 55);
 }
 
 runTests();


### PR DESCRIPTION
Test: Changed the order of the arguments for strictEqual to match the documentation

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
