### PR TITLE
test: use the correct parameter order on assert.strictEqual()

### DIFF
--- a/test/pummel/test-net-many-clients.js
+++ b/test/pummel/test-net-many-clients.js
@@ -70,8 +70,8 @@ function runClient(callback) {
 
   client.on('close', function(had_error) {
     console.log('.');
-    assert.strictEqual(false, had_error);
-    assert.strictEqual(bytes, client.recved.length);
+    assert.strictEqual(had_error, false);
+    assert.strictEqual(client.recved.length, bytes);
 
     if (client.fd) {
       console.log(client.fd);
@@ -96,6 +96,6 @@ server.listen(common.PORT, function() {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(connections_per_client * concurrency, total_connections);
+  assert.strictEqual(total_connections, connections_per_client * concurrency);
   console.log('\nokay!');
 });


### PR DESCRIPTION
The parameter order for `assert.strictEqual()` should be `strictEqual(actual, expected)`
rather than `strictEqual(expected, actual)` which can make test failure messages
confusing. This change reverses the order of the assertion to
match the documented parameter order.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
