### PR TITLE
test: correct order of args in buffer compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,12 @@ source and a list of supported platforms.
 
 ## Security
 
-Security flaws in Node.js should be reported by emailing security@nodejs.org.
-Please do not disclose security bugs publicly until they have been handled by
-the security team.
+If you find a security vulnerability in Node.js, please report it to
+security@nodejs.org. Please withhold public disclosure until after the security
+team has addressed the vulnerability.
 
-Your email will be acknowledged within 24 hours, and you will receive a more
-detailed response to your email within 48 hours indicating the next steps in
-handling your report.
+The security team will acknowledge your email within 24 hours. You will receive
+a more detailed response within 48 hours.
 
 There are no hard and fast rules to determine if a bug is worth reporting as
 a security issue. The general rule is an issue worth reporting should allow an

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -6,56 +6,56 @@ const assert = require('assert');
 const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 const b = Buffer.from([5, 6, 7, 8, 9, 0, 1, 2, 3, 4]);
 
-assert.strictEqual(-1, a.compare(b));
+assert.strictEqual(a.compare(b), -1);
 
 // Equivalent to a.compare(b).
-assert.strictEqual(-1, a.compare(b, 0));
-assert.strictEqual(-1, a.compare(b, '0'));
-assert.strictEqual(-1, a.compare(b, undefined));
+assert.strictEqual(a.compare(b, 0), -1);
+assert.strictEqual(a.compare(b, '0'), -1);
+assert.strictEqual(a.compare(b, undefined), -1);
 
 // Equivalent to a.compare(b).
-assert.strictEqual(-1, a.compare(b, 0, undefined, 0));
+assert.strictEqual(a.compare(b, 0, undefined, 0), -1);
 
 // Zero-length target, return 1
-assert.strictEqual(1, a.compare(b, 0, 0, 0));
-assert.strictEqual(1, a.compare(b, '0', '0', '0'));
+assert.strictEqual(a.compare(b, 0, 0, 0), 1);
+assert.strictEqual(a.compare(b, '0', '0', '0'), 1);
 
 // Equivalent to Buffer.compare(a, b.slice(6, 10))
-assert.strictEqual(1, a.compare(b, 6, 10));
+assert.strictEqual(a.compare(b, 6, 10), 1);
 
 // Zero-length source, return -1
-assert.strictEqual(-1, a.compare(b, 6, 10, 0, 0));
+assert.strictEqual(a.compare(b, 6, 10, 0, 0), -1);
 
 // Zero-length source and target, return 0
-assert.strictEqual(0, a.compare(b, 0, 0, 0, 0));
-assert.strictEqual(0, a.compare(b, 1, 1, 2, 2));
+assert.strictEqual(a.compare(b, 0, 0, 0, 0), 0);
+assert.strictEqual(a.compare(b, 1, 1, 2, 2), 0);
 
 // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 5))
-assert.strictEqual(1, a.compare(b, 0, 5, 4));
+assert.strictEqual(a.compare(b, 0, 5, 4), 1);
 
 // Equivalent to Buffer.compare(a.slice(1), b.slice(5))
-assert.strictEqual(1, a.compare(b, 5, undefined, 1));
+assert.strictEqual(a.compare(b, 5, undefined, 1), 1);
 
 // Equivalent to Buffer.compare(a.slice(2), b.slice(2, 4))
-assert.strictEqual(-1, a.compare(b, 2, 4, 2));
+assert.strictEqual(a.compare(b, 2, 4, 2), -1);
 
 // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 7))
-assert.strictEqual(-1, a.compare(b, 0, 7, 4));
+assert.strictEqual(a.compare(b, 0, 7, 4), -1);
 
 // Equivalent to Buffer.compare(a.slice(4, 6), b.slice(0, 7));
-assert.strictEqual(-1, a.compare(b, 0, 7, 4, 6));
+assert.strictEqual(a.compare(b, 0, 7, 4, 6), -1);
 
 // zero length target
-assert.strictEqual(1, a.compare(b, 0, null));
+assert.strictEqual(a.compare(b, 0, null), 1);
 
 // coerces to targetEnd == 5
-assert.strictEqual(-1, a.compare(b, 0, { valueOf: () => 5 }));
+assert.strictEqual(a.compare(b, 0, { valueOf: () => 5 }), -1);
 
 // zero length target
-assert.strictEqual(1, a.compare(b, Infinity, -Infinity));
+assert.strictEqual(a.compare(b, Infinity, -Infinity), 1);
 
 // zero length target because default for targetEnd <= targetSource
-assert.strictEqual(1, a.compare(b, '0xff'));
+assert.strictEqual(a.compare(b, '0xff'), 1);
 
 const oor = common.expectsError({ code: 'ERR_OUT_OF_RANGE' }, 7);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
