### PR TITLE
test: fix assert order in test-vm-context

### DIFF
--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -30,18 +30,18 @@ let script = new Script('"passed";');
 // Run in a new empty context
 let context = vm.createContext();
 let result = script.runInContext(context);
-assert.strictEqual('passed', result);
+assert.strictEqual(result, 'passed');
 
 // Create a new pre-populated context
 context = vm.createContext({ 'foo': 'bar', 'thing': 'lala' });
-assert.strictEqual('bar', context.foo);
-assert.strictEqual('lala', context.thing);
+assert.strictEqual(context.foo, 'bar');
+assert.strictEqual(context.thing, 'lala');
 
 // Test updating context
 script = new Script('foo = 3;');
 result = script.runInContext(context);
-assert.strictEqual(3, context.foo);
-assert.strictEqual('lala', context.thing);
+assert.strictEqual(context.foo, 3);
+assert.strictEqual(context.thing, 'lala');
 
 // Issue GH-227:
 common.expectsError(() => {


### PR DESCRIPTION
Fixed the assert order of test-vm-context to have expected value as the second parameter.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
