### PR TITLE
test: switched arguments of assert()

### DIFF
--- a/test/sequential/test-inspector-break-when-eval.js
+++ b/test/sequential/test-inspector-break-when-eval.js
@@ -63,7 +63,7 @@ async function runTests() {
   await breakOnLine(session);
   await stepOverConsoleStatement(session);
   await session.runToCompletion();
-  assert.strictEqual(0, (await child.expectShutdown()).exitCode);
+  assert.strictEqual((await child.expectShutdown()).exitCode, 0);
 }
 
 runTests();


### PR DESCRIPTION
The arguments of the assert were passed in the wrong order
(expected, actual). This would have been confusing in case
of an error. Changed it to be (actual, expected)

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines]
