### PR TITLE
test: swap assert argument order in test-vm-create-and-run-in-context.js

### DIFF
--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -33,13 +33,13 @@ assert.strictEqual('passed', result);
 
 // Create a new pre-populated context
 context = vm.createContext({ 'foo': 'bar', 'thing': 'lala' });
-assert.strictEqual('bar', context.foo);
-assert.strictEqual('lala', context.thing);
+assert.strictEqual(context.foo, 'bar');
+assert.strictEqual(context.thing, 'lala');
 
 // Test updating context
 result = vm.runInContext('var foo = 3;', context);
-assert.strictEqual(3, context.foo);
-assert.strictEqual('lala', context.thing);
+assert.strictEqual(context.foo, 3);
+assert.strictEqual(context.thing, 'lala');
 
 // https://github.com/nodejs/node/issues/5768
 // Run in contextified sandbox without referencing the context


### PR DESCRIPTION
Swap order of assert arguments

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
