### PR TITLE
lib: migrating process.binding to getOptions in default_resolve.js

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -6,8 +6,9 @@ const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { realpathSync } = require('fs');
-const preserveSymlinks = !!process.binding('config').preserveSymlinks;
-const preserveSymlinksMain = !!process.binding('config').preserveSymlinksMain;
+const { getOptions } = internalBinding('options');
+const preserveSymlinks = !!getOptions('--preserve-symlinks');
+const preserveSymlinksMain = !!getOptions('--preserve-symlinks-main');
 const {
   ERR_MISSING_MODULE,
   ERR_MODULE_RESOLUTION_LEGACY,

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -6,8 +6,9 @@ const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { realpathSync } = require('fs');
-const preserveSymlinks = !!process.binding('config').preserveSymlinks;
-const preserveSymlinksMain = !!process.binding('config').preserveSymlinksMain;
+const { getOptions } = internalBinding('options');
+const preserveSymlinks = !!getOptions('--preserve-symlinks');
+const preserveSymlinksMain = !!getOptions('--preserve-symlinks-main');
 const {
   ERR_MISSING_MODULE,
   ERR_MODULE_RESOLUTION_LEGACY,
@@ -33,7 +34,8 @@ function search(target, base) {
       const questionedBase = new URL(base);
       const tmpMod = new CJSmodule(questionedBase.pathname, null);
       tmpMod.paths = CJSmodule._nodeModulePaths(
-        new URL('./', questionedBase).pathname);
+        new URL('./', questionedBase).pathname
+      );
       const found = CJSmodule._resolveFilename(target, tmpMod);
       error = new ERR_MODULE_RESOLUTION_LEGACY(target, base, found);
     } catch (problemChecking) {
@@ -61,11 +63,15 @@ function resolve(specifier, parentURL) {
 
   let url;
   try {
-    url = search(specifier,
-                 parentURL || pathToFileURL(`${process.cwd()}/`).href);
+    url = search(
+      specifier,
+      parentURL || pathToFileURL(`${process.cwd()}/`).href
+    );
   } catch (e) {
-    if (typeof e.message === 'string' &&
-        StringStartsWith(e.message, 'Cannot find module'))
+    if (
+      typeof e.message === 'string' &&
+      StringStartsWith(e.message, 'Cannot find module')
+    )
       e.code = 'MODULE_NOT_FOUND';
     throw e;
   }
@@ -86,10 +92,8 @@ function resolve(specifier, parentURL) {
 
   let format = extensionFormatMap[ext];
   if (!format) {
-    if (isMain)
-      format = 'cjs';
-    else
-      throw new ERR_UNKNOWN_FILE_EXTENSION(url.pathname);
+    if (isMain) format = 'cjs';
+    else throw new ERR_UNKNOWN_FILE_EXTENSION(url.pathname);
   }
 
   return { url: `${url}`, format };

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -6,9 +6,8 @@ const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { realpathSync } = require('fs');
-const { getOptions } = internalBinding('options');
-const preserveSymlinks = !!getOptions('--preserve-symlinks');
-const preserveSymlinksMain = !!getOptions('--preserve-symlinks-main');
+const preserveSymlinks = !!process.binding('config').preserveSymlinks;
+const preserveSymlinksMain = !!process.binding('config').preserveSymlinksMain;
 const {
   ERR_MISSING_MODULE,
   ERR_MODULE_RESOLUTION_LEGACY,
@@ -34,8 +33,7 @@ function search(target, base) {
       const questionedBase = new URL(base);
       const tmpMod = new CJSmodule(questionedBase.pathname, null);
       tmpMod.paths = CJSmodule._nodeModulePaths(
-        new URL('./', questionedBase).pathname
-      );
+        new URL('./', questionedBase).pathname);
       const found = CJSmodule._resolveFilename(target, tmpMod);
       error = new ERR_MODULE_RESOLUTION_LEGACY(target, base, found);
     } catch (problemChecking) {
@@ -63,15 +61,11 @@ function resolve(specifier, parentURL) {
 
   let url;
   try {
-    url = search(
-      specifier,
-      parentURL || pathToFileURL(`${process.cwd()}/`).href
-    );
+    url = search(specifier,
+                 parentURL || pathToFileURL(`${process.cwd()}/`).href);
   } catch (e) {
-    if (
-      typeof e.message === 'string' &&
-      StringStartsWith(e.message, 'Cannot find module')
-    )
+    if (typeof e.message === 'string' &&
+        StringStartsWith(e.message, 'Cannot find module'))
       e.code = 'MODULE_NOT_FOUND';
     throw e;
   }
@@ -92,8 +86,10 @@ function resolve(specifier, parentURL) {
 
   let format = extensionFormatMap[ext];
   if (!format) {
-    if (isMain) format = 'cjs';
-    else throw new ERR_UNKNOWN_FILE_EXTENSION(url.pathname);
+    if (isMain)
+      format = 'cjs';
+    else
+      throw new ERR_UNKNOWN_FILE_EXTENSION(url.pathname);
   }
 
   return { url: `${url}`, format };

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -7,8 +7,8 @@ const { NativeModule } = require('internal/bootstrap/loaders');
 const { extname } = require('path');
 const { realpathSync } = require('fs');
 const { getOptions } = internalBinding('options');
-const preserveSymlinks = !!getOptions('--preserve-symlinks');
-const preserveSymlinksMain = !!getOptions('--preserve-symlinks-main');
+const preserveSymlinks = getOptions('--preserve-symlinks');
+const preserveSymlinksMain = getOptions('--preserve-symlinks-main');
 const {
   ERR_MISSING_MODULE,
   ERR_MODULE_RESOLUTION_LEGACY,


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included

