### PR TITLE
test: use correct argument order for assert.strictEqual()

### DIFF
--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -50,10 +50,10 @@ process.on('exit', function() {
   fs.unlinkSync(filepathTwoAbs);
   fs.unlinkSync(filenameThree);
   fs.unlinkSync(filenameFour);
-  assert.strictEqual(1, watchSeenOne);
-  assert.strictEqual(2, watchSeenTwo);
-  assert.strictEqual(1, watchSeenThree);
-  assert.strictEqual(1, watchSeenFour);
+  assert.strictEqual(watchSeenOne, 1);
+  assert.strictEqual(watchSeenTwo, 2);
+  assert.strictEqual(watchSeenThree, 1);
+  assert.strictEqual(watchSeenFour, 1);
 });
 
 
@@ -134,7 +134,7 @@ setTimeout(function() {
 { // Does not throw.
   function a() {
     ++watchSeenFour;
-    assert.strictEqual(1, watchSeenFour);
+    assert.strictEqual(watchSeenFour, 1);
     fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
   }
   fs.watchFile(filenameFour, a);


### PR DESCRIPTION
The previous code did not pass correct argument order to
assert.strictEqual().

Before:
First argument provided is expected value
Second argument provided is actual value

After:
First argument provided is actual value
Second argument provided is expected value

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
