### PR TITLE
test: corrected order of arguments in assert.strictEqual()

### DIFF
--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -171,8 +171,8 @@ function test(keyfn, certfn, check, next) {
 
 
   process.on('exit', function() {
-    assert.strictEqual(0, serverExitCode);
-    assert.strictEqual('WAIT-SERVER-CLOSE', state);
+    assert.strictEqual(serverExitCode, 0);
+    assert.strictEqual(state, 'WAIT-SERVER-CLOSE');
     assert.ok(gotWriteCallback);
   });
 }


### PR DESCRIPTION
**Changes made:**
- Corrected order of arguments in assert.strictEqual()

**Files changed**: `test/pummel/test-tls-securepair-client.js`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
