### PR TITLE
test: fix strictEqual assertion argument in test-tls-ecdh-auto

### DIFF
--- a/test/parallel/test-tls-ecdh-auto.js
+++ b/test/parallel/test-tls-ecdh-auto.js
@@ -48,7 +48,7 @@ server.listen(0, function() {
   });
 
   client.on('exit', function(code) {
-    assert.strictEqual(0, code);
+    assert.strictEqual(code, 0);
     server.close();
   });
 


### PR DESCRIPTION
##### Changes made
* Fix the order of argument for `assert.strictEqual()`

##### Files changed
* `test/parallel/test-tls-ecdh-auto.js`

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines]