### PR TITLE
src: use default initializers over settings fields on the constructor

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -50,9 +50,7 @@ using v8::String;
 using v8::Value;
 
 
-SyncProcessOutputBuffer::SyncProcessOutputBuffer()
-    : used_(0),
-      next_(nullptr) {
+SyncProcessOutputBuffer::SyncProcessOutputBuffer() {
 }
 
 

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -56,9 +56,9 @@ class SyncProcessOutputBuffer {
  private:
   // Use unsigned int because that's what `uv_buf_init` takes.
   mutable char data_[kBufferSize];
-  unsigned int used_;
+  unsigned int used_ = 0;
 
-  SyncProcessOutputBuffer* next_;
+  SyncProcessOutputBuffer* next_ = nullptr;
 };
 
 


### PR DESCRIPTION
Cleans up the initialization of default fields

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
