### PR TITLE
test: updating assertion on test so it fits the new method signature

### DIFF
--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -26,7 +26,7 @@ function runTest() {
     };
     // Will fail with ECONNREFUSED if the address family is not honored.
     tls.connect(options).once('secureConnect', common.mustCall(function() {
-      assert.strictEqual('::1', this.remoteAddress);
+      assert.strictEqual(this.remoteAddress, '::1');
       this.destroy();
     }));
   }));


### PR DESCRIPTION
One assertion on test-tls-connect-address-family.js was out fo date,
here we are fixing it to match the signature of strictEqual method.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ X ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
