### PR TITLE
test: assert.strictEqual parameters ordered correctly

### DIFF
--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -137,7 +137,7 @@ server.listen(0, common.mustCall(function() {
   client.stdout.pipe(process.stdout, { end: false });
 
   client.on('exit', common.mustCall(function(code) {
-    assert.strictEqual(0, code);
+    assert.strictEqual(code, 0);
     server.close();
   }));
 }));


### PR DESCRIPTION
The assert.strictEqual function should have the actual
value first and the expected value second to enable
easier debugging of AssertionErrors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
