### PR TITLE
test(pummel/test-net-pingpong-delay): swap expected and actual arguments in assert.strictEqual()

### DIFF
--- a/test/pummel/test-net-pingpong-delay.js
+++ b/test/pummel/test-net-pingpong-delay.js
@@ -35,11 +35,11 @@ function pingPongTest(port, host, on_complete) {
 
     socket.on('data', function(data) {
       console.log(data);
-      assert.strictEqual('PING', data);
-      assert.strictEqual('open', socket.readyState);
-      assert.strictEqual(true, count <= N);
+      assert.strictEqual(data, 'PING');
+      assert.strictEqual(socket.readyState, 'open');
+      assert.strictEqual(count <= N, true);
       setTimeout(function() {
-        assert.strictEqual('open', socket.readyState);
+        assert.strictEqual(socket.readyState, 'open');
         socket.write('PONG');
       }, DELAY);
     });
@@ -51,14 +51,14 @@ function pingPongTest(port, host, on_complete) {
 
     socket.on('end', function() {
       console.log('server-side socket EOF');
-      assert.strictEqual('writeOnly', socket.readyState);
+      assert.strictEqual(socket.readyState, 'writeOnly');
       socket.end();
     });
 
     socket.on('close', function(had_error) {
       console.log('server-side socket.end');
-      assert.strictEqual(false, had_error);
-      assert.strictEqual('closed', socket.readyState);
+      assert.strictEqual(had_error, false);
+      assert.strictEqual(socket.readyState, 'closed');
       socket.server.close();
     });
   });
@@ -69,17 +69,17 @@ function pingPongTest(port, host, on_complete) {
     client.setEncoding('utf8');
 
     client.on('connect', function() {
-      assert.strictEqual('open', client.readyState);
+      assert.strictEqual(client.readyState, 'open');
       client.write('PING');
     });
 
     client.on('data', function(data) {
       console.log(data);
-      assert.strictEqual('PONG', data);
-      assert.strictEqual('open', client.readyState);
+      assert.strictEqual(data, 'PONG');
+      assert.strictEqual(client.readyState, 'open');
 
       setTimeout(function() {
-        assert.strictEqual('open', client.readyState);
+        assert.strictEqual(client.readyState, 'open');
         if (count++ < N) {
           client.write('PING');
         } else {
@@ -97,7 +97,7 @@ function pingPongTest(port, host, on_complete) {
 
     client.on('close', common.mustCall(function() {
       console.log('client.end');
-      assert.strictEqual(N + 1, count);
+      assert.strictEqual(count, N + 1);
       assert.ok(client_ended);
       if (on_complete) on_complete();
     }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
