### PR TITLE
test: update strictEqual arguments order

### DIFF
--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -36,5 +36,5 @@ childProcess.exec(cmd, common.mustCall(function(err, stdout, stderr) {
 
   assert.ifError(err);
   assert.strictEqual(stdout, `hello world\r\n${string}`);
-  assert.strictEqual('', stderr);
+  assert.strictEqual(stderr, '');
 }));


### PR DESCRIPTION
The argument order in the strictEqual check against stderr is in the
wrong order. The first argument is now the actual value and the second
argument is the expected value.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
