### PR TITLE
test: removed unused error variable in try catch

### DIFF
--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -55,7 +55,7 @@ if (!common.isWindows && process.getuid() === 0) {
   try {
     process.setuid('nobody');
     hasWriteAccessForReadonlyFile = false;
-  } catch (err) {
+  } catch {
   }
 }
 


### PR DESCRIPTION
In test/parallel/test-fs-access.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
