### PR TITLE
build: add .DS_store to .gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ deps/uv/docs/src/guide/
 deps/v8/gypfiles/Debug/
 deps/v8/gypfiles/Release/
 deps/v8/third_party/eu-strip/
+
+.DS_Store


### PR DESCRIPTION
The following files were not being ignored:

deps/npm/node_modules/node-gyp/gyp/tools/.DS_Store
deps/npm/node_modules/node-gyp/gyp/tools/Xcode/.DS_Store

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
