### PR TITLE
test: increase test coverage for readfile with withFileTypes option

### DIFF
--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -49,6 +49,19 @@ function assertDirents(dirents) {
 // Check the readdir Sync version
 assertDirents(fs.readdirSync(readdirDir, { withFileTypes: true }));
 
+fs.readdir(__filename, {
+  withFileTypes: true
+}, common.mustCall((err) => {
+  assert.throws(
+    () => { throw err; },
+    {
+      code: 'ENOTDIR',
+      name: 'Error',
+      message: `ENOTDIR: not a directory, scandir '${__filename}'`
+    }
+  );
+}));
+
 // Check the readdir async version
 fs.readdir(readdirDir, {
   withFileTypes: true


### PR DESCRIPTION
According to the test coverage report a test case was missings checking
if an error is passed into the callback for readdir calls with withFileTypes
option.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
