### PR TITLE
test: fix order of assert arguments in vm-new-script-this-context

### DIFF
--- a/test/parallel/test-vm-new-script-this-context.js
+++ b/test/parallel/test-vm-new-script-this-context.js
@@ -27,7 +27,7 @@ const Script = require('vm').Script;
 // Run a string
 let script = new Script('\'passed\';');
 const result = script.runInThisContext(script);
-assert.strictEqual('passed', result);
+assert.strictEqual(result, 'passed');
 
 // Thrown error
 script = new Script('throw new Error(\'test\');');
@@ -38,7 +38,7 @@ assert.throws(() => {
 global.hello = 5;
 script = new Script('hello = 2');
 script.runInThisContext(script);
-assert.strictEqual(2, global.hello);
+assert.strictEqual(global.hello, 2);
 
 
 // Pass values
@@ -49,15 +49,15 @@ global.foo = 2;
 global.obj = { foo: 0, baz: 3 };
 script = new Script(global.code);
 script.runInThisContext(script);
-assert.strictEqual(0, global.obj.foo);
-assert.strictEqual(2, global.bar);
-assert.strictEqual(1, global.foo);
+assert.strictEqual(global.obj.foo, 0);
+assert.strictEqual(global.bar, 2);
+assert.strictEqual(global.foo, 1);
 
 // Call a function
 global.f = function() { global.foo = 100; };
 script = new Script('f()');
 script.runInThisContext(script);
-assert.strictEqual(100, global.foo);
+assert.strictEqual(global.foo, 100);
 
 common.allowGlobals(
   global.hello,


### PR DESCRIPTION
Fixes the order of assert.strictEqual arguments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
