### PR TITLE
test: fix strictEqual assertion order on readline tests

### DIFF
--- a/test/parallel/test-readline.js
+++ b/test/parallel/test-readline.js
@@ -143,7 +143,7 @@ const assert = require('assert');
     ''
   ].forEach(function(expectedLine) {
     rl.write.apply(rl, key.xterm.metad);
-    assert.strictEqual(0, rl.cursor);
-    assert.strictEqual(expectedLine, rl.line);
+    assert.strictEqual(rl.cursor, 0);
+    assert.strictEqual(rl.line, expectedLine);
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

In `test-readline.js`, there were `strictEquals` assertions in which the expected value was the first argument and the actual value is the second argument. The order for the offending tests has been reversed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
