### PR TITLE
crypto: migrate to getOptions()

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -35,7 +35,8 @@ const {
   ERR_CRYPTO_FIPS_UNAVAILABLE
 } = require('internal/errors').codes;
 const constants = process.binding('constants').crypto;
-const { pendingDeprecation } = process.binding('config');
+const { getOptions } = internalBinding('options');
+const pendingDeprecation = getOptions('--pending-deprecation');
 const {
   fipsMode,
   fipsForced


### PR DESCRIPTION
Migrating from process.binding('config') to getOptions() in crypto.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
