### PR TITLE
test: fix assert.strictEqual() parameter order

### DIFF
--- a/test/parallel/test-tcp-wrap-connect.js
+++ b/test/parallel/test-tcp-wrap-connect.js
@@ -18,20 +18,20 @@ function makeConnection() {
   assert.strictEqual(err, 0);
 
   req.oncomplete = function(status, client_, req_, readable, writable) {
-    assert.strictEqual(0, status);
-    assert.strictEqual(client, client_);
-    assert.strictEqual(req, req_);
-    assert.strictEqual(true, readable);
-    assert.strictEqual(true, writable);
+    assert.strictEqual(status, 0);
+    assert.strictEqual(client_, client);
+    assert.strictEqual(req_, req);
+    assert.strictEqual(readable, true);
+    assert.strictEqual(writable, true);
 
     const shutdownReq = new ShutdownWrap();
     const err = client.shutdown(shutdownReq);
     assert.strictEqual(err, 0);
 
     shutdownReq.oncomplete = function(status, client_, error) {
-      assert.strictEqual(0, status);
-      assert.strictEqual(client, client_);
-      assert.strictEqual(error, undefined);
+      assert.strictEqual(status, 0);
+      assert.strictEqual(client_, client);
+      assert.strictEqual(undefined, error);
       shutdownCount++;
       client.close();
     };
@@ -55,7 +55,7 @@ const server = require('net').Server(function(s) {
 server.listen(0, makeConnection);
 
 process.on('exit', function() {
-  assert.strictEqual(1, shutdownCount);
-  assert.strictEqual(1, connectCount);
-  assert.strictEqual(1, endCount);
+  assert.strictEqual(shutdownCount, 1);
+  assert.strictEqual(connectCount, 1);
+  assert.strictEqual(endCount, 1);
 });


### PR DESCRIPTION
…follow the order actual-value->expected-value.

According to the documentation, the strictEqual assertions should follow the order ``actual-value`` -> ``expected-value``. This PR is changing the current situation of the test ``parallel/test-tcp-wrap-connect.js`` to accomplish it.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)