### PR TITLE
test: fix assert value order

### DIFF
--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -32,7 +32,7 @@ server.listen(options, function() {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(false, /Cannot find module/.test(answer));
-  assert.strictEqual(false, /Error/.test(answer));
+  assert.strictEqual(/Cannot find module/.test(answer), false);
+  assert.strictEqual(/Error/.test(answer), false);
   assert.strictEqual(answer, '\'eye catcher\'\n\'perhaps I work\'\n');
 });


### PR DESCRIPTION
Switched assertion values to match order of assert.strictEqual() documentation

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]