### PR TITLE
test: fix order of arguments passed to strictEqual

### DIFF
--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -18,8 +18,8 @@ const server = net.createServer((socket) => {
 
 server.on('close', common.mustCall(() => {
   // client and server should agree on the ports used
-  assert.deepStrictEqual(clientLocalPorts, serverRemotePorts);
-  assert.strictEqual(2, conns);
+  assert.deepStrictEqual(serverRemotePorts, clientLocalPorts);
+  assert.strictEqual(conns, 2);
 }));
 
 server.listen(0, common.localhostIPv4, connect);


### PR DESCRIPTION
The argument order in the `strictEqual` check was in the wrong order. The first argument is now the actual value and the second argument is the expected value. This fix ensures that the expected and actual values are correctly labeled.

##### Checklis

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)