### PR TITLE
test: fixed strictEqual arguments order

### DIFF
--- a/test/parallel/test-process-wrap.js
+++ b/test/parallel/test-process-wrap.js
@@ -38,8 +38,8 @@ p.onexit = function(exitCode, signal) {
   p.close();
   pipe.readStart();
 
-  assert.strictEqual(0, exitCode);
-  assert.strictEqual('', signal);
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signal, '');
 
   processExited = true;
 };


### PR DESCRIPTION
Fixes usage of strictEqual arguments order in `test/parallel/test-process-wrap.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

**PS:**  Part of Node+JS Interactive 2018 Code & Learn
