### PR TITLE
test: fix parameter order passed to strictEqual

### DIFF
--- a/test/sequential/test-inspector-break-e.js
+++ b/test/sequential/test-inspector-break-e.js
@@ -16,7 +16,7 @@ async function runTests() {
   ]);
   await session.waitForBreakOnLine(2, '[eval]');
   await session.runToCompletion();
-  assert.strictEqual(0, (await instance.expectShutdown()).exitCode);
+  assert.strictEqual((await instance.expectShutdown()).exitCode, 0);
 }
 
 runTests();


### PR DESCRIPTION
strictEqual() expects the first argument to be the actual value and the
second argument to be the expected value. This fix will correctly label
the AssertionError.:

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
