### PR TITLE
test: add crypto.scrypt test case with different encoding

### DIFF
--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -189,6 +189,24 @@ for (const options of toobig) {
   }));
 }
 
+{
+  const defaultEncoding = crypto.DEFAULT_ENCODING;
+  const defaults = { N: 16384, p: 1, r: 8 };
+  const expected = crypto.scryptSync('pass', 'salt', 1, defaults);
+
+  const testEncoding = 'latin1';
+  crypto.DEFAULT_ENCODING = testEncoding;
+  const actual = crypto.scryptSync('pass', 'salt', 1);
+  assert.deepStrictEqual(actual, expected.toString(testEncoding));
+
+  crypto.scrypt('pass', 'salt', 1, common.mustCall((err, actual) => {
+    assert.ifError(err);
+    assert.deepStrictEqual(actual, expected.toString(testEncoding));
+  }));
+
+  crypto.DEFAULT_ENCODING = defaultEncoding;
+}
+
 for (const { args, expected } of badargs) {
   common.expectsError(() => crypto.scrypt(...args), expected);
   common.expectsError(() => crypto.scryptSync(...args), expected);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Improve test coverage for `lib/internal/crypto/scrypt.js`, by hitting the line 44 & line 58.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
