### PR TITLE
test: reversed actual and expected values for .strictEqual()

### DIFF
--- a/test/parallel/test-next-tick-ordering.js
+++ b/test/parallel/test-next-tick-ordering.js
@@ -47,7 +47,7 @@ console.log('Running from main.');
 
 
 process.on('exit', function() {
-  assert.strictEqual('nextTick', done[0]);
+  assert.strictEqual(done[0], 'nextTick');
   /* Disabling this test. I don't think we can ensure the order
   for (i = 0; i < N; i += 1) {
     assert.strictEqual(i, done[i + 1]);


### PR DESCRIPTION
Fixed strictEqual() parameters order according to the documentation
for the assertion.

Refs: https://nodejs.org/dist/latest-v10.x/docs/api/assert.html#assert_assert_strictequal_actual_expected_message

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
