### PR TITLE
test: swap the order arguments are passed to

### DIFF
--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -104,7 +104,20 @@ server.listen(common.PORT, () => {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(true, normalReqSec > 50);
-  assert.strictEqual(true, keepAliveReqSec > 50);
-  assert.strictEqual(true, normalReqSec < keepAliveReqSec);
+  assert.strictEqual(
+    normalReqSec > 50,
+    true,
+    `normalReqSec should be greater than 50, but got ${normalReqSec}`
+  );
+  assert.strictEqual(
+    keepAliveReqSec > 50,
+    true,
+    `keepAliveReqSec should be greater than 50, but got ${keepAliveReqSec}`
+  );
+  assert.strictEqual(
+    normalReqSec < keepAliveReqSec,
+    true,
+    'normalReqSec should be less than keepAliveReqSec, ' +
+    `but ${normalReqSec} is greater than ${keepAliveReqSec}`
+  );
 });


### PR DESCRIPTION
Documentation for assertions rule actual values should be passed first
followed by the expected value. This commit update the assertions the
changed file contains to comply to that rule. Changes also label the
assertions.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
