### PR TITLE
test: fix assert parameters order

### DIFF
--- a/test/known_issues/test-http-path-contains-unicode.js
+++ b/test/known_issues/test-http-path-contains-unicode.js
@@ -10,7 +10,7 @@ const http = require('http');
 
 const expected = '/café🐶';
 
-assert.strictEqual('/caf\u{e9}\u{1f436}', expected);
+assert.strictEqual(expected, '/caf\u{e9}\u{1f436}');
 
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(req.url, expected);

--- a/test/known_issues/test-http-path-contains-unicode.js
+++ b/test/known_issues/test-http-path-contains-unicode.js
@@ -10,7 +10,7 @@ const http = require('http');
 
 const expected = '/café🐶';
 
-assert.strictEqual(expected, '/caf\u{e9}\u{1f436}');
+assert.strictEqual('/caf\u{e9}\u{1f436}', expected);
 
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(req.url, expected);

--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -66,7 +66,7 @@ echo_server.listen(common.PORT, function() {
   });
 
   client.on('data', function(chunk) {
-    assert.strictEqual('hello\r\n', chunk);
+    assert.strictEqual(chunk, 'hello\r\n');
     if (exchanges++ < 5) {
       setTimeout(function() {
         console.log('client write "hello"');


### PR DESCRIPTION
Changes the order of the assertion parameters in `test/known_issues/test-http-path-contains-unicode`, so the first argument is the value and the second argument is the expected value as assertion documentation expects.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
