### PR TITLE
src: throw if functions used as constructors in node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3919,8 +3919,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
                             env->as_external(),
                             Signature::New(env->isolate(), t),
                             /* length */ 0,
-                            // TODO(TimothyGu): should be deny
-                            ConstructorBehavior::kAllow,
+                            ConstructorBehavior::kThrow,
                             SideEffectType::kHasNoSideEffect);
 
   t->InstanceTemplate()->SetAccessorProperty(
@@ -3948,8 +3947,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
                             env->as_external(),
                             Signature::New(env->isolate(), t2),
                             /* length */ 0,
-                            // TODO(TimothyGu): should be deny
-                            ConstructorBehavior::kAllow,
+                            ConstructorBehavior::kThrow,
                             SideEffectType::kHasNoSideEffect);
 
   t2->InstanceTemplate()->SetAccessorProperty(


### PR DESCRIPTION
Throw an error if verify_error_getter_templ or
verify_error_getter_templ2 are used as constructors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
