### PR TITLE
test: fix assertion arguments order

### DIFF
--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -177,9 +177,8 @@ const qsUnescapeTestCases = [
    ' !"#$%&\'()*+,-./01234567']
 ];
 
-assert.strictEqual('918854443121279438895193',
-                   qs.parse('id=918854443121279438895193').id);
-
+assert.strictEqual(qs.parse('id=918854443121279438895193').id,
+                   '918854443121279438895193');
 
 function check(actual, expected, input) {
   assert(!(actual instanceof Object));
@@ -221,7 +220,7 @@ qsWeirdObjects.forEach((testCase) => {
 });
 
 qsNoMungeTestCases.forEach((testCase) => {
-  assert.deepStrictEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
+  assert.deepStrictEqual(qs.stringify(testCase[1], '&', '='), testCase[0]);
 });
 
 // test the nested qs-in-qs case
@@ -259,15 +258,15 @@ qsNoMungeTestCases.forEach((testCase) => {
 
 // basic
 qsTestCases.forEach((testCase) => {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[2]));
+  assert.strictEqual(qs.stringify(testCase[2]), testCase[1]);
 });
 
 qsColonTestCases.forEach((testCase) => {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[2], ';', ':'));
+  assert.strictEqual(qs.stringify(testCase[2], ';', ':'), testCase[1]);
 });
 
 qsWeirdObjects.forEach((testCase) => {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[0]));
+  assert.strictEqual(qs.stringify(testCase[0]), testCase[1]);
 });
 
 // invalid surrogate pair throws URIError
@@ -281,12 +280,12 @@ common.expectsError(
 );
 
 // coerce numbers to string
-assert.strictEqual('foo=0', qs.stringify({ foo: 0 }));
-assert.strictEqual('foo=0', qs.stringify({ foo: -0 }));
-assert.strictEqual('foo=3', qs.stringify({ foo: 3 }));
-assert.strictEqual('foo=-72.42', qs.stringify({ foo: -72.42 }));
-assert.strictEqual('foo=', qs.stringify({ foo: NaN }));
-assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
+assert.strictEqual(qs.stringify({ foo: 0 }), 'foo=0');
+assert.strictEqual(qs.stringify({ foo: -0 }), 'foo=0');
+assert.strictEqual(qs.stringify({ foo: 3 }), 'foo=3');
+assert.strictEqual(qs.stringify({ foo: -72.42 }), 'foo=-72.42');
+assert.strictEqual(qs.stringify({ foo: NaN }), 'foo=');
+assert.strictEqual(qs.stringify({ foo: Infinity }), 'foo=');
 
 // nested
 {
@@ -360,26 +359,26 @@ assert.strictEqual(
   const b = qs.unescapeBuffer('%d3%f2Ug%1f6v%24%5e%98%cb' +
     '%0d%ac%a2%2f%9d%eb%d8%a2%e6');
   // <Buffer d3 f2 55 67 1f 36 76 24 5e 98 cb 0d ac a2 2f 9d eb d8 a2 e6>
-  assert.strictEqual(0xd3, b[0]);
-  assert.strictEqual(0xf2, b[1]);
-  assert.strictEqual(0x55, b[2]);
-  assert.strictEqual(0x67, b[3]);
-  assert.strictEqual(0x1f, b[4]);
-  assert.strictEqual(0x36, b[5]);
-  assert.strictEqual(0x76, b[6]);
-  assert.strictEqual(0x24, b[7]);
-  assert.strictEqual(0x5e, b[8]);
-  assert.strictEqual(0x98, b[9]);
-  assert.strictEqual(0xcb, b[10]);
-  assert.strictEqual(0x0d, b[11]);
-  assert.strictEqual(0xac, b[12]);
-  assert.strictEqual(0xa2, b[13]);
-  assert.strictEqual(0x2f, b[14]);
-  assert.strictEqual(0x9d, b[15]);
-  assert.strictEqual(0xeb, b[16]);
-  assert.strictEqual(0xd8, b[17]);
-  assert.strictEqual(0xa2, b[18]);
-  assert.strictEqual(0xe6, b[19]);
+  assert.strictEqual(b[0], 0xd3);
+  assert.strictEqual(b[1], 0xf2);
+  assert.strictEqual(b[2], 0x55);
+  assert.strictEqual(b[3], 0x67);
+  assert.strictEqual(b[4], 0x1f);
+  assert.strictEqual(b[5], 0x36);
+  assert.strictEqual(b[6], 0x76);
+  assert.strictEqual(b[7], 0x24);
+  assert.strictEqual(b[8], 0x5e);
+  assert.strictEqual(b[9], 0x98);
+  assert.strictEqual(b[10], 0xcb);
+  assert.strictEqual(b[11], 0x0d);
+  assert.strictEqual(b[12], 0xac);
+  assert.strictEqual(b[13], 0xa2);
+  assert.strictEqual(b[14], 0x2f);
+  assert.strictEqual(b[15], 0x9d);
+  assert.strictEqual(b[16], 0xeb);
+  assert.strictEqual(b[17], 0xd8);
+  assert.strictEqual(b[18], 0xa2);
+  assert.strictEqual(b[19], 0xe6);
 }
 
 assert.strictEqual(qs.unescapeBuffer('a+b', true).toString(), 'a b');


### PR DESCRIPTION
Several of the `assert.` calls' arguments were ordered `(expected, actual)` - swapped to comply with the documentation `(actual, expected)`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
