### PR TITLE
test: add test-benchmark-napi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ clear-stalled:
 		echo $${PS_OUT} | xargs kill -9; \
 	fi
 
-test-build: | all build-addons build-addons-napi
+test-build: | all build-addons build-addons-napi bench-addons-build
 
 test-build-addons-napi: all build-addons-napi
 
@@ -443,7 +443,7 @@ test-ci-native: | test/addons/.buildstamp test/addons-napi/.buildstamp
 test-ci-js: | clear-stalled
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
-		$(TEST_CI_ARGS) $(CI_JS_SUITES)
+		$(TEST_CI_ARGS) $(CI_JS_SUITES) --skip-tests=sequential/test-benchmark-napi
 	@echo "Clean up any leftover processes, error if found."
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
@@ -454,7 +454,7 @@ test-ci-js: | clear-stalled
 .PHONY: test-ci
 # Related CI jobs: most CI tests, excluding node-test-commit-arm-fanned
 test-ci: LOGLEVEL := info
-test-ci: | clear-stalled build-addons build-addons-napi doc-only
+test-ci: | clear-stalled build-addons build-addons-napi doc-only bench-addons-build
 	out/Release/cctest --gtest_output=tap:cctest.tap
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
@@ -492,7 +492,7 @@ test-debug: test-build
 test-message: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) message
 
-test-simple: | cctest  # Depends on 'all'.
+test-simple: | cctest bench-addons-build  # Depends on 'all'.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) parallel sequential
 
 test-pummel: all

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ v8:
 	tools/make-v8.sh $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
 .PHONY: jstest
-jstest: build-addons build-addons-napi ## Runs addon tests and JS tests
+jstest: build-addons build-addons-napi bench-addons-build ## Runs addon tests and JS tests
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) \
 		--skip-tests=$(CI_SKIP_TESTS) \
 		$(CI_JS_SUITES) \

--- a/benchmark/napi/function_args/napi_binding.c
+++ b/benchmark/napi/function_args/napi_binding.c
@@ -50,7 +50,8 @@ static napi_value CallWithArray(napi_env env, napi_callback_info info) {
     status = napi_get_array_length(env, array, &length);
     assert(status == napi_ok);
 
-    for (uint32_t i = 0; i < length; ++i) {
+    uint32_t i;
+    for (i = 0; i < length; ++i) {
       napi_value v;
       status = napi_get_element(env, array, i, &v);
       assert(status == napi_ok);
@@ -173,7 +174,8 @@ static napi_value CallWithArguments(napi_env env, napi_callback_info info) {
     status = napi_get_value_uint32(env, args[0], &loop);
     assert(status == napi_ok);
 
-    for (uint32_t i = 1; i < loop; ++i) {
+    uint32_t i;
+    for (i = 1; i < loop; ++i) {
       assert(i < argc);
       status = napi_typeof(env, args[i], types);
       assert(status == napi_ok);

--- a/test/sequential/test-benchmark-napi.js
+++ b/test/sequential/test-benchmark-napi.js
@@ -6,6 +6,10 @@ if (common.isWindows) {
   common.skip('vcbuild.bat doesn\'t build the n-api benchmarks yet');
 }
 
+if (!common.isMainThread) {
+  common.skip('addons are not supported in workers');
+}
+
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('napi',

--- a/test/sequential/test-benchmark-napi.js
+++ b/test/sequential/test-benchmark-napi.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+
+if (common.isWindows) {
+  common.skip('vcbuild.bat doesn\'t build the n-api benchmarks yet')
+}
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('napi',
+             [
+               "n=1",
+               "engine=v8",
+               "type=String"
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/sequential/test-benchmark-napi.js
+++ b/test/sequential/test-benchmark-napi.js
@@ -10,8 +10,8 @@ const runBenchmark = require('../common/benchmark');
 
 runBenchmark('napi',
              [
-               "n=1",
-               "engine=v8",
-               "type=String"
+               'n=1',
+               'engine=v8',
+               'type=String'
              ],
              { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/sequential/test-benchmark-napi.js
+++ b/test/sequential/test-benchmark-napi.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 if (common.isWindows) {
-  common.skip('vcbuild.bat doesn\'t build the n-api benchmarks yet')
+  common.skip('vcbuild.bat doesn\'t build the n-api benchmarks yet');
 }
 
 const runBenchmark = require('../common/benchmark');

--- a/test/sequential/test-benchmark-napi.js
+++ b/test/sequential/test-benchmark-napi.js
@@ -10,6 +10,9 @@ if (!common.isMainThread) {
   common.skip('addons are not supported in workers');
 }
 
+if (process.features.debug) {
+  common.skip('benchmark does not work with debug build yet');
+}
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('napi',


### PR DESCRIPTION
also makes sure that the napi benchmark is built before running jstest

skipped on windows since n-api benchmarks aren't built there yet

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
