### PR TITLE
test: ensure error function call on inspector disabled

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -415,7 +415,7 @@ module.exports = {
   compileFunction,
 };
 
-if (process.binding('config').experimentalVMModules) {
+if (internalBinding('options').getOptions('--experimental-vm-modules')) {
   const { SourceTextModule } = require('internal/vm/source_text_module');
   module.exports.SourceTextModule = SourceTextModule;
 }

--- a/test/sequential/test-inspector-has-inspector-false.js
+++ b/test/sequential/test-inspector-has-inspector-false.js
@@ -1,0 +1,20 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+// This is to ensure that the sendInspectorCommand function calls the error
+// function if its called with the v8_enable_inspector is disabled
+
+const v8EnableInspectorBk = process.config.variables.v8_enable_inspector;
+process.config.variables.v8_enable_inspector = 0;
+const inspector = require('internal/util/inspector');
+
+function restoreProcessVar() {
+  process.config.variables.v8_enable_inspector = v8EnableInspectorBk;
+}
+
+inspector.sendInspectorCommand(
+  common.mustNotCall('Inspector callback should not be called'),
+  common.mustCall(restoreProcessVar, 1),
+);

--- a/test/sequential/test-inspector-has-inspector-false.js
+++ b/test/sequential/test-inspector-has-inspector-false.js
@@ -6,15 +6,10 @@ const common = require('../common');
 // This is to ensure that the sendInspectorCommand function calls the error
 // function if its called with the v8_enable_inspector is disabled
 
-const v8EnableInspectorBk = process.config.variables.v8_enable_inspector;
 process.config.variables.v8_enable_inspector = 0;
 const inspector = require('internal/util/inspector');
 
-function restoreProcessVar() {
-  process.config.variables.v8_enable_inspector = v8EnableInspectorBk;
-}
-
 inspector.sendInspectorCommand(
   common.mustNotCall('Inspector callback should not be called'),
-  common.mustCall(restoreProcessVar, 1),
+  common.mustCall(1),
 );


### PR DESCRIPTION
If the process.config.variables.v8_enable_inspector
is undefined or set to 0 and the sendInspectorCommand
function is called, it should call the error function
and should NOT call the callback function.

Test added to cover ./internal/util/inspector.js L4
https://coverage.nodejs.org/coverage-be346d9d32e0aacc/root/internal/util/inspector.js.html#L4

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]


