### PR TITLE
test: fix assert.strictEqual() parameter order

### DIFF
--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -29,17 +29,18 @@ if (common.isWindows) {
   const file = fixtures.path('a.js');
   const resolvedFile = path.resolve(file);
 
-  assert.strictEqual(`\\\\?\\${resolvedFile}`,
-                     path.toNamespacedPath(file));
-  assert.strictEqual(`\\\\?\\${resolvedFile}`,
-                     path.toNamespacedPath(`\\\\?\\${file}`));
-  assert.strictEqual('\\\\?\\UNC\\someserver\\someshare\\somefile',
-                     path.toNamespacedPath(
-                       '\\\\someserver\\someshare\\somefile'));
-  assert.strictEqual('\\\\?\\UNC\\someserver\\someshare\\somefile', path
-    .toNamespacedPath('\\\\?\\UNC\\someserver\\someshare\\somefile'));
-  assert.strictEqual('\\\\.\\pipe\\somepipe',
-                     path.toNamespacedPath('\\\\.\\pipe\\somepipe'));
+  assert.strictEqual(path.toNamespacedPath(file),
+                     `\\\\?\\${resolvedFile}`);
+  assert.strictEqual(path.toNamespacedPath(`\\\\?\\${file}`),
+                     `\\\\?\\${resolvedFile}`);
+  assert.strictEqual(path.toNamespacedPath(
+    '\\\\someserver\\someshare\\somefile'),
+                     '\\\\?\\UNC\\someserver\\someshare\\somefile');
+  assert.strictEqual(path.toNamespacedPath(
+    '\\\\?\\UNC\\someserver\\someshare\\somefile'),
+                     '\\\\?\\UNC\\someserver\\someshare\\somefile');
+  assert.strictEqual(path.toNamespacedPath('\\\\.\\pipe\\somepipe'),
+                     '\\\\.\\pipe\\somepipe');
 }
 
 assert.strictEqual(path.toNamespacedPath(null), null);


### PR DESCRIPTION
The argument order in the strictEqual check was in the wrong order.
The first argument is now the actual value and the second argument is
the expected value.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
