### PR TITLE
Migrating from process.binding('config') to getOptions()

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -111,13 +111,18 @@
       NativeModule.require('internal/inspector_async_hook').setup();
     }
 
-    const options = internalBinding('options');
-    if (options.getOptions('--help')) {
+    const { getOptions } = internalBinding('options');
+    const helpOption = getOptions('--help');
+    const completionBashOption = getOptions('--completion-bash');
+    const experimentalModulesOption = getOptions('--experimental-modules');
+    const experimentalVMModulesOption = getOptions('--experimental-vm-modules');
+    const experimentalWorkerOption = getOptions('--experimental-worker');
+    if (helpOption) {
       NativeModule.require('internal/print_help').print(process.stdout);
       return;
     }
 
-    if (options.getOptions('--completion-bash')) {
+    if (completionBashOption) {
       NativeModule.require('internal/bash_completion').print(process.stdout);
       return;
     }
@@ -137,7 +142,7 @@
       setupQueueMicrotask();
     }
 
-    if (internalBinding('options').getOptions('--experimental-worker')) {
+    if (experimentalWorkerOption) {
       setupDOMException();
     }
 
@@ -169,9 +174,8 @@
         'DeprecationWarning', 'DEP0062', startup, true);
     }
 
-    if (internalBinding('options').getOptions('--experimental-modules') ||
-    internalBinding('options').getOptions('--experimental-vm-modules')) {
-      if (internalBinding('options').getOptions('--experimental-modules')) {
+    if (experimentalModulesOption || experimentalVMModulesOption) {
+      if (experimentalModulesOption) {
         process.emitWarning(
           'The ESM module loader is experimental.',
           'ExperimentalWarning', undefined);

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -639,7 +639,9 @@
           const { kExpandStackSymbol } = NativeModule.require('internal/util');
           if (typeof er[kExpandStackSymbol] === 'function')
             er[kExpandStackSymbol]();
-        } catch (er) {}
+        } catch {
+          // Nothing to be done about it at this point.
+        }
         return false;
       }
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -137,7 +137,7 @@
       setupQueueMicrotask();
     }
 
-    if (process.binding('config').experimentalWorker) {
+    if (internalBinding('options').getOptions('--experimental-worker')) {
       setupDOMException();
     }
 
@@ -169,9 +169,9 @@
         'DeprecationWarning', 'DEP0062', startup, true);
     }
 
-    if (process.binding('config').experimentalModules ||
-        process.binding('config').experimentalVMModules) {
-      if (process.binding('config').experimentalModules) {
+    if (internalBinding('options').getOptions('--experimental-modules') ||
+    internalBinding('options').getOptions('--experimental-vm-modules')) {
+      if (internalBinding('options').getOptions('--experimental-modules')) {
         process.emitWarning(
           'The ESM module loader is experimental.',
           'ExperimentalWarning', undefined);
@@ -183,7 +183,7 @@
     {
       // Install legacy getters on the `util` binding for typechecking.
       // TODO(addaleax): Turn into a full runtime deprecation.
-      const { pendingDeprecation } = process.binding('config');
+      const { pendingDeprecation } = internalBinding('options').getOptions();
       const utilBinding = internalBinding('util');
       const types = internalBinding('types');
       for (const name of [

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -183,7 +183,7 @@
     {
       // Install legacy getters on the `util` binding for typechecking.
       // TODO(addaleax): Turn into a full runtime deprecation.
-      const { pendingDeprecation } = internalBinding('options').getOptions();
+      const { pendingDeprecation } = process.binding('config');
       const utilBinding = internalBinding('util');
       const types = internalBinding('types');
       for (const name of [
@@ -635,9 +635,7 @@
           const { kExpandStackSymbol } = NativeModule.require('internal/util');
           if (typeof er[kExpandStackSymbol] === 'function')
             er[kExpandStackSymbol]();
-        } catch {
-          // Nothing to be done about it at this point.
-        }
+        } catch (er) {}
         return false;
       }
 


### PR DESCRIPTION
Change inside /lib/internal/bootstrap/node.js code from
process.binding('config') to
internalBinding('options).getOptions()

Changes are done for options:
--experimental-modules
--experimental-vm-modules
--experimental-worker

##### Checklist

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes