### PR TITLE
test: fix order of parameters to assert.strictEqual

### DIFF
--- a/test/parallel/test-net-server-listen-remove-callback.js
+++ b/test/parallel/test-net-server-listen-remove-callback.js
@@ -30,7 +30,7 @@ const server = net.createServer();
 server.on('close', function() {
   const listeners = server.listeners('listening');
   console.log('Closed, listeners:', listeners.length);
-  assert.strictEqual(0, listeners.length);
+  assert.strictEqual(listeners.length, 0);
 });
 
 server.listen(0, function() {


### PR DESCRIPTION
Usage of `assert.strictEqual` in` test-net-server-listen-remove-callback.js`
incorrectly passes the expected value as the first argument 
and actual value as the second argument. 

This should be reversed, per the assert documentation.

Refs: https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
