### PR TITLE
test: fix args order of assertions

### DIFF
--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -13,5 +13,5 @@ const cmd = `"${nodePath}" "${script}" | head -2`;
 exec(cmd, common.mustCall(function(err, stdout, stderr) {
   assert.ifError(err);
   const lines = stdout.split('\n');
-  assert.strictEqual(3, lines.length);
+  assert.strictEqual(lines.length,3);
 }));

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -13,5 +13,5 @@ const cmd = `"${nodePath}" "${script}" | head -2`;
 exec(cmd, common.mustCall(function(err, stdout, stderr) {
   assert.ifError(err);
   const lines = stdout.split('\n');
-  assert.strictEqual(lines.length,3);
+  assert.strictEqual(lines.length, 3);
 }));


### PR DESCRIPTION
reversed argument order for all assertions in `test/parallel/test-pipe-head.js` to match docs


##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
