### PR TITLE
test: change order of assert.strictEquals arguments

### DIFF
--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -10,7 +10,7 @@ const { WriteWrap } = internalBinding('stream_wrap');
 const server = new TCP(TCPConstants.SOCKET);
 
 const r = server.bind('0.0.0.0', 0);
-assert.strictEqual(0, r);
+assert.strictEqual(r, 0);
 let port = {};
 server.getsockname(port);
 port = port.port;
@@ -18,7 +18,7 @@ port = port.port;
 server.listen(128);
 
 server.onconnection = (err, client) => {
-  assert.strictEqual(0, client.writeQueueSize);
+  assert.strictEqual(client.writeQueueSize, 0);
   console.log('got connection');
 
   const maybeCloseClient = () => {
@@ -34,7 +34,7 @@ server.onconnection = (err, client) => {
     if (buffer) {
       assert.ok(buffer.length > 0);
 
-      assert.strictEqual(0, client.writeQueueSize);
+      assert.strictEqual(client.writeQueueSize, 0);
 
       const req = new WriteWrap();
       req.async = false;
@@ -44,7 +44,7 @@ server.onconnection = (err, client) => {
 
       console.log(`client.writeQueueSize: ${client.writeQueueSize}`);
       // 11 bytes should flush
-      assert.strictEqual(0, client.writeQueueSize);
+      assert.strictEqual(client.writeQueueSize, 0);
 
       if (req.async)
         req.oncomplete = common.mustCall(done);
@@ -52,15 +52,15 @@ server.onconnection = (err, client) => {
         process.nextTick(done.bind(null, 0, client, req));
 
       function done(status, client_, req_) {
-        assert.strictEqual(req, client.pendingWrites.shift());
+        assert.strictEqual(client.pendingWrites.shift(), req);
 
         // Check parameters.
-        assert.strictEqual(0, status);
-        assert.strictEqual(client, client_);
-        assert.strictEqual(req, req_);
+        assert.strictEqual(status, 0);
+        assert.strictEqual(client_, client);
+        assert.strictEqual(req_, req);
 
         console.log(`client.writeQueueSize: ${client.writeQueueSize}`);
-        assert.strictEqual(0, client.writeQueueSize);
+        assert.strictEqual(client.writeQueueSize, 0);
 
         maybeCloseClient();
       }
@@ -82,7 +82,7 @@ c.on('connect', common.mustCall(() => { c.end('hello world'); }));
 
 c.setEncoding('utf8');
 c.on('data', common.mustCall((d) => {
-  assert.strictEqual('hello world', d);
+  assert.strictEqual(d, 'hello world');
 }));
 
 c.on('close', () => {


### PR DESCRIPTION
Fix assert.strictEquals argument order.

Arguments were actual first, expected second, contrary to
the documentation. Now, actual value is first and expected
value is second.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
