### PR TITLE
test: Covering the case when fs-read get invalid argument for file ha…

### DIFF
--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -75,3 +75,11 @@ assert.throws(
     code: 'ERR_INVALID_CALLBACK',
   }
 );
+
+assert.throws(
+  () => fs.read(null, Buffer.alloc(1), 0, 1, 0),
+  {
+    message: 'The "fd" argument must be of type number. Received type object',
+    code: 'ERR_INVALID_ARG_TYPE',
+  }
+);


### PR DESCRIPTION
fs read checks that first parameter is a valid FileHandle object.
Here we are wrapping that case with test.

- [ X ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ X ] tests and/or benchmarks are included
- [ X ] commit message follows [commit guidelines]