### PR TITLE
src: change macro to fn

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -10,8 +10,9 @@
 
 namespace node {
 //// Base 64 ////
-#define base64_encoded_size(size) ((size + 2 - ((size + 2) % 3)) / 3 * 4)
-
+static inline constexpr size_t base64_encoded_size(size_t size) {
+  return ((size + 2 - ((size + 2) % 3)) / 3 * 4);
+}
 
 // Doesn't check for padding at the end.  Can be 1-2 bytes over.
 static inline size_t base64_decoded_size_fast(size_t size) {
@@ -48,8 +49,9 @@ size_t base64_decoded_size(const TypeName* src, size_t size) {
 extern const int8_t unbase64_table[256];
 
 
-#define unbase64(x)                                                           \
-  static_cast<uint8_t>(unbase64_table[static_cast<uint8_t>(x)])
+inline static int8_t unbase64(uint8_t x) {
+  return unbase64_table[x];
+}
 
 
 template <typename TypeName>

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -143,7 +143,6 @@ enum ws_decode_result {
   FRAME_OK, FRAME_INCOMPLETE, FRAME_CLOSE, FRAME_ERROR
 };
 
-
 static void generate_accept_string(const std::string& client_key,
                                    char (*buffer)[ACCEPT_KEY_LENGTH]) {
   // Magic string from websockets spec.

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -143,6 +143,7 @@ enum ws_decode_result {
   FRAME_OK, FRAME_INCOMPLETE, FRAME_CLOSE, FRAME_ERROR
 };
 
+
 static void generate_accept_string(const std::string& client_key,
                                    char (*buffer)[ACCEPT_KEY_LENGTH]) {
   // Magic string from websockets spec.


### PR DESCRIPTION
Change base64_encoded_size and unbase64 to inline functions. The base64_encoded_size
is a constexpr to be used in function declarations.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
