### PR TITLE
test: correct order of assert args in client response domain test

### DIFF
--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -45,7 +45,7 @@ server.listen(common.PIPE, function() {
 function test() {
 
   d.on('error', common.mustCall(function(err) {
-    assert.strictEqual('should be caught by domain', err.message);
+    assert.strictEqual(err.message, 'should be caught by domain');
   }));
 
   const req = http.get({

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -44,7 +44,7 @@ server.listen(common.PIPE, function() {
 
 function test() {
 
-  d.on('error', common.mustCall(function(err) {
+  d.on('error', common.mustCall((err) => {
     assert.strictEqual(err.message, 'should be caught by domain');
   }));
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
