### PR TITLE
tls: convertProtocols() error handling

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -825,10 +825,11 @@ E('ERR_NO_ICU',
   '%s is not supported on Node.js compiled without ICU', TypeError);
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported', Error);
 E('ERR_OUT_OF_RANGE',
-  (name, range, value, msg = null) => {
-    msg = msg ? msg : `The value of "${name}" is out of range.`;
+  (str, range, input, replaceDefaultBoolean = false) => {
+    let msg = replaceDefaultBoolean ? str :
+      `The value of "${str}" is out of range.`;
     if (range !== undefined) msg += ` It must be ${range}.`;
-    msg += ` Received ${value}`;
+    msg += ` Received ${input}`;
     return msg;
   }, RangeError);
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s', Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -825,8 +825,8 @@ E('ERR_NO_ICU',
   '%s is not supported on Node.js compiled without ICU', TypeError);
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported', Error);
 E('ERR_OUT_OF_RANGE',
-  (name, range, value) => {
-    let msg = `The value of "${name}" is out of range.`;
+  (name, range, value, msg = null) => {
+    msg = msg ? msg : `The value of "${name}" is out of range.`;
     if (range !== undefined) msg += ` It must be ${range}.`;
     msg += ` Received ${value}`;
     return msg;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -21,7 +21,10 @@
 
 'use strict';
 
-const { ERR_TLS_CERT_ALTNAME_INVALID } = require('internal/errors').codes;
+const {
+  ERR_TLS_CERT_ALTNAME_INVALID,
+  ERR_OUT_OF_RANGE
+} = require('internal/errors').codes;
 const internalUtil = require('internal/util');
 const internalTLS = require('internal/tls');
 internalUtil.assertCrypto();
@@ -60,6 +63,9 @@ function convertProtocols(protocols) {
   const lens = new Array(protocols.length);
   const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
     var len = Buffer.byteLength(c);
+    if (len > 255) {
+      throw new ERR_OUT_OF_RANGE('byte length of a protocol', '< 255', len);
+    }
     lens[i] = len;
     return p + 1 + len;
   }, 0));

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -64,7 +64,7 @@ function convertProtocols(protocols) {
   const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
     var len = Buffer.byteLength(c);
     if (len > 255) {
-      throw new ERR_OUT_OF_RANGE('byte length of a protocol', '< 255', len);
+      throw new ERR_OUT_OF_RANGE('byte length of a protocol', '<= 255', len);
     }
     lens[i] = len;
     return p + 1 + len;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -65,7 +65,7 @@ function convertProtocols(protocols) {
     var len = Buffer.byteLength(c);
     if (len > 255) {
       throw new ERR_OUT_OF_RANGE('', '<= 255', len, 'The byte length of the ' +
-        `protocol at index ${i} exceeds the maximum.`);
+        `protocol at index ${i} exceeds the maximum length.`);
     }
     lens[i] = len;
     return p + 1 + len;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -64,8 +64,8 @@ function convertProtocols(protocols) {
   const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
     var len = Buffer.byteLength(c);
     if (len > 255) {
-      throw new ERR_OUT_OF_RANGE('', '<= 255', len, 'The byte length of the ' +
-        `protocol at index ${i} exceeds the maximum length.`);
+      throw new ERR_OUT_OF_RANGE('The byte length of the protocol at index ' +
+        `${i} exceeds the maximum length.`, '<= 255', len, true);
     }
     lens[i] = len;
     return p + 1 + len;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -64,7 +64,8 @@ function convertProtocols(protocols) {
   const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
     var len = Buffer.byteLength(c);
     if (len > 255) {
-      throw new ERR_OUT_OF_RANGE('byte length of a protocol', '<= 255', len);
+      throw new ERR_OUT_OF_RANGE('', '<= 255', len, 'The byte length of the ' +
+        `protocol at index ${i} exceeds the maximum.`);
     }
     lens[i] = len;
     return p + 1 + len;

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -111,7 +111,7 @@ common.expectsError(
     {
       code: 'ERR_OUT_OF_RANGE',
       message: 'The value of "byte length of a protocol" is out ' +
-        'of range. It must be < 255. Received 500'
+        'of range. It must be <= 255. Received 500'
     }
   );
 }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -111,7 +111,7 @@ common.expectsError(
     {
       code: 'ERR_OUT_OF_RANGE',
       message: 'The byte length of the protocol at index 0 exceeds the ' +
-        'maximum. It must be <= 255. Received 500'
+        'maximum length. It must be <= 255. Received 500'
     }
   );
 }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -110,8 +110,8 @@ common.expectsError(
     () => tls.convertALPNProtocols(protocols, out),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'The value of "byte length of a protocol" is out ' +
-        'of range. It must be <= 255. Received 500'
+      message: 'The byte length of the protocol at index 0 exceeds the ' +
+        'maximum. It must be <= 255. Received 500'
     }
   );
 }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -102,3 +102,16 @@ common.expectsError(
     assert(out.ALPNProtocols.equals(Buffer.from(expectView)));
   }
 }
+
+{
+  const protocols = [(new String('a')).repeat(500)];
+  const out = {};
+  common.expectsError(
+    () => tls.convertALPNProtocols(protocols, out),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      message: 'The value of "byte length of a protocol" is out ' +
+        'of range. It must be < 255. Received 500'
+    }
+  );
+}


### PR DESCRIPTION
The convertProtocols() function now throws a range error when the byte
length of a protocol is too long to fit in a Buffer.

Also added a test case in test/parallel/test-tls-basic-validations.js
to cover this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
