### PR TITLE
test: fix assertions args order in test-http-chunk-problem.js

### DIFF
--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -53,8 +53,8 @@ function executeRequest(cb) {
            'shasum' ].join(' '),
           (err, stdout, stderr) => {
             assert.ifError(err);
-            assert.strictEqual('8c206a1a87599f532ce68675536f0b1546900d7a',
-                               stdout.slice(0, 40));
+            assert.strictEqual(stdout.slice(0, 40),
+                               '8c206a1a87599f532ce68675536f0b1546900d7a');
             cb();
           }
   );


### PR DESCRIPTION
Fix assertions arguments order in test-http-chunk-problem.js

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
