### PR TITLE
test: fix parameters in test-repl.js

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -784,8 +784,8 @@ function startTCPRepl() {
     client.setEncoding('utf8');
 
     client.on('connect', common.mustCall(() => {
-      assert.strictEqual(true, client.readable);
-      assert.strictEqual(true, client.writable);
+      assert.strictEqual(client.readable, true);
+      assert.strictEqual(client.writable, true);
 
       resolveSocket(client);
     }));
@@ -827,8 +827,8 @@ function startUnixRepl() {
     client.setEncoding('utf8');
 
     client.on('connect', common.mustCall(() => {
-      assert.strictEqual(true, client.readable);
-      assert.strictEqual(true, client.writable);
+      assert.strictEqual(client.readable, true);
+      assert.strictEqual(client.writable, true);
 
       resolveSocket(client);
     }));


### PR DESCRIPTION
fixed order of parameters in assert.strictEqual() assertion functions,
first argument provided was the expected value and the second value
was the actual value.

this is backwards from the documentation for assertions like
assert.strictEqual() where the first value being tested and the second
value is the expected value

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
