### PR TITLE
crypto: move field initialization to class

### DIFF
--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -34,14 +34,7 @@ inline ClientHelloParser::ClientHelloParser()
     : state_(kEnded),
       onhello_cb_(nullptr),
       onend_cb_(nullptr),
-      cb_arg_(nullptr),
-      session_size_(0),
-      session_id_(nullptr),
-      servername_size_(0),
-      servername_(nullptr),
-      ocsp_request_(0),
-      tls_ticket_size_(0),
-      tls_ticket_(nullptr) {
+      cb_arg_(nullptr) {
   Reset();
 }
 

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -44,12 +44,12 @@ class ClientHelloParser {
     inline int ocsp_request() const { return ocsp_request_; }
 
    private:
-    uint8_t session_size_;
-    const uint8_t* session_id_;
+    uint8_t session_size_ = 0;
+    const uint8_t* session_id_ = nullptr;
     bool has_ticket_;
-    uint8_t servername_size_;
-    const uint8_t* servername_;
-    int ocsp_request_;
+    uint8_t servername_size_ = 0;
+    const uint8_t* servername_ = nullptr;
+    int ocsp_request_ = 0;
 
     friend class ClientHelloParser;
   };
@@ -108,16 +108,16 @@ class ClientHelloParser {
   OnHelloCb onhello_cb_;
   OnEndCb onend_cb_;
   void* cb_arg_;
-  size_t frame_len_;
-  size_t body_offset_;
-  size_t extension_offset_;
+  size_t frame_len_ = 0;
+  size_t body_offset_ = 0;
+  size_t extension_offset_ = 0;
   uint8_t session_size_;
   const uint8_t* session_id_;
   uint16_t servername_size_;
   const uint8_t* servername_;
   uint8_t ocsp_request_;
-  uint16_t tls_ticket_size_;
-  const uint8_t* tls_ticket_;
+  uint16_t tls_ticket_size_ = -1;
+  const uint8_t* tls_ticket_ = nullptr;
 };
 
 }  // namespace crypto

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -44,12 +44,12 @@ class ClientHelloParser {
     inline int ocsp_request() const { return ocsp_request_; }
 
    private:
-    uint8_t session_size_ = 0;
-    const uint8_t* session_id_ = nullptr;
+    uint8_t session_size_;
+    const uint8_t* session_id_;
     bool has_ticket_;
-    uint8_t servername_size_ = 0;
-    const uint8_t* servername_ = nullptr;
-    int ocsp_request_ = 0;
+    uint8_t servername_size_;
+    const uint8_t* servername_;
+    int ocsp_request_;
 
     friend class ClientHelloParser;
   };
@@ -111,11 +111,11 @@ class ClientHelloParser {
   size_t frame_len_ = 0;
   size_t body_offset_ = 0;
   size_t extension_offset_ = 0;
-  uint8_t session_size_;
-  const uint8_t* session_id_;
-  uint16_t servername_size_;
-  const uint8_t* servername_;
-  uint8_t ocsp_request_;
+  uint8_t session_size_ = 0;
+  const uint8_t* session_id_ = nullptr;
+  uint16_t servername_size_ = 0;
+  const uint8_t* servername_ = nullptr;
+  uint8_t ocsp_request_ = 0;
   uint16_t tls_ticket_size_ = -1;
   const uint8_t* tls_ticket_ = nullptr;
 };


### PR DESCRIPTION
Initialize fields of `ClientHelloParser` in class rather than in constructor.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
