### PR TITLE
test: reverse arguments in assert.strictEqual

### DIFF
--- a/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/parallel/test-http-keep-alive-close-on-header.js
@@ -46,7 +46,7 @@ server.listen(0, function() {
     port: this.address().port,
     agent: agent
   }, function(res) {
-    assert.strictEqual(1, agent.sockets[name].length);
+    assert.strictEqual(agent.sockets[name].length, 1);
     res.resume();
   });
   request.on('socket', function(s) {
@@ -63,7 +63,7 @@ server.listen(0, function() {
     port: this.address().port,
     agent: agent
   }, function(res) {
-    assert.strictEqual(1, agent.sockets[name].length);
+    assert.strictEqual(agent.sockets[name].length, 1);
     res.resume();
   });
   request.on('socket', function(s) {
@@ -80,7 +80,7 @@ server.listen(0, function() {
     agent: agent
   }, function(response) {
     response.on('end', function() {
-      assert.strictEqual(1, agent.sockets[name].length);
+      assert.strictEqual(agent.sockets[name].length, 1);
       server.close();
     });
     response.resume();
@@ -94,5 +94,5 @@ server.listen(0, function() {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(3, connectCount);
+  assert.strictEqual(connectCount, 3);
 });


### PR DESCRIPTION
assert.strictEqual() had incorrect order of arguments with expected and
actual values reversed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
