### PR TITLE
test: correct assertion argument order in test/sequential/test-inspector.js

### DIFF
--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -8,7 +8,12 @@ const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
 
 function checkListResponse(response) {
-  assert.strictEqual(1, response.length);
+  const expectedResponseLength = 1;
+  assert.strictEqual(
+    response.length,
+    expectedResponseLength,
+    `Expected list response length to be ${expectedResponseLength}.`
+  );
   assert.ok(response[0].devtoolsFrontendUrl);
   assert.ok(
     /ws:\/\/localhost:\d+\/[0-9A-Fa-f]{8}-/
@@ -41,7 +46,11 @@ function assertScopeValues({ result }, expected) {
   for (const actual of result) {
     const value = expected[actual.name];
     if (value) {
-      assert.strictEqual(value, actual.value.value);
+      assert.strictEqual(
+        actual.value.value,
+        value,
+        `Expected scope values to be ${actual.value.value} instead of ${value}.`
+      );
       unmatched.delete(actual.name);
     }
   }
@@ -117,15 +126,24 @@ async function testBreakpoint(session) {
       'generatePreview': true
     }
   });
-
-  assert.strictEqual(1002, result.value);
+  const expectedEvaluation = 1002;
+  assert.strictEqual(
+    result.value,
+    expectedEvaluation,
+    `Expected evaluation to be ${expectedEvaluation}, got ${result.value}.`
+  );
 
   result = (await session.send({
     'method': 'Runtime.evaluate', 'params': {
       'expression': '5 * 5'
     }
   })).result;
-  assert.strictEqual(25, result.value);
+  const expectedResult = 25;
+  assert.strictEqual(
+    result.value,
+    expectedResult,
+    `Expected Runtime.evaluate to be ${expectedResult}, got ${result.value}.`
+  );
 }
 
 async function testI18NCharacters(session) {
@@ -288,7 +306,13 @@ async function runTest() {
   await testI18NCharacters(session);
   await testCommandLineAPI(session);
   await session.runToCompletion();
-  assert.strictEqual(55, (await child.expectShutdown()).exitCode);
+  const expectedExitCode = 55;
+  const { exitCode } = await child.expectShutdown();
+  assert.strictEqual(
+    exitCode,
+    expectedExitCode,
+    `Expected exit code to be ${expectedExitCode} but got ${expectedExitCode}.`
+  );
 }
 
 runTest();


### PR DESCRIPTION
This makes assertions in `sequential/test-inspector.js` conform to follow the argument order of asserted then actual, and adds more explicit messages to describe assertion failures.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
