### PR TITLE
test: add test coverage for fs.truncate

### DIFF
--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -239,6 +239,41 @@ function testFtruncate(cb) {
   }));
 }
 
+{
+  const file7 = path.resolve(tmp, 'truncate-file-7.txt');
+  fs.writeFileSync(file7, 'Hi');
+  fs.truncate(file7, undefined, common.mustCall(function(err) {
+    assert.ifError(err);
+    assert(fs.readFileSync(file7).equals(Buffer.from('')));
+  }));
+}
+
+{
+  const file8 = path.resolve(tmp, 'non-existent-truncate-file.txt');
+  const validateError = (err) => {
+    assert.strictEqual(file8, err.path);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, open '${file8}'`);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.syscall, 'open');
+    return true;
+  };
+  fs.truncate(file8, 0, common.mustCall(validateError));
+}
+
+['', false, null, {}, []].forEach((input) => {
+  assert.throws(
+    () => fs.truncate('/foo/bar', input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+      message: 'The "len" argument must be of type number. ' +
+               `Received type ${typeof input}`
+    }
+  );
+});
+
 ['', false, null, undefined, {}, []].forEach((input) => {
   ['ftruncate', 'ftruncateSync'].forEach((fnName) => {
     assert.throws(


### PR DESCRIPTION
Add test to check:
- for `null` as len parameter
- if error is propagated into callback if file doesn't exist
- if an error is actually thrown if len is not a number

I think it is safe to say that we could remove:
```js
  } else if (len === undefined) {
    len = 0;
  }
```
because there is an `validateInteger(len, 'len');` right after. Another option would be to just set `len` to `0` for all cases it is not a `Number`. What do you think?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
