### PR TITLE
crypto: fix length argument to snprintf()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5745,7 +5745,7 @@ std::string GetOpenSSLVersion() {
   const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
   const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ') + 1;
   const int len = end - start;
-  snprintf(buf, len, "%.*s\n", len, &OPENSSL_VERSION_TEXT[start]);
+  snprintf(buf, sizeof(buf), "%.*s\n", len, &OPENSSL_VERSION_TEXT[start]);
   return std::string(buf);
 }
 


### PR DESCRIPTION
Introduced in commit d3d6cd3eca ("src: improve SSL version extraction
logic".)