### PR TITLE
src: remove function hasTextDecoder in encoding.js

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -341,15 +341,10 @@ Object.defineProperties(
       value: 'TextEncoder'
     } });
 
-const { hasConverter, TextDecoder } =
+const { TextDecoder } =
   process.binding('config').hasIntl ?
     makeTextDecoderICU() :
     makeTextDecoderJS();
-
-function hasTextDecoder(encoding = 'utf-8') {
-  validateArgument(encoding, 'string', 'encoding', 'string');
-  return hasConverter(getEncodingFromLabel(encoding));
-}
 
 function makeTextDecoderICU() {
   const {
@@ -552,7 +547,6 @@ function makeTextDecoderJS() {
 
 module.exports = {
   getEncodingFromLabel,
-  hasTextDecoder,
   TextDecoder,
   TextEncoder
 };


### PR DESCRIPTION
Remove `hasTextDecoder` in `/lib/internal/encoding.js`. `hasTextDecoder` is unused. This has the benefit of increasing test coverage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
