### PR TITLE
tls: prevent multiple connection errors

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -248,8 +248,10 @@ function onocspresponse(resp) {
 function onerror(err) {
   const owner = this[owner_symbol];
 
-  if (owner._writableState.errorEmitted)
+  if (owner._hadError)
     return;
+
+  owner._hadError = true;
 
   // Destroy socket if error happened before handshake's finish
   if (!owner._secureEstablished) {
@@ -265,8 +267,6 @@ function onerror(err) {
     // Throw error
     owner._emitTLSError(err);
   }
-
-  owner._writableState.errorEmitted = true;
 }
 
 function initRead(tls, wrapped) {


### PR DESCRIPTION
`onConnectEnd()`, which is called by `TLSSocket`, has a guard to prevent being called multiple times, but it does not prevent the OpenSSL error handler from being called, leading to multiple `error` events. This commit adds that piece of missing logic.

Fixes: https://github.com/nodejs/node/issues/23631

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: https://ci.nodejs.org/job/node-test-pull-request/17937/