### PR TITLE
test: mark `test-http2-session-timeout` as flake on ARM

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -21,3 +21,7 @@ test-http2-large-file: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
+
+[$arch==arm]
+# https://github.com/nodejs/node/issues/20628
+test-http2-session-timeout: PASS,FLAKY


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/20628

Please 👍 to fast-track

CI: ~https://ci.nodejs.org/job/node-test-pull-request/17810/~
https://ci.nodejs.org/job/node-test-pull-request/17812/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
