### PR TITLE
src: malloced_unique_ptr & make_malloced_unique

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -487,6 +487,22 @@ template <typename T, typename U>
 inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
                                            const std::unordered_map<T, U>& map);
 
+// Helper for `malloced_unique_ptr`
+template<typename T>
+struct MallocDeleter {
+  void operator()(T* ptr) const { free(ptr); }
+};
+
+// Specialization of `std::unique_ptr` for data allocated with `Malloc<t>`
+template<typename T>
+using malloced_unique_ptr = std::unique_ptr<T, MallocDeleter<T>>;
+
+// Factory of `malloced_unique_ptr`
+template<typename T>
+malloced_unique_ptr<T> make_malloced_unique(size_t number_of_t) {
+  return malloced_unique_ptr<T>(Malloc<T>(number_of_t));
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS


### PR DESCRIPTION
`malloced_unique_ptr` is just a specialization of `std:unique_ptr` using `free` for deletion, and `make_malloced_unique<T>` is it's factory using `Malloc<T>`.

Ref: https://github.com/nodejs/node/pull/23641
Ref: https://github.com/nodejs/node/pull/23543#pullrequestreview-164467022
Ref: https://github.com/nodejs/node/pull/23434

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
