### PR TITLE
build: fix `./configure --enable-d8`

### DIFF
--- a/deps/v8/gypfiles/d8.gyp
+++ b/deps/v8/gypfiles/d8.gyp
@@ -23,6 +23,7 @@
       'include_dirs+': [
         '..',
         '<(DEPTH)',
+        '<(SHARED_INTERMEDIATE_DIR)',
       ],
       'sources': [
         '<(SHARED_INTERMEDIATE_DIR)/d8-js.cc',


### PR DESCRIPTION
Add SHARED_INTERMEDIATE_DIR to the include path because that is where
Torque-generated files live. d8.cc includes files from deps/v8/src
that depend on those generated files.