### PR TITLE
[WIP] events: add destroy

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -244,6 +244,56 @@ console.log(EventEmitter.listenerCount(myEmitter, 'event'));
 // Prints: 2
 ```
 
+### EventEmitter.customDestroySymbol
+<!-- YAML
+added: REPLACEME
+-->
+
+Sub-classes of `EventEmitter` may wish to implement their own logic for
+destroying the emitter. To do so, provide an implementation of the
+`emitter[EventEmitter.customDestroySymbol]()` function:
+
+```js
+const EventEmitter = require('events');
+
+class MyEmitter extends EventEmitter {
+  [EventEmitter.customDestroySymbol](err) {
+    // Do some cleanup here. The destroy() method will only call
+    // this if this.destroyed is false.
+    this._isDestroyed = true;
+  }
+  [EventEmitter.customDestroyedSymbol]() {
+    return this._isDestroyed;
+  }
+}
+```
+
+### EventEmitter.customDestroyedSymbol
+<!-- YAML
+added: REPLACEME
+-->
+
+Sub-classes of `EventEmitter` may wish to implement their own logic for
+destroying the emitter, and for tracking the destroyed state. To do so,
+provide an implementation of the `emitter[EventEmitter.customDestroyedSymbol]()`
+function:
+
+```js
+const EventEmitter = require('events');
+
+class MyEmitter extends EventEmitter {
+  [EventEmitter.customDestroySymbol](err) {
+    if (this._isDestroyed)
+      return;
+    // Do some cleanup here.
+    this._isDestroyed = true;
+  }
+  [EventEmitter.customDestroyedSymbol]() {
+    return this._isDestroyed;
+  }
+}
+```
+
 ### EventEmitter.defaultMaxListeners
 <!-- YAML
 added: v0.11.2
@@ -292,6 +342,33 @@ added: v0.1.26
 * `listener` {Function}
 
 Alias for `emitter.on(eventName, listener)`.
+
+#### emitter.destroy([error])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `error` {Error}
+* Returns: {this}
+
+Destroy the EventEmitter, and emit the passed `'error'` and a `'close'` event
+on `nextTick`. After this call, the `emitter.destroyed` property will be set to
+`true`. However, the `emitter.emit()` function will continue to operate.
+Implementors should not override this method,
+but instead implement [`emitter[EventEmitter.customDestroySymbol]()`][].
+
+#### emitter.destroyed
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Set to `true` if the `emitter.destroy()` method has been called. Sub-classes
+may implement [`emitter[EventEmitter.customDestroyedSymbol]()`][] to override
+the default method of determining if an `EventEmitter` has been destroyed
+(this would only be necessary when implementing a custom
+[`emitter[EventEmitter.customDestroySymbol]()`][]).
 
 ### emitter.emit(eventName[, ...args])
 <!-- YAML

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -169,6 +169,10 @@ const EventEmitter = require('events');
 All `EventEmitter`s emit the event `'newListener'` when new listeners are
 added and `'removeListener'` when existing listeners are removed.
 
+All `EventEmitter`'s emit the `'close'` event on `nextTick` when the
+`emitter.destroy()` method is called. If an `err` argument is passed to
+`emitter.destroy()`, an `'error'` event will be emitted.
+
 ### Event: 'newListener'
 <!-- YAML
 added: v0.1.26
@@ -355,7 +359,8 @@ Destroy the EventEmitter, and emit the passed `'error'` and a `'close'` event
 on `nextTick`. After this call, the `emitter.destroyed` property will be set to
 `true`. However, the `emitter.emit()` function will continue to operate.
 Implementors should not override this method,
-but instead implement [`emitter[EventEmitter.customDestroySymbol]()`][].
+but instead implement the `emitter[EventEmitter.customDestroySymbol](err)`
+function.
 
 #### emitter.destroyed
 <!-- YAML
@@ -365,10 +370,10 @@ added: REPLACEME
 * {boolean}
 
 Set to `true` if the `emitter.destroy()` method has been called. Sub-classes
-may implement [`emitter[EventEmitter.customDestroyedSymbol]()`][] to override
+may implement `emitter[EventEmitter.customDestroyedSymbol]()` to override
 the default method of determining if an `EventEmitter` has been destroyed
 (this would only be necessary when implementing a custom
-[`emitter[EventEmitter.customDestroySymbol]()`][]).
+`emitter[EventEmitter.customDestroySymbol]()`).
 
 ### emitter.emit(eventName[, ...args])
 <!-- YAML

--- a/lib/events.js
+++ b/lib/events.js
@@ -41,6 +41,12 @@ EventEmitter.prototype._maxListeners = undefined;
 // added to it. This is a useful default which helps finding memory leaks.
 var defaultMaxListeners = 10;
 
+const kDestroyed = Symbol('node-destroyed');
+const kErrorEmitted = Symbol('node-error-emitted');
+const kCloseEmitted = Symbol('node-close-emitted');
+const kCustomDestroy = Symbol('node-destroy');
+const kCustomDestroyed = Symbol('node-destroyed');
+
 var errors;
 function lazyErrors() {
   if (errors === undefined)
@@ -64,6 +70,20 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   }
 });
 
+// Allow EventEmitter implementations to provide customized destroy logic
+Object.defineProperties(EventEmitter, {
+  customDestroySymbol: {
+    enumerable: true,
+    configurable: false,
+    value: kCustomDestroy
+  },
+  customDestroyedSymbol: {
+    enumerable: true,
+    configurable: false,
+    value: kCustomDestroyed
+  }
+});
+
 EventEmitter.init = function() {
 
   if (this._events === undefined ||
@@ -73,8 +93,88 @@ EventEmitter.init = function() {
   }
 
   this._maxListeners = this._maxListeners || undefined;
+  Object.defineProperties(this, {
+    [kDestroyed]: {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: false
+    },
+    [kErrorEmitted]: {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: false
+    },
+    [kCloseEmitted]: {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: false
+    }
+  });
 };
 
+Object.defineProperty(EventEmitter.prototype, 'destroyed', {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return typeof this[kCustomDestroyed] === 'function' ?
+      this[kCustomDestroyed]() : this[kDestroyed];
+  }
+});
+
+EventEmitter.prototype.destroy = function destroy(err, cb) {
+  // cb is an undocumented internal API for Node.js internal use.
+  if (cb !== undefined && typeof cb !== 'function') {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_CALLBACK();
+  }
+
+  if (this.destroyed) {
+    if (cb) {
+      cb(err);
+    } else if (err && !this[kErrorEmitted]) {
+      this[kErrorEmitted] = true;
+      process.nextTick(emitErrorNT, this, err);
+    }
+    return this;
+  }
+
+  // Allow for a custom override of the the destroy function
+  if (typeof this[kCustomDestroy] === 'function') {
+    this[kCustomDestroy](err);
+  } else {
+    this[kDestroyed] = true;
+  }
+
+  if (!cb && err) {
+    process.nextTick(emitErrorAndCloseNT, this, err);
+    this[kErrorEmitted] = true;
+  } else if (cb) {
+    process.nextTick(emitCloseNT, this);
+    cb(err);
+  } else {
+    process.nextTick(emitCloseNT, this);
+  }
+  return this;
+};
+
+function emitErrorAndCloseNT(self, err) {
+  emitErrorNT(self, err);
+  emitCloseNT(self);
+}
+
+function emitCloseNT(self) {
+  if (self[kCloseEmitted])
+    return;
+  self[kCloseEmitted] = true;
+  self.emit('close');
+}
+
+function emitErrorNT(self, err) {
+  self.emit('error', err);
+}
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -120,7 +120,7 @@ Object.defineProperty(EventEmitter.prototype, 'destroyed', {
   configurable: true,
   get() {
     return typeof this[kCustomDestroyed] === 'function' ?
-      this[kCustomDestroyed]() : this[kDestroyed];
+      !!this[kCustomDestroyed]() : this[kDestroyed];
   }
 });
 

--- a/test/parallel/test-event-emitter-destroy.js
+++ b/test/parallel/test-event-emitter-destroy.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+// If the optional callback parameter is not a function, throw
+{
+  const ee = new EventEmitter();
+  common.expectsError(
+    () => ee.destroy('something', 'else'), {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError
+    }
+  );
+}
+
+// If no error argument is passed to destroy, error will not be emitted,
+// close will be emitted, and ee.destroyed will be true.
+{
+  const ee = new EventEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  ee.destroy();
+  ee.on('error', common.mustNotCall());
+  ee.on('close', common.mustCall(() => {
+    assert.strictEqual(ee.destroyed, true);
+  }));
+  ee.destroy();
+}
+
+// If destroy is called twice, once without an error, and once with an
+// error, a close event will be emitted first, followed by an error event.
+// Both will only be called once tho.
+{
+  let closeEmitted = false;
+  const ee = new EventEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  ee.destroy();
+  ee.destroy(new Error('foo'));
+  ee.on('error', common.expectsError({
+    code: undefined,
+    type: Error,
+    message: 'foo'
+  }));
+  ee.on('error', common.mustCall(() => {
+    assert.strictEqual(closeEmitted, true);
+  }));
+  ee.on('close', common.mustCall(() => {
+    assert.strictEqual(ee.destroyed, true);
+    closeEmitted = true;
+  }));
+}
+
+// If destroy is called twice, once with an error, and once without, an
+// error event will be emitted first, followed by a close event. Both will
+// only be called once tho.
+{
+  let errorEmitted = false;
+  const ee = new EventEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  ee.destroy(new Error('foo'));
+  ee.destroy();
+  ee.on('error', common.expectsError({
+    code: undefined,
+    type: Error,
+    message: 'foo'
+  }));
+  ee.on('error', common.mustCall(() => {
+    errorEmitted = true;
+  }));
+  ee.on('close', common.mustCall(() => {
+    assert.strictEqual(ee.destroyed, true);
+    assert.strictEqual(errorEmitted, true);
+  }));
+}
+
+// If a callback is provided, it will be invoked and an error event will not
+// be emitted.
+{
+  let errorCallback = false;
+  const ee = new EventEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  ee.destroy(undefined, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
+    errorCallback = true;
+  }));
+  ee.on('error', common.mustNotCall());
+  ee.on('close', common.mustCall(() => {
+    assert.strictEqual(errorCallback, true);
+  }));
+}
+
+// If destroy is called with an error and a callback is provided, the error
+// will be sent to the callback and the error event will not be emitted.
+{
+  const ee = new EventEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  ee.destroy(new Error('foo'), common.expectsError({
+    code: undefined,
+    type: Error,
+    message: 'foo'
+  }));
+  ee.on('error', common.mustNotCall());
+  ee.on('close', common.mustCall(() => {
+    assert.strictEqual(ee.destroyed, true);
+  }));
+}
+
+{
+  class MyEmitter extends EventEmitter {
+    constructor() {
+      super();
+      this._isDestroyed = false;
+    }
+    [EventEmitter.customDestroySymbol](err) {
+      assert(err);
+      assert.strictEqual(this._isDestroyed, false);
+      assert.strictEqual(err.message, 'foo');
+      this._isDestroyed = true;
+    }
+    [EventEmitter.customDestroyedSymbol]() {
+      return this._isDestroyed;
+    }
+  }
+  const ee = new MyEmitter();
+  assert.strictEqual(ee.destroyed, false);
+  assert.strictEqual(ee._isDestroyed, false);
+  ee.destroy(new Error('foo'));
+  assert.strictEqual(ee.destroyed, true);
+  assert.strictEqual(ee._isDestroyed, true);
+  ee.on('error', common.mustCall());
+  ee.on('close', common.mustCall());
+}


### PR DESCRIPTION
Calling `ee.emit('error', error')` on an event emitter is generally not a good practice. This introduces a destroy() method using the same logic used in streams, allowing an Event Emitter impl to provide proper cleanup before emitting an error event.

The `emitter.destroy()` and `emitter.destroyed` behavior may be customized by implementations but the implementation still ensures that `error` and `close` events are emitted in a consistent way.

Note that this causes the `'error'` to be emitted on nextTick. There are some places in core where the `emit('error')` is expected to be sync (in `zlib` for instance). Migrating those to use this will be a semver-major, unfortunately.

Also note that destroy will always emit a `'close'` event, which will be new to some EventEmitters and may conflict with others, which also means semver-major to migrate.

/cc @mcollina @mafintosh 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
