### PR TITLE
src: update v8::Object::GetPropertyNames() usage

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -508,7 +508,12 @@ void ContextifyContext::PropertyEnumeratorCallback(
   if (ctx->context_.IsEmpty())
     return;
 
-  args.GetReturnValue().Set(ctx->sandbox()->GetPropertyNames());
+  Local<Array> properties;
+
+  if (!ctx->sandbox()->GetPropertyNames(ctx->context()).ToLocal(&properties))
+    return;
+
+  args.GetReturnValue().Set(properties);
 }
 
 // static


### PR DESCRIPTION
Use the non-deprecated version of `GetPropertyNames()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/17938/
