### PR TITLE
src: expose Environment::kNodeContextTagPtr

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -951,7 +951,7 @@ class Environment {
   uint64_t thread_id_ = 0;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
 
-  static void* kNodeContextTagPtr;
+  NODE_EXTERN static void* kNodeContextTagPtr;
   static int const kNodeContextTag;
 
 #if HAVE_INSPECTOR


### PR DESCRIPTION
This PR exposes `Environment::kNodeContextTagPtr`. This was introduced a while back in https://github.com/nodejs/node/pull/19134, and then recently introduced into `Environment::GetCurrent`. 

Electron uses `Environment::GetCurrent` in several places (such as [here](https://github.com/electron/electron/blob/master/atom/renderer/atom_render_frame_observer.cc#L236)), and since `kNodeContextTagPtr` wasn't exposed, we began to run into undefined symbol errors. 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
