### PR TITLE
test: fix calls of deprecated assert methods

### DIFF
--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -120,8 +120,7 @@ class ActivityCollector {
     }
     if (violations.length) {
       console.error(violations.join('\n\n') + '\n');
-      assert.fail(violations.length, 0,
-                  `${violations.length} failed sanity checks`);
+      assert.fail(`${violations.length} failed sanity checks`);
     }
   }
 

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -70,7 +70,7 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
   })
   .on('error', function(err) {
     console.error(err);
-    assert.fail(null, null, `[Pipe server]${err}`);
+    assert.fail(`[Pipe server]${err}`);
   })
   .listen({ path: serverPath }, common.mustCall(function serverOnListen() {
     const getSocketOpt = (index) => {
@@ -94,7 +94,7 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
       console.error(`[Pipe]Sending data through fd ${oldHandle.fd}`);
       this.on('error', function(err) {
         console.error(err);
-        assert.fail(null, null, `[Pipe Client]${err}`);
+        assert.fail(`[Pipe Client]${err}`);
       });
     });
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -228,7 +228,7 @@ function test(encoding, input, expected, singleSequence) {
         `input: ${input.toString('hex').match(hexNumberRE)}\n` +
         `Write sequence: ${JSON.stringify(sequence)}\n` +
         `Full Decoder State: ${inspect(decoder)}`;
-      assert.fail(output, expected, message);
+      assert.fail(message);
     }
   });
 }

--- a/test/pseudo-tty/test-tty-get-color-depth.js
+++ b/test/pseudo-tty/test-tty-get-color-depth.js
@@ -10,7 +10,7 @@ const writeStream = new WriteStream(fd);
 
 {
   const depth = writeStream.getColorDepth();
-  assert.equal(typeof depth, 'number');
+  assert.strictEqual(typeof depth, 'number');
   assert(depth >= 1 && depth <= 24);
 }
 
@@ -44,7 +44,7 @@ const writeStream = new WriteStream(fd);
   [{ TERM: 'dumb', COLORTERM: '1' }, 4],
 ].forEach(([env, depth], i) => {
   const actual = writeStream.getColorDepth(env);
-  assert.equal(
+  assert.strictEqual(
     actual,
     depth,
     `i: ${i}, expected: ${depth}, actual: ${actual}, env: ${env}`
@@ -57,8 +57,8 @@ const writeStream = new WriteStream(fd);
   const [ value, depth1, depth2 ] = process.platform !== 'win32' ?
     ['win32', 1, 4] : ['linux', 4, 1];
 
-  assert.equal(writeStream.getColorDepth({}), depth1);
+  assert.strictEqual(writeStream.getColorDepth({}), depth1);
   Object.defineProperty(process, 'platform', { value });
-  assert.equal(writeStream.getColorDepth({}), depth2);
+  assert.strictEqual(writeStream.getColorDepth({}), depth2);
   Object.defineProperty(process, 'platform', platform);
 }

--- a/test/pseudo-tty/test-tty-get-color-depth.js
+++ b/test/pseudo-tty/test-tty-get-color-depth.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert').strict;
-/* eslint-disable no-restricted-properties */
 const { WriteStream } = require('tty');
 
 const fd = common.getTTYfd();


### PR DESCRIPTION
Just went through [assert docs](https://nodejs.org/api/assert.html) and fixed calls of deprecated methods in tests:

- Use [`assert.strictEqual`](https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message) instead of deprecated [`assert.equal`](https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message)
- Use [`assert.fail([message])`](https://nodejs.org/api/assert.html#assert_assert_fail_message) instead of deprecated [`assert.fail(actual, expected[, message[, operator[, stackStartFn]]])`](https://nodejs.org/api/assert.html#assert_assert_fail_actual_expected_message_operator_stackstartfn)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test