### PR TITLE
src: add trace events for env.cc

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -18,6 +18,7 @@ The available categories are:
   The [`async_hooks`] events have a unique `asyncId` and a special `triggerId`
   `triggerAsyncId` property.
 * `node.bootstrap` - Enables capture of Node.js bootstrap milestones.
+* `node.environment` - Enables capture of Node.js Environment milestones.
 * `node.fs.sync` - Enables capture of trace data for file system sync methods.
 * `node.perf` - Enables capture of [Performance API] measurements.
   * `node.perf.usertiming` - Enables capture of only Performance API User Timing

--- a/src/env.cc
+++ b/src/env.cc
@@ -41,7 +41,7 @@ class TraceEventScope {
   TraceEventScope(const char* category,
                   const char* name,
                   void* id) : category_(category), name_(name), id_(id) {
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(category_, name_, id);
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(category_, name_, id_);
   }
   ~TraceEventScope() {
     TRACE_EVENT_NESTABLE_ASYNC_END0(category_, name_, id_);
@@ -255,7 +255,7 @@ void Environment::Start(const std::vector<std::string>& args,
   Context::Scope context_scope(context());
 
   if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
-      TRACING_CATEGORY_NODE1(environment))) {
+      TRACING_CATEGORY_NODE1(environment)) != 0) {
     auto traced_value = tracing::TracedValue::Create();
     traced_value->BeginArray("args");
     for (const std::string& arg : args)

--- a/src/env.cc
+++ b/src/env.cc
@@ -262,7 +262,7 @@ void Environment::Start(const std::vector<std::string>& args,
       traced_value->AppendString(arg);
     traced_value->EndArray();
     traced_value->BeginArray("exec_args");
-    for (std::string arg : exec_args)
+    for (const std::string& arg : exec_args)
       traced_value->AppendString(arg);
     traced_value->EndArray();
     TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(

--- a/src/env.cc
+++ b/src/env.cc
@@ -46,6 +46,7 @@ class TraceEventScope {
   ~TraceEventScope() {
     TRACE_EVENT_NESTABLE_ASYNC_END0(category_, name_, id_);
   }
+
  private:
   const char* category_;
   const char* name_;
@@ -257,7 +258,7 @@ void Environment::Start(const std::vector<std::string>& args,
       TRACING_CATEGORY_NODE1(environment))) {
     auto traced_value = tracing::TracedValue::Create();
     traced_value->BeginArray("args");
-    for (std::string arg : args)
+    for (const std::string& arg : args)
       traced_value->AppendString(arg);
     traced_value->EndArray();
     traced_value->BeginArray("exec_args");

--- a/src/env.cc
+++ b/src/env.cc
@@ -7,6 +7,7 @@
 #include "node_context_data.h"
 #include "node_worker.h"
 #include "tracing/agent.h"
+#include "tracing/traced_value.h"
 
 #include <stdio.h>
 #include <algorithm>
@@ -32,6 +33,24 @@ using v8::Value;
 using worker::Worker;
 
 #define kTraceCategoryCount 1
+
+// TODO(@jasnell): Likely useful to move this to util or node_internal to
+// allow reuse. But since we're not reusing it yet...
+class TraceEventScope {
+ public:
+  TraceEventScope(const char* category,
+                  const char* name,
+                  void* id) : category_(category), name_(name), id_(id) {
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(category_, name_, id);
+  }
+  ~TraceEventScope() {
+    TRACE_EVENT_NESTABLE_ASYNC_END0(category_, name_, id_);
+  }
+ private:
+  const char* category_;
+  const char* name_;
+  void* id_;
+};
 
 int const Environment::kNodeContextTag = 0x6e6f64;
 void* Environment::kNodeContextTagPtr = const_cast<void*>(
@@ -223,6 +242,9 @@ Environment::~Environment() {
   delete[] heap_statistics_buffer_;
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
+
+  TRACE_EVENT_NESTABLE_ASYNC_END0(
+    TRACING_CATEGORY_NODE1(environment), "Environment", this);
 }
 
 void Environment::Start(const std::vector<std::string>& args,
@@ -230,6 +252,23 @@ void Environment::Start(const std::vector<std::string>& args,
                         bool start_profiler_idle_notifier) {
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
+
+  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+      TRACING_CATEGORY_NODE1(environment))) {
+    auto traced_value = tracing::TracedValue::Create();
+    traced_value->BeginArray("args");
+    for (std::string arg : args)
+      traced_value->AppendString(arg);
+    traced_value->EndArray();
+    traced_value->BeginArray("exec_args");
+    for (std::string arg : exec_args)
+      traced_value->AppendString(arg);
+    traced_value->EndArray();
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(
+      TRACING_CATEGORY_NODE1(environment),
+      "Environment", this,
+      "args", std::move(traced_value));
+  }
 
   CHECK_EQ(0, uv_timer_init(event_loop(), timer_handle()));
   uv_unref(reinterpret_cast<uv_handle_t*>(timer_handle()));
@@ -400,6 +439,8 @@ void Environment::PrintSyncTrace() const {
 }
 
 void Environment::RunCleanup() {
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "RunCleanup", this);
   CleanupHandles();
 
   while (!cleanup_hooks_.empty()) {
@@ -431,6 +472,8 @@ void Environment::RunCleanup() {
 }
 
 void Environment::RunBeforeExitCallbacks() {
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "BeforeExit", this);
   for (ExitCallback before_exit : before_exit_functions_) {
     before_exit.cb_(before_exit.arg_);
   }
@@ -442,6 +485,8 @@ void Environment::BeforeExit(void (*cb)(void* arg), void* arg) {
 }
 
 void Environment::RunAtExitCallbacks() {
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "AtExit", this);
   for (ExitCallback at_exit : at_exit_functions_) {
     at_exit.cb_(at_exit.arg_);
   }
@@ -495,13 +540,16 @@ void Environment::EnvPromiseHook(v8::PromiseHookType type,
 
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) return;
-
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "EnvPromiseHook", env);
   for (const PromiseHookCallback& hook : env->promise_hooks_) {
     hook.cb_(type, promise, parent, hook.arg_);
   }
 }
 
 void Environment::RunAndClearNativeImmediates() {
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "RunAndClearNativeImmediates", this);
   size_t count = native_immediate_callbacks_.size();
   if (count > 0) {
     size_t ref_count = 0;
@@ -554,6 +602,8 @@ void Environment::ToggleTimerRef(bool ref) {
 
 void Environment::RunTimers(uv_timer_t* handle) {
   Environment* env = Environment::from_timer_handle(handle);
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "RunTimers", env);
 
   if (!env->can_call_into_js())
     return;
@@ -614,6 +664,8 @@ void Environment::RunTimers(uv_timer_t* handle) {
 
 void Environment::CheckImmediate(uv_check_t* handle) {
   Environment* env = Environment::from_immediate_check_handle(handle);
+  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
+                              "CheckImmediate", env);
 
   if (env->immediate_info()->count() == 0)
     return;

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+const names = [
+  'Environment',
+  'RunAndClearNativeImmediates',
+  'CheckImmediate',
+  'RunTimers',
+  'BeforeExit',
+  'RunCleanup',
+  'AtExit'
+];
+
+if (process.argv[2] === 'child') {
+  1 + 1;
+} else {
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
+
+  const proc = cp.fork(__filename,
+                       [ 'child' ], {
+                         execArgv: [
+                           '--trace-event-categories',
+                           'node.environment'
+                         ]
+                       });
+
+  proc.once('exit', common.mustCall(() => {
+    const file = path.join(tmpdir.path, 'node_trace.1.log');
+
+    assert(fs.existsSync(file));
+    fs.readFile(file, common.mustCall((err, data) => {
+      const traces = JSON.parse(data.toString()).traceEvents
+        .filter((trace) => trace.cat !== '__metadata');
+      traces.forEach((trace) => {
+        assert.strictEqual(trace.pid, proc.pid);
+        assert(names.includes(trace.name));
+      });
+    }));
+  }));
+}

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -13,7 +13,7 @@ const tmpdir = require('../common/tmpdir');
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
 
-const names = [
+const names = new Set([
   'Environment',
   'RunAndClearNativeImmediates',
   'CheckImmediate',
@@ -21,7 +21,7 @@ const names = [
   'BeforeExit',
   'RunCleanup',
   'AtExit'
-];
+]);
 
 if (process.argv[2] === 'child') {
   // This is just so that the child has something to do.
@@ -52,12 +52,10 @@ if (process.argv[2] === 'child') {
       .filter((trace) => trace.cat !== '__metadata')
       .forEach((trace) => {
         assert.strictEqual(trace.pid, proc.pid);
-        assert(names.includes(trace.name));
+        assert(names.has(trace.name));
         checkSet.add(trace.name);
       });
 
-    let name;
-    while (name = names.shift())
-      assert(checkSet.has(name));
+    assert.deepStrictEqual(names, checkSet);
   }));
 }

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -1,3 +1,5 @@
+// Flags: --no-warnings
+
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -5,6 +7,8 @@ const cp = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
+
+// This tests the emission of node.environment trace events
 
 if (!common.isMainThread)
   common.skip('process.chdir is not available in Workers');
@@ -20,7 +24,12 @@ const names = [
 ];
 
 if (process.argv[2] === 'child') {
+  // This is just so that the child has something to do.
   1 + 1;
+  // These ensure that the RunTimers, CheckImmediate, and
+  // RunAndClearNativeImmediates appear in the list.
+  setImmediate(() => { 1 + 1; });
+  setTimeout(() => { 1 + 1; }, 1);
 } else {
   tmpdir.refresh();
   process.chdir(tmpdir.path);
@@ -33,17 +42,22 @@ if (process.argv[2] === 'child') {
                          ]
                        });
 
-  proc.once('exit', common.mustCall(() => {
+  proc.once('exit', common.mustCall(async () => {
     const file = path.join(tmpdir.path, 'node_trace.1.log');
+    const checkSet = new Set();
 
     assert(fs.existsSync(file));
-    fs.readFile(file, common.mustCall((err, data) => {
-      const traces = JSON.parse(data.toString()).traceEvents
-        .filter((trace) => trace.cat !== '__metadata');
-      traces.forEach((trace) => {
+    const data = await fs.promises.readFile(file);
+    JSON.parse(data.toString()).traceEvents
+      .filter((trace) => trace.cat !== '__metadata')
+      .forEach((trace) => {
         assert.strictEqual(trace.pid, proc.pid);
         assert(names.includes(trace.name));
+        checkSet.add(trace.name);
       });
-    }));
+
+    let name;
+    while (name = names.shift())
+      assert(checkSet.has(name));
   }));
 }


### PR DESCRIPTION
Adds a new `node.environment` trace event category that captures simple lifecycle events for an `Environment`:

This will be most useful for our own diagnostics around timers and such but it captures useful timing information for end users also.

![image](https://user-images.githubusercontent.com/439929/46967639-01308a00-d066-11e8-9ecc-2b401671153d.png)

![image](https://user-images.githubusercontent.com/439929/46967682-1f968580-d066-11e8-9cd9-4cb53bb19af4.png)

![image](https://user-images.githubusercontent.com/439929/46967718-3046fb80-d066-11e8-8a65-65be70e461e2.png)

Note: Will add test and docs in a bit

/cc @nodejs/diagnostics 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
