### PR TITLE
src: add public wrapper for Environment::GetCurrent

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2760,6 +2760,11 @@ void FreeEnvironment(Environment* env) {
 }
 
 
+Environment* GetCurrentEnvironment(Local<Context> context) {
+  return Environment::GetCurrent(context);
+}
+
+
 MultiIsolatePlatform* GetMainThreadMultiIsolatePlatform() {
   return v8_platform.Platform();
 }

--- a/src/node.h
+++ b/src/node.h
@@ -265,6 +265,9 @@ NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
 NODE_EXTERN void LoadEnvironment(Environment* env);
 NODE_EXTERN void FreeEnvironment(Environment* env);
 
+// This may return nullptr if context is not associated with a Node instance.
+NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
+
 // This returns the MultiIsolatePlatform used in the main thread of Node.js.
 // If NODE_USE_V8_PLATFORM haven't been defined when Node.js was built,
 // it returns nullptr.

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -80,13 +80,16 @@ TEST_F(EnvironmentTest, NonNodeJSContext) {
   node::Environment* env = *test_env;
   EXPECT_EQ(node::Environment::GetCurrent(isolate_), env);
   EXPECT_EQ(node::Environment::GetCurrent(env->context()), env);
+  EXPECT_EQ(node::GetCurrentEnvironment(env->context()), env);
 
   v8::Local<v8::Context> context = v8::Context::New(isolate_);
   EXPECT_EQ(node::Environment::GetCurrent(context), nullptr);
+  EXPECT_EQ(node::GetCurrentEnvironment(context), nullptr);
   EXPECT_EQ(node::Environment::GetCurrent(isolate_), env);
 
   v8::Context::Scope context_scope(context);
   EXPECT_EQ(node::Environment::GetCurrent(context), nullptr);
+  EXPECT_EQ(node::GetCurrentEnvironment(context), nullptr);
   EXPECT_EQ(node::Environment::GetCurrent(isolate_), nullptr);
 }
 


### PR DESCRIPTION
Follow-up for https://github.com/nodejs/node/pull/23672; this PR adds a public wrapper for `Environment::GetCurrent` in order to allow embedders like Electron access to the current environment without having to use private APIs and experience issues around private members like `Environment::kNodeContextTagPtr`.

Also adds a test to ensure that this new wrapper does not break on future changes.

/cc @addaleax

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
