### PR TITLE
crypto: strip unwanted space from openssl version

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5715,9 +5715,9 @@ std::string GetOpenSSLVersion() {
   // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
   char buf[128];
   const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
-  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ') + 1;
+  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ');
   const int len = end - start;
-  snprintf(buf, sizeof(buf), "%.*s\n", len, &OPENSSL_VERSION_TEXT[start]);
+  snprintf(buf, sizeof(buf), "%.*s", len, &OPENSSL_VERSION_TEXT[start]);
   return std::string(buf);
 }
 

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -33,6 +33,10 @@ assert(/^\d+\.\d+\.\d+(?:\.\d+)?-node\.\d+(?: \(candidate\))?$/
   .test(process.versions.v8));
 assert(/^\d+$/.test(process.versions.modules));
 
+if (common.hasCrypto) {
+  assert(/^\d+\.\d+\.\d+[a-z]?$/.test(process.versions.openssl));
+}
+
 for (let i = 0; i < expected_keys.length; i++) {
   const key = expected_keys[i];
   const descriptor = Object.getOwnPropertyDescriptor(process.versions, key);


### PR DESCRIPTION
Remove trailing " \n" from `process.versions.openssl`.

d3d6cd3ecad19 was incorrectly printing this trailer, but because the
target buffer size was claimed to be the length of the version string,
the trailer was truncated off.

9ed4646df05b9 corrected the target buffer size, but then the trailer
started to appear in process.versions.

Added a test to check for regressions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
