### PR TITLE
test: check version strings have expected pattern

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -34,7 +34,24 @@ assert(/^\d+\.\d+\.\d+(?:\.\d+)?-node\.\d+(?: \(candidate\))?$/
 assert(/^\d+$/.test(process.versions.modules));
 
 if (common.hasCrypto) {
+  // example: 1.1.0i
   assert(/^\d+\.\d+\.\d+[a-z]?$/.test(process.versions.openssl));
+}
+
+// example: 3
+assert(/^\d+$/.test(process.versions.napi));
+// example: 1.34.0
+assert(/^\d+\.\d+\.\d+$/.test(process.versions.nghttp2));
+
+if (common.hasIntl) {
+  // example: 2018e
+  assert(/^\d{4}[a-z]$/.test(process.versions.tz));
+  // example: 33.1
+  assert(/^\d+\.\d+$/.test(process.versions.cldr));
+  // example: 62.1
+  assert(/^\d+\.\d+$/.test(process.versions.icu));
+  // example: 11.0
+  assert(/^\d+\.\d+$/.test(process.versions.unicode));
 }
 
 for (let i = 0; i < expected_keys.length; i++) {


### PR DESCRIPTION
Many were checked, but a few were not.

Should wait on https://github.com/nodejs/node/pull/23678, which is included in this to make the openssl version check succeed and to avoid conflicts because of adjacent test assertions. I'll rebase after the other is merged.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
