### PR TITLE
module: don't search in require.resolve.paths

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -584,9 +584,6 @@ Module._resolveFilename = function(request, parent, isMain, options) {
       fakeParent.paths = Module._nodeModulePaths(path);
       const lookupPaths = Module._resolveLookupPaths(request, fakeParent, true);
 
-      if (!paths.includes(path))
-        paths.push(path);
-
       for (var j = 0; j < lookupPaths.length; j++) {
         if (!paths.includes(lookupPaths[j]))
           paths.push(lookupPaths[j]);

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -24,11 +24,12 @@ assert.throws(() => {
     require.resolve('three')
   }, /^Error: Cannot find module 'three'$/);
 
-  // However, it can be found if resolution contains the nested index directory.
-  assert.strictEqual(
-    require.resolve('three', { paths: [nestedIndex] }),
-    path.join(nestedIndex, 'three.js')
-  );
+  // If the nested-index directory is provided as a resolve path, 'three'
+  // cannot be found because nested-index is used as a starting point and not
+  // a searched directory.
+  assert.throws(() => {
+    require.resolve('three', { paths: [nestedIndex] })
+  }, /^Error: Cannot find module 'three'$/);
 
   // Resolution from nested index directory also checks node_modules.
   assert.strictEqual(
@@ -50,6 +51,6 @@ assert.throws(() => {
   paths.unshift(nestedNodeModules);
   assert.strictEqual(
     require.resolve('bar', { paths }),
-    path.join(nestedNodeModules, 'bar.js')
+    path.join(nodeModules, 'bar.js')
   );
 }


### PR DESCRIPTION
The paths used by `require.resolve()` should be treated as starting points for module resolution, and not actually searched. This change aligns the docs with the actual behavior.

Fixes: https://github.com/nodejs/node/issues/18408
Refs: https://github.com/nodejs/node/issues/23643

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
