### PR TITLE
repl: migrate from process.binding('config') to getOptions()

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -70,7 +70,9 @@ const {
   ERR_SCRIPT_EXECUTION_INTERRUPTED
 } = require('internal/errors').codes;
 const { sendInspectorCommand } = require('internal/util/inspector');
-const { experimentalREPLAwait } = process.binding('config');
+const experimentalREPLAwait = internalBinding('options').getOptions(
+  '--experimental-repl-await'
+);
 const { isRecoverableError } = require('internal/repl/recoverable');
 const {
   getOwnNonIndexProperties,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
