### PR TITLE
change the min mac os x version required for `node-gyp rebuild`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -367,7 +367,7 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
+          'MACOSX_DEPLOYMENT_TARGET': '10.9',       # -mmacosx-version-min=10.9
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',


### PR DESCRIPTION
It fixes an issue when running `npm install` for a project with **Node v6.11.5** and **npm v3.10.10** on **Mac OS X 10.4 Mojave** and **Xcode v9.4.1 || Xcode v10.0**. It asks for the 'utility' file when running `node-gyp rebuild`.

Fixes: https://github.com/nodejs/node-gyp/issues/1574

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This solution was based on [this fix](https://github.com/nodejs/node-gyp/issues/1564#issuecomment-430067150) from @yerassyl94.