### PR TITLE
doc: simplify security reporting text

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,10 @@ team has addressed the vulnerability.
 The security team will acknowledge your email within 24 hours. You will receive
 a more detailed response within 48 hours.
 
-There are no hard and fast rules to determine if a bug is worth reporting as
-a security issue. The general rule is an issue worth reporting should allow an
-attacker to compromise the confidentiality, integrity, or availability of the
-Node.js application or its system for which the attacker does not already have
-the capability.
-
-To illustrate the point, here are some examples of past issues and what the
-Security Response Team thinks of them. When in doubt, however, please do send
-us a report nonetheless.
+There are no hard and fast rules to determine if a bug is worth reporting as a
+security issue. Here are some examples of past issues and what the Security
+Response Team thinks of them. When in doubt, please do send us a report
+nonetheless.
 
 
 ### Public disclosure preferred


### PR DESCRIPTION
Edit security-reporting text in the README to keep it concise and
straightforward. The removed text may discourage reporting. Nothing like
it appears in similar security-reporting text that I have reviewed.
See, for example, the Linux kernel docs on security reporting:
https://www.kernel.org/doc/html/v4.11/admin-guide/security-bugs.html

@nodejs/security-wg @nodejs/security-triage 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
