### PR TITLE
n-api: make per-Context-ness of napi_env explicit

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -25,7 +25,7 @@ struct napi_env__ {
     CHECK_NOT_NULL(node_env());
   }
 
-  v8::Isolate* isolate;  // Shortcut for context()->GetIsolate()
+  v8::Isolate* const isolate;  // Shortcut for context()->GetIsolate()
   node::Persistent<v8::Context> context_persistent;
 
   inline v8::Local<v8::Context> context() const {


### PR DESCRIPTION
Because instances of `napi_env` are created on a per-global-object
basis and because most N-API functions refer to builtin JS
objects, `napi_env` is essentially in 1:1 correspondence with
`v8::Context`.

This was not clear from the implementation by itself, but has
emerged from conversations with the N-API team.

This patch changes the `napi_env` implementation to:

- Actually store the `v8::Context` it represents.
- Provide more direct access to the `node::Environment`
  to which the `Context` belongs.
- Do not store the `uv_loop_t*` explicitly, since it can be
  inferred from the `node::Environment` and we actually
  have an N-API method for that.
- Replace calls to `isolate->GetCurrentContext()` with
  the more appropriate `napi_env` `Context`.
- Implement a better (although not perfect) way of cleaning
  up `napi_env` instances.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
