### PR TITLE
test: fix test-require-symlink on Windows

### DIFF
--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -60,7 +60,7 @@ const linkScriptTarget = path.join(dirName, 'symlinked.js');
 test();
 
 function test() {
-  fs.symlinkSync(linkTarget, linkDir);
+  fs.symlinkSync(linkTarget, linkDir, 'dir');
   fs.symlinkSync(linkScriptTarget, linkScript);
 
   // load symlinked-module


### PR DESCRIPTION
Creating directory symlinks on Windows require 'dir' parameter to be provided.

Fixes: https://github.com/nodejs/node/issues/23596

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
