### PR TITLE
test: enable trace-events tests for workers

### DIFF
--- a/test/parallel/test-trace-events-all.js
+++ b/test/parallel/test-trace-events-all.js
@@ -3,20 +3,18 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
-                      [ '--trace-events-enabled', '-e', CODE ]);
+                      [ '--trace-events-enabled', '-e', CODE ],
+                      { cwd: tmpdir.path });
 
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));

--- a/test/parallel/test-trace-events-api.js
+++ b/test/parallel/test-trace-events-api.js
@@ -5,13 +5,11 @@ const common = require('../common');
 
 if (!process.binding('config').hasTracing)
   common.skip('missing trace events');
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const {
   createTracing,
@@ -109,7 +107,6 @@ if (isChild) {
   }
 
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const expectedMarks = ['A', 'B'];
   const expectedBegins = [
@@ -123,7 +120,8 @@ if (isChild) {
 
   const proc = cp.fork(__filename,
                        ['child'],
-                       { execArgv: [ '--expose-gc',
+                       { cwd: tmpdir.path,
+                         execArgv: [ '--expose-gc',
                                      '--trace-event-categories',
                                      'foo' ] });
 

--- a/test/parallel/test-trace-events-api.js
+++ b/test/parallel/test-trace-events-api.js
@@ -5,11 +5,12 @@ const common = require('../common');
 
 if (!process.binding('config').hasTracing)
   common.skip('missing trace events');
+common.skipIfWorker(); // https://github.com/nodejs/node/issues/22767
 
 const assert = require('assert');
 const cp = require('child_process');
-const fs = require('fs');
 const path = require('path');
+const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
 const {
   createTracing,
@@ -107,6 +108,7 @@ if (isChild) {
   }
 
   tmpdir.refresh();
+  process.chdir(tmpdir.path);
 
   const expectedMarks = ['A', 'B'];
   const expectedBegins = [
@@ -120,8 +122,7 @@ if (isChild) {
 
   const proc = cp.fork(__filename,
                        ['child'],
-                       { cwd: tmpdir.path,
-                         execArgv: [ '--expose-gc',
+                       { execArgv: [ '--expose-gc',
                                      '--trace-event-categories',
                                      'foo' ] });
 

--- a/test/parallel/test-trace-events-async-hooks.js
+++ b/test/parallel/test-trace-events-async-hooks.js
@@ -3,22 +3,20 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
+const path = require('path');
 const util = require('util');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-event-categories', 'node.async_hooks',
-                        '-e', CODE ]);
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
 
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));

--- a/test/parallel/test-trace-events-binding.js
+++ b/test/parallel/test-trace-events-binding.js
@@ -3,9 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const CODE = `
   const { internalBinding } = require('internal/test/binding');
@@ -18,17 +16,17 @@ const CODE = `
   trace('b'.charCodeAt(0), 'missing',
         'type-value', 10, {'extra-value': 20 });
 `;
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-event-categories', 'custom',
                         '--no-warnings',
                         '--expose-internals',
-                        '-e', CODE ]);
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
 
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));

--- a/test/parallel/test-trace-events-bootstrap.js
+++ b/test/parallel/test-trace-events-bootstrap.js
@@ -2,12 +2,9 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 const names = [
   'environment',
@@ -30,10 +27,10 @@ if (process.argv[2] === 'child') {
   1 + 1;
 } else {
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const proc = cp.fork(__filename,
                        [ 'child' ], {
+                         cwd: tmpdir.path,
                          execArgv: [
                            '--trace-event-categories',
                            'node.bootstrap'

--- a/test/parallel/test-trace-events-category-used.js
+++ b/test/parallel/test-trace-events-category-used.js
@@ -3,9 +3,6 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
-
 const CODE = `
   const { internalBinding } = require('internal/test/binding');
   const { isTraceCategoryEnabled } = internalBinding('trace_events');
@@ -16,7 +13,6 @@ const CODE = `
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
 
 const procEnabled = cp.spawn(
   process.execPath,
@@ -25,7 +21,8 @@ const procEnabled = cp.spawn(
     // emits a warning.
     '--no-warnings',
     '--expose-internals',
-    '-e', CODE ]
+    '-e', CODE ],
+  { cwd: tmpdir.path }
 );
 let procEnabledOutput = '';
 
@@ -42,7 +39,8 @@ const procDisabled = cp.spawn(
     // emits a warning.
     '--no-warnings',
     '--expose-internals',
-    '-e', CODE ]
+    '-e', CODE ],
+  { cwd: tmpdir.path }
 );
 let procDisabledOutput = '';
 

--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -3,13 +3,10 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
+const path = require('path');
 const util = require('util');
 
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
-
 const tests = new Array();
-const traceFile = 'node_trace.1.log';
 
 let gid = 1;
 let uid = 1;
@@ -119,14 +116,14 @@ if (common.canCreateSymLink()) {
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const traceFile = path.join(tmpdir.path, 'node_trace.1.log');
 
 for (const tr in tests) {
   const proc = cp.spawnSync(process.execPath,
                             [ '--trace-events-enabled',
                               '--trace-event-categories', 'node.fs.sync',
                               '-e', tests[tr] ],
-                            { encoding: 'utf8' });
+                            { cwd: tmpdir.path, encoding: 'utf8' });
   // Some AIX versions don't support futimes or utimes, so skip.
   if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.futimes') {
     continue;

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -3,23 +3,21 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1);' +
   'process.title = "foo"';
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-event-categories', 'node.perf.usertiming',
                         '--title=bar',
-                        '-e', CODE ]);
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));
   fs.readFile(FILE_NAME, common.mustCall((err, data) => {

--- a/test/parallel/test-trace-events-none.js
+++ b/test/parallel/test-trace-events-none.js
@@ -3,21 +3,19 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc_no_categories = cp.spawn(
   process.execPath,
-  [ '--trace-event-categories', '""', '-e', CODE ]
+  [ '--trace-event-categories', '""', '-e', CODE ],
+  { cwd: tmpdir.path }
 );
 
 proc_no_categories.once('exit', common.mustCall(() => {

--- a/test/parallel/test-trace-events-perf.js
+++ b/test/parallel/test-trace-events-perf.js
@@ -2,12 +2,9 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 if (process.argv[2] === 'child') {
   const { performance } = require('perf_hooks');
@@ -25,7 +22,6 @@ if (process.argv[2] === 'child') {
   ff();  // Will emit a timerify trace event
 } else {
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const expectedMarks = ['A', 'B'];
   const expectedBegins = [
@@ -41,6 +37,7 @@ if (process.argv[2] === 'child') {
                        [
                          'child'
                        ], {
+                         cwd: tmpdir.path,
                          execArgv: [
                            '--trace-event-categories',
                            'node.perf'

--- a/test/parallel/test-trace-events-process-exit.js
+++ b/test/parallel/test-trace-events-process-exit.js
@@ -3,20 +3,16 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const tmpdir = require('../common/tmpdir');
-
-const FILE_NAME = 'node_trace.1.log';
-
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',
-                        '-e', 'process.exit()' ]);
+                        '-e', 'process.exit()' ],
+                      { cwd: tmpdir.path });
 
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));

--- a/test/parallel/test-trace-events-promises.js
+++ b/test/parallel/test-trace-events-promises.js
@@ -2,14 +2,11 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 common.disableCrashOnUnhandledRejection();
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 if (process.argv[2] === 'child') {
   const p = Promise.reject(1);  // Handled later
@@ -19,10 +16,10 @@ if (process.argv[2] === 'child') {
   });
 } else {
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const proc = cp.fork(__filename,
                        [ 'child' ], {
+                         cwd: tmpdir.path,
                          execArgv: [
                            '--no-warnings',
                            '--trace-event-categories',

--- a/test/parallel/test-trace-events-v8.js
+++ b/test/parallel/test-trace-events-v8.js
@@ -3,22 +3,20 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
+const path = require('path');
 
 const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
-const FILE_NAME = 'node_trace.1.log';
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
-process.chdir(tmpdir.path);
+const FILE_NAME = path.join(tmpdir.path, 'node_trace.1.log');
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',
                         '--trace-event-categories', 'v8',
-                        '-e', CODE ]);
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
 
 proc.once('exit', common.mustCall(() => {
   assert(fs.existsSync(FILE_NAME));

--- a/test/parallel/test-trace-events-vm.js
+++ b/test/parallel/test-trace-events-vm.js
@@ -2,12 +2,9 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
-
-if (!common.isMainThread)
-  common.skip('process.chdir is not available in Workers');
 
 const names = [
   'ContextifyScript::New',
@@ -20,10 +17,10 @@ if (process.argv[2] === 'child') {
   vm.runInNewContext('1 + 1');
 } else {
   tmpdir.refresh();
-  process.chdir(tmpdir.path);
 
   const proc = cp.fork(__filename,
                        [ 'child' ], {
+                         cwd: tmpdir.path,
                          execArgv: [
                            '--trace-event-categories',
                            'node.vm.script'


### PR DESCRIPTION
Use the `cwd` option for `child_process` instead of `process.chdir()`
to enable the trace events tests to run on workers.

Refs: https://github.com/nodejs/node/pull/23674#discussion_r225335819

~I've split one of the tests (`test-trace-events-api.js`) into its own commit 
because it crashes when run under workers. Is this indicative of a real 
bug?~
_Edit:_ `test-trace-events-api.js` updated to be skipped for workers due 
to https://github.com/nodejs/node/issues/22767 

cc @nodejs/trace-events @nodejs/workers 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
