### PR TITLE
benchmark: fix bench-mkdirp to use recursive option

### DIFF
--- a/benchmark/fs/bench-mkdirp.js
+++ b/benchmark/fs/bench-mkdirp.js
@@ -16,7 +16,7 @@ function main({ n }) {
     if (cntr-- <= 0)
       return bench.end(n);
     const pathname = `${tmpdir.path}/${++dirc}/${++dirc}/${++dirc}/${++dirc}`;
-    fs.mkdir(pathname, { createParents: true }, (err) => {
+    fs.mkdir(pathname, { recursive: true }, (err) => {
       r(cntr);
     });
   }(n));


### PR DESCRIPTION
The original PR didn't update the benchmark after renaming the option.
