### PR TITLE
doc: add Backport-PR-URL info in backport guide

### DIFF
--- a/doc/guides/backporting-to-release-lines.md
+++ b/doc/guides/backporting-to-release-lines.md
@@ -68,17 +68,20 @@ hint: and commit the result with 'git commit'
    using `git add`, and then commit the changes. That can be done with
    `git cherry-pick --continue`.
 6. Leave the commit message as is. If you think it should be modified, comment
-   in the Pull Request.
+   in the Pull Request. The `Backport-PR-URL` metadata does need to be added to
+   the commit, but this will be done later.
 7. Make sure `make -j4 test` passes.
 8. Push the changes to your fork
 9. Open a pull request:
    1. Be sure to target the `v8.x-staging` branch in the pull request.
-   2. Include the backport target in the pull request title in the following
+   1. Include the backport target in the pull request title in the following
       format — `[v8.x backport] <commit title>`.
       Example: `[v8.x backport] process: improve performance of nextTick`
-   3. Check the checkbox labeled "Allow edits from maintainers".
-   4. In the description add a reference to the original PR
-   5. Run a [`node-test-pull-request`][] CI job (with `REBASE_ONTO` set to the
+   1. Check the checkbox labeled "Allow edits from maintainers".
+   1. In the description add a reference to the original PR.
+   1. Amend the commit message and include a `Backport-PR-URL:` metadata and
+      re-push the change to your fork.
+   1. Run a [`node-test-pull-request`][] CI job (with `REBASE_ONTO` set to the
       default `<pr base branch>`)
 10. If during the review process conflicts arise, use the following to rebase:
     `git pull --rebase upstream v8.x-staging`


### PR DESCRIPTION
This feedback was raised in https://github.com/nodejs/node/pull/23398#issuecomment-430134302. /cc @targos.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
