### PR TITLE
 build: for debug mode set `v8_optimized_debug`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -28,9 +28,6 @@
 
     'openssl_fips%': '',
 
-    # Default to -O0 for debug builds.
-    'v8_optimized_debug%': 0,
-
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
     'v8_embedder_string': '-node.7',

--- a/common.gypi
+++ b/common.gypi
@@ -30,7 +30,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.7',
+    'v8_embedder_string': '-node.8',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/configure.py
+++ b/configure.py
@@ -566,6 +566,12 @@ parser.add_option('--verbose',
     default=False,
     help='get more output from this script')
 
+parser.add_option('--v8-non-optimized-debug',
+    action='store_true',
+    dest='v8_non_optimized_debug',
+    default=False,
+    help='compile V8 with minimal optimizations and with runtime checks')
+
 # Create compile_commands.json in out/Debug and out/Release.
 parser.add_option('-C',
     action='store_true',
@@ -1138,7 +1144,7 @@ def configure_library(lib, output):
 def configure_v8(o):
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
-  o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
+  o['variables']['v8_optimized_debug'] = 0 if options.v8_non_optimized_debug else 1
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'

--- a/deps/v8/gypfiles/toolchain.gypi
+++ b/deps/v8/gypfiles/toolchain.gypi
@@ -1134,121 +1134,7 @@
       }],
     ],  # conditions
     'configurations': {
-      # Abstract configuration for v8_optimized_debug == 0.
-      'DebugBase0': {
-        'abstract': 1,
-        'msvs_settings': {
-          'VCCLCompilerTool': {
-            'Optimization': '0',
-            'conditions': [
-              ['component=="shared_library" or force_dynamic_crt==1', {
-                'RuntimeLibrary': '3',  # /MDd
-              }, {
-                'RuntimeLibrary': '1',  # /MTd
-              }],
-            ],
-          },
-          'VCLinkerTool': {
-            'LinkIncremental': '2',
-          },
-        },
-        'variables': {
-          'v8_enable_slow_dchecks%': 1,
-        },
-        'conditions': [
-          ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix"', {
-            'cflags!': [
-              '-O3',
-              '-O2',
-              '-O1',
-              '-Os',
-            ],
-            'cflags': [
-              '-fdata-sections',
-              '-ffunction-sections',
-            ],
-          }],
-          ['OS=="mac"', {
-            'xcode_settings': {
-               'GCC_OPTIMIZATION_LEVEL': '0',  # -O0
-            },
-          }],
-          ['v8_enable_slow_dchecks==1', {
-            'defines': [
-              'ENABLE_SLOW_DCHECKS',
-            ],
-          }],
-        ],
-      },  # DebugBase0
-      # Abstract configuration for v8_optimized_debug == 1.
-      'DebugBase1': {
-        'abstract': 1,
-        'msvs_settings': {
-          'VCCLCompilerTool': {
-            'Optimization': '2',
-            'InlineFunctionExpansion': '2',
-            'EnableIntrinsicFunctions': 'true',
-            'FavorSizeOrSpeed': '0',
-            'StringPooling': 'true',
-            'BasicRuntimeChecks': '0',
-            'conditions': [
-              ['component=="shared_library" or force_dynamic_crt==1', {
-                'RuntimeLibrary': '3',  #/MDd
-              }, {
-                'RuntimeLibrary': '1',  #/MTd
-              }],
-            ],
-          },
-          'VCLinkerTool': {
-            'LinkIncremental': '1',
-            'OptimizeReferences': '2',
-            'EnableCOMDATFolding': '2',
-          },
-        },
-        'variables': {
-          'v8_enable_slow_dchecks%': 0,
-        },
-        'conditions': [
-          ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix"', {
-            'cflags!': [
-              '-O0',
-              '-O1',
-              '-Os',
-            ],
-            'cflags': [
-              '-fdata-sections',
-              '-ffunction-sections',
-            ],
-            'conditions': [
-              # Don't use -O3 with sanitizers.
-              ['asan==0 and msan==0 and lsan==0 \
-                and tsan==0 and ubsan==0 and ubsan_vptr==0', {
-                'cflags': ['-O3'],
-                'cflags!': ['-O2'],
-                }, {
-                'cflags': ['-O2'],
-                'cflags!': ['-O3'],
-              }],
-            ],
-          }],
-          ['OS=="mac"', {
-            'xcode_settings': {
-              'GCC_OPTIMIZATION_LEVEL': '3',  # -O3
-              'GCC_STRICT_ALIASING': 'YES',
-            },
-          }],
-          ['v8_enable_slow_dchecks==1', {
-            'defines': [
-              'ENABLE_SLOW_DCHECKS',
-            ],
-          }],
-        ],
-      },  # DebugBase1
-      # Common settings for the Debug configuration.
-      'DebugBaseCommon': {
-        'abstract': 1,
+      'Debug': {
         'defines': [
           'ENABLE_DISASSEMBLER',
           'V8_ENABLE_CHECKS',
@@ -1311,27 +1197,126 @@
               }],
             ],
           }],
-        ],
-      },  # DebugBaseCommon
-      'Debug': {
-        'inherit_from': ['DebugBaseCommon'],
-        'conditions': [
           ['v8_optimized_debug==0', {
-            'inherit_from': ['DebugBase0'],
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'Optimization': '0',
+                'conditions': [
+                  ['component=="shared_library" or force_dynamic_crt==1', {
+                    'RuntimeLibrary': '3',  # /MDd
+                  }, {
+                     'RuntimeLibrary': '1',  # /MTd
+                   }],
+                ],
+              },
+              'VCLinkerTool': {
+                'LinkIncremental': '2',
+              },
+            },
+            'variables': {
+              'v8_enable_slow_dchecks%': 1,
+            },
+            'conditions': [
+              ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
+            OS=="qnx" or OS=="aix"', {
+                'cflags!': [
+                  '-O3',
+                  '-O2',
+                  '-O1',
+                  '-Os',
+                ],
+                'cflags': [
+                  '-fdata-sections',
+                  '-ffunction-sections',
+                ],
+              }],
+              ['OS=="mac"', {
+                'xcode_settings': {
+                  'GCC_OPTIMIZATION_LEVEL': '0',  # -O0
+                },
+              }],
+              ['v8_enable_slow_dchecks==1', {
+                'defines': [
+                  'ENABLE_SLOW_DCHECKS',
+                ],
+              }],
+            ],
           }, {
-            'inherit_from': ['DebugBase1'],
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'Optimization': '2',
+                'InlineFunctionExpansion': '2',
+                'EnableIntrinsicFunctions': 'true',
+                'FavorSizeOrSpeed': '0',
+                'StringPooling': 'true',
+                'BasicRuntimeChecks': '0',
+                'conditions': [
+                  ['component=="shared_library" or force_dynamic_crt==1', {
+                    'RuntimeLibrary': '3',  #/MDd
+                  }, {
+                     'RuntimeLibrary': '1',  #/MTd
+                   }],
+                ],
+              },
+              'VCLinkerTool': {
+                'LinkIncremental': '1',
+                'OptimizeReferences': '2',
+                'EnableCOMDATFolding': '2',
+              },
+            },
+            'variables': {
+              'v8_enable_slow_dchecks%': 0,
+            },
+            'conditions': [
+              ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
+            OS=="qnx" or OS=="aix"', {
+                'cflags!': [
+                  '-O0',
+                  '-O1',
+                  '-Os',
+                ],
+                'cflags': [
+                  '-fdata-sections',
+                  '-ffunction-sections',
+                ],
+                'conditions': [
+                  # Don't use -O3 with sanitizers.
+                  ['asan==0 and msan==0 and lsan==0 \
+                and tsan==0 and ubsan==0 and ubsan_vptr==0', {
+                    'cflags': ['-O3'],
+                    'cflags!': ['-O2'],
+                  }, {
+                     'cflags': ['-O2'],
+                     'cflags!': ['-O3'],
+                   }],
+                ],
+              }],
+              ['OS=="mac"', {
+                'xcode_settings': {
+                  'GCC_OPTIMIZATION_LEVEL': '3',  # -O3
+                  'GCC_STRICT_ALIASING': 'YES',
+                },
+              }],
+              ['v8_enable_slow_dchecks==1', {
+                'defines': [
+                  'ENABLE_SLOW_DCHECKS',
+                ],
+              }],
+            ],
           }],
           # Temporary refs: https://github.com/nodejs/node/pull/23801
           ['v8_enable_handle_zapping==1', {
             'defines': ['ENABLE_HANDLE_ZAPPING',],
           }],
         ],
-      },  # Debug
-      'ReleaseBase': {
-        'abstract': 1,
+
+      },  # DebugBaseCommon
+      'Release': {
         'variables': {
           'v8_enable_slow_dchecks%': 0,
         },
+         # Temporary refs: https://github.com/nodejs/node/pull/23801
+        'defines!': ['ENABLE_HANDLE_ZAPPING',],
         'conditions': [
           ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" \
             or OS=="aix"', {
@@ -1407,29 +1392,6 @@
           }],
         ],  # conditions
       },  # Release
-      'Release': {
-        'inherit_from': ['ReleaseBase'],
-        # Temporary refs: https://github.com/nodejs/node/pull/23801
-        'defines!': ['ENABLE_HANDLE_ZAPPING',],
-      },  # Debug
-      'conditions': [
-        [ 'OS=="win"', {
-          # TODO(bradnelson): add a gyp mechanism to make this more graceful.
-          'Debug_x64': {
-            'inherit_from': ['DebugBaseCommon'],
-            'conditions': [
-              ['v8_optimized_debug==0', {
-                'inherit_from': ['DebugBase0'],
-              }, {
-                'inherit_from': ['DebugBase1'],
-              }],
-            ],
-          },
-          'Release_x64': {
-            'inherit_from': ['ReleaseBase'],
-          },
-        }],
-      ],
     },  # configurations
     'msvs_disabled_warnings': [
       4245,  # Conversion with signed/unsigned mismatch.

--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -2539,23 +2539,10 @@
         '_HAS_EXCEPTIONS=0',
         'BUILDING_V8_SHARED=1',
       ],
-      # This is defined trough `configurations` for GYP+ninja compatibility
-      'configurations': {
-        'Debug': {
-          'msvs_settings': {
-            'VCCLCompilerTool': {
-              'RuntimeTypeInfo': 'true',
-              'ExceptionHandling': 1,
-            },
-          }
-        },
-        'Release': {
-          'msvs_settings': {
-            'VCCLCompilerTool': {
-              'RuntimeTypeInfo': 'true',
-              'ExceptionHandling': 1,
-            },
-          }
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'RuntimeTypeInfo': 'true',
+          'ExceptionHandling': 1,
         },
       },
       'sources': [


### PR DESCRIPTION
This cuts down the debug CI run from ~1:20h to 50m

Second commit is a bugfix in the V8 gypfiles. Since `common.gypi` already defines `target_defaults`, the previous setup in `gypfiles/toolchain.gypi` (with setting inheritance) simply didn't work. A partial comparison of the results of the two state of this flag are available at https://www.diffchecker.com/Q340bUuJ

Under the assumption that debugging is more often focused on node core source.
This setting still compiles V8 with partial optimizations and with debug symbols, so it is still very much debuggable, but it is much faster.
Override is configurable by `./configure --v8-non-optimized-debug`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
