### PR TITLE
http2: add Http2Stream.bufferSize

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1012,6 +1012,15 @@ added: v8.4.0
 Set to `true` if the `Http2Stream` instance was aborted abnormally. When set,
 the `'aborted'` event will have been emitted.
 
+### http2stream.bufferSize
+<!-- YAML
+added: REPLACEME
+-->
+* {number}
+
+This property shows the number of characters currently buffered to be written.
+See [`net.Socket.bufferSize`][] for details.
+
 #### http2stream.close(code[, callback])
 <!-- YAML
 added: v8.4.0
@@ -3418,6 +3427,7 @@ following additional properties:
 [`net.Socket.prototype.ref()`]: net.html#net_socket_ref
 [`net.Socket.prototype.unref()`]: net.html#net_socket_unref
 [`net.connect()`]: net.html#net_net_connect
+[`net.Socket.bufferSize`]: net.html#net_socket_buffersize
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`response.end()`]: #http2_response_end_data_encoding_callback
 [`response.setHeader()`]: #http2_response_setheader_name_value

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1012,7 +1012,7 @@ added: v8.4.0
 Set to `true` if the `Http2Stream` instance was aborted abnormally. When set,
 the `'aborted'` event will have been emitted.
 
-### http2stream.bufferSize
+#### http2stream.bufferSize
 <!-- YAML
 added: REPLACEME
 -->
@@ -3424,10 +3424,10 @@ following additional properties:
 [`http2stream.pushStream()`]: #http2_http2stream_pushstream_headers_options_callback
 [`net.Server.close()`]: net.html#net_server_close_callback
 [`net.Socket`]: net.html#net_class_net_socket
+[`net.Socket.bufferSize`]: net.html#net_socket_buffersize
 [`net.Socket.prototype.ref()`]: net.html#net_socket_ref
 [`net.Socket.prototype.unref()`]: net.html#net_socket_unref
 [`net.connect()`]: net.html#net_net_connect
-[`net.Socket.bufferSize`]: net.html#net_socket_buffersize
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`response.end()`]: #http2_response_end_data_encoding_callback
 [`response.setHeader()`]: #http2_response_setheader_name_value

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1685,6 +1685,12 @@ class Http2Stream extends Duplex {
     return `Http2Stream ${util.format(obj)}`;
   }
 
+  get bufferSize() {
+    // `bufferSize` properties of `net.Socket` are `undefined` when
+    // their `_handle` are falsy. Here we avoid the behavior.
+    return this[kState].writeQueueSize + this.writableLength;
+  }
+
   get endAfterHeaders() {
     return this[kState].endAfterHeaders;
   }

--- a/test/parallel/test-http2-buffersize.js
+++ b/test/parallel/test-http2-buffersize.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { mustCall, hasCrypto, skip } = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
+const assert = require('assert');
+const { createServer, connect } = require('http2');
+const Countdown = require('../common/countdown');
+
+// This test ensures that `bufferSize` of Http2Session and Http2Stream work
+// as expected.
+{
+  const SOCKETS = 2;
+  const TIMES = 10;
+  const BUFFER_SIZE = 30;
+  const server = createServer();
+
+  // Other `bufferSize` tests for net module and tls module
+  // don't assert `bufferSize` of server-side sockets.
+  server.on('stream', mustCall((stream) => {
+    stream.on('data', mustCall());
+    stream.on('end', mustCall());
+  }, SOCKETS));
+
+  server.listen(0, mustCall(() => {
+    const authority = `http://localhost:${server.address().port}`;
+    const client = connect(authority);
+    const countdown = new Countdown(SOCKETS, () => {
+      client.close();
+      server.close();
+    });
+
+    client.once('connect', mustCall());
+
+    for (let j = 0; j < SOCKETS; j += 1) {
+      const stream = client.request({ ':method': 'POST' });
+      stream.on('data', () => {});
+      stream.on('close', mustCall(() => {
+        countdown.dec();
+      }));
+
+      for (let i = 0; i < TIMES; i += 1) {
+        stream.write(Buffer.allocUnsafe(BUFFER_SIZE), mustCall());
+        const expectedSocketBufferSize = BUFFER_SIZE * (i + 1);
+        assert.strictEqual(stream.bufferSize, expectedSocketBufferSize);
+      }
+      stream.end();
+      stream.close();
+    }
+  }));
+}

--- a/test/parallel/test-tls-streamwrap-buffersize.js
+++ b/test/parallel/test-tls-streamwrap-buffersize.js
@@ -1,0 +1,72 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const makeDuplexPair = require('../common/duplexpair');
+const tls = require('tls');
+const net = require('net');
+
+// This test ensures that `bufferSize` also works for those tlsSockets
+// created from `socket` of `Duplex`, with which, TLSSocket will wrap
+// sockets in `StreamWrap`.
+{
+  const iter = 10;
+
+  function createDuplex(port) {
+    const { clientSide, serverSide } = makeDuplexPair();
+
+    return new Promise((resolve, reject) => {
+      const socket = net.connect({
+        port,
+      }, common.mustCall(() => {
+        clientSide.pipe(socket);
+        socket.pipe(clientSide);
+        clientSide.on('close', common.mustCall(() => socket.destroy()));
+        socket.on('close', common.mustCall(() => clientSide.destroy()));
+
+        resolve(serverSide);
+      }));
+    });
+  }
+
+  const server = tls.createServer({
+    key: fixtures.readKey('agent2-key.pem'),
+    cert: fixtures.readKey('agent2-cert.pem')
+  }, common.mustCall((socket) => {
+    let str = '';
+    socket.setEncoding('utf-8');
+    socket.on('data', (chunk) => { str += chunk; });
+
+    socket.on('end', common.mustCall(() => {
+      assert.strictEqual(str, 'a'.repeat(iter - 1));
+      server.close();
+    }));
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const { port } = server.address();
+    createDuplex(port).then((socket) => {
+      const client = tls.connect({
+        socket,
+        rejectUnauthorized: false,
+      }, common.mustCall(() => {
+        assert.strictEqual(client.bufferSize, 0);
+
+        for (let i = 1; i < iter; i++) {
+          client.write('a');
+          assert.strictEqual(client.bufferSize, i + 1);
+        }
+
+        // It seems that tlsSockets created from sockets of `Duplex` emit no
+        // "finish" events. We use "end" event instead.
+        client.on('end', common.mustCall(() => {
+          assert.strictEqual(client.bufferSize, undefined);
+        }));
+
+        client.end();
+      }));
+    });
+  }));
+}


### PR DESCRIPTION
This commit adds `bufferSize` for `Http2Stream`.

Refs: #21631

/cc @jasnell @addaleax @apapirovski 

From the code, I believe the `writeQueueSize` in http2 module could represent the `kLastWriteQueueSize` in net module:
https://github.com/nodejs/node/blob/deaddd212c499c7ff88d20034753b5f3f00d5153/lib/net.js#L518
and the tests following this PR seems okay. Can you help to confirm that?

BTW, we can add `Http2Session.bufferSize` basing on this which is what #21631 exactly requested.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
