### PR TITLE
Back-port v8 changes for ppc64, Aix platform (Node 8 backport)

### DIFF
--- a/deps/v8/gypfiles/standalone.gypi
+++ b/deps/v8/gypfiles/standalone.gypi
@@ -751,7 +751,10 @@
         'cflags': [
           '-Wall',
           '<(werror)',
+          '-Wno-nonnull-compare',
+          '-Wno-address',
           '-Wno-unused-parameter',
+          '-Wno-unused-function',
           '-pthread',
           '-pedantic',
           '-Wno-missing-field-initializers',

--- a/deps/v8/gypfiles/standalone.gypi
+++ b/deps/v8/gypfiles/standalone.gypi
@@ -751,10 +751,7 @@
         'cflags': [
           '-Wall',
           '<(werror)',
-          '-Wno-nonnull-compare',
-          '-Wno-address',
           '-Wno-unused-parameter',
-          '-Wno-unused-function',
           '-pthread',
           '-pedantic',
           '-Wno-missing-field-initializers',

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 67
+#define V8_PATCH_LEVEL 68
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/base/debug/stack_trace_posix.cc
+++ b/deps/v8/src/base/debug/stack_trace_posix.cc
@@ -72,6 +72,7 @@ const char kMangledSymbolPrefix[] = "_Z";
 const char kSymbolCharacters[] =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
 
+#if HAVE_EXECINFO_H
 // Demangles C++ symbols in the given text. Example:
 //
 // "out/Debug/base_unittests(_ZN10StackTraceC1Ev+0x20) [0x817778c]"
@@ -81,7 +82,6 @@ void DemangleSymbols(std::string* text) {
   // Note: code in this function is NOT async-signal safe (std::string uses
   // malloc internally).
 
-#if HAVE_EXECINFO_H
 
   std::string::size_type search_from = 0;
   while (search_from < text->size()) {
@@ -117,9 +117,8 @@ void DemangleSymbols(std::string* text) {
       search_from = mangled_start + 2;
     }
   }
-
-#endif  // HAVE_EXECINFO_H
 }
+#endif  // HAVE_EXECINFO_H
 
 class BacktraceOutputHandler {
  public:
@@ -129,6 +128,7 @@ class BacktraceOutputHandler {
   virtual ~BacktraceOutputHandler() {}
 };
 
+#if HAVE_EXECINFO_H
 void OutputPointer(void* pointer, BacktraceOutputHandler* handler) {
   // This should be more than enough to store a 64-bit number in hex:
   // 16 hex digits + 1 for null-terminator.
@@ -139,7 +139,6 @@ void OutputPointer(void* pointer, BacktraceOutputHandler* handler) {
   handler->HandleOutput(buf);
 }
 
-#if HAVE_EXECINFO_H
 void ProcessBacktrace(void* const* trace, size_t size,
                       BacktraceOutputHandler* handler) {
   // NOTE: This code MUST be async-signal safe (it's used by in-process

--- a/deps/v8/src/compiler/bytecode-graph-builder.cc
+++ b/deps/v8/src/compiler/bytecode-graph-builder.cc
@@ -475,7 +475,7 @@ Node* BytecodeGraphBuilder::Environment::Checkpoint(
 BytecodeGraphBuilder::BytecodeGraphBuilder(
     Zone* local_zone, Handle<SharedFunctionInfo> shared_info,
     Handle<FeedbackVector> feedback_vector, BailoutId osr_offset,
-    JSGraph* jsgraph, CallFrequency invocation_frequency,
+    JSGraph* jsgraph, CallFrequency& invocation_frequency,
     SourcePositionTable* source_positions, int inlining_id,
     JSTypeHintLowering::Flags flags, bool stack_check)
     : local_zone_(local_zone),

--- a/deps/v8/src/compiler/bytecode-graph-builder.h
+++ b/deps/v8/src/compiler/bytecode-graph-builder.h
@@ -28,7 +28,7 @@ class BytecodeGraphBuilder {
   BytecodeGraphBuilder(
       Zone* local_zone, Handle<SharedFunctionInfo> shared,
       Handle<FeedbackVector> feedback_vector, BailoutId osr_offset,
-      JSGraph* jsgraph, CallFrequency invocation_frequency,
+      JSGraph* jsgraph, CallFrequency& invocation_frequency,
       SourcePositionTable* source_positions,
       int inlining_id = SourcePosition::kNotInlined,
       JSTypeHintLowering::Flags flags = JSTypeHintLowering::kNoFlags,

--- a/deps/v8/src/compiler/js-inlining.cc
+++ b/deps/v8/src/compiler/js-inlining.cc
@@ -539,9 +539,10 @@ Reduction JSInliner::ReduceJSCall(Node* node) {
     if (info_->is_bailout_on_uninitialized()) {
       flags |= JSTypeHintLowering::kBailoutOnUninitialized;
     }
+    CallFrequency frequency = call.frequency();
     BytecodeGraphBuilder graph_builder(
         zone(), shared_info, feedback_vector, BailoutId::None(), jsgraph(),
-        call.frequency(), source_positions_, inlining_id, flags, false);
+        frequency, source_positions_, inlining_id, flags, false);
     graph_builder.CreateGraph();
 
     // Extract the inlinee start/end nodes.

--- a/deps/v8/src/compiler/js-operator.cc
+++ b/deps/v8/src/compiler/js-operator.cc
@@ -731,7 +731,8 @@ const Operator* JSOperatorBuilder::CallForwardVarargs(size_t arity,
       parameters);                                               // parameter
 }
 
-const Operator* JSOperatorBuilder::Call(size_t arity, CallFrequency frequency,
+const Operator* JSOperatorBuilder::Call(size_t arity,
+                                        CallFrequency const& frequency,
                                         VectorSlotPair const& feedback,
                                         ConvertReceiverMode convert_mode) {
   CallParameters parameters(arity, frequency, feedback, convert_mode);
@@ -751,7 +752,8 @@ const Operator* JSOperatorBuilder::CallWithArrayLike(CallFrequency frequency) {
 }
 
 const Operator* JSOperatorBuilder::CallWithSpread(
-    uint32_t arity, CallFrequency frequency, VectorSlotPair const& feedback) {
+    uint32_t arity, CallFrequency const& frequency,
+    VectorSlotPair const& feedback) {
   CallParameters parameters(arity, frequency, feedback,
                             ConvertReceiverMode::kAny);
   return new (zone()) Operator1<CallParameters>(             // --

--- a/deps/v8/src/compiler/js-operator.h
+++ b/deps/v8/src/compiler/js-operator.h
@@ -192,7 +192,7 @@ CallForwardVarargsParameters const& CallForwardVarargsParametersOf(
 // used as a parameter by JSCall and JSCallWithSpread operators.
 class CallParameters final {
  public:
-  CallParameters(size_t arity, CallFrequency frequency,
+  CallParameters(size_t arity, CallFrequency const& frequency,
                  VectorSlotPair const& feedback,
                  ConvertReceiverMode convert_mode)
       : bit_field_(ArityField::encode(arity) |
@@ -201,7 +201,7 @@ class CallParameters final {
         feedback_(feedback) {}
 
   size_t arity() const { return ArityField::decode(bit_field_); }
-  CallFrequency frequency() const { return frequency_; }
+  CallFrequency const& frequency() const { return frequency_; }
   ConvertReceiverMode convert_mode() const {
     return ConvertReceiverModeField::decode(bit_field_);
   }
@@ -647,12 +647,12 @@ class V8_EXPORT_PRIVATE JSOperatorBuilder final
 
   const Operator* CallForwardVarargs(size_t arity, uint32_t start_index);
   const Operator* Call(
-      size_t arity, CallFrequency frequency = CallFrequency(),
+      size_t arity, CallFrequency const& frequency = CallFrequency(),
       VectorSlotPair const& feedback = VectorSlotPair(),
       ConvertReceiverMode convert_mode = ConvertReceiverMode::kAny);
   const Operator* CallWithArrayLike(CallFrequency frequency);
   const Operator* CallWithSpread(
-      uint32_t arity, CallFrequency frequency = CallFrequency(),
+      uint32_t arity, CallFrequency const& frequency = CallFrequency(),
       VectorSlotPair const& feedback = VectorSlotPair());
   const Operator* CallRuntime(Runtime::FunctionId id);
   const Operator* CallRuntime(Runtime::FunctionId id, size_t arity);

--- a/deps/v8/src/compiler/pipeline.cc
+++ b/deps/v8/src/compiler/pipeline.cc
@@ -890,10 +890,11 @@ struct GraphBuilderPhase {
     if (data->info()->is_bailout_on_uninitialized()) {
       flags |= JSTypeHintLowering::kBailoutOnUninitialized;
     }
+    CallFrequency frequency = CallFrequency(1.0f);
     BytecodeGraphBuilder graph_builder(
         temp_zone, data->info()->shared_info(),
         handle(data->info()->closure()->feedback_vector()),
-        data->info()->osr_offset(), data->jsgraph(), CallFrequency(1.0f),
+        data->info()->osr_offset(), data->jsgraph(), frequency,
         data->source_positions(), SourcePosition::kNotInlined, flags);
     graph_builder.CreateGraph();
   }

--- a/deps/v8/src/compiler/store-store-elimination.cc
+++ b/deps/v8/src/compiler/store-store-elimination.cc
@@ -251,6 +251,9 @@ void StoreStoreElimination::Run(JSGraph* js_graph, Zone* temp_zone) {
   }
 }
 
+#if V8_OS_AIX
+ALLOW_UNUSED_TYPE
+#endif
 bool RedundantStoreFinder::IsEffectful(Node* node) {
   return (node->op()->EffectInputCount() >= 1);
 }
@@ -552,6 +555,9 @@ bool UnobservableStore::operator==(const UnobservableStore other) const {
   return (id_ == other.id_) && (offset_ == other.offset_);
 }
 
+#if V8_OS_AIX
+ALLOW_UNUSED_TYPE
+#endif
 bool UnobservableStore::operator!=(const UnobservableStore other) const {
   return !(*this == other);
 }

--- a/deps/v8/src/conversions.cc
+++ b/deps/v8/src/conversions.cc
@@ -53,11 +53,17 @@ class StringCharacterStreamIterator {
 };
 
 
+#if V8_OS_AIX
+ALLOW_UNUSED_TYPE
+#endif
 StringCharacterStreamIterator::StringCharacterStreamIterator(
     StringCharacterStream* stream) : stream_(stream) {
   ++(*this);
 }
 
+#if V8_OS_AIX
+ALLOW_UNUSED_TYPE
+#endif
 uint16_t StringCharacterStreamIterator::operator*() const {
   return current_;
 }

--- a/deps/v8/testing/gtest.gyp
+++ b/deps/v8/testing/gtest.gyp
@@ -94,6 +94,10 @@
                   'action????': ['$(TargetPath)', '--gtest_print_time'],
                 },
               }],
+              ['OS=="aix"', {
+               'cflags': [ '-Wno-nonnull-compare',
+                           '-Wno-address' ],
+              }],
             ],
           }],
         ],


### PR DESCRIPTION
Back-port v8 changes for ppc64, Aix platform
Changes included:

ppc64, aix: Pass CallFrequency object by const reference to avoid value copy error.
Bug: v8:8193
GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61976
V8 Revision: d2e0166ded485df126c765b9196f7edd1ce50f82
Link: https://chromium-review.googlesource.com/c/v8/v8/+/1228633

ppc64, aix: Fixes to V8 GN build process on aix platform
(Only changes to src/base/debug/stack_trace_posix.cc included)
V8 Revision: 6bc4bfea655723b6e71280e71a3dae07c37d7b44
Link: https://chromium-review.googlesource.com/c/v8/v8/+/927484