### PR TITLE
benchmark: coerce PORT to number

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -8,7 +8,7 @@ const requirementsURL =
   'https://github.com/nodejs/node/blob/master/doc/guides/writing-and-running-benchmarks.md#http-benchmark-requirements';
 
 // The port used by servers and wrk
-exports.PORT = process.env.PORT || 12346;
+exports.PORT = Number(process.env.PORT) || 12346;
 
 class AutocannonBenchmarker {
   constructor() {


### PR DESCRIPTION
Without this fix net/tcp-raw-c2s.js aborts in environments where PORT
is defined. TCPWrap::Connect expects the third arg to be a UInt32.

```sh
marceline :: ~/src/node ‹v10.x› » PORT=8080 node test/sequential/test-benchmark-net.js
/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node[152660]: ../src/tcp_wrap.cc:288:static void node::TCPWrap::Connect(const v8::FunctionCallbackInfo<v8::Value>&): Assertion `args[2]->IsUint32()' failed.
 1: 0x8daaa0 node::Abort() [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 2: 0x8dab75  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 3: 0x9af98a node::TCPWrap::Connect(v8::FunctionCallbackInfo<v8::Value> const&) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 4: 0xb6114f  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 5: 0xb61ca5 v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 6: 0x2ff8d73dbe1d
/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node[152680]: ../src/tcp_wrap.cc:288:static void node::TCPWrap::Connect(const v8::FunctionCallbackInfo<v8::Value>&): Assertion `args[2]->IsUint32()' failed.
 1: 0x8daaa0 node::Abort() [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 2: 0x8dab75  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 3: 0x9af98a node::TCPWrap::Connect(v8::FunctionCallbackInfo<v8::Value> const&) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 4: 0xb6114f  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 5: 0xb61ca5 v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 6: 0x244d20dbe1d
/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node[152700]: ../src/tcp_wrap.cc:288:static void node::TCPWrap::Connect(const v8::FunctionCallbackInfo<v8::Value>&): Assertion `args[2]->IsUint32()' failed.
 1: 0x8daaa0 node::Abort() [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 2: 0x8dab75  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 3: 0x9af98a node::TCPWrap::Connect(v8::FunctionCallbackInfo<v8::Value> const&) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 4: 0xb6114f  [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 5: 0xb61ca5 v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*) [/usr/local/google/home/ofrobots/.nvm/versions/node/v10.12.0/bin/node]
 6: 0x280a178dbe1d
assert.js:350
    throw err;
```

CI: https://ci.nodejs.org/job/node-test-pull-request/17981/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
