### PR TITLE
test: fix invalid modulesLength during DSA keygen

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -182,7 +182,7 @@ function convertDERToPEM(label, der) {
 {
   // Test async DSA key generation.
   generateKeyPair('dsa', {
-    modulusLength: 256,
+    modulusLength: 512,
     divisorLength: 256,
     publicKeyEncoding: {
       type: 'spki',


### PR DESCRIPTION
In https://github.com/nodejs/node/pull/23430, key sizes were reduced to speed up the test. Unfortunately this resulted in invalid DSA key generation parameters.

In standard build of OpenSSL, key generation uses dsa_builtin_paramgen and that will reset modulusLength to 512. But in dsa_builtin_paramgen2, used in FIPS, this does not happen, leading to an infinite loop and test failure.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
