### PR TITLE
build: spawn `make test-ci` with `-j1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,8 +480,11 @@ build-ci:
 #   of tests. See `test-ci-native` and `test-ci-js`.
 # - node-test-commit-linux-coverage: where the build and the tests need
 #   to be instrumented, see `coverage`.
+#
+# Using -j1 as the sub target in `test-ci` already have internal parallelism.
+# Refs: https://github.com/nodejs/node/pull/23733
 run-ci: build-ci
-	$(MAKE) test-ci
+	$(MAKE) test-ci -j1
 
 test-release: test-build
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER)


### PR DESCRIPTION
All the subtasks have internal parallelism, so there is minimal loss.
Also `make` doesn't do a good enough job of combining the output
streams, or eliminate races.

Fixes: https://github.com/nodejs/node/issues/22006
Ref: https://github.com/nodejs/node/pull/23423#issuecomment-430601541
Ref: https://github.com/nodejs/node/pull/23286#discussion_r223160825

/CC @nodejs/build @nodejs/build-files 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
