### PR TITLE
zlib: do not leak on destroy

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -430,6 +430,11 @@ Zlib.prototype.close = function close(callback) {
   this.destroy();
 };
 
+Zlib.prototype._destroy = function _destroy(err, callback) {
+  _close(this);
+  callback(err);
+};
+
 Zlib.prototype._transform = function _transform(chunk, encoding, cb) {
   var flushFlag = this._defaultFlushFlag;
   // We use a 'fake' zero-length chunk to carry information about flushes from
@@ -590,6 +595,10 @@ function processCallback() {
     self.push(out);
   } else if (have < 0) {
     assert(false, 'have should not go down');
+  }
+
+  if (self.destroyed) {
+    return;
   }
 
   // exhausted the output buffer, or used all the input create a new one.

--- a/test/parallel/test-zlib-close-in-ondata.js
+++ b/test/parallel/test-zlib-close-in-ondata.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const zlib = require('zlib');
 
 const ts = zlib.createGzip();
-const buf = Buffer.allocUnsafe(1024 * 1024 * 20);
+const buf = Buffer.alloc(1024 * 1024 * 20);
 
 ts.on('data', common.mustCall(() => ts.close()));
 ts.end(buf);

--- a/test/parallel/test-zlib-close-in-ondata.js
+++ b/test/parallel/test-zlib-close-in-ondata.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const common = require('../common');
+const zlib = require('zlib');
+
+const ts = zlib.createGzip();
+const buf = Buffer.allocUnsafe(1024 * 1024 * 20);
+
+ts.on('data', common.mustCall(() => ts.close()));
+ts.end(buf);

--- a/test/parallel/test-zlib-destroy.js
+++ b/test/parallel/test-zlib-destroy.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const zlib = require('zlib');
+
+// verify that the zlib transform does clean up
+// the handle when calling destroy.
+
+const ts = zlib.createGzip();
+ts.destroy();
+assert.strictEqual(ts._handle, null);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Currently zlib streams will leak their handles if the streams are destroyed using `.destroy()`, which means they'll leak when used with `stream.pipeline` or `pump` and an error happens.

This PR fixes that by implementing `_destroy` and call `_close` on the handle always.