### PR TITLE
build,meta: don't try to lint commit message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         - make lint
         # Lint the first commit in the PR.
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-            bash tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
+            bash tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST} || true;
           fi
     - name: "Test Suite"
       addons:


### PR DESCRIPTION
/CC @Trott 

I think <ins>in its current form</ins> the false negatives have outweighed the true negatives. All in all I don't think commit message formatting has been a limiting factor for landing velocity.

Fixes: https://github.com/nodejs/node/issues/23737
Refs: https://github.com/nodejs/node/pull/22452

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
