### PR TITLE
doc: remove reference to sslv3 in tls.md

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -677,7 +677,6 @@ be returned for server sockets or disconnected client sockets.
 
 Example responses include:
 
-* `SSLv3`
 * `TLSv1`
 * `TLSv1.1`
 * `TLSv1.2`


### PR DESCRIPTION
Issue https://github.com/nodejs/node/issues/9822 mentioned some no longer supported SSLv3 references in the tls.md docs. The references were removed since but there's one that still lingered.

Fixes: https://github.com/nodejs/node/issues/9822

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
