### PR TITLE
doc: remove security reporting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,45 +166,7 @@ team has addressed the vulnerability.
 The security team will acknowledge your email within 24 hours. You will receive
 a more detailed response within 48 hours.
 
-There are no hard and fast rules to determine if a bug is worth reporting as a
-security issue. Here are some examples of past issues and what the Security
-Response Team thinks of them. When in doubt, please do send us a report
-nonetheless.
-
-
-### Public disclosure preferred
-
-- [#14519](https://github.com/nodejs/node/issues/14519): _Internal domain
-  function can be used to cause segfaults_. Causing program termination using
-  either the public JavaScript APIs or the private bindings layer APIs requires
-  the ability to execute arbitrary JavaScript code, which is already the highest
-  level of privilege possible.
-
-- [#12141](https://github.com/nodejs/node/pull/12141): _buffer: zero fill
-  Buffer(num) by default_. The buffer constructor behavior was documented,
-  but found to be prone to [mis-use](https://snyk.io/blog/exploiting-buffer/).
-  It has since been changed, but despite much debate, was not considered misuse
-  prone enough to justify fixing in older release lines and breaking our
-  API stability contract.
-
-### Private disclosure preferred
-
-- [CVE-2016-7099](https://nodejs.org/en/blog/vulnerability/september-2016-security-releases/):
-  _Fix invalid wildcard certificate validation check_. This is a high severity
-  defect that would allow a malicious TLS server to serve an invalid wildcard
-  certificate for its hostname and be improperly validated by a Node.js client.
-
-- [#5507](https://github.com/nodejs/node/pull/5507): _Fix a defect that makes
-  the CacheBleed Attack possible_. Many, though not all, OpenSSL vulnerabilities
-  in the TLS/SSL protocols also affect Node.js.
-
-- [CVE-2016-2216](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/):
-  _Fix defects in HTTP header parsing for requests and responses that can allow
-  response splitting_. While the impact of this vulnerability is application and
-  network dependent, it is remotely exploitable in the HTTP protocol.
-
-When in doubt, please do send us a report.
-
+There are no hard and fast rules to determine if a bug is worth reporting as a security issue. If in doubt, please report the bug to security@nodejs.org.
 
 ## Current Project Team Members
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ team has addressed the vulnerability.
 The security team will acknowledge your email within 24 hours. You will receive
 a more detailed response within 48 hours.
 
-There are no hard and fast rules to determine if a bug is worth reporting as a security issue. If in doubt, please report the bug to security@nodejs.org.
+There are no hard and fast rules to determine if a bug is worth reporting as a
+security issue. If in doubt, please report the bug to security@nodejs.org.
 
 ## Current Project Team Members
 


### PR DESCRIPTION
Keep things concise and tell people to report stuff if in doubt.

This may be controversial (although I hope not). In my opinion, the level of detail provided seems  to be geared towards discouraging reports by making things seem unnecessarily complicated or nuanced.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
