### PR TITLE
test: increase coverage of internal/stream/end-of-stream

### DIFF
--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -153,3 +153,25 @@ const { promisify } = require('util');
   rs.push(null);
   rs.resume();
 }
+
+// Test that calling returned function removes listeners
+{
+  const ws = new Writable({
+    write(data, env, cb) {
+      cb();
+    }
+  });
+  const removeListener = finished(ws, common.mustNotCall());
+  removeListener();
+  ws.end();
+}
+
+{
+  const rs = new Readable();
+  const removeListeners = finished(rs, common.mustNotCall());
+  removeListeners();
+
+  rs.emit('close');
+  rs.push(null);
+  rs.resume();
+}


### PR DESCRIPTION
The `Stream.finished` function returns a function that should detach all the listeners from the wrapped stream which isn't covered by existed test cases.

This change adds test cases to call the function returned by
`Stream.finished` and asserts that callbacks are not called when
the stream is ended, or prematurely closed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
