### PR TITLE
src: reduce duplication in tcp_wrap Connect

### DIFF
--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -75,6 +75,9 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void Listen(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Connect6(const v8::FunctionCallbackInfo<v8::Value>& args);
+  template <typename T>
+  static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args,
+      std::function<int(const char* ip_address, T* addr)> uv_ip_addr);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 #ifdef _WIN32


### PR DESCRIPTION
This commit extracts identical code from Connect and Connect6 into a
separate function to avoid some code duplication.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
