### PR TITLE
test: fix issue in the comment

### DIFF
--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -242,7 +242,7 @@ assert.strictEqual(
 }
 
 // Test that `message` is mutable and that changing it alters `toString()` but
-// not `console.log()` results, which is the behavior of `Error` objects in the
+// not `stack` property, which is the behavior of `Error` objects in the
 // browser. Note that `message` remains non-enumerable after being assigned.
 {
   let initialConsoleLog = '';


### PR DESCRIPTION
I came across this, when playing around with source code. The comment is wrong, it should have been `stack` property instead of `console.log`. Fixed it. 

I guess we need to remove the `browser` word as well, because that's how even Node Error works 🤔 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
