### PR TITLE
 tools: add script to lint commit messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       script:
         - make lint
         # Lint the first commit in the PR.
-        - \[ -z "$TRAVIS_COMMIT_RANGE" \] || (echo -e '\nLinting the commit message according to the guidelines at https://goo.gl/p2fr5Q\n' && git log $TRAVIS_COMMIT_RANGE --pretty=format:'%h' --no-merges | tail -1 | xargs npx -q core-validate-commit --no-validate-metadata)
+        - bash tools/lint-commit-message.sh
     - name: "Test Suite"
       install:
         - ./configure

--- a/tools/lint-commit-message.sh
+++ b/tools/lint-commit-message.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Shell script to lint commit messages
+#
+# Depends on git, node, npm and npx being in $PATH.
+#
+# This script must be be in the tools directory when it runs because it uses
+# $BASH_SOURCE[0] to determine directories to work in.
+#
+# This script attempts to guess the target upstream branch. To manually specify:
+# e.g. to target `canary-base`:
+# TARGET_BRANCH=canary-base bash lint-commit-message.sh
+
+ROOT_DIR="$( dirname "${BASH_SOURCE[0]}" )/.."
+
+# Work out what branch is being targetted
+MAJOR_VERSION=$( grep '#define NODE_MAJOR_VERSION [0-9][0-9]*' "${ROOT_DIR}/src/node_version.h" | awk '{print $(NF)}' )
+MINOR_VERSION=$( grep '#define NODE_MINOR_VERSION [0-9][0-9]*' "${ROOT_DIR}/src/node_version.h" | awk '{print $(NF)}' )
+PATCH_VERSION=$( grep '#define NODE_PATCH_VERSION [0-9][0-9]*' "${ROOT_DIR}/src/node_version.h" | awk '{print $(NF)}' )
+# If the version is not in the CHANGELOG assume the target branch is master
+if grep -q "${MAJOR_VERSION}\.${MINOR_VERSION}\.${PATCH_VERSION}" "${ROOT_DIR}/CHANGELOG.md"; then
+  TARGET_BRANCH=${TARGET_BRANCH:-"v${MAJOR_VERSION}.x-staging"}
+else
+  TARGET_BRANCH=${TARGET_BRANCH:-"master"}
+fi
+echo "Target branch is ${TARGET_BRANCH}"
+
+# Make sure we're up to date
+UPSTREAM=$( git remote -v | grep "github\.com.*nodejs/node.* (fetch)" | awk '{print $(1)}' )
+echo "Fetching upstream remote ${UPSTREAM}"
+git fetch "${UPSTREAM}" "${TARGET_BRANCH}":"${TARGET_BRANCH}"
+COMMON_ANCESTOR=$( git merge-base "${UPSTREAM}/$TARGET_BRANCH" HEAD )
+FIRST_COMMIT=$( git rev-list --no-merges ${COMMON_ANCESTOR}..HEAD | tail -1 )
+
+if [ -n "${FIRST_COMMIT}" ]; then
+  echo "Linting the first commit message according to the guidelines at https://goo.gl/p2fr5Q"
+  echo "$( git log -1 ${FIRST_COMMIT} )"
+  echo "${FIRST_COMMIT}" | xargs npx -q core-validate-commit --no-validate-metadata
+else
+  echo "No commits found to lint"
+fi


### PR DESCRIPTION
Currently the "first PR commit message" linting is only done on Travis. This PR attempts to
decouple the logic from Travis and capture the logic in a bash shell script so that it can be
run locally.

I haven't (yet) added the scripts to `Makefile` or `vcbuild.bat` as the script requires git, node, 
npm and npx being in $PATH. 

Refs: https://github.com/nodejs/node/pull/22452

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
