### PR TITLE
doc: add missing deprecation labels

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1295,6 +1295,8 @@ added: v0.9.3
 deprecated: v10.0.0
 -->
 
+> Stability: 0 - Deprecated
+
 The default encoding to use for functions that can take either strings
 or [buffers][`Buffer`]. The default value is `'buffer'`, which makes methods
 default to [`Buffer`][] objects.
@@ -1311,6 +1313,8 @@ This property is deprecated.
 added: v6.0.0
 deprecated: v10.0.0
 -->
+
+> Stability: 0 - Deprecated
 
 Property for checking and controlling whether a FIPS compliant crypto provider
 is currently in use. Setting to true requires a FIPS build of Node.js.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/20841

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
