### PR TITLE
build: allow for overwriting of use_openssl_def

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -221,9 +221,9 @@
       [ 'OS=="win" and '
         'node_use_openssl=="true" and '
         'node_shared_openssl=="false"', {
-        'use_openssl_def': 1,
+        'use_openssl_def%': 1,
       }, {
-        'use_openssl_def': 0,
+        'use_openssl_def%': 0,
       }],
     ],
   },


### PR DESCRIPTION
This PR allows for `use_openssl_def` to be overwritten. This would allow for embedders to selectively opt-out of using `openssl.def` should other aspects of their use of embedded Node preclude that.

/cc @addaleax

##### Checklist

- [x] `make -j4 test` passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
