### PR TITLE
test: fix strictEqual() argument order

### DIFF
--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -42,13 +42,13 @@ server.listen(0, common.mustCall(function() {
   http.get({ port: this.address().port }, common.mustCall(function(res) {
     let response = '';
 
-    assert.strictEqual(200, res.statusCode);
+    assert.strictEqual(res.statusCode, 200);
     res.setEncoding('ascii');
     res.on('data', function(chunk) {
       response += chunk;
     });
     res.on('end', common.mustCall(function() {
-      assert.strictEqual('1\n2\n3\n', response);
+      assert.strictEqual(response, '1\n2\n3\n');
     }));
   }));
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
