### PR TITLE
build: fix coverage generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ coverage: coverage-test ## Run the tests and generate a coverage report.
 coverage-build: all
 	mkdir -p node_modules
 	if [ ! -d node_modules/nyc ]; then \
-		$(NODE) ./deps/npm install nyc --no-save --no-package-lock; fi
+		$(NODE) ./deps/npm install nyc@13 --no-save --no-package-lock; fi
 	if [ ! -d gcovr ]; then git clone -b 3.4 --depth=1 \
 		--single-branch git://github.com/gcovr/gcovr.git; fi
 	if [ ! -d build ]; then git clone --depth=1 \
@@ -234,8 +234,9 @@ coverage-test: coverage-build
 	$(NODE) ./node_modules/.bin/nyc merge 'out/Release/.coverage' \
 		.cov_tmp/libcov.json
 	(cd lib && .$(NODE) ../node_modules/.bin/nyc report \
-		--temp-directory "$(CURDIR)/.cov_tmp" \
-		--report-dir "$(CURDIR)/coverage")
+		--temp-dir "$(CURDIR)/.cov_tmp" \
+		--report-dir "$(CURDIR)/coverage" \
+		--reporter html)
 	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \
 		--gcov-exclude='.*usr' -v -r Release/obj.target \
 		--html --html-detail -o ../coverage/cxxcoverage.html \


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

build: fix coverage generation

Changes in command line options for nyc resulted in the
coverage target no longer working.

Pin the major version of nyc and update the options to
get it working again.

Fixes: https://github.com/nodejs/node/issues/23690
