### PR TITLE
test: fix strictEqual() arguments order

### DIFF
--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -82,7 +82,7 @@ demoBug('POST /1/22 HTTP/1.1\r\n' +
         'pong');
 
 process.on('exit', function() {
-  assert.strictEqual(2, headersComplete);
-  assert.strictEqual(2, messagesComplete);
+  assert.strictEqual(headersComplete, 2);
+  assert.strictEqual(messagesComplete, 2);
   console.log('done!');
 });


### PR DESCRIPTION
Thanks to @targos for the opportunity to create this pull-request.

Note: core-validate-commit return K.O on PR-URL and must have one reviewer (I did not know how to solve these two).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
