### PR TITLE
[v8.x backport] http2: simplify timeout tracking

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1798,10 +1798,6 @@ inline Http2Stream* Http2Session::SubmitRequest(
   return stream;
 }
 
-inline void Http2Session::SetChunksSinceLastWrite(size_t n) {
-  chunks_sent_since_last_write_ = n;
-}
-
 // Allocates the data buffer used to pass outbound data to the i/o stream.
 WriteWrap* Http2Session::AllocateSend() {
   HandleScope scope(env()->isolate());
@@ -2257,7 +2253,6 @@ inline int Http2Stream::DoWrite(WriteWrap* req_wrap,
   CHECK(!this->IsDestroyed());
   CHECK_EQ(send_handle, nullptr);
   Http2Scope h2scope(this);
-  session_->SetChunksSinceLastWrite();
   req_wrap->Dispatched();
   if (!IsWritable()) {
     req_wrap->Done(UV_EOF);
@@ -2750,8 +2745,6 @@ void Http2Stream::RespondFD(const FunctionCallbackInfo<Value>& args) {
   int64_t offset = args[2]->IntegerValue(context).ToChecked();
   int64_t length = args[3]->IntegerValue(context).ToChecked();
   int options = args[4]->IntegerValue(context).ToChecked();
-
-  stream->session()->SetChunksSinceLastWrite();
 
   Headers list(isolate, context, headers);
   args.GetReturnValue().Set(stream->SubmitFile(fd, *list, list.length(),

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -815,8 +815,6 @@ class Http2Session : public AsyncWrap {
   // Write data to the session
   inline ssize_t Write(const uv_buf_t* bufs, size_t nbufs);
 
-  inline void SetChunksSinceLastWrite(size_t n = 0);
-
   size_t self_size() const override { return sizeof(*this); }
 
   char* stream_alloc() {


### PR DESCRIPTION
See #19206

cc/ @BethGriggs @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
