### PR TITLE
build,meta: bump gcc on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: cpp
-compiler:
-  - clang
 sudo: false
 cache: ccache
 os: linux
@@ -15,12 +13,15 @@ matrix:
         # Lint the first commit in the PR.
         - \[ -z "$TRAVIS_COMMIT_RANGE" \] || (echo -e '\nLinting the commit message according to the guidelines at https://goo.gl/p2fr5Q\n' && git log $TRAVIS_COMMIT_RANGE --pretty=format:'%h' --no-merges | tail -1 | xargs npx -q core-validate-commit --no-validate-metadata)
     - name: "Test Suite"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
       install:
+        - export CC='ccache gcc-4.9' CXX='ccache g++-4.9' JOBS=2
         - ./configure
         - make -j2 V=
       script:
-        - make -j2 test
-      before_install:
-        - export CXX="ccache clang++ -Qunused-arguments"
-        - export CC="ccache clang -Qunused-arguments -Wno-unknown-warning-option"
-        - export JOBS=2
+        - PARALLEL_ARGS='--flaky-tests=skip' make -j1 test


### PR DESCRIPTION
The version of `clang` provided in the Travis linux image uses
libstdc++4.8 whice is below our minimal supported version.

Switching to `make test -j1` is to avoid races during the test cycle
causes by the main target being "unstable", that is it always builds
some files, and relinks the binary, which is used by the test procedure.


<details>

```
../src/node_crypto.cc:3641:29: error: no matching function for call to 'get'
    return sign->CheckThrow(std::get<Error>(ret));
                            ^~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/utility:142:5: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Int'
    get(std::pair<_Tp1, _Tp2>& __in) noexcept
    ^
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/utility:147:5: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Int'
    get(std::pair<_Tp1, _Tp2>&& __in) noexcept
    ^
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/utility:152:5: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Int'
    get(const std::pair<_Tp1, _Tp2>& __in) noexcept
    ^
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/array:268:5: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Int'
    get(array<_Tp, _Nm>& __arr) noexcept
    ^
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/array:277:5: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Int'
```

</details>
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
