### PR TITLE
src: use more explicit return type in Sign::SignFinal()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3553,22 +3553,20 @@ static MallocedBuffer<unsigned char> Node_SignFinal(EVPMDPointer&& mdctx,
   return MallocedBuffer<unsigned char>();
 }
 
-std::pair<SignBase::Error, MallocedBuffer<unsigned char>> Sign::SignFinal(
+Sign::SignResult Sign::SignFinal(
     const char* key_pem,
     int key_pem_len,
     const char* passphrase,
     int padding,
     int salt_len) {
-  MallocedBuffer<unsigned char> buffer;
-
   if (!mdctx_)
-    return std::make_pair(kSignNotInitialised, std::move(buffer));
+    return SignResult(kSignNotInitialised);
 
   EVPMDPointer mdctx = std::move(mdctx_);
 
   BIOPointer bp(BIO_new_mem_buf(const_cast<char*>(key_pem), key_pem_len));
   if (!bp)
-    return std::make_pair(kSignPrivateKey, std::move(buffer));
+    return SignResult(kSignPrivateKey);
 
   EVPKeyPointer pkey(PEM_read_bio_PrivateKey(bp.get(),
                                              nullptr,
@@ -3579,7 +3577,7 @@ std::pair<SignBase::Error, MallocedBuffer<unsigned char>> Sign::SignFinal(
   // without `pkey` being set to nullptr;
   // cf. the test of `test_bad_rsa_privkey.pem` for an example.
   if (!pkey || 0 != ERR_peek_error())
-    return std::make_pair(kSignPrivateKey, std::move(buffer));
+    return SignResult(kSignPrivateKey);
 
 #ifdef NODE_FIPS_MODE
   /* Validate DSA2 parameters from FIPS 186-4 */
@@ -3603,9 +3601,10 @@ std::pair<SignBase::Error, MallocedBuffer<unsigned char>> Sign::SignFinal(
   }
 #endif  // NODE_FIPS_MODE
 
+  MallocedBuffer<unsigned char> buffer;
   buffer = Node_SignFinal(std::move(mdctx), pkey, padding, salt_len);
   Error error = buffer.is_empty() ? kSignPrivateKey : kSignOk;
-  return std::make_pair(error, std::move(buffer));
+  return SignResult(error, std::move(buffer));
 }
 
 
@@ -3630,18 +3629,18 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
 
   ClearErrorOnReturn clear_error_on_return;
 
-  std::pair<Error, MallocedBuffer<unsigned char>> ret = sign->SignFinal(
+  SignResult ret = sign->SignFinal(
       buf,
       buf_len,
       len >= 2 && !args[1]->IsNull() ? *passphrase : nullptr,
       padding,
       salt_len);
 
-  if (std::get<Error>(ret) != kSignOk)
-    return sign->CheckThrow(std::get<Error>(ret));
+  if (ret.error != kSignOk)
+    return sign->CheckThrow(ret.error);
 
   MallocedBuffer<unsigned char> sig =
-      std::move(std::get<MallocedBuffer<unsigned char>>(ret));
+      std::move(ret.signature);
 
   Local<Object> rc =
       Buffer::New(env, reinterpret_cast<char*>(sig.release()), sig.size)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3601,8 +3601,8 @@ Sign::SignResult Sign::SignFinal(
   }
 #endif  // NODE_FIPS_MODE
 
-  MallocedBuffer<unsigned char> buffer;
-  buffer = Node_SignFinal(std::move(mdctx), pkey, padding, salt_len);
+  MallocedBuffer<unsigned char> buffer =
+      Node_SignFinal(std::move(mdctx), pkey, padding, salt_len);
   Error error = buffer.is_empty() ? kSignPrivateKey : kSignOk;
   return SignResult(error, std::move(buffer));
 }

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -518,7 +518,17 @@ class Sign : public SignBase {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
-  std::pair<Error, MallocedBuffer<unsigned char>> SignFinal(
+  struct SignResult {
+    Error error;
+    MallocedBuffer<unsigned char> signature;
+
+    explicit inline SignResult(
+        Error err,
+        MallocedBuffer<unsigned char>&& sig = MallocedBuffer<unsigned char>())
+      : error(err), signature(std::move(sig)) {}
+  };
+
+  SignResult SignFinal(
       const char* key_pem,
       int key_pem_len,
       const char* passphrase,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -522,7 +522,7 @@ class Sign : public SignBase {
     Error error;
     MallocedBuffer<unsigned char> signature;
 
-    explicit inline SignResult(
+    explicit SignResult(
         Error err,
         MallocedBuffer<unsigned char>&& sig = MallocedBuffer<unsigned char>())
       : error(err), signature(std::move(sig)) {}


### PR DESCRIPTION
Using the non-indexed variant of `std::get<>` broke Travis CI.
Also, this allows us to be a bit more concise when returning
from `SignFinal()` due to some error condition.

Refs: https://github.com/nodejs/node/pull/23427

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
