### PR TITLE
test: fix assertion arguments order

### DIFF
--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -44,13 +44,13 @@ const server = http.createServer(function(request, response) {
 let response = '';
 
 process.on('exit', function() {
-  assert.strictEqual('beep boop\n', response);
+  assert.strictEqual(response, 'beep boop\n');
   console.log('ok');
 });
 
 server.listen(0, function() {
   http.get({ port: this.address().port }, function(res) {
-    assert.strictEqual(200, res.statusCode);
+    assert.strictEqual(res.statusCode, 200);
     assert.deepStrictEqual(res.headers, { date: 'coffee o clock' });
 
     res.setEncoding('ascii');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixed assertion arguments order on ``strictEqual()`` and ``deepStrictEqual()``.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
