### PR TITLE
 src: refactor out some warnings from `FillStatsArray` and `node_file.h`

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -2,7 +2,7 @@
 
 const errors = require('internal/errors');
 const {
-  kFsStatsFieldsLength,
+  kFsStatsFieldsNumber,
   StatWatcher: _StatWatcher
 } = process.binding('fs');
 const { FSEvent } = internalBinding('fs_event_wrap');
@@ -48,7 +48,7 @@ function onchange(newStatus, stats) {
 
   self[kOldStatus] = newStatus;
   self.emit('change', getStatsFromBinding(stats),
-            getStatsFromBinding(stats, kFsStatsFieldsLength));
+            getStatsFromBinding(stats, kFsStatsFieldsNumber));
 }
 
 // FIXME(joyeecheung): this method is not documented.

--- a/src/env.cc
+++ b/src/env.cc
@@ -169,8 +169,8 @@ Environment::Environment(IsolateData* isolate_data,
       trace_category_state_(isolate_, kTraceCategoryCount),
       stream_base_state_(isolate_, StreamBase::kNumStreamBaseStateFields),
       http_parser_buffer_(nullptr),
-      fs_stats_field_array_(isolate_, kFsStatsFieldsLength * 2),
-      fs_stats_field_bigint_array_(isolate_, kFsStatsFieldsLength * 2),
+      fs_stats_field_array_(isolate_, kFsStatsBufferLength),
+      fs_stats_field_bigint_array_(isolate_, kFsStatsBufferLength),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());

--- a/src/env.h
+++ b/src/env.h
@@ -84,9 +84,12 @@ struct PackageConfig {
 
 // The number of items passed to push_values_to_array_function has diminishing
 // returns around 8. This should be used at all call sites using said function.
-#ifndef NODE_PUSH_VAL_TO_ARRAY_MAX
-#define NODE_PUSH_VAL_TO_ARRAY_MAX 8
-#endif
+constexpr size_t NODE_PUSH_VAL_TO_ARRAY_MAX = 8;
+
+// Stat fields buffers contain twice the number of entries in an uv_stat_t
+// because `fs.StatWatcher` needs room to store 2 `fs.Stats` instances.
+constexpr size_t kFsStatsFieldsNumber = 14;
+constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
 
 // PER_ISOLATE_* macros: We have a lot of per-isolate properties
 // and adding and maintaining their getters and setters by hand would be
@@ -709,10 +712,6 @@ class Environment {
   inline AliasedBuffer<double, v8::Float64Array>* fs_stats_field_array();
   inline AliasedBuffer<uint64_t, v8::BigUint64Array>*
       fs_stats_field_bigint_array();
-
-  // stat fields contains twice the number of entries because `fs.StatWatcher`
-  // needs room to store data for *two* `fs.Stats` instances.
-  static const int kFsStatsFieldsLength = 14;
 
   inline std::vector<std::unique_ptr<fs::FileHandleReadWrap>>&
       file_handle_read_wrap_freelist();

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -426,7 +426,7 @@ void FSReqCallback::Reject(Local<Value> reject) {
 }
 
 void FSReqCallback::ResolveStat(const uv_stat_t* stat) {
-  Resolve(node::FillGlobalStatsArray(env(), stat, use_bigint()));
+  Resolve(FillGlobalStatsArray(env(), use_bigint(), stat));
 }
 
 void FSReqCallback::Resolve(Local<Value> value) {
@@ -949,8 +949,8 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
+    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
 }
@@ -980,8 +980,8 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
+    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
 }
@@ -1010,8 +1010,8 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
       return;  // error info is in ctx
     }
 
-    Local<Value> arr = node::FillGlobalStatsArray(env,
-        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr), use_bigint);
+    Local<Value> arr = FillGlobalStatsArray(env, use_bigint,
+        static_cast<const uv_stat_t*>(req_wrap_sync.req.ptr));
     args.GetReturnValue().Set(arr);
   }
 }
@@ -2237,8 +2237,8 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "mkdtemp", Mkdtemp);
 
   target->Set(context,
-              FIXED_ONE_BYTE_STRING(isolate, "kFsStatsFieldsLength"),
-              Integer::New(isolate, env->kFsStatsFieldsLength))
+              FIXED_ONE_BYTE_STRING(isolate, "kFsStatsFieldsNumber"),
+              Integer::New(isolate, kFsStatsFieldsNumber))
         .FromJust();
 
   target->Set(context,

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -406,7 +406,7 @@ class FileHandle : public AsyncWrap, public StreamBase {
       ref_.Reset(env->isolate(), ref);
     }
 
-    ~CloseReq() {
+    ~CloseReq() override {
       uv_fs_req_cleanup(req());
       promise_.Reset();
       ref_.Reset();

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -30,7 +30,7 @@ class FSContinuationData : public MemoryRetainer {
 
   uv_fs_t* req;
   int mode;
-  std::vector<std::string> paths;
+  std::vector<std::string> paths{};
 
   void PushPath(std::string&& path) {
     paths.emplace_back(std::move(path));
@@ -244,9 +244,10 @@ class FSReqPromise : public FSReqBase {
                   AsyncWrap::PROVIDER_FSREQPROMISE,
                   use_bigint),
         stats_field_array_(env->isolate(), kFsStatsFieldsNumber) {
-    auto resolver = Promise::Resolver::New(env->context()).ToLocalChecked();
-    object()->Set(env->context(), env->promise_string(),
-                  resolver).FromJust();
+    const auto resolver =
+      Promise::Resolver::New(env->context()).ToLocalChecked();
+    USE(object()->Set(env->context(), env->promise_string(),
+                      resolver).FromJust());
   }
 
   ~FSReqPromise() override {
@@ -262,7 +263,7 @@ class FSReqPromise : public FSReqBase {
         object()->Get(env()->context(),
                       env()->promise_string()).ToLocalChecked();
     Local<Promise::Resolver> resolver = value.As<Promise::Resolver>();
-    resolver->Reject(env()->context(), reject).FromJust();
+    USE(resolver->Reject(env()->context(), reject).FromJust());
   }
 
   void Resolve(Local<Value> value) override {
@@ -273,7 +274,7 @@ class FSReqPromise : public FSReqBase {
         object()->Get(env()->context(),
                       env()->promise_string()).ToLocalChecked();
     Local<Promise::Resolver> resolver = val.As<Promise::Resolver>();
-    resolver->Resolve(env()->context(), value).FromJust();
+    USE(resolver->Resolve(env()->context(), value).FromJust());
   }
 
   void ResolveStat(const uv_stat_t* stat) override {
@@ -297,10 +298,14 @@ class FSReqPromise : public FSReqBase {
   SET_MEMORY_INFO_NAME(FSReqPromise)
   SET_SELF_SIZE(FSReqPromise)
 
+  FSReqPromise(const FSReqPromise&) = delete;
+  FSReqPromise& operator=(const FSReqPromise&) = delete;
+  FSReqPromise(const FSReqPromise&&) = delete;
+  FSReqPromise& operator=(const FSReqPromise&&) = delete;
+
  private:
   bool finished_ = false;
   AliasedBuffer<NativeT, V8T> stats_field_array_;
-  DISALLOW_COPY_AND_ASSIGN(FSReqPromise);
 };
 
 class FSReqAfterScope {
@@ -311,6 +316,11 @@ class FSReqAfterScope {
   bool Proceed();
 
   void Reject(uv_fs_t* req);
+
+  FSReqAfterScope(const FSReqAfterScope&) = delete;
+  FSReqAfterScope& operator=(const FSReqAfterScope&) = delete;
+  FSReqAfterScope(const FSReqAfterScope&&) = delete;
+  FSReqAfterScope& operator=(const FSReqAfterScope&&) = delete;
 
  private:
   FSReqBase* wrap_ = nullptr;
@@ -388,6 +398,11 @@ class FileHandle : public AsyncWrap, public StreamBase {
   SET_MEMORY_INFO_NAME(FileHandle)
   SET_SELF_SIZE(FileHandle)
 
+  FileHandle(const FileHandle&) = delete;
+  FileHandle& operator=(const FileHandle&) = delete;
+  FileHandle(const FileHandle&&) = delete;
+  FileHandle& operator=(const FileHandle&&) = delete;
+
  private:
   // Synchronous close that emits a warning
   void Close();
@@ -430,9 +445,14 @@ class FileHandle : public AsyncWrap, public StreamBase {
       return static_cast<CloseReq*>(ReqWrap::from_req(req));
     }
 
+    CloseReq(const CloseReq&) = delete;
+    CloseReq& operator=(const CloseReq&) = delete;
+    CloseReq(const CloseReq&&) = delete;
+    CloseReq& operator=(const CloseReq&&) = delete;
+
    private:
-    Persistent<Promise> promise_;
-    Persistent<Value> ref_;
+    Persistent<Promise> promise_{};
+    Persistent<Value> ref_{};
   };
 
   // Asynchronous close
@@ -446,9 +466,6 @@ class FileHandle : public AsyncWrap, public StreamBase {
 
   bool reading_ = false;
   std::unique_ptr<FileHandleReadWrap> current_read_ = nullptr;
-
-
-  DISALLOW_COPY_AND_ASSIGN(FileHandle);
 };
 
 }  // namespace fs

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -22,8 +22,8 @@
 #include "node_stat_watcher.h"
 #include "node_internals.h"
 #include "async_wrap-inl.h"
-#include "env-inl.h"
-#include "util-inl.h"
+#include "env.h"
+#include "node_file.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -80,15 +80,10 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  Local<Value> arr = node::FillGlobalStatsArray(env, curr,
-                                                wrap->use_bigint_);
-  node::FillGlobalStatsArray(env, prev, wrap->use_bigint_,
-                             env->kFsStatsFieldsLength);
+  Local<Value> arr = fs::FillGlobalStatsArray(env, wrap->use_bigint_, curr);
+  USE(fs::FillGlobalStatsArray(env, wrap->use_bigint_, prev, true));
 
-  Local<Value> argv[2] {
-    Integer::New(env->isolate(), status),
-    arr
-  };
+  Local<Value> argv[2] = { Integer::New(env->isolate(), status), arr };
   wrap->MakeCallback(env->onchange_string(), arraysize(argv), argv);
 }
 


### PR DESCRIPTION
~#### adds a the Guideline Support Library to `/deps/`:~

### src: refactor out warnings from FillStatsArray
* move FillStatsArray to `node_file.h` minimize number of template instantions
* change inline to constexpr
* change MACRO consts to constexpr
* correct polymorphic conversion from `uv_timespec_t`
* DRY `FillGlobalStatsArray`
* change `FillGlobalStatsArray` signature to have one less default arg
* reduce some `include`s

### src: clean clang-tidy errors in node_file.h
* __fix bug with non virtual dtor__
* delete move constructors
* default initialize all members
* discard unneeded return values
* const some possibles


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
