### PR TITLE
lib: fix grammar error and make it more clear in comments

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -126,8 +126,9 @@ function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-// Can overridden with custom print functions, such as `probe` or `eyes.js`.
-// This is the default "writer" value if none is passed in the REPL options.
+// This is the default "writer" value, if none is passed in the REPL options,
+// and it can be overridden by custom print functions, such as `probe` or
+// `eyes.js`.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
 writer.options = Object.assign({},
                                util.inspect.defaultOptions,


### PR DESCRIPTION
1) Should be passive voice instead of `can overridden`.
2) Change the order of the two sentences to make it more clear about
'What can be overridden' instead of 'Can overridden'.

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
