### PR TITLE
deps: fix wrong default for v8 handle zapping

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -103,7 +103,9 @@
     # Enable mitigations for executing untrusted code.
     'v8_untrusted_code_mitigations%': 'true',
 
-    'v8_enable_handle_zapping%': 1,
+    # Currently set for node by common.gypi, avoiding default because of gyp file bug.
+    # Should be turned on only for debugging.
+    #'v8_enable_handle_zapping%': 0,
   },
   'target_defaults': {
     'conditions': [
@@ -164,9 +166,10 @@
       ['v8_untrusted_code_mitigations=="false"', {
         'defines': ['DISABLE_UNTRUSTED_CODE_MITIGATIONS',],
       }],
-      ['v8_enable_handle_zapping==1', {
-        'defines': ['ENABLE_HANDLE_ZAPPING',],
-      }],
+      # Refs: https://github.com/nodejs/node/pull/23801
+      # ['v8_enable_handle_zapping==1', {
+      #  'defines': ['ENABLE_HANDLE_ZAPPING',],
+      # }],
     ],  # conditions
     'defines': [
       'V8_GYP_BUILD',

--- a/deps/v8/gypfiles/toolchain.gypi
+++ b/deps/v8/gypfiles/toolchain.gypi
@@ -1321,6 +1321,10 @@
           }, {
             'inherit_from': ['DebugBase1'],
           }],
+          # Temporary refs: https://github.com/nodejs/node/pull/23801
+          ['v8_enable_handle_zapping==1', {
+            'defines': ['ENABLE_HANDLE_ZAPPING',],
+          }],
         ],
       },  # Debug
       'ReleaseBase': {
@@ -1405,6 +1409,8 @@
       },  # Release
       'Release': {
         'inherit_from': ['ReleaseBase'],
+        # Temporary refs: https://github.com/nodejs/node/pull/23801
+        'defines!': ['ENABLE_HANDLE_ZAPPING',],
       },  # Debug
       'conditions': [
         [ 'OS=="win"', {


### PR DESCRIPTION
Can we devise a test for this?

Fixes: https://github.com/nodejs/node/issues/23796
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
