### PR TITLE
src: fix missing deprecation assignment

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2235,7 +2235,7 @@ It will become an error in future versions of Node.js.
 
 <a id="DEP0119"></a>
 ### DEP0119: process.binding('uv').errname() private API
-<!--
+<!-- YAML
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/23597
@@ -2249,12 +2249,14 @@ Please make sure to use [`util.getSystemErrorName()`][] instead.
 
 <a id="DEP0120"></a>
 ### DEP0120: Windows Performance Counter Support
-<!--
+<!-- YAML
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/22485
     description: Runtime deprecation.
 -->
+
+Type: Runtime
 
 Windows Performance Counter support has been removed from Node.js. The
 undocumented  `COUNTER_NET_SERVER_CONNECTION()`,

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2247,6 +2247,21 @@ Type: Documentation-only (supports [`--pending-deprecation`][])
 Directly calling `process.binding('uv').errname(<val>)` is deprecated.
 Please make sure to use [`util.getSystemErrorName()`][] instead.
 
+<a id="DEP0120"></a>
+### DEP0120: Windows Performance Counter Support
+<!--
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/22485
+    description: Runtime deprecation.
+-->
+
+Windows Performance Counter support has been removed from Node.js. The
+undocumented  `COUNTER_NET_SERVER_CONNECTION()`,
+`COUNTER_NET_SERVER_CONNECTION_CLOSE()`, `COUNTER_HTTP_SERVER_REQUEST()`,
+`COUNTER_HTTP_SERVER_RESPONSE()`, `COUNTER_HTTP_CLIENT_REQUEST()`, and
+`COUNTER_HTTP_CLIENT_RESPONSE()` functions have been deprecated.
+
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2259,7 +2259,7 @@ changes:
 Type: Runtime
 
 Windows Performance Counter support has been removed from Node.js. The
-undocumented  `COUNTER_NET_SERVER_CONNECTION()`,
+undocumented `COUNTER_NET_SERVER_CONNECTION()`,
 `COUNTER_NET_SERVER_CONNECTION_CLOSE()`, `COUNTER_HTTP_SERVER_REQUEST()`,
 `COUNTER_HTTP_SERVER_RESPONSE()`, `COUNTER_HTTP_CLIENT_REQUEST()`, and
 `COUNTER_HTTP_CLIENT_RESPONSE()` functions have been deprecated.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -222,7 +222,7 @@
           enumerable: false,
           value: deprecate(noop,
                            `COUNTER_${names[n]}() is deprecated.`,
-                           'DEP00XX')
+                           'DEP0120')
         });
       }
     }


### PR DESCRIPTION
Missed the assignment when landing

This needs a fast-track for v11.0.0

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
