### PR TITLE
tls: disable TLS v1.0 and v1.1 by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -323,6 +323,22 @@ added: v4.0.0
 Specify an alternative default TLS cipher list. Requires Node.js to be built
 with crypto support (default).
 
+### `--tls-v1.0`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable TLSv1.0. This should only be used for compatibility with old TLS
+clients or servers.
+
+### `--tls-v1.1`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable TLSv1.1. This should only be used for compatibility with old TLS
+clients or servers.
+
 ### `--trace-deprecation`
 <!-- YAML
 added: v0.8.0

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1119,7 +1119,8 @@ changes:
     [OpenSSL Options][].
   * `secureProtocol` {string} SSL method to use. The possible values are listed
     as [SSL_METHODS][], use the function names as strings. For example,
-    `'TLSv1_2_method'` to force TLS version 1.2. **Default:** `'TLS_method'`.
+    `'TLSv1_2_method'` to force TLS version 1.2.
+    **Default:** `'TLSv1_2_method'`.
   * `sessionIdContext` {string} Opaque identifier used by servers to ensure
     session state is not shared between applications. Unused by clients.
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -183,6 +183,14 @@ Specify process.title on startup.
 Specify an alternative default TLS cipher list.
 Requires Node.js to be built with crypto support. (Default)
 .
+.It Fl -tls-v1.0
+Enable TLSv1.0. This should only be used for compatibility with old TLS
+clients or servers.
+.
+.It Fl -tls-v1.1
+Enable TLSv1.1. This should only be used for compatibility with old TLS
+clients or servers.
+.
 .It Fl -trace-deprecation
 Print stack traces for deprecations.
 .

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -396,7 +396,7 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
   Environment* env = sc->env();
 
-  int min_version = 0;
+  int min_version = TLS1_2_VERSION;
   int max_version = 0;
   const SSL_METHOD* method = TLS_method();
 
@@ -425,6 +425,9 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       method = TLS_server_method();
     } else if (strcmp(*sslmethod, "SSLv23_client_method") == 0) {
       method = TLS_client_method();
+    } else if (strcmp(*sslmethod, "TLS_method") == 0) {
+      min_version = 0;
+      max_version = 0;
     } else if (strcmp(*sslmethod, "TLSv1_method") == 0) {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -400,6 +400,9 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   int max_version = 0;
   const SSL_METHOD* method = TLS_method();
 
+  if (env->options()->tls_v1_1) min_version = TLS1_1_VERSION;
+  if (env->options()->tls_v1_0) min_version = TLS1_VERSION;
+
   if (args.Length() == 1 && args[0]->IsString()) {
     const node::Utf8Value sslmethod(env->isolate(), args[0]);
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -189,6 +189,17 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 
   AddOption("--napi-modules", "", NoOp{}, kAllowedInEnvironment);
 
+#if HAVE_OPENSSL
+  AddOption("--tls-v1.0",
+            "enable TLSv1.0",
+            &EnvironmentOptions::tls_v1_0,
+            kAllowedInEnvironment);
+  AddOption("--tls-v1.1",
+            "enable TLSv1.1",
+            &EnvironmentOptions::tls_v1_1,
+            kAllowedInEnvironment);
+#endif
+
   Insert(&DebugOptionsParser::instance,
          &EnvironmentOptions::get_debug_options);
 }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -92,6 +92,11 @@ class EnvironmentOptions : public Options {
   bool print_eval = false;
   bool force_repl = false;
 
+#if HAVE_OPENSSL
+  bool tls_v1_0 = false;
+  bool tls_v1_1 = false;
+#endif
+
   std::vector<std::string> preload_modules;
 
   std::vector<std::string> user_argv;

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -11,7 +11,8 @@ const fixtures = require('../common/fixtures');
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
-  ca: fixtures.readKey('ca1-cert.pem')
+  ca: fixtures.readKey('ca1-cert.pem'),
+  secureProtocol: 'TLS_method',
 };
 
 const server = https.Server(options, function(req, res) {

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -1,3 +1,4 @@
+// Flags: --tls-v1.1
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -11,8 +12,7 @@ const fixtures = require('../common/fixtures');
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
-  ca: fixtures.readKey('ca1-cert.pem'),
-  secureProtocol: 'TLS_method',
+  ca: fixtures.readKey('ca1-cert.pem')
 };
 
 const server = https.Server(options, function(req, res) {
@@ -35,7 +35,7 @@ const updatedValues = new Map([
   ['ecdhCurve', 'secp384r1'],
   ['honorCipherOrder', true],
   ['secureOptions', crypto.constants.SSL_OP_CIPHER_SERVER_PREFERENCE],
-  ['secureProtocol', 'TLSv1_method'],
+  ['secureProtocol', 'TLSv1_1_method'],
   ['sessionIdContext', 'sessionIdContext'],
 ]);
 

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -1,3 +1,4 @@
+// Flags: --tls-v1.0
 'use strict';
 
 const common = require('../common');
@@ -54,8 +55,7 @@ function faultyServer(port) {
 function second(server, session) {
   const req = https.request({
     port: server.address().port,
-    rejectUnauthorized: false,
-    secureProtocol: 'TLS_method',
+    rejectUnauthorized: false
   }, function(res) {
     res.resume();
   });

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -54,7 +54,8 @@ function faultyServer(port) {
 function second(server, session) {
   const req = https.request({
     port: server.address().port,
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
+    secureProtocol: 'TLS_method',
   }, function(res) {
     res.resume();
   });

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -51,7 +51,8 @@ require('../common');
 // assert all "canonical" flags begin with dash(es)
 {
   process.allowedNodeEnvironmentFlags.forEach((flag) => {
-    assert(/^--?[a-z8_-]+$/.test(flag), `Unexpected format for flag ${flag}`);
+    assert(/^--?[a-z0-9._-]+$/.test(flag),
+           `Unexpected format for flag ${flag}`);
   });
 }
 

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -17,6 +17,7 @@ const clientConfigs = [
 ];
 
 const serverConfig = {
+  secureProtocol: 'TLS_method',
   key: fixtures.readSync('/keys/agent2-key.pem'),
   cert: fixtures.readSync('/keys/agent2-cert.pem')
 };

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -48,7 +48,8 @@ function doTest(testOptions, callback) {
     cert,
     ca: [cert],
     requestCert: true,
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
+    secureProtocol: 'TLS_method',
   };
   let requestCount = 0;
   let resumeCount = 0;


### PR DESCRIPTION
Refs: https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/

Firefox will drop support for TLS < 1.2 in March 2020. Given the usage numbers, I'd say that makes sense. This PR is a discussion starter about when to disable it in Node.js.

v12 will be released in April 2019. That might be too early. But v12 is supported until April 2022. That's too late. So what is a good time?

Users can programmatically re-enable TLS 1.0 and 1.1 with this PR. To what extent does that alleviate backwards compatibility concerns? Would a command line flag be better?