### PR TITLE
deps: cherry-pick 078e1dc from upstream c-ares

### DIFF
--- a/deps/cares/src/ares_options.c
+++ b/deps/cares/src/ares_options.c
@@ -153,6 +153,9 @@ int ares_set_servers(ares_channel channel,
   if (!channel)
     return ARES_ENODATA;
 
+  if (!ares__is_list_empty(&channel->all_queries))
+    return ARES_ENOTIMP;
+
   ares__destroy_servers_state(channel);
 
   for (srvr = servers; srvr; srvr = srvr->next)
@@ -201,6 +204,9 @@ int ares_set_servers_ports(ares_channel channel,
 
   if (!channel)
     return ARES_ENODATA;
+
+  if (!ares__is_list_empty(&channel->all_queries))
+    return ARES_ENOTIMP;
 
   ares__destroy_servers_state(channel);
 


### PR DESCRIPTION
Original commit message:

    Prevent changing name servers while queries are outstanding

    Changing name servers doesn't work, per c-ares/c-ares#41.
    Better to return an error code than to crash.

Refs: https://github.com/c-ares/c-ares/issues/41
Refs: https://github.com/c-ares/c-ares/pull/191
Refs: https://github.com/nodejs/node/issues/894