### PR TITLE
doc: remove problematic example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,6 @@ nonetheless.
   arbitrary JavaScript code. That is already the highest level of privilege
   possible.
 
-- [#12141](https://github.com/nodejs/node/pull/12141): _buffer: zero fill
-  Buffer(num) by default_. The documented `Buffer()` behavior was prone to
-  [misuse](https://snyk.io/blog/exploiting-buffer/). It has since changed. It
-  was not deemed serious enough to fix in older releases and breaking API
-  stability.
-
 ### Private disclosure preferred
 
 - [CVE-2016-7099](https://nodejs.org/en/blog/vulnerability/september-2016-security-releases/):


### PR DESCRIPTION
Remove Buffer constructor example from security reporting examples. Even
though the example text focuses on API compatibility, the pull request
cited is about zero-filling vs. not zero-filling, which is not an API
compatibility change (or at least is not unambiguously one). The fact
that it's a pull request is also problematic, since it's not reporting a
security issue but instead proposing a way to address one that has
already been reported publicly. Finally, the text focuses on the fact
that it was not deemed worthy of backporting, but that was determined by
a vote by a divided CTC. It is unreasonable to ask someone reporting an
issue to make a determination that the CTC/TSC is divided on.

In short, it's not a good example for the list it is in. Remove it.

Refs: https://github.com/nodejs/node/pull/23759#discussion_r226804801

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
