### PR TITLE
module: allow passing a directory to createRequireFromPath

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -916,7 +916,7 @@ added: v10.12.0
 
 ```js
 const { createRequireFromPath } = require('module');
-const requireUtil = createRequireFromPath('../src/utils');
+const requireUtil = createRequireFromPath('../src/utils/');
 
 // Require `../src/utils/some-tool`
 requireUtil('./some-tool');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -825,9 +825,15 @@ Module.runMain = function() {
 };
 
 Module.createRequireFromPath = (filename) => {
-  const m = new Module(filename);
-  m.filename = filename;
-  m.paths = Module._nodeModulePaths(path.dirname(filename));
+  // Allow a directory to be passed as the filename
+  const proxyPath = filename.endsWith('/') ?
+    path.join(filename, 'noop.js') :
+    filename;
+
+  const m = new Module(proxyPath);
+  m.filename = proxyPath;
+
+  m.paths = Module._nodeModulePaths(path.dirname(proxyPath));
   return makeRequireFunction(m);
 };
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -826,7 +826,11 @@ Module.runMain = function() {
 
 Module.createRequireFromPath = (filename) => {
   // Allow a directory to be passed as the filename
-  const proxyPath = filename.endsWith('/') ?
+  const normalized = path.win32.normalize(filename);
+  const trailingSlash = normalized.charCodeAt(normalized.length - 1) ===
+    CHAR_BACKWARD_SLASH;
+
+  const proxyPath = trailingSlash ?
     path.join(filename, 'noop.js') :
     filename;
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -826,9 +826,8 @@ Module.runMain = function() {
 
 Module.createRequireFromPath = (filename) => {
   // Allow a directory to be passed as the filename
-  const normalized = path.win32.normalize(filename);
-  const trailingSlash = normalized.charCodeAt(normalized.length - 1) ===
-    CHAR_BACKWARD_SLASH;
+  const trailingSlash =
+    filename.endsWith(path.sep) || path.sep !== '/' && filename.endsWith('\\');
 
   const proxyPath = trailingSlash ?
     path.join(filename, 'noop.js') :
@@ -837,7 +836,7 @@ Module.createRequireFromPath = (filename) => {
   const m = new Module(proxyPath);
   m.filename = proxyPath;
 
-  m.paths = Module._nodeModulePaths(path.dirname(proxyPath));
+  m.paths = Module._nodeModulePaths(m.path);
   return makeRequireFunction(m);
 };
 

--- a/test/parallel/test-module-create-require-from-directory.js
+++ b/test/parallel/test-module-create-require-from-directory.js
@@ -1,0 +1,12 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const path = require('path');
+
+const { createRequireFromPath } = require('module');
+
+const p = path.join(path.resolve(__dirname, '..', 'fixtures'), '/');
+
+const req = createRequireFromPath(p);
+assert.strictEqual(req('./baz'), 'perhaps I work');

--- a/test/parallel/test-module-create-require-from-directory.js
+++ b/test/parallel/test-module-create-require-from-directory.js
@@ -6,7 +6,13 @@ const path = require('path');
 
 const { createRequireFromPath } = require('module');
 
-const p = path.join(path.resolve(__dirname, '..', 'fixtures'), path.sep);
+const fixPath = path.resolve(__dirname, '..', 'fixtures');
+const p = path.join(fixPath, path.sep);
 
 const req = createRequireFromPath(p);
+const reqFromNotDir = createRequireFromPath(fixPath);
+
 assert.strictEqual(req('./baz'), 'perhaps I work');
+assert.throws(() => {
+  reqFromNotDir('./baz');
+}, { code: 'MODULE_NOT_FOUND' });

--- a/test/parallel/test-module-create-require-from-directory.js
+++ b/test/parallel/test-module-create-require-from-directory.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 const { createRequireFromPath } = require('module');
 
-const p = path.join(path.resolve(__dirname, '..', 'fixtures'), '/');
+const p = path.join(path.resolve(__dirname, '..', 'fixtures'), path.sep);
 
 const req = createRequireFromPath(p);
 assert.strictEqual(req('./baz'), 'perhaps I work');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/23710

I still need to update the documentation for this change, I'm not quite sure if we should update the documentation to encourage users to pass a directory or do we prefer a file path?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
