### PR TITLE
tls: deprecate Server.prototype.setOptions()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2279,6 +2279,20 @@ and `cluster` modules on Windows. The function is not generally useful and
 is being removed. See discussion here:
 https://github.com/nodejs/node/issues/18391
 
+<a id="DEP0122"></a>
+### DEP0122: tls Server.prototype.setOptions()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/23820
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Please use `Server.prototype.setSecureContext()` instead.
+
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -827,16 +827,19 @@ function Server(options, listener) {
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
 
-
   this._contexts = [];
+  this.requestCert = options.requestCert === true;
+  this.rejectUnauthorized = options.rejectUnauthorized !== false;
 
-  // Handle option defaults:
-  this.setOptions(options);
+  if (options.sessionTimeout)
+    this.sessionTimeout = options.sessionTimeout;
 
-  // setSecureContext() overlaps with setOptions() quite a bit. setOptions()
-  // is an undocumented API that was probably never intended to be exposed
-  // publicly. Unfortunately, it would be a breaking change to just remove it,
-  // and there is at least one test that depends on it.
+  if (options.ticketKeys)
+    this.ticketKeys = options.ticketKeys;
+
+  if (options.ALPNProtocols)
+    tls.convertALPNProtocols(options.ALPNProtocols, this);
+
   this.setSecureContext(options);
 
   this[kHandshakeTimeout] = options.handshakeTimeout || (120 * 1000);
@@ -998,7 +1001,7 @@ Server.prototype.setTicketKeys = function setTicketKeys(keys) {
 };
 
 
-Server.prototype.setOptions = function(options) {
+Server.prototype.setOptions = util.deprecate(function(options) {
   this.requestCert = options.requestCert === true;
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
 
@@ -1033,7 +1036,7 @@ Server.prototype.setOptions = function(options) {
                                   .digest('hex')
                                   .slice(0, 32);
   }
-};
+}, 'Server.prototype.setOptions() is deprecated', 'DEP0122');
 
 // SNI Contexts High-Level API
 Server.prototype.addContext = function(servername, context) {

--- a/test/parallel/test-tls-server-setoptions-clientcertengine.js
+++ b/test/parallel/test-tls-server-setoptions-clientcertengine.js
@@ -10,6 +10,9 @@ const tls = require('tls');
 {
   const server = tls.createServer();
   assert.strictEqual(server.clientCertEngine, undefined);
+  common.expectWarning('DeprecationWarning',
+                       'Server.prototype.setOptions() is deprecated',
+                       'DEP0122');
   server.setOptions({ clientCertEngine: 'Cannonmouth' });
   assert.strictEqual(server.clientCertEngine, 'Cannonmouth');
 }


### PR DESCRIPTION
This function was undocumented and only used in one place
throughout the codebase, plus a test. It was almost entirely duplicated in public API by `Server.prototype.setSecureContext()` recently.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
