### PR TITLE
src,win: informative stack traces

### DIFF
--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -6,6 +6,7 @@
 #include "async_wrap.h"
 #include "env.h"
 #include <string>
+#include <sstream>
 
 // Use FORCE_INLINE on functions that have a debug-category-enabled check first
 // and then ideally only a single function call following it, to maintain
@@ -93,14 +94,25 @@ class NativeSymbolDebuggingContext {
    public:
     std::string name;
     std::string filename;
+    size_t line = 0;
+    size_t dis = 0;
 
     std::string Display() const;
   };
 
+  NativeSymbolDebuggingContext() = default;
   virtual ~NativeSymbolDebuggingContext() {}
-  virtual SymbolInfo LookupSymbol(void* address) { return { "", "" }; }
+
+  virtual SymbolInfo LookupSymbol(void* address) { return {}; }
   virtual bool IsMapped(void* address) { return false; }
   virtual int GetStackTrace(void** frames, int count) { return 0; }
+
+  NativeSymbolDebuggingContext(const NativeSymbolDebuggingContext&) = delete;
+  NativeSymbolDebuggingContext(NativeSymbolDebuggingContext&&) = delete;
+  NativeSymbolDebuggingContext operator=(NativeSymbolDebuggingContext&)
+    = delete;
+  NativeSymbolDebuggingContext operator=(NativeSymbolDebuggingContext&&)
+    = delete;
 };
 
 // Variant of `uv_loop_close` that tries to be as helpful as possible


### PR DESCRIPTION
Refresh `Win32SymbolDebuggingContext::LookupSymbol` to use more APIs
Refs: https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-symbol-information-by-address
Refs: https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-undecorated-symbol-names

Before:
```
DEV D:\code\node>Debug\node.exe test\parallel\test-fs-stat-bigint.js
C:\WINDOWS\system32\cmd.exe - Debug\node.exe  test\parallel\test-fs-stat-bigint.js [37304]: d:\code\node\deps\gsl\gsl\gsl_assert:132: Assertion `unknown' failed.
 1: 00007FF7A3B9F67A
 2: 00007FF7A3B0A1B7
 3: 00007FF7A3B0A307
 4: 00007FF7A394BB25
 5: 00007FF7A394B844
 6: 00007FF7A394AC6A
 7: 00007FF7A394BF91
 8: 00007FF7A3A7C36B
 9: 00007FF7A480D165
10: 00007FF7A480BB5C
11: 00007FF7A480CE1B
12: 00007FF7A480C6C3
13: 0000039475106628
```
After (with PDB available):
```
DEV D:\code\node>Debug\node.exe test\parallel\test-fs-stat-bigint.js
C:\WINDOWS\system32\cmd.exe - Debug\node.exe  test\parallel\test-fs-stat-bigint.js [38392]: d:\code\node\deps\gsl\gsl\gsl_assert:132: Assertion `unknown' failed.
 1: 00007FF7A3B9F67A node::DumpBacktrace [d:\code\node\src\debug_utils.cc]:L237+138
 2: 00007FF7A3B0A1B7 node::Abort [d:\code\node\src\node.cc]:L1030+39
 3: 00007FF7A3B0A307 node::Assert [d:\code\node\src\node.cc]:L1049+295
 4: 00007FF7A394BB25 gsl::details::throw_exception<gsl::narrowing_error> [d:\code\node\deps\gsl\gsl\gsl_assert]:L137+149
 5: 00007FF7A394B844 gsl::narrow<double,unsigned __int64> [d:\code\node\deps\gsl\gsl\gsl_util]:L117+148
 6: 00007FF7A394AC6A node::FillStatsArray<double,v8::Float64Array> [d:\code\node\src\node_internals.h]:L328+634
 7: 00007FF7A394BF91 node::FillGlobalStatsArray [d:\code\node\src\node_internals.h]:L360+129
 8: 00007FF7A3A7C36B node::fs::LStat [d:\code\node\src\node_file.cc]:L985+1083
 9: 00007FF7A480D165 v8::internal::FunctionCallbackArguments::Call [d:\code\node\deps\v8\src\api-arguments-inl.h]:L120+469
10: 00007FF7A480BB5C v8::internal::`anonymous namespace'::HandleApiCallHelper<0> [d:\code\node\deps\v8\src\builtins\builtins-api.cc]:L111+684
11: 00007FF7A480CE1B v8::internal::Builtin_Impl_HandleApiCall [d:\code\node\deps\v8\src\builtins\builtins-api.cc]:L139+507
12: 00007FF7A480C6C3 v8::internal::Builtin_HandleApiCall [d:\code\node\deps\v8\src\builtins\builtins-api.cc]:L127+451
13: 000003BBE9486628
```

Fallback with no PDB loaded:
```
 1: 00007FF7A3B9F67A AES_cbc_encrypt+5220586
 2: 00007FF7A3B0A1B7 AES_cbc_encrypt+4609063
 3: 00007FF7A3B0A307 AES_cbc_encrypt+4609399
 4: 00007FF7A394BB25 AES_cbc_encrypt+2780565
 5: 00007FF7A394B844 AES_cbc_encrypt+2779828
 6: 00007FF7A394AC6A AES_cbc_encrypt+2776794
 7: 00007FF7A394BF91 AES_cbc_encrypt+2781697
 8: 00007FF7A3A7C36B AES_cbc_encrypt+4027867
 9: 00007FF7A480D165 AES_cbc_encrypt+18252757
10: 00007FF7A480BB5C AES_cbc_encrypt+18247116
11: 00007FF7A480CE1B AES_cbc_encrypt+18251915
12: 00007FF7A480C6C3 AES_cbc_encrypt+18250035
13: 0000039475106628
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
