### PR TITLE
test: fix strictEqual() argument order

### DIFF
--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -37,7 +37,7 @@ const https = require('https');
     };
     // Will fail with ECONNREFUSED if the address family is not honored.
     https.get(options, common.mustCall(function() {
-      assert.strictEqual('::1', this.socket.remoteAddress);
+      assert.strictEqual(this.socket.remoteAddress, '::1');
       this.destroy();
     }));
   }));

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -37,7 +37,7 @@ const https = require('https');
     };
     // Will fail with ECONNREFUSED if the address family is not honored.
     https.get(options, common.mustCall(function() {
-      assert.strictEqual(this.socket.remoteAddress, '::1');
+      assert.strictEqual(this.socket.remoteAddress, hostAddrIPv6);
       this.destroy();
     }));
   }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
