### PR TITLE
src: prefer param function check over args length

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -415,7 +415,7 @@ function open(path, flags, mode, callback) {
     callback = flags;
     flags = 'r';
     mode = 0o666;
-  } else if (arguments.length === 3) {
+  } else if (typeof mode === 'function') {
     callback = mode;
     mode = 0o666;
   }
@@ -808,7 +808,7 @@ function readdirSync(path, options) {
 }
 
 function fstat(fd, options, callback) {
-  if (arguments.length < 3) {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }
@@ -819,7 +819,7 @@ function fstat(fd, options, callback) {
 }
 
 function lstat(path, options, callback) {
-  if (arguments.length < 3) {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }
@@ -832,7 +832,7 @@ function lstat(path, options, callback) {
 }
 
 function stat(path, options, callback) {
-  if (arguments.length < 3) {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }


### PR DESCRIPTION
We have to override some `fs` methods in Electron, and as I looked at their original impls I believe that checking the type of the second argument as opposed to simply the number of arguments passed is more consistent and reliable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
