### PR TITLE
lib: modify NativeModule to use compileFunction

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -268,6 +268,7 @@
         false,          // produce cached data
         undefined,      // parsing context
         undefined,      // context extensions
+        // arguments to the function
         ['exports', 'require', 'module', 'process', 'internalBinding']
       );
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -259,6 +259,8 @@
       const cache = codeCacheHash[id] &&
         (codeCacheHash[id] === sourceHash[id]) ? codeCache[id] : undefined;
 
+      const params = ['exports', 'require', 'module', 'process', 'internalBinding'];
+
       const fn = compileFunction(
         source,         // source code
         this.filename,  // filename
@@ -268,8 +270,7 @@
         false,          // produce cached data
         undefined,      // parsing context
         undefined,      // context extensions
-        // arguments to the function
-        ['exports', 'require', 'module', 'process', 'internalBinding']
+        params          // arguments to the function
       );
 
       // One of these conditions may be false when any of the inputs

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -261,6 +261,7 @@
 
       const params = ['exports', 'require', 'module', 'process', 'internalBinding'];
 
+      // TODO(@joyeecheung): figure out way to expose wrapped source for code cache
       const fn = compileFunction(
         source,         // source code
         this.filename,  // filename

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -225,6 +225,14 @@
       undefined;
   };
 
+  NativeModule.parameters = Object.freeze([
+    'exports',
+    'require',
+    'module',
+    'process',
+    'internalBinding'
+  ]);
+
   NativeModule.prototype.compile = function() {
     const id = this.id;
     const source = NativeModule.getSource(id);
@@ -259,19 +267,17 @@
       const cache = codeCacheHash[id] &&
         (codeCacheHash[id] === sourceHash[id]) ? codeCache[id] : undefined;
 
-      const params = ['exports', 'require', 'module', 'process', 'internalBinding'];
-
-      // TODO(@joyeecheung): figure out way to expose wrapped source for code cache
+      // TODO(@joyee): figure out way to expose wrapped source for code cache
       const fn = compileFunction(
-        source,         // source code
-        this.filename,  // filename
-        0,              // line offset
-        0,              // column offset
-        cache,          // cached data
-        false,          // produce cached data
-        undefined,      // parsing context
-        undefined,      // context extensions
-        params          // arguments to the function
+        source,                 // source code
+        this.filename,          // filename
+        0,                      // line offset
+        0,                      // column offset
+        cache,                  // cached data
+        false,                  // produce cached data
+        undefined,              // parsing context
+        undefined,              // context extensions
+        NativeModule.parameters // arguments to the function
       );
 
       // One of these conditions may be false when any of the inputs

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -109,7 +109,6 @@
 
   // Create this WeakMap in js-land because V8 has no C++ API for WeakMap
   internalBinding('module_wrap').callbackMap = new WeakMap();
-  const { ContextifyScript } = internalBinding('contextify');
 
   // Set up NativeModule
   function NativeModule(id) {
@@ -120,7 +119,6 @@
     this.exportKeys = undefined;
     this.loaded = false;
     this.loading = false;
-    this.script = null;  // The ContextifyScript of the module
   }
 
   NativeModule._source = getInternalBinding('natives');
@@ -220,15 +218,6 @@
     return NativeModule._source[id];
   };
 
-  NativeModule.wrap = function(script) {
-    return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
-  };
-
-  NativeModule.wrapper = [
-    '(function (exports, require, module, process, internalBinding) {',
-    '\n});'
-  ];
-
   const getOwn = (target, property, receiver) => {
     return ReflectApply(ObjectHasOwnProperty, target, [property]) ?
       ReflectGet(target, property, receiver) :
@@ -237,8 +226,7 @@
 
   NativeModule.prototype.compile = function() {
     const id = this.id;
-    let source = NativeModule.getSource(id);
-    source = NativeModule.wrap(source);
+    const source = NativeModule.getSource(id);
 
     this.loading = true;
 
@@ -270,29 +258,29 @@
       const cache = codeCacheHash[id] &&
         (codeCacheHash[id] === sourceHash[id]) ? codeCache[id] : undefined;
 
-      // (code, filename, lineOffset, columnOffset
-      // cachedData, produceCachedData, parsingContext)
-      const script = new ContextifyScript(
-        source, this.filename, 0, 0,
-        cache, false, undefined
+      const fn = internalBinding('contextify').compileFunction(
+        source,
+        this.filename,
+        0,
+        0,
+        cache,
+        false,
+        undefined,
+        [],
+        ['exports', 'require', 'module', 'process', 'internalBinding']
       );
-
-      // This will be used to create code cache in tools/generate_code_cache.js
-      this.script = script;
 
       // One of these conditions may be false when any of the inputs
       // of the `node_js2c` target in node.gyp is modified.
       // FIXME(joyeecheung): Figure out how to resolve the dependency issue.
       // When the code cache was introduced we were at a point where refactoring
       // node.gyp may not be worth the effort.
-      if (!cache || script.cachedDataRejected) {
+      if (!cache) {
         compiledWithoutCache.push(this.id);
       } else {
         compiledWithCache.push(this.id);
       }
 
-      // Arguments: timeout, displayErrors, breakOnSigint
-      const fn = script.runInThisContext(-1, true, false);
       const requireFn = this.id.startsWith('internal/deps/') ?
         NativeModule.requireForDeps :
         NativeModule.require;

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -260,14 +260,14 @@
         (codeCacheHash[id] === sourceHash[id]) ? codeCache[id] : undefined;
 
       const fn = compileFunction(
-        source,
-        this.filename,
-        0,
-        0,
-        cache,
-        false,
-        undefined,
-        [],
+        source,         // source code
+        this.filename,  // filename
+        0,              // line offset
+        0,              // column offset
+        cache,          // cached data
+        false,          // produce cached data
+        undefined,      // parsing context
+        undefined,      // context extensions
         ['exports', 'require', 'module', 'process', 'internalBinding']
       );
 

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -109,6 +109,7 @@
 
   // Create this WeakMap in js-land because V8 has no C++ API for WeakMap
   internalBinding('module_wrap').callbackMap = new WeakMap();
+  const { compileFunction } = internalBinding('contextify');
 
   // Set up NativeModule
   function NativeModule(id) {
@@ -258,7 +259,7 @@
       const cache = codeCacheHash[id] &&
         (codeCacheHash[id] === sourceHash[id]) ? codeCache[id] : undefined;
 
-      const fn = internalBinding('contextify').compileFunction(
+      const fn = compileFunction(
         source,
         this.filename,
         0,

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -276,7 +276,7 @@
       // FIXME(joyeecheung): Figure out how to resolve the dependency issue.
       // When the code cache was introduced we were at a point where refactoring
       // node.gyp may not be worth the effort.
-      if (!cache) {
+      if (!cache || fn.cachedDataRejected) {
         compiledWithoutCache.push(this.id);
       } else {
         compiledWithCache.push(this.id);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1099,10 +1099,21 @@ void ContextifyContext::CompileFunction(
           env->cached_data_string(),
           buf.ToLocalChecked()).IsNothing()) return;
     }
+
+    // Report if cache was produced.
     if (fun->Set(
         parsing_context,
         env->cached_data_produced_string(),
         Boolean::New(isolate, cached_data_produced)).IsNothing()) return;
+  }
+
+  // Report if cache was rejected.
+  if (options == ScriptCompiler::kConsumeCodeCache) {
+    if (fun->Set(parsing_context,
+                 env->cached_data_rejected_string(),
+                 Boolean::New(isolate, source.GetCachedData()->rejected))
+            .IsNothing())
+      return;
   }
 
   args.GetReturnValue().Set(fun);


### PR DESCRIPTION
Modify the NativeModule class to use compileFunction instead of manually
wrapping the string source code and then compiling it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @devsnek @bcoe 
