### PR TITLE
repl: support top-level for-await-of

### DIFF
--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -11,6 +11,12 @@ const visitorsWithoutAncestors = {
     }
     walk.base.ClassDeclaration(node, state, c);
   },
+  ForOfStatement(node, state, c) {
+    if (node.await === true) {
+      state.containsAwait = true;
+    }
+    walk.base.ForOfStatement(node, state, c);
+  },
   FunctionDeclaration(node, state, c) {
     state.prepend(node, `${node.id.name}=`);
   },

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -130,7 +130,8 @@ async function ordinaryTests() {
     [ 'let o = await 1, p', 'undefined' ],
     [ 'p', 'undefined' ],
     [ 'let q = 1, s = await 2', 'undefined' ],
-    [ 's', '2' ]
+    [ 's', '2' ],
+    [ 'for await (let i of [1,2,3]) console.log(i)', 'undefined', { line: 3 } ]
   ];
 
   for (const [input, expected, options = {}] of testCases) {


### PR DESCRIPTION
Resolves https://github.com/nodejs/node/issues/23836.

Ensures that visitors check for a for-of statement with `await: true` so that `state.containsAwait` is then properly handled.

/cc @devsnek

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
