### PR TITLE
src: improve StreamBase write throughput

### DIFF
--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -6,7 +6,7 @@ const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  len: [102400, 1024 * 1024 * 16],
+  len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 });

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -6,7 +6,7 @@ const net = require('net');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  len: [102400, 1024 * 1024 * 16],
+  len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 });

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -5,7 +5,7 @@ const common = require('../common.js');
 const PORT = common.PORT;
 
 const bench = common.createBenchmark(main, {
-  len: [102400, 1024 * 1024 * 16],
+  len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 });

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -5,7 +5,7 @@ const common = require('../common.js');
 const { PassThrough } = require('stream');
 
 const bench = common.createBenchmark(main, {
-  len: [102400, 1024 * 1024 * 16],
+  len: [64, 102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
 }, {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -26,6 +26,7 @@ const {
   WriteWrap,
   kReadBytesOrError,
   kArrayBufferOffset,
+  kLastWriteWasAsync,
   streamBaseState
 } = internalBinding('stream_wrap');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
@@ -717,10 +718,10 @@ function setupChannel(target, channel) {
     }
 
     var req = new WriteWrap();
-    req.async = false;
 
     var string = JSON.stringify(message) + '\n';
     var err = channel.writeUtf8String(req, string, handle);
+    var wasAsyncWrite = streamBaseState[kLastWriteWasAsync];
 
     if (err === 0) {
       if (handle) {
@@ -730,7 +731,7 @@ function setupChannel(target, channel) {
           obj.postSend(message, handle, options, callback, target);
       }
 
-      if (req.async) {
+      if (wasAsyncWrite) {
         req.oncomplete = function() {
           control.unref();
           if (typeof callback === 'function')

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -6,6 +6,8 @@ const {
   WriteWrap,
   kReadBytesOrError,
   kArrayBufferOffset,
+  kBytesWritten,
+  kLastWriteWasAsync,
   streamBaseState
 } = internalBinding('stream_wrap');
 const { UV_EOF } = internalBinding('uv');
@@ -20,7 +22,10 @@ function handleWriteReq(req, data, encoding) {
 
   switch (encoding) {
     case 'buffer':
-      return handle.writeBuffer(req, data);
+      const ret = handle.writeBuffer(req, data);
+      if (streamBaseState[kLastWriteWasAsync])
+        req.buffer = data;
+      return ret;
     case 'latin1':
     case 'binary':
       return handle.writeLatin1String(req, data);
@@ -35,7 +40,7 @@ function handleWriteReq(req, data, encoding) {
     case 'utf-16le':
       return handle.writeUcs2String(req, data);
     default:
-      return handle.writeBuffer(req, Buffer.from(data, encoding));
+      return handleWriteReq(req, Buffer.from(data, encoding), 'buffer');
   }
 }
 
@@ -45,6 +50,8 @@ function createWriteWrap(handle, oncomplete) {
   req.handle = handle;
   req.oncomplete = oncomplete;
   req.async = false;
+  req.bytes = 0;
+  req.buffer = null;
 
   return req;
 }
@@ -80,6 +87,9 @@ function writeGeneric(self, req, data, encoding, cb) {
 }
 
 function afterWriteDispatched(self, req, err, cb) {
+  req.bytes = streamBaseState[kBytesWritten];
+  req.async = !!streamBaseState[kLastWriteWasAsync];
+
   if (err !== 0)
     return self.destroy(errnoException(err, 'write', req.error), cb);
 

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -22,10 +22,12 @@ function handleWriteReq(req, data, encoding) {
 
   switch (encoding) {
     case 'buffer':
+    {
       const ret = handle.writeBuffer(req, data);
       if (streamBaseState[kLastWriteWasAsync])
         req.buffer = data;
       return ret;
+    }
     case 'latin1':
     case 'binary':
       return handle.writeLatin1String(req, data);
@@ -40,7 +42,13 @@ function handleWriteReq(req, data, encoding) {
     case 'utf-16le':
       return handle.writeUcs2String(req, data);
     default:
-      return handleWriteReq(req, Buffer.from(data, encoding), 'buffer');
+    {
+      const buffer = Buffer.from(data, encoding);
+      const ret = handle.writeBuffer(req, buffer);
+      if (streamBaseState[kLastWriteWasAsync])
+        req.buffer = buffer;
+      return ret;
+    }
   }
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -125,10 +125,8 @@ struct PackageConfig {
   V(address_string, "address")                                                \
   V(aliases_string, "aliases")                                                \
   V(args_string, "args")                                                      \
-  V(async, "async")                                                           \
   V(async_ids_stack_string, "async_ids_stack")                                \
   V(buffer_string, "buffer")                                                  \
-  V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(bytes_read_string, "bytesRead")                                           \
   V(bytes_written_string, "bytesWritten")                                     \

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -332,12 +332,16 @@ class StreamBase : public StreamResource {
   enum StreamBaseStateFields {
     kReadBytesOrError,
     kArrayBufferOffset,
+    kBytesWritten,
+    kLastWriteWasAsync,
     kNumStreamBaseStateFields
   };
 
  private:
   Environment* env_;
   EmitToJSStreamListener default_listener_;
+
+  void SetWriteResult(const StreamWriteResult& res);
 
   friend class WriteWrap;
   friend class ShutdownWrap;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -83,6 +83,8 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
 
   NODE_DEFINE_CONSTANT(target, kReadBytesOrError);
   NODE_DEFINE_CONSTANT(target, kArrayBufferOffset);
+  NODE_DEFINE_CONSTANT(target, kBytesWritten);
+  NODE_DEFINE_CONSTANT(target, kLastWriteWasAsync);
   target->Set(context, FIXED_ONE_BYTE_STRING(env->isolate(), "streamBaseState"),
               env->stream_base_state().GetJSArray()).FromJust();
 }

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -239,7 +239,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
       const err = handle.writeLatin1String(wreq, 'hi'.repeat(100000));
       if (err)
         throw new Error(`write failed: ${getSystemErrorName(err)}`);
-      if (!wreq.async) {
+      if (!stream_wrap.streamBaseState[stream_wrap.kLastWriteWasAsync]) {
         testUninitialized(wreq, 'WriteWrap');
         // Synchronous finish. Write more data until we hit an
         // asynchronous write.


### PR DESCRIPTION
Improve performance by transferring information about write status
to JS through an `AliasedBuffer`, rather than object properties
set from C++.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
