### PR TITLE
src: avoid extra `Persistent` in `DefaultTriggerAsyncIdScope`

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -186,20 +186,20 @@ inline void Environment::AsyncHooks::clear_async_id_stack() {
 inline Environment::AsyncHooks::DefaultTriggerAsyncIdScope
   ::DefaultTriggerAsyncIdScope(Environment* env,
                                double default_trigger_async_id)
-    : async_id_fields_ref_(env->async_hooks()->async_id_fields()) {
+    : async_hooks_(env->async_hooks()) {
   if (env->async_hooks()->fields()[AsyncHooks::kCheck] > 0) {
     CHECK_GE(default_trigger_async_id, 0);
   }
 
   old_default_trigger_async_id_ =
-    async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId];
-  async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId] =
+    async_hooks_->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId];
+  async_hooks_->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] =
     default_trigger_async_id;
 }
 
 inline Environment::AsyncHooks::DefaultTriggerAsyncIdScope
   ::~DefaultTriggerAsyncIdScope() {
-  async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId] =
+  async_hooks_->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] =
     old_default_trigger_async_id_;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -487,7 +487,7 @@ class Environment {
       ~DefaultTriggerAsyncIdScope();
 
      private:
-      AliasedBuffer<double, v8::Float64Array> async_id_fields_ref_;
+      AsyncHooks* async_hooks_;
       double old_default_trigger_async_id_;
 
       DISALLOW_COPY_AND_ASSIGN(DefaultTriggerAsyncIdScope);


### PR DESCRIPTION
Instead of getting a reference to the main `AliasedBuffer`, which
would always unnecesarily allocate and destroy a `Persistent`
handle, store and use a reference to the owning object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
