### PR TITLE
src: avoid `std::make_unique` for now

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -193,7 +193,7 @@ Environment::Environment(IsolateData* isolate_data,
   AssignToContext(context, ContextInfo(""));
 
   if (tracing::AgentWriterHandle* writer = GetTracingAgentWriter()) {
-    trace_state_observer_ = std::make_unique<TrackingTraceStateObserver>(this);
+    trace_state_observer_.reset(new TrackingTraceStateObserver(this));
     v8::TracingController* tracing_controller = writer->GetTracingController();
     if (tracing_controller != nullptr)
       tracing_controller->AddTraceStateObserver(trace_state_observer_.get());


### PR DESCRIPTION
This broke Travis CI. We have run into this problem with
`std::make_unique` in the past, and opted to not use it
for now, e.g. in https://github.com/nodejs/node/pull/20386.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
