### PR TITLE
test: add a test for "tls.Socket" with "StreamWrap" and "allowHalfOpen"

### DIFF
--- a/test/parallel/test-tls-net-socket-keepalive.js
+++ b/test/parallel/test-tls-net-socket-keepalive.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+const net = require('net');
+
+// This test ensures that when tls sockets are created with `allowHalfOpen`,
+// they won't hang.
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
+const options = {
+  key,
+  cert,
+  ca: [ca],
+};
+
+const server = tls.createServer(options, common.mustCall((conn) => {
+  conn.write('hello');
+  conn.on('data', common.mustCall());
+  conn.end();
+})).listen(0, common.mustCall(() => {
+  const netSocket = new net.Socket({
+    allowHalfOpen: true,
+  });
+
+  const socket = tls.connect({
+    socket: netSocket,
+    rejectUnauthorized: false,
+  });
+
+  const { port, address } = server.address();
+
+  // Doing `net.Socket.connect()` after `tls.connect()` will make tls module
+  // wrap the socket in StreamWrap.
+  netSocket.connect({
+    port,
+    address,
+  });
+
+  socket.on('end', common.mustCall());
+  socket.on('data', common.mustCall());
+  socket.on('close', common.mustCall(() => {
+    server.close();
+  }));
+
+  socket.write('hello');
+  socket.end();
+}));


### PR DESCRIPTION
~A tls client socket using `StreamWrap` with `allowHalfOpen` option might hang instead of exiting automatically because the 'drain' event may not be emitted. This commit corrects it by making `StreamWrap` try `doShutdown` in `finishWrite`.~

~Before this commit, running the following test will make processes hang.~

This test ensures that a tls client socket using `StreamWrap` with `allowHalfOpen` option won't hang.

Refs: #23654

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
