### PR TITLE
lib: remove useless null assignment

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1062,9 +1062,7 @@ const win32 = {
 
 
   sep: '\\',
-  delimiter: ';',
-  win32: null,
-  posix: null
+  delimiter: ';'
 };
 
 
@@ -1520,9 +1518,7 @@ const posix = {
 
 
   sep: '/',
-  delimiter: ':',
-  win32: null,
-  posix: null
+  delimiter: ':'
 };
 
 


### PR DESCRIPTION
Is it useless to assign null to `win32.win32` & 'win32.posix' & `posix.win32` & `posix.posix` since they are be assigned ultimately ?

> posix.win32 = win32.win32 = win32;
> posix.posix = win32.posix = posix; 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
