### PR TITLE
Fix test regression for OpenSSL compiled with FIPS

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -34,7 +34,7 @@ assert(/^\d+\.\d+\.\d+(?:\.\d+)?-node\.\d+(?: \(candidate\))?$/
 assert(/^\d+$/.test(process.versions.modules));
 
 if (common.hasCrypto) {
-  assert(/^\d+\.\d+\.\d+[a-z]?$/.test(process.versions.openssl));
+  assert(/^\d+\.\d+\.\d+[a-z]?(-fips)?$/.test(process.versions.openssl));
 }
 
 for (let i = 0; i < expected_keys.length; i++) {


### PR DESCRIPTION
In commit bff53c5a9d6, a check was added for very specific OpenSSL
format. Unfortunately, when OpenSSL is compiled in FIPS mode, this
check fails. Added additional regex to satisfy OpenSSL version
strings in both regular and FIPS modes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
