### PR TITLE
[v10.x] Revert buffer crash

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -341,22 +341,16 @@ Object.defineProperties(
       value: 'TextEncoder'
     } });
 
-const { hasConverter, TextDecoder } =
+const TextDecoder =
   process.binding('config').hasIntl ?
     makeTextDecoderICU() :
     makeTextDecoderJS();
-
-function hasTextDecoder(encoding = 'utf-8') {
-  validateArgument(encoding, 'string', 'encoding', 'string');
-  return hasConverter(getEncodingFromLabel(encoding));
-}
 
 function makeTextDecoderICU() {
   const {
     decode: _decode,
     getConverter,
-    hasConverter
-  } = process.binding('icu');
+  } = internalBinding('icu');
 
   class TextDecoder {
     constructor(encoding = 'utf-8', options = {}) {
@@ -409,7 +403,7 @@ function makeTextDecoderICU() {
     }
   }
 
-  return { hasConverter, TextDecoder };
+  return TextDecoder;
 }
 
 function makeTextDecoderJS() {
@@ -497,7 +491,7 @@ function makeTextDecoderJS() {
     }
   }
 
-  return { hasConverter, TextDecoder };
+  return TextDecoder;
 }
 
 // Mix in some shared properties.
@@ -552,7 +546,6 @@ function makeTextDecoderJS() {
 
 module.exports = {
   getEncodingFromLabel,
-  hasTextDecoder,
   TextDecoder,
   TextEncoder
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -2217,10 +2217,11 @@ void DebugProcess(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Invalid number of arguments.");
   }
 
-  CHECK(args[0]->IsNumber());
-  pid_t pid = args[0].As<Integer>()->Value();
-  int r = kill(pid, SIGUSR1);
+  pid_t pid;
+  int r;
 
+  pid = args[0]->IntegerValue();
+  r = kill(pid, SIGUSR1);
   if (r != 0) {
     return env->ThrowErrnoException(errno, "kill");
   }
@@ -2262,8 +2263,7 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
       CloseHandle(mapping);
   });
 
-  CHECK(args[0]->IsNumber());
-  pid = args[0].As<Integer>()->Value();
+  pid = (DWORD) args[0]->IntegerValue();
 
   process = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
                             PROCESS_VM_OPERATION | PROCESS_VM_WRITE |

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -170,8 +170,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
     return true;
   }
 
-  CHECK(arg->IsNumber());
-  int64_t tmp_i = arg.As<Integer>()->Value();
+  int64_t tmp_i = arg->IntegerValue();
 
   if (tmp_i < 0)
     return false;
@@ -772,7 +771,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   Local<String> needle = args[1].As<String>();
-  int64_t offset_i64 = args[2].As<Integer>()->Value();
+  int64_t offset_i64 = args[2]->IntegerValue();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -888,7 +887,7 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(Environment::GetCurrent(args), args[1]);
   SPREAD_BUFFER_ARG(args[0], ts_obj);
   SPREAD_BUFFER_ARG(args[1], buf);
-  int64_t offset_i64 = args[2].As<Integer>()->Value();
+  int64_t offset_i64 = args[2]->IntegerValue();
   bool is_forward = args[4]->IsTrue();
 
   const char* haystack = ts_obj_data;
@@ -958,7 +957,7 @@ void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
   SPREAD_BUFFER_ARG(args[0], ts_obj);
 
   uint32_t needle = args[1].As<Uint32>()->Value();
-  int64_t offset_i64 = args[2].As<Integer>()->Value();
+  int64_t offset_i64 = args[2]->IntegerValue();
   bool is_forward = args[3]->IsTrue();
 
   int64_t opt_offset = IndexOfOffset(ts_obj_length, offset_i64, 1, is_forward);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -977,16 +977,15 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetOptions(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
-  int64_t val;
 
-  if (args.Length() != 1 ||
-      !args[0]->IntegerValue(args.GetIsolate()->GetCurrentContext()).To(&val)) {
+  if (args.Length() != 1 || !args[0]->IntegerValue()) {
     return THROW_ERR_INVALID_ARG_TYPE(
         sc->env(), "Options must be an integer value");
   }
 
-  SSL_CTX_set_options(sc->ctx_.get(),
-                      static_cast<long>(val));  // NOLINT(runtime/int)
+  SSL_CTX_set_options(
+      sc->ctx_.get(),
+      static_cast<long>(args[0]->IntegerValue()));  // NOLINT(runtime/int)
 }
 
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -289,16 +289,12 @@ class Parser : public AsyncWrap, public StreamListener {
     MaybeLocal<Value> head_response =
         MakeCallback(cb.As<Function>(), arraysize(argv), argv);
 
-    int64_t val;
-
-    if (head_response.IsEmpty() || !head_response.ToLocalChecked()
-                                        ->IntegerValue(env()->context())
-                                        .To(&val)) {
+    if (head_response.IsEmpty()) {
       got_exception_ = true;
       return -1;
     }
 
-    return val;
+    return head_response.ToLocalChecked()->IntegerValue();
   }
 
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -128,9 +128,8 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream = StreamForWrap(env, stdio);
       } else {
         Local<String> fd_key = env->fd_string();
-        Local<Value> fd_value = stdio->Get(context, fd_key).ToLocalChecked();
-        CHECK(fd_value->IsNumber());
-        int fd = static_cast<int>(fd_value.As<Integer>()->Value());
+        int fd = static_cast<int>(
+            stdio->Get(context, fd_key).ToLocalChecked()->IntegerValue());
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
       }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -207,10 +207,7 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
-  int64_t val;
-  if (!args[0]->IntegerValue(args.GetIsolate()->GetCurrentContext()).To(&val))
-    return;
-  int fd = static_cast<int>(val);
+  int fd = static_cast<int>(args[0]->IntegerValue());
   int err = uv_tcp_open(&wrap->handle_, fd);
 
   if (err == 0)

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -19,6 +19,17 @@ let cntr = 0;
 }
 
 {
+  // Current behavior is to coerce values to integers.
+  b.fill(++cntr);
+  c.fill(++cntr);
+  const copied = b.copy(c, '0', '0', '512');
+  assert.strictEqual(copied, 512);
+  for (let i = 0; i < c.length; i++) {
+    assert.strictEqual(c[i], b[i]);
+  }
+}
+
+{
   // copy c into b, without specifying sourceEnd
   b.fill(++cntr);
   c.fill(++cntr);
@@ -144,3 +155,13 @@ assert.strictEqual(b.copy(c, 512, 0, 10), 0);
     assert.strictEqual(c[i], e[i]);
   }
 }
+
+// https://github.com/nodejs/node/issues/23668: Do not crash for invalid input.
+c.fill('c');
+b.copy(c, 'not a valid offset');
+// Make sure this acted like a regular copy with `0` offset.
+assert.deepStrictEqual(c, b.slice(0, c.length));
+
+assert.throws(() => {
+  b.copy(c, { [Symbol.toPrimitive]() { throw new Error('foo'); } });
+}, /foo/);


### PR DESCRIPTION
Patch for the node10 branch

This reverts https://github.com/nodejs/node/commit/2555cb4a4049dc4c41d8a2f4ce50909cc0a12a4a that introduced a native crash, and adds the regression test authored for (https://github.com/nodejs/node/pull/23795)

Refs: https://github.com/nodejs/node/pull/23795
Refs: https://github.com/nodejs/node/pull/22129
Fixes: https://github.com/nodejs/node/issues/23668



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
