### PR TITLE
src: minor refactor to node_errors.h

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -41,7 +41,7 @@
 #define THROW_AND_RETURN_IF_OOB(r)                                          \
   do {                                                                      \
     if (!(r))                                                               \
-      return node::THROW_ERR_OUT_OF_RANGE(env,  "Index out of range");      \
+      return node::THROW_ERR_OUT_OF_RANGE(env, "Index out of range");       \
   } while (0)                                                               \
 
 #define SLICE_START_END(start_arg, end_arg, end_max)                        \

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -41,8 +41,7 @@
 #define THROW_AND_RETURN_IF_OOB(r)                                          \
   do {                                                                      \
     if (!(r))                                                               \
-      return node::THROW_ERR_OUT_OF_RANGE_WITH_TEXT(env,                    \
-                                                    "Index out of range");  \
+      return node::THROW_ERR_OUT_OF_RANGE(env,  "Index out of range");      \
   } while (0)                                                               \
 
 #define SLICE_START_END(start_arg, end_arg, end_max)                        \
@@ -494,7 +493,7 @@ void Copy(const FunctionCallbackInfo<Value> &args) {
     return args.GetReturnValue().Set(0);
 
   if (source_start > ts_obj_length)
-    return node::THROW_ERR_OUT_OF_RANGE_WITH_TEXT(
+    return THROW_ERR_OUT_OF_RANGE(
         env, "The value of \"sourceStart\" is out of range.");
 
   if (source_end - source_start > target_length - target_start)
@@ -685,10 +684,10 @@ void CompareOffset(const FunctionCallbackInfo<Value> &args) {
   THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[5], ts_obj_length, &source_end));
 
   if (source_start > ts_obj_length)
-    return node::THROW_ERR_OUT_OF_RANGE_WITH_TEXT(
+    return THROW_ERR_OUT_OF_RANGE(
         env, "The value of \"sourceStart\" is out of range.");
   if (target_start > target_length)
-    return node::THROW_ERR_OUT_OF_RANGE_WITH_TEXT(
+    return THROW_ERR_OUT_OF_RANGE(
         env, "The value of \"targetStart\" is out of range.");
 
   CHECK_LE(source_start, source_end);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -52,8 +52,11 @@ namespace node {
            js_code).FromJust();                                               \
     return e;                                                                 \
   }                                                                           \
+  inline void THROW_ ## code(v8::Isolate* isolate, const char* message) {     \
+    isolate->ThrowException(code(isolate, message));                          \
+  }                                                                           \
   inline void THROW_ ## code(Environment* env, const char* message) {         \
-    env->isolate()->ThrowException(code(env->isolate(), message));            \
+    THROW_ ## code(env->isolate(), message);                                  \
   }
   ERRORS_WITH_CODE(V)
 #undef V
@@ -80,8 +83,11 @@ namespace node {
   inline v8::Local<v8::Value> code(v8::Isolate* isolate) {                   \
     return code(isolate, message);                                           \
   }                                                                          \
+  inline void THROW_ ## code(v8::Isolate* isolate) {                         \
+    isolate->ThrowException(code(isolate, message));                         \
+  }                                                                          \
   inline void THROW_ ## code(Environment* env) {                             \
-    env->isolate()->ThrowException(code(env->isolate(), message));           \
+    THROW_ ## code(env->isolate());                                          \
   }
   PREDEFINED_ERROR_MESSAGES(V)
 #undef V
@@ -93,13 +99,6 @@ inline void THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(Environment* env,
   message << "Script execution timed out after ";
   message << timeout << "ms";
   THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(env, message.str().c_str());
-}
-
-inline void THROW_ERR_OUT_OF_RANGE_WITH_TEXT(Environment* env,
-                                             const char* messageText) {
-  std::ostringstream message;
-  message << messageText;
-  THROW_ERR_OUT_OF_RANGE(env, message.str().c_str());
 }
 
 inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {


### PR DESCRIPTION
Add overloads of the error generation/throwing methods
that take an `Isolate*` argument, since the created objects
don’t depend on the `Environment*` in question.

Also, remove `THROW_ERR_OUT_OF_RANGE_WITH_TEXT`, which did the
same thing as `THROW_ERR_OUT_OF_RANGE` in a more convoluted way.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
