### PR TITLE
doc: update missing deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2264,8 +2264,8 @@ undocumented `COUNTER_NET_SERVER_CONNECTION()`,
 `COUNTER_HTTP_SERVER_RESPONSE()`, `COUNTER_HTTP_CLIENT_REQUEST()`, and
 `COUNTER_HTTP_CLIENT_RESPONSE()` functions have been deprecated.
 
-<a id="DEP00XX"></a>
-### DEP00XX: net._setSimultaneousAccepts()
+<a id="DEP0121"></a>
+### DEP0121: net._setSimultaneousAccepts()
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/lib/net.js
+++ b/lib/net.js
@@ -1677,7 +1677,7 @@ if (process.platform === 'win32') {
     if (warnSimultaneousAccepts) {
       process.emitWarning(
         'net._setSimultaneousAccepts() is deprecated and will be removed.',
-        'DeprecationWarning', 'DEP00XX');
+        'DeprecationWarning', 'DEP0121');
       warnSimultaneousAccepts = false;
     }
     if (handle === undefined) {
@@ -1699,7 +1699,7 @@ if (process.platform === 'win32') {
     if (warnSimultaneousAccepts) {
       process.emitWarning(
         'net._setSimultaneousAccepts() is deprecated and will be removed.',
-        'DeprecationWarning', 'DEP00XX');
+        'DeprecationWarning', 'DEP0121');
       warnSimultaneousAccepts = false;
     }
   };

--- a/test/parallel/test-net-deprecated-setsimultaneousaccepts.js
+++ b/test/parallel/test-net-deprecated-setsimultaneousaccepts.js
@@ -11,6 +11,6 @@ const {
 expectWarning(
   'DeprecationWarning',
   'net._setSimultaneousAccepts() is deprecated and will be removed.',
-  'DEP00XX');
+  'DEP0121');
 
 _setSimultaneousAccepts();


### PR DESCRIPTION
The deprecation code was not updated when landing the PR.

Refs: https://github.com/nodejs/node/pull/23760

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
