### PR TITLE
doc: remove "idiomatic choice" from queueMicrotask

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -122,7 +122,6 @@ The `queueMicrotask()` method queues a microtask to invoke `callback`. If
 `callback` throws an exception, the [`process` object][] `'uncaughtException'`
 event will be emitted.
 
-In general, `queueMicrotask` is the idiomatic choice over `process.nextTick()`.
 `process.nextTick()` will always run before the microtask queue, and so
 unexpected execution order may be observed.
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -122,8 +122,10 @@ The `queueMicrotask()` method queues a microtask to invoke `callback`. If
 `callback` throws an exception, the [`process` object][] `'uncaughtException'`
 event will be emitted.
 
-`process.nextTick()` will always run before the microtask queue, and so
-unexpected execution order may be observed.
+The microtask queue is managed by V8 and may be used in a similar manner to
+the `process.nextTick()` queue, which is managed by Node.js. The
+`process.nextTick()` queue is always processed before the microtask queue
+within each turn of the Node.js event loop.
 
 ```js
 // Here, `queueMicrotask()` is used to ensure the 'load' event is always


### PR DESCRIPTION
It can't be idiomatic if it's not in general use and therefore hasn't
been picked up by users. It's not even in browsers yet.

"Idiomatic" use is an emergent property that comes from observed use
and this feature is so new (to browsers and Node) that it can't
possibly be. In general I don't think it's the place of the Node API
docs to observe what emerges as idiomatic Node.js.

It also can't be a recommended feature (if that was the intent of the
language) because it's marked experimental. For now, it's just a
feature, nothing more. Recommendations and/or observations about it
being 'idiomatic' can come later.