### PR TITLE
fs: refactor to not rely on write only permission for lchmod

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -35,7 +35,7 @@ const {
   R_OK,
   W_OK,
   X_OK,
-  O_WRONLY,
+  O_RDONLY,
   O_SYMLINK
 } = constants;
 
@@ -987,7 +987,7 @@ function fchmodSync(fd, mode) {
 
 function lchmod(path, mode, callback) {
   callback = maybeCallback(callback);
-  fs.open(path, O_WRONLY | O_SYMLINK, function(err, fd) {
+  fs.open(path, O_RDONLY | O_SYMLINK, function(err, fd) {
     if (err) {
       callback(err);
       return;
@@ -1003,7 +1003,7 @@ function lchmod(path, mode, callback) {
 }
 
 function lchmodSync(path, mode) {
-  const fd = fs.openSync(path, O_WRONLY | O_SYMLINK);
+  const fd = fs.openSync(path, O_RDONLY | O_SYMLINK);
 
   // Prefer to return the chmod error, if one occurs,
   // but still try to close, and report closing errors if they occur.

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -3,7 +3,7 @@
 const {
   F_OK,
   O_SYMLINK,
-  O_WRONLY,
+  O_RDONLY,
   S_IFMT,
   S_IFREG
 } = internalBinding('constants').fs;
@@ -400,7 +400,7 @@ async function lchmod(path, mode) {
   if (O_SYMLINK === undefined)
     throw new ERR_METHOD_NOT_IMPLEMENTED('lchmod()');
 
-  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  const fd = await open(path, O_RDONLY | O_SYMLINK);
   return fchmod(fd, mode).finally(fd.close.bind(fd));
 }
 


### PR DESCRIPTION
Refactor to remove the use of O_WRONLY for lchmod, lchmodSync and promisified lchmod.
Fixes: https://github.com/nodejs/node/issues/23736

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)