### PR TITLE
lib: refactor constant in querystring

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -84,21 +84,21 @@ function unescapeBuffer(s, decodeSpaces) {
   var hasHex = false;
   while (index < s.length) {
     currentChar = s.charCodeAt(index);
-    if (currentChar === CHAR_PLUS /* '+' */ && decodeSpaces) {
-      out[outIndex++] = CHAR_SPACE; // ' '
+    if (currentChar === CHAR_PLUS && decodeSpaces) {
+      out[outIndex++] = CHAR_SPACE;
       index++;
       continue;
     }
-    if (currentChar === CHAR_PERCENT /* '%' */ && index < maxLength) {
+    if (currentChar === CHAR_PERCENT && index < maxLength) {
       currentChar = s.charCodeAt(++index);
       hexHigh = unhexTable[currentChar];
       if (!(hexHigh >= 0)) {
-        out[outIndex++] = CHAR_PERCENT; // '%'
+        out[outIndex++] = CHAR_PERCENT;
       } else {
         nextChar = s.charCodeAt(++index);
         hexLow = unhexTable[nextChar];
         if (!(hexLow >= 0)) {
-          out[outIndex++] = CHAR_PERCENT; // '%'
+          out[outIndex++] = CHAR_PERCENT;
           out[outIndex++] = currentChar;
           currentChar = nextChar;
         } else {
@@ -262,8 +262,8 @@ function charCodes(str) {
     ret[ret.length] = str.charCodeAt(i);
   return ret;
 }
-const defSepCodes = [CHAR_AMPERSAND]; // &
-const defEqCodes = [CHAR_EQUAL]; // =
+const defSepCodes = [CHAR_AMPERSAND];
+const defEqCodes = [CHAR_EQUAL];
 
 // Parse a key/val string.
 function parse(qs, sep, eq, options) {
@@ -373,7 +373,7 @@ function parse(qs, sep, eq, options) {
           if (!keyEncoded) {
             // Try to match an (valid) encoded byte once to minimize unnecessary
             // calls to string decoding functions
-            if (code === CHAR_PERCENT /* % */) {
+            if (code === CHAR_PERCENT) {
               encodeCheck = 1;
               continue;
             } else if (encodeCheck > 0) {
@@ -388,7 +388,7 @@ function parse(qs, sep, eq, options) {
             }
           }
         }
-        if (code === CHAR_PLUS /* + */) {
+        if (code === CHAR_PLUS) {
           if (lastPos < i)
             key += qs.slice(lastPos, i);
           key += plusChar;
@@ -396,7 +396,7 @@ function parse(qs, sep, eq, options) {
           continue;
         }
       }
-      if (code === CHAR_PLUS /* + */) {
+      if (code === CHAR_PLUS) {
         if (lastPos < i)
           value += qs.slice(lastPos, i);
         value += plusChar;
@@ -404,7 +404,7 @@ function parse(qs, sep, eq, options) {
       } else if (!valEncoded) {
         // Try to match an (valid) encoded byte (once) to minimize unnecessary
         // calls to string decoding functions
-        if (code === CHAR_PERCENT /* % */) {
+        if (code === CHAR_PERCENT) {
           encodeCheck = 1;
         } else if (encodeCheck > 0) {
           // eslint-disable-next-line no-extra-boolean-cast

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -29,6 +29,14 @@ const {
   hexTable,
   isHexTable
 } = require('internal/querystring');
+const {
+  CHAR_SPACE,
+  CHAR_PERCENT,
+  CHAR_AMPERSAND,
+  CHAR_PLUS,
+  CHAR_EQUAL
+} = require('internal/constants');
+
 const QueryString = module.exports = {
   unescapeBuffer,
   // `unescape()` is a JS global, so we need to use a different local name
@@ -76,21 +84,21 @@ function unescapeBuffer(s, decodeSpaces) {
   var hasHex = false;
   while (index < s.length) {
     currentChar = s.charCodeAt(index);
-    if (currentChar === 43 /* '+' */ && decodeSpaces) {
-      out[outIndex++] = 32; // ' '
+    if (currentChar === CHAR_PLUS /* '+' */ && decodeSpaces) {
+      out[outIndex++] = CHAR_SPACE; // ' '
       index++;
       continue;
     }
-    if (currentChar === 37 /* '%' */ && index < maxLength) {
+    if (currentChar === CHAR_PERCENT /* '%' */ && index < maxLength) {
       currentChar = s.charCodeAt(++index);
       hexHigh = unhexTable[currentChar];
       if (!(hexHigh >= 0)) {
-        out[outIndex++] = 37; // '%'
+        out[outIndex++] = CHAR_PERCENT; // '%'
       } else {
         nextChar = s.charCodeAt(++index);
         hexLow = unhexTable[nextChar];
         if (!(hexLow >= 0)) {
-          out[outIndex++] = 37; // '%'
+          out[outIndex++] = CHAR_PERCENT; // '%'
           out[outIndex++] = currentChar;
           currentChar = nextChar;
         } else {
@@ -254,8 +262,8 @@ function charCodes(str) {
     ret[ret.length] = str.charCodeAt(i);
   return ret;
 }
-const defSepCodes = [38]; // &
-const defEqCodes = [61]; // =
+const defSepCodes = [CHAR_AMPERSAND]; // &
+const defEqCodes = [CHAR_EQUAL]; // =
 
 // Parse a key/val string.
 function parse(qs, sep, eq, options) {
@@ -365,7 +373,7 @@ function parse(qs, sep, eq, options) {
           if (!keyEncoded) {
             // Try to match an (valid) encoded byte once to minimize unnecessary
             // calls to string decoding functions
-            if (code === 37/* % */) {
+            if (code === CHAR_PERCENT /* % */) {
               encodeCheck = 1;
               continue;
             } else if (encodeCheck > 0) {
@@ -380,7 +388,7 @@ function parse(qs, sep, eq, options) {
             }
           }
         }
-        if (code === 43/* + */) {
+        if (code === CHAR_PLUS /* + */) {
           if (lastPos < i)
             key += qs.slice(lastPos, i);
           key += plusChar;
@@ -388,7 +396,7 @@ function parse(qs, sep, eq, options) {
           continue;
         }
       }
-      if (code === 43/* + */) {
+      if (code === CHAR_PLUS /* + */) {
         if (lastPos < i)
           value += qs.slice(lastPos, i);
         value += plusChar;
@@ -396,7 +404,7 @@ function parse(qs, sep, eq, options) {
       } else if (!valEncoded) {
         // Try to match an (valid) encoded byte (once) to minimize unnecessary
         // calls to string decoding functions
-        if (code === 37/* % */) {
+        if (code === CHAR_PERCENT /* % */) {
           encodeCheck = 1;
         } else if (encodeCheck > 0) {
           // eslint-disable-next-line no-extra-boolean-cast


### PR DESCRIPTION
Refactor: use constant from `internal/constant`.
I think maybe it makes more readable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
