### PR TITLE
doc: add decode & encode method in querystring.md

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -13,6 +13,20 @@ query strings. It can be accessed using:
 const querystring = require('querystring');
 ```
 
+## querystring.decode()
+<!-- YAML
+added: v0.1.99
+-->
+
+The `querystring.decode()` function is an alias for `querystring.parse()`.
+
+## querystring.encode()
+<!-- YAML
+added: v0.1.99
+-->
+
+The `querystring.encode()` function is an alias for `querystring.stringify()`.
+
 ## querystring.escape(str)
 <!-- YAML
 added: v0.1.25


### PR DESCRIPTION
I found there are `querystring.decode` method and `querystring.encode` in the [querystring.js](https://github.com/nodejs/node/blob/master/lib/querystring.js) but they are not shown on the document. So maybe we need to add these right ?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
