### PR TITLE
src: use "constants" string instead of creating new one

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3111,7 +3111,7 @@ HTTP_STATUS_CODES(V)
   env->SetMethod(target, "packSettings", PackSettings);
 
   target->Set(context,
-              FIXED_ONE_BYTE_STRING(isolate, "constants"),
+              env->constants_string(),
               constants).FromJust();
   target->Set(context,
               FIXED_ONE_BYTE_STRING(isolate, "nameForErrorCode"),

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -109,7 +109,7 @@ void PipeWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, UV_READABLE);
   NODE_DEFINE_CONSTANT(constants, UV_WRITABLE);
   target->Set(context,
-              FIXED_ONE_BYTE_STRING(env->isolate(), "constants"),
+              env->constants_string(),
               constants).FromJust();
 }
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -124,7 +124,7 @@ void TCPWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, SOCKET);
   NODE_DEFINE_CONSTANT(constants, SERVER);
   target->Set(context,
-              FIXED_ONE_BYTE_STRING(env->isolate(), "constants"),
+              env->constants_string(),
               constants).FromJust();
 }
 


### PR DESCRIPTION
I think it's ok to create them separately but it would be better if we use the same one especially when they have the exact same semantics.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
