### PR TITLE
deps: fix shim for `v8::Value::IntegerValue()`

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -3901,7 +3901,7 @@ double Value::NumberValue() const {
 
 
 int64_t Value::IntegerValue() const {
-  return NumberValue(Isolate::GetCurrent()->GetCurrentContext())
+  return IntegerValue(Isolate::GetCurrent()->GetCurrentContext())
       .FromMaybe(0);
 }
 


### PR DESCRIPTION
This was introduced in 48d1335bbc100. Previously, values such as
`undefined` would not be coerced properly because `NumberValue()`
returns `NaN` for them.

Refs: https://github.com/nodejs/node/pull/23158

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
