### PR TITLE
lib: remove useless cwd in posix.resolve

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1073,16 +1073,13 @@ const posix = {
   resolve: function resolve() {
     var resolvedPath = '';
     var resolvedAbsolute = false;
-    var cwd;
 
     for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
       var path;
       if (i >= 0)
         path = arguments[i];
       else {
-        if (cwd === undefined)
-          cwd = process.cwd();
-        path = cwd;
+        path = process.cwd();
       }
 
       assertPath(path);


### PR DESCRIPTION
It seems that variable `cwd` is useless in `posix.resolve()` method.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
