### PR TITLE
docs: fix LOAD_AS_FILE in cjs high-level doc

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -152,19 +152,20 @@ require(X) from module at path Y
 3. If X begins with './' or '/' or '../'
    a. LOAD_AS_FILE(Y + X)
    b. LOAD_AS_DIRECTORY(Y + X)
+   c. LOAD_AS_FILE_EXT(Y + X)
 4. LOAD_NODE_MODULES(X, dirname(Y))
 5. THROW "not found"
 
 LOAD_AS_FILE(X)
 1. If X is a file, load X as JavaScript text.  STOP
+
+LOAD_AS_FILE_EXT(X)
 2. If X.js is a file, load X.js as JavaScript text.  STOP
 3. If X.json is a file, parse X.json to a JavaScript Object.  STOP
 4. If X.node is a file, load X.node as binary addon.  STOP
 
 LOAD_INDEX(X)
-1. If X/index.js is a file, load X/index.js as JavaScript text.  STOP
-2. If X/index.json is a file, parse X/index.json to a JavaScript object. STOP
-3. If X/index.node is a file, load X/index.node as binary addon.  STOP
+1. LOAD_AS_FILE_EXT(X/index)
 
 LOAD_AS_DIRECTORY(X)
 1. If X/package.json is a file,


### PR DESCRIPTION
Hey folks. I've been re-implementing cjs external to node and fixing this one point in particular would have saved some bugs.

this pr breaks up LOAD_AS_FILE into 2 stages.
LOAD_AS_FILE only finds an exact file.
LOAD_AS_FILE_EXT finds the file with supported file extension types added.

the implementation is here
https://github.com/nodejs/node/blob/master/lib/internal/modules/cjs/loader.js#L283
reading the directory is done before scanning for files by extension but after exact match checking.

this behavior is covered by the test
https://github.com/nodejs/node/blob/master/test/parallel/test-require-extensions-same-filename-as-dir.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
