### PR TITLE
inspector: add promisified inspector module

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -149,6 +149,118 @@ by V8. Chrome DevTools Protocol domain provides an interface for interacting
 with one of the runtime agents used to inspect the application state and listen
 to the run-time events.
 
+## Inspector Promises API
+<!-- YAML
+added: vX.Y.0
+-->
+
+> Stability: 1 - Experimental
+
+The `inspector.promises` API provides an alternative set of asynchronous inspector methods
+that return `Promise` objects rather than using callbacks. The API is accessible
+via `require('inspector').promises`. Since callbacks are used only with Session objects,
+other parts of the API don't differ from `require('inspector')`.
+
+## Class: inspector.Session
+
+The `inspector.Session` is used for dispatching messages to the V8 inspector
+back-end and receiving message responses and notifications.
+
+### Constructor: new inspector.Session()
+<!-- YAML
+added: vX.Y.0
+-->
+
+Create a new instance of the `inspector.promises.Session` class. The inspector session
+needs to be connected through [`session.connect()`][] before the messages
+can be dispatched to the inspector backend.
+
+`inspector.promises.Session` is an [`EventEmitter`][] with the following events:
+
+### Event: 'inspectorNotification'
+<!-- YAML
+added: vX.Y.0
+-->
+
+* {Object} The notification message object
+
+Emitted when any notification from the V8 Inspector is received.
+
+```js
+session.on('inspectorNotification', (message) => console.log(message.method));
+// Debugger.paused
+// Debugger.resumed
+```
+
+It is also possible to subscribe only to notifications with specific method:
+
+### Event: &lt;inspector-protocol-method&gt;
+<!-- YAML
+added: vX.Y.0
+-->
+
+* {Object} The notification message object
+
+Emitted when an inspector notification is received that has its method field set
+to the `<inspector-protocol-method>` value.
+
+The following snippet installs a listener on the [`'Debugger.paused'`][]
+event, and prints the reason for program suspension whenever program
+execution is suspended (through breakpoints, for example):
+
+```js
+session.on('Debugger.paused', ({ params }) => {
+  console.log(params.hitBreakpoints);
+});
+// [ '/the/file/that/has/the/breakpoint.js:11:0' ]
+```
+
+### session.connect()
+<!-- YAML
+added: vX.Y.0
+-->
+
+Connects a session to the inspector back-end. An exception will be thrown
+if there is already a connected session established either through the API or by
+a front-end connected to the Inspector WebSocket port.
+
+### session.disconnect()
+<!-- YAML
+added: vX.Y.0
+-->
+
+Immediately close the session. All pending message promises will be rejected. 
+[`session.connect()`] will need to be called to be able to send
+messages again. Reconnected session will lose all inspector state, such as
+enabled agents or configured breakpoints.
+
+### session.post(method[, params])
+<!-- YAML
+added: v8.0.0
+-->
+
+* `method` {string}
+* `params` {Object}
+
+Posts a message to the inspector back-end. 
+
+```js
+async function postRuntimeEvaluate() {
+  const expression = '2 + 2';
+  const { result } = await session.post('Runtime.evaluate', { expression });
+  console.log(result);
+}
+// Output: { type: 'number', value: 4, description: '4' }
+```
+
+The latest version of the V8 inspector protocol is published on the
+[Chrome DevTools Protocol Viewer][].
+
+Node inspector supports all the Chrome DevTools Protocol domains declared
+by V8. Chrome DevTools Protocol domain provides an interface for interacting
+with one of the runtime agents used to inspect the application state and listen
+to the run-time events.
+
 ## Example usage
 
 ### CPU Profiler
@@ -177,8 +289,34 @@ session.post('Profiler.enable', () => {
 });
 ```
 
+It is also possible to use V8 Profilers with the experimental [Promises API][]:
+
+```js
+const { Session } = require('inspector').promises;
+const fs = require('fs').promises;
+const session = new inspector.Session();
+session.connect();
+
+async function main() {
+  await session.post('Profiler.enable');
+  await session.post('Profiler.start');
+  // invoke business logic under measurement here...
+
+  // some time later...
+  const { profile } = await session.post('Profiler.stop');
+  // write profile to disk, upload, etc.
+  await fs.writeFile('./profile.cpuprofile', JSON.stringify(profile));
+}
+
+main();
+```
+
+Apart from the debugger, various V8 Profilers are available through the DevTools
+protocol. Here's a simple example showing how to use the [CPU profiler][]:
+
 [`'Debugger.paused'`]: https://chromedevtools.github.io/devtools-protocol/v8/Debugger#event-paused
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`session.connect()`]: #inspector_session_connect
 [Chrome DevTools Protocol Viewer]: https://chromedevtools.github.io/devtools-protocol/v8/
 [CPU Profiler]: https://chromedevtools.github.io/devtools-protocol/v8/Profiler
+[Promises API]: #inspector_inspector_promises_api

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -151,7 +151,7 @@ to the run-time events.
 
 ## Inspector Promises API
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 > Stability: 1 - Experimental
@@ -168,7 +168,7 @@ back-end and receiving message responses and notifications.
 
 ### Constructor: new inspector.Session()
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 Create a new instance of the `inspector.promises.Session` class. The inspector session
@@ -179,7 +179,7 @@ can be dispatched to the inspector backend.
 
 ### Event: 'inspectorNotification'
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 * {Object} The notification message object
@@ -196,7 +196,7 @@ It is also possible to subscribe only to notifications with specific method:
 
 ### Event: &lt;inspector-protocol-method&gt;
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 * {Object} The notification message object
@@ -217,7 +217,7 @@ session.on('Debugger.paused', ({ params }) => {
 
 ### session.connect()
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 Connects a session to the inspector back-end. An exception will be thrown
@@ -226,7 +226,7 @@ a front-end connected to the Inspector WebSocket port.
 
 ### session.disconnect()
 <!-- YAML
-added: vX.Y.0
+added: REPLACEME
 -->
 
 Immediately close the session. All pending message promises will be rejected. 
@@ -236,7 +236,7 @@ enabled agents or configured breakpoints.
 
 ### session.post(method[, params])
 <!-- YAML
-added: v8.0.0
+added: REPLACEME
 -->
 
 * `method` {string}
@@ -256,7 +256,7 @@ async function postRuntimeEvaluate() {
 The latest version of the V8 inspector protocol is published on the
 [Chrome DevTools Protocol Viewer][].
 
-Node inspector supports all the Chrome DevTools Protocol domains declared
+Node.js inspector supports all the Chrome DevTools Protocol domains declared
 by V8. Chrome DevTools Protocol domain provides an interface for interacting
 with one of the runtime agents used to inspect the application state and listen
 to the run-time events.
@@ -310,9 +310,6 @@ async function main() {
 
 main();
 ```
-
-Apart from the debugger, various V8 Profilers are available through the DevTools
-protocol. Here's a simple example showing how to use the [CPU profiler][]:
 
 [`'Debugger.paused'`]: https://chromedevtools.github.io/devtools-protocol/v8/Debugger#event-paused
 [`EventEmitter`]: events.html#events_class_eventemitter

--- a/lib/internal/inspector/promises.js
+++ b/lib/internal/inspector/promises.js
@@ -3,11 +3,9 @@
 const {
   ERR_INSPECTOR_CLOSED,
   ERR_INSPECTOR_NOT_CONNECTED,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_CALLBACK
+  ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
-const util = require('util');
 const { url } = process.binding('inspector');
 const { originalConsole } = require('internal/process/per_thread');
 const {
@@ -18,22 +16,24 @@ const {
   nextIdSymbol
 } = require('internal/inspector/utils');
 
-const messageCallbacksSymbol = Symbol('messageCallbacks');
+const messagePromisesSymbol = Symbol('messagePromises');
 
 class Session extends BaseSession {
   constructor() {
     super();
-    this[messageCallbacksSymbol] = new Map();
+    this[messagePromisesSymbol] = new Map();
   }
 
   [onMessageSymbol](message) {
     const parsed = JSON.parse(message);
     try {
       if (parsed.id) {
-        const callback = this[messageCallbacksSymbol].get(parsed.id);
-        this[messageCallbacksSymbol].delete(parsed.id);
-        if (callback)
-          callback(parsed.error || null, parsed.result || null);
+        const fn = this[messagePromisesSymbol].get(parsed.id);
+        this[messagePromisesSymbol].delete(parsed.id);
+        if (parsed.error)
+          fn.reject(parsed.error);
+        else
+          fn.resolve(parsed.result);
       } else {
         this.emit(parsed.method, parsed);
         this.emit('inspectorNotification', parsed);
@@ -43,17 +43,10 @@ class Session extends BaseSession {
     }
   }
 
-  post(method, params, callback) {
+  async post(method, params) {
     validateString(method, 'method');
-    if (!callback && util.isFunction(params)) {
-      callback = params;
-      params = null;
-    }
     if (params && typeof params !== 'object') {
       throw new ERR_INVALID_ARG_TYPE('params', 'Object', params);
-    }
-    if (callback && typeof callback !== 'function') {
-      throw new ERR_INVALID_CALLBACK();
     }
 
     if (!this[connectionSymbol]) {
@@ -64,10 +57,19 @@ class Session extends BaseSession {
     if (params) {
       message.params = params;
     }
-    if (callback) {
-      this[messageCallbacksSymbol].set(id, callback);
-    }
+
+    const fn = {
+      resolve: null,
+      reject: null,
+    };
+    const p = new Promise((resolve, reject) => {
+      fn.resolve = resolve;
+      fn.reject = reject;
+    });
+    this[messagePromisesSymbol].set(id, fn);
+
     this[connectionSymbol].dispatch(JSON.stringify(message));
+    return p;
   }
 
   disconnect() {
@@ -75,11 +77,11 @@ class Session extends BaseSession {
       return;
     this[connectionSymbol].disconnect();
     this[connectionSymbol] = null;
-    const remainingCallbacks = this[messageCallbacksSymbol].values();
-    for (const callback of remainingCallbacks) {
-      process.nextTick(callback, new ERR_INSPECTOR_CLOSED());
+    const remainingPromises = this[messagePromisesSymbol].values();
+    for (const fn of remainingPromises) {
+      fn.reject(new ERR_INSPECTOR_CLOSED());
     }
-    this[messageCallbacksSymbol].clear();
+    this[messagePromisesSymbol].clear();
     this[nextIdSymbol] = 1;
   }
 }
@@ -91,22 +93,3 @@ module.exports = {
   console: originalConsole,
   Session
 };
-
-let promisesWarn = true;
-let promises = null;
-
-Object.defineProperties(module.exports, {
-  promises: {
-    configurable: true,
-    enumerable: false,
-    get() {
-      if (promisesWarn) {
-        promises = require('internal/inspector/promises');
-        promisesWarn = false;
-        process.emitWarning('The inspector.promises API is experimental',
-                            'ExperimentalWarning');
-      }
-      return promises;
-    }
-  }
-});

--- a/lib/internal/inspector/utils.js
+++ b/lib/internal/inspector/utils.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const EventEmitter = require('events');
+const {
+  ERR_INSPECTOR_ALREADY_CONNECTED,
+  ERR_INSPECTOR_NOT_AVAILABLE
+} = require('internal/errors').codes;
+const { Connection, open } = process.binding('inspector');
+
+if (!Connection)
+  throw new ERR_INSPECTOR_NOT_AVAILABLE();
+
+const connectionSymbol = Symbol('connectionProperty');
+const nextIdSymbol = Symbol('nextId');
+const onMessageSymbol = Symbol('onMessage');
+
+class BaseSession extends EventEmitter {
+  constructor() {
+    super();
+    this[connectionSymbol] = null;
+    this[nextIdSymbol] = 1;
+  }
+
+  connect() {
+    if (this[connectionSymbol])
+      throw new ERR_INSPECTOR_ALREADY_CONNECTED('The inspector session');
+    const connection =
+      new Connection((message) => this[onMessageSymbol](message));
+    if (connection.sessionAttached) {
+      throw new ERR_INSPECTOR_ALREADY_CONNECTED('Another inspector session');
+    }
+    this[connectionSymbol] = connection;
+  }
+}
+
+module.exports = {
+  open: (port, host, wait) => open(port, host, !!wait),
+  connectionSymbol,
+  onMessageSymbol,
+  nextIdSymbol,
+  BaseSession
+};

--- a/node.gyp
+++ b/node.gyp
@@ -122,6 +122,8 @@
       'lib/internal/fs/watchers.js',
       'lib/internal/http.js',
       'lib/internal/inspector_async_hook.js',
+      'lib/internal/inspector/promises.js',
+      'lib/internal/inspector/utils.js',
       'lib/internal/linkedlist.js',
       'lib/internal/modules/cjs/helpers.js',
       'lib/internal/modules/cjs/loader.js',

--- a/test/parallel/test-inspector-multisession-js.js
+++ b/test/parallel/test-inspector-multisession-js.js
@@ -76,11 +76,11 @@ async function promiseTest() {
   session1.on('Debugger.paused', () => session1Paused = true);
   session2.on('Debugger.paused', () => session2Paused = true);
 
-  console.log('Connected');
+  // console.log('Connected');
 
   session1.post('Debugger.enable');
   session2.post('Debugger.enable');
-  console.log('Debugger was enabled');
+  // console.log('Debugger was enabled');
 
   await session1.post('Debugger.setBreakpointByUrl', {
     'lineNumber': 12,
@@ -88,18 +88,18 @@ async function promiseTest() {
     'columnNumber': 0,
     'condition': ''
   });
-  console.log('Breakpoint was set');
+  // console.log('Breakpoint was set');
 
   debugged();
 
   // Both sessions will receive the paused event
   assert(session1Paused);
   assert(session2Paused);
-  console.log('Breakpoint was hit');
+  // console.log('Breakpoint was hit');
 
   session1.disconnect();
   session2.disconnect();
-  console.log('Sessions were disconnected');
+  // console.log('Sessions were disconnected');
 }
 
 promiseTest();

--- a/test/parallel/test-inspector-multisession-js.js
+++ b/test/parallel/test-inspector-multisession-js.js
@@ -6,6 +6,7 @@ common.skipIfInspectorDisabled();
 
 const assert = require('assert');
 const { Session } = require('inspector');
+const PromiseSession = require('inspector').promises.Session;
 const path = require('path');
 const { pathToFileURL } = require('url');
 
@@ -61,3 +62,44 @@ test().then(() => {
   clearInterval(interval);
   console.log('Done!');
 });
+
+async function promiseTest() {
+  const session1 = new PromiseSession();
+  const session2 = new PromiseSession();
+
+  session1.connect();
+  session2.connect();
+
+  let session1Paused = false;
+  let session2Paused = false;
+
+  session1.on('Debugger.paused', () => session1Paused = true);
+  session2.on('Debugger.paused', () => session2Paused = true);
+
+  console.log('Connected');
+
+  session1.post('Debugger.enable');
+  session2.post('Debugger.enable');
+  console.log('Debugger was enabled');
+
+  await session1.post('Debugger.setBreakpointByUrl', {
+    'lineNumber': 12,
+    'url': pathToFileURL(path.resolve(__dirname, __filename)).toString(),
+    'columnNumber': 0,
+    'condition': ''
+  });
+  console.log('Breakpoint was set');
+
+  debugged();
+
+  // Both sessions will receive the paused event
+  assert(session1Paused);
+  assert(session2Paused);
+  console.log('Breakpoint was hit');
+
+  session1.disconnect();
+  session2.disconnect();
+  console.log('Sessions were disconnected');
+}
+
+promiseTest();

--- a/test/parallel/test-inspector-multisession-ws.js
+++ b/test/parallel/test-inspector-multisession-ws.js
@@ -36,7 +36,7 @@ session.on('Debugger.paused', () => {
 });
 session.connect();
 session.post('Debugger.enable');
-console.log('Ready');
+// console.log('Ready');
 `;
 
 async function setupSession(node) {

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -98,7 +98,7 @@ async function promiseTest() {
   assert(traceNotification.data.value.length > 0);
   assert(tracingComplete);
   clearInterval(interval);
-  console.log('Success');
+  // console.log('Success');
 }
 
 promiseTest();

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -7,24 +7,12 @@ common.skipIfWorker(); // https://github.com/nodejs/node/issues/22767
 
 const assert = require('assert');
 const { Session } = require('inspector');
-
-const session = new Session();
+const PromiseSession = require('inspector').promises.Session;
 
 function compareIgnoringOrder(array1, array2) {
   const set = new Set(array1);
   const test = set.size === array2.length && array2.every((el) => set.has(el));
   assert.ok(test, `[${array1}] differs from [${array2}]`);
-}
-
-function post(message, data) {
-  return new Promise((resolve, reject) => {
-    session.post(message, data, (err, result) => {
-      if (err)
-        reject(new Error(JSON.stringify(err)));
-      else
-        resolve(result);
-    });
-  });
 }
 
 function generateTrace() {
@@ -37,6 +25,19 @@ function generateTrace() {
 }
 
 async function test() {
+  const session = new Session();
+
+  function post(message, data) {
+    return new Promise((resolve, reject) => {
+      session.post(message, data, (err, result) => {
+        if (err)
+          reject(new Error(JSON.stringify(err)));
+        else
+          resolve(result);
+      });
+    });
+  }
+
   // This interval ensures Node does not terminate till the test is finished.
   // Inspector session does not keep the node process running (e.g. it does not
   // have async handles on the main event loop). It is debatable whether this
@@ -67,3 +68,37 @@ async function test() {
 }
 
 test();
+
+async function promiseTest() {
+  const session = new PromiseSession();
+
+  // This interval ensures Node does not terminate till the test is finished.
+  // Inspector session does not keep the node process running (e.g. it does not
+  // have async handles on the main event loop). It is debatable whether this
+  // should be considered a bug, and there are no plans to fix it atm.
+  const interval = setInterval(() => {}, 5000);
+  session.connect();
+  let traceNotification = null;
+  let tracingComplete = false;
+  session.on('NodeTracing.dataCollected', (n) => traceNotification = n);
+  session.on('NodeTracing.tracingComplete', () => tracingComplete = true);
+  const { categories } = await session.post('NodeTracing.getCategories');
+  compareIgnoringOrder(['node', 'node.async', 'node.bootstrap', 'node.fs.sync',
+                        'node.perf', 'node.perf.usertiming',
+                        'node.perf.timerify', 'v8'],
+                       categories);
+
+  const traceConfig = { includedCategories: ['v8'] };
+  await session.post('NodeTracing.start', { traceConfig });
+
+  for (let i = 0; i < 5; i++)
+    await generateTrace();
+  JSON.stringify(await session.post('NodeTracing.stop', { traceConfig }));
+  session.disconnect();
+  assert(traceNotification.data.value.length > 0);
+  assert(tracingComplete);
+  clearInterval(interval);
+  console.log('Success');
+}
+
+promiseTest();


### PR DESCRIPTION
The `inspector` module has only one method which receives a callback, but it seems like a good candidate for promisification since we even promisify it in our tests. I still have to update some tests in `tests/sequential/`, but I'm opening early to gather feedback while I work on those.   

The goal here is to follow the same approach used in `fs` and `dns` (`require('inspect').promises`, lazy loading, experimental warning, etc.).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
