### PR TITLE
tls: deprecate undocumented tlsSocket.ssl property, add docs

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2301,7 +2301,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-The undocumented `tlsSocket.ssl` property has been deprecated.
+`tlsSocket.ssl` is deprecated.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2292,6 +2292,16 @@ Type: Runtime
 
 Please use `Server.prototype.setSecureContext()` instead.
 
+<a id="DEP00XX"></a>
+### DEP00XX: TLSSocket.prototype.ssl
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/23915
+    description: Runtime deprecation.
+-->
+
+The undocumented `tlsSocket.ssl` property has been deprecated.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -56,6 +56,7 @@ const kErrorEmitted = Symbol('error-emitted');
 const kHandshakeTimeout = Symbol('handshake-timeout');
 const kRes = Symbol('res');
 const kSNICallback = Symbol('snicallback');
+const kSSL = Symbol('ssl');
 
 const noop = () => {};
 
@@ -325,7 +326,17 @@ function TLSSocket(socket, opts) {
   });
 
   // Proxy for API compatibility
-  this.ssl = this._handle;
+  this[kSSL] = this._handle;
+  Object.defineProperty(this, 'ssl', {
+    enumerable: true,
+    configurable: true,
+    get: util.deprecate(() => this[kSSL],
+                        'The tlsSocket.ssl property is deprecated.',
+                        'DEP00XX'),
+    set: util.deprecate((val) => this[kSSL] = val,
+                        'The tlsSocket.ssl property is deprecated.',
+                        'DEP00XX')
+  });
 
   this.on('error', this._tlsError);
 
@@ -366,8 +377,8 @@ for (var n = 0; n < proxiedMethods.length; n++) {
 tls_wrap.TLSWrap.prototype.close = function close(cb) {
   let ssl;
   if (this[owner_symbol]) {
-    ssl = this[owner_symbol].ssl;
-    this[owner_symbol].ssl = null;
+    ssl = this[owner_symbol][kSSL];
+    this[owner_symbol][kSSL] = null;
   }
 
   // Invoke `destroySSL` on close to clean up possibly pending write requests
@@ -457,13 +468,13 @@ function destroySSL(self) {
 }
 
 TLSSocket.prototype._destroySSL = function _destroySSL() {
-  if (!this.ssl) return;
-  this.ssl.destroySSL();
-  if (this.ssl._secureContext.singleUse) {
-    this.ssl._secureContext.context.close();
-    this.ssl._secureContext.context = null;
+  if (!this[kSSL]) return;
+  this[kSSL].destroySSL();
+  if (this[kSSL]._secureContext.singleUse) {
+    this[kSSL]._secureContext.context.close();
+    this[kSSL]._secureContext.context = null;
   }
-  this.ssl = null;
+  this[kSSL] = null;
 };
 
 TLSSocket.prototype._init = function(socket, wrap) {
@@ -584,6 +595,12 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   }
 
   return true;
+};
+
+TLSSocket.prototype.verifyError = function verifyError(...args) {
+  if (this.destroyed)
+    return;
+  return this._handle.verifyError(...args);
 };
 
 TLSSocket.prototype.setMaxSendFragment = function setMaxSendFragment(size) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -56,7 +56,7 @@ const kErrorEmitted = Symbol('error-emitted');
 const kHandshakeTimeout = Symbol('handshake-timeout');
 const kRes = Symbol('res');
 const kSNICallback = Symbol('snicallback');
-const kSSL = Symbol('ssl');
+const kHandle = Symbol('ssl');
 
 const noop = () => {};
 
@@ -326,14 +326,14 @@ function TLSSocket(socket, opts) {
   });
 
   // Proxy for API compatibility
-  this[kSSL] = this._handle;
+  this[kHandle] = this._handle;
   Object.defineProperty(this, 'ssl', {
     enumerable: true,
     configurable: true,
-    get: util.deprecate(() => this[kSSL],
+    get: util.deprecate(() => this[kHandle],
                         'The tlsSocket.ssl property is deprecated.',
                         'DEP00XX'),
-    set: util.deprecate((val) => this[kSSL] = val,
+    set: util.deprecate((val) => this[kHandle] = val,
                         'The tlsSocket.ssl property is deprecated.',
                         'DEP00XX')
   });
@@ -377,8 +377,8 @@ for (var n = 0; n < proxiedMethods.length; n++) {
 tls_wrap.TLSWrap.prototype.close = function close(cb) {
   let ssl;
   if (this[owner_symbol]) {
-    ssl = this[owner_symbol][kSSL];
-    this[owner_symbol][kSSL] = null;
+    ssl = this[owner_symbol][kHandle];
+    this[owner_symbol][kHandle] = null;
   }
 
   // Invoke `destroySSL` on close to clean up possibly pending write requests
@@ -468,13 +468,13 @@ function destroySSL(self) {
 }
 
 TLSSocket.prototype._destroySSL = function _destroySSL() {
-  if (!this[kSSL]) return;
-  this[kSSL].destroySSL();
-  if (this[kSSL]._secureContext.singleUse) {
-    this[kSSL]._secureContext.context.close();
-    this[kSSL]._secureContext.context = null;
+  if (!this[kHandle]) return;
+  this[kHandle].destroySSL();
+  if (this[kHandle]._secureContext.singleUse) {
+    this[kHandle]._secureContext.context.close();
+    this[kHandle]._secureContext.context = null;
   }
-  this[kSSL] = null;
+  this[kHandle] = null;
 };
 
 TLSSocket.prototype._init = function(socket, wrap) {

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -61,7 +61,7 @@ function test(client, callback) {
         this.end('hello');
       }))
       .on('secure', common.mustCall(function() {
-        callback(this.ssl.verifyError());
+        callback(this.verifyError());
       }));
   });
 }

--- a/test/parallel/test-tls-socket-ssl-deprecated.js
+++ b/test/parallel/test-tls-socket-ssl-deprecated.js
@@ -1,0 +1,31 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const key = fixtures.readKey('agent2-key.pem');
+const cert = fixtures.readKey('agent2-cert.pem');
+
+const server = tls.createServer({ key, cert }, (socket) => {
+  socket.ssl;  // This should trigger a deprecation warning
+  socket.setEncoding('utf8');
+  socket.pipe(socket);
+});
+server.listen(0, () => {
+  const options = { rejectUnauthorized: false };
+  const socket =
+    tls.connect(server.address().port, options, common.mustCall(() => {
+      socket.end('hello');
+    }));
+  socket.resume();
+  socket.on('end', () => server.close());
+});
+
+common.expectWarning('DeprecationWarning',
+                     'The tlsSocket.ssl property is deprecated.',
+                     'DEP00XX');

--- a/test/parallel/test-tls-tlswrap-segfault.js
+++ b/test/parallel/test-tls-tlswrap-segfault.js
@@ -31,8 +31,8 @@ const server = tls.createServer(options, function(s) {
 
 function putImmediate(client) {
   setImmediate(function() {
-    if (client.ssl) {
-      const fd = client.ssl.fd;
+    if (client._handle) {
+      const fd = client._handle.fd;
       assert(!!fd);
       putImmediate(client);
     } else {


### PR DESCRIPTION
Updated take on https://github.com/nodejs/node/pull/10846

Fixes: https://github.com/nodejs/node/issues/10555

/cc @sam-github 

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
