### PR TITLE
net: `net.Server.listen()` avoid operations on `null` when fail

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1435,6 +1435,13 @@ Server.prototype.listen = function(...args) {
     backlog = options.backlog || backlogFromArgs;
     listenInCluster(this, pipeName, -1, -1,
                     backlog, undefined, options.exclusive);
+
+    if (!this._handle) {
+      // Failed and an error shall be emitted in the next tick.
+      // Therefore, we directly return.
+      return this;
+    }
+
     let mode = 0;
     if (options.readableAll === true)
       mode |= PipeConstants.UV_READABLE;

--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -69,3 +69,17 @@ function randomPipePath() {
       srv.close();
     }));
 }
+
+// Test should emit "error" events when listening fails.
+{
+  const srv = net.createServer()
+    .listen({
+      path: tmpdir.path,
+      writableAll: true,
+    }, common.mustNotCall());
+
+  srv.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'EADDRINUSE');
+    assert(/^listen EADDRINUSE: address already in use/.test(err.message));
+  }));
+}


### PR DESCRIPTION
When `net.Server` fails to create a new handle, an error shall be emitted in the next tick. Therefore, we make `net.Server.listen()` directly  return to avoid following operations on `null` `this._handle`.

Fixes: https://github.com/nodejs/node/issues/23917

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
