### PR TITLE
take ownership of prepareStackTrace for upstream v8 changes

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -35,6 +35,8 @@
 // passed by node::RunBootstrapping()
 /* global process, require, internalBinding, isMainThread, ownsProcessState */
 
+setupPrepareStackTrace();
+
 const { JSON, Object, Symbol } = primordials;
 const config = internalBinding('config');
 const { deprecate } = require('internal/util');
@@ -288,6 +290,12 @@ process.emitWarning = emitWarning;
   // - processTimers will be run in the callback of the per-Environment timer.
   setupTimers(processImmediate, processTimers);
   // Note: only after this point are the timers effective
+}
+
+function setupPrepareStackTrace() {
+  const { setPrepareStackTraceCallback } = internalBinding('errors');
+  const { prepareStackTrace } = require('internal/errors');
+  setPrepareStackTraceCallback(prepareStackTrace);
 }
 
 function setupProcessObject() {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -19,6 +19,31 @@ const codes = {};
 
 const { kMaxLength } = internalBinding('buffer');
 
+const MainContextError = Error;
+const ErrorToString = Error.prototype.toString;
+// Polyfill of V8's Error.prepareStackTrace API.
+// https://crbug.com/v8/7848
+const prepareStackTrace = (globalThis, error, trace) => {
+  // `globalThis` is the global that contains the constructor which
+  // created `error`.
+  if (typeof globalThis.Error.prepareStackTrace === 'function') {
+    return globalThis.Error.prepareStackTrace(error, trace);
+  }
+  // We still have legacy usage that depends on the main context's `Error`
+  // being used, even when the error is from a different context.
+  // TODO(devsnek): evaluate if this can be eventually deprecated/removed.
+  if (typeof MainContextError.prepareStackTrace === 'function') {
+    return MainContextError.prepareStackTrace(error, trace);
+  }
+
+  const errorString = ErrorToString.call(error);
+  if (trace.length === 0) {
+    return errorString;
+  }
+  return `${errorString}\n    at ${trace.join('\n    at ')}`;
+};
+
+
 let excludedStackFn;
 
 // Lazily loaded
@@ -598,7 +623,8 @@ module.exports = {
   uvExceptionWithHostPort,
   SystemError,
   // This is exported only to facilitate testing.
-  E
+  E,
+  prepareStackTrace,
 };
 
 // To declare an error message, use the E(sym, val, def) function above. The sym

--- a/src/env.h
+++ b/src/env.h
@@ -402,6 +402,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(native_module_require, v8::Function)                                       \
   V(performance_entry_callback, v8::Function)                                  \
   V(performance_entry_template, v8::Function)                                  \
+  V(prepare_stack_trace_callback, v8::Function)                                \
   V(process_object, v8::Object)                                                \
   V(primordials, v8::Object)                                                   \
   V(promise_reject_callback, v8::Function)                                     \

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -48,6 +48,7 @@
   V(contextify)                                                                \
   V(credentials)                                                               \
   V(domain)                                                                    \
+  V(errors)                                                                    \
   V(fs)                                                                        \
   V(fs_event_wrap)                                                             \
   V(heap_utils)                                                                \

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -17,6 +17,7 @@ using v8::Boolean;
 using v8::Context;
 using v8::Exception;
 using v8::Function;
+using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Int32;
 using v8::Isolate;
@@ -767,6 +768,21 @@ void PerIsolateMessageListener(Local<Message> message, Local<Value> error) {
   }
 }
 
+void SetPrepareStackTraceCallback(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsFunction());
+  env->set_prepare_stack_trace_callback(args[0].As<Function>());
+}
+
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
+                void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+  env->SetMethod(
+      target, "setPrepareStackTraceCallback", SetPrepareStackTraceCallback);
+}
+
 }  // namespace errors
 
 void DecorateErrorStack(Environment* env,
@@ -880,3 +896,5 @@ void FatalException(Isolate* isolate,
 }
 
 }  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(errors, node::errors::Initialize)

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -9,6 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const expectedModules = new Set([
+  'Internal Binding errors',
   'Internal Binding async_wrap',
   'Internal Binding buffer',
   'Internal Binding config',


### PR DESCRIPTION
These changes exist for a few reasons:
- We have a double-decoration problem where people need to use `process.binding('util')` to stop node from decorating errors if they want to do their own thing.
- V8 is making upstream changes to Error.prepareStackTrace which scope it per-context and can't land those until we fix how we handle Error.prepareStackTrace in repl
- Error stack decoration was not very consistent, as it pinged around between two methods in C++ and JS that had to be called in the correct order

Closes #21958

/cc @BridgeAR @joyeecheung @bmeck @jdalton @mmarchini @ljharb
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
