### PR TITLE
doc: remove mailing list

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -61,4 +61,3 @@
 <div class="line"></div>
 
 * [GitHub Repo & Issue Tracker](https://github.com/nodejs/node)
-* [Mailing List](https://groups.google.com/forum/#!forum/nodejs)

--- a/doc/node.1
+++ b/doc/node.1
@@ -399,10 +399,6 @@ GitHub repository & Issue Tracker:
 .Sy https://github.com/nodejs/node
 .
 .Pp
-Mailing list:
-.Sy http://groups.google.com/group/nodejs
-.
-.Pp
 IRC (general questions):
 .Sy "chat.freenode.net #node.js"
 (unofficial)


### PR DESCRIPTION
We removed the mailing list from the README and other places quite some
time ago. Core devs don't monitor it much. However, it is still linked
in a couple places in the docs directory. Remove those links.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
