### PR TITLE
src: fix CreatePlatform header param mismatch

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -100,14 +100,15 @@
 // Forward-declare libuv loop
 struct uv_loop_s;
 
-// Forward-declare TracingController, used by CreatePlatform.
-namespace v8 {
-class TracingController;
-}
-
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h
 namespace node {
+
+namespace tracing {
+
+class TracingController;
+
+}
 
 NODE_EXTERN v8::Local<v8::Value> ErrnoException(v8::Isolate* isolate,
                                                 int errorno,
@@ -275,7 +276,7 @@ NODE_EXTERN MultiIsolatePlatform* GetMainThreadMultiIsolatePlatform();
 
 NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
-    v8::TracingController* tracing_controller);
+    node::tracing::TracingController* tracing_controller);
 MultiIsolatePlatform* InitializeV8Platform(int thread_pool_size);
 NODE_EXTERN void FreePlatform(MultiIsolatePlatform* platform);
 


### PR DESCRIPTION
This PR forward-declares `node::tracing::TracingController` instead of `v8::TracingController` to correct for the existing mismatch in parameters between MultiIsolatePlatform `CreatePlatform` in the header and impl. It can cause inconsistencies in exported symbols. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)