### PR TITLE
deps: float 99540ec from openssl (CVE-2018-0735)

### DIFF
--- a/deps/openssl/openssl/crypto/ec/ec_mult.c
+++ b/deps/openssl/openssl/crypto/ec/ec_mult.c
@@ -177,8 +177,8 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
      */
     cardinality_bits = BN_num_bits(cardinality);
     group_top = bn_get_top(cardinality);
-    if ((bn_wexpand(k, group_top + 1) == NULL)
-        || (bn_wexpand(lambda, group_top + 1) == NULL))
+    if ((bn_wexpand(k, group_top + 2) == NULL)
+        || (bn_wexpand(lambda, group_top + 2) == NULL))
         goto err;
 
     if (!BN_copy(k, scalar))
@@ -205,7 +205,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
      * k := scalar + 2*cardinality
      */
     kbit = BN_is_bit_set(lambda, cardinality_bits);
-    BN_consttime_swap(kbit, k, lambda, group_top + 1);
+    BN_consttime_swap(kbit, k, lambda, group_top + 2);
 
     group_top = bn_get_top(group->field);
     if ((bn_wexpand(s->X, group_top) == NULL)


### PR DESCRIPTION
Low severity timing vulnerability in ECDSA signature generation. Publicly disclosed but unreleased, pending OpenSSL 1.1.0j.

This is for master, 10.x and 11.x, should cherry-pick without problem.

There is a version of this for 1.0.2 @ https://github.com/openssl/openssl/pull/7513 but as yet it's unreviewed so we shouldn't jump the gun.

I don't think we need to rush a release out for this, but it should certainly go out with whatever the next releases are for 10 and 11, security or standard.

/cc @nodejs/crypto @nodejs/release 

Ref: https://www.openssl.org/news/secadv/20181029.txt
Ref: https://github.com/openssl/openssl/pull/7486
PR-URL: https://github.com/nodejs/node/pull/???
Upstream: https://github.com/openssl/openssl/commit/99540ec

Original commit message:

    Timing vulnerability in ECDSA signature generation (CVE-2018-0735)

    Preallocate an extra limb for some of the big numbers to avoid a reallocation
    that can potentially provide a side channel.

    Reviewed-by: Bernd Edlinger <bernd.edlinger@hotmail.de>
    (Merged from https://github.com/openssl/openssl/pull/7486)