### PR TITLE
v8 module: allow TypedArray and DataView

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -185,7 +185,7 @@ Uses a [`DefaultSerializer`][] to serialize `value` into a buffer.
 added: v8.0.0
 -->
 
-* `buffer` {Buffer|Uint8Array} A buffer returned by [`serialize()`][].
+* `buffer` {Buffer|TypedArray|DataView} A buffer returned by [`serialize()`][].
 
 Uses a [`DefaultDeserializer`][] with default options to read a JS value
 from a buffer.
@@ -252,7 +252,7 @@ For use inside of a custom [`serializer._writeHostObject()`][].
 
 #### serializer.writeRawBytes(buffer)
 
-* `buffer` {Buffer|Uint8Array}
+* `buffer` {Buffer|TypedArray|DataView}
 
 Write raw bytes into the serializer’s internal buffer. The deserializer
 will require a way to compute the length of the buffer.
@@ -308,7 +308,7 @@ added: v8.0.0
 
 #### new Deserializer(buffer)
 
-* `buffer` {Buffer|Uint8Array} A buffer returned by
+* `buffer` {Buffer|TypedArray|DataView} A buffer returned by
   [`serializer.releaseBuffer()`][].
 
 Creates a new `Deserializer` object.

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -266,9 +266,9 @@ void SerializerContext::WriteRawBytes(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
   ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
 
-  if (!args[0]->IsUint8Array()) {
+  if (!args[0]->IsArrayBufferView()) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
-        ctx->env(), "source must be a Uint8Array");
+        ctx->env(), "source must be a TypedArray or a DataView");
   }
 
   ctx->serializer_.WriteRawBytes(Buffer::Data(args[0]),
@@ -317,9 +317,9 @@ MaybeLocal<Object> DeserializerContext::ReadHostObject(Isolate* isolate) {
 void DeserializerContext::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!args[0]->IsUint8Array()) {
+  if (!args[0]->IsArrayBufferView()) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
-        env, "buffer must be a Uint8Array");
+        env, "buffer must be a TypedArray or a DataView");
   }
 
   new DeserializerContext(env, args.This(), args[0]);


### PR DESCRIPTION
This commit allow passing `TypedArray` and `DataView` to:
- `v8.deserialize()`
- `new v8.Deserializer()`
- `v8.serializer.writeRawBytes()`

Refs: https://github.com/nodejs/node/issues/1826

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
