### PR TITLE
doc: clarify when `'listening'` event is emitted

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -64,8 +64,8 @@ function is passed a single `Error` object.
 added: v0.1.99
 -->
 
-The `'listening'` event is emitted whenever a socket begins listening for
-datagram messages. This occurs as soon as UDP sockets are created.
+The `'listening'` event is emitted on the first invocation of either `socket.send()`
+or `socket.bind()` for the respective socket.
 
 ### Event: 'message'
 <!-- YAML


### PR DESCRIPTION
Clarify that the `'listening'` event for a UDP socket in NodeJS is emitted when the
underlying OS socket is created. 

This occurs when either `socket.send()` or `socket.bind()`
are first invoked for the respective socket.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
