### PR TITLE
build: add -Werror=undefined-inline to clang builds

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -32,9 +32,13 @@
       '-Wendif-labels',
       '-W',
       '-Wno-unused-parameter',
+      '-Werror=undefined-inline',
     ],
   },
   'conditions': [
+    ['clang==1', {
+      'cflags': [ '-Werror=undefined-inline', ]
+    }],
     [ 'node_shared=="false"', {
       'msvs_settings': {
         'VCManifestTool': {


### PR DESCRIPTION
Hopefully the start of a trend to move more cases to `-Werror`

Refs: https://github.com/nodejs/node/pull/23954
Refs: https://github.com/nodejs/node/pull/23910
Refs: https://github.com/nodejs/node/pull/23880

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
