### PR TITLE
deps: float two (more) OpenSSL patches for DSA vulnerabilities

### DIFF
--- a/deps/openssl/openssl/crypto/dsa/dsa_ossl.c
+++ b/deps/openssl/openssl/crypto/dsa/dsa_ossl.c
@@ -25,6 +25,8 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
                          DSA_SIG *sig, DSA *dsa);
 static int dsa_init(DSA *dsa);
 static int dsa_finish(DSA *dsa);
+static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
+                                      BN_CTX *ctx);
 
 static DSA_METHOD openssl_dsa_meth = {
     "OpenSSL DSA method",
@@ -261,7 +263,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
         goto err;
 
     /* Compute  part of 's = inv(k) (m + xr) mod q' */
-    if ((kinv = BN_mod_inverse(NULL, k, dsa->q, ctx)) == NULL)
+    if ((kinv = dsa_mod_inverse_fermat(k, dsa->q, ctx)) == NULL)
         goto err;
 
     BN_clear_free(*kinvp);
@@ -394,4 +396,32 @@ static int dsa_finish(DSA *dsa)
 {
     BN_MONT_CTX_free(dsa->method_mont_p);
     return (1);
+}
+
+/*
+ * Compute the inverse of k modulo q.
+ * Since q is prime, Fermat's Little Theorem applies, which reduces this to
+ * mod-exp operation.  Both the exponent and modulus are public information
+ * so a mod-exp that doesn't leak the base is sufficient.  A newly allocated
+ * BIGNUM is returned which the caller must free.
+ */
+static BIGNUM *dsa_mod_inverse_fermat(const BIGNUM *k, const BIGNUM *q,
+                                      BN_CTX *ctx)
+{
+    BIGNUM *res = NULL;
+    BIGNUM *r, *e;
+
+    if ((r = BN_new()) == NULL)
+        return NULL;
+
+    BN_CTX_start(ctx);
+    if ((e = BN_CTX_get(ctx)) != NULL
+            && BN_set_word(r, 2)
+            && BN_sub(e, q, r)
+            && BN_mod_exp_mont(r, k, e, q, ctx, NULL))
+        res = r;
+    else
+        BN_free(r);
+    BN_CTX_end(ctx);
+    return res;
 }


### PR DESCRIPTION
Build on from https://github.com/nodejs/node/pull/23950 we have two more issues surrounding DSA. 

One has a CVE, CVE-2018-0734 @ https://www.openssl.org/news/secadv/20181030.txt

> Severity: Low
>
> The OpenSSL DSA signature algorithm has been shown to be vulnerable to a
> timing side channel attack. An attacker could use variations in the signing
> algorithm to recover the private key.
> 
> Due to the low severity of this issue we are not issuing a new release
> of OpenSSL 1.1.1, 1.1.0 or 1.0.2 at this time. The fix will be included
> in OpenSSL 1.1.1a, OpenSSL 1.1.0j and OpenSSL 1.0.2q when they become
> available.

The other runs into OpenSSL's severity-level policy for CVE assignment and doesn't quite make it so we don't have a CVE for it. https://github.com/openssl/openssl/pull/7487

> There is a side channel attack against the division used to calculate one of
> the modulo inverses in the DSA algorithm.  This change takes advantage of the
> primality of the modulo and Fermat's little theorem to calculate the inverse
> without leaking information.

If this is accepted I'll put in a PR for 6 & 8 since they have different patches (for 1.0.2).

FWIW I don't believe any of these rise to much of a meaningful level of severity. We're seeing an expected wave of timing attack vulnerabilities being discovered because this is the hottest area for research right now (for good reason, it's fascinating!). But a lot of them are more academic in nature in that they require very specific circumstances to be able to build a successful attack. And in these cases I don't believe exploits have been published anywhere.

Still worth floating on our releases I reckon though. Erring on the side of security is what the vast majority of our users want to see us do.

/cc @nodejs/crypto @nodejs/security