### PR TITLE
doc: fix headings for CHANGELOG_v10.md

### DIFF
--- a/doc/changelogs/CHANGELOG_V10.md
+++ b/doc/changelogs/CHANGELOG_V10.md
@@ -5,11 +5,14 @@
 
 <table>
 <tr>
-<th>Current</th>
+<th>LTS 'Dubnium'</th>
+<th title="Previously called 'Stable'">Current</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 <a href="#10.13.0">10.13.0</a><br/>
+</td>
+<td valign="top">
 <a href="#10.12.0">10.12.0</a><br/>
 <a href="#10.11.0">10.11.0</a><br/>
 <a href="#10.10.0">10.10.0</a><br/>


### PR DESCRIPTION
The LTS bit flip did not include the new title heading for LTS in the
changelog. This commit fixes that.
