### PR TITLE
tools,gyp: don't force build actions with multiple outputs

### DIFF
--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -1758,8 +1758,15 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
       self.WriteLn('\t%s' % '@:')
       self.WriteLn('%s: %s' % ('.INTERMEDIATE', intermediate))
-      self.WriteLn('%s: %s%s' %
-                   (intermediate, ' '.join(inputs), force_append))
+      # Don't add `force_append` (FORCE_DO_CMD) to the intermediate sentinal.
+      # Adding it makes the action run alway, even when there are no changes.
+      # Excluding macOS which has a different way of resolving dependancies
+      # which can lead to deadlocks.
+      # (refack): AFAICT because `*.intermediate` files don't have build rules.
+      if self.flavor == 'mac':
+        self.WriteLn('%s: %s%s' % (intermediate, ' '.join(inputs), force_append))
+      else:
+        self.WriteLn('%s: %s' % (intermediate, ' '.join(inputs)))
       actions.insert(0, '$(call do_cmd,touch)')
 
     if actions:


### PR DESCRIPTION
Excluding macOS which has a different way of resolving dependencies which can lead to deadlocks.

Reroll: https://github.com/nodejs/node/pull/23156
Refs: https://github.com/nodejs/node/pull/23257
Fixes: https://github.com/nodejs/node/issues/23255

Don't add `force_append` (FORCE_DO_CMD) to the intermediate sentinel.
Adding it makes the action run alway, even when there are no changes.
(refack): AFAICT because `*.intermediate` files don't have build rules.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
