### PR TITLE
deps,v8: cherry-pick dc704497

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -30,7 +30,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.8',
+    'v8_embedder_string': '-node.9',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/base/debug/stack_trace_win.cc
+++ b/deps/v8/src/base/debug/stack_trace_win.cc
@@ -7,6 +7,13 @@
 
 #include "src/base/debug/stack_trace.h"
 
+// This file can't use "src/base/win32-headers.h" because it defines symbols
+// that lead to compilation errors. But `NOMINMAX` should be defined to disable
+// defining of the `min` and `max` MACROS.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <windows.h>
 #include <dbghelp.h>
 #include <Shlwapi.h>


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/19630
Refs: https://github.com/v8/v8/commit/dc704497ee84245931533c3575dd250d4b498300

Original commit message:
```
  undef min,max macros on windows

  This blocks building with official clang-cl and Windows SDK

  Refs: https://github.com/nodejs/node/issues/19630
  Change-Id: I41fdf934f486c660df7a9e0dd284f6eb3c294dd4
  Reviewed-on: https://chromium-review.googlesource.com/c/1297479
  Commit-Queue: Jakob Gruber <jgruber@chromium.org>
  Reviewed-by: Jakob Gruber <jgruber@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#57053}
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
