### PR TITLE
win: add prompt to tools installation script

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -47,7 +47,23 @@ echo script is at your own risk. Please read the Chocolatey's legal terms of use
 echo and the Boxstarter project license as well as how the community repository
 echo for Chocolatey.org is maintained.
 echo.
-echo You can close this window to stop now.
+pause
+
+cls
+echo !!!!!WARNING!!!!!
+echo -----------------
+echo Use of Boxstarter may reboot your box automatically multiple times. When
+echo performing a reboot, Boxstarter will need to disable UAC to allow the
+echo script to run immediately after the reboot. When the scripts have
+echo completed, Boxstarter will re-enable UAC. If you prematurely stop the
+echo process, UAC will need to be re-enabled manually.
+echo.
+echo Sometimes the scripts may install all necessary Windows Updates which
+echo could cause a high number of reboots that appear to be a reboot loop when
+echo in fact it is just a normal Windows Updates reboot cycle.
+echo.
+echo If this is not what you would like to occur, you can close this window
+echo to stop now.
 pause
 
 "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://boxstarter.org/bootstrapper.ps1'')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName ''%~dp0\install_tools.txt''; Read-Host ''Type ENTER to exit'' ' -Verb RunAs

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -1,5 +1,7 @@
 @echo off
 
+setlocal
+
 cls
 echo ====================================================
 echo Tools for Node.js Native Modules Installation Script
@@ -64,6 +66,14 @@ echo in fact it is just a normal Windows Updates reboot cycle.
 echo.
 echo If this is not what you would like to occur, you can close this window
 echo to stop now.
-pause
+:acceptretry
+echo.
+echo Your computer may REBOOT SEVERAL TIMES WITHOUT FURTHER WARNING.
+echo Please type YES followed by enter to confirm that you have saved all your
+set /p "ACCEPT_PROMPT=work and closed all open programs: "
+if /i not "%ACCEPT_PROMPT%"=="yes" (
+  echo Please type YES to confirm, or close the window to exit.
+  goto acceptretry
+)
 
 "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://boxstarter.org/bootstrapper.ps1'')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName ''%~dp0\install_tools.txt''; Read-Host ''Type ENTER to exit'' ' -Verb RunAs

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -52,11 +52,11 @@ pause
 cls
 echo !!!!!WARNING!!!!!
 echo -----------------
-echo Use of Boxstarter may reboot your box automatically multiple times. When
-echo performing a reboot, Boxstarter will need to disable UAC to allow the
-echo script to run immediately after the reboot. When the scripts have
-echo completed, Boxstarter will re-enable UAC. If you prematurely stop the
-echo process, UAC will need to be re-enabled manually.
+echo Use of Boxstarter may reboot your computer automatically multiple times.
+echo When performing a reboot, Boxstarter will need to disable User Account
+echo Control (UAC) to allow the script to run immediately after the reboot. When
+echo the scripts have completed, Boxstarter will re-enable UAC. If you prematurely
+echo stop the process, UAC will need to be re-enabled manually.
 echo.
 echo Sometimes the scripts may install all necessary Windows Updates which
 echo could cause a high number of reboots that appear to be a reboot loop when

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -63,9 +63,6 @@ echo.
 echo Sometimes the scripts may install all necessary Windows Updates which
 echo could cause a high number of reboots that appear to be a reboot loop when
 echo in fact it is just a normal Windows Updates reboot cycle.
-echo.
-echo If this is not what you would like to occur, you can close this window
-echo to stop now.
 :acceptretry
 echo.
 echo Your computer may REBOOT SEVERAL TIMES WITHOUT FURTHER WARNING.


### PR DESCRIPTION
Since the script to install tools for native modules (https://github.com/nodejs/node/pull/22645) was included in releases, we've got several comments from users surprised by reboots.

This adds a more visible warning and a prompt to lessen the probability of users skipping ahead without reading.

Fixes: https://github.com/nodejs/Release/issues/369

cc @nodejs/platform-windows 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
