### PR TITLE
src: fix compiler warning for debug build

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -292,7 +292,7 @@ void StreamBase::CallJSOnreadMethod(ssize_t nread,
 
 #ifdef DEBUG
   CHECK_EQ(static_cast<int32_t>(nread), nread);
-  CHECK_EQ(static_cast<int32_t>(offset), offset);
+  CHECK_LE(offset, INT32_MAX);
 
   if (ab.IsEmpty()) {
     CHECK_EQ(offset, 0);


### PR DESCRIPTION
This commit updates the check of the offset argument passed to
CallJSOnreadMethod to avoid doing a cast as this currently generates
the following compiler warning when doing a debug build:
```console
./src/stream_base.cc:295:3:
warning: comparison of integers of different signs:
'int32_t' (aka 'int') and 'size_t' (aka 'unsigned long')
[-Wsign-compare]
  CHECK_EQ(static_cast<int32_t>(offset), offset);
  ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
