### PR TITLE
lib: remove useless getLibuvNow in internal/timers

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -32,8 +32,7 @@ module.exports = {
   kRefed,
   initAsyncResource,
   setUnrefTimeout,
-  validateTimerDuration,
-  getLibuvNow: internalBinding('timers').getLibuvNow,
+  validateTimerDuration
 };
 
 var timers;

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -3,7 +3,8 @@
 
 require('../common');
 const assert = require('assert');
-const { getLibuvNow } = require('internal/timers');
+const { internalBinding } = require('internal/test/binding');
+const { getLibuvNow } = internalBinding('timers');
 
 // Return value of getLibuvNow() should easily fit in a SMI after start-up.
 assert(getLibuvNow() < 0x3ffffff);

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -24,7 +24,8 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { getLibuvNow } = require('internal/timers');
+const { internalBinding } = require('internal/test/binding');
+const { getLibuvNow } = internalBinding('timers');
 
 const N = 30;
 


### PR DESCRIPTION
Remove unused `getLibuvNow` in `lib/internal/timers.js` since we are using this function through `internalBinding('timers')` directly in `lib/timers.js`.
Maybe make bit of optimization ?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)