### PR TITLE
test: increase --stack_size test-async-wrap-pop

### DIFF
--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -16,7 +16,7 @@ const { spawnSync } = require('child_process');
 
 const ret = spawnSync(
   process.execPath,
-  ['--stack_size=80', __filename, 'async']
+  ['--stack_size=150', __filename, 'async']
 );
 assert.strictEqual(ret.status, 0,
                    `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -16,7 +16,7 @@ const { spawnSync } = require('child_process');
 
 const ret = spawnSync(
   process.execPath,
-  ['--stack_size=75', __filename, 'async']
+  ['--stack_size=80', __filename, 'async']
 );
 assert.strictEqual(ret.status, 0,
                    `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);


### PR DESCRIPTION
Currently, when building with `--debug`
test-async-wrap-pop-id-during-load fails on macosx with the following
error:
```console
$ out/Debug/node test/parallel/test-async-wrap-pop-id-during-load.js
assert.js:86
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: EXIT CODE: 1, STDERR:
internal/bootstrap/loaders.js:275
      const script = new ContextifyScript(
                     ^

RangeError: Maximum call stack size exceeded
    at NativeModule.compile (internal/bootstrap/loaders.js:275:22)
    at NativeModule.require (internal/bootstrap/loaders.js:168:18)
    at assert.js:31:43
    at NativeModule.compile (internal/bootstrap/loaders.js:299:7)
    at NativeModule.require (internal/bootstrap/loaders.js:168:18)
    at internal/process/main_thread_only.js:23:16
    at NativeModule.compile (internal/bootstrap/loaders.js:299:7)
    at Function.NativeModule.require
      (internal/bootstrap/loaders.js:168:18)
    at startup (internal/bootstrap/node.js:58:38)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:878:3)

    at Object.<anonymous>
       (/node/test/parallel/test-async-wrap-pop-id-during-load.js:21:8)
    at Module._compile (internal/modules/cjs/loader.js:707:30)
    at Object.Module._extensions..js
      (internal/modules/cjs/loader.js:718:10)
    at Module.load (internal/modules/cjs/loader.js:605:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:544:12)
    at Function.Module._load (internal/modules/cjs/loader.js:536:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:760:12)
    at startup (internal/bootstrap/node.js:308:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:878:3)
```
This commit suggests increasing the stack_size to 80. 

The suggestion is based mainly on the referred to PR below. I'm currently bisecting (slow process for debug builds) this, but wanted to open this PR to see if anyone has any ideas.

Refs: https://github.com/nodejs/node/pull/20940


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
