### PR TITLE
doc: clarify Boxstarter behavior on install tools

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -47,7 +47,23 @@ echo script is at your own risk. Please read the Chocolatey's legal terms of use
 echo and the Boxstarter project license as well as how the community repository
 echo for Chocolatey.org is maintained.
 echo.
-echo You can close this window to stop now.
+pause
+
+cls
+echo !!!!!WARNING!!!!!
+echo -----------------
+echo Use of Boxstarter may reboot your box automatically multiple times. When
+echo performing a reboot, Boxstarter will need to disable UAC to allow the
+echo script to run immediately after the reboot. When the scripts have
+echo completed, Boxstarter will re-enable UAC. If you prematurely stop the
+echo process, UAC will need to be re-enabled manually.
+echo.
+echo Sometimes the scripts may install all necessary Windows Updates which
+echo could cause a high number of reboots that appear to be a reboot loop when
+echo in fact it is just a normal Windows Updates reboot cycle.
+echo.
+echo If this is not what you would like to occur, you can close this window
+echo to stop now.
 pause
 
 "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://boxstarter.org/bootstrapper.ps1'')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName ''%~dp0\install_tools.txt''; Read-Host ''Type ENTER to exit'' ' -Verb RunAs


### PR DESCRIPTION
Clarify the behavior of what Boxstarter may do when it runs on a box
to install all the necessary tools so that there are no surprises to
the end user when the script is run.

Currently there is no interface that warns the user that Boxstarter will
reboot the machine possibly multiple times depending on how many
dependencies need to be installed and doesn't mention a need to disable
UAC. For folks who see what may look like a reboot loop, we feel it is
necessary to make them aware that UAC will be disabled and they will need
to take action to re-enable UAC manually if they interfere/stop the script
from finishing.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

References #23838 