### PR TITLE
tools: fix c++ code coverage on macOS

### DIFF
--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -949,6 +949,8 @@ class XcodeSettings(object):
     libtoolflags = []
 
     for libtoolflag in self._Settings().get('OTHER_LDFLAGS', []):
+      if libtoolflag == "--coverage":
+        continue
       libtoolflags.append(libtoolflag)
     # TODO(thakis): ARCHS?
 


### PR DESCRIPTION
Recent libtool on macOS does not support the --coverage flag that was
being passed through in the final linking stage.
This change patches gyp-mac-tool to not pass the --coverage flag through
to libtool. It is now possible to generate code coverage for src/ on macOS.

Fixes: https://github.com/nodejs/node/issues/19057

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
