### PR TITLE
n-api: add missing handle scopes

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1084,6 +1084,7 @@ class ThreadSafeFunction : public node::AsyncResource {
   }
 
   void CloseHandlesAndMaybeDelete(bool set_closing = false) {
+    v8::HandleScope scope(env->isolate);
     if (set_closing) {
       node::Mutex::ScopedLock lock(this->mutex);
       is_closing = true;
@@ -1101,6 +1102,7 @@ class ThreadSafeFunction : public node::AsyncResource {
           ThreadSafeFunction* ts_fn =
               node::ContainerOf(&ThreadSafeFunction::async,
                                 reinterpret_cast<uv_async_t*>(handle));
+          v8::HandleScope scope(ts_fn->env->isolate);
           ts_fn->env->node_env()->CloseHandle(
               reinterpret_cast<uv_handle_t*>(&ts_fn->idle),
               [](uv_handle_t* handle) -> void {


### PR DESCRIPTION
Currently when building with `--debug`
`test/addons-napi/test_threadsafe_function` will error:
```console
$  out/Debug/node test/addons-napi/test_threadsafe_function/test.js
FATAL ERROR: v8::HandleScope::CreateHandle()
  Cannot create a handle without a HandleScope
 1: 0x10004e287 node::DumpBacktrace(__sFILE*) [node/out/Debug/node]
 2: 0x1000cd37b node::Abort() [/node/out/Debug/node]
 3: 0x1000cd69f node::OnFatalError(char const*, char const*)
    [/node/out/Debug/node]
 4: 0x1004df0b1 v8::Utils::ReportApiFailure(char const*, char const*)
    [/nodejs/node/out/Debug/node]
 5: 0x100a8c0a9 v8::internal::HandleScope::Extend(
        v8::internal::Isolate*)
    [/node/out/Debug/node]
 6: 0x1004e4229 v8::EmbedderDataFor(v8::Context*,
                                    int, bool,
                                    char const*)
    [/node/out/Debug/node]
 7: 0x1004e43fa v8::Context::SlowGetAlignedPointerFromEmbedderData(int)
    [/node/out/Debug/node]
 8: 0x10001c26b v8::Context::GetAlignedPointerFromEmbedderData(int)
    [/node/out/Debug/node]
 9: 0x1000144ea node::Environment::GetCurrent(v8::Local<v8::Context>)
    [/node/out/Debug/node]
10: 0x1000f49e2 napi_env__::node_env() const
    [/node/out/Debug/node]
11: 0x1000f9885
    (anonymous namespace)::v8impl::ThreadSafeFunction::
        CloseHandlesAndMaybeDelete(bool)
    [/node/out/Debug/node]
12: 0x1000fb34f (anonymous namespace)::v8impl::ThreadSafeFunction::
        DispatchOne()
    [/node/out/Debug/node]
13: 0x1000fb129
    (anonymous namespace)::v8impl::ThreadSafeFunction::
        IdleCb(uv_idle_s*)
    [/node/out/Debug/node]
14: 0x1011a1b69 uv__run_idle
    [/node/out/Debug/node]
15: 0x101198179 uv_run
    [/node/out/Debug/node]
16: 0x1000dfca1
    node::Start(...)
    [/node/out/Debug/node]
17: 0x1000dae50 node::Start(...)
    [/node/out/Debug/node]
18: 0x1000da56f node::Start(int, char**)
    [/node/out/Debug/node]
19: 0x10141112e main
    [/node/out/Debug/node]
20: 0x100001034 start
    [/node/out/Debug/node]
Abort trap: 6
```
This commit adds two HandleScope's, one to CloseHandlesAndMaybeDelete
and one to the lambda.

[SlowGetAlignedPointerFromEmbedderData](https://github.com/v8/v8/blob/2ef0aa662fe907a1b36ac1abe7d77ad2bcd27733/include/v8.h#L10440-L10447) will only be called for debug builds.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
