### PR TITLE
doc: add link to VSCode config in testing

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -366,6 +366,10 @@ loopback interface on Ubuntu:
 sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
 ```
 
+You can use
+[node-code-ide-configs](https://github.com/nodejs/node-code-ide-configs)
+to run/debug tests, if your IDE configs are present.
+
 #### Running Coverage
 
 It's good practice to ensure any code you add or change is covered by tests.


### PR DESCRIPTION
Refs: https://github.com/orgs/nodejs/teams/collaborators/discussions/58

This config will help contributors to run/debug tests on VSCode

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
