### PR TITLE
http2: add test for ERR_HTTP2_ORIGIN_LENGTH

### DIFF
--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -70,6 +70,15 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
         }
       );
     });
+
+    const longInput = 'https://foo.org' + 'a'.repeat(17000);
+    throws(
+      () => session.origin(longInput),
+      {
+        code: 'ERR_HTTP2_ORIGIN_LENGTH',
+        name: 'TypeError [ERR_HTTP2_ORIGIN_LENGTH]'
+      }
+    );
   }));
 
   server.listen(0, mustCall(() => {


### PR DESCRIPTION
Adds test for [ERR_HTTP2_ORIGIN_LENGTH](https://github.com/nodejs/node/blob/7b09f5b14f11d4e362e8e84560e483d6b29d73d2/lib/internal/http2/core.js#L1418)
It's not covered in the [latest coverage](https://coverage.nodejs.org/coverage-d32b5bd567544f5b/root/internal/http2/core.js.html#L1418)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
