### PR TITLE
fs: handle result of access binding directly in fs.existsSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -228,11 +228,14 @@ Object.defineProperty(exists, internalUtil.promisify.custom, {
 // TODO(joyeecheung): deprecate the never-throw-on-invalid-arguments behavior
 function existsSync(path) {
   try {
-    fs.accessSync(path, F_OK);
-    return true;
+    path = toPathIfFileURL(path);
+    validatePath(path);
   } catch (e) {
     return false;
   }
+  const ctx = { path };
+  binding.access(pathModule.toNamespacedPath(path), F_OK, undefined, ctx);
+  return ctx.errno === undefined;
 }
 
 function readFileAfterOpen(err, fd) {


### PR DESCRIPTION
Instead of throwing errors in fs.accessSync and then catching it,
handle the result from the binding directly in fs.existsSync.

Note that the argument validation errors still needs to be caught
until we properly deprecate the don't-thrown-on-invalid-arguments
behavior.

Fixes: https://github.com/nodejs/node/issues/24008