### PR TITLE
[v8.x] backport assert: add rejects() and doesNotReject()

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -242,6 +242,43 @@ If the values are not equal, an `AssertionError` is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
+## assert.doesNotReject(block[, error][, message])
+<!-- YAML
+added: REPLACEME
+-->
+* `block` {Function}
+* `error` {RegExp|Function}
+* `message` {any}
+
+Awaits for the promise returned by function `block` to complete and not be
+rejected. See [`assert.rejects()`][] for more details.
+
+When `assert.doesNotReject()` is called, it will immediately call the `block`
+function, and awaits for completion.
+
+Besides the async nature to await the completion behaves identical to
+[`assert.doesNotThrow()`][].
+
+```js
+(async () => {
+  await assert.doesNotReject(
+    async () => {
+      throw new TypeError('Wrong value');
+    },
+    SyntaxError
+  );
+})();
+```
+
+```js
+assert.doesNotReject(
+  () => Promise.reject(new TypeError('Wrong value')),
+  SyntaxError
+).then(() => {
+  // ...
+});
+```
+
 ## assert.doesNotThrow(block[, error][, message])
 <!-- YAML
 added: v0.1.21
@@ -631,6 +668,48 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 `message` property set equal to the value of the `message` parameter. If the
 `message` parameter is undefined, a default error message is assigned.
 
+## assert.rejects(block[, error][, message])
+<!-- YAML
+added: REPLACEME
+-->
+* `block` {Function}
+* `error` {RegExp|Function|Object}
+* `message` {any}
+
+Awaits for promise returned by function `block` to be rejected.
+
+When `assert.rejects()` is called, it will immediately call the `block`
+function, and awaits for completion.
+
+Besides the async nature to await the completion behaves identical to
+[`assert.throws()`][].
+
+If specified, `error` can be a constructor, [`RegExp`][], a validation
+function, or an object where each property will be tested for.
+
+If specified, `message` will be the message provided by the `AssertionError` if
+the block fails to reject.
+
+```js
+(async () => {
+  await assert.rejects(
+    async () => {
+      throw new Error('Wrong value');
+    },
+    Error
+  );
+})();
+```
+
+```js
+assert.rejects(
+  () => Promise.reject(new Error('Wrong value')),
+  Error
+).then(() => {
+  // ...
+});
+```
+
 ## assert.throws(block[, error][, message])
 <!-- YAML
 added: v0.1.21
@@ -786,6 +865,7 @@ For more information, see
 [`assert.ok()`]: #assert_assert_ok_value_message
 [`assert.strictEqual()`]: #assert_assert_strictequal_actual_expected_message
 [`assert.throws()`]: #assert_assert_throws_block_error_message
+[`assert.rejects()`]: #assert_assert_rejects_block_error_message
 [`strict mode`]: #assert_strict_mode
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
 [Object.prototype.toString()]: https://tc39.github.io/ecma262/#sec-object.prototype.tostring

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -722,8 +722,11 @@ async function waitForActual(block) {
   if (typeof block !== 'function') {
     throw new errors.ERR_INVALID_ARG_TYPE('block', 'Function', block);
   }
+
+  // Return a rejected promise if `block` throws synchronously.
+  const resultPromise = block();
   try {
-    await block();
+    await resultPromise;
   } catch (e) {
     return e;
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -718,17 +718,27 @@ function getActual(block) {
   }
 }
 
-// Expected to throw an error.
-assert.throws = function throws(block, error, message) {
-  const actual = getActual(block);
+async function waitForActual(block) {
+  if (typeof block !== 'function') {
+    throw new errors.ERR_INVALID_ARG_TYPE('block', 'Function', block);
+  }
+  try {
+    await block();
+  } catch (e) {
+    return e;
+  }
+  return errors.NO_EXCEPTION_SENTINEL;
+}
 
+// Expected to throw an error.
+function expectsError(stackStartFn, actual, error, message) {
   if (typeof error === 'string') {
-    if (arguments.length === 3)
+    if (arguments.length === 4) {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                  'error',
                                  ['Function', 'RegExp'],
                                  error);
-
+    }
     message = error;
     error = null;
   }
@@ -739,21 +749,21 @@ assert.throws = function throws(block, error, message) {
       details += ` (${error.name})`;
     }
     details += message ? `: ${message}` : '.';
+    const fnType = stackStartFn === rejects ? 'rejection' : 'exception';
     innerFail({
       actual,
       expected: error,
-      operator: 'throws',
-      message: `Missing expected exception${details}`,
-      stackStartFn: throws
+      operator: stackStartFn.name,
+      message: `Missing expected ${fnType}${details}`,
+      stackStartFn
     });
   }
   if (error && expectedException(actual, error, message) === false) {
     throw actual;
   }
-};
+}
 
-assert.doesNotThrow = function doesNotThrow(block, error, message) {
-  const actual = getActual(block);
+function expectsNoError(stackStartFn, actual, error, message) {
   if (actual === undefined)
     return;
 
@@ -764,16 +774,41 @@ assert.doesNotThrow = function doesNotThrow(block, error, message) {
 
   if (!error || expectedException(actual, error)) {
     const details = message ? `: ${message}` : '.';
+    const fnType = stackStartFn === doesNotReject ? 'rejection' : 'exception';
     innerFail({
       actual,
       expected: error,
-      operator: 'doesNotThrow',
-      message: `Got unwanted exception${details}\n${actual.message}`,
-      stackStartFn: doesNotThrow
+      operator: stackStartFn.name,
+      message: `Got unwanted ${fnType}${details}\n${actual.message}`,
+      stackStartFn
     });
   }
   throw actual;
-};
+}
+
+function throws(block, ...args) {
+  expectsError(throws, getActual(block), ...args);
+}
+
+assert.throws = throws;
+
+async function rejects(block, ...args) {
+  expectsError(rejects, await waitForActual(block), ...args);
+}
+
+assert.rejects = rejects;
+
+function doesNotThrow(block, ...args) {
+  expectsNoError(doesNotThrow, getActual(block), ...args);
+}
+
+assert.doesNotThrow = doesNotThrow;
+
+async function doesNotReject(block, ...args) {
+  expectsNoError(doesNotReject, await waitForActual(block), ...args);
+}
+
+assert.doesNotReject = doesNotReject;
 
 assert.ifError = function ifError(err) { if (err) throw err; };
 

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -13,7 +13,7 @@ common.crashOnUnhandledRejection();
 
 (async () => {
   await assert.rejects(
-    () => assert.fail(),
+    async () => assert.fail(),
     common.expectsError({
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,
@@ -56,5 +56,18 @@ common.crashOnUnhandledRejection();
         return true;
       }
     );
+  }
+
+  {
+    const THROWN_ERROR = new Error();
+
+    await assert.rejects(() => {
+      throw THROWN_ERROR;
+    }).then(common.mustNotCall())
+      .catch(
+        common.mustCall((err) => {
+          assert.strictEqual(err, THROWN_ERROR);
+        })
+      );
   }
 })().then(common.mustCall());

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -1,0 +1,66 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { promisify } = require('util');
+const wait = promisify(setTimeout);
+
+/* eslint-disable prefer-common-expectserror, no-restricted-properties */
+
+// Test assert.rejects() and assert.doesNotReject() by checking their
+// expected output and by verifying that they do not work sync
+
+assert.rejects(
+  () => assert.fail(),
+  common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'Failed'
+  })
+);
+
+assert.doesNotReject(() => {});
+
+{
+  const promise = assert.rejects(async () => {
+    await wait(1);
+    assert.fail();
+  }, common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'Failed'
+  }));
+  assert.doesNotReject(() => promise);
+}
+
+{
+  const promise = assert.doesNotReject(async () => {
+    await wait(1);
+    throw new Error();
+  });
+  assert.rejects(() => promise,
+                 (err) => {
+                   assert(err instanceof assert.AssertionError,
+                          `${err.name} is not instance of AssertionError`);
+                   assert.strictEqual(err.code, 'ERR_ASSERTION');
+                   assert(/^Got unwanted rejection\.\n$/.test(err.message));
+                   assert.strictEqual(err.operator, 'doesNotReject');
+                   assert.ok(!err.stack.includes('at Function.doesNotReject'));
+                   return true;
+                 }
+  );
+}
+
+{
+  const promise = assert.rejects(() => {});
+  assert.rejects(() => promise,
+                 (err) => {
+                   assert(err instanceof assert.AssertionError,
+                          `${err.name} is not instance of AssertionError`);
+                   assert.strictEqual(err.code, 'ERR_ASSERTION');
+                   assert(/^Missing expected rejection\.$/.test(err.message));
+                   assert.strictEqual(err.operator, 'rejects');
+                   assert.ok(!err.stack.includes('at Function.rejects'));
+                   return true;
+                 }
+  );
+}

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -9,58 +9,52 @@ const wait = promisify(setTimeout);
 // Test assert.rejects() and assert.doesNotReject() by checking their
 // expected output and by verifying that they do not work sync
 
-assert.rejects(
-  () => assert.fail(),
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'Failed'
-  })
-);
+common.crashOnUnhandledRejection();
 
-assert.doesNotReject(() => {});
-
-{
-  const promise = assert.rejects(async () => {
-    await wait(1);
-    assert.fail();
-  }, common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'Failed'
-  }));
-  assert.doesNotReject(() => promise);
-}
-
-{
-  const promise = assert.doesNotReject(async () => {
-    await wait(1);
-    throw new Error();
-  });
-  assert.rejects(() => promise,
-                 (err) => {
-                   assert(err instanceof assert.AssertionError,
-                          `${err.name} is not instance of AssertionError`);
-                   assert.strictEqual(err.code, 'ERR_ASSERTION');
-                   assert(/^Got unwanted rejection\.\n$/.test(err.message));
-                   assert.strictEqual(err.operator, 'doesNotReject');
-                   assert.ok(!err.stack.includes('at Function.doesNotReject'));
-                   return true;
-                 }
+(async () => {
+  await assert.rejects(
+    () => assert.fail(),
+    common.expectsError({
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'Failed'
+    })
   );
-}
 
-{
-  const promise = assert.rejects(() => {});
-  assert.rejects(() => promise,
-                 (err) => {
-                   assert(err instanceof assert.AssertionError,
-                          `${err.name} is not instance of AssertionError`);
-                   assert.strictEqual(err.code, 'ERR_ASSERTION');
-                   assert(/^Missing expected rejection\.$/.test(err.message));
-                   assert.strictEqual(err.operator, 'rejects');
-                   assert.ok(!err.stack.includes('at Function.rejects'));
-                   return true;
-                 }
-  );
-}
+  await assert.doesNotReject(() => {});
+
+  {
+    const promise = assert.doesNotReject(async () => {
+      await wait(1);
+      throw new Error();
+    });
+    await assert.rejects(
+      () => promise,
+      (err) => {
+        assert(err instanceof assert.AssertionError,
+               `${err.name} is not instance of AssertionError`);
+        assert.strictEqual(err.code, 'ERR_ASSERTION');
+        assert(/^Got unwanted rejection\.\n$/.test(err.message));
+        assert.strictEqual(err.operator, 'doesNotReject');
+        assert.ok(!err.stack.includes('at Function.doesNotReject'));
+        return true;
+      }
+    );
+  }
+
+  {
+    const promise = assert.rejects(() => {});
+    await assert.rejects(
+      () => promise,
+      (err) => {
+        assert(err instanceof assert.AssertionError,
+               `${err.name} is not instance of AssertionError`);
+        assert.strictEqual(err.code, 'ERR_ASSERTION');
+        assert(/^Missing expected rejection\.$/.test(err.message));
+        assert.strictEqual(err.operator, 'rejects');
+        assert.ok(!err.stack.includes('at Function.rejects'));
+        return true;
+      }
+    );
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -13,7 +13,7 @@ common.crashOnUnhandledRejection();
 
 (async () => {
   await assert.rejects(
-    async () => assert.fail(),
+    async () => assert.fail('Failed'),
     common.expectsError({
       code: 'ERR_ASSERTION',
       type: assert.AssertionError,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -443,6 +443,7 @@ assert.throws(makeBlock(thrower, TypeError));
   } catch (e) {
     threw = true;
     assert.ok(e instanceof a.AssertionError);
+    assert.ok(!e.stack.includes('at Function.doesNotThrow'));
   }
   assert.strictEqual(true, threw,
                      'a.doesNotThrow is not catching type matching errors');
@@ -544,6 +545,16 @@ a.throws(makeBlock(thrower, TypeError), (err) => {
       code: 'ERR_ASSERTION',
       message: /^Missing expected exception \(TypeError\): fhqwhgads$/
     }));
+
+  let threw = false;
+  try {
+    a.throws(noop);
+  } catch (e) {
+    threw = true;
+    assert.ok(e instanceof a.AssertionError);
+    assert.ok(!e.stack.includes('at Function.throws'));
+  }
+  assert.ok(threw);
 }
 
 const circular = { y: 1 };


### PR DESCRIPTION
Implement asynchronous equivalent for assert.throws() and
assert.doesNotThrow().

PR-URL: https://github.com/nodejs/node/pull/18023
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Shingo Inoue <leko.noor@gmail.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
