### PR TITLE
test: fix calls of deprecated server.connections property

### DIFF
--- a/test/parallel/test-net-server-close.js
+++ b/test/parallel/test-net-server-close.js
@@ -28,7 +28,7 @@ const events = [];
 const sockets = [];
 
 process.on('exit', function() {
-  assert.strictEqual(server.connections, 0);
+  assert.strictEqual(server.getConnections(), 0);
   assert.strictEqual(events.length, 3);
   // Expect to see one server event and two client events. The order of the
   // events is undefined because they arrive on the same event loop tick.

--- a/test/parallel/test-net-server-connections-child-null.js
+++ b/test/parallel/test-net-server-connections-child-null.js
@@ -20,8 +20,8 @@ if (process.argv[2] === 'child') {
 
     const server = net.createServer();
 
-    // server.connections should start as 0
-    assert.strictEqual(server.connections, 0);
+    // server connection count should start at 0
+    assert.strictEqual(server.getConnections(), 0);
     server.on('connection', (socket) => {
       child.send({ what: 'socket' }, socket);
     });
@@ -33,8 +33,8 @@ if (process.argv[2] === 'child') {
       const connect = net.connect(server.address().port);
 
       connect.on('close', common.mustCall(() => {
-        // now server.connections should be null
-        assert.strictEqual(server.connections, null);
+        // now server connection count should be null
+        assert.strictEqual(server.getConnections(), null);
         server.close();
       }));
 

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -34,11 +34,11 @@ s.server = new net.Server();
 s.server.connections = 10;
 s._server = s.server;
 
-assert.strictEqual(10, s.server.connections);
+assert.strictEqual(10, s.server.getConnections());
 s.destroy();
-assert.strictEqual(9, s.server.connections);
+assert.strictEqual(9, s.server.getConnections());
 s.destroy();
-assert.strictEqual(9, s.server.connections);
+assert.strictEqual(9, s.server.getConnections());
 
 const SIZE = 2E6;
 const N = 10;
@@ -69,5 +69,5 @@ const server = net.createServer(function(socket) {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(0, server.connections);
+  assert.strictEqual(0, server.getConnections());
 });


### PR DESCRIPTION
Fixes calls of [`deprecated server.connections`](https://nodejs.org/api/net.html#net_server_connections) property in tests

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
test