### PR TITLE
doc: edit man page for superfluous "node" usage

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -66,7 +66,7 @@ Alias for stdin, analogous to the use of - in other command-line utilities.
 The executed script is read from stdin, and remaining arguments are passed to the script.
 .
 .It Fl -
-Indicate the end of node options.
+Indicate the end of command-line options.
 Pass the rest of the arguments to the script.
 .Pp
 If no script filename or eval/print script is supplied prior to this, then
@@ -246,7 +246,7 @@ Evaluate
 as JavaScript.
 .
 .It Fl h , Fl -help
-Print Node.js command line options.
+Print command-line options.
 The output of this option is less detailed than this document.
 .
 .It Fl i , Fl -interactive


### PR DESCRIPTION
Rather than ponder "node" vs. "Node.js", remove the descriptor so it's
just "command-line options" rather than "node command-line options" or
"Node.js command-line options".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
