### PR TITLE
doc: add SECURITY.md to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,43 +159,7 @@ source and a list of supported platforms.
 
 ## Security
 
-If you find a security vulnerability in Node.js, please report it to
-security@nodejs.org. Please withhold public disclosure until after the security
-team has addressed the vulnerability.
-
-The security team will acknowledge your email within 24 hours. You will receive
-a more detailed response within 48 hours.
-
-There are no hard and fast rules to determine if a bug is worth reporting as a
-security issue. Here are some examples of past issues and what the Security
-Response Team thinks of them. When in doubt, please do send us a report
-nonetheless.
-
-
-### Public disclosure preferred
-
-- [#14519](https://github.com/nodejs/node/issues/14519): _Internal domain
-  function can be used to cause segfaults_. Requires the ability to execute
-  arbitrary JavaScript code. That is already the highest level of privilege
-  possible.
-
-### Private disclosure preferred
-
-- [CVE-2016-7099](https://nodejs.org/en/blog/vulnerability/september-2016-security-releases/):
-  _Fix invalid wildcard certificate validation check_. This was a high-severity
-  defect. It caused Node.js TLS clients to accept invalid wildcard certificates.
-
-- [#5507](https://github.com/nodejs/node/pull/5507): _Fix a defect that makes
-  the CacheBleed Attack possible_. Many, though not all, OpenSSL vulnerabilities
-  in the TLS/SSL protocols also affect Node.js.
-
-- [CVE-2016-2216](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/):
-  _Fix defects in HTTP header parsing for requests and responses that can allow
-  response splitting_. This was a remotely-exploitable defect in the Node.js
-  HTTP implementation.
-
-When in doubt, please do send us a report.
-
+For information about security of the Node.js project, see [Seucrity.md](https://github.com/nodejs/node/blob/master/SECURITY.md).
 
 ## Current Project Team Members
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ source and a list of supported platforms.
 
 ## Security
 
-For information about security of the Node.js project, see [Seucrity.md](https://github.com/nodejs/node/blob/master/SECURITY.md).
+For information on reporting security vulnerabilities in Node.js, see
+[SECURITY.md](./SECURITY.md).
 
 ## Current Project Team Members
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security
+If you find a security vulnerability in Node.js, please report it to
+security@nodejs.org. Please withhold public disclosure until after the security
+team has addressed the vulnerability.
+
+The security team will acknowledge your email within 24 hours. You will receive
+a more detailed response within 48 hours.
+
+There are no hard and fast rules to determine if a bug is worth reporting as a
+security issue. Here are some examples of past issues and what the Security
+Response Team thinks of them. When in doubt, please do send us a report
+nonetheless.
+
+
+## Public disclosure preferred
+
+- [#14519](https://github.com/nodejs/node/issues/14519): _Internal domain
+  function can be used to cause segfaults_. Requires the ability to execute
+  arbitrary JavaScript code. That is already the highest level of privilege
+  possible.
+
+## Private disclosure preferred
+
+- [CVE-2016-7099](https://nodejs.org/en/blog/vulnerability/september-2016-security-releases/):
+  _Fix invalid wildcard certificate validation check_. This was a high-severity
+  defect. It caused Node.js TLS clients to accept invalid wildcard certificates.
+
+- [#5507](https://github.com/nodejs/node/pull/5507): _Fix a defect that makes
+  the CacheBleed Attack possible_. Many, though not all, OpenSSL vulnerabilities
+  in the TLS/SSL protocols also affect Node.js.
+
+- [CVE-2016-2216](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/):
+  _Fix defects in HTTP header parsing for requests and responses that can allow
+  response splitting_. This was a remotely-exploitable defect in the Node.js
+  HTTP implementation.
+
+When in doubt, please do send us a report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,5 @@
 # Security
+
 If you find a security vulnerability in Node.js, please report it to
 security@nodejs.org. Please withhold public disclosure until after the security
 team has addressed the vulnerability.
@@ -10,7 +11,6 @@ There are no hard and fast rules to determine if a bug is worth reporting as a
 security issue. Here are some examples of past issues and what the Security
 Response Team thinks of them. When in doubt, please do send us a report
 nonetheless.
-
 
 ## Public disclosure preferred
 


### PR DESCRIPTION
This adds a SECURITY.md file and links to the security document per the
request of @Trott at a recent SF Node meetup.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
