### PR TITLE
Define getters and setters for EventEmitter.defaultMaxListeners with arrow functions

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -51,7 +51,7 @@ function lazyErrors() {
 Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   enumerable: true,
   get: () => defaultMaxListeners,
-  set: arg => {
+  set: (arg) => {
     if (typeof arg !== 'number' || arg < 0 || Number.isNaN(arg)) {
       const errors = lazyErrors();
       throw new errors.ERR_OUT_OF_RANGE('defaultMaxListeners',

--- a/lib/events.js
+++ b/lib/events.js
@@ -39,9 +39,9 @@ EventEmitter.prototype._maxListeners = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
-var defaultMaxListeners = 10;
+let defaultMaxListeners = 10;
 
-var errors;
+let errors;
 function lazyErrors() {
   if (errors === undefined)
     errors = require('internal/errors').codes;
@@ -50,10 +50,8 @@ function lazyErrors() {
 
 Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   enumerable: true,
-  get: function() {
-    return defaultMaxListeners;
-  },
-  set: function(arg) {
+  get: () => defaultMaxListeners,
+  set: arg => {
     if (typeof arg !== 'number' || arg < 0 || Number.isNaN(arg)) {
       const errors = lazyErrors();
       throw new errors.ERR_OUT_OF_RANGE('defaultMaxListeners',


### PR DESCRIPTION
I just put an arrow function for define `get/set` methods for `EventEmitter.defaultMaxListeners` attribute

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
