### PR TITLE
build: use BUILDTYPE in bench-addons-build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ test-valgrind: all
 test-check-deopts: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) --check-deopts parallel sequential
 
-benchmark/napi/function_call/build/Release/binding.node: \
+benchmark/napi/function_call/build/$(BUILDTYPE)/binding.node: \
 		benchmark/napi/function_call/napi_binding.c \
 		benchmark/napi/function_call/binding.cc \
 		benchmark/napi/function_call/binding.gyp | all
@@ -317,7 +317,7 @@ benchmark/napi/function_call/build/Release/binding.node: \
 		--directory="$(shell pwd)/benchmark/napi/function_call" \
 		--nodedir="$(shell pwd)"
 
-benchmark/napi/function_args/build/Release/binding.node: \
+benchmark/napi/function_args/build/$(BUILDTYPE)/binding.node: \
 		benchmark/napi/function_args/napi_binding.c \
 		benchmark/napi/function_args/binding.cc \
 		benchmark/napi/function_args/binding.gyp | all
@@ -1044,8 +1044,8 @@ bench: bench-addons-build
 
 # Build required addons for benchmark before running it.
 .PHONY: bench-addons-build
-bench-addons-build: benchmark/napi/function_call/build/Release/binding.node \
-	benchmark/napi/function_args/build/Release/binding.node
+bench-addons-build: benchmark/napi/function_call/build/$(BUILDTYPE)/binding.node \
+	benchmark/napi/function_args/build/$(BUILDTYPE)/binding.node
 
 .PHONY: bench-addons-clean
 bench-addons-clean:

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -3,6 +3,8 @@
 const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
+exports.buildType = process.features.debug ? 'Debug' : 'Release';
+
 exports.createBenchmark = function(fn, configs, options) {
   return new Benchmark(fn, configs, options);
 };

--- a/benchmark/napi/function_args/index.js
+++ b/benchmark/napi/function_args/index.js
@@ -10,14 +10,14 @@ let v8;
 let napi;
 
 try {
-  v8 = require('./build/Release/binding');
+  v8 = require(`./build/${common.buildType}/binding`);
 } catch {
   console.error(`${__filename}: V8 Binding failed to load`);
   process.exit(0);
 }
 
 try {
-  napi = require('./build/Release/napi_binding');
+  napi = require(`./build/${common.buildType}/napi_binding`);
 } catch {
   console.error(`${__filename}: NAPI-Binding failed to load`);
   process.exit(0);

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -12,7 +12,7 @@ const common = require('../../common.js');
 // abort quietly.
 
 try {
-  var binding = require('./build/Release/binding');
+  var binding = require(`./build/${common.buildType}/binding`);
 } catch {
   console.error('misc/function_call.js Binding failed to load');
   process.exit(0);
@@ -21,7 +21,7 @@ const cxx = binding.hello;
 
 let napi_binding;
 try {
-  napi_binding = require('./build/Release/napi_binding');
+  napi_binding = require(`./build/${common.buildType}/napi_binding`);
 } catch {
   console.error('misc/function_call/index.js NAPI-Binding failed to load');
   process.exit(0);


### PR DESCRIPTION
This commit uses the `BUILDTYPE` for the benchmark targets that currently
explicitly use `Release` as the build type.

The motivation for this change is allows switching between debug builds
and release builds using the `bench-addons-clean`/`bench-addons-build`
targets.

@nodejs/build-files

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
