### PR TITLE
Revert "child_process: change windowsHide default to true"

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -748,7 +748,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/22409
     description: The `input` option can now be any `TypedArray` or a
                  `DataView`.
-    - version: v8.8.0
+  - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
   - version: v8.0.0

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -131,9 +131,6 @@ exec('"my script.cmd" a b', (err, stdout, stderr) => {
 <!-- YAML
 added: v0.1.90
 changes:
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -156,7 +153,7 @@ changes:
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
 * `callback` {Function} called with the output when process terminates.
   * `error` {Error}
   * `stdout` {string|Buffer}
@@ -235,9 +232,6 @@ lsExample();
 <!-- YAML
 added: v0.1.91
 changes:
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -257,7 +251,7 @@ changes:
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
   * `windowsVerbatimArguments` {boolean} No quoting or escaping of arguments is
     done on Windows. Ignored on Unix. **Default:** `false`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
@@ -381,9 +375,6 @@ The `shell` option available in [`child_process.spawn()`][] is not supported by
 <!-- YAML
 added: v0.1.90
 changes:
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -417,7 +408,7 @@ changes:
     done on Windows. Ignored on Unix. This is set to `true` automatically
     when `shell` is specified and is CMD. **Default:** `false`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {ChildProcess}
 
 The `child_process.spawn()` method spawns a new process using the given
@@ -690,9 +681,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/22409
     description: The `input` option can now be any `TypedArray` or a
                  `DataView`.
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -727,7 +715,7 @@ changes:
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell Requirements][] and
@@ -760,10 +748,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/22409
     description: The `input` option can now be any `TypedArray` or a
                  `DataView`.
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
-  - version: v8.8.0
+    - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
   - version: v8.0.0
@@ -796,7 +781,7 @@ changes:
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {Buffer|string} The stdout from the command.
 
 The `child_process.execSync()` method is generally identical to
@@ -822,9 +807,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/22409
     description: The `input` option can now be any `TypedArray` or a
                  `DataView`.
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -869,7 +851,7 @@ changes:
     done on Windows. Ignored on Unix. This is set to `true` automatically
     when `shell` is specified and is CMD. **Default:** `false`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {Object}
   * `pid` {number} Pid of the child process.
   * `output` {Array} Array of results from stdio output.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -703,9 +703,6 @@ values are `'rr'` and `'none'`.
 <!-- YAML
 added: v0.7.1
 changes:
-  - version: v11.0.0
-    pr-url: https://github.com/nodejs/node/pull/21316
-    description: The `windowsHide` option now defaults to `true`.
   - version: v9.5.0
     pr-url: https://github.com/nodejs/node/pull/18399
     description: The `cwd` option is supported now.
@@ -740,7 +737,7 @@ changes:
     number. By default each worker gets its own port, incremented from the
     master's `process.debugPort`.
   * `windowsHide` {boolean} Hide the forked processes console window that would
-    normally be created on Windows systems. **Default:** `true`.
+    normally be created on Windows systems. **Default:** `false`.
 
 After calling `.setupMaster()` (or `.fork()`) this settings object will contain
 the settings, including the default values.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -224,7 +224,7 @@ exports.execFile = function execFile(file /* , args, options, callback */) {
     gid: options.gid,
     uid: options.uid,
     shell: options.shell,
-    windowsHide: options.windowsHide !== false,
+    windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
@@ -544,7 +544,7 @@ var spawn = exports.spawn = function spawn(/* file, args, options */) {
     file: opts.file,
     args: opts.args,
     cwd: options.cwd,
-    windowsHide: options.windowsHide !== false,
+    windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments,
     detached: !!options.detached,
     envPairs: opts.envPairs,
@@ -577,8 +577,6 @@ function spawnSync(/* file, args, options */) {
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
   options.stdio = _validateStdio(options.stdio || 'pipe', true).stdio;
-
-  options.windowsHide = options.windowsHide !== false;
 
   if (options.input) {
     var stdin = options.stdio[0] = util._extend({}, options.stdio[0]);

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -67,7 +67,7 @@ assert.strictEqual(env.stdout.toString().trim(), 'buzz');
       assert.strictEqual(opts.options.shell, shell);
       assert.strictEqual(opts.options.file, opts.file);
       assert.deepStrictEqual(opts.options.args, opts.args);
-      assert.strictEqual(opts.options.windowsHide, true);
+      assert.strictEqual(opts.options.windowsHide, undefined);
       assert.strictEqual(opts.options.windowsVerbatimArguments,
                          windowsVerbatim);
     });


### PR DESCRIPTION
This reverts commit 420d8afe3db22ad703e74892f58f9e32d34ff699.

I'm opening this not because I'm convinced the commit needs to be reverted, but to hopefully elicit a prompt conversation and decision about whether or not it should be reverted.

Refs: https://github.com/nodejs/node/pull/21316#issuecomment-434854492 and several subsequent comments. 

I'm particularly interested in what embedders, especially Electron folks, think.  @MarshallOfSound has already weighed in that they don't believe a revert is warranted, but also expressed it as a personal opinion (so, I assume, not speaking on behalf of Electron). Would love to hear from @codebytere or @zeke or @groundwater or someone, either to get a consensus of personal opinions or else to get a semi-official "Electron prefers revert/no-revert".

@nodejs/embedders 

IIUC, this is only affecting developers and not end users. Doing this out of an abundance of caution and in case I"m wrong about that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
