### PR TITLE
lib: gather all errors constant in the same place for consistency

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -64,31 +64,29 @@ const {
   onStreamRead,
   kUpdateTimer
 } = require('internal/stream_base_commons');
-const errors = require('internal/errors');
 const {
-  ERR_INVALID_ADDRESS_FAMILY,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_FD_TYPE,
-  ERR_INVALID_IP_ADDRESS,
-  ERR_INVALID_OPT_VALUE,
-  ERR_SERVER_ALREADY_LISTEN,
-  ERR_SERVER_NOT_RUNNING,
-  ERR_SOCKET_BAD_PORT,
-  ERR_SOCKET_CLOSED
-} = errors.codes;
+  codes: {
+    ERR_INVALID_ADDRESS_FAMILY,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_FD_TYPE,
+    ERR_INVALID_IP_ADDRESS,
+    ERR_INVALID_OPT_VALUE,
+    ERR_SERVER_ALREADY_LISTEN,
+    ERR_SERVER_NOT_RUNNING,
+    ERR_SOCKET_BAD_PORT,
+    ERR_SOCKET_CLOSED
+  },
+  errnoException,
+  exceptionWithHostPort,
+  uvExceptionWithHostPort
+} = require('internal/errors');
 const { validateInt32, validateString } = require('internal/validators');
 const kLastWriteQueueSize = Symbol('lastWriteQueueSize');
 
 // Lazy loaded to improve startup performance.
 let cluster;
 let dns;
-
-const {
-  errnoException,
-  exceptionWithHostPort,
-  uvExceptionWithHostPort
-} = errors;
 
 const {
   kTimeout,


### PR DESCRIPTION
Gather all errors constant in the same place for consistency in [lib/net.js](https://github.com/nodejs/node/blob/74ba48294b115364b92bbd5c87c8025cd109e303/lib/net.js#L67)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)