### PR TITLE
console: bind methods from the prototype chain in Console

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -129,7 +129,10 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   var keys = Object.keys(Console.prototype);
   for (var v = 0; v < keys.length; v++) {
     var k = keys[v];
-    this[k] = Console.prototype[k].bind(this);
+    // We have to bind the methods grabbed from the instance instead of from
+    // the prototype so that users extending the Console can override them
+    // from the prototype chain of the subclass.
+    this[k] = this[k].bind(this);
   }
 }
 

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -105,10 +105,16 @@ out.write = err.write = (d) => {};
 {
   class MyConsole extends Console {
     hello() {}
+    // See if the methods on Console.prototype are overridable.
+    log() { return 'overridden'; }
   }
   const myConsole = new MyConsole(process.stdout);
   assert.strictEqual(typeof myConsole.hello, 'function');
   assert.ok(myConsole instanceof Console);
+  assert.strictEqual(myConsole.log(), 'overridden');
+
+  const log = myConsole.log;
+  assert.strictEqual(log(), 'overridden');
 }
 
 // Instance that does not ignore the stream errors.


### PR DESCRIPTION
In 62232361 we made the console.Console function construct an object
with methods from Console.prototype bound to the instance, instead of
with methods found on the prototype chain to be bound on the instances,
thus breaking users overriding these methods when subclassing Console
because they are not expecting this function to construct a
namespace whose methods are not looked up from the prototype
chain.

This patch restores the previous behavior since it does not affect
the characteristics of the global console anyway. So after this patch,
the Console function still constructs normal objects with function
properties looked up from the prototype chain but bound to the
instances always.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
