### PR TITLE
deps: introduce experimental `llhttp` HTTP parser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -114,6 +114,32 @@ The externally maintained libraries used by Node.js are:
     IN THE SOFTWARE.
   """
 
+- llhttp, located at deps/llhttp, is licensed as follows:
+  """
+    This software is licensed under the MIT License.
+
+    Copyright Fedor Indutny, 2018.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit
+    persons to whom the Software is furnished to do so, subject to the
+    following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+    USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
 - ICU, located at deps/icu-small, is licensed as follows:
   """
     COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)

--- a/LICENSE
+++ b/LICENSE
@@ -114,32 +114,6 @@ The externally maintained libraries used by Node.js are:
     IN THE SOFTWARE.
   """
 
-- llhttp, located at deps/llhttp, is licensed as follows:
-  """
-    This software is licensed under the MIT License.
-
-    Copyright Fedor Indutny, 2018.
-
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and associated documentation files (the
-    "Software"), to deal in the Software without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to permit
-    persons to whom the Software is furnished to do so, subject to the
-    following conditions:
-
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-    USE OR OTHER DEALINGS IN THE SOFTWARE.
-  """
-
 - ICU, located at deps/icu-small, is licensed as follows:
   """
     COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
@@ -630,6 +604,32 @@ The externally maintained libraries used by Node.js are:
       - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design
         Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
         n° 289016). Three clause BSD license.
+  """
+
+- llhttp, located at deps/llhttp, is licensed as follows:
+  """
+    This software is licensed under the MIT License.
+
+    Copyright Fedor Indutny, 2018.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to permit
+    persons to whom the Software is furnished to do so, subject to the
+    following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+    USE OR OTHER DEALINGS IN THE SOFTWARE.
   """
 
 - OpenSSL, located at deps/openssl, is licensed as follows:

--- a/configure.py
+++ b/configure.py
@@ -182,6 +182,11 @@ parser.add_option('--openssl-system-ca-path',
     help='Use the specified path to system CA (PEM format) in addition to '
          'the OpenSSL supplied CA store or compiled-in Mozilla CA copy.')
 
+parser.add_option('--experimental-http-parser',
+    action='store_true',
+    dest='experimental_http_parser',
+    help='use llhttp instead of http_parser')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -1099,6 +1104,9 @@ def configure_node(o):
     o['variables']['node_target_type'] = 'static_library'
   else:
     o['variables']['node_target_type'] = 'executable'
+
+  o['variables']['node_experimental_http_parser'] = \
+      'true' if options.experimental_http_parser else 'false'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/configure.py
+++ b/configure.py
@@ -1106,7 +1106,7 @@ def configure_node(o):
     o['variables']['node_target_type'] = 'executable'
 
   o['variables']['node_experimental_http_parser'] = \
-      'true' if options.experimental_http_parser else 'false'
+      b(options.experimental_http_parser)
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/deps/llhttp/LICENSE-MIT
+++ b/deps/llhttp/LICENSE-MIT
@@ -1,0 +1,22 @@
+This software is licensed under the MIT License.
+
+Copyright Fedor Indutny, 2018.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/deps/llhttp/README.md
+++ b/deps/llhttp/README.md
@@ -1,0 +1,129 @@
+# llhttp
+[![Build Status](https://secure.travis-ci.org/indutny/llhttp.svg)](http://travis-ci.org/indutny/llhttp)
+
+Port of [http_parser][0] to [llparse][1].
+
+## Why?
+
+Let's face it, [http_parser][0] is practically unmaintainable. Even
+introduction of a single new method results in a significant code churn.
+
+This project aims to:
+
+* Make it maintainable
+* Verifiable
+* Improving benchmarks where possible
+
+## How?
+
+Over time, different approaches for improving [http_parser][0]'s code base
+were tried. However, all of them failed due to resulting significant performance
+degradation.
+
+This project is a port of [http_parser][0] to TypeScript. [llparse][1] is used
+to generate the output C and/or bitcode artifacts, which could be compiled and
+linked with the embedder's program (like [Node.js][7]).
+
+## Peformance
+
+So far llhttp outperforms http_parser:
+
+|                 | input size |  bandwidth   |  reqs/sec  |   time  |
+|:----------------|-----------:|-------------:|-----------:|--------:|
+| **llhttp** _(C)_ | 8192.00 mb | 1497.88 mb/s | 3020458.87 ops/sec | 5.47 s |
+| **llhttp** _(bitcode)_ | 8192.00 mb | 1131.75 mb/s | 2282171.24 ops/sec | 7.24 s |
+| **http_parser** | 8192.00 mb | 694.66 mb/s | 1406180.33 req/sec | 11.79 s |
+
+llhttp is faster by approximately **116%**.
+
+## Maintenance
+
+llhttp project has about 1400 lines of TypeScript code describing the parser
+itself and around 450 lines of C code and headers providing the helper methods.
+The whole [http_parser][0] is implemented in approximately 2500 lines of C, and
+436 lines of headers.
+
+All optimizations and multi-character matching in llhttp are generated
+automatically, and thus doesn't add any extra maintenance cost. On the contrary,
+most of http_parser's code is hand-optimized and unrolled. Instead describing
+"how" it should parse the HTTP requests/responses, a maintainer should
+implement the new features in [http_parser][0] cautiously, considering
+possible performance degradation and manually optimizing the new code.
+
+## Verification
+
+The state machine graph is encoded explicitly in llhttp. The [llparse][1]
+automatically checks the graph for absence of loops and correct reporting of the
+input ranges (spans) like header names and values. In the future, additional
+checks could be performed to get even stricter verification of the llhttp.
+
+## Usage
+
+```C
+#include "llhttp.h"
+
+llhttp_t parser;
+llhttp_settings_t settings;
+
+/* Initialize user callbacks and settings */
+llhttp_settings_init(&settings);
+
+/* Set user callback */
+settings.on_message_complete = handle_on_message_complete;
+
+/* Initialize the parser in HTTP_BOTH mode, meaning that it will select between
+ * HTTP_REQUEST and HTTP_RESPONSE parsing automatically while reading the first
+ * input.
+ */
+llhttp_init(&parser, HTTP_BOTH, &settings);
+
+/* Use `llhttp_set_type(&parser, HTTP_REQUEST);` to override the mode */
+
+/* Parse request! */
+const char* request = "GET / HTTP/1.1\r\n\r\n";
+int request_len = strlen(request);
+
+enum llhttp_errno err = llhttp_execute(&parser, request, request_len);
+if (err == HPE_OK) {
+  /* Successfully parsed! */
+} else {
+  fprintf(stderr, "Parse error: %s %s\n", llhttp_errno_name(err),
+          parser.reason);
+}
+```
+
+---
+
+#### LICENSE
+
+This software is licensed under the MIT License.
+
+Copyright Fedor Indutny, 2018.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[0]: https://github.com/nodejs/http-parser
+[1]: https://github.com/indutny/llparse
+[2]: https://en.wikipedia.org/wiki/Register_allocation#Spilling
+[3]: https://en.wikipedia.org/wiki/Tail_call
+[4]: https://llvm.org/docs/LangRef.html
+[5]: https://llvm.org/docs/LangRef.html#call-instruction
+[6]: https://clang.llvm.org/
+[7]: https://github.com/nodejs/node

--- a/deps/llhttp/common.gypi
+++ b/deps/llhttp/common.gypi
@@ -1,0 +1,46 @@
+{
+  'target_defaults': {
+    'default_configuration': 'Debug',
+    'configurations': {
+      # TODO: hoist these out and put them somewhere common, because
+      #       RuntimeLibrary MUST MATCH across the entire project
+      'Debug': {
+        'defines': [ 'DEBUG', '_DEBUG' ],
+        'cflags': [ '-Wall', '-Wextra', '-O0', '-g', '-ftrapv' ],
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'RuntimeLibrary': 1, # static debug
+          },
+        },
+      },
+      'Release': {
+        'defines': [ 'NDEBUG' ],
+        'cflags': [ '-Wall', '-Wextra', '-O3' ],
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'RuntimeLibrary': 0, # static release
+          },
+        },
+      }
+    },
+    'msvs_settings': {
+      'VCCLCompilerTool': {
+        # Compile as C++. llhttp.c is actually C99, but C++ is
+        # close enough in this case.
+        'CompileAs': 2,
+      },
+      'VCLibrarianTool': {
+      },
+      'VCLinkerTool': {
+        'GenerateDebugInformation': 'true',
+      },
+    },
+    'conditions': [
+      ['OS == "win"', {
+        'defines': [
+          'WIN32'
+        ],
+      }]
+    ],
+  },
+}

--- a/deps/llhttp/include/llhttp.h
+++ b/deps/llhttp/include/llhttp.h
@@ -1,0 +1,353 @@
+#ifndef INCLUDE_LLHTTP_H_
+#define INCLUDE_LLHTTP_H_
+
+#define LLHTTP_VERSION_MAJOR 1
+#define LLHTTP_VERSION_MINOR 0
+#define LLHTTP_VERSION_PATCH 0
+
+#ifndef INCLUDE_LLHTTP_ITSELF_H_
+#define INCLUDE_LLHTTP_ITSELF_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+typedef struct llhttp__internal_s llhttp__internal_t;
+struct llhttp__internal_s {
+  int32_t _index;
+  void* _span_pos0;
+  void* _span_cb0;
+  int32_t error;
+  const char* reason;
+  const char* error_pos;
+  void* data;
+  void* _current;
+  uint64_t content_length;
+  uint8_t type;
+  uint8_t method;
+  uint8_t http_major;
+  uint8_t http_minor;
+  uint8_t header_state;
+  uint8_t flags;
+  uint8_t upgrade;
+  uint16_t status_code;
+  uint8_t finish;
+  void* settings;
+};
+
+int llhttp__internal_init(llhttp__internal_t* s);
+int llhttp__internal_execute(llhttp__internal_t* s, const char* p, const char* endp);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+#endif  /* INCLUDE_LLHTTP_ITSELF_H_ */
+
+#ifndef LLLLHTTP_C_HEADERS_
+#define LLLLHTTP_C_HEADERS_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum llhttp_errno {
+  HPE_OK = 0,
+  HPE_INTERNAL = 1,
+  HPE_STRICT = 2,
+  HPE_LF_EXPECTED = 3,
+  HPE_UNEXPECTED_CONTENT_LENGTH = 4,
+  HPE_CLOSED_CONNECTION = 5,
+  HPE_INVALID_METHOD = 6,
+  HPE_INVALID_URL = 7,
+  HPE_INVALID_CONSTANT = 8,
+  HPE_INVALID_VERSION = 9,
+  HPE_INVALID_HEADER_TOKEN = 10,
+  HPE_INVALID_CONTENT_LENGTH = 11,
+  HPE_INVALID_CHUNK_SIZE = 12,
+  HPE_INVALID_STATUS = 13,
+  HPE_INVALID_EOF_STATE = 14,
+  HPE_CB_MESSAGE_BEGIN = 15,
+  HPE_CB_HEADERS_COMPLETE = 16,
+  HPE_CB_MESSAGE_COMPLETE = 17,
+  HPE_CB_CHUNK_HEADER = 18,
+  HPE_CB_CHUNK_COMPLETE = 19,
+  HPE_PAUSED = 20,
+  HPE_PAUSED_UPGRADE = 21,
+  HPE_USER = 22
+};
+typedef enum llhttp_errno llhttp_errno_t;
+
+enum llhttp_flags {
+  F_CONNECTION_KEEP_ALIVE = 0x1,
+  F_CONNECTION_CLOSE = 0x2,
+  F_CONNECTION_UPGRADE = 0x4,
+  F_CHUNKED = 0x8,
+  F_UPGRADE = 0x10,
+  F_CONTENT_LENGTH = 0x20,
+  F_SKIPBODY = 0x40,
+  F_TRAILING = 0x80
+};
+typedef enum llhttp_flags llhttp_flags_t;
+
+enum llhttp_type {
+  HTTP_BOTH = 0,
+  HTTP_REQUEST = 1,
+  HTTP_RESPONSE = 2
+};
+typedef enum llhttp_type llhttp_type_t;
+
+enum llhttp_finish {
+  HTTP_FINISH_SAFE = 0,
+  HTTP_FINISH_SAFE_WITH_CB = 1,
+  HTTP_FINISH_UNSAFE = 2
+};
+typedef enum llhttp_finish llhttp_finish_t;
+
+enum llhttp_method {
+  HTTP_DELETE = 0,
+  HTTP_GET = 1,
+  HTTP_HEAD = 2,
+  HTTP_POST = 3,
+  HTTP_PUT = 4,
+  HTTP_CONNECT = 5,
+  HTTP_OPTIONS = 6,
+  HTTP_TRACE = 7,
+  HTTP_COPY = 8,
+  HTTP_LOCK = 9,
+  HTTP_MKCOL = 10,
+  HTTP_MOVE = 11,
+  HTTP_PROPFIND = 12,
+  HTTP_PROPPATCH = 13,
+  HTTP_SEARCH = 14,
+  HTTP_UNLOCK = 15,
+  HTTP_BIND = 16,
+  HTTP_REBIND = 17,
+  HTTP_UNBIND = 18,
+  HTTP_ACL = 19,
+  HTTP_REPORT = 20,
+  HTTP_MKACTIVITY = 21,
+  HTTP_CHECKOUT = 22,
+  HTTP_MERGE = 23,
+  HTTP_MSEARCH = 24,
+  HTTP_NOTIFY = 25,
+  HTTP_SUBSCRIBE = 26,
+  HTTP_UNSUBSCRIBE = 27,
+  HTTP_PATCH = 28,
+  HTTP_PURGE = 29,
+  HTTP_MKCALENDAR = 30,
+  HTTP_LINK = 31,
+  HTTP_UNLINK = 32,
+  HTTP_SOURCE = 33
+};
+typedef enum llhttp_method llhttp_method_t;
+
+#define HTTP_ERRNO_MAP(XX) \
+  XX(0, OK, OK) \
+  XX(1, INTERNAL, INTERNAL) \
+  XX(2, STRICT, STRICT) \
+  XX(3, LF_EXPECTED, LF_EXPECTED) \
+  XX(4, UNEXPECTED_CONTENT_LENGTH, UNEXPECTED_CONTENT_LENGTH) \
+  XX(5, CLOSED_CONNECTION, CLOSED_CONNECTION) \
+  XX(6, INVALID_METHOD, INVALID_METHOD) \
+  XX(7, INVALID_URL, INVALID_URL) \
+  XX(8, INVALID_CONSTANT, INVALID_CONSTANT) \
+  XX(9, INVALID_VERSION, INVALID_VERSION) \
+  XX(10, INVALID_HEADER_TOKEN, INVALID_HEADER_TOKEN) \
+  XX(11, INVALID_CONTENT_LENGTH, INVALID_CONTENT_LENGTH) \
+  XX(12, INVALID_CHUNK_SIZE, INVALID_CHUNK_SIZE) \
+  XX(13, INVALID_STATUS, INVALID_STATUS) \
+  XX(14, INVALID_EOF_STATE, INVALID_EOF_STATE) \
+  XX(15, CB_MESSAGE_BEGIN, CB_MESSAGE_BEGIN) \
+  XX(16, CB_HEADERS_COMPLETE, CB_HEADERS_COMPLETE) \
+  XX(17, CB_MESSAGE_COMPLETE, CB_MESSAGE_COMPLETE) \
+  XX(18, CB_CHUNK_HEADER, CB_CHUNK_HEADER) \
+  XX(19, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
+  XX(20, PAUSED, PAUSED) \
+  XX(21, PAUSED_UPGRADE, PAUSED_UPGRADE) \
+  XX(22, USER, USER) \
+
+
+#define HTTP_METHOD_MAP(XX) \
+  XX(0, DELETE, DELETE) \
+  XX(1, GET, GET) \
+  XX(2, HEAD, HEAD) \
+  XX(3, POST, POST) \
+  XX(4, PUT, PUT) \
+  XX(5, CONNECT, CONNECT) \
+  XX(6, OPTIONS, OPTIONS) \
+  XX(7, TRACE, TRACE) \
+  XX(8, COPY, COPY) \
+  XX(9, LOCK, LOCK) \
+  XX(10, MKCOL, MKCOL) \
+  XX(11, MOVE, MOVE) \
+  XX(12, PROPFIND, PROPFIND) \
+  XX(13, PROPPATCH, PROPPATCH) \
+  XX(14, SEARCH, SEARCH) \
+  XX(15, UNLOCK, UNLOCK) \
+  XX(16, BIND, BIND) \
+  XX(17, REBIND, REBIND) \
+  XX(18, UNBIND, UNBIND) \
+  XX(19, ACL, ACL) \
+  XX(20, REPORT, REPORT) \
+  XX(21, MKACTIVITY, MKACTIVITY) \
+  XX(22, CHECKOUT, CHECKOUT) \
+  XX(23, MERGE, MERGE) \
+  XX(24, MSEARCH, M-SEARCH) \
+  XX(25, NOTIFY, NOTIFY) \
+  XX(26, SUBSCRIBE, SUBSCRIBE) \
+  XX(27, UNSUBSCRIBE, UNSUBSCRIBE) \
+  XX(28, PATCH, PATCH) \
+  XX(29, PURGE, PURGE) \
+  XX(30, MKCALENDAR, MKCALENDAR) \
+  XX(31, LINK, LINK) \
+  XX(32, UNLINK, UNLINK) \
+  XX(33, SOURCE, SOURCE) \
+
+
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+#endif  /* LLLLHTTP_C_HEADERS_ */
+
+#ifndef INCLUDE_LLHTTP_API_H_
+#define INCLUDE_LLHTTP_API_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef llhttp__internal_t llhttp_t;
+typedef struct llhttp_settings_s llhttp_settings_t;
+
+typedef int (*llhttp_data_cb)(llhttp_t*, const char *at, size_t length);
+typedef int (*llhttp_cb)(llhttp_t*);
+
+struct llhttp_settings_s {
+  /* Possible return values 0, -1, `HPE_PAUSED` */
+  llhttp_cb      on_message_begin;
+
+  llhttp_data_cb on_url;
+  llhttp_data_cb on_status;
+  llhttp_data_cb on_header_field;
+  llhttp_data_cb on_header_value;
+
+  /* Possible return values:
+   * 0  - Proceed normally
+   * 1  - Assume that request/response has no body, and proceed to parsing the
+   *      next message
+   * 2  - Assume absence of body (as above) and make `llhttp_execute()` return
+   *      `HPE_PAUSED_UPGRADE`
+   * -1 - Error
+   * `HPE_PAUSED`
+   */
+  llhttp_cb      on_headers_complete;
+
+  llhttp_data_cb on_body;
+
+  /* Possible return values 0, -1, `HPE_PAUSED` */
+  llhttp_cb      on_message_complete;
+
+  /* When on_chunk_header is called, the current chunk length is stored
+   * in parser->content_length.
+   * Possible return values 0, -1, `HPE_PAUSED`
+   */
+  llhttp_cb      on_chunk_header;
+  llhttp_cb      on_chunk_complete;
+};
+
+/* Initialize the parser with specific type and user settings */
+void llhttp_init(llhttp_t* parser, llhttp_type_t type,
+                 const llhttp_settings_t* settings);
+
+/* Initialize the settings object */
+void llhttp_settings_init(llhttp_settings_t* settings);
+
+/* Parse full or partial request/response, invoking user callbacks along the
+ * way.
+ *
+ * If any of `llhttp_data_cb` returns errno not equal to `HPE_OK` - the parsing
+ * interrupts, and such errno is returned from `llhttp_execute()`. If
+ * `HPE_PAUSED` was used as a errno, the execution can be resumed with
+ * `llhttp_resume()` call.
+ *
+ * In a special case of CONNECT/Upgrade request/response `HPE_PAUSED_UPGRADE`
+ * is returned after fully parsing the request/response. If the user wishes to
+ * continue parsing, they need to invoke `llhttp_resume_after_upgrade()`.
+ */
+llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len);
+
+/* This method should be called when the other side has no further bytes to
+ * send (e.g. shutdown of readable side of the TCP connection.)
+ *
+ * Requests without `Content-Length` and other messages might require treating
+ * all incoming bytes as the part of the body, up to the last byte of the
+ * connection. This method will invoke `on_message_complete()` callback if the
+ * request was terminated safely. Otherwise a error code would be returned.
+ */
+llhttp_errno_t llhttp_finish(llhttp_t* parser);
+
+/* Returns `1` if the incoming message is parsed until the last byte, and has
+ * to be completed by calling `llhttp_finish()` on EOF
+ */
+int llhttp_message_needs_eof(const llhttp_t* parser);
+
+/* Returns `1` if there might be any other messages following the last that was
+ * successfuly parsed.
+ */
+int llhttp_should_keep_alive(const llhttp_t* parser);
+
+/* Make further calls of `llhttp_execute()` return `HPE_PAUSED` and set
+ * appropriate error reason.
+ *
+ * Important: do not call this from user callbacks! User callbacks must return
+ * `HPE_PAUSED` if pausing is required.
+ */
+void llhttp_pause(llhttp_t* parser);
+
+/* Might be called to resume the execution after the pause in user's callback.
+ * See `llhttp_execute()` above for details.
+ *
+ * Call this only if `llhttp_execute()` returns `HPE_PAUSED`.
+ */
+void llhttp_resume(llhttp_t* parser);
+
+/* Might be called to resume the execution after the pause in user's callback.
+ * See `llhttp_execute()` above for details.
+ *
+ * Call this only if `llhttp_execute()` returns `HPE_PAUSED_UPGRADE`
+ */
+void llhttp_resume_after_upgrade(llhttp_t* parser);
+
+/* Returns the latest return error */
+llhttp_errno_t llhttp_get_errno(const llhttp_t* parser);
+
+/* Returns the verbal explanation of the latest returned error.
+ *
+ * Note: User callback should set error reason when returning the error. See
+ * `llhttp_set_error_reason()` for details.
+ */
+const char* llhttp_get_error_reason(const llhttp_t* parser);
+
+/* Assign verbal description to the returned error. Must be called in user
+ * callbacks right before returning the errno.
+ *
+ * Note: `HPE_USER` error code might be useful in user callbacks.
+ */
+void llhttp_set_error_reason(llhttp_t* parser, const char* reason);
+
+/* Returns the pointer to the last parsed byte before the returned error. The
+ * pointer is relative to the `data` argument of `llhttp_execute()`.
+ *
+ * Note: this method might be useful for counting the number of parsed bytes.
+ */
+const char* llhttp_get_error_pos(const llhttp_t* parser);
+
+/* Returns textual name of error code */
+const char* llhttp_errno_name(llhttp_errno_t err);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+#endif  /* INCLUDE_LLHTTP_API_H_ */
+
+#endif  /* INCLUDE_LLHTTP_H_ */

--- a/deps/llhttp/llhttp.gyp
+++ b/deps/llhttp/llhttp.gyp
@@ -1,0 +1,13 @@
+{
+  'targets': [
+    {
+      'target_name': 'llhttp',
+      'type': 'static_library',
+      'include_dirs': [ '.', 'include' ],
+      'direct_dependent_settings': {
+        'include_dirs': [ 'include' ],
+      },
+      'sources': [ 'src/llhttp.c', 'src/api.c', 'src/http.c' ],
+    },
+  ]
+}

--- a/deps/llhttp/src/api.c
+++ b/deps/llhttp/src/api.c
@@ -1,0 +1,205 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "llhttp.h"
+
+#define CALLBACK_MAYBE(PARSER, NAME, ...)                                     \
+  do {                                                                        \
+    llhttp_settings_t* settings;                                              \
+    settings = (llhttp_settings_t*) (PARSER)->settings;                       \
+    if (settings == NULL || settings->NAME == NULL) {                         \
+      err = 0;                                                                \
+      break;                                                                  \
+    }                                                                         \
+    err = settings->NAME(__VA_ARGS__);                                        \
+  } while (0)
+
+void llhttp_init(llhttp_t* parser, llhttp_type_t type,
+                 const llhttp_settings_t* settings) {
+  llhttp__internal_init(parser);
+
+  parser->type = type;
+  parser->settings = (void*) settings;
+}
+
+
+llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len) {
+  return llhttp__internal_execute(parser, data, data + len);
+}
+
+
+void llhttp_settings_init(llhttp_settings_t* settings) {
+  memset(settings, 0, sizeof(*settings));
+}
+
+
+llhttp_errno_t llhttp_finish(llhttp_t* parser) {
+  int err;
+
+  /* We're in an error state. Don't bother doing anything. */
+  if (parser->error != 0) {
+    return 0;
+  }
+
+  switch (parser->finish) {
+    case HTTP_FINISH_SAFE_WITH_CB:
+      CALLBACK_MAYBE(parser, on_message_complete, parser);
+      if (err != HPE_OK) return err;
+
+    /* FALLTHROUGH */
+    case HTTP_FINISH_SAFE:
+      return HPE_OK;
+    case HTTP_FINISH_UNSAFE:
+      parser->reason = "Invalid EOF state";
+      return HPE_INVALID_EOF_STATE;
+    default:
+      abort();
+  }
+}
+
+
+void llhttp_pause(llhttp_t* parser) {
+  if (parser->error != HPE_OK) {
+    return;
+  }
+
+  parser->error = HPE_PAUSED;
+  parser->reason = "Paused";
+}
+
+
+void llhttp_resume(llhttp_t* parser) {
+  if (parser->error != HPE_PAUSED) {
+    return;
+  }
+
+  parser->error = 0;
+}
+
+
+void llhttp_resume_after_upgrade(llhttp_t* parser) {
+  if (parser->error != HPE_PAUSED_UPGRADE) {
+    return;
+  }
+
+  parser->error = 0;
+}
+
+
+llhttp_errno_t llhttp_get_errno(const llhttp_t* parser) {
+  return parser->error;
+}
+
+
+const char* llhttp_get_error_reason(const llhttp_t* parser) {
+  return parser->reason;
+}
+
+
+void llhttp_set_error_reason(llhttp_t* parser, const char* reason) {
+  parser->reason = reason;
+}
+
+
+const char* llhttp_get_error_pos(const llhttp_t* parser) {
+  return parser->error_pos;
+}
+
+
+const char* llhttp_errno_name(llhttp_errno_t err) {
+#define HTTP_ERRNO_GEN(CODE, NAME, _) case HPE_##NAME: return "HPE_" #NAME;
+  switch (err) {
+    HTTP_ERRNO_MAP(HTTP_ERRNO_GEN)
+    default: abort();
+  }
+#undef HTTP_ERRNO_GEN
+}
+
+
+/* Callbacks */
+
+
+int llhttp__on_message_begin(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_message_begin, s);
+  return err;
+}
+
+
+int llhttp__on_url(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_url, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_status, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_header_field(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_field, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_header_value(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_value, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_headers_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_headers_complete, s);
+  return err;
+}
+
+
+int llhttp__on_message_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_message_complete, s);
+  return err;
+}
+
+
+int llhttp__on_body(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_body, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_chunk_header(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_header, s);
+  return err;
+}
+
+
+int llhttp__on_chunk_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_complete, s);
+  return err;
+}
+
+
+/* Private */
+
+
+void llhttp__debug(llhttp_t* s, const char* p, const char* endp,
+                   const char* msg) {
+  if (p == endp) {
+    fprintf(stderr, "p=%p type=%d flags=%02x next=null debug=%s\n", s, s->type,
+            s->flags, msg);
+  } else {
+    fprintf(stderr, "p=%p type=%d flags=%02x next=%02x   debug=%s\n", s,
+            s->type, s->flags, *p, msg);
+  }
+}

--- a/deps/llhttp/src/http.c
+++ b/deps/llhttp/src/http.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#ifndef LLHTTP__TEST
+# include "llhttp.h"
+#else
+# define llhttp_t llparse_t
+#endif  /* */
+
+int llhttp_message_needs_eof(const llhttp_t* parser);
+int llhttp_should_keep_alive(const llhttp_t* parser);
+
+int llhttp__before_headers_complete(llhttp_t* parser, const char* p,
+                                    const char* endp) {
+  /* Set this here so that on_headers_complete() callbacks can see it */
+  if ((parser->flags & F_UPGRADE) &&
+      (parser->flags & F_CONNECTION_UPGRADE)) {
+    /* For responses, "Upgrade: foo" and "Connection: upgrade" are
+     * mandatory only when it is a 101 Switching Protocols response,
+     * otherwise it is purely informational, to announce support.
+     */
+    parser->upgrade =
+        (parser->type == HTTP_REQUEST || parser->status_code == 101);
+  } else {
+    parser->upgrade = (parser->method == HTTP_CONNECT);
+  }
+  return 0;
+}
+
+
+/* Return values:
+ * 0 - No body, `restart`, message_complete
+ * 1 - CONNECT request, `restart`, message_complete, and pause
+ * 2 - chunk_size_start
+ * 3 - body_identity
+ * 4 - body_identity_eof
+ */
+int llhttp__after_headers_complete(llhttp_t* parser, const char* p,
+                                   const char* endp) {
+  int hasBody;
+
+  hasBody = parser->flags & F_CHUNKED || parser->content_length > 0;
+  if (parser->upgrade && (parser->method == HTTP_CONNECT ||
+                          (parser->flags & F_SKIPBODY) || !hasBody)) {
+    /* Exit, the rest of the message is in a different protocol. */
+    return 1;
+  }
+
+  if (parser->flags & F_SKIPBODY) {
+    return 0;
+  } else if (parser->flags & F_CHUNKED) {
+    /* chunked encoding - ignore Content-Length header */
+    return 2;
+  } else {
+    if (!(parser->flags & F_CONTENT_LENGTH)) {
+      if (!llhttp_message_needs_eof(parser)) {
+        /* Assume content-length 0 - read the next */
+        return 0;
+      } else {
+        /* Read body until EOF */
+        return 4;
+      }
+    } else if (parser->content_length == 0) {
+      /* Content-Length header given but zero: Content-Length: 0\r\n */
+      return 0;
+    } else {
+      /* Content-Length header given and non-zero */
+      return 3;
+    }
+  }
+}
+
+
+int llhttp__after_message_complete(llhttp_t* parser, const char* p,
+                                   const char* endp) {
+  int should_keep_alive;
+
+  should_keep_alive = llhttp_should_keep_alive(parser);
+  parser->flags = 0;
+  parser->finish = HTTP_FINISH_SAFE;
+
+  /* NOTE: this is ignored in loose parsing mode */
+  return should_keep_alive;
+}
+
+
+int llhttp_message_needs_eof(const llhttp_t* parser) {
+  if (parser->type == HTTP_REQUEST) {
+    return 0;
+  }
+
+  /* See RFC 2616 section 4.4 */
+  if (parser->status_code / 100 == 1 || /* 1xx e.g. Continue */
+      parser->status_code == 204 ||     /* No Content */
+      parser->status_code == 304 ||     /* Not Modified */
+      (parser->flags & F_SKIPBODY)) {     /* response to a HEAD request */
+    return 0;
+  }
+
+  if (parser->flags & (F_CHUNKED | F_CONTENT_LENGTH)) {
+    return 0;
+  }
+
+  return 1;
+}
+
+
+int llhttp_should_keep_alive(const llhttp_t* parser) {
+  if (parser->http_major > 0 && parser->http_minor > 0) {
+    /* HTTP/1.1 */
+    if (parser->flags & F_CONNECTION_CLOSE) {
+      return 0;
+    }
+  } else {
+    /* HTTP/1.0 or earlier */
+    if (!(parser->flags & F_CONNECTION_KEEP_ALIVE)) {
+      return 0;
+    }
+  }
+
+  return !llhttp_message_needs_eof(parser);
+}

--- a/deps/llhttp/src/llhttp.c
+++ b/deps/llhttp/src/llhttp.c
@@ -1,0 +1,6044 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "llhttp.h"
+
+typedef int (*llhttp__internal__span_cb)(
+             llhttp__internal_t*, const char*, const char*);
+
+static const unsigned char llparse_blob0[] = {
+  'C', 'L'
+};
+static const unsigned char llparse_blob1[] = {
+  'o', 'n'
+};
+static const unsigned char llparse_blob2[] = {
+  'e', 'c', 't', 'i', 'o', 'n'
+};
+static const unsigned char llparse_blob3[] = {
+  'l', 'o', 's', 'e'
+};
+static const unsigned char llparse_blob4[] = {
+  'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
+};
+static const unsigned char llparse_blob5[] = {
+  'p', 'g', 'r', 'a', 'd', 'e'
+};
+static const unsigned char llparse_blob6[] = {
+  'h', 'u', 'n', 'k', 'e', 'd'
+};
+static const unsigned char llparse_blob7[] = {
+  'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
+};
+static const unsigned char llparse_blob8[] = {
+  'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
+  't', 'i', 'o', 'n'
+};
+static const unsigned char llparse_blob9[] = {
+  'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
+  'o', 'd', 'i', 'n', 'g'
+};
+static const unsigned char llparse_blob10[] = {
+  'p', 'g', 'r', 'a', 'd', 'e'
+};
+static const unsigned char llparse_blob11[] = {
+  0xd, 0xa
+};
+static const unsigned char llparse_blob12[] = {
+  'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob13[] = {
+  'C', 'E', '/'
+};
+static const unsigned char llparse_blob14[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob15[] = {
+  'E', 'C', 'K', 'O', 'U', 'T'
+};
+static const unsigned char llparse_blob16[] = {
+  'N', 'E', 'C', 'T'
+};
+static const unsigned char llparse_blob17[] = {
+  'E', 'L', 'E', 'T', 'E'
+};
+static const unsigned char llparse_blob18[] = {
+  'E', 'T'
+};
+static const unsigned char llparse_blob19[] = {
+  'E', 'A', 'D'
+};
+static const unsigned char llparse_blob20[] = {
+  'N', 'K'
+};
+static const unsigned char llparse_blob21[] = {
+  'C', 'K'
+};
+static const unsigned char llparse_blob22[] = {
+  'S', 'E', 'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob23[] = {
+  'R', 'G', 'E'
+};
+static const unsigned char llparse_blob24[] = {
+  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+};
+static const unsigned char llparse_blob25[] = {
+  'L', 'E', 'N', 'D', 'A', 'R'
+};
+static const unsigned char llparse_blob26[] = {
+  'V', 'E'
+};
+static const unsigned char llparse_blob27[] = {
+  'O', 'T', 'I', 'F', 'Y'
+};
+static const unsigned char llparse_blob28[] = {
+  'P', 'T', 'I', 'O', 'N', 'S'
+};
+static const unsigned char llparse_blob29[] = {
+  'T', 'C', 'H'
+};
+static const unsigned char llparse_blob30[] = {
+  'S', 'T'
+};
+static const unsigned char llparse_blob31[] = {
+  'O', 'P'
+};
+static const unsigned char llparse_blob32[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob33[] = {
+  'A', 'T', 'C', 'H'
+};
+static const unsigned char llparse_blob34[] = {
+  'G', 'E'
+};
+static const unsigned char llparse_blob35[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob36[] = {
+  'O', 'R', 'T'
+};
+static const unsigned char llparse_blob37[] = {
+  'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob38[] = {
+  'U', 'R', 'C', 'E'
+};
+static const unsigned char llparse_blob39[] = {
+  'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob40[] = {
+  'R', 'A', 'C', 'E'
+};
+static const unsigned char llparse_blob41[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob42[] = {
+  'N', 'K'
+};
+static const unsigned char llparse_blob43[] = {
+  'C', 'K'
+};
+static const unsigned char llparse_blob44[] = {
+  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob45[] = {
+  'H', 'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob46[] = {
+  'A', 'D'
+};
+static const unsigned char llparse_blob47[] = {
+  'T', 'P', '/'
+};
+
+enum llparse_match_status_e {
+  kMatchComplete,
+  kMatchPause,
+  kMatchMismatch
+};
+typedef enum llparse_match_status_e llparse_match_status_t;
+
+struct llparse_match_s {
+  llparse_match_status_t status;
+  const unsigned char* current;
+};
+typedef struct llparse_match_s llparse_match_t;
+
+static llparse_match_t llparse__match_sequence_id(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp,
+    const unsigned char* seq, uint32_t seq_len) {
+  uint32_t index;
+  llparse_match_t res;
+
+  index = s->_index;
+  for (; p != endp; p++) {
+    unsigned char current;
+
+    current = *p;
+    if (current == seq[index]) {
+      if (++index == seq_len) {
+        res.status = kMatchComplete;
+        goto reset;
+      }
+    } else {
+      res.status = kMatchMismatch;
+      goto reset;
+    }
+  }
+  s->_index = index;
+  res.status = kMatchPause;
+  res.current = p;
+  return res;
+reset:
+  s->_index = 0;
+  res.current = p;
+  return res;
+}
+
+static llparse_match_t llparse__match_sequence_to_lower_unsafe(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp,
+    const unsigned char* seq, uint32_t seq_len) {
+  uint32_t index;
+  llparse_match_t res;
+
+  index = s->_index;
+  for (; p != endp; p++) {
+    unsigned char current;
+
+    current = ((*p) | 0x20);
+    if (current == seq[index]) {
+      if (++index == seq_len) {
+        res.status = kMatchComplete;
+        goto reset;
+      }
+    } else {
+      res.status = kMatchMismatch;
+      goto reset;
+    }
+  }
+  s->_index = index;
+  res.status = kMatchPause;
+  res.current = p;
+  return res;
+reset:
+  s->_index = 0;
+  res.current = p;
+  return res;
+}
+
+enum llparse_state_e {
+  s_error,
+  s_n_llhttp__internal__n_invoke_llhttp__after_message_complete,
+  s_n_llhttp__internal__n_pause_1,
+  s_n_llhttp__internal__n_invoke_is_equal_upgrade,
+  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
+  s_n_llhttp__internal__n_chunk_data_almost_done_skip,
+  s_n_llhttp__internal__n_chunk_data_almost_done,
+  s_n_llhttp__internal__n_consume_content_length,
+  s_n_llhttp__internal__n_span_start_llhttp__on_body,
+  s_n_llhttp__internal__n_invoke_is_equal_content_length,
+  s_n_llhttp__internal__n_chunk_size_almost_done,
+  s_n_llhttp__internal__n_chunk_parameters,
+  s_n_llhttp__internal__n_chunk_size_otherwise,
+  s_n_llhttp__internal__n_chunk_size,
+  s_n_llhttp__internal__n_invoke_update_content_length,
+  s_n_llhttp__internal__n_consume_content_length_1,
+  s_n_llhttp__internal__n_span_start_llhttp__on_body_1,
+  s_n_llhttp__internal__n_eof,
+  s_n_llhttp__internal__n_span_start_llhttp__on_body_2,
+  s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
+  s_n_llhttp__internal__n_headers_almost_done,
+  s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
+  s_n_llhttp__internal__n_header_value_discard_lws,
+  s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
+  s_n_llhttp__internal__n_header_value_lws,
+  s_n_llhttp__internal__n_header_value_almost_done,
+  s_n_llhttp__internal__n_header_value_otherwise,
+  s_n_llhttp__internal__n_header_value_connection_token,
+  s_n_llhttp__internal__n_header_value_connection_ws,
+  s_n_llhttp__internal__n_header_value_connection_1,
+  s_n_llhttp__internal__n_header_value_connection_2,
+  s_n_llhttp__internal__n_header_value_connection_3,
+  s_n_llhttp__internal__n_header_value_connection,
+  s_n_llhttp__internal__n_error_14,
+  s_n_llhttp__internal__n_header_value,
+  s_n_llhttp__internal__n_header_value_discard_rws,
+  s_n_llhttp__internal__n_error_15,
+  s_n_llhttp__internal__n_header_value_content_length_ws,
+  s_n_llhttp__internal__n_header_value_content_length,
+  s_n_llhttp__internal__n_header_value_te_chunked_1,
+  s_n_llhttp__internal__n_header_value_te_chunked,
+  s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
+  s_n_llhttp__internal__n_header_value_discard_ws,
+  s_n_llhttp__internal__n_header_field_general_otherwise,
+  s_n_llhttp__internal__n_header_field_general,
+  s_n_llhttp__internal__n_header_field_colon,
+  s_n_llhttp__internal__n_header_field_3,
+  s_n_llhttp__internal__n_header_field_4,
+  s_n_llhttp__internal__n_header_field_2,
+  s_n_llhttp__internal__n_header_field_1,
+  s_n_llhttp__internal__n_header_field_5,
+  s_n_llhttp__internal__n_header_field_6,
+  s_n_llhttp__internal__n_header_field_7,
+  s_n_llhttp__internal__n_header_field,
+  s_n_llhttp__internal__n_span_start_llhttp__on_header_field,
+  s_n_llhttp__internal__n_header_field_start,
+  s_n_llhttp__internal__n_url_skip_to_http09,
+  s_n_llhttp__internal__n_url_skip_lf_to_http09,
+  s_n_llhttp__internal__n_req_http_end_1,
+  s_n_llhttp__internal__n_req_http_end,
+  s_n_llhttp__internal__n_req_http_minor,
+  s_n_llhttp__internal__n_req_http_dot,
+  s_n_llhttp__internal__n_req_http_major,
+  s_n_llhttp__internal__n_req_http_start_1,
+  s_n_llhttp__internal__n_req_http_start_2,
+  s_n_llhttp__internal__n_req_http_start,
+  s_n_llhttp__internal__n_url_skip_to_http,
+  s_n_llhttp__internal__n_url_fragment,
+  s_n_llhttp__internal__n_span_end_stub_query_3,
+  s_n_llhttp__internal__n_url_query,
+  s_n_llhttp__internal__n_url_query_or_fragment,
+  s_n_llhttp__internal__n_url_path,
+  s_n_llhttp__internal__n_span_start_stub_path_2,
+  s_n_llhttp__internal__n_span_start_stub_path,
+  s_n_llhttp__internal__n_span_start_stub_path_1,
+  s_n_llhttp__internal__n_url_server_with_at,
+  s_n_llhttp__internal__n_url_server,
+  s_n_llhttp__internal__n_url_schema_delim_1,
+  s_n_llhttp__internal__n_url_schema_delim,
+  s_n_llhttp__internal__n_span_end_stub_schema,
+  s_n_llhttp__internal__n_url_schema,
+  s_n_llhttp__internal__n_url_start,
+  s_n_llhttp__internal__n_span_start_llhttp__on_url_1,
+  s_n_llhttp__internal__n_span_start_llhttp__on_url,
+  s_n_llhttp__internal__n_req_spaces_before_url,
+  s_n_llhttp__internal__n_req_first_space_before_url,
+  s_n_llhttp__internal__n_start_req_1,
+  s_n_llhttp__internal__n_start_req_2,
+  s_n_llhttp__internal__n_start_req_4,
+  s_n_llhttp__internal__n_start_req_6,
+  s_n_llhttp__internal__n_start_req_7,
+  s_n_llhttp__internal__n_start_req_5,
+  s_n_llhttp__internal__n_start_req_3,
+  s_n_llhttp__internal__n_start_req_8,
+  s_n_llhttp__internal__n_start_req_9,
+  s_n_llhttp__internal__n_start_req_10,
+  s_n_llhttp__internal__n_start_req_12,
+  s_n_llhttp__internal__n_start_req_13,
+  s_n_llhttp__internal__n_start_req_11,
+  s_n_llhttp__internal__n_start_req_15,
+  s_n_llhttp__internal__n_start_req_16,
+  s_n_llhttp__internal__n_start_req_18,
+  s_n_llhttp__internal__n_start_req_20,
+  s_n_llhttp__internal__n_start_req_21,
+  s_n_llhttp__internal__n_start_req_19,
+  s_n_llhttp__internal__n_start_req_17,
+  s_n_llhttp__internal__n_start_req_22,
+  s_n_llhttp__internal__n_start_req_14,
+  s_n_llhttp__internal__n_start_req_23,
+  s_n_llhttp__internal__n_start_req_24,
+  s_n_llhttp__internal__n_start_req_26,
+  s_n_llhttp__internal__n_start_req_27,
+  s_n_llhttp__internal__n_start_req_30,
+  s_n_llhttp__internal__n_start_req_31,
+  s_n_llhttp__internal__n_start_req_29,
+  s_n_llhttp__internal__n_start_req_28,
+  s_n_llhttp__internal__n_start_req_33,
+  s_n_llhttp__internal__n_start_req_32,
+  s_n_llhttp__internal__n_start_req_25,
+  s_n_llhttp__internal__n_start_req_36,
+  s_n_llhttp__internal__n_start_req_37,
+  s_n_llhttp__internal__n_start_req_35,
+  s_n_llhttp__internal__n_start_req_34,
+  s_n_llhttp__internal__n_start_req_39,
+  s_n_llhttp__internal__n_start_req_40,
+  s_n_llhttp__internal__n_start_req_41,
+  s_n_llhttp__internal__n_start_req_38,
+  s_n_llhttp__internal__n_start_req_42,
+  s_n_llhttp__internal__n_start_req_45,
+  s_n_llhttp__internal__n_start_req_47,
+  s_n_llhttp__internal__n_start_req_48,
+  s_n_llhttp__internal__n_start_req_46,
+  s_n_llhttp__internal__n_start_req_49,
+  s_n_llhttp__internal__n_start_req_44,
+  s_n_llhttp__internal__n_start_req_43,
+  s_n_llhttp__internal__n_start_req,
+  s_n_llhttp__internal__n_res_line_almost_done,
+  s_n_llhttp__internal__n_res_status,
+  s_n_llhttp__internal__n_span_start_llhttp__on_status,
+  s_n_llhttp__internal__n_res_status_start,
+  s_n_llhttp__internal__n_res_status_code_otherwise,
+  s_n_llhttp__internal__n_res_status_code,
+  s_n_llhttp__internal__n_res_http_end,
+  s_n_llhttp__internal__n_res_http_minor,
+  s_n_llhttp__internal__n_res_http_dot,
+  s_n_llhttp__internal__n_res_http_major,
+  s_n_llhttp__internal__n_start_res,
+  s_n_llhttp__internal__n_req_or_res_method_2,
+  s_n_llhttp__internal__n_req_or_res_method_3,
+  s_n_llhttp__internal__n_req_or_res_method_1,
+  s_n_llhttp__internal__n_req_or_res_method,
+  s_n_llhttp__internal__n_start_req_or_res,
+  s_n_llhttp__internal__n_invoke_load_type,
+  s_n_llhttp__internal__n_start,
+};
+typedef enum llparse_state_e llparse_state_t;
+
+int llhttp__on_url(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_header_field(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_header_value(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_body(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_status(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_update_finish(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->finish = 2;
+  return 0;
+}
+
+int llhttp__on_message_begin(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_load_type(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->type;
+}
+
+int llhttp__internal__c_store_method(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  state->method = match;
+  return 0;
+}
+
+int llhttp__internal__c_is_equal_method(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->method == 5;
+}
+
+int llhttp__internal__c_update_http_major(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->http_major = 0;
+  return 0;
+}
+
+int llhttp__internal__c_update_http_minor(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->http_minor = 9;
+  return 0;
+}
+
+int llhttp__internal__c_test_flags(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 128) == 128;
+}
+
+int llhttp__on_chunk_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_message_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_is_equal_upgrade(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->upgrade == 1;
+}
+
+int llhttp__after_message_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_test_flags_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 40) == 40;
+}
+
+int llhttp__before_headers_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_headers_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__after_headers_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_update_content_length(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->content_length = 0;
+  return 0;
+}
+
+int llhttp__internal__c_mul_add_content_length(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  /* Multiplication overflow */
+  if (state->content_length > 0xffffffffffffffffULL / 16) {
+    return 1;
+  }
+  
+  state->content_length *= 16;
+  
+  /* Addition overflow */
+  if (match >= 0) {
+    if (state->content_length > 0xffffffffffffffffULL - match) {
+      return 1;
+    }
+  } else {
+    if (state->content_length < 0ULL - match) {
+      return 1;
+    }
+  }
+  state->content_length += match;
+  return 0;
+}
+
+int llhttp__on_chunk_header(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_is_equal_content_length(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->content_length == 0;
+}
+
+int llhttp__internal__c_or_flags(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 128;
+  return 0;
+}
+
+int llhttp__internal__c_update_finish_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->finish = 1;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 64;
+  return 0;
+}
+
+int llhttp__internal__c_update_upgrade(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->upgrade = 1;
+  return 0;
+}
+
+int llhttp__internal__c_store_header_state(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  state->header_state = match;
+  return 0;
+}
+
+int llhttp__internal__c_load_header_state(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->header_state;
+}
+
+int llhttp__internal__c_or_flags_3(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 1;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 1;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_4(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 2;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_5(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 4;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_6(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 8;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 6;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state_4(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 0;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state_5(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 5;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state_6(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 7;
+  return 0;
+}
+
+int llhttp__internal__c_test_flags_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 32) == 32;
+}
+
+int llhttp__internal__c_mul_add_content_length_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  /* Multiplication overflow */
+  if (state->content_length > 0xffffffffffffffffULL / 10) {
+    return 1;
+  }
+  
+  state->content_length *= 10;
+  
+  /* Addition overflow */
+  if (match >= 0) {
+    if (state->content_length > 0xffffffffffffffffULL - match) {
+      return 1;
+    }
+  } else {
+    if (state->content_length < 0ULL - match) {
+      return 1;
+    }
+  }
+  state->content_length += match;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_15(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 32;
+  return 0;
+}
+
+int llhttp__internal__c_update_header_state_8(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->header_state = 8;
+  return 0;
+}
+
+int llhttp__internal__c_or_flags_16(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 16;
+  return 0;
+}
+
+int llhttp__internal__c_store_http_major(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  state->http_major = match;
+  return 0;
+}
+
+int llhttp__internal__c_store_http_minor(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  state->http_minor = match;
+  return 0;
+}
+
+int llhttp__internal__c_is_equal_method_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->method == 33;
+}
+
+int llhttp__internal__c_update_status_code(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->status_code = 0;
+  return 0;
+}
+
+int llhttp__internal__c_mul_add_status_code(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp,
+    int match) {
+  /* Multiplication overflow */
+  if (state->status_code > 0xffff / 10) {
+    return 1;
+  }
+  
+  state->status_code *= 10;
+  
+  /* Addition overflow */
+  if (match >= 0) {
+    if (state->status_code > 0xffff - match) {
+      return 1;
+    }
+  } else {
+    if (state->status_code < 0 - match) {
+      return 1;
+    }
+  }
+  state->status_code += match;
+  
+  /* Enforce maximum */
+  if (state->status_code > 999) {
+    return 1;
+  }
+  return 0;
+}
+
+int llhttp__internal__c_update_type(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->type = 1;
+  return 0;
+}
+
+int llhttp__internal__c_update_type_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->type = 2;
+  return 0;
+}
+
+int llhttp__internal_init(llhttp__internal_t* state) {
+  memset(state, 0, sizeof(*state));
+  state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_start;
+  return 0;
+}
+
+static llparse_state_t llhttp__internal__run(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  int match;
+  switch ((llparse_state_t) (intptr_t) state->_current) {
+    case s_n_llhttp__internal__n_invoke_llhttp__after_message_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
+      switch (llhttp__after_message_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_start;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_pause_1:
+    s_n_llhttp__internal__n_pause_1: {
+      state->error = 0x15;
+      state->reason = "Pause on CONNECT/Upgrade";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_is_equal_upgrade:
+    s_n_llhttp__internal__n_invoke_is_equal_upgrade: {
+      switch (llhttp__internal__c_is_equal_upgrade(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
+        default:
+          goto s_n_llhttp__internal__n_pause_1;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2:
+    s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2: {
+      switch (llhttp__on_message_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
+        case 20:
+          goto s_n_llhttp__internal__n_pause_5;
+        default:
+          goto s_n_llhttp__internal__n_error_8;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_data_almost_done_skip:
+    s_n_llhttp__internal__n_chunk_data_almost_done_skip: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_data_almost_done_skip;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_data_almost_done:
+    s_n_llhttp__internal__n_chunk_data_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_data_almost_done;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_chunk_data_almost_done_skip;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_consume_content_length:
+    s_n_llhttp__internal__n_consume_content_length: {
+      size_t avail;
+      size_t need;
+      
+      avail = endp - p;
+      need = state->content_length;
+      if (avail >= need) {
+        p += need;
+        state->content_length = 0;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_body;
+      }
+      
+      state->content_length -= avail;
+      return s_n_llhttp__internal__n_consume_content_length;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_body:
+    s_n_llhttp__internal__n_span_start_llhttp__on_body: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_body;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_body;
+      goto s_n_llhttp__internal__n_consume_content_length;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_is_equal_content_length:
+    s_n_llhttp__internal__n_invoke_is_equal_content_length: {
+      switch (llhttp__internal__c_is_equal_content_length(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_body;
+        default:
+          goto s_n_llhttp__internal__n_invoke_or_flags;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_size_almost_done:
+    s_n_llhttp__internal__n_chunk_size_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_size_almost_done;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_parameters:
+    s_n_llhttp__internal__n_chunk_parameters: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_parameters;
+      }
+      switch (*p) {
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        }
+        default: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_parameters;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_size_otherwise:
+    s_n_llhttp__internal__n_chunk_size_otherwise: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_size_otherwise;
+      }
+      switch (*p) {
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_parameters;
+        }
+        case ';': {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_parameters;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_7;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_size:
+    s_n_llhttp__internal__n_chunk_size: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_size;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'A': {
+          p++;
+          match = 10;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'B': {
+          p++;
+          match = 11;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'C': {
+          p++;
+          match = 12;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'D': {
+          p++;
+          match = 13;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'E': {
+          p++;
+          match = 14;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'F': {
+          p++;
+          match = 15;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'a': {
+          p++;
+          match = 10;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'b': {
+          p++;
+          match = 11;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'c': {
+          p++;
+          match = 12;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'd': {
+          p++;
+          match = 13;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'e': {
+          p++;
+          match = 14;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        case 'f': {
+          p++;
+          match = 15;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_chunk_size_otherwise;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_update_content_length:
+    s_n_llhttp__internal__n_invoke_update_content_length: {
+      switch (llhttp__internal__c_update_content_length(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_chunk_size;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_consume_content_length_1:
+    s_n_llhttp__internal__n_consume_content_length_1: {
+      size_t avail;
+      size_t need;
+      
+      avail = endp - p;
+      need = state->content_length;
+      if (avail >= need) {
+        p += need;
+        state->content_length = 0;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_body_1;
+      }
+      
+      state->content_length -= avail;
+      return s_n_llhttp__internal__n_consume_content_length_1;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_body_1:
+    s_n_llhttp__internal__n_span_start_llhttp__on_body_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_body;
+      goto s_n_llhttp__internal__n_consume_content_length_1;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_eof:
+    s_n_llhttp__internal__n_eof: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_eof;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_eof;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_body_2:
+    s_n_llhttp__internal__n_span_start_llhttp__on_body_2: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_body;
+      goto s_n_llhttp__internal__n_invoke_update_finish_1;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete: {
+      switch (llhttp__after_headers_complete(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1;
+        case 2:
+          goto s_n_llhttp__internal__n_invoke_update_content_length;
+        case 3:
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
+        case 4:
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
+        default:
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_headers_almost_done:
+    s_n_llhttp__internal__n_headers_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_headers_almost_done;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_invoke_test_flags;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value:
+    s_n_llhttp__internal__n_span_start_llhttp__on_header_value: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_header_value;
+      goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_discard_lws:
+    s_n_llhttp__internal__n_header_value_discard_lws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_discard_lws;
+      }
+      switch (*p) {
+        case 9: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_load_header_state;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_discard_ws_almost_done:
+    s_n_llhttp__internal__n_header_value_discard_ws_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_header_value_discard_lws;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_lws:
+    s_n_llhttp__internal__n_header_value_lws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_lws;
+      }
+      switch (*p) {
+        case 9: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+        }
+        case ' ': {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_load_header_state_2;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_almost_done:
+    s_n_llhttp__internal__n_header_value_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_almost_done;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_lws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_11;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_otherwise:
+    s_n_llhttp__internal__n_header_value_otherwise: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_otherwise;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_12;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection_token:
+    s_n_llhttp__internal__n_header_value_connection_token: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection_token;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection_token;
+        }
+        case 2: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection_ws:
+    s_n_llhttp__internal__n_header_value_connection_ws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection_ws;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection_ws;
+        }
+        case ',': {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection_1:
+    s_n_llhttp__internal__n_header_value_connection_1: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection_1;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob3, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_value_connection_1;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_header_value_connection_token;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection_2:
+    s_n_llhttp__internal__n_header_value_connection_2: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection_2;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob4, 9);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_value_connection_2;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_header_value_connection_token;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection_3:
+    s_n_llhttp__internal__n_header_value_connection_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection_3;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob5, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_value_connection_3;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_header_value_connection_token;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_connection:
+    s_n_llhttp__internal__n_header_value_connection: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_connection;
+      }
+      switch (((*p) | 0x20)) {
+        case 9: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection;
+        }
+        case 'c': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection_1;
+        }
+        case 'k': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection_2;
+        }
+        case 'u': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_connection_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_connection_token;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_14:
+    s_n_llhttp__internal__n_error_14: {
+      state->error = 0xb;
+      state->reason = "Content-Length overflow";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value:
+    s_n_llhttp__internal__n_header_value: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_discard_rws:
+    s_n_llhttp__internal__n_header_value_discard_rws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_discard_rws;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_header_value_otherwise;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_rws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_15:
+    s_n_llhttp__internal__n_error_15: {
+      state->error = 0xb;
+      state->reason = "Invalid character in Content-Length";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_content_length_ws:
+    s_n_llhttp__internal__n_header_value_content_length_ws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_content_length_ws;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_invoke_or_flags_15;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_invoke_or_flags_15;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_content_length_ws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_content_length:
+    s_n_llhttp__internal__n_header_value_content_length: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_content_length;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_content_length_ws;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_te_chunked_1:
+    s_n_llhttp__internal__n_header_value_te_chunked_1: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_te_chunked_1;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_value_te_chunked_1;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_te_chunked:
+    s_n_llhttp__internal__n_header_value_te_chunked: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_te_chunked;
+      }
+      switch (((*p) | 0x20)) {
+        case 10: {
+          goto s_n_llhttp__internal__n_header_value_discard_rws;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_header_value_discard_rws;
+        }
+        case ' ': {
+          goto s_n_llhttp__internal__n_header_value_discard_rws;
+        }
+        case 'c': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_chunked_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1:
+    s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_header_value;
+      goto s_n_llhttp__internal__n_invoke_load_header_state_1;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_discard_ws:
+    s_n_llhttp__internal__n_header_value_discard_ws: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_discard_ws;
+      }
+      switch (*p) {
+        case 9: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+        }
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_lws;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_general_otherwise:
+    s_n_llhttp__internal__n_header_field_general_otherwise: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_general_otherwise;
+      }
+      switch (*p) {
+        case ':': {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_16;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_general:
+    s_n_llhttp__internal__n_header_field_general: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_general;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_general;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_field_general_otherwise;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_colon:
+    s_n_llhttp__internal__n_header_field_colon: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_colon;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_colon;
+        }
+        case ':': {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_3:
+    s_n_llhttp__internal__n_header_field_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_3;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob2, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_header_state;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_3;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_4:
+    s_n_llhttp__internal__n_header_field_4: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_4;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob7, 10);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_header_state;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_4;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_2:
+    s_n_llhttp__internal__n_header_field_2: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_2;
+      }
+      switch (((*p) | 0x20)) {
+        case 'n': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_3;
+        }
+        case 't': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_4;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_1:
+    s_n_llhttp__internal__n_header_field_1: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_1;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob1, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_2;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_1;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_5:
+    s_n_llhttp__internal__n_header_field_5: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_5;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob8, 15);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_header_state;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_5;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_6:
+    s_n_llhttp__internal__n_header_field_6: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_6;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob9, 16);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_header_state;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_6;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_7:
+    s_n_llhttp__internal__n_header_field_7: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_7;
+      }
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob10, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_header_state;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_field_7;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field:
+    s_n_llhttp__internal__n_header_field: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field;
+      }
+      switch (((*p) | 0x20)) {
+        case 'c': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_1;
+        }
+        case 'p': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_5;
+        }
+        case 't': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_6;
+        }
+        case 'u': {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_7;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_header_field:
+    s_n_llhttp__internal__n_span_start_llhttp__on_header_field: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_header_field;
+      goto s_n_llhttp__internal__n_header_field;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_field_start:
+    s_n_llhttp__internal__n_header_field_start: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_field_start;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_headers_almost_done;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_headers_almost_done;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_skip_to_http09:
+    s_n_llhttp__internal__n_url_skip_to_http09: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_skip_to_http09;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_invoke_update_http_major;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_skip_lf_to_http09:
+    s_n_llhttp__internal__n_url_skip_lf_to_http09: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob11, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_http_major;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_url_skip_lf_to_http09;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_17;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_end_1:
+    s_n_llhttp__internal__n_req_http_end_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_end_1;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_start;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_18;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_end:
+    s_n_llhttp__internal__n_req_http_end: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_end;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_start;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_end_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_18;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_minor:
+    s_n_llhttp__internal__n_req_http_minor: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_minor;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_19;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_dot:
+    s_n_llhttp__internal__n_req_http_dot: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_dot;
+      }
+      switch (*p) {
+        case '.': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_minor;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_20;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_major:
+    s_n_llhttp__internal__n_req_http_major: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_major;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_store_http_major;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_21;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_start_1:
+    s_n_llhttp__internal__n_req_http_start_1: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_start_1;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob12, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_major;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_http_start_1;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_23;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_start_2:
+    s_n_llhttp__internal__n_req_http_start_2: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_start_2;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob13, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_is_equal_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_http_start_2;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_23;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_start:
+    s_n_llhttp__internal__n_req_http_start: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_start;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_start;
+        }
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_start_1;
+        }
+        case 'I': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_start_2;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_23;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_skip_to_http:
+    s_n_llhttp__internal__n_url_skip_to_http: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_skip_to_http;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_req_http_start;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_fragment:
+    s_n_llhttp__internal__n_url_fragment: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_fragment;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_url_fragment;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_6;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_7;
+        }
+        case 4: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_24;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_end_stub_query_3:
+    s_n_llhttp__internal__n_span_end_stub_query_3: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_end_stub_query_3;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_url_fragment;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_query:
+    s_n_llhttp__internal__n_url_query: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        4, 1, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_query;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_url_query;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_9;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_10;
+        }
+        case 4: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_11;
+        }
+        case 5: {
+          goto s_n_llhttp__internal__n_span_end_stub_query_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_25;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_query_or_fragment:
+    s_n_llhttp__internal__n_url_query_or_fragment: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_query_or_fragment;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_3;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_4;
+        }
+        case ' ': {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_5;
+        }
+        case '#': {
+          p++;
+          goto s_n_llhttp__internal__n_url_fragment;
+        }
+        case '?': {
+          p++;
+          goto s_n_llhttp__internal__n_url_query;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_26;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_path:
+    s_n_llhttp__internal__n_url_path: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_path;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_url_path;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_url_query_or_fragment;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_stub_path_2:
+    s_n_llhttp__internal__n_span_start_stub_path_2: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_stub_path_2;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_url_path;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_stub_path:
+    s_n_llhttp__internal__n_span_start_stub_path: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_stub_path;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_url_path;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_stub_path_1:
+    s_n_llhttp__internal__n_span_start_stub_path_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_stub_path_1;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_url_path;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_server_with_at:
+    s_n_llhttp__internal__n_url_server_with_at: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
+        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
+        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_server_with_at;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_12;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_13;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_14;
+        }
+        case 4: {
+          p++;
+          goto s_n_llhttp__internal__n_url_server;
+        }
+        case 5: {
+          goto s_n_llhttp__internal__n_span_start_stub_path_1;
+        }
+        case 6: {
+          p++;
+          goto s_n_llhttp__internal__n_url_query;
+        }
+        case 7: {
+          p++;
+          goto s_n_llhttp__internal__n_error_27;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_28;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_server:
+    s_n_llhttp__internal__n_url_server: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
+        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
+        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_server;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_1;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_2;
+        }
+        case 4: {
+          p++;
+          goto s_n_llhttp__internal__n_url_server;
+        }
+        case 5: {
+          goto s_n_llhttp__internal__n_span_start_stub_path;
+        }
+        case 6: {
+          p++;
+          goto s_n_llhttp__internal__n_url_query;
+        }
+        case 7: {
+          p++;
+          goto s_n_llhttp__internal__n_url_server_with_at;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_29;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_schema_delim_1:
+    s_n_llhttp__internal__n_url_schema_delim_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_schema_delim_1;
+      }
+      switch (*p) {
+        case '/': {
+          p++;
+          goto s_n_llhttp__internal__n_url_server;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_31;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_schema_delim:
+    s_n_llhttp__internal__n_url_schema_delim: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_schema_delim;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_error_30;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_error_30;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_error_30;
+        }
+        case '/': {
+          p++;
+          goto s_n_llhttp__internal__n_url_schema_delim_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_31;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_end_stub_schema:
+    s_n_llhttp__internal__n_span_end_stub_schema: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_end_stub_schema;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_url_schema_delim;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_schema:
+    s_n_llhttp__internal__n_url_schema: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_schema;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_error_30;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_end_stub_schema;
+        }
+        case 3: {
+          p++;
+          goto s_n_llhttp__internal__n_url_schema;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_32;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_url_start:
+    s_n_llhttp__internal__n_url_start: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_url_start;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_error_30;
+        }
+        case 2: {
+          goto s_n_llhttp__internal__n_span_start_stub_path_2;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_url_schema;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_33;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_url_1:
+    s_n_llhttp__internal__n_span_start_llhttp__on_url_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_url;
+      goto s_n_llhttp__internal__n_url_start;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_url:
+    s_n_llhttp__internal__n_span_start_llhttp__on_url: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_url;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_url;
+      goto s_n_llhttp__internal__n_url_server;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_spaces_before_url:
+    s_n_llhttp__internal__n_req_spaces_before_url: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_spaces_before_url;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_req_spaces_before_url;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_is_equal_method;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_first_space_before_url:
+    s_n_llhttp__internal__n_req_first_space_before_url: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_first_space_before_url;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_req_spaces_before_url;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_34;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_1:
+    s_n_llhttp__internal__n_start_req_1: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_1;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob0, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 19;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_1;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_2:
+    s_n_llhttp__internal__n_start_req_2: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_2;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 16;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_2;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_4:
+    s_n_llhttp__internal__n_start_req_4: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_4;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 22;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_4;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_6:
+    s_n_llhttp__internal__n_start_req_6: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_6;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_6;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_7:
+    s_n_llhttp__internal__n_start_req_7: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_7;
+      }
+      switch (*p) {
+        case 'Y': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_5:
+    s_n_llhttp__internal__n_start_req_5: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_5;
+      }
+      switch (*p) {
+        case 'N': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_6;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_7;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_3:
+    s_n_llhttp__internal__n_start_req_3: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_3;
+      }
+      switch (*p) {
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_4;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_5;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_8:
+    s_n_llhttp__internal__n_start_req_8: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_8;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_8;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_9:
+    s_n_llhttp__internal__n_start_req_9: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_9;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_9;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_10:
+    s_n_llhttp__internal__n_start_req_10: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_10;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_10;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_12:
+    s_n_llhttp__internal__n_start_req_12: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_12;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 31;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_12;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_13:
+    s_n_llhttp__internal__n_start_req_13: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_13;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_13;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_11:
+    s_n_llhttp__internal__n_start_req_11: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_11;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_12;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_13;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_15:
+    s_n_llhttp__internal__n_start_req_15: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_15;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 24;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_15;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_16:
+    s_n_llhttp__internal__n_start_req_16: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_16;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 23;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_16;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_18:
+    s_n_llhttp__internal__n_start_req_18: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_18;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 7);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 21;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_18;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_20:
+    s_n_llhttp__internal__n_start_req_20: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_20;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 30;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_20;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_21:
+    s_n_llhttp__internal__n_start_req_21: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_21;
+      }
+      switch (*p) {
+        case 'L': {
+          p++;
+          match = 10;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_19:
+    s_n_llhttp__internal__n_start_req_19: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_19;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_20;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_21;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_17:
+    s_n_llhttp__internal__n_start_req_17: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_17;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_18;
+        }
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_19;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_22:
+    s_n_llhttp__internal__n_start_req_22: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_22;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 11;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_22;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_14:
+    s_n_llhttp__internal__n_start_req_14: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_14;
+      }
+      switch (*p) {
+        case '-': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_15;
+        }
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_16;
+        }
+        case 'K': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_17;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_22;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_23:
+    s_n_llhttp__internal__n_start_req_23: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_23;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 25;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_23;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_24:
+    s_n_llhttp__internal__n_start_req_24: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_24;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_24;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_26:
+    s_n_llhttp__internal__n_start_req_26: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_26;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 28;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_26;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_27:
+    s_n_llhttp__internal__n_start_req_27: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_27;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_27;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_30:
+    s_n_llhttp__internal__n_start_req_30: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_30;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 12;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_30;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_31:
+    s_n_llhttp__internal__n_start_req_31: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_31;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 13;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_31;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_29:
+    s_n_llhttp__internal__n_start_req_29: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_29;
+      }
+      switch (*p) {
+        case 'F': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_30;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_31;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_28:
+    s_n_llhttp__internal__n_start_req_28: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_28;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_29;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_28;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_33:
+    s_n_llhttp__internal__n_start_req_33: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_33;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 29;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_33;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_32:
+    s_n_llhttp__internal__n_start_req_32: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_32;
+      }
+      switch (*p) {
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_33;
+        }
+        case 'T': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_25:
+    s_n_llhttp__internal__n_start_req_25: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_25;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_26;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_27;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_28;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_32;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_36:
+    s_n_llhttp__internal__n_start_req_36: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_36;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 17;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_36;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_37:
+    s_n_llhttp__internal__n_start_req_37: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_37;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 20;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_37;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_35:
+    s_n_llhttp__internal__n_start_req_35: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_35;
+      }
+      switch (*p) {
+        case 'B': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_36;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_37;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_34:
+    s_n_llhttp__internal__n_start_req_34: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_34;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_35;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_39:
+    s_n_llhttp__internal__n_start_req_39: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_39;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 14;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_39;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_40:
+    s_n_llhttp__internal__n_start_req_40: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_40;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 33;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_40;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_41:
+    s_n_llhttp__internal__n_start_req_41: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_41;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 7);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 26;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_41;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_38:
+    s_n_llhttp__internal__n_start_req_38: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_38;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_39;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_40;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_41;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_42:
+    s_n_llhttp__internal__n_start_req_42: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_42;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_42;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_45:
+    s_n_llhttp__internal__n_start_req_45: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_45;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 18;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_45;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_47:
+    s_n_llhttp__internal__n_start_req_47: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_47;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 32;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_47;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_48:
+    s_n_llhttp__internal__n_start_req_48: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_48;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 15;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_48;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_46:
+    s_n_llhttp__internal__n_start_req_46: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_46;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_47;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_48;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_49:
+    s_n_llhttp__internal__n_start_req_49: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_49;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 8);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 27;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_49;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_44:
+    s_n_llhttp__internal__n_start_req_44: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_44;
+      }
+      switch (*p) {
+        case 'B': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_45;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_46;
+        }
+        case 'S': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_49;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_43:
+    s_n_llhttp__internal__n_start_req_43: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_43;
+      }
+      switch (*p) {
+        case 'N': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_44;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req:
+    s_n_llhttp__internal__n_start_req: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_1;
+        }
+        case 'B': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_2;
+        }
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_3;
+        }
+        case 'D': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_8;
+        }
+        case 'G': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_9;
+        }
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_10;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_11;
+        }
+        case 'M': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_14;
+        }
+        case 'N': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_23;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_24;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_25;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_34;
+        }
+        case 'S': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_38;
+        }
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_42;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_43;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_42;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_line_almost_done:
+    s_n_llhttp__internal__n_res_line_almost_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_line_almost_done;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_header_field_start;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status:
+    s_n_llhttp__internal__n_res_status: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_status;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_status_1;
+        }
+        default: {
+          p++;
+          goto s_n_llhttp__internal__n_res_status;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_status:
+    s_n_llhttp__internal__n_span_start_llhttp__on_status: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_status;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_status;
+      goto s_n_llhttp__internal__n_res_status;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_start:
+    s_n_llhttp__internal__n_res_status_start: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_start;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_field_start;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_res_line_almost_done;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_status;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code_otherwise:
+    s_n_llhttp__internal__n_res_status_code_otherwise: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code_otherwise;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_res_status_start;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_res_status_start;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_res_status_start;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_36;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code:
+    s_n_llhttp__internal__n_res_status_code: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_res_status_code_otherwise;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_http_end:
+    s_n_llhttp__internal__n_res_http_end: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_http_end;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_status_code;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_37;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_http_minor:
+    s_n_llhttp__internal__n_res_http_minor: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_http_minor;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_38;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_http_dot:
+    s_n_llhttp__internal__n_res_http_dot: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_http_dot;
+      }
+      switch (*p) {
+        case '.': {
+          p++;
+          goto s_n_llhttp__internal__n_res_http_minor;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_39;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_http_major:
+    s_n_llhttp__internal__n_res_http_major: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_http_major;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_40;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_res:
+    s_n_llhttp__internal__n_start_res: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_res;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_res_http_major;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_res;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_43;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_or_res_method_2:
+    s_n_llhttp__internal__n_req_or_res_method_2: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_or_res_method_2;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_store_method;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_or_res_method_2;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_41;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_or_res_method_3:
+    s_n_llhttp__internal__n_req_or_res_method_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_or_res_method_3;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_update_type_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_or_res_method_3;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_41;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_or_res_method_1:
+    s_n_llhttp__internal__n_req_or_res_method_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_or_res_method_1;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_req_or_res_method_2;
+        }
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_req_or_res_method_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_41;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_or_res_method:
+    s_n_llhttp__internal__n_req_or_res_method: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_or_res_method;
+      }
+      switch (*p) {
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_req_or_res_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_41;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_or_res:
+    s_n_llhttp__internal__n_start_req_or_res: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_or_res;
+      }
+      switch (*p) {
+        case 'H': {
+          goto s_n_llhttp__internal__n_req_or_res_method;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_type_2;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_load_type:
+    s_n_llhttp__internal__n_invoke_load_type: {
+      switch (llhttp__internal__c_load_type(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_start_req;
+        case 2:
+          goto s_n_llhttp__internal__n_start_res;
+        default:
+          goto s_n_llhttp__internal__n_start_req_or_res;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start:
+    s_n_llhttp__internal__n_start: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_start;
+        }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_start;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_update_finish;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    default:
+      /* UNREACHABLE */
+      abort();
+  }
+  s_n_llhttp__internal__n_error_30: {
+    state->error = 0x7;
+    state->reason = "Invalid characters in url";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_5: {
+    state->error = 0x14;
+    state->reason = "on_message_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_8: {
+    state->error = 0x11;
+    state->reason = "`on_message_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_7: {
+    state->error = 0x14;
+    state->reason = "on_chunk_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_10: {
+    state->error = 0x13;
+    state->reason = "`on_chunk_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1: {
+    switch (llhttp__on_chunk_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_7;
+      default:
+        goto s_n_llhttp__internal__n_error_10;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_9: {
+    state->error = 0x4;
+    state->reason = "Content-Length can't be present with chunked encoding";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_2: {
+    state->error = 0x14;
+    state->reason = "on_message_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_pause_1;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_3: {
+    state->error = 0x11;
+    state->reason = "`on_message_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1: {
+    switch (llhttp__on_message_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_pause_1;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_2;
+      default:
+        goto s_n_llhttp__internal__n_error_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_4: {
+    state->error = 0xc;
+    state->reason = "Chunk size overflow";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_content_length: {
+    switch (llhttp__internal__c_mul_add_content_length(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_4;
+      default:
+        goto s_n_llhttp__internal__n_chunk_size;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_3: {
+    state->error = 0x14;
+    state->reason = "on_chunk_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_6: {
+    state->error = 0x13;
+    state->reason = "`on_chunk_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete: {
+    switch (llhttp__on_chunk_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_update_content_length;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_3;
+      default:
+        goto s_n_llhttp__internal__n_error_6;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_body: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_body(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_data_almost_done;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_chunk_data_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags: {
+    switch (llhttp__internal__c_or_flags(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_4: {
+    state->error = 0x14;
+    state->reason = "on_chunk_header pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_content_length;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_5: {
+    state->error = 0x12;
+    state->reason = "`on_chunk_header` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header: {
+    switch (llhttp__on_chunk_header(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_is_equal_content_length;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_4;
+      default:
+        goto s_n_llhttp__internal__n_error_5;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_7: {
+    state->error = 0xc;
+    state->reason = "Invalid character in chunk size";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_body_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_body(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_finish_1: {
+    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_eof;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause: {
+    state->error = 0x14;
+    state->reason = "on_message_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_2: {
+    state->error = 0x11;
+    state->reason = "`on_message_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete: {
+    switch (llhttp__on_message_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
+      case 20:
+        goto s_n_llhttp__internal__n_pause;
+      default:
+        goto s_n_llhttp__internal__n_error_2;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_1: {
+    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_2: {
+    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_upgrade: {
+    switch (llhttp__internal__c_update_upgrade(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_or_flags_2;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_6: {
+    state->error = 0x14;
+    state->reason = "Paused by on_headers_complete";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_1: {
+    state->error = 0x10;
+    state->reason = "User callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete: {
+    switch (llhttp__on_headers_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_or_flags_1;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_update_upgrade;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_6;
+      default:
+        goto s_n_llhttp__internal__n_error_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete: {
+    switch (llhttp__before_headers_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_1: {
+    switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_9;
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags: {
+    switch (llhttp__internal__c_test_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1;
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_flags_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_header_field_start;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state: {
+    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_3: {
+    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_4: {
+    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_5: {
+    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_6: {
+    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 5:
+        goto s_n_llhttp__internal__n_invoke_or_flags_3;
+      case 6:
+        goto s_n_llhttp__internal__n_invoke_or_flags_4;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_5;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_6;
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_1: {
+    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_7: {
+    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_8: {
+    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_9: {
+    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_10: {
+    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state_2: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 5:
+        goto s_n_llhttp__internal__n_invoke_or_flags_7;
+      case 6:
+        goto s_n_llhttp__internal__n_invoke_or_flags_8;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_9;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_10;
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_11: {
+    state->error = 0x3;
+    state->reason = "Missing expected LF after header value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_header_value_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_value_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_12: {
+    state->error = 0xa;
+    state->reason = "Invalid header value char";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_11: {
+    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_12: {
+    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_13: {
+    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_14: {
+    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 5:
+        goto s_n_llhttp__internal__n_invoke_or_flags_11;
+      case 6:
+        goto s_n_llhttp__internal__n_invoke_or_flags_12;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_13;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_14;
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_4: {
+    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection_token;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_2: {
+    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_14;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_14;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
+    switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+      default:
+        goto s_n_llhttp__internal__n_header_value_content_length;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_15: {
+    switch (llhttp__internal__c_or_flags_15(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_rws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_15;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_15;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_13: {
+    state->error = 0x4;
+    state->reason = "Duplicate Content-Length";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_2: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_header_value_content_length;
+      default:
+        goto s_n_llhttp__internal__n_error_13;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_rws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_16: {
+    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state_1: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_connection;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_test_flags_2;
+      case 3:
+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+      case 4:
+        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+      default:
+        goto s_n_llhttp__internal__n_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_field: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_field(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_field(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_16: {
+    state->error = 0xa;
+    state->reason = "Invalid header token";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_general;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_header_state: {
+    switch (llhttp__internal__c_store_header_state(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_colon;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_general;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_http_minor: {
+    switch (llhttp__internal__c_update_http_minor(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_http_major: {
+    switch (llhttp__internal__c_update_http_major(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_http_minor;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_17: {
+    state->error = 0x7;
+    state->reason = "Expected CRLF";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_4: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_18: {
+    state->error = 0x9;
+    state->reason = "Expected CRLF after version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_req_http_end;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_19: {
+    state->error = 0x9;
+    state->reason = "Invalid minor version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_20: {
+    state->error = 0x9;
+    state->reason = "Expected dot";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_major: {
+    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_req_http_dot;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_21: {
+    state->error = 0x9;
+    state->reason = "Invalid major version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_23: {
+    state->error = 0x8;
+    state->reason = "Expected HTTP/";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_22: {
+    state->error = 0x8;
+    state->reason = "Expected SOURCE method for ICE/x.x request";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_is_equal_method_1: {
+    switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_error_22;
+      default:
+        goto s_n_llhttp__internal__n_req_http_major;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_5: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_6: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_7: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_8: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_24: {
+    state->error = 0x7;
+    state->reason = "Invalid char in url fragment start";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_9: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_10: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_11: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_25: {
+    state->error = 0x7;
+    state->reason = "Invalid char in url query";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_26: {
+    state->error = 0x7;
+    state->reason = "Invalid char in url path";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_12: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_13: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_url_14: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_url(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_url_skip_to_http;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_27: {
+    state->error = 0x7;
+    state->reason = "Double @ in url";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_28: {
+    state->error = 0x7;
+    state->reason = "Unexpected char in url server";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_29: {
+    state->error = 0x7;
+    state->reason = "Unexpected char in url server";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_31: {
+    state->error = 0x7;
+    state->reason = "Unexpected char in url schema";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_32: {
+    state->error = 0x7;
+    state->reason = "Unexpected char in url schema";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_33: {
+    state->error = 0x7;
+    state->reason = "Unexpected start char in url";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_is_equal_method: {
+    switch (llhttp__internal__c_is_equal_method(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_url;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_34: {
+    state->error = 0x6;
+    state->reason = "Expected space after method";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_method_1: {
+    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_req_first_space_before_url;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_42: {
+    state->error = 0x6;
+    state->reason = "Invalid method encountered";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_35: {
+    state->error = 0xd;
+    state->reason = "Response overflow";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_status_code: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_35;
+      default:
+        goto s_n_llhttp__internal__n_res_status_code;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_status: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_status(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_field_start;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_status_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_status(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_line_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_res_line_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_36: {
+    state->error = 0xd;
+    state->reason = "Invalid response status";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_status_code: {
+    switch (llhttp__internal__c_update_status_code(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_res_status_code;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_37: {
+    state->error = 0x9;
+    state->reason = "Expected space after version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_res_http_end;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_38: {
+    state->error = 0x9;
+    state->reason = "Invalid minor version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_39: {
+    state->error = 0x9;
+    state->reason = "Expected dot";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_major_1: {
+    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_res_http_dot;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_40: {
+    state->error = 0x9;
+    state->reason = "Invalid major version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_43: {
+    state->error = 0x8;
+    state->reason = "Expected HTTP/";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_type: {
+    switch (llhttp__internal__c_update_type(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_req_first_space_before_url;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_method: {
+    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_type;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_41: {
+    state->error = 0x8;
+    state->reason = "Invalid word encountered";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_type_1: {
+    switch (llhttp__internal__c_update_type_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_res_http_major;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_type_2: {
+    switch (llhttp__internal__c_update_type(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_start_req;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_8: {
+    state->error = 0x14;
+    state->reason = "on_message_begin pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_type;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error: {
+    state->error = 0xf;
+    state->reason = "`on_message_begin` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_message_begin: {
+    switch (llhttp__on_message_begin(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_type;
+      case 20:
+        goto s_n_llhttp__internal__n_pause_8;
+      default:
+        goto s_n_llhttp__internal__n_error;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_finish: {
+    switch (llhttp__internal__c_update_finish(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_begin;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+}
+
+int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const char* endp) {
+  llparse_state_t next;
+
+  /* check lingering errors */
+  if (state->error != 0) {
+    return state->error;
+  }
+
+  /* restart spans */
+  if (state->_span_pos0 != NULL) {
+    state->_span_pos0 = (void*) p;
+  }
+  
+  next = llhttp__internal__run(state, (const unsigned char*) p, (const unsigned char*) endp);
+  if (next == s_error) {
+    return state->error;
+  }
+  state->_current = (void*) (intptr_t) next;
+
+  /* execute spans */
+  if (state->_span_pos0 != NULL) {
+    int error;
+  
+    error = ((llhttp__internal__span_cb) state->_span_cb0)(state, state->_span_pos0, (const char*) endp);
+    if (error != 0) {
+      state->error = error;
+      state->error_pos = endp;
+    }
+  }
+  
+  return 0;
+}

--- a/node.gyp
+++ b/node.gyp
@@ -12,6 +12,7 @@
     'force_dynamic_crt%': 0,
     'node_module_version%': '',
     'node_shared_zlib%': 'false',
+    'node_experimental_http_parser%': 'false',
     'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
     'node_shared_libuv%': 'false',

--- a/node.gypi
+++ b/node.gypi
@@ -159,9 +159,14 @@
       ],
     }],
 
-    [ 'node_shared_http_parser=="false"', {
-      'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
-    }],
+    [ 'node_experimental_http_parser=="true"', {
+      'defines': [ 'NODE_EXPERIMENTAL_HTTP' ],
+      'dependencies': [ 'deps/llhttp/llhttp.gyp:llhttp' ],
+    }, {
+      'conditions': [ [ 'node_shared_http_parser=="false"', {
+        'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+      } ] ],
+    } ],
 
     [ 'node_shared_cares=="false"', {
       'dependencies': [ 'deps/cares/cares.gyp:cares' ],

--- a/src/env.h
+++ b/src/env.h
@@ -246,7 +246,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(options_string, "options")                                                \
   V(output_string, "output")                                                  \
   V(order_string, "order")                                                    \
-  V(parse_error_string, "Parse Error")                                      \
+  V(parse_error_string, "Parse Error")                                        \
   V(password_string, "password")                                              \
   V(path_string, "path")                                                      \
   V(pending_handle_string, "pendingHandle")                                   \

--- a/src/env.h
+++ b/src/env.h
@@ -246,7 +246,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(options_string, "options")                                                \
   V(output_string, "output")                                                  \
   V(order_string, "order")                                                    \
-  V(parse_error_string, "Parse Error")                                        \
+  V(parse_error_string, "Parse Error")                                      \
   V(password_string, "password")                                              \
   V(path_string, "path")                                                      \
   V(pending_handle_string, "pendingHandle")                                   \
@@ -265,6 +265,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \
   V(readable_string, "readable")                                              \
+  V(reason_string, "reason")                                                  \
   V(refresh_string, "refresh")                                                \
   V(regexp_string, "regexp")                                                  \
   V(rename_string, "rename")                                                  \

--- a/src/http_parser_adaptor.h
+++ b/src/http_parser_adaptor.h
@@ -1,0 +1,24 @@
+#ifndef SRC_HTTP_PARSER_ADAPTOR_H_
+#define SRC_HTTP_PARSER_ADAPTOR_H_
+
+#ifdef NODE_EXPERIMENTAL_HTTP
+# include "llhttp.h"
+
+typedef llhttp_type_t parser_type_t;
+typedef llhttp_errno_t parser_errno_t;
+typedef llhttp_settings_t parser_settings_t;
+typedef llhttp_t parser_t;
+
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+# include "http_parser.h"
+
+typedef enum http_parser_type parser_type_t;
+typedef enum http_errno parser_errno_t;
+typedef http_parser_settings parser_settings_t;
+typedef http_parser parser_t;
+
+#define HPE_USER HPE_UNKNOWN
+
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
+#endif  /* SRC_HTTP_PARSER_ADAPTOR_H_ */

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -493,7 +493,7 @@ class HttpHandler : public ProtocolHandler {
     }
 #else  /* !NODE_EXPERIMENTAL_HTTP */
     http_parser_execute(&parser_, &parser_settings, data->data(), data->size());
-    err = parser_.http_errno;
+    err = HTTP_PARSER_ERRNO(&parser_);
 #endif  /* NODE_EXPERIMENTAL_HTTP */
     data->clear();
     if (err != HPE_OK) {

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -1,6 +1,6 @@
 #include "inspector_socket.h"
 
-#include "http_parser.h"
+#include "http_parser_adaptor.h"
 #include "util-inl.h"
 
 #define NODE_WANT_INTERNALS 1
@@ -433,8 +433,13 @@ class HttpHandler : public ProtocolHandler {
   explicit HttpHandler(InspectorSocket* inspector, TcpHolder::Pointer tcp)
                        : ProtocolHandler(inspector, std::move(tcp)),
                          parsing_value_(false) {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    llhttp_init(&parser_, HTTP_REQUEST, &parser_settings);
+    llhttp_settings_init(&parser_settings);
+#else  /* !NODE_EXPERIMENTAL_HTTP */
     http_parser_init(&parser_, HTTP_REQUEST);
     http_parser_settings_init(&parser_settings);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
     parser_settings.on_header_field = OnHeaderField;
     parser_settings.on_header_value = OnHeaderValue;
     parser_settings.on_message_complete = OnMessageComplete;
@@ -478,9 +483,20 @@ class HttpHandler : public ProtocolHandler {
   }
 
   void OnData(std::vector<char>* data) override {
+    parser_errno_t err;
+#ifdef NODE_EXPERIMENTAL_HTTP
+    err = llhttp_execute(&parser_, data->data(), data->size());
+
+    if (err == HPE_PAUSED_UPGRADE) {
+      err = HPE_OK;
+      llhttp_resume_after_upgrade(&parser_);
+    }
+#else  /* !NODE_EXPERIMENTAL_HTTP */
     http_parser_execute(&parser_, &parser_settings, data->data(), data->size());
+    err = parser_.http_errno;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
     data->clear();
-    if (parser_.http_errno != HPE_OK) {
+    if (err != HPE_OK) {
       CancelHandshake();
     }
     // Event handling may delete *this
@@ -517,14 +533,14 @@ class HttpHandler : public ProtocolHandler {
     handler->inspector()->SwitchProtocol(nullptr);
   }
 
-  static int OnHeaderValue(http_parser* parser, const char* at, size_t length) {
+  static int OnHeaderValue(parser_t* parser, const char* at, size_t length) {
     HttpHandler* handler = From(parser);
     handler->parsing_value_ = true;
     handler->headers_[handler->current_header_].append(at, length);
     return 0;
   }
 
-  static int OnHeaderField(http_parser* parser, const char* at, size_t length) {
+  static int OnHeaderField(parser_t* parser, const char* at, size_t length) {
     HttpHandler* handler = From(parser);
     if (handler->parsing_value_) {
       handler->parsing_value_ = false;
@@ -534,17 +550,17 @@ class HttpHandler : public ProtocolHandler {
     return 0;
   }
 
-  static int OnPath(http_parser* parser, const char* at, size_t length) {
+  static int OnPath(parser_t* parser, const char* at, size_t length) {
     HttpHandler* handler = From(parser);
     handler->path_.append(at, length);
     return 0;
   }
 
-  static HttpHandler* From(http_parser* parser) {
+  static HttpHandler* From(parser_t* parser) {
     return node::ContainerOf(&HttpHandler::parser_, parser);
   }
 
-  static int OnMessageComplete(http_parser* parser) {
+  static int OnMessageComplete(parser_t* parser) {
     // Event needs to be fired after the parser is done.
     HttpHandler* handler = From(parser);
     handler->events_.push_back(
@@ -581,8 +597,8 @@ class HttpHandler : public ProtocolHandler {
   }
 
   bool parsing_value_;
-  http_parser parser_;
-  http_parser_settings parser_settings;
+  parser_t parser_;
+  parser_settings_t parser_settings;
   std::vector<HttpEvent> events_;
   std::string current_header_;
   std::map<std::string, std::string> headers_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1746,9 +1746,7 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(versions,
                     "llhttp",
                     FIXED_ONE_BYTE_STRING(env->isolate(), llhttp_version));
-  READONLY_PROPERTY(versions, "http_parser", Null(env->isolate()));
 #else  /* !NODE_EXPERIMENTAL_HTTP */
-  READONLY_PROPERTY(versions, "llhttp", Null(env->isolate()));
   READONLY_PROPERTY(versions,
                     "http_parser",
                     FIXED_ONE_BYTE_STRING(env->isolate(), http_parser_version));

--- a/src/node.cc
+++ b/src/node.cc
@@ -51,7 +51,11 @@
 #include "async_wrap-inl.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
-#include "http_parser.h"
+#ifdef NODE_EXPERIMENTAL_HTTP
+# include "llhttp.h"
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+# include "http_parser.h"
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 #include "nghttp2/nghttp2ver.h"
 #include "req_wrap-inl.h"
 #include "string_bytes.h"
@@ -177,6 +181,22 @@ static node_module* modlist_internal;
 static node_module* modlist_linked;
 static node_module* modlist_addon;
 
+#ifdef NODE_EXPERIMENTAL_HTTP
+static const char llhttp_version[] =
+    NODE_STRINGIFY(LLHTTP_VERSION_MAJOR)
+    "."
+    NODE_STRINGIFY(LLHTTP_VERSION_MINOR)
+    "."
+    NODE_STRINGIFY(LLHTTP_VERSION_PATCH);
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+static const char http_parser_version[] =
+    NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR)
+    "."
+    NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR)
+    "."
+    NODE_STRINGIFY(HTTP_PARSER_VERSION_PATCH);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
 // Bit flag used to track security reverts (see node_revert.h)
 unsigned int reverted = 0;
 
@@ -215,17 +235,15 @@ class NodeTraceStateObserver :
     auto trace_process = tracing::TracedValue::Create();
     trace_process->BeginDictionary("versions");
 
-    const char http_parser_version[] =
-        NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR)
-        "."
-        NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR)
-        "."
-        NODE_STRINGIFY(HTTP_PARSER_VERSION_PATCH);
+#ifdef NODE_EXPERIMENTAL_HTTP
+    trace_process->SetString("llhttp", llhttp_version);
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+    trace_process->SetString("http_parser", http_parser_version);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 
     const char node_napi_version[] = NODE_STRINGIFY(NAPI_VERSION);
     const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
 
-    trace_process->SetString("http_parser", http_parser_version);
     trace_process->SetString("node", NODE_VERSION_STRING);
     trace_process->SetString("v8", V8::GetVersion());
     trace_process->SetString("uv", uv_version_string());
@@ -1724,14 +1742,18 @@ void SetupProcessObject(Environment* env,
   Local<Object> versions = Object::New(env->isolate());
   READONLY_PROPERTY(process, "versions", versions);
 
-  const char http_parser_version[] = NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR)
-                                     "."
-                                     NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR)
-                                     "."
-                                     NODE_STRINGIFY(HTTP_PARSER_VERSION_PATCH);
+#ifdef NODE_EXPERIMENTAL_HTTP
+  READONLY_PROPERTY(versions,
+                    "llhttp",
+                    FIXED_ONE_BYTE_STRING(env->isolate(), llhttp_version));
+  READONLY_PROPERTY(versions, "http_parser", Null(env->isolate()));
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+  READONLY_PROPERTY(versions, "llhttp", Null(env->isolate()));
   READONLY_PROPERTY(versions,
                     "http_parser",
                     FIXED_ONE_BYTE_STRING(env->isolate(), http_parser_version));
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
   // +1 to get rid of the leading 'v'
   READONLY_PROPERTY(versions,
                     "node",

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -25,13 +25,14 @@
 
 #include "async_wrap-inl.h"
 #include "env-inl.h"
-#include "http_parser.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
 #include "v8.h"
 
 #include <stdlib.h>  // free()
 #include <string.h>  // strdup()
+
+#include "http_parser_adaptor.h"
 
 // This is a binding to http_parser (https://github.com/nodejs/http-parser)
 // The goal is to decouple sockets from parsing for more javascript-level
@@ -148,10 +149,15 @@ struct StringPtr {
 
 class Parser : public AsyncWrap, public StreamListener {
  public:
-  Parser(Environment* env, Local<Object> wrap, enum http_parser_type type)
+  Parser(Environment* env, Local<Object> wrap, parser_type_t type)
       : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTPPARSER),
         current_buffer_len_(0),
         current_buffer_data_(nullptr) {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    executing_ = 0;
+    pending_pause_ = false;
+    header_nread_ = 0;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
     Init(type);
   }
 
@@ -172,18 +178,33 @@ class Parser : public AsyncWrap, public StreamListener {
 
 
   int on_url(const char* at, size_t length) {
+    int rv = TrackHeader(length);
+    if (rv != 0) {
+      return rv;
+    }
+
     url_.Update(at, length);
     return 0;
   }
 
 
   int on_status(const char* at, size_t length) {
+    int rv = TrackHeader(length);
+    if (rv != 0) {
+      return rv;
+    }
+
     status_message_.Update(at, length);
     return 0;
   }
 
 
   int on_header_field(const char* at, size_t length) {
+    int rv = TrackHeader(length);
+    if (rv != 0) {
+      return rv;
+    }
+
     if (num_fields_ == num_values_) {
       // start of new field name
       num_fields_++;
@@ -206,6 +227,11 @@ class Parser : public AsyncWrap, public StreamListener {
 
 
   int on_header_value(const char* at, size_t length) {
+    int rv = TrackHeader(length);
+    if (rv != 0) {
+      return rv;
+    }
+
     if (num_values_ != num_fields_) {
       // start of new header value
       num_values_++;
@@ -222,6 +248,10 @@ class Parser : public AsyncWrap, public StreamListener {
 
 
   int on_headers_complete() {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    header_nread_ = 0;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
     // Arguments for the on-headers-complete javascript callback. This
     // list needs to be kept in sync with the actual argument list for
     // `parserOnHeadersComplete` in lib/_http_common.js.
@@ -279,8 +309,15 @@ class Parser : public AsyncWrap, public StreamListener {
     argv[A_VERSION_MAJOR] = Integer::New(env()->isolate(), parser_.http_major);
     argv[A_VERSION_MINOR] = Integer::New(env()->isolate(), parser_.http_minor);
 
+    bool should_keep_alive;
+#ifdef NODE_EXPERIMENTAL_HTTP
+    should_keep_alive = llhttp_should_keep_alive(&parser_);
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+    should_keep_alive = http_should_keep_alive(&parser_);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
     argv[A_SHOULD_KEEP_ALIVE] =
-        Boolean::New(env()->isolate(), http_should_keep_alive(&parser_));
+        Boolean::New(env()->isolate(), should_keep_alive);
 
     argv[A_UPGRADE] = Boolean::New(env()->isolate(), parser_.upgrade);
 
@@ -332,7 +369,10 @@ class Parser : public AsyncWrap, public StreamListener {
 
     if (r.IsEmpty()) {
       got_exception_ = true;
-      return -1;
+#ifdef NODE_EXPERIMENTAL_HTTP
+      llhttp_set_error_reason(&parser_, "JS Exception");
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+      return HPE_USER;
     }
 
     return 0;
@@ -357,18 +397,33 @@ class Parser : public AsyncWrap, public StreamListener {
 
     if (r.IsEmpty()) {
       got_exception_ = true;
-      return -1;
+      return HPE_USER;
     }
 
     return 0;
   }
 
+#ifdef NODE_EXPERIMENTAL_HTTP
+  // Reset nread for the next chunk
+  int on_chunk_header() {
+    header_nread_ = 0;
+    return 0;
+  }
+
+
+  // Reset nread for the next chunk
+  int on_chunk_complete() {
+    header_nread_ = 0;
+    return 0;
+  }
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+
 
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    http_parser_type type =
-        static_cast<http_parser_type>(args[0].As<Int32>()->Value());
+    parser_type_t type =
+        static_cast<parser_type_t>(args[0].As<Int32>()->Value());
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     new Parser(env, args.This(), type);
   }
@@ -434,30 +489,11 @@ class Parser : public AsyncWrap, public StreamListener {
 
 
   static void Finish(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
-
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
 
     CHECK(parser->current_buffer_.IsEmpty());
-    parser->got_exception_ = false;
-
-    int rv = http_parser_execute(&(parser->parser_), &settings, nullptr, 0);
-
-    if (parser->got_exception_)
-      return;
-
-    if (rv != 0) {
-      enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
-
-      Local<Value> e = Exception::Error(env->parse_error_string());
-      Local<Object> obj = e.As<Object>();
-      obj->Set(env->bytes_parsed_string(), Integer::New(env->isolate(), 0));
-      obj->Set(env->code_string(),
-               OneByteString(env->isolate(), http_errno_name(err)));
-
-      args.GetReturnValue().Set(e);
-    }
+    parser->Execute(nullptr, 0);
   }
 
 
@@ -467,8 +503,8 @@ class Parser : public AsyncWrap, public StreamListener {
     CHECK(args[0]->IsInt32());
     CHECK(args[1]->IsBoolean());
     bool isReused = args[1]->IsTrue();
-    http_parser_type type =
-        static_cast<http_parser_type>(args[0].As<Int32>()->Value());
+    parser_type_t type =
+        static_cast<parser_type_t>(args[0].As<Int32>()->Value());
 
     CHECK(type == HTTP_REQUEST || type == HTTP_RESPONSE);
     Parser* parser;
@@ -492,7 +528,21 @@ class Parser : public AsyncWrap, public StreamListener {
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
     // Should always be called from the same context.
     CHECK_EQ(env, parser->env());
+
+#ifdef NODE_EXPERIMENTAL_HTTP
+    if (parser->executing_) {
+      parser->pending_pause_ = should_pause;
+      return;
+    }
+
+    if (should_pause) {
+      llhttp_pause(&parser->parser_);
+    } else {
+      llhttp_resume(&parser->parser_);
+    }
+#else  /* !NODE_EXPERIMENTAL_HTTP */
     http_parser_pause(&parser->parser_, should_pause);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
   }
 
 
@@ -602,10 +652,46 @@ class Parser : public AsyncWrap, public StreamListener {
     current_buffer_data_ = data;
     got_exception_ = false;
 
-    size_t nparsed =
-      http_parser_execute(&parser_, &settings, data, len);
+    parser_errno_t err;
 
-    Save();
+#ifdef NODE_EXPERIMENTAL_HTTP
+    // Do not allow re-entering `http_parser_execute()`
+    CHECK_EQ(executing_, 0);
+
+    executing_++;
+    if (data == nullptr) {
+      err = llhttp_finish(&parser_);
+    } else {
+      err = llhttp_execute(&parser_, data, len);
+      Save();
+    }
+    executing_--;
+
+    // Calculate bytes read and resume after Upgrade/CONNECT pause
+    size_t nread = len;
+    if (err != HPE_OK) {
+      nread = llhttp_get_error_pos(&parser_) - data;
+
+      /* This isn't a real pause, just a way to stop parsing early */
+      if (err == HPE_PAUSED_UPGRADE) {
+        err = HPE_OK;
+        llhttp_resume_after_upgrade(&parser_);
+      }
+    }
+
+    // Apply pending pause
+    if (pending_pause_) {
+      pending_pause_ = false;
+      llhttp_pause(&parser_);
+    }
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+    size_t nread = http_parser_execute(&parser_, &settings, data, len);
+    if (data != nullptr) {
+      Save();
+    }
+
+    err = HTTP_PARSER_ERRNO(&parser_);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 
     // Unassign the 'buffer_' variable
     current_buffer_.Clear();
@@ -616,22 +702,29 @@ class Parser : public AsyncWrap, public StreamListener {
     if (got_exception_)
       return scope.Escape(Local<Value>());
 
-    Local<Integer> nparsed_obj = Integer::New(env()->isolate(), nparsed);
+    Local<Integer> nread_obj = Integer::New(env()->isolate(), nread);
+
     // If there was a parse error in one of the callbacks
     // TODO(bnoordhuis) What if there is an error on EOF?
-    if (!parser_.upgrade && nparsed != len) {
-      enum http_errno err = HTTP_PARSER_ERRNO(&parser_);
-
+    if (!parser_.upgrade && err != HPE_OK) {
       Local<Value> e = Exception::Error(env()->parse_error_string());
       Local<Object> obj = e->ToObject(env()->isolate()->GetCurrentContext())
         .ToLocalChecked();
-      obj->Set(env()->bytes_parsed_string(), nparsed_obj);
+      obj->Set(env()->bytes_parsed_string(), nread_obj);
+#ifdef NODE_EXPERIMENTAL_HTTP
+      obj->Set(env()->code_string(),
+               OneByteString(env()->isolate(), llhttp_errno_name(err)));
+      obj->Set(env()->reason_string(),
+               OneByteString(env()->isolate(), parser_.reason));
+#else  /* !NODE_EXPERIMENTAL_HTTP */
       obj->Set(env()->code_string(),
                OneByteString(env()->isolate(), http_errno_name(err)));
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 
       return scope.Escape(e);
     }
-    return scope.Escape(nparsed_obj);
+
+    return scope.Escape(nread_obj);
   }
 
   Local<Array> CreateHeaders() {
@@ -684,8 +777,12 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  void Init(enum http_parser_type type) {
+  void Init(parser_type_t type) {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    llhttp_init(&parser_, type, &settings);
+#else  /* !NODE_EXPERIMENTAL_HTTP */
     http_parser_init(&parser_, type);
+#endif  /* NODE_EXPERIMENTAL_HTTP */
     url_.Reset();
     status_message_.Reset();
     num_fields_ = 0;
@@ -695,7 +792,35 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
 
-  http_parser parser_;
+  int TrackHeader(size_t len) {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    header_nread_ += len;
+    if (header_nread_ >= kMaxHeaderSize) {
+      llhttp_set_error_reason(&parser_, "Headers overflow");
+      return HPE_USER;
+    }
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+    return 0;
+  }
+
+
+  int MaybePause() {
+#ifdef NODE_EXPERIMENTAL_HTTP
+    CHECK_NE(executing_, 0);
+
+    if (!pending_pause_) {
+      return 0;
+    }
+
+    pending_pause_ = false;
+    llhttp_set_error_reason(&parser_, "Paused in callback");
+    return HPE_PAUSED;
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+    return 0;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
+  }
+
+  parser_t parser_;
   StringPtr fields_[32];  // header fields
   StringPtr values_[32];  // header values
   StringPtr url_;
@@ -707,25 +832,37 @@ class Parser : public AsyncWrap, public StreamListener {
   Local<Object> current_buffer_;
   size_t current_buffer_len_;
   char* current_buffer_data_;
+#ifdef NODE_EXPERIMENTAL_HTTP
+  unsigned int executing_;
+  bool pending_pause_;
+  uint64_t header_nread_;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 
   // These are helper functions for filling `http_parser_settings`, which turn
   // a member function of Parser into a C-style HTTP parser callback.
   template <typename Parser, Parser> struct Proxy;
   template <typename Parser, typename ...Args, int (Parser::*Member)(Args...)>
   struct Proxy<int (Parser::*)(Args...), Member> {
-    static int Raw(http_parser* p, Args ... args) {
+    static int Raw(parser_t* p, Args ... args) {
       Parser* parser = ContainerOf(&Parser::parser_, p);
-      return (parser->*Member)(std::forward<Args>(args)...);
+      int rv = (parser->*Member)(std::forward<Args>(args)...);
+      if (rv == 0) {
+        rv = parser->MaybePause();
+      }
+      return rv;
     }
   };
 
   typedef int (Parser::*Call)();
   typedef int (Parser::*DataCall)(const char* at, size_t length);
 
-  static const struct http_parser_settings settings;
+  static const parser_settings_t settings;
+#ifdef NODE_EXPERIMENTAL_HTTP
+  static const uint64_t kMaxHeaderSize = 80 * 1024;
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 };
 
-const struct http_parser_settings Parser::settings = {
+const parser_settings_t Parser::settings = {
   Proxy<Call, &Parser::on_message_begin>::Raw,
   Proxy<DataCall, &Parser::on_url>::Raw,
   Proxy<DataCall, &Parser::on_status>::Raw,
@@ -734,8 +871,13 @@ const struct http_parser_settings Parser::settings = {
   Proxy<Call, &Parser::on_headers_complete>::Raw,
   Proxy<DataCall, &Parser::on_body>::Raw,
   Proxy<Call, &Parser::on_message_complete>::Raw,
-  nullptr,  // on_chunk_header
-  nullptr   // on_chunk_complete
+#ifdef NODE_EXPERIMENTAL_HTTP
+  Proxy<Call, &Parser::on_chunk_header>::Raw,
+  Proxy<Call, &Parser::on_chunk_complete>::Raw,
+#else  /* !NODE_EXPERIMENTAL_HTTP */
+  nullptr,
+  nullptr,
+#endif  /* NODE_EXPERIMENTAL_HTTP */
 };
 
 

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -25,7 +25,7 @@ function flushPool() {
 function demoBug(part1, part2) {
   flushPool();
 
-  const parser = new HTTPParser(0);
+  const parser = new HTTPParser(HTTPParser.REQUEST);
 
   parser.headers = [];
   parser.url = '';

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const expected_keys = ['ares', 'http_parser', 'modules', 'node',
+const expected_keys = ['ares', 'llhttp', 'http_parser', 'modules', 'node',
                        'uv', 'v8', 'zlib', 'nghttp2', 'napi'];
 
 if (common.hasCrypto) {
@@ -24,7 +24,8 @@ assert.deepStrictEqual(actual_keys, expected_keys);
 const commonTemplate = /^\d+\.\d+\.\d+(?:-.*)?$/;
 
 assert(commonTemplate.test(process.versions.ares));
-assert(commonTemplate.test(process.versions.http_parser));
+assert(commonTemplate.test(process.versions.llhttp === null ?
+  process.versions.http_parser : process.versions.llhttp));
 assert(commonTemplate.test(process.versions.node));
 assert(commonTemplate.test(process.versions.uv));
 assert(commonTemplate.test(process.versions.zlib));

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -24,7 +24,7 @@ assert.deepStrictEqual(actual_keys, expected_keys);
 const commonTemplate = /^\d+\.\d+\.\d+(?:-.*)?$/;
 
 assert(commonTemplate.test(process.versions.ares));
-assert(commonTemplate.test(process.versions.llhttp === null ?
+assert(commonTemplate.test(process.versions.llhttp === undefined ?
   process.versions.http_parser : process.versions.llhttp));
 assert(commonTemplate.test(process.versions.node));
 assert(commonTemplate.test(process.versions.uv));

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const expected_keys = ['ares', 'llhttp', 'http_parser', 'modules', 'node',
+const expected_keys = ['ares', 'modules', 'node',
                        'uv', 'v8', 'zlib', 'nghttp2', 'napi'];
 
 if (common.hasCrypto) {
@@ -15,6 +15,9 @@ if (common.hasIntl) {
   expected_keys.push('tz');
   expected_keys.push('unicode');
 }
+
+expected_keys.push(
+  process.versions.llhttp === undefined ? 'http_parser' : 'llhttp');
 
 expected_keys.sort();
 const actual_keys = Object.keys(process.versions).sort();

--- a/test/parallel/test-trace-events-metadata.js
+++ b/test/parallel/test-trace-events-metadata.js
@@ -36,8 +36,9 @@ proc.once('exit', common.mustCall(() => {
 
     assert(traces.some((trace) =>
       trace.name === 'node' &&
-        trace.args.process.versions.http_parser ===
-          process.versions.http_parser &&
+        (trace.args.process.versions.http_parser ===
+           process.versions.http_parser ||
+         trace.args.process.versions.llhttp === process.versions.llhttp) &&
         trace.args.process.versions.node ===
           process.versions.node &&
         trace.args.process.versions.v8 ===

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -149,7 +149,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
 
 {
   const { HTTPParser } = internalBinding('http_parser');
-  testInitialized(new HTTPParser(0), 'HTTPParser');
+  testInitialized(new HTTPParser(HTTPParser.REQUEST), 'HTTPParser');
 }
 
 

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -32,6 +32,7 @@ fi
 addlicense "Acorn" "deps/acorn" "$(cat ${rootdir}/deps/acorn/LICENSE)"
 addlicense "c-ares" "deps/cares" "$(tail -n +3 ${rootdir}/deps/cares/LICENSE.md)"
 addlicense "HTTP Parser" "deps/http_parser" "$(cat deps/http_parser/LICENSE-MIT)"
+addlicense "llhttp" "deps/llhttp" "$(cat deps/llhttp/LICENSE-MIT)"
 if [ -f "${rootdir}/deps/icu/LICENSE" ]; then
   # ICU 57 and following. Drop the BOM
   addlicense "ICU" "deps/icu" \

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -32,7 +32,6 @@ fi
 addlicense "Acorn" "deps/acorn" "$(cat ${rootdir}/deps/acorn/LICENSE)"
 addlicense "c-ares" "deps/cares" "$(tail -n +3 ${rootdir}/deps/cares/LICENSE.md)"
 addlicense "HTTP Parser" "deps/http_parser" "$(cat deps/http_parser/LICENSE-MIT)"
-addlicense "llhttp" "deps/llhttp" "$(cat deps/llhttp/LICENSE-MIT)"
 if [ -f "${rootdir}/deps/icu/LICENSE" ]; then
   # ICU 57 and following. Drop the BOM
   addlicense "ICU" "deps/icu" \
@@ -59,6 +58,7 @@ else
 fi
 
 addlicense "libuv" "deps/uv" "$(cat ${rootdir}/deps/uv/LICENSE)"
+addlicense "llhttp" "deps/llhttp" "$(cat deps/llhttp/LICENSE-MIT)"
 addlicense "OpenSSL" "deps/openssl" \
            "$(sed -e '/^ \*\/$/,$d' -e '/^ [^*].*$/d' -e '/\/\*.*$/d' -e '/^$/d' -e 's/^[/ ]\* *//' ${rootdir}/deps/openssl/openssl/LICENSE)"
 addlicense "Punycode.js" "lib/punycode.js" \


### PR DESCRIPTION
[llhttp](https://github.com/indutny/llhttp) is modern, written in human-readable [TypeScript](https://github.com/indutny/llhttp/blob/master/src/llhttp/http.ts), verifiable, and
is very easy to maintain.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
