### PR TITLE
src: replace some deprecated uses of Get() and Set()

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -347,8 +347,13 @@ void AsyncWrap::WeakCallback(const v8::WeakCallbackInfo<DestroyParam>& info) {
 
   std::unique_ptr<DestroyParam> p{info.GetParameter()};
   Local<Object> prop_bag = PersistentToLocal(info.GetIsolate(), p->propBag);
+  Local<Value> val;
 
-  Local<Value> val = prop_bag->Get(p->env->destroyed_string());
+  if (!prop_bag->Get(p->env->context(), p->env->destroyed_string())
+        .ToLocal(&val)) {
+    return;
+  }
+
   if (val->IsFalse()) {
     AsyncWrap::EmitDestroy(p->env, p->asyncId);
   }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -736,7 +736,7 @@ inline void Environment::SetMethod(v8::Local<v8::Object> that,
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(name_string, function);
+  that->Set(context, name_string, function).FromJust();
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
@@ -756,7 +756,7 @@ inline void Environment::SetMethodNoSideEffect(v8::Local<v8::Object> that,
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(name_string, function);
+  that->Set(context, name_string, function).FromJust();
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -369,7 +369,7 @@ inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name,
       v8::NewStringType::kInternalized).ToLocalChecked();
   fn->SetName(fn_name);
-  recv->Set(fn_name, fn);
+  recv->Set(context, fn_name, fn).FromJust();
 }
 #define NODE_SET_METHOD node::NODE_SET_METHOD
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
