### PR TITLE
Fixes NODE_OPTIONS when spaces are escaped

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -774,9 +774,11 @@ if they had been specified on the command line before the actual command line
 (so they can be overridden). Node.js will exit with an error if an option
 that is not allowed in the environment is used, such as `-p` or a script file.
 
-In case an option happens to contain a space or a backslash (for example within
-the path passed to `--require`), they must be escaped using an additional
-backslash.
+In case an option value happens to contain a space (for example a path listed in
+`--require`), it must be escaped using double quotes. For example:
+```
+--require "./my path/file.js"
+```
 
 Node.js options that are allowed are:
 - `--diagnostic-report-directory`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -774,6 +774,10 @@ if they had been specified on the command line before the actual command line
 (so they can be overridden). Node.js will exit with an error if an option
 that is not allowed in the environment is used, such as `-p` or a script file.
 
+In case an option happens to contain a space or a backslash (for example within
+the path passed to `--require`), they must be escaped using an additional
+backslash.
+
 Node.js options that are allowed are:
 - `--diagnostic-report-directory`
 - `--diagnostic-report-filename`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -776,7 +776,8 @@ that is not allowed in the environment is used, such as `-p` or a script file.
 
 In case an option value happens to contain a space (for example a path listed in
 `--require`), it must be escaped using double quotes. For example:
-```
+
+```bash
 --require "./my path/file.js"
 ```
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -687,10 +687,9 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
       // Backslashes escape the following character
       if (c == '\\' && is_in_string) {
         if (index + 1 == node_options.size()) {
-          fprintf(stderr,
-                  "%s: invalid escaping for NODE_OPTIONS\n",
-                  argv->at(0).c_str());
-          exit(9);
+          errors->push_back("invalid value for NODE_OPTIONS "
+                            "(invalid escape)\n");
+          return 9;
         } else {
           c = node_options.at(++index);
         }
@@ -708,6 +707,12 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
       } else {
         env_argv.back() += c;
       }
+    }
+
+    if (is_in_string) {
+      errors->push_back("invalid value for NODE_OPTIONS "
+                        "(unterminated string)\n");
+      return 9;
     }
 
     const int exit_code = ProcessGlobalArgs(&env_argv, nullptr, errors, true);

--- a/src/node.cc
+++ b/src/node.cc
@@ -677,6 +677,7 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
     // [0] is expected to be the program name, fill it in from the real argv.
     env_argv.push_back(argv->at(0));
 
+    bool is_in_string = false;
     bool will_start_new_arg = true;
     for (std::string::size_type index = 0;
          index < node_options.size();
@@ -684,7 +685,7 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
       char c = node_options.at(index);
 
       // Backslashes escape the following character
-      if (c == '\\') {
+      if (c == '\\' && is_in_string) {
         if (index + 1 == node_options.size()) {
           fprintf(stderr,
                   "%s: invalid escaping for NODE_OPTIONS\n",
@@ -693,8 +694,11 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
         } else {
           c = node_options.at(++index);
         }
-      } else if (c == ' ') {
+      } else if (c == ' ' && !is_in_string) {
         will_start_new_arg = true;
+        continue;
+      } else if (c == '"') {
+        is_in_string = !is_in_string;
         continue;
       }
 

--- a/test/fixtures/print A.js
+++ b/test/fixtures/print A.js
@@ -1,0 +1,1 @@
+console.log('A');

--- a/test/fixtures/print A.js
+++ b/test/fixtures/print A.js
@@ -1,1 +1,1 @@
-console.log('A');
+console.log('A')

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -14,9 +14,10 @@ tmpdir.refresh();
 const printA = require.resolve('../fixtures/printA.js');
 const printSpaceA = require.resolve('../fixtures/print A.js');
 
+expect(` -r ${printA} `, 'A\nB\n');
 expect(`-r ${printA}`, 'A\nB\n');
-expect(`-r ${printA.replace(/[a-z]/gi, '\\$&')}`, 'A\nB\n');
-expect(`-r ${printSpaceA.replace(/[\\ ]/g, '\\$&')}`, 'A\nB\n');
+expect(`-r ${JSON.stringify(printA)}`, 'A\nB\n');
+expect(`-r ${JSON.stringify(printSpaceA)}`, 'A\nB\n');
 expect(`-r ${printA} -r ${printA}`, 'A\nB\n');
 expect(`   -r ${printA}    -r ${printA}`, 'A\nB\n');
 expect(`   --require ${printA}    --require ${printA}`, 'A\nB\n');

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -12,7 +12,11 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 const printA = require.resolve('../fixtures/printA.js');
+const printSpaceA = require.resolve('../fixtures/print A.js');
+
 expect(`-r ${printA}`, 'A\nB\n');
+expect(`-r ${printA.replace(/[a-z]/gi, '\\$&')}`, 'A\nB\n');
+expect(`-r ${printSpaceA.replace(/[\\ ]/g, '\\$&')}`, 'A\nB\n');
 expect(`-r ${printA} -r ${printA}`, 'A\nB\n');
 expect(`   -r ${printA}    -r ${printA}`, 'A\nB\n');
 expect(`   --require ${printA}    --require ${printA}`, 'A\nB\n');


### PR DESCRIPTION
This PR fixes #12971. It adds a way to properly escape spaces when found within `NODE_OPTIONS`. The previous behavior was problematic because there was no way to use `--require` with paths containing spaces.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
