### PR TITLE
fs: makes existsSync stop using errors

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -227,12 +227,19 @@ Object.defineProperty(exists, internalUtil.promisify.custom, {
 // validation errors to users properly out of compatibility concerns.
 // TODO(joyeecheung): deprecate the never-throw-on-invalid-arguments behavior
 function existsSync(path) {
+  let ctx;
+
   try {
-    fs.accessSync(path, F_OK);
-    return true;
-  } catch (e) {
+    path = toPathIfFileURL(path);
+    validatePath(path);
+
+    ctx = { path };
+    binding.access(pathModule.toNamespacedPath(path), F_OK, undefined, ctx);
+  } catch {
     return false;
   }
+
+  return ctx.errno === undefined && ctx.error === undefined;
 }
 
 function readFileAfterOpen(err, fd) {


### PR DESCRIPTION
The previous implementation of `existsSync` was a try/catch on top
of `accessSync`. While conceptually sound it was a performance problem
when running it repeatedly on non-existing files, because `accessSync`
had to create an `Error` object that was immediatly discarded (because
`existsSync` never reports anything else than `true` / `false`).

This implementation simply checks whether the context would have caused
an exception to be thrown, but doesn't actually create it.

I benchmarked it as such:

```js
const fs = require('fs');

console.time();
for (let t = 0; t < 100000; ++t) fs.existsSync('./doesnt-exist');
console.timeEnd();
```

```
❯ [mael-mbp?] node git:(existssync-no-errors) ✗ ❯ node --version
v11.1.0

❯ [mael-mbp?] node git:(existssync-no-errors) ✗ ❯ node test.js
default: 2543.314ms

❯ [mael-mbp?] node git:(existssync-no-errors) ✗ ❯ ./node test.js
default: 287.442ms
```

Fixes: https://github.com/nodejs/node/issues/24008

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
