### PR TITLE
vm: add createCacheForFunction

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -25,7 +25,8 @@ const {
   ContextifyScript,
   makeContext,
   isContext: _isContext,
-  compileFunction: _compileFunction
+  compileFunction: _compileFunction,
+  createCacheForFunction
 } = internalBinding('contextify');
 const { callbackMap } = internalBinding('module_wrap');
 const {
@@ -390,7 +391,7 @@ function compileFunction(code, params, options = {}) {
     }
   });
 
-  return _compileFunction(
+  const fn = _compileFunction(
     code,
     filename,
     lineOffset,
@@ -401,6 +402,16 @@ function compileFunction(code, params, options = {}) {
     contextExtensions,
     params
   );
+
+  if (produceCachedData) {
+    const cache = createCacheForFunction(fn);
+    fn.cachedDataProduced = cache !== undefined;
+    if (fn.cachedDataProduced) {
+      fn.cachedData = cache;
+    }
+  }
+
+  return fn;
 }
 
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -397,7 +397,6 @@ function compileFunction(code, params, options = {}) {
     lineOffset,
     columnOffset,
     cachedData,
-    produceCachedData,
     parsingContext,
     contextExtensions,
     params

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1119,9 +1119,7 @@ void ContextifyContext::CreateCacheForFunction(
   const std::unique_ptr<ScriptCompiler::CachedData> cache(
       ScriptCompiler::CreateCodeCacheForFunction(function));
 
-  if (cache == nullptr) {
-    args.GetReturnValue().SetUndefined();
-  } else {
+  if (cache != nullptr) {
     args.GetReturnValue().Set(
         Buffer::Copy(
             env, reinterpret_cast<const char*>(cache->data), cache->length)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1001,35 +1001,31 @@ void ContextifyContext::CompileFunction(
     cached_data_buf = args[4].As<Uint8Array>();
   }
 
-  // Argument 6: produce cache data
-  CHECK(args[5]->IsBoolean());
-  bool produce_cached_data = args[5]->IsTrue();
-
-  // Argument 7: parsing context (optional)
+  // Argument 6: parsing context (optional)
   Local<Context> parsing_context;
-  if (!args[6]->IsUndefined()) {
-    CHECK(args[6]->IsObject());
+  if (!args[5]->IsUndefined()) {
+    CHECK(args[5]->IsObject());
     ContextifyContext* sandbox =
         ContextifyContext::ContextFromContextifiedSandbox(
-            env, args[6].As<Object>());
+            env, args[5].As<Object>());
     CHECK_NOT_NULL(sandbox);
     parsing_context = sandbox->context();
   } else {
     parsing_context = context;
   }
 
-  // Argument 8: context extensions (optional)
+  // Argument 7: context extensions (optional)
   Local<Array> context_extensions_buf;
-  if (!args[7]->IsUndefined()) {
-    CHECK(args[7]->IsArray());
-    context_extensions_buf = args[7].As<Array>();
+  if (!args[6]->IsUndefined()) {
+    CHECK(args[6]->IsArray());
+    context_extensions_buf = args[6].As<Array>();
   }
 
-  // Argument 9: params for the function (optional)
+  // Argument 8: params for the function (optional)
   Local<Array> params_buf;
-  if (!args[8]->IsUndefined()) {
-    CHECK(args[8]->IsArray());
-    params_buf = args[8].As<Array>();
+  if (!args[7]->IsUndefined()) {
+    CHECK(args[7]->IsArray());
+    params_buf = args[7].As<Array>();
   }
 
   // Read cache from cached data buffer
@@ -1084,26 +1080,6 @@ void ContextifyContext::CompileFunction(
     ContextifyScript::DecorateErrorStack(env, try_catch);
     try_catch.ReThrow();
     return;
-  }
-
-  if (produce_cached_data) {
-    const std::unique_ptr<ScriptCompiler::CachedData> cached_data(
-        ScriptCompiler::CreateCodeCacheForFunction(fun));
-    bool cached_data_produced = cached_data != nullptr;
-    if (cached_data_produced) {
-      MaybeLocal<Object> buf = Buffer::Copy(
-          env,
-          reinterpret_cast<const char*>(cached_data->data),
-          cached_data->length);
-      if (fun->Set(
-          parsing_context,
-          env->cached_data_string(),
-          buf.ToLocalChecked()).IsNothing()) return;
-    }
-    if (fun->Set(
-        parsing_context,
-        env->cached_data_produced_string(),
-        Boolean::New(isolate, cached_data_produced)).IsNothing()) return;
   }
 
   args.GetReturnValue().Set(fun);

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -61,6 +61,8 @@ class ContextifyContext {
   static void IsContext(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CompileFunction(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CreateCacheForFunction(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(


### PR DESCRIPTION
###### TODO:

- [ ] Use the binding in vm.compileFunction and family, removing the C++ code that currently handles caching.

/cc @joyeecheung @devsnek 