### PR TITLE
net: simplify Socket.prototype._final

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -373,7 +373,7 @@ function afterShutdown(status, handle) {
   if (self.destroyed)
     return;
 
-  if (self._readableState.ended) {
+  if (!self.readable || self._readableState.ended) {
     debug('readableState ended, destroying');
     self.destroy();
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -336,14 +336,6 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 };
 
 
-function shutdownSocket(self, callback) {
-  var req = new ShutdownWrap();
-  req.oncomplete = afterShutdown;
-  req.handle = self._handle;
-  req.callback = callback;
-  return self._handle.shutdown(req);
-}
-
 // the user has called .end(), and all the bytes have been
 // sent out to the other side.
 Socket.prototype._final = function(cb) {
@@ -353,23 +345,16 @@ Socket.prototype._final = function(cb) {
     return this.once('connect', () => this._final(cb));
   }
 
-  if (!this.readable || this._readableState.ended) {
-    debug('_final: ended, destroy', this._readableState);
-    cb();
-    return this.destroy();
-  }
+  if (!this._handle)
+    return cb();
 
   debug('_final: not ended, call shutdown()');
 
-  // otherwise, just shutdown, or destroy() if not possible
-  if (!this._handle || !this._handle.shutdown) {
-    cb();
-    return this.destroy();
-  }
-
-  var err = defaultTriggerAsyncIdScope(
-    this[async_id_symbol], shutdownSocket, this, cb
-  );
+  var req = new ShutdownWrap();
+  req.oncomplete = afterShutdown;
+  req.handle = this._handle;
+  req.callback = cb;
+  var err = this._handle.shutdown(req);
 
   if (err)
     return this.destroy(errnoException(err, 'shutdown'));


### PR DESCRIPTION
Remove conditions that should be irrelevant since we started
using `_final`, as well as an extra `defaultTriggerAsyncIdScope()`
call which is unnecessary because there is an equivalent
scope already present on the native side.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
