### PR TITLE
build: do not lint on non-PR Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       script:
         - make lint
         # Lint the first commit in the PR.
-        - \[ "${TRAVIS_PULL_REQUEST}" != "false" \] && PR_ID=${TRAVIS_PULL_REQUEST}; bash tools/lint-pr-commit-message.sh ${PR_ID}
+        - \[ "${TRAVIS_PULL_REQUEST}" != "false" \] && bash tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST}
     - name: "Test Suite"
       addons:
         apt:


### PR DESCRIPTION
Do not run any linting at all when `TRAVIS_PULL_REQUEST` is `false`.
This would otherwise break Travis CI for `master` and release branches.

Refs: https://github.com/nodejs/node/pull/24030

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
