### PR TITLE
test: add test for socket.end callback

### DIFF
--- a/test/parallel/test-net-socket-end-callback.js
+++ b/test/parallel/test-net-socket-end-callback.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
-
-let ends = 0;
 
 const server = net.createServer((socket) => {
   socket.resume();
@@ -17,15 +14,9 @@ server.listen(common.mustCall(() => {
     });
   };
 
-  const cb = () => {
-    ends++;
-  };
+  const cb = common.mustCall(() => {}, 3);
 
-  connect(common.mustCall(cb));
-  connect('foo', common.mustCall(cb));
-  connect('foo', 'utf8', common.mustCall(cb));
+  connect(cb);
+  connect('foo', cb);
+  connect('foo', 'utf8', cb);
 }));
-
-process.on('exit', () => {
-  assert.strictEqual(ends, 3);
-});

--- a/test/parallel/test-net-socket-end-callback.js
+++ b/test/parallel/test-net-socket-end-callback.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+let ends = 0;
+
+const server = net.createServer((socket) => {
+  socket.resume();
+}).unref();
+
+server.listen(common.mustCall(() => {
+  const connect = (...args) => {
+    const socket = net.createConnection(server.address().port, () => {
+      socket.end(...args);
+    });
+  };
+
+  const cb = () => {
+    ends++;
+  };
+
+  connect(common.mustCall(cb));
+  connect('foo', common.mustCall(cb));
+  connect('foo', 'utf8', common.mustCall(cb));
+}));
+
+process.on('exit', () => {
+  assert.strictEqual(ends, 3);
+});


### PR DESCRIPTION
This test checks the callback of socket.end is called.

Refs: https://github.com/nodejs/node/pull/23937

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
