### PR TITLE
lib: move internalBinding whitelisting into loaders.js

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -70,12 +70,52 @@
     writable: false
   });
 
+  // internalBindingWhitelist contains the name of internalBinding modules
+  // that are whitelisted for access via process.binding()... this is used
+  // to provide a transition path for modules that are being moved over to
+  // internalBinding.
+  const internalBindingWhitelist = [
+    'cares_wrap',
+    'fs_event_wrap',
+    'icu',
+    'udp_wrap',
+    'uv',
+    'pipe_wrap',
+    'http_parser',
+    'process_wrap',
+    'v8',
+    'tty_wrap',
+    'stream_wrap',
+    'signal_wrap',
+    'crypto',
+    'contextify',
+    'tcp_wrap',
+    'tls_wrap',
+    'util',
+    'async_wrap',
+    'url',
+    'spawn_sync',
+    'js_stream',
+    'zlib',
+    'buffer',
+    'natives',
+    'constants'
+  ];
+  // We will use a lazy loaded SafeSet in internalBindingWhitelistHas
+  // for checking existence in this list.
+  let internalBindingWhitelistSet;
+
   // Set up process.binding() and process._linkedBinding()
   {
     const bindingObj = ObjectCreate(null);
 
     process.binding = function binding(module) {
       module = String(module);
+      // Deprecated specific process.binding() modules, but not all, allow
+      // selective fallback to internalBinding for the deprecated ones.
+      if (internalBindingWhitelistHas(module)) {
+        return internalBinding(module);
+      }
       let mod = bindingObj[module];
       if (typeof mod !== 'object') {
         mod = bindingObj[module] = getBinding(module);
@@ -366,6 +406,14 @@
   // it for Node.js' own internal libraries.
   if (process.env.NODE_V8_COVERAGE) {
     NativeModule.require('internal/process/coverage').setup();
+  }
+
+  function internalBindingWhitelistHas(name) {
+    if (!internalBindingWhitelistSet) {
+      const { SafeSet } = NativeModule.require('internal/safe_globals');
+      internalBindingWhitelistSet = new SafeSet(internalBindingWhitelist);
+    }
+    return internalBindingWhitelistSet.has(name);
   }
 
   // This will be passed to the bootstrapNodeJSCore function in

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -384,47 +384,6 @@
       for (var i = 0; i < arguments.length; i++)
         this.push(arguments[i]);
     }
-
-    // Deprecated specific process.binding() modules, but not all, allow
-    // selective fallback to internalBinding for the deprecated ones.
-    const { SafeSet } = NativeModule.require('internal/safe_globals');
-    const processBinding = process.binding;
-    // internalBindingWhitelist contains the name of internalBinding modules
-    // that are whitelisted for access via process.binding()... this is used
-    // to provide a transition path for modules that are being moved over to
-    // internalBinding.
-    const internalBindingWhitelist =
-      new SafeSet([
-        'cares_wrap',
-        'fs_event_wrap',
-        'icu',
-        'udp_wrap',
-        'uv',
-        'pipe_wrap',
-        'http_parser',
-        'process_wrap',
-        'v8',
-        'tty_wrap',
-        'stream_wrap',
-        'signal_wrap',
-        'crypto',
-        'contextify',
-        'tcp_wrap',
-        'tls_wrap',
-        'util',
-        'async_wrap',
-        'url',
-        'spawn_sync',
-        'js_stream',
-        'zlib',
-        'buffer',
-        'natives',
-        'constants']);
-    process.binding = function binding(name) {
-      return internalBindingWhitelist.has(name) ?
-        internalBinding(name) :
-        processBinding(name);
-    };
   }
 
   function setupGlobalVariables() {


### PR DESCRIPTION
Instead of setting the internalBinding white list in node.js and
wrapping process.binding twice, put it directly in loaders.js
where the user land process.binding is defined.
