### PR TITLE
lib: move process prototype manipulation into setupProcessObject

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -30,13 +30,6 @@
   const isMainThread = internalBinding('worker').threadId === 0;
 
   function startup() {
-    const EventEmitter = NativeModule.require('events');
-
-    const origProcProto = Object.getPrototypeOf(process);
-    Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
-
-    EventEmitter.call(process);
-
     setupTraceCategoryState();
 
     setupProcessObject();
@@ -378,6 +371,11 @@
   }
 
   function setupProcessObject() {
+    const EventEmitter = NativeModule.require('events');
+    const origProcProto = Object.getPrototypeOf(process);
+    Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
+    EventEmitter.call(process);
+
     _setupProcessObject(pushValueToArray);
 
     function pushValueToArray() {


### PR DESCRIPTION
Since no operation is requiring process to be an EventEmitter before
setupProcessObject is called, it's safe to set up the prototype chain
in setupProcessObject and make the main code path more readable.
