### PR TITLE
tools: lint to wrap markdown at 80 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Select a Node.js version below to view the changelog history:
 Please use the following table to find the changelog for a specific Node.js
 release.
 
+<!--lint disable maximum-line-length-->
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V11.md">11</a><sup>Current</sup></th>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -123,8 +123,8 @@ The meeting chair is responsible for ensuring that minutes are taken and that a
 pull request with the minutes is submitted after the meeting.
 
 Due to the challenges of scheduling a global meeting with participants in
-several time zones, the TSC will seek to resolve as many agenda items as possible
-outside of meetings using
+several time zones, the TSC will seek to resolve as many agenda items as
+possible outside of meetings using
 [the TSC issue tracker](https://github.com/nodejs/TSC/issues). The process in
 the issue tracker is:
 

--- a/tools/lint-md.js
+++ b/tools/lint-md.js
@@ -5673,7 +5673,7 @@ var deepExtend = module.exports = function (/*obj_1, [obj_2], [obj_N]*/) {
 
 var minimist = function (args, opts) {
     if (!opts) opts = {};
-
+    
     var flags = { bools : {}, strings : {}, unknownFn: null };
 
     if (typeof opts['unknown'] === 'function') {
@@ -5687,7 +5687,7 @@ var minimist = function (args, opts) {
           flags.bools[key] = true;
       });
     }
-
+    
     var aliases = {};
     Object.keys(opts.alias || {}).forEach(function (key) {
         aliases[key] = [].concat(opts.alias[key]);
@@ -5706,12 +5706,12 @@ var minimist = function (args, opts) {
      });
 
     var defaults = opts['default'] || {};
-
+    
     var argv = { _ : [] };
     Object.keys(flags.bools).forEach(function (key) {
         setArg(key, defaults[key] === undefined ? false : defaults[key]);
     });
-
+    
     var notFlags = [];
 
     if (args.indexOf('--') !== -1) {
@@ -5732,7 +5732,7 @@ var minimist = function (args, opts) {
         var value = !flags.strings[key] && isNumber(val)
             ? Number(val) : val;
         setKey(argv, key.split('.'), value);
-
+        
         (aliases[key] || []).forEach(function (x) {
             setKey(argv, x.split('.'), value);
         });
@@ -5756,7 +5756,7 @@ var minimist = function (args, opts) {
             o[key] = [ o[key], value ];
         }
     }
-
+    
     function aliasIsBoolean(key) {
       return aliases[key].some(function (x) {
           return flags.bools[x];
@@ -5765,7 +5765,7 @@ var minimist = function (args, opts) {
 
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
-
+        
         if (/^--.+=/.test(arg)) {
             // Using [\s\S] instead of . because js doesn't support the
             // 'dotall' regex modifier. See:
@@ -5802,29 +5802,29 @@ var minimist = function (args, opts) {
         }
         else if (/^-[^-]+/.test(arg)) {
             var letters = arg.slice(1,-1).split('');
-
+            
             var broken = false;
             for (var j = 0; j < letters.length; j++) {
                 var next = arg.slice(j+2);
-
+                
                 if (next === '-') {
                     setArg(letters[j], next, arg);
                     continue;
                 }
-
+                
                 if (/[A-Za-z]/.test(letters[j]) && /=/.test(next)) {
                     setArg(letters[j], next.split('=')[1], arg);
                     broken = true;
                     break;
                 }
-
+                
                 if (/[A-Za-z]/.test(letters[j])
                 && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
                     setArg(letters[j], next, arg);
                     broken = true;
                     break;
                 }
-
+                
                 if (letters[j+1] && letters[j+1].match(/\W/)) {
                     setArg(letters[j], arg.slice(j+2), arg);
                     broken = true;
@@ -5834,7 +5834,7 @@ var minimist = function (args, opts) {
                     setArg(letters[j], flags.strings[letters[j]] ? '' : true, arg);
                 }
             }
-
+            
             var key = arg.slice(-1)[0];
             if (!broken && key !== '-') {
                 if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
@@ -5864,17 +5864,17 @@ var minimist = function (args, opts) {
             }
         }
     }
-
+    
     Object.keys(defaults).forEach(function (key) {
         if (!hasKey(argv, key.split('.'))) {
             setKey(argv, key.split('.'), defaults[key]);
-
+            
             (aliases[key] || []).forEach(function (x) {
                 setKey(argv, x.split('.'), defaults[key]);
             });
         }
     });
-
+    
     if (opts['--']) {
         argv['--'] = new Array();
         notFlags.forEach(function(key) {
@@ -8325,7 +8325,7 @@ function parse$2 (pattern, isSub) {
           // to do safely.  For now, this is safe and works.
           var cs = pattern.substring(classStart + 1, i);
           try {
-
+            
           } catch (er) {
             // not a valid class!
             var sp = this.parse(cs, SUBPARSE);
@@ -13780,7 +13780,7 @@ var textTable = function (rows_, opts) {
     var align = opts.align || [];
     var stringLength = opts.stringLength
         || function (s) { return String(s).length; };
-
+    
     var dotsizes = reduce(rows_, function (acc, row) {
         forEach(row, function (c, ix) {
             var n = dotindex(c);
@@ -13788,7 +13788,7 @@ var textTable = function (rows_, opts) {
         });
         return acc;
     }, []);
-
+    
     var rows = map$2(rows_, function (row) {
         return map$2(row, function (c_, ix) {
             var c = String(c_);
@@ -13801,7 +13801,7 @@ var textTable = function (rows_, opts) {
             else return c;
         });
     });
-
+    
     var sizes = reduce(rows, function (acc, row) {
         forEach(row, function (c, ix) {
             var n = stringLength(c);
@@ -13809,7 +13809,7 @@ var textTable = function (rows_, opts) {
         });
         return acc;
     }, []);
-
+    
     return map$2(rows, function (row) {
         return map$2(row, function (c, ix) {
             var n = (sizes[ix] - stringLength(c)) || 0;
@@ -13822,7 +13822,7 @@ var textTable = function (rows_, opts) {
                     + c + Array(Math.floor(n / 2 + 1)).join(' ')
                 ;
             }
-
+            
             return c + s;
         }).join(hsep).replace(/\s+$/, '');
     }).join('\n');
@@ -30293,88 +30293,61 @@ function stringify$7(options) {
 
 var remark = unified_1().use(remarkParse).use(remarkStringify).freeze();
 
-const _args = [["remark@8.0.0","D:\\code\\prws\\tools\\node-lint-md-cli-rollup"]];
-const _from = "remark@8.0.0";
-const _id = "remark@8.0.0";
-const _inBundle = false;
-const _integrity = "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==";
-const _location = "/remark";
-const _phantomChildren = {};
-const _requested = {"type":"version","registry":true,"raw":"remark@8.0.0","name":"remark","escapedName":"remark","rawSpec":"8.0.0","saveSpec":null,"fetchSpec":"8.0.0"};
-const _requiredBy = ["/"];
-const _resolved = "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz";
-const _spec = "8.0.0";
-const _where = "D:\\code\\prws\\tools\\node-lint-md-cli-rollup";
-const author = {"name":"Titus Wormer","email":"tituswormer@gmail.com","url":"http://wooorm.com"};
-const bugs = {"url":"https://github.com/wooorm/remark/issues"};
-const contributors = [{"name":"Titus Wormer","email":"tituswormer@gmail.com","url":"http://wooorm.com"}];
-const dependencies = {"remark-parse":"^4.0.0","remark-stringify":"^4.0.0","unified":"^6.0.0"};
-const description = "Markdown processor powered by plugins";
-const files = ["index.js"];
-const homepage = "http://remark.js.org";
-const keywords = ["markdown","abstract","syntax","tree","ast","parse","stringify","process"];
-const license = "MIT";
 const name = "remark";
-const repository = {"type":"git","url":"https://github.com/wooorm/remark/tree/master/packages/remark"};
-const scripts = {};
 const version$1 = "8.0.0";
+const description = "Markdown processor powered by plugins";
+const license = "MIT";
+const keywords = ["markdown","abstract","syntax","tree","ast","parse","stringify","process"];
+const dependencies = {"remark-parse":"^4.0.0","remark-stringify":"^4.0.0","unified":"^6.0.0"};
+const homepage = "http://remark.js.org";
+const repository = "https://github.com/wooorm/remark/tree/master/packages/remark";
+const bugs = "https://github.com/wooorm/remark/issues";
+const author = "Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)";
+const contributors = ["Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)"];
+const files = ["index.js"];
+const scripts = {};
 const xo = false;
+const _resolved = "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz";
+const _integrity = "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==";
+const _from = "remark@8.0.0";
 var _package = {
-	_args: _args,
-	_from: _from,
-	_id: _id,
-	_inBundle: _inBundle,
-	_integrity: _integrity,
-	_location: _location,
-	_phantomChildren: _phantomChildren,
-	_requested: _requested,
-	_requiredBy: _requiredBy,
-	_resolved: _resolved,
-	_spec: _spec,
-	_where: _where,
-	author: author,
-	bugs: bugs,
-	contributors: contributors,
-	dependencies: dependencies,
-	description: description,
-	files: files,
-	homepage: homepage,
-	keywords: keywords,
-	license: license,
 	name: name,
-	repository: repository,
-	scripts: scripts,
 	version: version$1,
-	xo: xo
+	description: description,
+	license: license,
+	keywords: keywords,
+	dependencies: dependencies,
+	homepage: homepage,
+	repository: repository,
+	bugs: bugs,
+	author: author,
+	contributors: contributors,
+	files: files,
+	scripts: scripts,
+	xo: xo,
+	_resolved: _resolved,
+	_integrity: _integrity,
+	_from: _from
 };
 
 var _package$1 = Object.freeze({
-	_args: _args,
-	_from: _from,
-	_id: _id,
-	_inBundle: _inBundle,
-	_integrity: _integrity,
-	_location: _location,
-	_phantomChildren: _phantomChildren,
-	_requested: _requested,
-	_requiredBy: _requiredBy,
-	_resolved: _resolved,
-	_spec: _spec,
-	_where: _where,
-	author: author,
-	bugs: bugs,
-	contributors: contributors,
-	dependencies: dependencies,
-	description: description,
-	files: files,
-	homepage: homepage,
-	keywords: keywords,
-	license: license,
 	name: name,
-	repository: repository,
-	scripts: scripts,
 	version: version$1,
+	description: description,
+	license: license,
+	keywords: keywords,
+	dependencies: dependencies,
+	homepage: homepage,
+	repository: repository,
+	bugs: bugs,
+	author: author,
+	contributors: contributors,
+	files: files,
+	scripts: scripts,
 	xo: xo,
+	_resolved: _resolved,
+	_integrity: _integrity,
+	_from: _from,
 	default: _package
 });
 
@@ -30382,7 +30355,7 @@ const name$1 = "node-lint-md-cli-rollup";
 const description$1 = "remark packaged for node markdown linting";
 const version$2 = "1.0.0";
 const devDependencies = {"rollup":"^0.55.5","rollup-plugin-commonjs":"^8.0.2","rollup-plugin-json":"^2.3.1","rollup-plugin-node-resolve":"^3.4.0"};
-const dependencies$1 = {"markdown-extensions":"^1.1.0","remark":"^8.0.0","remark-lint":"^6.0.2","remark-preset-lint-node":"^1.0.3","unified-args":"^6.0.0","unified-engine":"^5.1.0"};
+const dependencies$1 = {"markdown-extensions":"^1.1.0","remark":"^8.0.0","remark-lint":"^6.0.2","remark-preset-lint-node":"^1.1.0","unified-args":"^6.0.0","unified-engine":"^5.1.0"};
 const scripts$1 = {"build":"rollup -c","build-node":"npm run build && cp dist/* .."};
 var _package$2 = {
 	name: name$1,
@@ -32479,7 +32452,84 @@ function noInlinePadding(tree, file) {
   }
 }
 
+var remarkLintMaximumLineLength = unifiedLintRule('remark-lint:maximum-line-length', maximumLineLength);
+
 var start$6 = unistUtilPosition.start;
+var end$4 = unistUtilPosition.end;
+
+function maximumLineLength(tree, file, pref) {
+  var style = typeof pref === 'number' && !isNaN(pref) ? pref : 80;
+  var content = String(file);
+  var lines = content.split(/\r?\n/);
+  var length = lines.length;
+  var index = -1;
+  var lineLength;
+
+  unistUtilVisit(tree, ['heading', 'table', 'code', 'definition'], ignore);
+  unistUtilVisit(tree, ['link', 'image', 'inlineCode'], inline);
+
+  /* Iterate over every line, and warn for violating lines. */
+  while (++index < length) {
+    lineLength = lines[index].length;
+
+    if (lineLength > style) {
+      file.message('Line must be at most ' + style + ' characters', {
+        line: index + 1,
+        column: lineLength + 1
+      });
+    }
+  }
+
+  /* Finally, whitelist some inline spans, but only if they occur at or after
+   * the wrap.  However, when they do, and there’s white-space after it, they
+   * are not whitelisted. */
+  function inline(node, pos, parent) {
+    var next = parent.children[pos + 1];
+    var initial;
+    var final;
+
+    /* istanbul ignore if - Nothing to whitelist when generated. */
+    if (unistUtilGenerated(node)) {
+      return
+    }
+
+    initial = start$6(node);
+    final = end$4(node);
+
+    /* No whitelisting when starting after the border, or ending before it. */
+    if (initial.column > style || final.column < style) {
+      return
+    }
+
+    /* No whitelisting when there’s white-space after
+     * the link. */
+    if (
+      next &&
+      start$6(next).line === initial.line &&
+      (!next.value || /^(.+?[ \t].+?)/.test(next.value))
+    ) {
+      return
+    }
+
+    whitelist(initial.line - 1, final.line);
+  }
+
+  function ignore(node) {
+    /* istanbul ignore else - Hard to test, as we only run this case on `position: true` */
+    if (!unistUtilGenerated(node)) {
+      whitelist(start$6(node).line - 1, end$4(node).line);
+    }
+  }
+
+  /* Whitelist from `initial` to `final`, zero-based. */
+  function whitelist(initial, final) {
+    while (initial < final) {
+      lines[initial++] = '';
+    }
+  }
+}
+
+var start$7 = unistUtilPosition.start;
 
 
 
@@ -32502,7 +32552,7 @@ function noMultipleToplevelHeadings(tree, file, pref) {
           node
         );
       } else {
-        duplicate = unistUtilStringifyPosition(start$6(node));
+        duplicate = unistUtilStringifyPosition(start$7(node));
       }
     }
   }
@@ -32664,8 +32714,8 @@ var rule$1 = unifiedLintRule;
 
 var remarkLintRuleStyle = rule$1('remark-lint:rule-style', ruleStyle);
 
-var start$7 = unistUtilPosition.start;
-var end$4 = unistUtilPosition.end;
+var start$8 = unistUtilPosition.start;
+var end$5 = unistUtilPosition.end;
 
 function ruleStyle(tree, file, pref) {
   var contents = String(file);
@@ -32681,8 +32731,8 @@ function ruleStyle(tree, file, pref) {
   unistUtilVisit(tree, 'thematicBreak', visitor);
 
   function visitor(node) {
-    var initial = start$7(node).offset;
-    var final = end$4(node).offset;
+    var initial = start$8(node).offset;
+    var final = end$5(node).offset;
     var rule;
 
     if (!unistUtilGenerated(node)) {
@@ -32701,8 +32751,8 @@ function ruleStyle(tree, file, pref) {
 
 var remarkLintTablePipes = unifiedLintRule('remark-lint:table-pipes', tablePipes);
 
-var start$8 = unistUtilPosition.start;
-var end$5 = unistUtilPosition.end;
+var start$9 = unistUtilPosition.start;
+var end$6 = unistUtilPosition.end;
 
 var reasonStart = 'Missing initial pipe in table fence';
 var reasonEnd = 'Missing final pipe in table fence';
@@ -32730,15 +32780,15 @@ function tablePipes(tree, file) {
         cells = row.children;
         head = cells[0];
         tail = cells[cells.length - 1];
-        initial = contents.slice(start$8(row).offset, start$8(head).offset);
-        final = contents.slice(end$5(tail).offset, end$5(row).offset);
+        initial = contents.slice(start$9(row).offset, start$9(head).offset);
+        final = contents.slice(end$6(tail).offset, end$6(row).offset);
 
         if (initial.indexOf('|') === -1) {
-          file.message(reasonStart, start$8(row));
+          file.message(reasonStart, start$9(row));
         }
 
         if (final.indexOf('|') === -1) {
-          file.message(reasonEnd, end$5(row));
+          file.message(reasonEnd, end$6(row));
         }
       }
     }
@@ -32800,8 +32850,8 @@ var remarkLintCheckboxCharacterStyle = unifiedLintRule(
   checkboxCharacterStyle
 );
 
-var start$9 = unistUtilPosition.start;
-var end$6 = unistUtilPosition.end;
+var start$10 = unistUtilPosition.start;
+var end$7 = unistUtilPosition.end;
 
 var checked = {x: true, X: true};
 var unchecked = {' ': true, '\t': true};
@@ -32846,8 +32896,8 @@ function checkboxCharacterStyle(tree, file, pref) {
     }
 
     type = types[node.checked];
-    initial = start$9(node).offset;
-    final = (node.children.length ? start$9(node.children[0]) : end$6(node)).offset;
+    initial = start$10(node).offset;
+    final = (node.children.length ? start$10(node.children[0]) : end$7(node)).offset;
 
     /* For a checkbox to be parsed, it must be followed by a white space. */
     value = contents
@@ -32881,8 +32931,8 @@ function checkboxCharacterStyle(tree, file, pref) {
 
 var remarkLintCodeBlockStyle = unifiedLintRule('remark-lint:code-block-style', codeBlockStyle);
 
-var start$10 = unistUtilPosition.start;
-var end$7 = unistUtilPosition.end;
+var start$11 = unistUtilPosition.start;
+var end$8 = unistUtilPosition.end;
 
 var styles = {null: true, fenced: true, indented: true};
 
@@ -32915,8 +32965,8 @@ function codeBlockStyle(tree, file, pref) {
 
   /* Get the style of `node`. */
   function check(node) {
-    var initial = start$10(node).offset;
-    var final = end$7(node).offset;
+    var initial = start$11(node).offset;
+    var final = end$8(node).offset;
 
     if (unistUtilGenerated(node)) {
       return null
@@ -33111,8 +33161,8 @@ function strongMarker(tree, file, pref) {
 
 var remarkLintTableCellPadding = unifiedLintRule('remark-lint:table-cell-padding', tableCellPadding);
 
-var start$11 = unistUtilPosition.start;
-var end$8 = unistUtilPosition.end;
+var start$12 = unistUtilPosition.start;
+var end$9 = unistUtilPosition.end;
 
 var styles$1 = {null: true, padded: true, compact: true};
 
@@ -33160,8 +33210,8 @@ function tableCellPadding(tree, file, pref) {
         next = cells[column + 1];
 
         fence = contents.slice(
-          cell ? end$8(cell).offset : start$11(row).offset,
-          next ? start$11(next).offset : end$8(row).offset
+          cell ? end$9(cell).offset : start$12(row).offset,
+          next ? start$12(next).offset : end$9(row).offset
         );
 
         pos = fence.indexOf('|');
@@ -33238,7 +33288,7 @@ function tableCellPadding(tree, file, pref) {
 }
 
 function size(node) {
-  return end$8(node).offset - start$11(node).offset
+  return end$9(node).offset - start$12(node).offset
 }
 
 var plugins$1 = [
@@ -33258,6 +33308,7 @@ var plugins$1 = [
   remarkLintNoHeadingContentIndent,
   remarkLintNoHeadingIndent,
   remarkLintNoInlinePadding,
+  remarkLintMaximumLineLength,
   remarkLintNoMultipleToplevelHeadings,
   remarkLintNoShellDollars,
   remarkLintNoShortcutReferenceImage,

--- a/tools/node-lint-md-cli-rollup/package-lock.json
+++ b/tools/node-lint-md-cli-rollup/package-lock.json
@@ -2108,6 +2108,17 @@
         "unist-util-visit": "^1.1.1"
       }
     },
+    "remark-lint-maximum-line-length": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.1.0.tgz",
+      "integrity": "sha512-L+jI6+DReoxHyAWRIxABjX8hPDgxB8B5Lzp0/nDYjWbjl7I4vTsdEvejpmP1K8LVvZ7Ew0XcVHd1zt+p2O8tDg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-lint-no-auto-link-without-protocol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-1.0.2.tgz",
@@ -2352,9 +2363,9 @@
       }
     },
     "remark-preset-lint-node": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-1.0.3.tgz",
-      "integrity": "sha512-Ztmm7tcdWWmz/tpCU+bBz9QDRfjrTsa4PUSUWXwPBjQA07asGmw9qUzNTFc1iHXpXVs9xEz1IbVXpWwEJ+9uvA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-1.1.0.tgz",
+      "integrity": "sha512-wT37p0rYGgSy92XNjd7S5WZmtzRLq5iYT9mhVo/p3dVG9oF5NjOjFNUFu/6JBYgGBmZllftWvhrUpKNg+QXqug==",
       "requires": {
         "remark-lint": "^6.0.0",
         "remark-lint-blockquote-indentation": "^1.0.0",
@@ -2370,6 +2381,7 @@
         "remark-lint-first-heading-level": "^1.0.0",
         "remark-lint-hard-break-spaces": "^1.0.1",
         "remark-lint-heading-style": "^1.0.0",
+        "remark-lint-maximum-line-length": "^1.1.0",
         "remark-lint-no-auto-link-without-protocol": "^1.0.0",
         "remark-lint-no-blockquote-without-caret": "^1.0.0",
         "remark-lint-no-duplicate-definitions": "^1.0.0",
@@ -3173,9 +3185,9 @@
       }
     },
     "unist-util-generated": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.2.tgz",
-      "integrity": "sha512-1HcwiEO62dr0XWGT+abVK4f0aAm8Ik8N08c5nAYVmuSxfvpA9rCcNyX/le8xXj1pJK5nBrGlZefeWB6bN8Pstw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.3.tgz",
+      "integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg=="
     },
     "unist-util-inspect": {
       "version": "4.1.3",
@@ -3191,9 +3203,9 @@
       "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
     },
     "unist-util-position": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.1.tgz",
-      "integrity": "sha512-05QfJDPI7PE1BIUtAxeSV+cDx21xP7+tUZgSval5CA7tr0pHBwybF7OnEa1dOFqg6BfYH/qiMUnWwWj+Frhlww=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.2.tgz",
+      "integrity": "sha512-npmFu92l/+b1Ao6uGP4I1WFz9hsKv7qleZ4aliw6x0RVu6A9A3tAf57NMpFfzQ02jxRtJZuRn+C8xWT7GWnH0g=="
     },
     "unist-util-remove-position": {
       "version": "1.1.2",

--- a/tools/node-lint-md-cli-rollup/package.json
+++ b/tools/node-lint-md-cli-rollup/package.json
@@ -12,7 +12,7 @@
     "markdown-extensions": "^1.1.0",
     "remark": "^8.0.0",
     "remark-lint": "^6.0.2",
-    "remark-preset-lint-node": "^1.0.3",
+    "remark-preset-lint-node": "^1.1.0",
     "unified-args": "^6.0.0",
     "unified-engine": "^5.1.0"
   },


### PR DESCRIPTION
Not sure what the whitespace thrashing in lint-md.js is all about, but it's a generated file so I'm reluctant to "fix" it. /cc @refack 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
