### PR TITLE
test: add crypto check to test-benchmark-http2

### DIFF
--- a/test/sequential/test-benchmark-http2.js
+++ b/test/sequential/test-benchmark-http2.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 if (!common.enoughTestMem)
   common.skip('Insufficient memory for HTTP/2 benchmark test');


### PR DESCRIPTION
Currently, this test will fail when configured --without-ssl. This
commit adds a crypto check to have this test skipped when configured
without crypto support.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
