### PR TITLE
lib: add crypto dependant modules cannotUseCache

### DIFF
--- a/lib/internal/bootstrap/cache.js
+++ b/lib/internal/bootstrap/cache.js
@@ -52,6 +52,27 @@ if (process.config.variables.v8_enable_inspector !== 1) {
 if (!hasTracing) {
   cannotUseCache.push('trace_events');
 }
+if (!process.versions.openssl) {
+  cannotUseCache.push('crypto');
+  cannotUseCache.push('https');
+  cannotUseCache.push('http2');
+  cannotUseCache.push('tls');
+  cannotUseCache.push('_tls_common');
+  cannotUseCache.push('_tls_wrap');
+  cannotUseCache.push('internal/crypto/certificate');
+  cannotUseCache.push('internal/crypto/cipher');
+  cannotUseCache.push('internal/crypto/diffiehellman');
+  cannotUseCache.push('internal/crypto/hash');
+  cannotUseCache.push('internal/crypto/keygen');
+  cannotUseCache.push('internal/crypto/pbkdf2');
+  cannotUseCache.push('internal/crypto/random');
+  cannotUseCache.push('internal/crypto/scrypt');
+  cannotUseCache.push('internal/crypto/sig');
+  cannotUseCache.push('internal/crypto/util');
+  cannotUseCache.push('internal/http2/core');
+  cannotUseCache.push('internal/http2/compat');
+  cannotUseCache.push('internal/streams/lazy_transform');
+}
 
 module.exports = {
   cachableBuiltins: Object.keys(NativeModule._source).filter(


### PR DESCRIPTION
This commit adds JavaScript modules that depend on crypto to the cannotUseCache array. This is to avoid having them compiled when node has been configured --without-ssl which currently fails.

With this change the complete testsuite passes again when configured `--without-ssl`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
