### PR TITLE
test: use NULL instead of 0 in common.h

### DIFF
--- a/test/addons-napi/common.h
+++ b/test/addons-napi/common.h
@@ -54,7 +54,7 @@
   NAPI_CALL_BASE(env, the_call, NAPI_RETVAL_NOTHING)
 
 #define DECLARE_NAPI_PROPERTY(name, func)                                \
-  { (name), 0, (func), 0, 0, 0, napi_default, 0 }
+  { (name), NULL, (func), NULL, NULL, NULL, napi_default, NULL }
 
 #define DECLARE_NAPI_GETTER(name, func)                                  \
-  { (name), 0, 0, (func), 0, 0, napi_default, 0 }
+  { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }


### PR DESCRIPTION
This commit updates the macros in `test/addons-napi/common.h` to use `NULL`
instead of `0`. This is very minor, but I had to look twice while going
through the code and finding what the macro was doing and comparing
with the struct definition. Using `NULL` makes it a little clearer I
think.

@nodejs/n-api 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
