### PR TITLE
tracing: fix static destruction order issue

### DIFF
--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -61,7 +61,7 @@ class NodeTraceWriter : public AsyncTraceWriter {
   int highest_request_id_completed_ = 0;
   int total_traces_ = 0;
   int file_num_ = 0;
-  const std::string& log_file_pattern_;
+  std::string log_file_pattern_;
   std::ostringstream stream_;
   std::unique_ptr<TraceWriter> json_trace_writer_;
   bool exited_ = false;

--- a/test/parallel/test-tracing-no-crash.js
+++ b/test/parallel/test-tracing-no-crash.js
@@ -8,7 +8,15 @@ function CheckNoSignalAndErrorCodeOne(code, signal) {
   assert.strictEqual(code, 1);
 }
 
-const child = spawn(process.execPath,
-                    ['--trace-event-categories', 'madeup', '-e',
-                     'throw new Error()'], { stdio: 'inherit' });
+const child = spawn(process.execPath, [
+  '--trace-event-categories', 'madeup', '-e', 'throw new Error()'
+], { stdio: [ 'inherit', 'inherit', 'pipe' ] });
 child.on('exit', common.mustCall(CheckNoSignalAndErrorCodeOne));
+
+let stderr;
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (chunk) => stderr += chunk);
+child.stderr.on('end', common.mustCall(() => {
+  assert(stderr.includes('throw new Error()'), stderr);
+  assert(!stderr.includes('Could not open trace file'), stderr);
+}));


### PR DESCRIPTION
Sometimes, the `parallel/test-tracing-no-crash` would not work as
expected, at least on Windows, because there is a static destruction
race between tearing down the `NodeTraceWriter` instance and the
per-process options struct. If the per-process options were destroyed
before the `NodeTraceWriter`, the reference to the tracing filename
would be gone before opening the file was attempted.

This can be solved by creating a copy of the string when creating the
`NodeTraceWriter` instance rather than taking a reference.

Fixes: https://github.com/nodejs/node/issues/22523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (presumably)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
