### PR TITLE
src: replace pushValueToArray with pure C++ API

### DIFF
--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -5,16 +5,19 @@ const fs = require('fs');
 const path = require('path');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
+  n: [10],
+  dir: [ 'lib', 'test/parallel'],
+  withFileTypes: ['true', 'false']
 });
 
-
-function main({ n }) {
+function main({ n, dir, withFileTypes }) {
+  withFileTypes = withFileTypes === 'true';
   bench.start();
   (function r(cntr) {
     if (cntr-- <= 0)
       return bench.end(n);
-    fs.readdir(path.resolve(__dirname, '../../lib/'), function() {
+    const fullPath = path.resolve(__dirname, '../../', dir);
+    fs.readdir(fullPath, { withFileTypes }, function() {
       r(cntr);
     });
   }(n));

--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -12,11 +12,11 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, dir, withFileTypes }) {
   withFileTypes = withFileTypes === 'true';
+  const fullPath = path.resolve(__dirname, '../../', dir);
   bench.start();
   (function r(cntr) {
     if (cntr-- <= 0)
       return bench.end(n);
-    const fullPath = path.resolve(__dirname, '../../', dir);
     fs.readdir(fullPath, { withFileTypes }, function() {
       r(cntr);
     });

--- a/benchmark/fs/bench-readdirSync.js
+++ b/benchmark/fs/bench-readdirSync.js
@@ -13,9 +13,9 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, dir, withFileTypes }) {
   withFileTypes = withFileTypes === 'true';
+  const fullPath = path.resolve(__dirname, '../../', dir);
   bench.start();
   for (var i = 0; i < n; i++) {
-    const fullPath = path.resolve(__dirname, '../../', dir);
     fs.readdirSync(fullPath, { withFileTypes });
   }
   bench.end(n);

--- a/benchmark/fs/bench-readdirSync.js
+++ b/benchmark/fs/bench-readdirSync.js
@@ -5,14 +5,18 @@ const fs = require('fs');
 const path = require('path');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
+  n: [10],
+  dir: [ 'lib', 'test/parallel'],
+  withFileTypes: ['true', 'false']
 });
 
 
-function main({ n }) {
+function main({ n, dir, withFileTypes }) {
+  withFileTypes = withFileTypes === 'true';
   bench.start();
   for (var i = 0; i < n; i++) {
-    fs.readdirSync(path.resolve(__dirname, '../../lib/'));
+    const fullPath = path.resolve(__dirname, '../../', dir);
+    fs.readdirSync(fullPath, { withFileTypes });
   }
   bench.end(n);
 }

--- a/common.gypi
+++ b/common.gypi
@@ -32,7 +32,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -3779,6 +3779,12 @@ class V8_EXPORT Array : public Object {
    */
   static Local<Array> New(Isolate* isolate, int length = 0);
 
+  /**
+   * Creates a JavaScript array out of a Local<Value> array in C++
+   * with a known length.
+   */
+  static Local<Array> New(Isolate* isolate, Local<Value>* elements,
+                          size_t length);
   V8_INLINE static Array* Cast(Value* obj);
  private:
   Array();

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -6981,6 +6981,23 @@ Local<v8::Array> v8::Array::New(Isolate* isolate, int length) {
   return Utils::ToLocal(obj);
 }
 
+Local<v8::Array> v8::Array::New(Isolate* isolate, Local<Value>* elements,
+                                size_t length) {
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+  i::Factory* factory = i_isolate->factory();
+  LOG_API(i_isolate, Array, New);
+  ENTER_V8_NO_SCRIPT_NO_EXCEPTION(i_isolate);
+  int len = static_cast<int>(length);
+
+  i::Handle<i::FixedArray> result = factory->NewFixedArray(len);
+  for (int i = 0; i < len; i++) {
+    i::Handle<i::Object> element = Utils::OpenHandle(*elements[i]);
+    result->set(i, *element);
+  }
+
+  return Utils::ToLocal(
+      factory->NewJSArrayWithElements(result, i::PACKED_ELEMENTS, len));
+}
 
 uint32_t v8::Array::Length() const {
   i::Handle<i::JSArray> obj = Utils::OpenHandle(this);

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -5247,6 +5247,22 @@ THREADED_TEST(Array) {
   CHECK_EQ(27u, array->Length());
   array = v8::Array::New(context->GetIsolate(), -27);
   CHECK_EQ(0u, array->Length());
+
+  std::vector<Local<Value>> vector = {v8_num(1), v8_num(2), v8_num(3)};
+  array = v8::Array::New(context->GetIsolate(), vector.data(), vector.size());
+  CHECK_EQ(vector.size(), array->Length());
+  CHECK_EQ(1, arr->Get(context.local(), 0)
+                  .ToLocalChecked()
+                  ->Int32Value(context.local())
+                  .FromJust());
+  CHECK_EQ(2, arr->Get(context.local(), 1)
+                  .ToLocalChecked()
+                  ->Int32Value(context.local())
+                  .FromJust());
+  CHECK_EQ(3, arr->Get(context.local(), 2)
+                  .ToLocalChecked()
+                  ->Int32Value(context.local())
+                  .FromJust());
 }
 
 

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -16,5 +16,7 @@ runBenchmark('fs', [
   'statType=fstat',
   'statSyncType=fstatSync',
   'encodingType=buf',
-  'filesize=1024'
+  'filesize=1024',
+  'dir=.github',
+  'withFileTypes=false'
 ], { NODE_TMPDIR: tmpdir.path, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
The first commit just landed upstream: https://chromium-review.googlesource.com/c/1317049
The second commit replaces the pushValueToArray hack with the new V8 API in fs.readdir and fs.readdirSync.
The third commit added more options to the readdir benchmark.

Local benchmark results:

```
                                                                        confidence improvement accuracy (*)   (**)  (***)
 fs/bench-readdir.js withFileTypes='false' dir='lib' n=10                              -0.33 %       ±4.75% ±6.33% ±8.26%
 fs/bench-readdir.js withFileTypes='false' dir='test/parallel' n=10            ***      8.96 %       ±2.83% ±3.78% ±4.93%
 fs/bench-readdir.js withFileTypes='true' dir='lib' n=10                                0.17 %       ±4.36% ±5.80% ±7.56%
 fs/bench-readdir.js withFileTypes='true' dir='test/parallel' n=10                      0.53 %       ±2.37% ±3.16% ±4.11%
 fs/bench-readdirSync.js withFileTypes='false' dir='lib' n=10                  ***      6.21 %       ±3.41% ±4.56% ±5.97%
 fs/bench-readdirSync.js withFileTypes='false' dir='test/parallel' n=10        ***     13.29 %       ±2.35% ±3.13% ±4.08%
 fs/bench-readdirSync.js withFileTypes='true' dir='lib' n=10                   ***      6.27 %       ±1.81% ±2.41% ±3.15%
 fs/bench-readdirSync.js withFileTypes='true' dir='test/parallel' n=10         ***      9.88 %       ±2.51% ±3.34% ±4.35%
```

With this I hope we can remove all the `push_values_to_array_function` usage and get rid of `SetupProcessObject` eventually - that can be done in later PRs, of course.

### deps: cherry-pick 0483e9a from upstream V8

Original commit message:

    [api] Allow embedder to construct an Array from Local<Value>*

    Currently to obtain a v8::Array out of a C array or a std::vector,
    one needs to loop through the elements and call array->Set() multiple
    times, and these calls go into v8::Object::Set() which can be slow.
    This patch adds a new Array::New overload that converts a
    Local<Value>* with known size into a Local<Array>.

    Change-Id: I0a768f0e18eec51e78d58be455482ec6425ca188
    Reviewed-on: https://chromium-review.googlesource.com/c/1317049
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Reviewed-by: Adam Klein <adamk@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/master@{#57261}

Refs: https://github.com/v8/v8/commit/0483e9a9abe77a73632fd85b9c0cd608efa9aa0d

### fs: replace pushValueToArray with pure C++ API

Instead of calling into JS from C++ to push values into an array,
use the new Array::New API that takes a pointer and a length
directly.

### benchmark: add dir and withFileTypes option readdir benchmarks

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
