### PR TITLE
test: add test for autoDestroy in stream

### DIFF
--- a/test/parallel/test-stream-auto-destroy.js
+++ b/test/parallel/test-stream-auto-destroy.js
@@ -82,3 +82,31 @@ const assert = require('assert');
     assert(finished);
   }));
 }
+
+{
+  const r = new stream.Readable({
+    read() {
+      r2.emit('error', new Error('fail'));
+    }
+  });
+  const r2 = new stream.Readable({
+    autoDestroy: true,
+    destroy: common.mustCall((err, cb) => cb())
+  });
+
+  r.pipe(r2);
+}
+
+{
+  const r = new stream.Readable({
+    read() {
+      w.emit('error', new Error('fail'));
+    }
+  });
+  const w = new stream.Writable({
+    autoDestroy: true,
+    destroy: common.mustCall((err, cb) => cb())
+  });
+
+  r.pipe(w);
+}


### PR DESCRIPTION
##### Summary
Apparently, `stream.destroy(err)` in `errorOrDestroy` is not called. Adding two test cases to cover that line.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### References
+ https://github.com/nodejs/node/pull/22795
+ https://coverage.nodejs.org/coverage-17e4213987c6ad8d/root/internal/streams/destroy.js.html#L96