### PR TITLE
net: some scattered cleanup

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -768,6 +768,11 @@ unless either the `--pending-deprecation` command line flag, or the
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
+### `NODE_PENDING_PIPE_INSTANCES=instances`
+
+Set the number of pending pipe instance handles when the pipe server is waiting
+for connections. This setting applies to Windows only.
+
 ### `NODE_PRESERVE_SYMLINKS=1`
 <!-- YAML
 added: v7.1.0

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -28,6 +28,8 @@ const envVars = new Map([
     'of directories prefixed to the module search path' }],
   ['NODE_PENDING_DEPRECATION', { helpText: 'set to 1 to emit pending ' +
     'deprecation warnings' }],
+  ['NODE_PENDING_PIPE_INSTANCES', { helpText: 'set the number of pending ' +
+    'pipe instance handles on Windows' }],
   ['NODE_PRESERVE_SYMLINKS', { helpText: 'set to 1 to preserve symbolic ' +
     'links when resolving and caching modules' }],
   ['NODE_REDIRECT_WARNINGS', { helpText: 'write warnings to path instead ' +

--- a/lib/net.js
+++ b/lib/net.js
@@ -96,6 +96,9 @@ let dns;
 
 const { kTimeout } = require('internal/timers');
 
+const DEFAULT_IPV4_ADDR = '0.0.0.0';
+const DEFAULT_IPV6_ADDR = '::';
+
 function noop() {}
 
 function getFlags(ipv6Only) {
@@ -789,10 +792,10 @@ function internalConnect(
 
   if (localAddress || localPort) {
     if (addressType === 4) {
-      localAddress = localAddress || '0.0.0.0';
+      localAddress = localAddress || DEFAULT_IPV4_ADDR;
       err = self._handle.bind(localAddress, localPort);
     } else { // addressType === 6
-      localAddress = localAddress || '::';
+      localAddress = localAddress || DEFAULT_IPV6_ADDR;
       err = self._handle.bind6(localAddress, localPort, flags);
     }
     debug('binding to localAddress: %s and localPort: %d (addressType: %d)',
@@ -1145,8 +1148,6 @@ function createServerHandle(address, port, addressType, fd, flags) {
     if (err)
       return err;
 
-    handle.readable = true;
-    handle.writable = true;
     assert(!address && !port);
   } else if (port === -1 && addressType === -1) {
     handle = new Pipe(PipeConstants.SERVER);
@@ -1165,11 +1166,11 @@ function createServerHandle(address, port, addressType, fd, flags) {
     debug('bind to', address || 'any');
     if (!address) {
       // Try binding to ipv6 first
-      err = handle.bind6('::', port, flags);
+      err = handle.bind6(DEFAULT_IPV6_ADDR, port, flags);
       if (err) {
         handle.close();
         // Fallback to ipv4
-        return createServerHandle('0.0.0.0', port);
+        return createServerHandle(DEFAULT_IPV4_ADDR, port);
       }
     } else if (addressType === 6) {
       err = handle.bind6(address, port, flags);
@@ -1200,14 +1201,14 @@ function setupListenHandle(address, port, addressType, backlog, fd, flags) {
 
     // Try to bind to the unspecified IPv6 address, see if IPv6 is available
     if (!address && typeof fd !== 'number') {
-      rval = createServerHandle('::', port, 6, fd, flags);
+      rval = createServerHandle(DEFAULT_IPV6_ADDR, port, 6, fd, flags);
 
       if (typeof rval === 'number') {
         rval = null;
-        address = '0.0.0.0';
+        address = DEFAULT_IPV4_ADDR;
         addressType = 4;
       } else {
-        address = '::';
+        address = DEFAULT_IPV6_ADDR;
         addressType = 6;
       }
     }


### PR DESCRIPTION
This commit cleans up net module, including:
  - Remove assigning `handle.readable` and `handle.writable`. It's add in https://github.com/nodejs/node-v0.x-archive/pull/3422 and I see nowhere we use these two properties right now. 
  - Documents the enviroment variable of `NODE_PENDING_PIPE_INSTANCES`. It was add in https://github.com/nodejs/node/commit/99c9d19184fdd46ae88464d7a608aac57a530634 long time ago but was not documented and there is no test for it. Maybe we can consider removing it?
  - Use constants for '0.0.0.0' and '::'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
