### PR TITLE
test: fs readfile, swap arguments in strictEqual

### DIFF
--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -17,7 +17,7 @@ tempFd(function(fd, close) {
 
 tempFd(function(fd, close) {
   fs.readFile(fd, 'utf8', function(err, data) {
-    assert.strictEqual('', data);
+    assert.strictEqual(data, '');
     close();
   });
 });
@@ -27,7 +27,7 @@ tempFdSync(function(fd) {
 });
 
 tempFdSync(function(fd) {
-  assert.strictEqual('', fs.readFileSync(fd, 'utf8'));
+  assert.strictEqual(fs.readFileSync(fd, 'utf8'), '');
 });
 
 function tempFd(callback) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
