### PR TITLE
test: swap the order of arguments

### DIFF
--- a/test/parallel/test-fs-write-sync.js
+++ b/test/parallel/test-fs-write-sync.js
@@ -34,7 +34,7 @@ tmpdir.refresh();
   const fd = fs.openSync(filename, 'w');
 
   let written = fs.writeSync(fd, '');
-  assert.strictEqual(0, written);
+  assert.strictEqual(written, 0);
 
   fs.writeSync(fd, 'foo');
 
@@ -50,7 +50,7 @@ tmpdir.refresh();
   const fd = fs.openSync(filename, 'w');
 
   let written = fs.writeSync(fd, '');
-  assert.strictEqual(0, written);
+  assert.strictEqual(written, 0);
 
   fs.writeSync(fd, 'foo');
 
@@ -66,7 +66,7 @@ tmpdir.refresh();
   const fd = fs.openSync(filename, 'w');
 
   let written = fs.writeSync(fd, '');
-  assert.strictEqual(0, written);
+  assert.strictEqual(written, 0);
 
   fs.writeSync(fd, 'foo');
 


### PR DESCRIPTION
Swapped the actual and expected arguments in `assert.strictEqual()` calls.
Arguments are now in correct order.
Literal value is now the second argument and the value returned by the
function is the first argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
