### PR TITLE
test: fix invalid argument order in test-http-expect-continue.js

### DIFF
--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -67,7 +67,7 @@ server.on('listening', common.mustCall(() => {
   }));
   req.on('response', common.mustCall((res) => {
     assert.ok(got_continue, 'Full response received before 100 Continue');
-    assert.strictEqual(200, res.statusCode,
+    assert.strictEqual(res.statusCode, 200,
                        `Final status code was ${res.statusCode}, not 200.`);
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });


### PR DESCRIPTION
`assert.strictEqual` expects arguments in the following order:

actual, expected[, message]

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
