### PR TITLE
 test: fixes order of arguments in assert.strictEqual

### DIFF
--- a/test/parallel/test-http-client-upload-buf.js
+++ b/test/parallel/test-http-client-upload-buf.js
@@ -27,8 +27,7 @@ const http = require('http');
 const N = 1024;
 
 const server = http.createServer(common.mustCall(function(req, res) {
-  assert.strictEqual('POST', req.method);
-
+  assert.strictEqual(req.method, 'POST');
   let bytesReceived = 0;
 
   req.on('data', function(chunk) {


### PR DESCRIPTION
This PR fixes the order of the arguments of the `assert.strictEqual()` of `test/parallel/test-http-client-upload-buf.js.`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
