### PR TITLE
test: switch arguments in strictEqual

### DIFF
--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -29,7 +29,7 @@ const vm = require('vm');
 // Run in a new empty context
 let context = vm.createContext();
 let result = vm.runInContext('"passed";', context);
-assert.strictEqual('passed', result);
+assert.strictEqual(result, 'passed');
 
 // Create a new pre-populated context
 context = vm.createContext({ 'foo': 'bar', 'thing': 'lala' });


### PR DESCRIPTION
In the `test/parallel/test-vm-create-and-run-in-context.js` test the actual and expected arguments in the `assert.strictEqual()` call on line 32 are in the wrong order and they have to be switched around.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
