### PR TITLE
test: fix arguments order in assert.strictEqual

### DIFF
--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(common.mustCall(function(req, res) {
-  assert.strictEqual('POST', req.method);
+  assert.strictEqual(req.method, 'POST');
   req.setEncoding('utf8');
 
   let sent_body = '';
@@ -36,7 +36,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
   });
 
   req.on('end', common.mustCall(function() {
-    assert.strictEqual('1\n2\n3\n', sent_body);
+    assert.strictEqual(sent_body, '1\n2\n3\n');
     console.log('request complete from server');
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('hello\n');


### PR DESCRIPTION
In the test test/parallel/test-http-client-upload.js test the
actual and expected arguments in assert.strictEqual() calls
were in the wrong order. Switched them around so the returned
value by the function is the first argument and the literal
value is the second argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
