### PR TITLE
test: fix argument order in assert.strictEqual()

### DIFF
--- a/test/parallel/test-http-chunked.js
+++ b/test/parallel/test-http-chunked.js
@@ -48,7 +48,7 @@ server.listen(0, common.mustCall(() => {
     x.setEncoding('utf8');
     x.on('data', (c) => data += c);
     x.on('end', common.mustCall(() => {
-      assert.strictEqual('string', typeof data);
+      assert.strictEqual(typeof data, 'string');
       assert.strictEqual(UTF8_STRING, data);
       server.close();
     }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
The arguments on the assertion on https://github.com/nodejs/node/blob/master/test/parallel/test-http-chunked.js#L51 are inverted. The first argument should be the actual value and the second argument should be the expected value.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
