### PR TITLE
test: add tests for OutgoingMessage setTimeout

### DIFF
--- a/test/parallel/test-http-outgoing-settimeout.js
+++ b/test/parallel/test-http-outgoing-settimeout.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { OutgoingMessage } = require('http');
+
+{
+  // tests for settimeout method with socket
+  const expectedMsecs = 42;
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.socket = {
+    setTimeout: common.mustCall((msecs) => {
+      assert.strictEqual(msecs, expectedMsecs);
+    })
+  };
+  outgoingMessage.setTimeout(expectedMsecs);
+}
+
+{
+  // tests for settimeout method without socket
+  const expectedMsecs = 23;
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setTimeout(expectedMsecs);
+
+  outgoingMessage.emit('socket', {
+    setTimeout: common.mustCall((msecs) => {
+      assert.strictEqual(msecs, expectedMsecs);
+    })
+  });
+}


### PR DESCRIPTION
These tests ensure that OutgoingMessage setTimeout method
will call setTimeout on its socket

Co-authored-by: ZauberNerd <zaubernerd@zaubernerd.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
