### PR TITLE
test: increase coverage internal readline

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -99,11 +99,12 @@ addTest('\n\r\t', [
 ]);
 
 // space and backspace
-addTest('\b\x7f\x1b\b\x1b\x7f \x1b ', [
+addTest('\b\x7f\x1b\b\x1b\x7f\x1b\x1b  \x1b ', [
   { name: 'backspace', sequence: '\b' },
   { name: 'backspace', sequence: '\x7f' },
   { name: 'backspace', sequence: '\x1b\b', meta: true },
   { name: 'backspace', sequence: '\x1b\x7f', meta: true },
+  { name: 'space', sequence: '\x1b\x1b ', meta: true },
   { name: 'space', sequence: ' ' },
   { name: 'space', sequence: '\x1b ', meta: true },
 ]);


### PR DESCRIPTION
Added test that ensures a double escapeKey sequence is being handled correctly by emitKeys

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
