### PR TITLE
test: fix arguments order

### DIFF
--- a/test/parallel/test-fs-readfile-empty.js
+++ b/test/parallel/test-fs-readfile-empty.js
@@ -35,12 +35,12 @@ fs.readFile(fn, function(err, data) {
 });
 
 fs.readFile(fn, 'utf8', function(err, data) {
-  assert.strictEqual('', data);
+  assert.strictEqual(data, '');
 });
 
 fs.readFile(fn, { encoding: 'utf8' }, function(err, data) {
-  assert.strictEqual('', data);
+  assert.strictEqual(data, '');
 });
 
 assert.ok(fs.readFileSync(fn));
-assert.strictEqual('', fs.readFileSync(fn, 'utf8'));
+assert.strictEqual(fs.readFileSync(fn, 'utf8'), '');


### PR DESCRIPTION
the actual and expected arguments in assert.strictEqual() calls are in
the wrong order. Any literal value should be the second argument while
the first argument should be the value returned by a function/be the
calculated value.

@jasnell: LGTM
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
