### PR TITLE
fix: correct order of args in assert.strictEqual()

### DIFF
--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -303,19 +303,19 @@ Buffer.alloc(8, '');
 
   buf.fill(0);
   for (let i = 0; i < buf.length; i++)
-    assert.strictEqual(0, buf[i]);
+    assert.strictEqual(buf[i], 0);
 
   buf.fill(null);
   for (let i = 0; i < buf.length; i++)
-    assert.strictEqual(0, buf[i]);
+    assert.strictEqual(buf[i], 0);
 
   buf.fill(1, 16, 32);
   for (let i = 0; i < 16; i++)
-    assert.strictEqual(0, buf[i]);
+    assert.strictEqual(buf[i], 0);
   for (let i = 16; i < 32; i++)
-    assert.strictEqual(1, buf[i]);
+    assert.strictEqual(buf[i], 1);
   for (let i = 32; i < buf.length; i++)
-    assert.strictEqual(0, buf[i]);
+    assert.strictEqual(buf[i], 0);
 }
 
 {


### PR DESCRIPTION
Ensure literal values are passed in as second argument

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
