### PR TITLE
net: remove unreachable check in internalConnect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -839,7 +839,7 @@ function internalConnect(
     if (addressType === 4) {
       localAddress = localAddress || '0.0.0.0';
       err = self._handle.bind(localAddress, localPort);
-    } else if (addressType === 6) {
+    } else { // addressType === 6
       localAddress = localAddress || '::';
       err = self._handle.bind6(localAddress, localPort);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -842,9 +842,6 @@ function internalConnect(
     } else if (addressType === 6) {
       localAddress = localAddress || '::';
       err = self._handle.bind6(localAddress, localPort);
-    } else {
-      self.destroy(new ERR_INVALID_ADDRESS_FAMILY(addressType));
-      return;
     }
     debug('binding to localAddress: %s and localPort: %d (addressType: %d)',
           localAddress, localPort, addressType);


### PR DESCRIPTION
Checked all call-sites to ensure that this code is truly unreachable.
addressType is always checked before internalConnect is even called.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
