### PR TITLE
lib: remove additional param from uvExceptionWithHostPort

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -294,10 +294,9 @@ function uvException(ctx) {
  * @param {string} syscall
  * @param {string} address
  * @param {number} [port]
- * @param {string} [additional]
  * @returns {Error}
  */
-function uvExceptionWithHostPort(err, syscall, address, port, additional) {
+function uvExceptionWithHostPort(err, syscall, address, port) {
   const [ code, uvmsg ] = errmap.get(err);
   const message = `${syscall} ${code}: ${uvmsg}`;
   let details = '';
@@ -306,9 +305,6 @@ function uvExceptionWithHostPort(err, syscall, address, port, additional) {
     details = ` ${address}:${port}`;
   } else if (address) {
     details = ` ${address}`;
-  }
-  if (additional) {
-    details += ` - Local (${additional})`;
   }
 
   // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
This PR removes an unnecessary parameter and `if` case in the function `uvExceptionWithHostPort`, since there is no call site that has a fifth argument.

From the NodeConf EU Code and Learn 💃 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
