### PR TITLE
test: add else and error case for TextDecoder

### DIFF
--- a/test/parallel/test-whatwg-encoding-textdecoder-fatal.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder-fatal.js
@@ -88,3 +88,15 @@ bad.forEach((t) => {
   assert(!new TextDecoder().fatal);
   assert(new TextDecoder('utf-8', { fatal: true }).fatal);
 }
+
+{
+  const notArrayBufferViewExamples = [false, {}, 1, '', new Error()];
+  notArrayBufferViewExamples.forEach((invalidInputType) => {
+    common.expectsError(() => {
+      new TextDecoder(undefined, null).decode(invalidInputType);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    });
+  });
+}

--- a/test/parallel/test-whatwg-encoding-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder.js
@@ -75,6 +75,14 @@ if (common.hasIntl) {
     });
 }
 
+// Test TextDecoder, label undefined, options null
+{
+  const dec = new TextDecoder(undefined, null);
+  assert.strictEqual(dec.encoding, 'utf-8');
+  assert.strictEqual(dec.fatal, false);
+  assert.strictEqual(dec.ignoreBOM, false);
+}
+
 // Test TextDecoder, UTF-16le
 {
   const dec = new TextDecoder('utf-16le');


### PR DESCRIPTION
 - add test for https://coverage.nodejs.org/coverage-17e4213987c6ad8d/root/internal/encoding.js.html#L365 missing else path
 - add test for https://coverage.nodejs.org/coverage-17e4213987c6ad8d/root/internal/encoding.js.html#L385 missing error case

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
