### PR TITLE
test: test add and remove for lib/domain

### DIFF
--- a/test/parallel/test-domain-add-remove.js
+++ b/test/parallel/test-domain-add-remove.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const EventEmitter = require('events');
+
+const d = new domain.Domain();
+const e = new EventEmitter();
+const e2 = new EventEmitter();
+
+d.add(e);
+assert.strictEqual(e.domain, d);
+
+// Adding the same event to a domain should not change the member count
+let previousMemberCount = d.members.length;
+d.add(e);
+assert.strictEqual(previousMemberCount, d.members.length);
+
+d.add(e2);
+assert.strictEqual(e2.domain, d);
+
+previousMemberCount = d.members.length;
+d.remove(e2);
+assert.notStrictEqual(e2.domain, d);
+assert.strictEqual(previousMemberCount - 1, d.members.length);


### PR DESCRIPTION
Testing some of the more specific cases of using domain.add and
domain.remove. For example, calling domain.add twice with same event
emmiter and actually removing an event emitter from the domain.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
