### PR TITLE
test: add test for deepEqual Float32Array byte length difference

### DIFF
--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -47,6 +47,7 @@ const notEqualArrayPairs = [
   [new Int16Array([-256]), new Uint16Array([0xff00])], // same bits
   [new Int32Array([-256]), new Uint32Array([0xffffff00])], // ditto
   [new Float32Array([0.1]), new Float32Array([0.0])],
+  [new Float32Array([0.1]), new Float32Array([0.1, 0.2])],
   [new Float64Array([0.1]), new Float64Array([0.0])],
   [new Uint8Array([1, 2, 3]).buffer, new Uint8Array([4, 5, 6]).buffer],
   [


### PR DESCRIPTION
Add test to check when two Float32Array's length is different

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
