### PR TITLE
Add deprecation warning DEP0066

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1344,12 +1344,15 @@ removed. Please use `sloppy` instead.
 ### DEP0066: outgoingMessage.\_headers, outgoingMessage.\_headerNames
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/24167
+    description: Runtime deprecation.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/10941
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The `http` module `outgoingMessage._headers` and `outgoingMessage._headerNames`
 properties are deprecated. Use one of the public methods

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -110,10 +110,10 @@ util.inherits(OutgoingMessage, Stream);
 
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
-  get: function() {
+  get: util.deprecate(function() {
     return this.getHeaders();
-  },
-  set: function(val) {
+  }, 'OutgoingMessage.prototype._headers is deprecated', 'DEP0066'),
+  set: util.deprecate(function(val) {
     if (val == null) {
       this[outHeadersKey] = null;
     } else if (typeof val === 'object') {
@@ -124,11 +124,11 @@ Object.defineProperty(OutgoingMessage.prototype, '_headers', {
         headers[name.toLowerCase()] = [name, val[name]];
       }
     }
-  }
+  }, 'OutgoingMessage.prototype._headers is deprecated', 'DEP0066')
 });
 
 Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
-  get: function() {
+  get: util.deprecate(function() {
     const headers = this[outHeadersKey];
     if (headers !== null) {
       const out = Object.create(null);
@@ -141,8 +141,8 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
       return out;
     }
     return null;
-  },
-  set: function(val) {
+  }, 'OutgoingMessage.prototype._headerNames is deprecated', 'DEP0066'),
+  set: util.deprecate(function(val) {
     if (typeof val === 'object' && val !== null) {
       const headers = this[outHeadersKey];
       if (!headers)
@@ -154,7 +154,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
           header[0] = val[keys[i]];
       }
     }
-  }
+  }, 'OutgoingMessage.prototype._headerNames is deprecated', 'DEP0066')
 });
 
 

--- a/test/parallel/test-http-outgoing-internal-headernames-getter.js
+++ b/test/parallel/test-http-outgoing-internal-headernames-getter.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../common');
+
+const { OutgoingMessage } = require('http');
+
+const warn = 'OutgoingMessage.prototype._headerNames is deprecated';
+common.expectWarning('DeprecationWarning', warn, 'DEP0066');
+
+{
+  // tests for _headerNames get method
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._headerNames;
+}

--- a/test/parallel/test-http-outgoing-internal-headernames-setter.js
+++ b/test/parallel/test-http-outgoing-internal-headernames-setter.js
@@ -7,12 +7,6 @@ const warn = 'OutgoingMessage.prototype._headerNames is deprecated';
 common.expectWarning('DeprecationWarning', warn, 'DEP0066');
 
 {
-  // tests for _headerNames get method
-  const outgoingMessage = new OutgoingMessage();
-  outgoingMessage._headerNames;
-}
-
-{
   // tests for _headerNames set method
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage._headerNames = {

--- a/test/parallel/test-http-outgoing-internal-headernames.js
+++ b/test/parallel/test-http-outgoing-internal-headernames.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+
+const { OutgoingMessage } = require('http');
+
+const warn = 'OutgoingMessage.prototype._headerNames is deprecated';
+common.expectWarning('DeprecationWarning', warn, 'DEP0066');
+
+{
+  // tests for _headerNames get method
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._headerNames;
+}
+
+{
+  // tests for _headerNames set method
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._headerNames = {
+    'x-flow-id': '61bba6c5-28a3-4eab-9241-2ecaa6b6a1fd'
+  };
+}

--- a/test/parallel/test-http-outgoing-internal-headers.js
+++ b/test/parallel/test-http-outgoing-internal-headers.js
@@ -6,6 +6,9 @@ const assert = require('assert');
 const { outHeadersKey } = require('internal/http');
 const { OutgoingMessage } = require('http');
 
+const warn = 'OutgoingMessage.prototype._headers is deprecated';
+common.expectWarning('DeprecationWarning', warn, 'DEP0066');
+
 {
   // tests for _headers get method
   const outgoingMessage = new OutgoingMessage();


### PR DESCRIPTION
This PR makes the deprecation for `DEP0066` an active deprecation in code.

Hello from NodeConfEU 👋 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
