### PR TITLE
test: add test case for completion bash flag

### DIFF
--- a/test/parallel/test-bash-completion.js
+++ b/test/parallel/test-bash-completion.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+
+const p = child_process.spawnSync(
+  process.execPath, [ '--completion-bash' ]);
+assert.ifError(p.error);
+assert.ok(p.stdout.toString().includes(
+  `_node_complete() {
+  local cur_word options
+  cur_word="\${COMP_WORDS[COMP_CWORD]}"
+  if [[ "\${cur_word}" == -* ]] ; then
+    COMPREPLY=( $(compgen -W '`));
+assert.ok(p.stdout.toString().includes(
+  `' -- "\${cur_word}") )
+    return 0
+  else
+    COMPREPLY=( $(compgen -f "\${cur_word}") )
+    return 0
+  fi
+}
+complete -F _node_complete node node_g`));


### PR DESCRIPTION
This test case verifies that starting Node.js with the completion
bash flag prints out the expected result and ends right after.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
