### PR TITLE
http: remove obsolete function escapeHeaderValue

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -409,7 +409,7 @@ function processHeader(self, state, key, value, validate) {
 function storeHeader(self, state, key, value, validate) {
   if (validate)
     validateHeaderValue(key, value);
-  state.header += key + ': ' + escapeHeaderValue(value) + CRLF;
+  state.header += key + ': ' + value + CRLF;
   matchHeader(self, state, key, value);
 }
 
@@ -642,13 +642,6 @@ function connectionCorkNT(msg, conn) {
 }
 
 
-function escapeHeaderValue(value) {
-  // Protect against response splitting. The regex test is there to
-  // minimize the performance impact in the common case.
-  return /[\r\n]/.test(value) ? value.replace(/[\r\n]+[ \t]*/g, '') : value;
-}
-
-
 OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   this._trailer = '';
   var keys = Object.keys(headers);
@@ -670,7 +663,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
       debug('Trailer "%s" contains invalid characters', field);
       throw new ERR_INVALID_CHAR('trailer content', field);
     }
-    this._trailer += field + ': ' + escapeHeaderValue(value) + CRLF;
+    this._trailer += field + ': ' + value + CRLF;
   }
 };
 


### PR DESCRIPTION
 - there are test cases which validate the useful
   path of the function never runs
 - the functionality of it is obsoleted by
   `checkInvalidHeaderChar` in `addTrailers` and `storeHeader`

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
