### PR TITLE
http: else case is not reachable

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -47,6 +47,7 @@ const { IncomingMessage } = require('_http_incoming');
 const {
   ERR_HTTP_HEADERS_SENT,
   ERR_HTTP_INVALID_STATUS_CODE,
+  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CHAR
 } = require('internal/errors').codes;
 const Buffer = require('buffer').Buffer;
@@ -281,6 +282,8 @@ function Server(options, requestListener) {
     options = {};
   } else if (options == null || typeof options === 'object') {
     options = util._extend({}, options);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
   }
 
   this[kIncomingMessage] = options.IncomingMessage || IncomingMessage;

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -27,6 +27,19 @@ const http = require('http');
 const url = require('url');
 const qs = require('querystring');
 
+// TODO: documentation does not allow Array as an option, so testing that
+// should fail, but currently http.Server does not typecheck further than
+// if `option` is `typeof object` - so we don't test that here right now
+const invalid_options = [ 'foo', 42, true ];
+
+invalid_options.forEach((option) => {
+  assert.throws(() => {
+    new http.Server(option);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
 let request_number = 0;
 let requests_sent = 0;
 let server_response = '';


### PR DESCRIPTION
While checking the arguments passed to http.Server, the case where
the options argument was of wrong type was not handled. Now it
throws an ERR_INVALID_ARG_TYPE error if the options argument is
not a function, object, null, or undefined.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
