### PR TITLE
test: test dgram socket prints deprecation warnings

### DIFF
--- a/test/parallel/test-dgram-deprecation-error.js
+++ b/test/parallel/test-dgram-deprecation-error.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common');
+const dgram = require('dgram');
+const fork = require('child_process').fork;
+
+const sock = dgram.createSocket('udp4');
+
+const testNumber = parseInt(process.argv[2], 10);
+
+const propertiesToTest = [
+  '_handle',
+  '_receiving',
+  '_bindState',
+  '_queue',
+  '_reuseAddr'
+];
+
+const methodsToTest = [
+  '_healthCheck',
+  '_stopReceiving'
+];
+
+const propertyCases = propertiesToTest.map((propName) => {
+  return [
+    () => {
+      // Test property getter
+      common.expectWarning(
+        'DeprecationWarning',
+        `Socket.prototype.${propName} is deprecated`,
+        'DEP0112'
+      );
+      sock[propName];
+    },
+    () => {
+      // Test property setter
+      common.expectWarning(
+        'DeprecationWarning',
+        `Socket.prototype.${propName} is deprecated`,
+        'DEP0112'
+      );
+      sock[propName] = null;
+    }
+  ];
+});
+
+const methodCases = methodsToTest.map((propName) => {
+  return () => {
+    common.expectWarning(
+      'DeprecationWarning',
+      `Socket.prototype.${propName}() is deprecated`,
+      'DEP0112'
+    );
+    sock[propName]();
+  };
+});
+
+const cases = [].concat(
+  ...propertyCases,
+  ...methodCases
+);
+
+// If we weren't passed a test ID then we need to spawn all of the cases.
+// We run the cases in child processes since deprecations print once.
+if (Number.isNaN(testNumber)) {
+  const children = cases.map((_case, i) =>
+    fork(process.argv[1], [ String(i) ]));
+
+  children.forEach((child) => {
+    child.on('close', (code) => {
+      // Pass on child exit code
+      if (code > 0) {
+        process.exit(code);
+      }
+    });
+  });
+
+  return;
+}
+
+// We were passed a test ID - run the test case
+assert.ok(cases[testNumber]);
+cases[testNumber]();


### PR DESCRIPTION
Adds tests assert the deprecated properties
and methods in the dgram socket warn. It
runs each test in a separate child process
since each deprecation will only warn once.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
