### PR TITLE
test: add typeerror for vm/compileFunction params

### DIFF
--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -209,19 +209,19 @@ const vm = require('vm');
     }
   );
 
-    // Testing for non Array type-based failures
-    [Boolean(), Number(), null, Object(), Symbol(), {}].forEach(
-      (value) => {
-        common.expectsError(() => {
-          vm.compileFunction('', value);
-        }, {
-          type: TypeError,
-          code: 'ERR_INVALID_ARG_TYPE',
-          message: 'The "params" argument must be of type Array. ' 
-          + `Received type ${typeof value}`
-        });
-      }
-    );
+  // Testing for non Array type-based failures
+  [Boolean(), Number(), null, Object(), Symbol(), {}].forEach(
+    (value) => {
+      common.expectsError(() => {
+        vm.compileFunction('', value);
+      }, {
+        type: TypeError,
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: 'The "params" argument must be of type Array. ' +
+          `Received type ${typeof value}`
+      });
+    }
+  );
 
   assert.strictEqual(
     vm.compileFunction(

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -209,6 +209,20 @@ const vm = require('vm');
     }
   );
 
+    // Testing for non Array type-based failures
+    [Boolean(), Number(), null, Object(), Symbol(), {}].forEach(
+      (value) => {
+        common.expectsError(() => {
+          vm.compileFunction('', value);
+        }, {
+          type: TypeError,
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: 'The "params" argument must be of type Array. ' 
+          + `Received type ${typeof value}`
+        });
+      }
+    );
+
   assert.strictEqual(
     vm.compileFunction(
       'return a;',


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added