### PR TITLE
test: add test for _setSimultaneousAccepts()

### DIFF
--- a/test/parallel/test-net-server-simultaneous-accepts-produce-warning-once.js
+++ b/test/parallel/test-net-server-simultaneous-accepts-produce-warning-once.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { expectWarning } = require('../common');
+const net = require('net');
+
+expectWarning(
+  'DeprecationWarning',
+  'net._setSimultaneousAccepts() is deprecated and will be removed.',
+  'DEP0121');
+
+net._setSimultaneousAccepts();
+net._setSimultaneousAccepts();


### PR DESCRIPTION
Add a test case that verifies that calling the `_setSimultaneousAccepts()`
function twice does not trigger the deprecation warning twice.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
