### PR TITLE
test: assert diff no color

### DIFF
--- a/test/pseudo-tty/test-assert-no-color.js
+++ b/test/pseudo-tty/test-assert-no-color.js
@@ -5,8 +5,15 @@ const assert = require('assert').strict;
 process.env.NODE_DISABLE_COLORS = true;
 
 try {
-  assert.strictEqual(1, 3);
+  assert.deepStrictEqual({}, { foo: 'bar' });
 } catch (error) {
-  const expected = 'Expected values to be strictly equal:\n\n1 !== 3\n';
+  const expected =
+    'Expected values to be strictly deep-equal:\n' +
+    '+ actual - expected\n' +
+    '\n' +
+    '+ {}\n' +
+    '- {\n' +
+    '-   foo: \'bar\'\n' +
+    '- }';
   assert.strictEqual(error.message, expected);
 }

--- a/test/pseudo-tty/test-assert-no-color.js
+++ b/test/pseudo-tty/test-assert-no-color.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const assert = require('assert').strict;
+
+process.env.NODE_DISABLE_COLORS = true;
+
+try {
+  assert.strictEqual(1, 3);
+} catch (error) {
+  const expected = 'Expected values to be strictly equal:\n\n1 !== 3\n';
+  assert.strictEqual(error.message, expected);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
This pull request adds a test that covers lines 313-316 from `root/internal assert.js`. Specifically it tests the scenario when the tty does not support colors and the assert messages should not be decorated.

I emulated the scenario by setting the environment variable `NODE_DISABLE_COLORS` to `true`

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
