### PR TITLE
console: cover .assert with single argument

### DIFF
--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -180,6 +180,8 @@ assert.strictEqual(errStrings[errStrings.length - 1],
 
 console.assert(true, 'this should not throw');
 
+console.assert(true);
+
 assert.strictEqual(strings.length, process.stdout.writeTimes);
 assert.strictEqual(errStrings.length, process.stderr.writeTimes);
 restoreStdout();


### PR DESCRIPTION
This PR covers `console.assert` with a single argument.

See https://coverage.nodejs.org/coverage-d32b5bd567544f5b/root/console.js.html#L295

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)