### PR TITLE
lib: fixed unreachable if statements in zlib

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -350,8 +350,7 @@ Object.defineProperty(Zlib.prototype, 'bytesRead', {
 // `params()` function should not happen while a write is currently in progress
 // on the threadpool.
 function paramsAfterFlushCallback(level, strategy, callback) {
-  if (!this._handle)
-    assert(false, 'zlib binding closed');
+  assert(this._handle, 'zlib binding closed');
   this._handle.params(level, strategy);
   if (!this._hadError) {
     this._level = level;
@@ -507,8 +506,8 @@ function processChunkSync(self, chunk, flushFlag) {
       else
         buffers.push(out);
       nread += out.byteLength;
-    } else if (have < 0) {
-      assert(false, 'have should not go down');
+    } else {
+      assert(have >= 0, 'have should not go down');
     }
 
     // exhausted the output buffer, or used all the input create a new one.
@@ -545,8 +544,7 @@ function processChunkSync(self, chunk, flushFlag) {
 
 function processChunk(self, chunk, flushFlag, cb) {
   var handle = self._handle;
-  if (!handle)
-    assert(false, 'zlib binding closed');
+  assert(handle, 'zlib binding closed');
 
   handle.buffer = chunk;
   handle.cb = cb;
@@ -593,8 +591,8 @@ function processCallback() {
     var out = self._outBuffer.slice(self._outOffset, self._outOffset + have);
     self._outOffset += have;
     self.push(out);
-  } else if (have < 0) {
-    assert(false, 'have should not go down');
+  } else {
+    assert(have >= 0, 'have should not go down');
   }
 
   if (self.destroyed) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -507,7 +507,7 @@ function processChunkSync(self, chunk, flushFlag) {
         buffers.push(out);
       nread += out.byteLength;
     } else {
-      assert(have >= 0, 'have should not go down');
+      assert(have === 0, 'have should not go down');
     }
 
     // exhausted the output buffer, or used all the input create a new one.
@@ -592,7 +592,7 @@ function processCallback() {
     self._outOffset += have;
     self.push(out);
   } else {
-    assert(have >= 0, 'have should not go down');
+    assert(have === 0, 'have should not go down');
   }
 
   if (self.destroyed) {


### PR DESCRIPTION
Refactored assertions in lib/zlib to be reachable

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
