### PR TITLE
test: fixing arguments order in assert.strictEqual()

### DIFF
--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -58,9 +58,9 @@ function test(handler, request_generator, response_validator) {
 
 {
   function handler(req, res) {
-    assert.strictEqual('1.0', req.httpVersion);
-    assert.strictEqual(1, req.httpVersionMajor);
-    assert.strictEqual(0, req.httpVersionMinor);
+    assert.strictEqual(req.httpVersion, '1.0');
+    assert.strictEqual(req.httpVersionMajor, 1);
+    assert.strictEqual(req.httpVersionMinor, 0);
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end(body);
   }
@@ -72,8 +72,8 @@ function test(handler, request_generator, response_validator) {
   function response_validator(server_response, client_got_eof, timed_out) {
     const m = server_response.split('\r\n\r\n');
     assert.strictEqual(m[1], body);
-    assert.strictEqual(true, client_got_eof);
-    assert.strictEqual(false, timed_out);
+    assert.strictEqual(client_got_eof, true);
+    assert.strictEqual(timed_out, false);
   }
 
   test(handler, request_generator, response_validator);
@@ -86,9 +86,9 @@ function test(handler, request_generator, response_validator) {
 //
 {
   function handler(req, res) {
-    assert.strictEqual('1.0', req.httpVersion);
-    assert.strictEqual(1, req.httpVersionMajor);
-    assert.strictEqual(0, req.httpVersionMinor);
+    assert.strictEqual(req.httpVersion, '1.0');
+    assert.strictEqual(req.httpVersionMajor, 1);
+    assert.strictEqual(req.httpVersionMinor, 0);
     res.sendDate = false;
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('Hello, '); res._send('');
@@ -113,8 +113,8 @@ function test(handler, request_generator, response_validator) {
                               'Hello, world!';
 
     assert.strictEqual(expected_response, server_response);
-    assert.strictEqual(true, client_got_eof);
-    assert.strictEqual(false, timed_out);
+    assert.strictEqual(client_got_eof, true);
+    assert.strictEqual(timed_out, false);
   }
 
   test(handler, request_generator, response_validator);
@@ -122,9 +122,9 @@ function test(handler, request_generator, response_validator) {
 
 {
   function handler(req, res) {
-    assert.strictEqual('1.1', req.httpVersion);
-    assert.strictEqual(1, req.httpVersionMajor);
-    assert.strictEqual(1, req.httpVersionMinor);
+    assert.strictEqual(req.httpVersion, '1.1');
+    assert.strictEqual(req.httpVersionMajor, 1);
+    assert.strictEqual(req.httpVersionMinor, 1);
     res.sendDate = false;
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('Hello, '); res._send('');
@@ -156,8 +156,8 @@ function test(handler, request_generator, response_validator) {
                               '\r\n';
 
     assert.strictEqual(expected_response, server_response);
-    assert.strictEqual(true, client_got_eof);
-    assert.strictEqual(false, timed_out);
+    assert.strictEqual(client_got_eof, true);
+    assert.strictEqual(timed_out, false);
   }
 
   test(handler, request_generator, response_validator);

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -112,7 +112,7 @@ function test(handler, request_generator, response_validator) {
                               '\r\n' +
                               'Hello, world!';
 
-    assert.strictEqual(expected_response, server_response);
+    assert.strictEqual(server_response, expected_response);
     assert.strictEqual(client_got_eof, true);
     assert.strictEqual(timed_out, false);
   }

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -155,7 +155,7 @@ function test(handler, request_generator, response_validator) {
                               '0\r\n' +
                               '\r\n';
 
-    assert.strictEqual(expected_response, server_response);
+    assert.strictEqual(server_response, expected_response);
     assert.strictEqual(client_got_eof, true);
     assert.strictEqual(timed_out, false);
   }


### PR DESCRIPTION
Certain lines on `test/parallel/test-http-1.0.js` have the arguments switched around on the assert.strictEqual(). This switch the values in the correct order (calculated value, literal value).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
