### PR TITLE
test: add coverage for escape in readline

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -108,6 +108,11 @@ addTest('\b\x7f\x1b\b\x1b\x7f \x1b ', [
   { name: 'space', sequence: '\x1b ', meta: true },
 ]);
 
+// escape key
+addTest('\x1b\x1b\x1b', [
+  { name: 'escape', sequence: '\x1b\x1b\x1b', meta: true },
+]);
+
 // control keys
 addTest('\x01\x0b\x10', [
   { name: 'a', sequence: '\x01', ctrl: true },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Add a test case that covers this if path:
https://coverage.nodejs.org/coverage-d32b5bd567544f5b/root/internal/readline.js.html#L398

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
