### PR TITLE
deps: partially revert 'increase V8 deprecation levels'

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.36',
+    'v8_embedder_string': '-node.37',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1019,9 +1019,9 @@ class V8_EXPORT PrimitiveArray {
  public:
   static Local<PrimitiveArray> New(Isolate* isolate, int length);
   int Length() const;
-  V8_DEPRECATED("Use Isolate* version",
+  V8_DEPRECATE_SOON("Use Isolate* version",
       void Set(int index, Local<Primitive> item));
-  V8_DEPRECATED("Use Isolate* version",
+  V8_DEPRECATE_SOON("Use Isolate* version",
       Local<Primitive> Get(int index));
   void Set(Isolate* isolate, int index, Local<Primitive> item);
   Local<Primitive> Get(Isolate* isolate, int index);
@@ -1739,8 +1739,8 @@ class V8_EXPORT StackTrace {
   /**
    * Returns a StackFrame at a particular index.
    */
-  V8_DEPRECATED("Use Isolate version",
-                Local<StackFrame> GetFrame(uint32_t index) const);
+  V8_DEPRECATE_SOON("Use Isolate version",
+                    Local<StackFrame> GetFrame(uint32_t index) const);
   Local<StackFrame> GetFrame(Isolate* isolate, uint32_t index) const;
 
   /**
@@ -2451,7 +2451,7 @@ class V8_EXPORT Value : public Data {
 
   inline V8_DEPRECATED("Use maybe version",
                        Local<Boolean> ToBoolean() const);
-  inline V8_DEPRECATED("Use maybe version", Local<String> ToString() const);
+  inline V8_DEPRECATE_SOON("Use maybe version", Local<String> ToString() const);
   inline V8_DEPRECATED("Use maybe version", Local<Object> ToObject() const);
   inline V8_DEPRECATED("Use maybe version",
                        Local<Integer> ToInteger() const);
@@ -2471,7 +2471,7 @@ class V8_EXPORT Value : public Data {
       Local<Context> context) const;
   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
 
-  V8_DEPRECATED("Use maybe version", bool BooleanValue() const);
+  V8_DEPRECATE_SOON("Use maybe version", bool BooleanValue() const);
   V8_DEPRECATED("Use maybe version", double NumberValue() const);
   V8_DEPRECATED("Use maybe version", int64_t IntegerValue() const);
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
@@ -2584,7 +2584,7 @@ class V8_EXPORT String : public Name {
    * Returns the number of bytes in the UTF-8 encoded
    * representation of this string.
    */
-  V8_DEPRECATED("Use Isolate version instead", int Utf8Length() const);
+  V8_DEPRECATE_SOON("Use Isolate version instead", int Utf8Length() const);
 
   int Utf8Length(Isolate* isolate) const;
 
@@ -2642,23 +2642,23 @@ class V8_EXPORT String : public Name {
   // 16-bit character codes.
   int Write(Isolate* isolate, uint16_t* buffer, int start = 0, int length = -1,
             int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int Write(uint16_t* buffer, int start = 0, int length = -1,
-                          int options = NO_OPTIONS) const);
+  V8_DEPRECATE_SOON("Use Isolate* version",
+                    int Write(uint16_t* buffer, int start = 0, int length = -1,
+                              int options = NO_OPTIONS) const);
   // One byte characters.
   int WriteOneByte(Isolate* isolate, uint8_t* buffer, int start = 0,
                    int length = -1, int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int WriteOneByte(uint8_t* buffer, int start = 0,
-                                 int length = -1, int options = NO_OPTIONS)
+  V8_DEPRECATE_SOON("Use Isolate* version",
+                    int WriteOneByte(uint8_t* buffer, int start = 0,
+                                     int length = -1, int options = NO_OPTIONS)
                     const);
   // UTF-8 encoded characters.
   int WriteUtf8(Isolate* isolate, char* buffer, int length = -1,
                 int* nchars_ref = NULL, int options = NO_OPTIONS) const;
-  V8_DEPRECATED("Use Isolate* version",
-                int WriteUtf8(char* buffer, int length = -1,
-                              int* nchars_ref = NULL,
-                              int options = NO_OPTIONS) const);
+  V8_DEPRECATE_SOON("Use Isolate* version",
+                    int WriteUtf8(char* buffer, int length = -1,
+                                  int* nchars_ref = NULL,
+                                  int options = NO_OPTIONS) const);
 
   /**
    * A zero length string.
@@ -2822,9 +2822,9 @@ class V8_EXPORT String : public Name {
    */
   static Local<String> Concat(Isolate* isolate, Local<String> left,
                               Local<String> right);
-  static V8_DEPRECATED("Use Isolate* version",
-                       Local<String> Concat(Local<String> left,
-                                            Local<String> right));
+  static V8_DEPRECATE_SOON("Use Isolate* version",
+                           Local<String> Concat(Local<String> left,
+                                                Local<String> right));
 
   /**
    * Creates a new external string using the data defined in the given
@@ -5049,8 +5049,8 @@ class V8_EXPORT BooleanObject : public Object {
 class V8_EXPORT StringObject : public Object {
  public:
   static Local<Value> New(Isolate* isolate, Local<String> value);
-  V8_DEPRECATED("Use Isolate* version",
-                static Local<Value> New(Local<String> value));
+  V8_DEPRECATE_SOON("Use Isolate* version",
+                    static Local<Value> New(Local<String> value));
 
   Local<String> ValueOf() const;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

The V8 CI on `v10x-staging` won't build because deprecation warnings are raised to errors at compile time. This is a partial revert of https://github.com/nodejs/node/pull/23159 so that the build can run again.