### PR TITLE
build: use latest node on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os: linux
 matrix:
   include:
     - name: "Linter"
-      node_js: "latest"
+      language: node_js
+      node_js: "node"
       env:
         - NODE=$(which node)
       script:


### PR DESCRIPTION
Our Travis setup asks for the latest node version when running the linter. We're actually ending up with Node 8.9.1. Trying this instead...

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: https://ci.nodejs.org/job/node-test-pull-request/18379/