### PR TITLE
test: add coverage for systemerror set name

### DIFF
--- a/test/parallel/test-errors-systemerror.js
+++ b/test/parallel/test-errors-systemerror.js
@@ -111,3 +111,25 @@ const { ERR_TEST } = codes;
   assert.strictEqual(err.path, 'path');
   assert.strictEqual(err.dest, 'path');
 }
+
+{
+  const ctx = {
+    code: 'ERR_TEST',
+    message: 'Error occurred',
+    syscall: 'syscall_test'
+  };
+  assert.throws(
+    () => {
+      const err = new ERR_TEST(ctx);
+      err.name = 'SystemError [CUSTOM_ERR_TEST]';
+      throw err;
+    },
+    {
+      code: 'ERR_TEST',
+      name: 'SystemError [CUSTOM_ERR_TEST]',
+      message: 'custom message: syscall_test returned ERR_TEST ' +
+               '(Error occurred)',
+      info: ctx
+    }
+  );
+}


### PR DESCRIPTION
Coverage for 
https://coverage.nodejs.org/coverage-d32b5bd567544f5b/root/internal/errors.js.html#L83

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)