### PR TITLE
lib: removed redundant checking of bad importModuleDynamically throwing `ERR_VM_MODULE_NOT_MODULE`

### DIFF
--- a/lib/internal/vm/source_text_module.js
+++ b/lib/internal/vm/source_text_module.js
@@ -121,8 +121,6 @@ class SourceTextModule {
         if (isModuleNamespaceObject(m)) {
           return m;
         }
-        if (!m || !wrapMap.has(m))
-          throw new ERR_VM_MODULE_NOT_MODULE();
         const childLinkingStatus = linkingStatusMap.get(m);
         if (childLinkingStatus === 'errored')
           throw m.error;

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -29,8 +29,7 @@ const {
 } = internalBinding('contextify');
 const { callbackMap } = internalBinding('module_wrap');
 const {
-  ERR_INVALID_ARG_TYPE,
-  ERR_VM_MODULE_NOT_MODULE,
+  ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
 const { isModuleNamespaceObject, isArrayBufferView } = require('util').types;
 const { validateInt32, validateUint32 } = require('internal/validators');
@@ -97,15 +96,12 @@ class Script extends ContextifyScript {
                                        'function',
                                        importModuleDynamically);
       }
-      const { wrapMap, linkingStatusMap } =
-        require('internal/vm/source_text_module');
+      const { linkingStatusMap } = require('internal/vm/source_text_module');
       callbackMap.set(this, { importModuleDynamically: async (...args) => {
         const m = await importModuleDynamically(...args);
         if (isModuleNamespaceObject(m)) {
           return m;
         }
-        if (!m || !wrapMap.has(m))
-          throw new ERR_VM_MODULE_NOT_MODULE();
         const childLinkingStatus = linkingStatusMap.get(m);
         if (childLinkingStatus === 'errored')
           throw m.error;


### PR DESCRIPTION
`ERR_VM_MODULE_NOT_MODULE` error is already checked in `linkingStatusMap.get`.
Thrown in [source_text_module.js#L188](https://github.com/nodejs/node/blob/master/lib/internal/vm/source_text_module.js#L188)
Tests are in #24161

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines]