### PR TITLE
test: disable color formatting for test-internal-errors.js

### DIFF
--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -10,6 +10,10 @@ const { internalBinding } = require('internal/test/binding');
 const assert = require('assert');
 const errors = require('internal/errors');
 
+// Turn off ANSI color formatting for this test file.
+const { inspect } = require('util');
+inspect.defaultOptions.colors = false;
+
 errors.E('TEST_ERROR_1', 'Error for testing purposes: %s',
          Error, TypeError, RangeError);
 errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`, Error);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24193
Refs: https://github.com/nodejs/node/pull/19723

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
