### PR TITLE
test: http[s] deprecated-URL coverage

### DIFF
--- a/test/parallel/test-http-deprecated-urls.js
+++ b/test/parallel/test-http-deprecated-urls.js
@@ -5,29 +5,22 @@
 const common = require('../common');
 
 const http = require('http');
-const modules = { http };
 
 const deprecations = [
   ['The provided URL http://[www.nodejs.org] is not a valid URL, and is supported ' +
   'in the http module solely for compatibility.',
    'DEP0109'],
 ];
-
-if (common.hasCrypto) {
-  const https = require('https');
-  modules.https = https;
-  deprecations.push(
-    ['The provided URL https://[www.nodejs.org] is not a valid URL, and is supported ' +
-    'in the https module solely for compatibility.',
-     'DEP0109'],
-  );
-}
-
 common.expectWarning('DeprecationWarning', deprecations);
 
-Object.keys(modules).forEach((module) => {
-  const doNotCall = common.mustNotCall(
-    `${module}.request should not connect to ${module}://[www.nodejs.org]`
-  );
-  modules[module].request(`${module}://[www.nodejs.org]`, doNotCall).abort();
-});
+const doNotCall = common.mustNotCall(
+  'http.request should not connect to http://[www.nodejs.org]'
+);
+
+// Ensure that only a single warning is emitted
+process.on('warning', common.mustCall());
+
+http.request('http://[www.nodejs.org]', doNotCall).abort();
+
+// Call request() a second time to ensure DeprecationWarning not duplicated
+http.request('http://[www.nodejs.org]', doNotCall).abort();

--- a/test/parallel/test-https-deprecated-urls.js
+++ b/test/parallel/test-https-deprecated-urls.js
@@ -1,0 +1,29 @@
+/* eslint-disable node-core/crypto-check */
+
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const https = require('https');
+
+
+const deprecations = [
+  ['The provided URL https://[www.nodejs.org] is not a valid URL, and is supported ' +
+  'in the https module solely for compatibility.',
+   'DEP0109'],
+];
+common.expectWarning('DeprecationWarning', deprecations);
+
+const doNotCall = common.mustNotCall(
+  'https.request should not connect to https://[www.nodejs.org]'
+);
+
+// Ensure that only a single warning is emitted
+process.on('warning', common.mustCall());
+
+https.request('https://[www.nodejs.org]', doNotCall).abort();
+
+// Call request() a second time to ensure DeprecationWarning not duplicated
+https.request('https://[www.nodejs.org]', doNotCall).abort();


### PR DESCRIPTION
The `else` code path was not covered by tests. Adding coverage and
ensuring a single warning is emitted.

Splitting the http and https cases into separate test units to ensure
that the process.on('warning') is only called a single time.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
