### PR TITLE
test: fix NewFromUtf8 compiler warning

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -63,13 +63,15 @@ namespace demo {
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
 
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(String::NewFromUtf8(
+      isolate, "world", NewStringType::kNormal).ToLocalChecked());
 }
 
 void Initialize(Local<Object> exports) {
@@ -464,6 +466,7 @@ using v8::Exception;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::String;
@@ -479,14 +482,18 @@ void Add(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 2) {
     // Throw an Error that is passed back to JavaScript
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+        String::NewFromUtf8(isolate,
+                            "Wrong number of arguments",
+                            NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
   // Check the argument types
   if (!args[0]->IsNumber() || !args[1]->IsNumber()) {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong arguments")));
+        String::NewFromUtf8(isolate,
+                            "Wrong arguments",
+                            NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
@@ -534,6 +541,7 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Null;
 using v8::Object;
 using v8::String;
@@ -543,7 +551,10 @@ void RunCallback(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Function> cb = Local<Function>::Cast(args[0]);
   const unsigned argc = 1;
-  Local<Value> argv[argc] = { String::NewFromUtf8(isolate, "hello world") };
+  Local<Value> argv[argc] = {
+      String::NewFromUtf8(isolate,
+                          "hello world",
+                          NewStringType::kNormal).ToLocalChecked() };
   cb->Call(Null(isolate), argc, argv);
 }
 
@@ -591,6 +602,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -600,7 +612,9 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Local<Context> context = isolate->GetCurrentContext();
 
   Local<Object> obj = Object::New(isolate);
-  obj->Set(String::NewFromUtf8(isolate, "msg"),
+  obj->Set(String::NewFromUtf8(isolate,
+                               "msg",
+                               NewStringType::kNormal).ToLocalChecked(),
                                args[0]->ToString(context).ToLocalChecked());
 
   args.GetReturnValue().Set(obj);
@@ -644,13 +658,15 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
 
 void MyFunction(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "hello world"));
+  args.GetReturnValue().Set(String::NewFromUtf8(
+      isolate, "hello world", NewStringType::kNormal).ToLocalChecked());
 }
 
 void CreateFunction(const FunctionCallbackInfo<Value>& args) {
@@ -661,7 +677,8 @@ void CreateFunction(const FunctionCallbackInfo<Value>& args) {
   Local<Function> fn = tpl->GetFunction(context).ToLocalChecked();
 
   // omit this to make it anonymous
-  fn->SetName(String::NewFromUtf8(isolate, "theFunction"));
+  fn->SetName(String::NewFromUtf8(
+      isolate, "theFunction", NewStringType::kNormal).ToLocalChecked());
 
   args.GetReturnValue().Set(fn);
 }
@@ -757,6 +774,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::Persistent;
@@ -776,7 +794,8 @@ void MyObject::Init(Local<Object> exports) {
 
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
+  tpl->SetClassName(String::NewFromUtf8(
+      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Prototype
@@ -784,7 +803,8 @@ void MyObject::Init(Local<Object> exports) {
 
   Local<Context> context = isolate->GetCurrentContext();
   constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
-  exports->Set(String::NewFromUtf8(isolate, "MyObject"),
+  exports->Set(String::NewFromUtf8(
+      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked(),
                tpl->GetFunction(context).ToLocalChecked());
 }
 
@@ -952,6 +972,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::Persistent;
@@ -969,7 +990,8 @@ MyObject::~MyObject() {
 void MyObject::Init(Isolate* isolate) {
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
+  tpl->SetClassName(String::NewFromUtf8(
+      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Prototype
@@ -1167,6 +1189,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::Persistent;
 using v8::String;
@@ -1183,7 +1206,8 @@ MyObject::~MyObject() {
 void MyObject::Init(Isolate* isolate) {
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject"));
+  tpl->SetClassName(String::NewFromUtf8(
+      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   Local<Context> context = isolate->GetCurrentContext();

--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -15,6 +15,7 @@ using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
+using v8::NewStringType;
 using v8::String;
 using v8::Value;
 
@@ -33,7 +34,8 @@ void LoadLibrary(const FunctionCallbackInfo<Value>& args) {
 void Ping(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   assert(ping_func != nullptr);
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, ping_func()));
+  args.GetReturnValue().Set(String::NewFromUtf8(
+        isolate, ping_func(), NewStringType::kNormal).ToLocalChecked());
 }
 
 void init(Local<Object> exports) {

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -19,7 +19,8 @@ inline void Test(const v8::FunctionCallbackInfo<v8::Value>& args) {
 inline void Initialize(v8::Local<v8::Object> binding) {
   v8::Isolate* const isolate = binding->GetIsolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  binding->Set(v8::String::NewFromUtf8(isolate, "test"),
+  binding->Set(v8::String::NewFromUtf8(
+        isolate, "test", v8::NewStringType::kNormal).ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, Test)
                    ->GetFunction(context)
                    .ToLocalChecked());

--- a/test/addons/hello-world-esm/binding.cc
+++ b/test/addons/hello-world-esm/binding.cc
@@ -3,7 +3,8 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(
+        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports) {

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -3,7 +3,8 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(
+        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -3,7 +3,8 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(
+        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 // Not using the full NODE_MODULE_INIT() macro here because we want to test the

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -3,7 +3,8 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(
+        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports) {

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -12,7 +12,8 @@ inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>& args) {
 inline void Initialize(v8::Local<v8::Object> binding) {
   auto isolate = binding->GetIsolate();
   auto context = isolate->GetCurrentContext();
-  binding->Set(v8::String::NewFromUtf8(isolate, "Class"),
+  binding->Set(v8::String::NewFromUtf8(
+        isolate, "Class", v8::NewStringType::kNormal).ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, NewClass)
                    ->GetFunction(context)
                    .ToLocalChecked());

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -22,7 +22,8 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
-  auto key = v8::String::NewFromUtf8(isolate, "randomBytes");
+  auto key = v8::String::NewFromUtf8(
+      isolate, "randomBytes", v8::NewStringType::kNormal).ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, RandomBytes)
                    ->GetFunction(context)
                    .ToLocalChecked();

--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -3,7 +3,8 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(
+        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports) {

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -45,7 +45,8 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
-  auto key = v8::String::NewFromUtf8(isolate, "compressBytes");
+  auto key = v8::String::NewFromUtf8(
+      isolate, "compressBytes", v8::NewStringType::kNormal).ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, CompressBytes)
                    ->GetFunction(context)
                    .ToLocalChecked();


### PR DESCRIPTION
Currently there are a number of compiler warnings like the following:
```console
../binding.cc:6:41:
warning: 'NewFromUtf8' is deprecated:
Use maybe version [-Wdeprecated-declarations]
  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
                                        ^
/node/deps/v8/include/v8.h:2883:10:
note: 'NewFromUtf8' has been explicitly marked deprecated here
  static V8_DEPRECATE_SOON(
         ^
/node/deps/v8/include/v8config.h:341:29:
note: expanded from macro 'V8_DEPRECATE_SOON'
  declarator __attribute__((deprecated(message)))
                            ^
```
This commit updates the code to use the maybe versions.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
