### PR TITLE
url: make the context non-enumerable

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -245,7 +245,14 @@ function onParseError(flags, input) {
 // Reused by URL constructor and URL#href setter.
 function parse(url, input, base) {
   const base_context = base ? base[context] : undefined;
-  url[context] = new URLContext();
+  // In the URL#href setter
+  if (!url[context]) {
+    Object.defineProperty(url, context, {
+      enumerable: false,
+      configurable: false,
+      value: new URLContext()
+    });
+  }
   _parse(input.trim(), -1, base_context, undefined,
          onParseComplete.bind(url), onParseError);
 }
@@ -1437,7 +1444,11 @@ function toPathIfFileURL(fileURLOrPath) {
 }
 
 function NativeURL(ctx) {
-  this[context] = ctx;
+  Object.defineProperty(this, context, {
+    enumerable: false,
+    configurable: false,
+    value: ctx
+  });
 }
 NativeURL.prototype = URL.prototype;
 

--- a/test/parallel/test-whatwg-url-custom-no-enumerable-context.js
+++ b/test/parallel/test-whatwg-url-custom-no-enumerable-context.js
@@ -1,0 +1,14 @@
+'use strict';
+// This tests that the context of URL objects are not
+// enumerable and thus considered by assert libraries.
+// See https://github.com/nodejs/node/issues/24211
+
+// Tests below are not from WPT.
+
+require('../common');
+const assert = require('assert');
+
+assert.deepStrictEqual(
+  new URL('./foo', 'https://example.com/'),
+  new URL('https://example.com/foo')
+);


### PR DESCRIPTION
At the moment we expose the context as a normal property on the URL
which makes them enumerable and considered
by assert libraries even though the context carries path-dependent
information that do not affect the equivalence of these objects.
This patch fixes it in a minimal manner by marking the context
non-enumerable as making it full private would require more
refactoring and can be done in a bigger patch later.

Refs: https://github.com/nodejs/node/issues/24211

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
