### PR TITLE
benchmark: support more options in startup benchmark

### DIFF
--- a/benchmark/fixtures/require-cachable.js
+++ b/benchmark/fixtures/require-cachable.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const list = require('internal/bootstrap/cache');
+const {
+  isMainThread
+} = require('worker_threads');
+
+for (const key of list.cachableBuiltins) {
+  if (!isMainThread && key === 'trace_events') {
+    continue;
+  }
+  require(key);
+}

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -13,13 +13,13 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals', '--experimental-worker']  // for workers
 });
 
-function spwanProcess(script) {
+function spawnProcess(script) {
   const cmd = process.execPath || process.argv[0];
   const argv = ['--expose-internals', script];
   return spawn(cmd, argv);
 }
 
-function spwanWorker(script) {
+function spawnWorker(script) {
   return new Worker(script, { stderr: true, stdout: true });
 }
 
@@ -68,9 +68,9 @@ function main({ dur, script, mode }) {
   if (mode === 'worker') {
     Worker = require('worker_threads').Worker;
     bench.start();
-    start(state, script, bench, spwanWorker);
+    start(state, script, bench, spawnWorker);
   } else {
     bench.start();
-    start(state, script, bench, spwanProcess);
+    start(state, script, bench, spawnProcess);
   }
 }

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -1,36 +1,76 @@
 'use strict';
 const common = require('../common.js');
-const spawn = require('child_process').spawn;
+const { spawn } = require('child_process');
 const path = require('path');
-const emptyJsFile = path.resolve(__dirname, '../../test/fixtures/semicolon.js');
 
-const bench = common.createBenchmark(startNode, {
-  dur: [1]
+let Worker;  // Lazy loaded in main
+
+const bench = common.createBenchmark(main, {
+  dur: [1],
+  script: ['benchmark/fixtures/require-cachable', 'test/fixtures/semicolon'],
+  mode: ['process', 'worker']
+}, {
+  flags: ['--expose-internals', '--experimental-worker']  // for workers
 });
 
-function startNode({ dur }) {
-  var go = true;
-  var starts = 0;
+function spwanProcess(script) {
+  const cmd = process.execPath || process.argv[0];
+  const argv = ['--expose-internals', script];
+  return spawn(cmd, argv);
+}
+
+function spwanWorker(script) {
+  return new Worker(script, { stderr: true, stdout: true });
+}
+
+function start(state, script, bench, getNode) {
+  const node = getNode(script);
+  let stdout = '';
+  let stderr = '';
+
+  node.stdout.on('data', (data) => {
+    stdout += data;
+  });
+
+  node.stderr.on('data', (data) => {
+    stderr += data;
+  });
+
+  node.on('exit', (code) => {
+    if (code !== 0) {
+      console.error('------ stdout ------');
+      console.error(stdout);
+      console.error('------ stderr ------');
+      console.error(stderr);
+      throw new Error(`Error during node startup, exit code ${code}`);
+    }
+    state.throughput++;
+
+    if (state.go) {
+      start(state, script, bench, getNode);
+    } else {
+      bench.end(state.throughput);
+    }
+  });
+}
+
+function main({ dur, script, mode }) {
+  const state = {
+    go: true,
+    throughput: 0
+  };
 
   setTimeout(function() {
-    go = false;
+    state.go = false;
   }, dur * 1000);
 
-  bench.start();
-  start();
-
-  function start() {
-    const node = spawn(process.execPath || process.argv[0], [emptyJsFile]);
-    node.on('exit', function(exitCode) {
-      if (exitCode !== 0) {
-        throw new Error('Error during node startup');
-      }
-      starts++;
-
-      if (go)
-        start();
-      else
-        bench.end(starts);
-    });
+  script = path.resolve(__dirname, '../../', `${script}.js`);
+  if (mode === 'worker') {
+    Worker = require('worker_threads').Worker;
+    bench.start();
+    start(state, script, bench, spwanWorker);
+  } else {
+    bench.start();
+    start(state, script, bench, spwanProcess);
   }
 }

--- a/test/parallel/test-benchmark-misc.js
+++ b/test/parallel/test-benchmark-misc.js
@@ -11,4 +11,6 @@ runBenchmark('misc', [
   'n=1',
   'type=',
   'val=magyarország.icom.museum',
+  'script=test/fixtures/semicolon',
+  'mode=worker'
 ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
1. Add options to benchmark the startup performance of a node
  "instance" after running a script. By default there are two options:
  `test/fixtures/semicolon` which is basically an empty file,
  and `benchmark/fixtures/require-cachable` which require all
  the cachable modules before exiting. This allows us to measure
  the overhead of bootstrap in more scenarios.
2. Add options to benchmark the overhead of spinning
  node through a process and through a worker.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
