### PR TITLE
net: remove unreachable error

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -272,7 +272,7 @@ function Socket(options) {
 
     // While difficult to fabricate, in some architectures
     // `open` may return an error code for valid file descriptors
-    // which cannot be openned. This is difficult to test as most
+    // which cannot be opened. This is difficult to test as most
     // un-openable fds will throw on `createHandle`
     if (err)
       throw errnoException(err, 'open');

--- a/lib/net.js
+++ b/lib/net.js
@@ -264,9 +264,17 @@ function Socket(options) {
     const { fd } = options;
     let err;
 
+    // createHandle will throw ERR_INVALID_FD_TYPE if `fd` is not
+    // a valid `PIPE` or `TCP` descriptor
     this._handle = createHandle(fd, false);
 
-    this._handle.open(fd);
+    err = this._handle.open(fd);
+
+    // While difficult to fabricate, in some architectures, `open` may return an error
+    // code for valid file descriptors which cannot be openned
+    // This is difficult to test as most un-openable fds will throw on `createHandle`
+    if (err)
+      throw errnoException(err, 'open');
 
     this[async_id_symbol] = this._handle.getAsyncId();
     // options.fd can be string (since it is user-defined),

--- a/lib/net.js
+++ b/lib/net.js
@@ -270,9 +270,10 @@ function Socket(options) {
 
     err = this._handle.open(fd);
 
-    // While difficult to fabricate, in some architectures, `open` may return an error
-    // code for valid file descriptors which cannot be openned
-    // This is difficult to test as most un-openable fds will throw on `createHandle`
+    // While difficult to fabricate, in some architectures
+    // `open` may return an error code for valid file descriptors
+    // which cannot be openned. This is difficult to test as most
+    // un-openable fds will throw on `createHandle`
     if (err)
       throw errnoException(err, 'open');
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -266,9 +266,7 @@ function Socket(options) {
 
     this._handle = createHandle(fd, false);
 
-    err = this._handle.open(fd);
-    if (err)
-      throw errnoException(err, 'open');
+    this._handle.open(fd);
 
     this[async_id_symbol] = this._handle.getAsyncId();
     // options.fd can be string (since it is user-defined),


### PR DESCRIPTION
When creating a socket, if the file descriptor is not a valid PIPE or
TCP type, createHandle throws an ERR_INVALID_FD_TYPE. This means that
`this._handle.open` is guaranteed to succeed and will never return an
error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
