### PR TITLE
test: fixed the arguments order in `assert.strictEqual`

### DIFF
--- a/test/parallel/test-fs-read-stream-fd-leak.js
+++ b/test/parallel/test-fs-read-stream-fd-leak.js
@@ -37,8 +37,8 @@ function testLeak(endFn, callback) {
     }
 
     assert.strictEqual(
-      0,
       openCount,
+      0,
       `no leaked file descriptors using ${endFn}() (got ${openCount})`
     );
 


### PR DESCRIPTION
This change was initiated from the NodeConfEU session.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
