### PR TITLE
test: fixed the arguments order in `assert.strictEqual`

### DIFF
--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -15,7 +15,7 @@ fs.writeFileSync(srcPath, 'hello world');
 function callback(err) {
   assert.ifError(err);
   const dstContent = fs.readFileSync(dstPath, 'utf8');
-  assert.strictEqual('hello world', dstContent);
+  assert.strictEqual(dstContent, 'hello world');
 }
 
 fs.link(srcPath, dstPath, common.mustCall(callback));


### PR DESCRIPTION
This change was initiated from the NodeConfEU session.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
