### PR TITLE
build,win: open shortcut folder instead of running script

### DIFF
--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -14,15 +14,8 @@
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
     <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
     <String Id="NativeToolsDlgInstallCheckbox">Open the shortcut folder to run the tools install script.</String>
-    <String Id="NativeToolsDlgManualDetails">
-      Note that the tools install script will also install
-      <![CDATA[<a href="https://boxstarter.org/">Boxstarter</a>]]>
-      and
-      <![CDATA[<a href="https://chocolatey.org/">Chocolatey</a>]]>
-      Alternatively, follow the instructions at
-      <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]>
-      to install the dependencies yourself.
-    </String>
+    <String Id="NativeToolsDlgManualDetails">Note that the tools install script will also install <![CDATA[<a href="https://boxstarter.org/">Boxstarter</a>]]> and <![CDATA[<a href="https://chocolatey.org/">Chocolatey</a>]]>.
+Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
 
     <!-- References like [ProductName] or $(var.ProductName) don't seem to work in Title attributes -->
     <String Id="NodeRuntime_Title">Node.js runtime</String>

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -12,9 +12,23 @@
     <String Id="NativeToolsDlgTitle">{\WixUI_Font_Title}Tools for Native Modules</String>
     <String Id="NativeToolsDlgDescription">Optionally install the tools necessary to compile native modules.</String>
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
-    <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
-    <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. Note that this will also install Boxstarter and Chocolatey. The script will pop-up in a new window after the installation completes.</String>
-    <String Id="NativeToolsDlgManualDetails">Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
+    <String Id="NativeToolsDlgIntro">
+      Some npm modules need to be compiled from C/C++ when installing.
+      If you want to be able to install such modules,
+      some tools (Python 2 and Visual Studio Build Tools) need to be installed.
+    </String>
+    <String Id="NativeToolsDlgInstallCheckbox">
+      Open the shortcut folder to run the tools install script.
+      Note that it will also install
+      <![CDATA[<a href="https://boxstarter.org/">Boxstarter</a>]]>
+      and
+      <![CDATA[<a href="https://chocolatey.org/">Chocolatey</a>]]>
+    </String>
+    <String Id="NativeToolsDlgManualDetails">
+      Alternatively, follow the instructions at
+      <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]>
+      to install the dependencies yourself.
+    </String>
 
     <!-- References like [ProductName] or $(var.ProductName) don't seem to work in Title attributes -->
     <String Id="NodeRuntime_Title">Node.js runtime</String>

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -12,19 +12,13 @@
     <String Id="NativeToolsDlgTitle">{\WixUI_Font_Title}Tools for Native Modules</String>
     <String Id="NativeToolsDlgDescription">Optionally install the tools necessary to compile native modules.</String>
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
-    <String Id="NativeToolsDlgIntro">
-      Some npm modules need to be compiled from C/C++ when installing.
-      If you want to be able to install such modules,
-      some tools (Python 2 and Visual Studio Build Tools) need to be installed.
-    </String>
-    <String Id="NativeToolsDlgInstallCheckbox">
-      Open the shortcut folder to run the tools install script.
-      Note that it will also install
+    <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
+    <String Id="NativeToolsDlgInstallCheckbox">Open the shortcut folder to run the tools install script.</String>
+    <String Id="NativeToolsDlgManualDetails">
+      Note that the tools install script will also install
       <![CDATA[<a href="https://boxstarter.org/">Boxstarter</a>]]>
       and
       <![CDATA[<a href="https://chocolatey.org/">Chocolatey</a>]]>
-    </String>
-    <String Id="NativeToolsDlgManualDetails">
       Alternatively, follow the instructions at
       <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]>
       to install the dependencies yourself.

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -384,7 +384,7 @@
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="NativeToolsDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenShurtcutFolder">NATIVETOOLSCHECKBOX = 1</Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenShortcutFolder">NATIVETOOLSCHECKBOX = 1</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="!(loc.WIXUI_EXITDIALOGOPTIONALTEXT)"/>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -311,8 +311,8 @@
                   Execute="immediate"
                   Return="check" />
 
-    <Property Id="WixShellExecTarget" Value="[#ApplicationProgramsFolder]" />
-    <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" />
+    <Property Id="WixShellExecTarget" Value="explorer [#ApplicationProgramsFolder]" />
+    <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
     <InstallUISequence>
       <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -311,8 +311,8 @@
                   Execute="immediate"
                   Return="check" />
 
-    <Property Id="WixShellExecTarget" Value="[#NodeStartMenu]" />
-    <CustomAction Id="OpenShortcutFolder" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+    <Property Id="WixShellExecTarget" Value="[#ApplicationProgramsFolder]" />
+    <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" />
 
     <InstallUISequence>
       <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>
@@ -384,7 +384,7 @@
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="NativeToolsDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenShortcutFolder">NATIVETOOLSCHECKBOX = 1</Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">NATIVETOOLSCHECKBOX = 1</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="!(loc.WIXUI_EXITDIALOGOPTIONALTEXT)"/>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -311,8 +311,8 @@
                   Execute="immediate"
                   Return="check" />
 
-    <Property Id="WixShellExecTarget" Value="[#InstallToolsBat]" />
-    <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" />
+    <Property Id="WixShellExecTarget" Value="[#NodeStartMenu]" />
+    <CustomAction Id="OpenShurtcutFolder" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
     <InstallUISequence>
       <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>
@@ -384,7 +384,7 @@
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="NativeToolsDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">1</Publish>
       <Publish Dialog="NativeToolsDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">NATIVETOOLSCHECKBOX = 1</Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="OpenShurtcutFolder">NATIVETOOLSCHECKBOX = 1</Publish>
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
       <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="!(loc.WIXUI_EXITDIALOGOPTIONALTEXT)"/>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -312,7 +312,7 @@
                   Return="check" />
 
     <Property Id="WixShellExecTarget" Value="[#NodeStartMenu]" />
-    <CustomAction Id="OpenShurtcutFolder" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+    <CustomAction Id="OpenShortcutFolder" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
     <InstallUISequence>
       <Custom Action='SetInstallScope' Before='FindRelatedProducts'/>


### PR DESCRIPTION
An alternative UX idea:
At the end of the installer open the created Shortcut dir, where the users can explicitly call the new `Install Additional Tools for Node.js` shortcut.
Refs: https://github.com/nodejs/node/pull/22645
Fixes: https://github.com/nodejs/node/issues/23838

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
