### PR TITLE
doc: update fs.open() changes record for optional 'flags'

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2315,7 +2315,7 @@ added: v0.0.2
 changes:
   - version: v11.1.0
     pr-url: https://github.com/nodejs/node/pull/23767
-    description: The `flags` argument is now optional and defaults to `'r'`
+    description: The `flags` argument is now optional and defaults to `'r'`.
   - version: v9.9.0
     pr-url: https://github.com/nodejs/node/pull/18801
     description: The `as` and `as+` modes are supported now.
@@ -2353,6 +2353,12 @@ Functions based on `fs.open()` exhibit this behavior as well:
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: v11.1.0
+    pr-url: https://github.com/nodejs/node/pull/23767
+    description: The `flags` argument is now optional and defaults to `'r'`.
+  - version: v9.9.0
+    pr-url: https://github.com/nodejs/node/pull/18801
+    description: The `as` and `as+` modes are supported now.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using `file:`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4220,6 +4220,10 @@ characters directly to the `prefix` string. For instance, given a directory
 ### fsPromises.open(path, flags[, mode])
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: v11.1.0
+    pr-url: https://github.com/nodejs/node/pull/23767
+    description: The `flags` argument is now optional and defaults to `'r'`.
 -->
 
 * `path` {string|Buffer|URL}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4228,6 +4228,7 @@ changes:
 
 * `path` {string|Buffer|URL}
 * `flags` {string|number} See [support of file system `flags`][].
+  **Default:** `'r'`.
 * `mode` {integer} **Default:** `0o666` (readable and writable)
 * Returns: {Promise}
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2313,6 +2313,9 @@ object with an `encoding` property specifying the character encoding to use.
 <!-- YAML
 added: v0.0.2
 changes:
+  - version: v11.1.0
+    pr-url: https://github.com/nodejs/node/pull/23767
+    description: The `flags` argument is now optional and defaults to `'r'`
   - version: v9.9.0
     pr-url: https://github.com/nodejs/node/pull/18801
     description: The `as` and `as+` modes are supported now.


### PR DESCRIPTION
Was missed on original PR.

Ref: https://github.com/nodejs/node/pull/23767