### PR TITLE
lib: move encodeStr function to internal for reusable

### DIFF
--- a/lib/internal/querystring.js
+++ b/lib/internal/querystring.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { ERR_INVALID_URI } = require('internal/errors').codes;
+
 const hexTable = new Array(256);
 for (var i = 0; i < 256; ++i)
   hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
@@ -23,7 +25,72 @@ const isHexTable = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  // ... 256
 ];
 
+function encodeStr(str, noEscapeTable, hexTable) {
+  const len = str.length;
+  if (len === 0)
+    return '';
+
+  var out = '';
+  var lastPos = 0;
+
+  for (var i = 0; i < len; i++) {
+    var c = str.charCodeAt(i);
+
+    // ASCII
+    if (c < 0x80) {
+      if (noEscapeTable[c] === 1)
+        continue;
+      if (lastPos < i)
+        out += str.slice(lastPos, i);
+      lastPos = i + 1;
+      out += hexTable[c];
+      continue;
+    }
+
+    if (lastPos < i)
+      out += str.slice(lastPos, i);
+
+    // Multi-byte characters ...
+    if (c < 0x800) {
+      lastPos = i + 1;
+      out += hexTable[0xC0 | (c >> 6)] +
+             hexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    if (c < 0xD800 || c >= 0xE000) {
+      lastPos = i + 1;
+      out += hexTable[0xE0 | (c >> 12)] +
+             hexTable[0x80 | ((c >> 6) & 0x3F)] +
+             hexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    // Surrogate pair
+    ++i;
+
+    // This branch should never happen because all URLSearchParams entries
+    // should already be converted to USVString. But, included for
+    // completion's sake anyway.
+    if (i >= len)
+      throw new ERR_INVALID_URI();
+
+    var c2 = str.charCodeAt(i) & 0x3FF;
+
+    lastPos = i + 1;
+    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
+    out += hexTable[0xF0 | (c >> 18)] +
+           hexTable[0x80 | ((c >> 12) & 0x3F)] +
+           hexTable[0x80 | ((c >> 6) & 0x3F)] +
+           hexTable[0x80 | (c & 0x3F)];
+  }
+  if (lastPos === 0)
+    return str;
+  if (lastPos < len)
+    return out + str.slice(lastPos);
+  return out;
+}
+
 module.exports = {
+  encodeStr,
   hexTable,
   isHexTable
 };

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -2,6 +2,7 @@
 
 const util = require('util');
 const {
+  encodeStr,
   hexTable,
   isHexTable
 } = require('internal/querystring');
@@ -825,70 +826,6 @@ const noEscape = [
 // Special version of hexTable that uses `+` for U+0020 SPACE.
 const paramHexTable = hexTable.slice();
 paramHexTable[0x20] = '+';
-
-function encodeStr(str, noEscapeTable, hexTable) {
-  const len = str.length;
-  if (len === 0)
-    return '';
-
-  var out = '';
-  var lastPos = 0;
-
-  for (var i = 0; i < len; i++) {
-    var c = str.charCodeAt(i);
-
-    // ASCII
-    if (c < 0x80) {
-      if (noEscapeTable[c] === 1)
-        continue;
-      if (lastPos < i)
-        out += str.slice(lastPos, i);
-      lastPos = i + 1;
-      out += hexTable[c];
-      continue;
-    }
-
-    if (lastPos < i)
-      out += str.slice(lastPos, i);
-
-    // Multi-byte characters ...
-    if (c < 0x800) {
-      lastPos = i + 1;
-      out += hexTable[0xC0 | (c >> 6)] +
-             hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    if (c < 0xD800 || c >= 0xE000) {
-      lastPos = i + 1;
-      out += hexTable[0xE0 | (c >> 12)] +
-             hexTable[0x80 | ((c >> 6) & 0x3F)] +
-             hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    // Surrogate pair
-    ++i;
-    var c2;
-    if (i < len)
-      c2 = str.charCodeAt(i) & 0x3FF;
-    else {
-      // This branch should never happen because all URLSearchParams entries
-      // should already be converted to USVString. But, included for
-      // completion's sake anyway.
-      c2 = 0;
-    }
-    lastPos = i + 1;
-    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
-    out += hexTable[0xF0 | (c >> 18)] +
-           hexTable[0x80 | ((c >> 12) & 0x3F)] +
-           hexTable[0x80 | ((c >> 6) & 0x3F)] +
-           hexTable[0x80 | (c & 0x3F)];
-  }
-  if (lastPos === 0)
-    return str;
-  if (lastPos < len)
-    return out + str.slice(lastPos);
-  return out;
-}
 
 // application/x-www-form-urlencoded serializer
 // Ref: https://url.spec.whatwg.org/#concept-urlencoded-serializer

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -24,8 +24,8 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { ERR_INVALID_URI } = require('internal/errors').codes;
 const {
+  encodeStr,
   hexTable,
   isHexTable
 } = require('internal/querystring');
@@ -140,59 +140,8 @@ function qsEscape(str) {
     else
       str += '';
   }
-  var out = '';
-  var lastPos = 0;
 
-  for (var i = 0; i < str.length; ++i) {
-    var c = str.charCodeAt(i);
-
-    // ASCII
-    if (c < 0x80) {
-      if (noEscape[c] === 1)
-        continue;
-      if (lastPos < i)
-        out += str.slice(lastPos, i);
-      lastPos = i + 1;
-      out += hexTable[c];
-      continue;
-    }
-
-    if (lastPos < i)
-      out += str.slice(lastPos, i);
-
-    // Multi-byte characters ...
-    if (c < 0x800) {
-      lastPos = i + 1;
-      out += hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    if (c < 0xD800 || c >= 0xE000) {
-      lastPos = i + 1;
-      out += hexTable[0xE0 | (c >> 12)] +
-             hexTable[0x80 | ((c >> 6) & 0x3F)] +
-             hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    // Surrogate pair
-    ++i;
-
-    if (i >= str.length)
-      throw new ERR_INVALID_URI();
-
-    var c2 = str.charCodeAt(i) & 0x3FF;
-
-    lastPos = i + 1;
-    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
-    out += hexTable[0xF0 | (c >> 18)] +
-           hexTable[0x80 | ((c >> 12) & 0x3F)] +
-           hexTable[0x80 | ((c >> 6) & 0x3F)] +
-           hexTable[0x80 | (c & 0x3F)];
-  }
-  if (lastPos === 0)
-    return str;
-  if (lastPos < str.length)
-    return out + str.slice(lastPos);
-  return out;
+  return encodeStr(str, noEscape, hexTable);
 }
 
 function stringifyPrimitive(v) {


### PR DESCRIPTION
The [encodeStr](https://github.com/nodejs/node/blob/master/lib/internal/url.js#L829) function and [qsEscape](https://github.com/nodejs/node/blob/master/lib/querystring.js#L136) function are almost the same.  
Extract encodeStr function and move it to internal for reusable.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @mscdex 