### PR TITLE
querystring: simplify charCodes function

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -247,7 +247,9 @@ function stringify(obj, sep, eq, options) {
 }
 
 function charCodes(str) {
-  const ret = [...str];
+  if (str.length === 0) return [];
+  if (str.length === 1) return [str.charCodeAt(0)];
+  const ret = [];
   for (var i = 0; i < str.length; ++i)
     ret[i] = str.charCodeAt(i);
   return ret;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -247,11 +247,9 @@ function stringify(obj, sep, eq, options) {
 }
 
 function charCodes(str) {
-  if (str.length === 0) return [];
-  if (str.length === 1) return [str.charCodeAt(0)];
-  const ret = [];
+  const ret = [...str];
   for (var i = 0; i < str.length; ++i)
-    ret[ret.length] = str.charCodeAt(i);
+    ret[i] = str.charCodeAt(i);
   return ret;
 }
 const defSepCodes = [38]; // &


### PR DESCRIPTION
Use spread operator to simplify `charCodes` function.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
