### PR TITLE
src, test: fix V8 compiler warnings

### DIFF
--- a/benchmark/napi/function_args/binding.cc
+++ b/benchmark/napi/function_args/binding.cc
@@ -33,7 +33,8 @@ void CallWithArray(const FunctionCallbackInfo<Value>& args) {
     uint32_t length = array->Length();
     for (uint32_t i = 0; i < length; ++ i) {
       Local<Value> v;
-      v = array->Get(i);
+      v = array->Get(args.GetIsolate()->GetCurrentContext(),
+                     i).ToLocalChecked();
     }
   }
 }

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -537,6 +537,7 @@ to invoke such callbacks:
 
 namespace demo {
 
+using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
@@ -549,13 +550,14 @@ using v8::Value;
 
 void RunCallback(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
   Local<Function> cb = Local<Function>::Cast(args[0]);
   const unsigned argc = 1;
   Local<Value> argv[argc] = {
       String::NewFromUtf8(isolate,
                           "hello world",
                           NewStringType::kNormal).ToLocalChecked() };
-  cb->Call(Null(isolate), argc, argv);
+  cb->Call(context, Null(isolate), argc, argv).ToLocalChecked();
 }
 
 void Init(Local<Object> exports, Local<Object> module) {
@@ -612,10 +614,12 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Local<Context> context = isolate->GetCurrentContext();
 
   Local<Object> obj = Object::New(isolate);
-  obj->Set(String::NewFromUtf8(isolate,
+  obj->Set(context,
+           String::NewFromUtf8(isolate,
                                "msg",
                                NewStringType::kNormal).ToLocalChecked(),
-                               args[0]->ToString(context).ToLocalChecked());
+                               args[0]->ToString(context).ToLocalChecked())
+           .FromJust();
 
   args.GetReturnValue().Set(obj);
 }
@@ -803,9 +807,9 @@ void MyObject::Init(Local<Object> exports) {
 
   Local<Context> context = isolate->GetCurrentContext();
   constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
-  exports->Set(String::NewFromUtf8(
+  exports->Set(context, String::NewFromUtf8(
       isolate, "MyObject", NewStringType::kNormal).ToLocalChecked(),
-               tpl->GetFunction(context).ToLocalChecked());
+               tpl->GetFunction(context).ToLocalChecked()).FromJust();
 }
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1851,7 +1851,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
           continue;
 
         Local<String> s = OneByteString(env->isolate(), ip);
-        results->Set(n, s);
+        results->Set(env->context(), n, s).FromJust();
         n++;
       }
     };
@@ -2053,10 +2053,12 @@ void GetServers(const FunctionCallbackInfo<Value>& args) {
     CHECK_EQ(err, 0);
 
     Local<Array> ret = Array::New(env->isolate(), 2);
-    ret->Set(0, OneByteString(env->isolate(), ip));
-    ret->Set(1, Integer::New(env->isolate(), cur->udp_port));
+    ret->Set(env->context(), 0, OneByteString(env->isolate(), ip)).FromJust();
+    ret->Set(env->context(),
+             1,
+             Integer::New(env->isolate(), cur->udp_port)).FromJust();
 
-    server_array->Set(i, ret);
+    server_array->Set(env->context(), i, ret).FromJust();
   }
 
   ares_free_data(servers);
@@ -2179,16 +2181,19 @@ void Initialize(Local<Object> target,
 
   env->SetMethod(target, "strerror", StrError);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET"),
-              Integer::New(env->isolate(), AF_INET));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET6"),
-              Integer::New(env->isolate(), AF_INET6));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AF_UNSPEC"),
-              Integer::New(env->isolate(), AF_UNSPEC));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_ADDRCONFIG"),
-              Integer::New(env->isolate(), AI_ADDRCONFIG));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "AI_V4MAPPED"),
-              Integer::New(env->isolate(), AI_V4MAPPED));
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET"),
+              Integer::New(env->isolate(), AF_INET)).FromJust();
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "AF_INET6"),
+              Integer::New(env->isolate(), AF_INET6)).FromJust();
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
+                                                    "AF_UNSPEC"),
+              Integer::New(env->isolate(), AF_UNSPEC)).FromJust();
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
+                                                    "AI_ADDRCONFIG"),
+              Integer::New(env->isolate(), AI_ADDRCONFIG)).FromJust();
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(),
+                                                    "AI_V4MAPPED"),
+              Integer::New(env->isolate(), AI_V4MAPPED)).FromJust();
 
   Local<FunctionTemplate> aiw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2196,7 +2201,9 @@ void Initialize(Local<Object> target,
   Local<String> addrInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap");
   aiw->SetClassName(addrInfoWrapString);
-  target->Set(addrInfoWrapString, aiw->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(),
+              addrInfoWrapString,
+              aiw->GetFunction(context).ToLocalChecked()).FromJust();
 
   Local<FunctionTemplate> niw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2204,7 +2211,9 @@ void Initialize(Local<Object> target,
   Local<String> nameInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap");
   niw->SetClassName(nameInfoWrapString);
-  target->Set(nameInfoWrapString, niw->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(),
+              nameInfoWrapString,
+              niw->GetFunction(context).ToLocalChecked()).FromJust();
 
   Local<FunctionTemplate> qrw =
       BaseObject::MakeLazilyInitializedJSTemplate(env);
@@ -2212,7 +2221,9 @@ void Initialize(Local<Object> target,
   Local<String> queryWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap");
   qrw->SetClassName(queryWrapString);
-  target->Set(queryWrapString, qrw->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(),
+              queryWrapString,
+              qrw->GetFunction(context).ToLocalChecked()).FromJust();
 
   Local<FunctionTemplate> channel_wrap =
       env->NewFunctionTemplate(ChannelWrap::New);
@@ -2239,8 +2250,8 @@ void Initialize(Local<Object> target,
   Local<String> channelWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap");
   channel_wrap->SetClassName(channelWrapString);
-  target->Set(channelWrapString,
-              channel_wrap->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(), channelWrapString,
+              channel_wrap->GetFunction(context).ToLocalChecked()).FromJust();
 }
 
 }  // anonymous namespace

--- a/src/env.cc
+++ b/src/env.cc
@@ -755,7 +755,9 @@ void CollectExceptionInfo(Environment* env,
                           const char* message,
                           const char* path,
                           const char* dest) {
-  obj->Set(env->errno_string(), v8::Integer::New(env->isolate(), errorno));
+  obj->Set(env->context(),
+           env->errno_string(),
+           v8::Integer::New(env->isolate(), errorno)).FromJust();
 
   obj->Set(env->context(), env->code_string(),
            OneByteString(env->isolate(), err_string)).FromJust();

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -51,15 +51,19 @@ Local<Value> ErrnoException(Isolate* isolate,
   e = Exception::Error(cons);
 
   Local<Object> obj = e.As<Object>();
-  obj->Set(env->errno_string(), Integer::New(isolate, errorno));
-  obj->Set(env->code_string(), estring);
+  obj->Set(env->context(),
+           env->errno_string(),
+           Integer::New(isolate, errorno)).FromJust();
+  obj->Set(env->context(), env->code_string(), estring).FromJust();
 
   if (path_string.IsEmpty() == false) {
-    obj->Set(env->path_string(), path_string);
+    obj->Set(env->context(), env->path_string(), path_string).FromJust();
   }
 
   if (syscall != nullptr) {
-    obj->Set(env->syscall_string(), OneByteString(isolate, syscall));
+    obj->Set(env->context(),
+             env->syscall_string(),
+             OneByteString(isolate, syscall)).FromJust();
   }
 
   return e;
@@ -132,13 +136,15 @@ Local<Value> UVException(Isolate* isolate,
     Exception::Error(js_msg)->ToObject(isolate->GetCurrentContext())
       .ToLocalChecked();
 
-  e->Set(env->errno_string(), Integer::New(isolate, errorno));
-  e->Set(env->code_string(), js_code);
-  e->Set(env->syscall_string(), js_syscall);
+  e->Set(env->context(),
+         env->errno_string(),
+         Integer::New(isolate, errorno)).FromJust();
+  e->Set(env->context(), env->code_string(), js_code).FromJust();
+  e->Set(env->context(), env->syscall_string(), js_syscall).FromJust();
   if (!js_path.IsEmpty())
-    e->Set(env->path_string(), js_path);
+    e->Set(env->context(), env->path_string(), js_path).FromJust();
   if (!js_dest.IsEmpty())
-    e->Set(env->dest_string(), js_dest);
+    e->Set(env->context(), env->dest_string(), js_dest).FromJust();
 
   return e;
 }

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -119,7 +119,9 @@ void FSEventWrap::Initialize(Local<Object> target,
       Local<FunctionTemplate>(),
       static_cast<PropertyAttribute>(ReadOnly | DontDelete | v8::DontEnum));
 
-  target->Set(fsevent_string, t->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(),
+              fsevent_string,
+              t->GetFunction(context).ToLocalChecked()).FromJust();
 }
 
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -118,7 +118,7 @@ int JSStream::DoWrite(WriteWrap* w,
   Local<Object> buf;
   for (size_t i = 0; i < count; i++) {
     buf = Buffer::Copy(env(), bufs[i].base, bufs[i].len).ToLocalChecked();
-    bufs_arr->Set(i, buf);
+    bufs_arr->Set(env()->context(), i, buf).FromJust();
   }
 
   Local<Value> argv[] = {
@@ -210,7 +210,9 @@ void JSStream::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "emitEOF", EmitEOF);
 
   StreamBase::AddMethods<JSStream>(env, t);
-  target->Set(jsStreamString, t->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(),
+              jsStreamString,
+              t->GetFunction(context).ToLocalChecked()).FromJust();
 }
 
 }  // namespace node

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -837,8 +837,8 @@ void ModuleWrap::Initialize(Local<Object> target,
   env->SetProtoMethodNoSideEffect(tpl, "getStaticDependencySpecifiers",
                                   GetStaticDependencySpecifiers);
 
-  target->Set(FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"),
-              tpl->GetFunction(context).ToLocalChecked());
+  target->Set(env->context(), FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"),
+              tpl->GetFunction(context).ToLocalChecked()).FromJust();
   env->SetMethod(target, "resolve", Resolve);
   env->SetMethod(target,
                  "setImportModuleDynamicallyCallback",

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1347,15 +1347,33 @@ void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
   // Define libuv constants.
   NODE_DEFINE_CONSTANT(os_constants, UV_UDP_REUSEADDR);
 
-  os_constants->Set(OneByteString(isolate, "dlopen"), dlopen_constants);
-  os_constants->Set(OneByteString(isolate, "errno"), err_constants);
-  os_constants->Set(OneByteString(isolate, "signals"), sig_constants);
-  os_constants->Set(OneByteString(isolate, "priority"), priority_constants);
-  target->Set(OneByteString(isolate, "os"), os_constants);
-  target->Set(OneByteString(isolate, "fs"), fs_constants);
-  target->Set(OneByteString(isolate, "crypto"), crypto_constants);
-  target->Set(OneByteString(isolate, "zlib"), zlib_constants);
-  target->Set(OneByteString(isolate, "trace"), trace_constants);
+  os_constants->Set(env->context(),
+                    OneByteString(isolate, "dlopen"),
+                    dlopen_constants).FromJust();
+  os_constants->Set(env->context(),
+                    OneByteString(isolate, "errno"),
+                    err_constants).FromJust();
+  os_constants->Set(env->context(),
+                    OneByteString(isolate, "signals"),
+                    sig_constants).FromJust();
+  os_constants->Set(env->context(),
+                    OneByteString(isolate, "priority"),
+                    priority_constants).FromJust();
+  target->Set(env->context(),
+              OneByteString(isolate, "os"),
+              os_constants).FromJust();
+  target->Set(env->context(),
+              OneByteString(isolate, "fs"),
+              fs_constants).FromJust();
+  target->Set(env->context(),
+              OneByteString(isolate, "crypto"),
+              crypto_constants).FromJust();
+  target->Set(env->context(),
+              OneByteString(isolate, "zlib"),
+              zlib_constants).FromJust();
+  target->Set(env->context(),
+              OneByteString(isolate, "trace"),
+              trace_constants).FromJust();
 }
 
 }  // namespace node

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -640,8 +640,14 @@ void AfterScanDirWithTypes(uv_fs_t* req) {
   }
 
   Local<Array> result = Array::New(isolate, 2);
-  result->Set(0, Array::New(isolate, name_v.data(), name_v.size()));
-  result->Set(1, Array::New(isolate, type_v.data(), type_v.size()));
+  result->Set(env->context(),
+              0,
+              Array::New(isolate, name_v.data(),
+              name_v.size())).FromJust();
+  result->Set(env->context(),
+              1,
+              Array::New(isolate, type_v.data(),
+              type_v.size())).FromJust();
   req_wrap->Resolve(result);
 }
 
@@ -1482,8 +1488,11 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     Local<Array> names = Array::New(isolate, name_v.data(), name_v.size());
     if (with_types) {
       Local<Array> result = Array::New(isolate, 2);
-      result->Set(0, names);
-      result->Set(1, Array::New(isolate, type_v.data(), type_v.size()));
+      result->Set(env->context(), 0, names).FromJust();
+      result->Set(env->context(),
+                  1,
+                  Array::New(isolate, type_v.data(),
+                             type_v.size())).FromJust();
       args.GetReturnValue().Set(result);
     } else {
       args.GetReturnValue().Set(names);
@@ -1667,7 +1676,7 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
   MaybeStackBuffer<uv_buf_t> iovs(chunks->Length());
 
   for (uint32_t i = 0; i < iovs.length(); i++) {
-    Local<Value> chunk = chunks->Get(i);
+    Local<Value> chunk = chunks->Get(env->context(), i).ToLocalChecked();
     CHECK(Buffer::HasInstance(chunk));
     iovs[i] = uv_buf_init(Buffer::Data(chunk), Buffer::Length(chunk));
   }

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3057,8 +3057,10 @@ void Initialize(Local<Object> target,
 
 #define V(name)                                                         \
   NODE_DEFINE_CONSTANT(constants, name);                                \
-  name_for_error_code->Set(static_cast<int>(name),                      \
-                           FIXED_ONE_BYTE_STRING(isolate, #name));
+  name_for_error_code->Set(env->context(),                              \
+                           static_cast<int>(name),                      \
+                           FIXED_ONE_BYTE_STRING(isolate,               \
+                                                 #name)).FromJust();
   NODE_NGHTTP2_ERROR_CODES(V)
 #undef V
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -488,7 +488,8 @@ void GetGroups(const FunctionCallbackInfo<Value>& args) {
   gid_t egid = getegid();
 
   for (int i = 0; i < ngroups; i++) {
-    groups_list->Set(i, Integer::New(env->isolate(), groups[i]));
+    groups_list->Set(env->context(),
+                     i, Integer::New(env->isolate(), groups[i])).FromJust();
     if (groups[i] == egid)
       seen_egid = true;
   }
@@ -496,7 +497,9 @@ void GetGroups(const FunctionCallbackInfo<Value>& args) {
   delete[] groups;
 
   if (seen_egid == false)
-    groups_list->Set(ngroups, Integer::New(env->isolate(), egid));
+    groups_list->Set(env->context(),
+                     ngroups,
+                     Integer::New(env->isolate(), egid)).FromJust();
 
   args.GetReturnValue().Set(groups_list);
 }
@@ -513,7 +516,9 @@ void SetGroups(const FunctionCallbackInfo<Value>& args) {
   gid_t* groups = new gid_t[size];
 
   for (size_t i = 0; i < size; i++) {
-    gid_t gid = gid_by_name(env->isolate(), groups_list->Get(i));
+    gid_t gid = gid_by_name(env->isolate(),
+                            groups_list->Get(env->context(),
+                                             i).ToLocalChecked());
 
     if (gid == gid_not_found) {
       delete[] groups;

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -54,8 +54,8 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
 
   env->SetProtoMethod(t, "start", StatWatcher::Start);
 
-  target->Set(statWatcherString,
-              t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(), statWatcherString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
 }
 
 

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -110,8 +110,10 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(category_set, "enable", NodeCategorySet::Enable);
   env->SetProtoMethod(category_set, "disable", NodeCategorySet::Disable);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "CategorySet"),
-              category_set->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "CategorySet"),
+              category_set->GetFunction(env->context()).ToLocalChecked())
+              .FromJust();
 
   Local<String> isTraceCategoryEnabled =
       FIXED_ONE_BYTE_STRING(env->isolate(), "isTraceCategoryEnabled");

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -57,6 +57,7 @@ static void GetOwnNonIndexProperties(
 }
 
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
     return;
@@ -67,14 +68,15 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   Local<Array> ret = Array::New(isolate, 2);
 
   int state = promise->State();
-  ret->Set(0, Integer::New(isolate, state));
+  ret->Set(env->context(), 0, Integer::New(isolate, state)).FromJust();
   if (state != Promise::PromiseState::kPending)
-    ret->Set(1, promise->Result());
+    ret->Set(env->context(), 1, promise->Result()).FromJust();
 
   args.GetReturnValue().Set(ret);
 }
 
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;
@@ -82,8 +84,8 @@ static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
   Local<Proxy> proxy = args[0].As<Proxy>();
 
   Local<Array> ret = Array::New(args.GetIsolate(), 2);
-  ret->Set(0, proxy->GetTarget());
-  ret->Set(1, proxy->GetHandler());
+  ret->Set(env->context(), 0, proxy->GetTarget()).FromJust();
+  ret->Set(env->context(), 1, proxy->GetHandler()).FromJust();
 
   args.GetReturnValue().Set(ret);
 }

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -134,23 +134,27 @@ void Initialize(Local<Object> target,
   const size_t heap_statistics_buffer_byte_length =
       sizeof(*env->heap_statistics_buffer()) * kHeapStatisticsPropertiesCount;
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapStatisticsArrayBuffer"),
               ArrayBuffer::New(env->isolate(),
                                env->heap_statistics_buffer(),
-                               heap_statistics_buffer_byte_length));
+                               heap_statistics_buffer_byte_length)).FromJust();
 
 #define V(i, _, name)                                                         \
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Uint32::NewFromUnsigned(env->isolate(), i));
+  target->Set(env->context(),                                                 \
+              FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
+              Uint32::NewFromUnsigned(env->isolate(), i)).FromJust();
 
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "kHeapSpaceStatisticsPropertiesCount"),
               Uint32::NewFromUnsigned(env->isolate(),
-                                      kHeapSpaceStatisticsPropertiesCount));
+                                      kHeapSpaceStatisticsPropertiesCount))
+              .FromJust();
 
   size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
 
@@ -165,10 +169,11 @@ void Initialize(Local<Object> target,
                                                         s.space_name(),
                                                         NewStringType::kNormal)
                                         .ToLocalChecked();
-    heap_spaces->Set(i, heap_space_name);
+    heap_spaces->Set(env->context(), i, heap_space_name).FromJust();
   }
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kHeapSpaces"),
-              heap_spaces);
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "kHeapSpaces"),
+              heap_spaces).FromJust();
 
   env->SetMethod(target,
                  "updateHeapSpaceStatisticsArrayBuffer",
@@ -182,15 +187,18 @@ void Initialize(Local<Object> target,
       kHeapSpaceStatisticsPropertiesCount *
       number_of_heap_spaces;
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(),
                                     "heapSpaceStatisticsArrayBuffer"),
               ArrayBuffer::New(env->isolate(),
                                env->heap_space_statistics_buffer(),
-                               heap_space_statistics_buffer_byte_length));
+                               heap_space_statistics_buffer_byte_length))
+              .FromJust();
 
 #define V(i, _, name)                                                         \
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Uint32::NewFromUnsigned(env->isolate(), i));
+  target->Set(env->context(),                                                 \
+              FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
+              Uint32::NewFromUnsigned(env->isolate(), i)).FromJust();
 
   HEAP_SPACE_STATISTICS_PROPERTIES(V)
 #undef V

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -490,7 +490,9 @@ void InitWorker(Local<Object> target,
     Local<String> workerString =
         FIXED_ONE_BYTE_STRING(env->isolate(), "Worker");
     w->SetClassName(workerString);
-    target->Set(workerString, w->GetFunction(env->context()).ToLocalChecked());
+    target->Set(env->context(),
+                workerString,
+                w->GetFunction(env->context()).ToLocalChecked()).FromJust();
   }
 
   env->SetMethod(target, "getEnvMessagePort", GetEnvMessagePort);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -896,10 +896,13 @@ void Initialize(Local<Object> target,
 
   Local<String> zlibString = FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib");
   z->SetClassName(zlibString);
-  target->Set(zlibString, z->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              zlibString,
+              z->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
-              FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
+              FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION)).FromJust();
 }
 
 }  // anonymous namespace

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -90,7 +90,9 @@ void PipeWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "fchmod", Fchmod);
 
-  target->Set(pipeString, t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              pipeString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_pipe_constructor_template(t);
 
   // Create FunctionTemplate for PipeConnectWrap.
@@ -99,7 +101,9 @@ void PipeWrap::Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap");
   cwt->SetClassName(wrapString);
-  target->Set(wrapString, cwt->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              wrapString,
+              cwt->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -62,8 +62,9 @@ class ProcessWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "spawn", Spawn);
     env->SetProtoMethod(constructor, "kill", Kill);
 
-    target->Set(processString,
-                constructor->GetFunction(context).ToLocalChecked());
+    target->Set(env->context(),
+                processString,
+                constructor->GetFunction(context).ToLocalChecked()).FromJust();
   }
 
   SET_NO_MEMORY_INFO()

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -55,8 +55,9 @@ class SignalWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 
-    target->Set(signalString,
-                constructor->GetFunction(env->context()).ToLocalChecked());
+    target->Set(env->context(), signalString,
+                constructor->GetFunction(env->context()).ToLocalChecked())
+                .FromJust();
   }
 
   SET_NO_MEMORY_INFO()

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -179,7 +179,9 @@ inline int StreamBase::Shutdown(v8::Local<v8::Object> req_wrap_obj) {
 
   const char* msg = Error();
   if (msg != nullptr) {
-    req_wrap_obj->Set(env->error_string(), OneByteString(env->isolate(), msg));
+    req_wrap_obj->Set(
+        env->context(),
+        env->error_string(), OneByteString(env->isolate(), msg)).FromJust();
     ClearError();
   }
 
@@ -228,7 +230,9 @@ inline StreamWriteResult StreamBase::Write(
 
   const char* msg = Error();
   if (msg != nullptr) {
-    req_wrap_obj->Set(env->error_string(), OneByteString(env->isolate(), msg));
+    req_wrap_obj->Set(env->context(),
+                      env->error_string(),
+                      OneByteString(env->isolate(), msg)).FromJust();
     ClearError();
   }
 
@@ -434,8 +438,10 @@ inline void StreamReq::Done(int status, const char* error_str) {
   AsyncWrap* async_wrap = GetAsyncWrap();
   Environment* env = async_wrap->env();
   if (error_str != nullptr) {
-    async_wrap->object()->Set(env->error_string(),
-                              OneByteString(env->isolate(), error_str));
+    async_wrap->object()->Set(env->context(),
+                              env->error_string(),
+                              OneByteString(env->isolate(), error_str))
+                              .FromJust();
   }
 
   OnDone(status);

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -83,7 +83,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   if (!all_buffers) {
     // Determine storage size first
     for (size_t i = 0; i < count; i++) {
-      Local<Value> chunk = chunks->Get(i * 2);
+      Local<Value> chunk = chunks->Get(env->context(), i * 2).ToLocalChecked();
 
       if (Buffer::HasInstance(chunk))
         continue;
@@ -92,7 +92,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
       // String chunk
       Local<String> string = chunk->ToString(env->context()).ToLocalChecked();
       enum encoding encoding = ParseEncoding(env->isolate(),
-                                             chunks->Get(i * 2 + 1));
+          chunks->Get(env->context(), i * 2 + 1).ToLocalChecked());
       size_t chunk_size;
       if (encoding == UTF8 && string->Length() > 65535 &&
           !StringBytes::Size(env->isolate(), string, encoding).To(&chunk_size))
@@ -107,7 +107,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
       return UV_ENOBUFS;
   } else {
     for (size_t i = 0; i < count; i++) {
-      Local<Value> chunk = chunks->Get(i);
+      Local<Value> chunk = chunks->Get(env->context(), i).ToLocalChecked();
       bufs[i].base = Buffer::Data(chunk);
       bufs[i].len = Buffer::Length(chunk);
     }
@@ -120,7 +120,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   offset = 0;
   if (!all_buffers) {
     for (size_t i = 0; i < count; i++) {
-      Local<Value> chunk = chunks->Get(i * 2);
+      Local<Value> chunk = chunks->Get(env->context(), i * 2).ToLocalChecked();
 
       // Write buffer
       if (Buffer::HasInstance(chunk)) {
@@ -136,7 +136,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
       Local<String> string = chunk->ToString(env->context()).ToLocalChecked();
       enum encoding encoding = ParseEncoding(env->isolate(),
-                                             chunks->Get(i * 2 + 1));
+          chunks->Get(env->context(), i * 2 + 1).ToLocalChecked());
       str_size = StringBytes::Write(env->isolate(),
                                     str_storage,
                                     str_size,
@@ -270,7 +270,9 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
     send_handle = reinterpret_cast<uv_stream_t*>(wrap->GetHandle());
     // Reference LibuvStreamWrap instance to prevent it from being garbage
     // collected before `AfterWrite` is called.
-    req_wrap_obj->Set(env->handle_string(), send_handle_obj);
+    req_wrap_obj->Set(env->context(),
+                      env->handle_string(),
+                      send_handle_obj).FromJust();
   }
 
   StreamWriteResult res = Write(&buf, 1, send_handle, req_wrap_obj);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -67,7 +67,9 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
       FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap");
   sw->SetClassName(wrapString);
   sw->Inherit(AsyncWrap::GetConstructorTemplate(env));
-  target->Set(wrapString, sw->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              wrapString,
+              sw->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_shutdown_wrap_template(sw->InstanceTemplate());
 
   Local<FunctionTemplate> ww =
@@ -77,8 +79,9 @@ void LibuvStreamWrap::Initialize(Local<Object> target,
       FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap");
   ww->SetClassName(writeWrapString);
   ww->Inherit(AsyncWrap::GetConstructorTemplate(env));
-  target->Set(writeWrapString,
-              ww->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              writeWrapString,
+              ww->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_write_wrap_template(ww->InstanceTemplate());
 
   NODE_DEFINE_CONSTANT(target, kReadBytesOrError);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -107,7 +107,9 @@ void TCPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
 
-  target->Set(tcpString, t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              tcpString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_tcp_constructor_template(t);
 
   // Create FunctionTemplate for TCPConnectWrap.
@@ -117,7 +119,9 @@ void TCPWrap::Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap");
   cwt->SetClassName(wrapString);
-  target->Set(wrapString, cwt->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              wrapString,
+              cwt->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
   // Define constants
   Local<Object> constants = Object::New(env->isolate());
@@ -349,22 +353,36 @@ Local<Object> AddressToJS(Environment* env,
     a6 = reinterpret_cast<const sockaddr_in6*>(addr);
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
     port = ntohs(a6->sin6_port);
-    info->Set(env->address_string(), OneByteString(env->isolate(), ip));
-    info->Set(env->family_string(), env->ipv6_string());
-    info->Set(env->port_string(), Integer::New(env->isolate(), port));
+    info->Set(env->context(),
+              env->address_string(),
+              OneByteString(env->isolate(), ip)).FromJust();
+    info->Set(env->context(),
+              env->family_string(),
+              env->ipv6_string()).FromJust();
+    info->Set(env->context(),
+              env->port_string(),
+              Integer::New(env->isolate(), port)).FromJust();
     break;
 
   case AF_INET:
     a4 = reinterpret_cast<const sockaddr_in*>(addr);
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
-    info->Set(env->address_string(), OneByteString(env->isolate(), ip));
-    info->Set(env->family_string(), env->ipv4_string());
-    info->Set(env->port_string(), Integer::New(env->isolate(), port));
+    info->Set(env->context(),
+              env->address_string(),
+              OneByteString(env->isolate(), ip)).FromJust();
+    info->Set(env->context(),
+              env->family_string(),
+              env->ipv4_string()).FromJust();
+    info->Set(env->context(),
+              env->port_string(),
+              Integer::New(env->isolate(), port)).FromJust();
     break;
 
   default:
-    info->Set(env->address_string(), String::Empty(env->isolate()));
+    info->Set(env->context(),
+              env->address_string(),
+              String::Empty(env->isolate())).FromJust();
   }
 
   return scope.Escape(info);

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -909,7 +909,9 @@ void TLSWrap::Initialize(Local<Object> target,
   env->set_tls_wrap_constructor_function(
       t->GetFunction(env->context()).ToLocalChecked());
 
-  target->Set(tlsWrapString, t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              tlsWrapString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
 }
 
 }  // namespace node

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -59,7 +59,9 @@ void TTYWrap::Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "isTTY", IsTTY);
   env->SetMethodNoSideEffect(target, "guessHandleType", GuessHandleType);
 
-  target->Set(ttyString, t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              ttyString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_tty_constructor_template(t);
 }
 
@@ -112,8 +114,8 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 
   if (err == 0) {
     Local<v8::Array> a = args[0].As<Array>();
-    a->Set(0, Integer::New(env->isolate(), width));
-    a->Set(1, Integer::New(env->isolate(), height));
+    a->Set(env->context(), 0, Integer::New(env->isolate(), width)).FromJust();
+    a->Set(env->context(), 1, Integer::New(env->isolate(), height)).FromJust();
   }
 
   args.GetReturnValue().Set(err);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -133,7 +133,9 @@ void UDPWrap::Initialize(Local<Object> target,
 
   t->Inherit(HandleWrap::GetConstructorTemplate(env));
 
-  target->Set(udpString, t->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              udpString,
+              t->GetFunction(env->context()).ToLocalChecked()).FromJust();
   env->set_udp_constructor_function(
       t->GetFunction(env->context()).ToLocalChecked());
 
@@ -144,8 +146,9 @@ void UDPWrap::Initialize(Local<Object> target,
   Local<String> sendWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap");
   swt->SetClassName(sendWrapString);
-  target->Set(sendWrapString,
-              swt->GetFunction(env->context()).ToLocalChecked());
+  target->Set(env->context(),
+              sendWrapString,
+              swt->GetFunction(env->context()).ToLocalChecked()).FromJust();
 }
 
 
@@ -373,7 +376,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
 
   // construct uv_buf_t array
   for (size_t i = 0; i < count; i++) {
-    Local<Value> chunk = chunks->Get(i);
+    Local<Value> chunk = chunks->Get(env->context(), i).ToLocalChecked();
 
     size_t length = Buffer::Length(chunk);
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -63,10 +63,11 @@ void Initialize(Local<Object> target,
                 Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  target->Set(FIXED_ONE_BYTE_STRING(isolate, "errname"),
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(isolate, "errname"),
               env->NewFunctionTemplate(ErrName)
                   ->GetFunction(env->context())
-                  .ToLocalChecked());
+                  .ToLocalChecked()).FromJust();
 
 #define V(name, _) NODE_DEFINE_CONSTANT(target, UV_##name);
   UV_ERRNO_MAP(V)
@@ -76,8 +77,8 @@ void Initialize(Local<Object> target,
 
 #define V(name, msg) do {                                                     \
   Local<Array> arr = Array::New(isolate, 2);                                  \
-  arr->Set(0, OneByteString(isolate, #name));                                 \
-  arr->Set(1, OneByteString(isolate, msg));                                   \
+  arr->Set(env->context(), 0, OneByteString(isolate, #name)).FromJust();      \
+  arr->Set(env->context(), 1, OneByteString(isolate, msg)).FromJust();        \
   err_map->Set(context,                                                       \
                Integer::New(isolate, UV_##name),                              \
                arr).ToLocalChecked();                                         \

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -53,7 +53,8 @@ void AfterAsync(uv_work_t* r) {
     // This should be changed to an empty handle.
     assert(!ret.IsEmpty());
   } else {
-    callback->Call(global, 2, argv);
+    callback->Call(isolate->GetCurrentContext(),
+                   global, 2, argv).ToLocalChecked();
   }
 
   // cleanup

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -19,11 +19,11 @@ inline void Test(const v8::FunctionCallbackInfo<v8::Value>& args) {
 inline void Initialize(v8::Local<v8::Object> binding) {
   v8::Isolate* const isolate = binding->GetIsolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  binding->Set(v8::String::NewFromUtf8(
+  binding->Set(context, v8::String::NewFromUtf8(
         isolate, "test", v8::NewStringType::kNormal).ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, Test)
                    ->GetFunction(context)
-                   .ToLocalChecked());
+                   .ToLocalChecked()).FromJust();
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -12,11 +12,11 @@ inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>& args) {
 inline void Initialize(v8::Local<v8::Object> binding) {
   auto isolate = binding->GetIsolate();
   auto context = isolate->GetCurrentContext();
-  binding->Set(v8::String::NewFromUtf8(
+  binding->Set(context, v8::String::NewFromUtf8(
         isolate, "Class", v8::NewStringType::kNormal).ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, NewClass)
                    ->GetFunction(context)
-                   .ToLocalChecked());
+                   .ToLocalChecked()).FromJust();
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)


### PR DESCRIPTION
This pull request follows up on https://github.com/nodejs/node/pull/24060 and attempts to fix all the remaining v8 warnings regarding Set/Get.

~There is currently one warning still being generated from [src/node.cc]~(https://github.com/nodejs/node/commit/a52528321fb5f493ed70b981900e4bca5aa109e9#diff-cd53544f44aab2c697bcd7b6a57f23ccR675-677)

~I've left a comment in the code as I was not sure how to get the correct context. Hopefully someone can help out and advise on this.~


The commits are currently separate for each C++ source file but can be squashed unless anyone objects.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
