### PR TITLE
test: https agent clientcertengine coverage

### DIFF
--- a/test/parallel/test-https-agent-getname.js
+++ b/test/parallel/test-https-agent-getname.js
@@ -22,6 +22,7 @@ const options = {
   localAddress: '192.168.1.1',
   ca: 'ca',
   cert: 'cert',
+  clientCertEngine: 'dynamic',
   ciphers: 'ciphers',
   crl: [Buffer.from('c'), Buffer.from('r'), Buffer.from('l')],
   dhparam: 'dhparam',
@@ -38,6 +39,6 @@ const options = {
 
 assert.strictEqual(
   agent.getName(options),
-  '0.0.0.0:443:192.168.1.1:ca:cert::ciphers:key:pfx:false:localhost:' +
+  '0.0.0.0:443:192.168.1.1:ca:cert:dynamic:ciphers:key:pfx:false:localhost:' +
     'secureProtocol:c,r,l:false:ecdhCurve:dhparam:0:sessionIdContext'
 );


### PR DESCRIPTION
Code path for `clientCertEngine` in `getName` was not covered by the test.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
