### PR TITLE
test: add tests for Socket.setNoDelay

### DIFF
--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const truthyValues = [true, 1, 'true', {}, []];
+const falseyValues = [false, 0, ''];
+const genSetNoDelay = (desiredArg) => (enable) => {
+  assert.strictEqual(enable, desiredArg);
+};
+
+// setNoDelay should default to true
+let socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(genSetNoDelay(true))
+  }
+});
+socket.setNoDelay();
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(genSetNoDelay(true), truthyValues.length)
+  }
+});
+truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(genSetNoDelay(false), falseyValues.length)
+  }
+});
+falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+// if a handler doesn't have a setNoDelay function it shouldn't be called.
+// In the case below, if it is called an exception will be thrown
+socket = new net.Socket({
+  handle: {
+    setNoDelay: null
+  }
+});
+const returned = socket.setNoDelay(true);
+assert.ok(returned instanceof net.Socket);


### PR DESCRIPTION
Add tests for the Socket.setNoDelay function. The tests use the `handle` option when creating a socket so that the function can be tested without having to rely on any underlying transport layer which could result in a flakey test (platform/timing dependent).

I wasn't able to figure out how to test the case whereby `setNoDelay` is called before the socket connects - suggestions welcome here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
