### PR TITLE
test: fix flaky test-vm-timeout-escape-nexttick

### DIFF
--- a/test/known_issues/test-vm-timeout-escape-nexttick.js
+++ b/test/known_issues/test-vm-timeout-escape-nexttick.js
@@ -35,7 +35,7 @@ assert.throws(() => {
       nextTick,
       loop
     },
-    { timeout: common.platformTimeout(5) }
+    { timeout: common.platformTimeout(10) }
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT'


### PR DESCRIPTION
Increase the VM timeout. If it is too small, the VM does not exit before
the code has a chance to create the problematic condition that causes
the timeout to be ignored.

Fixes: https://github.com/nodejs/node/issues/24120

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
