### PR TITLE
WIP fs: implement fs.rmdir recursive

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2880,7 +2880,7 @@ changes:
 
 Synchronous rename(2). Returns `undefined`.
 
-## fs.rmdir(path, callback)
+## fs.rmdir(path[, options], callback)
 <!-- YAML
 added: v0.0.2
 changes:
@@ -2899,6 +2899,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `recursive` {boolean} **Default:** `false`
 * `callback` {Function}
   * `err` {Error}
 
@@ -2908,7 +2910,17 @@ to the completion callback.
 Using `fs.rmdir()` on a file (not a directory) results in an `ENOENT` error on
 Windows and an `ENOTDIR` error on POSIX.
 
-## fs.rmdirSync(path)
+The optional `options` argument can be an object with a `recursive` property
+indicating whether a folder with sub folders or files should be deleted.
+
+```js
+// Delete /path/to/foler, regardless of whether sub folders or files exist.
+fs.rmdir('/path/to/folder', { recursive: true }, (err) => {
+  if (err) throw err;
+});
+```
+
+## fs.rmdirSync(path[, options])
 <!-- YAML
 added: v0.1.21
 changes:
@@ -2919,6 +2931,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `recursive` {boolean} **Default:** `false`
 
 Synchronous rmdir(2). Returns `undefined`.
 
@@ -4336,12 +4350,14 @@ added: v10.0.0
 Renames `oldPath` to `newPath` and resolves the `Promise` with no arguments
 upon success.
 
-### fsPromises.rmdir(path)
+### fsPromises.rmdir(path[, options])
 <!-- YAML
 added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
+* `options` {Object}
+  * `recursive` {boolean} **Default:** `false`
 * Returns: {Promise}
 
 Removes the directory identified by `path` then resolves the `Promise` with
@@ -4835,7 +4851,7 @@ the file contents.
 [`fs.readFile()`]: #fs_fs_readfile_path_options_callback
 [`fs.readFileSync()`]: #fs_fs_readfilesync_path_options
 [`fs.realpath()`]: #fs_fs_realpath_path_options_callback
-[`fs.rmdir()`]: #fs_fs_rmdir_path_callback
+[`fs.rmdir()`]: #fs_fs_rmdir_path_options_callback
 [`fs.stat()`]: #fs_fs_stat_path_options_callback
 [`fs.symlink()`]: #fs_fs_symlink_target_path_type_callback
 [`fs.utimes()`]: #fs_fs_utimes_path_atime_mtime_callback

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -686,20 +686,34 @@ function ftruncateSync(fd, len = 0) {
   handleErrorFromBinding(ctx);
 }
 
-function rmdir(path, callback) {
+function rmdir(path, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  const {
+    recursive = false
+  } = options || {};
   callback = makeCallback(callback);
   path = toPathIfFileURL(path);
   validatePath(path);
+  if (typeof recursive !== 'boolean')
+    throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.rmdir(pathModule.toNamespacedPath(path), req);
+  binding.rmdir(pathModule.toNamespacedPath(path), recursive, req);
 }
 
-function rmdirSync(path) {
+function rmdirSync(path, options) {
   path = toPathIfFileURL(path);
+  const {
+    recursive = false
+  } = options || {};
   validatePath(path);
+  if (typeof recursive !== 'boolean')
+    throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
   const ctx = { path };
-  binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
+  binding.rmdir(pathModule.toNamespacedPath(path), recursive, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -278,10 +278,17 @@ async function ftruncate(handle, len = 0) {
   return binding.ftruncate(handle.fd, len, kUsePromises);
 }
 
-async function rmdir(path) {
+async function rmdir(path, options) {
+  const {
+    recursive = false
+  } = options || {};
   path = toPathIfFileURL(path);
   validatePath(path);
-  return binding.rmdir(pathModule.toNamespacedPath(path), kUsePromises);
+  if (typeof recursive !== 'boolean')
+    throw new ERR_INVALID_ARG_TYPE('recursive', 'boolean', recursive);
+  return binding.rmdir(pathModule.toNamespacedPath(path),
+                       recursive,
+                       kUsePromises);
 }
 
 async function fdatasync(handle) {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const paramdir = path.join(tmpdir.path, 'dir');
+
+// fs.rmdir - recursive: true
+{
+  const d = path.join(tmpdir.path, 'dir', 'test_rmdir');
+  // Make sure the directory does not exist
+  assert(!fs.existsSync(d));
+  // Create the directory now
+  fs.mkdirSync(d, { recursive: true });
+  assert(fs.existsSync(d));
+  // Create files
+  fs.writeFileSync(path.join(d, 'test.txt'), 'test');
+
+  fs.rmdir(paramdir, { recursive: true }, common.mustCall((err) => {
+    assert.ifError(err);
+    assert(!fs.existsSync(d));
+  }));
+}
+
+// fs.rmdirSync - recursive: true
+{
+  const d = path.join(tmpdir.path, 'dir', 'test_rmdirSync');
+  // Make sure the directory does not exist
+  assert(!fs.existsSync(d));
+  // Create the directory now
+  fs.mkdirSync(d, { recursive: true });
+  assert(fs.existsSync(d));
+  // Create files
+  fs.writeFileSync(path.join(d, 'test.txt'), 'test');
+
+  fs.rmdirSync(paramdir, { recursive: true });
+  assert(!fs.existsSync(d));
+}
+
+// fs.promises.rmdir - recursive: true
+{
+  const d = path.join(tmpdir.path, 'dir', 'test_promises_rmdir');
+  // Make sure the directory does not exist
+  assert(!fs.existsSync(d));
+  // Create the directory now
+  fs.mkdirSync(d, { recursive: true });
+  assert(fs.existsSync(d));
+  // Create files
+  fs.writeFileSync(path.join(d, 'test.txt'), 'test');
+
+  async () => {
+    await fs.promises.rmdir(paramdir, { recursive: true });
+    assert(!fs.existsSync(d));
+  };
+}
+
+// recursive: false
+{
+  const d = path.join(tmpdir.path, 'dir', 'test_rmdir_recursive_false');
+  // Make sure the directory does not exist
+  assert(!fs.existsSync(d));
+  // Create the directory now
+  fs.mkdirSync(d, { recursive: true });
+  assert(fs.existsSync(d));
+
+  // fs.rmdir
+  fs.rmdir(paramdir, { recursive: false }, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ENOTEMPTY');
+  }));
+
+  // fs.rmdirSync
+  common.expectsError(
+    () => fs.rmdirSync(paramdir, { recursive: false }),
+    {
+      code: 'ENOTEMPTY'
+    }
+  );
+
+  // fs.promises.rmdir
+  assert.rejects(
+    fs.promises.rmdir(paramdir, { recursive: false }),
+    {
+      code: 'ENOTEMPTY'
+    }
+  );
+}

--- a/test/parallel/test-fs-rmdir-type-check.js
+++ b/test/parallel/test-fs-rmdir-type-check.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const common = require('../common');
+const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 [false, 1, [], {}, null, undefined].forEach((i) => {
   common.expectsError(
@@ -16,6 +20,38 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
+    }
+  );
+});
+
+const d = path.join(tmpdir.path, 'dir', 'test_rmdir_typecheck');
+// Make sure the directory does not exist
+assert(!fs.existsSync(d));
+// Create the directory now
+fs.mkdirSync(d, { recursive: true });
+
+// tests for recursive option
+['true', 1, [], {}].forEach((i) => {
+  common.expectsError(
+    () => fs.rmdirSync(d, { recursive: i }),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+  common.expectsError(
+    () => fs.rmdir(d, { recursive: i }, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+  assert.rejects(
+    fs.promises.rmdir(d, { recursive: i }),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "recursive" argument must be of type boolean. ' +
+               `Received type ${typeof i}`
     }
   );
 });


### PR DESCRIPTION
Added recursive option into fs.rmdir and fs.rmdirSync to
delete a forder with sub folders or files.

Fix #22686

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
