### PR TITLE
build: lint commit message in separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: ccache
 os: linux
 matrix:
   include:
-    - name: "First commit message adheres to guidelines at https://goo.gl/p2fr5Q"
+    - name: "First commit message adheres to guidelines at <a href=\"https://goo.gl/p2fr5Q\">https://goo.gl/p2fr5Q</a>"
       if: type = pull_request
       language: node_js
       node_js: "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os: linux
 matrix:
   include:
     - name: "First commit message adheres to guidelines at https://goo.gl/p2fr5Q"
+      if: type = pull_request
       language: node_js
       node_js: "node"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ cache: ccache
 os: linux
 matrix:
   include:
+    - name: "Check First Commit Message"
+      language: node_js
+      node_js: "node"
+      script:
+        - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+            bash -x tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST};
+          fi
     - name: "Linter"
       language: node_js
       node_js: "node"
@@ -11,10 +18,6 @@ matrix:
         - NODE=$(which node)
       script:
         - make lint
-        # Lint the first commit in the PR.
-        - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-            bash tools/lint-pr-commit-message.sh ${TRAVIS_PULL_REQUEST} || true;
-          fi
     - name: "Test Suite"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: ccache
 os: linux
 matrix:
   include:
-    - name: "Check First Commit Message"
+    - name: "First commit message adheres to guidelines at https://goo.gl/p2fr5Q"
       language: node_js
       node_js: "node"
       script:


### PR DESCRIPTION
https://github.com/nodejs/node/pull/23739 changed the Travis Linter job so that it never fails if the first
commit message linting step fails. This was done in response to a
[false positive](https://github.com/nodejs/node/pull/23739#issuecomment-436271622) which we speculate was perhaps due to hitting the
GitHub API rate limit or a network issue (https://github.com/nodejs/node/pull/23739#issuecomment-436271622).

This PR:
* Moves the first commit message linting step to a separate Travis job. This will keep the amount of output in the individual jobs down.
* Runs the script in bash debug mode to capture any issues communicating with the
GitHub API (e.g. network issues, rate limits).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
