### PR TITLE
deps: bump minimum icu version to 63

### DIFF
--- a/tools/icu/icu_versions.json
+++ b/tools/icu/icu_versions.json
@@ -1,3 +1,3 @@
 {
-    "minimum_icu": 57
+    "minimum_icu": 63
 }


### PR DESCRIPTION
Bump minimum version of ICU needed to build node to 63.

Refs: https://github.com/v8/v8/commit/30a350f298732d6622712aa113d72fe3382c7f39
Co-authored-by: Steven R Loomis <srloomis@us.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @srl295 @nodejs/v8-update @targos @refack 

P.S. Please react with 👍 to approve fast-tracking this PR (it should optimally land before tonight's canary CI run).