### PR TITLE
test: url format path ending hashchar not covered

### DIFF
--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -173,6 +173,16 @@ const formatTests = {
     hash: '#bar'
   },
 
+  // `#` in path end + `#` in query
+  '/path/to/%%23?foo=the%231#bar': {
+    href: '/path/to/%%23?foo=the%231#bar',
+    pathname: '/path/to/%#',
+    query: {
+      foo: 'the#1'
+    },
+    hash: '#bar'
+  },
+
   // `?` and `#` in path and search
   'http://ex.com/foo%3F100%m%23r?abc=the%231?&foo=bar#frag': {
     href: 'http://ex.com/foo%3F100%m%23r?abc=the%231?&foo=bar#frag',


### PR DESCRIPTION
The url format path that returns when hashchar is encountered as the last char was not covered.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
