### PR TITLE
tls: get the local certificate after tls handshake

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -566,6 +566,22 @@ added: v0.11.4
 Always returns `true`. This may be used to distinguish TLS sockets from regular
 `net.Socket` instances.
 
+### tlsSocket.getCertificate()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Object}
+
+Returns an object representing the local certificate. The returned object has
+some properties corresponding to the fields of the certificate.
+
+See [`tls.TLSSocket.getPeerCertificate()`][] for an example of the certificate
+structure.
+
+If there is no local certificate, an empty object will be returned. If the
+socket has been destroyed, `null` will be returned.
+
 ### tlsSocket.getCipher()
 <!-- YAML
 added: v0.11.4
@@ -658,6 +674,7 @@ certificate.
 ```
 
 If the peer does not provide a certificate, an empty object will be returned.
+If the socket has been destroyed, `null` will be returned.
 
 ### tlsSocket.getPeerFinished()
 <!-- YAML

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -202,6 +202,9 @@ exports.createSecureContext = function createSecureContext(options) {
   return c;
 };
 
+// Translate some fields from the handle's C-friendly format into more idiomatic
+// javascript object representations before passing them back to the user.  Can
+// be used on any cert object, but changing the name would be semver-major.
 exports.translatePeerCertificate = function translatePeerCertificate(c) {
   if (!c)
     return null;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -660,7 +660,17 @@ TLSSocket.prototype.setSession = function(session) {
 TLSSocket.prototype.getPeerCertificate = function(detailed) {
   if (this._handle) {
     return common.translatePeerCertificate(
-      this._handle.getPeerCertificate(detailed));
+      this._handle.getPeerCertificate(detailed)) || {};
+  }
+
+  return null;
+};
+
+TLSSocket.prototype.getCertificate = function() {
+  if (this._handle) {
+    // It's not a peer cert, but the formatting is identical.
+    return common.translatePeerCertificate(
+      this._handle.getCertificate()) || {};
   }
 
   return null;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -272,6 +272,7 @@ class SSLWrap {
 
   static void GetPeerCertificate(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetFinished(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPeerFinished(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetSession(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -43,6 +43,8 @@ connect({
 }, function(err, pair, cleanup) {
   assert.ifError(err);
   const socket = pair.client.conn;
+  const localCert = socket.getCertificate();
+  assert.deepStrictEqual(localCert, {});
   let peerCert = socket.getPeerCertificate();
   assert.ok(!peerCert.issuerCertificate);
 

--- a/test/parallel/test-tls-pfx-authorizationerror.js
+++ b/test/parallel/test-tls-pfx-authorizationerror.js
@@ -22,6 +22,8 @@ const server = tls
       rejectUnauthorized: false
     },
     common.mustCall(function(c) {
+      assert.strictEqual(c.getPeerCertificate().serialNumber,
+                         'FAD50CC6A07F516C');
       assert.strictEqual(c.authorizationError, null);
       c.end();
     })
@@ -35,6 +37,8 @@ const server = tls
         rejectUnauthorized: false
       },
       function() {
+        assert.strictEqual(client.getCertificate().serialNumber,
+                           'FAD50CC6A07F516C');
         client.end();
         server.close();
       }


### PR DESCRIPTION
Add an API to get the local certificate chosen during TLS handshake from
the SSL context.

Fix: https://github.com/nodejs/node/issues/24095

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
