### PR TITLE
src: remove pushValueToArray and setupProcessObject

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -17,7 +17,7 @@
                               // avoid retaining a reference to the bootstrap
                               // object.
                               { _setupTraceCategoryState,
-                                _setupProcessObject, _setupNextTick,
+                                _setupNextTick,
                                 _setupPromises, _chdir, _cpuUsage,
                                 _hrtime, _hrtimeBigInt,
                                 _memoryUsage, _rawDebug,
@@ -376,13 +376,6 @@
     const origProcProto = Object.getPrototypeOf(process);
     Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
     EventEmitter.call(process);
-
-    _setupProcessObject(pushValueToArray);
-
-    function pushValueToArray() {
-      for (var i = 0; i < arguments.length; i++)
-        this.push(arguments[i]);
-    }
   }
 
   function setupGlobalVariables() {

--- a/lib/os.js
+++ b/lib/os.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const { pushValToArrayMax, safeGetenv } = internalBinding('util');
+const { safeGetenv } = internalBinding('util');
 const constants = internalBinding('constants').os;
 const { deprecate } = require('internal/util');
 const isWindows = process.platform === 'win32';
@@ -82,31 +82,29 @@ const getNetworkInterfacesDepMsg =
   'os.getNetworkInterfaces is deprecated. Use os.networkInterfaces instead.';
 
 const avgValues = new Float64Array(3);
-const cpuValues = new Float64Array(6 * pushValToArrayMax);
 
 function loadavg() {
   getLoadAvg(avgValues);
   return [avgValues[0], avgValues[1], avgValues[2]];
 }
 
-function addCPUInfo() {
-  for (var i = 0, c = 0; i < arguments.length; ++i, c += 6) {
-    this[this.length] = {
-      model: arguments[i],
-      speed: cpuValues[c],
-      times: {
-        user: cpuValues[c + 1],
-        nice: cpuValues[c + 2],
-        sys: cpuValues[c + 3],
-        idle: cpuValues[c + 4],
-        irq: cpuValues[c + 5]
-      }
-    };
-  }
-}
-
 function cpus() {
-  return getCPUs(addCPUInfo, cpuValues, []);
+  const data = getCPUs();
+  const result = [];
+  for (var i = 0; i < data.length; i += 7) {
+    result.push({
+      model: data[i],
+      speed: data[i + 1],
+      times: {
+        user: data[i + 2],
+        nice: data[i + 3],
+        sys: data[i + 4],
+        idle: data[i + 5],
+        irq: data[i + 6]
+      }
+    });
+  }
+  return result;
 }
 
 function arch() {

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -26,12 +26,6 @@ using v8::PromiseRejectMessage;
 using v8::String;
 using v8::Value;
 
-void SetupProcessObject(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  CHECK(args[0]->IsFunction());
-  env->set_push_values_to_array_function(args[0].As<Function>());
-}
-
 void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {
   args.GetIsolate()->RunMicrotasks();
 }
@@ -142,7 +136,6 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 void SetupBootstrapObject(Environment* env,
                           Local<Object> bootstrapper) {
   BOOTSTRAP_METHOD(_setupTraceCategoryState, SetupTraceCategoryState);
-  BOOTSTRAP_METHOD(_setupProcessObject, SetupProcessObject);
   BOOTSTRAP_METHOD(_setupNextTick, SetupNextTick);
   BOOTSTRAP_METHOD(_setupPromises, SetupPromises);
   BOOTSTRAP_METHOD(_chdir, Chdir);

--- a/src/env.h
+++ b/src/env.h
@@ -82,10 +82,6 @@ struct PackageConfig {
 };
 }  // namespace loader
 
-// The number of items passed to push_values_to_array_function has diminishing
-// returns around 8. This should be used at all call sites using said function.
-constexpr size_t NODE_PUSH_VAL_TO_ARRAY_MAX = 8;
-
 // Stat fields buffers contain twice the number of entries in an uv_stat_t
 // because `fs.StatWatcher` needs room to store 2 `fs.Stats` instances.
 constexpr size_t kFsStatsFieldsNumber = 14;
@@ -353,7 +349,6 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(process_object, v8::Object)                                               \
   V(promise_handler_function, v8::Function)                                   \
   V(promise_wrap_template, v8::ObjectTemplate)                                \
-  V(push_values_to_array_function, v8::Function)                              \
   V(sab_lifetimepartner_constructor_template, v8::FunctionTemplate)           \
   V(script_context_constructor_template, v8::FunctionTemplate)                \
   V(script_data_constructor_function, v8::Function)                           \

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1302,7 +1302,7 @@ void Http2Session::HandleHeadersFrame(const nghttp2_frame* frame) {
   size_t headers_size = headers.size();
   std::vector<Local<Value>> headers_v(headers_size * 2);
   for (size_t i = 0; i < headers_size; ++i) {
-    nghttp2_header item = headers[i];
+    const nghttp2_header& item = headers[i];
     // The header name and value are passed as external one-byte strings
     headers_v[i * 2] =
         ExternalHeader::New<true>(this, item.name).ToLocalChecked();

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1428,13 +1428,13 @@ void Http2Session::HandleOriginFrame(const nghttp2_frame* frame) {
   std::vector<Local<Value>> origin_v(nov);
 
   for (size_t i = 0; i < nov; ++i) {
-    auto entry = origin->ov[i];
+    const nghttp2_origin_entry& entry = origin->ov[i];
     origin_v[i] =
         String::NewFromOneByte(
             isolate, entry.origin, v8::NewStringType::kNormal, entry.origin_len)
             .ToLocalChecked();
   }
-  Local<Value> holder = Array::New(isolate, origin_v.data(), nov);
+  Local<Value> holder = Array::New(isolate, origin_v.data(), origin_v.size());
   MakeCallback(env()->onorigin_string(), 1, &holder);
 }
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1424,25 +1424,17 @@ void Http2Session::HandleOriginFrame(const nghttp2_frame* frame) {
   nghttp2_extension ext = frame->ext;
   nghttp2_ext_origin* origin = static_cast<nghttp2_ext_origin*>(ext.payload);
 
-  Local<Value> holder = Array::New(isolate);
-  Local<Function> fn = env()->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
+  size_t nov = origin->nov;
+  std::vector<Local<Value>> origin_v(nov);
 
-  size_t n = 0;
-  while (n < origin->nov) {
-    size_t j = 0;
-    while (n < origin->nov && j < arraysize(argv)) {
-      auto entry = origin->ov[n++];
-      argv[j++] =
-        String::NewFromOneByte(isolate,
-                               entry.origin,
-                               v8::NewStringType::kNormal,
-                               entry.origin_len).ToLocalChecked();
-    }
-    if (j > 0)
-      fn->Call(context, holder, j, argv).ToLocalChecked();
+  for (size_t i = 0; i < nov; ++i) {
+    auto entry = origin->ov[i];
+    origin_v[i] =
+        String::NewFromOneByte(
+            isolate, entry.origin, v8::NewStringType::kNormal, entry.origin_len)
+            .ToLocalChecked();
   }
-
+  Local<Value> holder = Array::New(isolate, origin_v.data(), nov);
   MakeCallback(env()->onorigin_string(), 1, &holder);
 }
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -158,6 +158,10 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
   if (err)
     return;
 
+  // It's faster to create an array packed with all the data and
+  // assemble them into objects in JS than to call Object::Set() repeatedly
+  // The array is in the format
+  // [model, speed, (5 entries of cpu_times), model2, speed2, ...]
   std::vector<Local<Value>> result(count * 7);
   for (size_t i = 0; i < count; i++) {
     uv_cpu_info_t* ci = cpu_infos + i;

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -54,6 +54,7 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Int32;
 using v8::Integer;
+using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Null;
@@ -148,52 +149,29 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
 
 static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+
   uv_cpu_info_t* cpu_infos;
-  int count, i, field_idx;
+  int count;
 
   int err = uv_cpu_info(&cpu_infos, &count);
   if (err)
     return;
 
-  CHECK(args[0]->IsFunction());
-  Local<Function> addfn = args[0].As<Function>();
-
-  CHECK(args[1]->IsFloat64Array());
-  Local<Float64Array> array = args[1].As<Float64Array>();
-  CHECK_EQ(array->Length(), 6 * NODE_PUSH_VAL_TO_ARRAY_MAX);
-  Local<ArrayBuffer> ab = array->Buffer();
-  double* fields = static_cast<double*>(ab->GetContents().Data());
-
-  CHECK(args[2]->IsArray());
-  Local<Array> cpus = args[2].As<Array>();
-
-  Local<Value> model_argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  unsigned int model_idx = 0;
-
-  for (i = 0, field_idx = 0; i < count; i++) {
+  std::vector<Local<Value>> result(count * 7);
+  for (size_t i = 0; i < count; i++) {
     uv_cpu_info_t* ci = cpu_infos + i;
-
-    fields[field_idx++] = ci->speed;
-    fields[field_idx++] = ci->cpu_times.user;
-    fields[field_idx++] = ci->cpu_times.nice;
-    fields[field_idx++] = ci->cpu_times.sys;
-    fields[field_idx++] = ci->cpu_times.idle;
-    fields[field_idx++] = ci->cpu_times.irq;
-    model_argv[model_idx++] = OneByteString(env->isolate(), ci->model);
-
-    if (model_idx >= NODE_PUSH_VAL_TO_ARRAY_MAX) {
-      addfn->Call(env->context(), cpus, model_idx, model_argv).ToLocalChecked();
-      model_idx = 0;
-      field_idx = 0;
-    }
-  }
-
-  if (model_idx > 0) {
-    addfn->Call(env->context(), cpus, model_idx, model_argv).ToLocalChecked();
+    result[i * 7] = OneByteString(isolate, ci->model);
+    result[i * 7 + 1] = Number::New(isolate, ci->speed);
+    result[i * 7 + 2] = Number::New(isolate, ci->cpu_times.user);
+    result[i * 7 + 3] = Number::New(isolate, ci->cpu_times.nice);
+    result[i * 7 + 4] = Number::New(isolate, ci->cpu_times.sys);
+    result[i * 7 + 5] = Number::New(isolate, ci->cpu_times.idle);
+    result[i * 7 + 6] = Number::New(isolate, ci->cpu_times.irq);
   }
 
   uv_free_cpu_info(cpu_infos, count);
-  args.GetReturnValue().Set(cpus);
+  args.GetReturnValue().Set(Array::New(isolate, result.data(), result.size()));
 }
 
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -814,26 +814,14 @@ void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
 void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  Local<Array> ary = Array::New(env->isolate());
-  Local<Context> ctx = env->context();
-  Local<Function> fn = env->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  size_t idx = 0;
-
+  std::vector<Local<Value>> handle_v;
   for (auto w : *env->handle_wrap_queue()) {
     if (!HandleWrap::HasRef(w))
       continue;
-    argv[idx] = w->GetOwner();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
+    handle_v.push_back(w->GetOwner());
   }
-  if (idx > 0) {
-    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-  }
-
-  args.GetReturnValue().Set(ary);
+  args.GetReturnValue().Set(
+      Array::New(env->isolate(), handle_v.data(), handle_v.size()));
 }
 
 void DebugPortGetter(Local<Name> property,

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -730,40 +730,29 @@ void EnvDeleter(Local<Name> property,
 void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
   Environment* env = Environment::GetCurrent(info);
   Isolate* isolate = env->isolate();
-  Local<Context> ctx = env->context();
-  Local<Function> fn = env->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  size_t idx = 0;
 
   Mutex::ScopedLock lock(environ_mutex);
+  Local<Array> envarr;
+  int env_size = 0;
 #ifdef __POSIX__
-  int size = 0;
-  while (environ[size])
-    size++;
+  while (environ[env_size]) {
+    env_size++;
+  }
+  std::vector<Local<Value>> env_v(env_size);
 
-  Local<Array> envarr = Array::New(isolate);
-
-  for (int i = 0; i < size; ++i) {
+  for (int i = 0; i < env_size; ++i) {
     const char* var = environ[i];
     const char* s = strchr(var, '=');
     const int length = s ? s - var : strlen(var);
-    argv[idx] = String::NewFromUtf8(isolate,
-                                    var,
-                                    v8::NewStringType::kNormal,
-                                    length).ToLocalChecked();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, envarr, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
-  }
-  if (idx > 0) {
-    fn->Call(ctx, envarr, idx, argv).ToLocalChecked();
+    env_v[i] =
+        String::NewFromUtf8(isolate, var, v8::NewStringType::kNormal, length)
+            .ToLocalChecked();
   }
 #else  // _WIN32
+  std::vector<Local<Value>> env_v;
   WCHAR* environment = GetEnvironmentStringsW();
   if (environment == nullptr)
     return;  // This should not happen.
-  Local<Array> envarr = Array::New(isolate);
   WCHAR* p = environment;
   while (*p) {
     WCHAR* s;
@@ -789,19 +778,14 @@ void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
       FreeEnvironmentStringsW(environment);
       return;
     }
-    argv[idx] = rc.ToLocalChecked();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, envarr, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
+    env_v.push_back(rc.ToLocalChecked());
+    size++;
     p = s + wcslen(s) + 1;
-  }
-  if (idx > 0) {
-    fn->Call(ctx, envarr, idx, argv).ToLocalChecked();
   }
   FreeEnvironmentStringsW(environment);
 #endif
 
+  envarr = Array::New(isolate, env_v.data(), env_size);
   info.GetReturnValue().Set(envarr);
 }
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -798,28 +798,16 @@ void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   Local<Array> ary = Array::New(args.GetIsolate());
-  Local<Context> ctx = env->context();
-  Local<Function> fn = env->push_values_to_array_function();
-  Local<Value> argv[NODE_PUSH_VAL_TO_ARRAY_MAX];
-  size_t idx = 0;
-
+  std::vector<Local<Value>> request_v;
   for (auto w : *env->req_wrap_queue()) {
     if (w->persistent().IsEmpty())
       continue;
-    argv[idx] = w->GetOwner();
-    if (++idx >= arraysize(argv)) {
-      fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-      idx = 0;
-    }
+    request_v.push_back(w->GetOwner());
   }
 
-  if (idx > 0) {
-    fn->Call(ctx, ary, idx, argv).ToLocalChecked();
-  }
-
-  args.GetReturnValue().Set(ary);
+  args.GetReturnValue().Set(
+      Array::New(env->isolate(), request_v.data(), request_v.size()));
 }
-
 
 // Non-static, friend of HandleWrap. Could have been a HandleWrap method but
 // implemented here for consistency with GetActiveRequests().

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -779,13 +779,12 @@ void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
       return;
     }
     env_v.push_back(rc.ToLocalChecked());
-    size++;
     p = s + wcslen(s) + 1;
   }
   FreeEnvironmentStringsW(environment);
 #endif
 
-  envarr = Array::New(isolate, env_v.data(), env_size);
+  envarr = Array::New(isolate, env_v.data(), env_v.size());
   info.GetReturnValue().Set(envarr);
 }
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -24,7 +24,6 @@ using v8::Private;
 using v8::Promise;
 using v8::PropertyFilter;
 using v8::Proxy;
-using v8::ReadOnly;
 using v8::SKIP_STRINGS;
 using v8::SKIP_SYMBOLS;
 using v8::String;
@@ -205,12 +204,6 @@ void Initialize(Local<Object> target,
     PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
   }
 #undef V
-
-  target->DefineOwnProperty(
-    env->context(),
-    OneByteString(env->isolate(), "pushValToArrayMax"),
-    Integer::NewFromUnsigned(env->isolate(), NODE_PUSH_VAL_TO_ARRAY_MAX),
-    ReadOnly).FromJust();
 
 #define V(name)                                                               \
   target->Set(context,                                                        \

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -92,6 +92,15 @@ assert.ok(uptime > 0);
 const cpus = os.cpus();
 is.array(cpus);
 assert.ok(cpus.length > 0);
+for (const cpu of cpus) {
+  assert.strictEqual(typeof cpu.model, 'string');
+  assert.strictEqual(typeof cpu.speed, 'number');
+  assert.strictEqual(typeof cpu.times.user, 'number');
+  assert.strictEqual(typeof cpu.times.nice, 'number');
+  assert.strictEqual(typeof cpu.times.sys, 'number');
+  assert.strictEqual(typeof cpu.times.idle, 'number');
+  assert.strictEqual(typeof cpu.times.irq, 'number');
+}
 
 const type = os.type();
 is.string(type);

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -91,6 +91,7 @@ assert.strictEqual(5, date.getHours());
 // case-sensitive on other platforms.
 process.env.TEST = 'test';
 assert.strictEqual(process.env.TEST, 'test');
+
 // Check both mixed case and lower case, to avoid any regressions that might
 // simply convert input to lower case.
 if (common.isWindows) {
@@ -99,4 +100,9 @@ if (common.isWindows) {
 } else {
   assert.strictEqual(process.env.test, undefined);
   assert.strictEqual(process.env.teST, undefined);
+}
+
+{
+  const keys = Object.keys(process.env);
+  assert.ok(keys.length > 0);
 }


### PR DESCRIPTION
This PR removes

- `pushValueToArray`
- `NODE_PUSH_VAL_TO_ARRAY_MAX`
- `env->env->push_values_to_array_function()`

In favor of the new V8 C++ API that constructs an Array from a C++ array directly.

Also removes `setupProcessObject` since by now it is only doing the `push_values_to_array_function` setup.
Also added a test for `os.cpus()` values.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
