### PR TITLE
Fixing child_process module to check values passed strictly to the options object

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -135,7 +135,9 @@ function normalizeExecArgs(command, options, callback) {
     options = undefined;
   }
 
-  // Make a shallow copy so we don't clobber the user's options object.
+  // Make a shallow copy so we don't clobber the user's options object
+  // and we strictly make use of Object.create(null) so that only self
+  // properties are checked.
   options = Object.assign(Object.create(null), options);
   options.shell = typeof options.shell === 'string' ? options.shell : true;
 
@@ -418,7 +420,7 @@ function normalizeSpawnArguments(file, args, options) {
 
   // Make a shallow copy so we don't clobber the user's options object
   // and we strictly make use of Object.create(null) so that only self
-  // properties are checked
+  // properties are checked.
   options = Object.assign(Object.create(null), options);
 
   // Validate the cwd, if present.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -136,7 +136,7 @@ function normalizeExecArgs(command, options, callback) {
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
+  options = Object.assign(Object.create(null), options);
   options.shell = typeof options.shell === 'string' ? options.shell : true;
 
   return {
@@ -416,6 +416,11 @@ function normalizeSpawnArguments(file, args, options) {
   else if (options === null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
 
+  // Make a shallow copy so we don't clobber the user's options object
+  // and we strictly make use of Object.create(null) so that only self
+  // properties are checked
+  options = Object.assign(Object.create(null), options);
+
   // Validate the cwd, if present.
   if (options.cwd != null &&
       typeof options.cwd !== 'string') {
@@ -467,9 +472,6 @@ function normalizeSpawnArguments(file, args, options) {
                                    'boolean',
                                    options.windowsVerbatimArguments);
   }
-
-  // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -72,17 +72,14 @@ const execOpts = { encoding: 'utf8', shell: true };
   // object prototype
   Object.prototype.shell = true;
 
-  let assertionExpected = 0;
-  try {
+  assert.throws(function() {
     execFileSync(
       'date',
       ['; echo baz']
     );
-  } catch (err) {
-    assertionExpected++;
-    assert.strictEqual(err.status, 1);
-  }
+  }, {
+    status: 1
+  }, 'No safe-guard detected against value present on the prototype chain');
 
-  assert.strictEqual(assertionExpected, 1);
   Reflect.deleteProperty(Object.prototype, 'shell');
 }

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -2,63 +2,92 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
+{
+  // Verify that a shell is, in fact, executed
+  const doesNotExist = cp.spawn('does-not-exist', { shell: true });
 
-// Verify that a shell is, in fact, executed
-const doesNotExist = cp.spawn('does-not-exist', { shell: true });
+  assert.notStrictEqual(doesNotExist.spawnfile, 'does-not-exist');
+  doesNotExist.on('error', common.mustNotCall());
+  doesNotExist.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(signal, null);
 
-assert.notStrictEqual(doesNotExist.spawnfile, 'does-not-exist');
-doesNotExist.on('error', common.mustNotCall());
-doesNotExist.on('exit', common.mustCall((code, signal) => {
-  assert.strictEqual(signal, null);
+    if (common.isWindows)
+      assert.strictEqual(code, 1);    // Exit code of cmd.exe
+    else
+      assert.strictEqual(code, 127);  // Exit code of /bin/sh
+  }));
+}
 
-  if (common.isWindows)
-    assert.strictEqual(code, 1);    // Exit code of cmd.exe
-  else
-    assert.strictEqual(code, 127);  // Exit code of /bin/sh
-}));
+{
+  // Verify that passing arguments works
+  const echo = cp.spawn('echo', ['foo'], {
+    encoding: 'utf8',
+    shell: true
+  });
+  let echoOutput = '';
 
-// Verify that passing arguments works
-const echo = cp.spawn('echo', ['foo'], {
-  encoding: 'utf8',
-  shell: true
-});
-let echoOutput = '';
+  assert.strictEqual(echo.spawnargs[echo.spawnargs.length - 1].replace(/"/g, ''),
+                     'echo foo');
+  echo.stdout.on('data', (data) => {
+    echoOutput += data;
+  });
+  echo.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(echoOutput.trim(), 'foo');
+  }));
+}
 
-assert.strictEqual(echo.spawnargs[echo.spawnargs.length - 1].replace(/"/g, ''),
-                   'echo foo');
-echo.stdout.on('data', (data) => {
-  echoOutput += data;
-});
-echo.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(echoOutput.trim(), 'foo');
-}));
+{
+  // Verify that shell features can be used
+  const cmd = 'echo bar | cat';
+  const command = cp.spawn(cmd, {
+    encoding: 'utf8',
+    shell: true
+  });
+  let commandOutput = '';
 
-// Verify that shell features can be used
-const cmd = 'echo bar | cat';
-const command = cp.spawn(cmd, {
-  encoding: 'utf8',
-  shell: true
-});
-let commandOutput = '';
+  command.stdout.on('data', (data) => {
+    commandOutput += data;
+  });
+  command.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(commandOutput.trim(), 'bar');
+  }));
+}
 
-command.stdout.on('data', (data) => {
-  commandOutput += data;
-});
-command.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(commandOutput.trim(), 'bar');
-}));
+{
+  // Verify that shell features can not be passed through
+  // object prototype manipulation, and must be strictly
+  // passed through the options object
+  const spawnCmd = 'date';
+  const spawnCmdArgs = ['; echo baz'];
+  Object.prototype.shell = true;
 
-// Verify that the environment is properly inherited
-const env = cp.spawn(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: Object.assign({}, process.env, { BAZ: 'buzz' }),
-  encoding: 'utf8',
-  shell: true
-});
-let envOutput = '';
+  const spawnHandler = cp.spawn(spawnCmd, spawnCmdArgs, {
+    encoding: 'utf8'
+  });
 
-env.stdout.on('data', (data) => {
-  envOutput += data;
-});
-env.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(envOutput.trim(), 'buzz');
-}));
+  // assertion is expected to fail due to `spawnCmdArgs` not
+  // being a valid argument to the date command
+  const SUCCESS_CODE = 0;
+  spawnHandler.on('close', common.mustCall((code) => {
+    assert.notStrictEqual(code, SUCCESS_CODE);
+  }));
+
+  Reflect.deleteProperty(Object.prototype, 'shell');
+}
+
+{
+  // Verify that the environment is properly inherited
+  const env = cp.spawn(`"${process.execPath}" -pe process.env.BAZ`, {
+    env: Object.assign({}, process.env, { BAZ: 'buzz' }),
+    encoding: 'utf8',
+    shell: true
+  });
+  let envOutput = '';
+
+  env.stdout.on('data', (data) => {
+    envOutput += data;
+  });
+  env.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(envOutput.trim(), 'buzz');
+  }));
+}


### PR DESCRIPTION
## Issue

The way the `child_process` module currently works with validating the extra options passed to it is by accessing the properties on the options object. However, there is no strict check to validate that the property has been defined on the direct object, and so what happens is that when accessing the property it will bubble up to the prototype chain until it hits the Object prototype and use that.

It draws attention to a possible security implication where-as the prototype chain can be manipulated and thus triggering a further vulnerability with the `child_process` module to execute via shell expansion which allows to execute arbitrary commands.

## Reproduce

Steps To Reproduce:
1. Create a snippet file as follows:

```
  const { spawn } = require('child_process');
  Object.prototype.shell = true;
  const cmd = 'ls'
  const args = ['; echo baz']
  const ls = spawn(cmd, args, {stdio: 'inherit'}, function(a,b,c) {
    console.log(a, b, c)
  });
```
2. Run it
3. Observe the baz word added to the output even though the options passed to spawn don't directly include the `shell` option

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
