### PR TITLE
test: remove unused parameters in function definition

### DIFF
--- a/test/async-hooks/test-async-await.js
+++ b/test/async-hooks/test-async-await.js
@@ -26,7 +26,7 @@ const hooks = initHooks({
 });
 hooks.enable();
 
-function oninit(asyncId, type, triggerAsyncId, resource) {
+function oninit(asyncId, type) {
   if (type === 'PROMISE') {
     promisesInitState.set(asyncId, 'inited');
   }


### PR DESCRIPTION
Remove unused parameters triggerAsyncId and resource from oninit function in test-async-await.js.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]