### PR TITLE
crypto: put legacy _handle accessors on prototypes

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -74,7 +74,7 @@ function getUIntOption(options, key) {
 function createCipherBase(cipher, credential, options, decipher, iv) {
   const authTagLength = getUIntOption(options, 'authTagLength');
 
-  legacyNativeHandle(this, new CipherBase(decipher));
+  this[kHandle] = new CipherBase(decipher);
   if (iv === undefined) {
     this[kHandle].init(cipher, credential, authTagLength);
   } else {
@@ -219,6 +219,8 @@ Cipher.prototype.setAAD = function setAAD(aadbuf, options) {
   return this;
 };
 
+legacyNativeHandle(Cipher);
+
 function Cipheriv(cipher, key, iv, options) {
   if (!(this instanceof Cipheriv))
     return new Cipheriv(cipher, key, iv, options);
@@ -254,6 +256,7 @@ function addCipherPrototypeFunctions(constructor) {
 
 inherits(Cipheriv, LazyTransform);
 addCipherPrototypeFunctions(Cipheriv);
+legacyNativeHandle(Cipheriv);
 
 function Decipher(cipher, password, options) {
   if (!(this instanceof Decipher))
@@ -264,6 +267,7 @@ function Decipher(cipher, password, options) {
 
 inherits(Decipher, LazyTransform);
 addCipherPrototypeFunctions(Decipher);
+legacyNativeHandle(Decipher);
 
 
 function Decipheriv(cipher, key, iv, options) {
@@ -275,6 +279,7 @@ function Decipheriv(cipher, key, iv, options) {
 
 inherits(Decipheriv, LazyTransform);
 addCipherPrototypeFunctions(Decipheriv);
+legacyNativeHandle(Decipheriv);
 
 module.exports = {
   Cipher,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -61,7 +61,7 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   else if (typeof generator !== 'number')
     generator = toBuf(generator, genEncoding);
 
-  legacyNativeHandle(this, new _DiffieHellman(sizeOrKey, generator));
+  this[kHandle] = new _DiffieHellman(sizeOrKey, generator);
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
     value: this[kHandle].verifyError,
@@ -73,7 +73,7 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
 function DiffieHellmanGroup(name) {
   if (!(this instanceof DiffieHellmanGroup))
     return new DiffieHellmanGroup(name);
-  legacyNativeHandle(this, new _DiffieHellmanGroup(name));
+  this[kHandle] = new _DiffieHellmanGroup(name);
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
     value: this[kHandle].verifyError,
@@ -165,13 +165,16 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
   return this;
 };
 
+legacyNativeHandle(DiffieHellman);
+legacyNativeHandle(DiffieHellmanGroup);
+
 
 function ECDH(curve) {
   if (!(this instanceof ECDH))
     return new ECDH(curve);
 
   validateString(curve, 'curve');
-  legacyNativeHandle(this, new _ECDH(curve));
+  this[kHandle] = new _ECDH(curve);
 }
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
@@ -191,6 +194,8 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 };
+
+legacyNativeHandle(ECDH);
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   if (typeof key !== 'string' && !isArrayBufferView(key)) {

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -32,7 +32,7 @@ function Hash(algorithm, options) {
   if (!(this instanceof Hash))
     return new Hash(algorithm, options);
   validateString(algorithm, 'algorithm');
-  legacyNativeHandle(this, new _Hash(algorithm));
+  this[kHandle] = new _Hash(algorithm);
   this[kState] = {
     [kFinalized]: false
   };
@@ -81,6 +81,8 @@ Hash.prototype.digest = function digest(outputEncoding) {
   return ret;
 };
 
+legacyNativeHandle(Hash);
+
 
 function Hmac(hmac, key, options) {
   if (!(this instanceof Hmac))
@@ -90,7 +92,7 @@ function Hmac(hmac, key, options) {
     throw new ERR_INVALID_ARG_TYPE('key',
                                    ['string', 'TypedArray', 'DataView'], key);
   }
-  legacyNativeHandle(this, new _Hmac());
+  this[kHandle] = new _Hmac();
   this[kHandle].init(hmac, toBuf(key));
   this[kState] = {
     [kFinalized]: false
@@ -121,6 +123,8 @@ Hmac.prototype.digest = function digest(outputEncoding) {
 
 Hmac.prototype._flush = Hash.prototype._flush;
 Hmac.prototype._transform = Hash.prototype._transform;
+
+legacyNativeHandle(Hmac);
 
 module.exports = {
   Hash,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -24,7 +24,7 @@ function Sign(algorithm, options) {
   if (!(this instanceof Sign))
     return new Sign(algorithm, options);
   validateString(algorithm, 'algorithm');
-  legacyNativeHandle(this, new _Sign());
+  this[kHandle] = new _Sign();
   this[kHandle].init(algorithm);
 
   Writable.call(this, options);
@@ -44,6 +44,8 @@ Sign.prototype.update = function update(data, encoding) {
   this[kHandle].update(data);
   return this;
 };
+
+legacyNativeHandle(Sign);
 
 function getPadding(options) {
   return getIntOption('padding', RSA_PKCS1_PADDING, options);
@@ -93,7 +95,7 @@ function Verify(algorithm, options) {
   if (!(this instanceof Verify))
     return new Verify(algorithm, options);
   validateString(algorithm, 'algorithm');
-  legacyNativeHandle(this, new _Verify());
+  this[kHandle] = new _Verify();
   this[kHandle].init(algorithm);
 
   Writable.call(this, options);
@@ -120,6 +122,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   return this[kHandle].verify(key, signature, rsaPadding, pssSaltLength);
 };
+
+legacyNativeHandle(Verify);
 
 module.exports = {
   Sign,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -30,15 +30,14 @@ const {
 
 const kHandle = Symbol('kHandle');
 
-function legacyNativeHandle(obj, handle) {
-  obj[kHandle] = handle;
-  Object.defineProperty(obj, '_handle', {
-    get: deprecate(() => handle,
-                   `${obj.constructor.name}._handle is deprecated. Use the ` +
-                   'public API instead.', 'DEP0117'),
-    set: deprecate((h) => obj[kHandle] = handle = h,
-                   `${obj.constructor.name}._handle is deprecated. Use the ` +
-                   'public API instead.', 'DEP0117'),
+function legacyNativeHandle(clazz) {
+  Object.defineProperty(clazz.prototype, '_handle', {
+    get: deprecate(function() { return this[kHandle]; },
+                   `${clazz.name}._handle is deprecated. Use the public API ` +
+                   'instead.', 'DEP0117'),
+    set: deprecate(function(h) { this[kHandle] = h; },
+                   `${clazz.name}._handle is deprecated. Use the public API ` +
+                   'instead.', 'DEP0117'),
     enumerable: false
   });
 }


### PR DESCRIPTION
Creating deprecated accessors each time an object is created is very
time consuming.

Refs: https://github.com/nodejs/node/pull/22747
Fixes: https://github.com/nodejs/node/issues/24266

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
