### PR TITLE
build: disable openssl asm on arm64 for now

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,6 @@
 
     'clang%': 0,
 
-    'openssl_no_asm%': 0,
     'openssl_fips%': '',
 
     # Reset this number to 0 on major V8 upgrades.
@@ -52,6 +51,12 @@
     'icu_use_data_file_flag%': 0,
 
     'conditions': [
+      ['target_arch=="arm64"', {
+        # Disabled pending https://github.com/nodejs/node/issues/23913.
+        'openssl_no_asm%': 1,
+      }, {
+        'openssl_no_asm%': 0,
+      }],
       ['GENERATOR=="ninja"', {
         'obj_dir': '<(PRODUCT_DIR)/obj',
         'conditions': [

--- a/configure.py
+++ b/configure.py
@@ -1175,8 +1175,10 @@ def configure_openssl(o):
   variables = o['variables']
   variables['node_use_openssl'] = b(not options.without_ssl)
   variables['node_shared_openssl'] = b(options.shared_openssl)
-  variables['openssl_no_asm'] = 1 if options.openssl_no_asm else 0
   variables['openssl_fips'] = ''
+
+  if options.openssl_no_asm:
+    variables['openssl_no_asm'] = 1
 
   if options.without_ssl:
     def without_ssl_error(option):

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -1,7 +1,4 @@
 {
-  'variables': {
-    'openssl_no_asm%': 0,
-  },
   'targets': [
     {
       'target_name': 'openssl',


### PR DESCRIPTION
There is reason to believe the generated assembly isn't working
correctly so let's disable it for now pending further investigation.

Refs: https://github.com/nodejs/node/issues/23913