### PR TITLE
async_hooks: add HandleScopes to C++ embedder/addon API

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -693,6 +693,8 @@ MaybeLocal<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
 
 async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
+  // Environment::GetCurrent() allocates a Local<> handle.
+  v8::HandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   if (env == nullptr) return -1;
   return env->execution_async_id();
@@ -700,6 +702,8 @@ async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
 
 
 async_id AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
+  // Environment::GetCurrent() allocates a Local<> handle.
+  v8::HandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   if (env == nullptr) return -1;
   return env->trigger_async_id();
@@ -710,6 +714,7 @@ async_context EmitAsyncInit(Isolate* isolate,
                             Local<Object> resource,
                             const char* name,
                             async_id trigger_async_id) {
+  v8::HandleScope handle_scope(isolate);
   Local<String> type =
       String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized)
           .ToLocalChecked();
@@ -720,6 +725,7 @@ async_context EmitAsyncInit(Isolate* isolate,
                             Local<Object> resource,
                             v8::Local<v8::String> name,
                             async_id trigger_async_id) {
+  v8::HandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   CHECK_NOT_NULL(env);
 
@@ -740,6 +746,8 @@ async_context EmitAsyncInit(Isolate* isolate,
 }
 
 void EmitAsyncDestroy(Isolate* isolate, async_context asyncContext) {
+  // Environment::GetCurrent() allocates a Local<> handle.
+  v8::HandleScope handle_scope(isolate);
   AsyncWrap::EmitDestroy(
       Environment::GetCurrent(isolate), asyncContext.async_id);
 }

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -56,6 +56,8 @@ void AfterAsync(uv_work_t* r) {
     callback->Call(global, 2, argv);
   }
 
+  // None of the following operations should allocate handles into this scope.
+  v8::SealHandleScope seal_handle_scope(isolate);
   // cleanup
   node::EmitAsyncDestroy(isolate, req->context);
   req->callback.Reset();


### PR DESCRIPTION
Add `HandleScope`s to the public C++ API for embedders/addons,
since these methods create V8 handles that should not leak into
the outer scopes.

In particular, for some of the methods it was not clear from
the function signatures that these functions previously
needed to be invoked with a `HandleScope`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
