### PR TITLE
console: fix and test console.timeLog() using the default label

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -260,7 +260,7 @@ Console.prototype.timeEnd = function timeEnd(label = 'default') {
   }
 };
 
-Console.prototype.timeLog = function timeLog(label, ...data) {
+Console.prototype.timeLog = function timeLog(label = 'default', ...data) {
   // Coerces everything other than Symbol to a string
   label = `${label}`;
   timeLogImpl(this, 'timeLog', label, data);
@@ -268,7 +268,7 @@ Console.prototype.timeLog = function timeLog(label, ...data) {
 };
 
 // Returns true if label was not found
-function timeLogImpl(self, name, label = 'default', data) {
+function timeLogImpl(self, name, label, data) {
   const time = self._times.get(label);
   if (!time) {
     process.emitWarning(`No such label '${label}' for console.${name}()`);

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -45,6 +45,10 @@ common.expectWarning(
     ['Count for \'noLabel\' does not exist', common.noWarnCode],
     ['No such label \'noLabel\' for console.timeLog()', common.noWarnCode],
     ['No such label \'noLabel\' for console.timeEnd()', common.noWarnCode],
+    ['Count for \'default\' does not exist', common.noWarnCode],
+    ['No such label \'default\' for console.timeLog()', common.noWarnCode],
+    ['No such label \'default\' for console.timeEnd()', common.noWarnCode],
+    ['Label \'default\' already exists for console.time()', common.noWarnCode],
     ['Label \'test\' already exists for console.time()', common.noWarnCode]
   ]
 );
@@ -55,6 +59,17 @@ console.timeEnd('noLabel');
 
 console.time('label');
 console.timeEnd('label');
+
+// Test using the default label
+// on console.time(), console.countReset(), console.timeLog(), console.timeEnd()
+console.countReset();
+console.timeLog();
+console.timeEnd();
+
+console.time();
+console.time();
+console.timeLog();
+console.timeEnd();
 
 // Check that the `Error` is a `TypeError` but do not check the message as it
 // will be different in different JavaScript engines.


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
