### PR TITLE
net: partially revert "simplify Socket.prototype._final"

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -345,6 +345,12 @@ Socket.prototype._final = function(cb) {
     return this.once('connect', () => this._final(cb));
   }
 
+  // TODO(addaleax): This should not be necessary.
+  if (!this.readable || this._readableState.ended) {
+    cb();
+    return this.destroy();
+  }
+
   if (!this._handle)
     return cb();
 


### PR DESCRIPTION
Partially revert b7e6ccd0cc60f20cc397e6ac0705bb3f38c7d225 because it broke a test that was added since its last CI run.

Refs: https://github.com/nodejs/node/pull/24075
Refs: https://github.com/nodejs/node/pull/23866

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
