### PR TITLE
doc: document NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -665,6 +665,12 @@ Path to the file used to store the persistent REPL history. The default path is
 `~/.node_repl_history`, which is overridden by this variable. Setting the value
 to an empty string (`''` or `' '`) disables persistent REPL history.
 
+### `NODE_TLS_REJECT_UNAUTHORIZED=value`
+
+If `value` equals `'0'`, certificate validation is disabled for TLS connections.
+This makes TLS, and HTTPS by extension, insecure. The use of this environment
+variable is strongly discouraged.
+
 ### `NODE_V8_COVERAGE=dir`
 
 When set, Node.js will begin outputting [V8 JavaScript code coverage][] to the


### PR DESCRIPTION
This commit documents the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable so that the world can know how potentially dangerous it is.

Fixes: https://github.com/nodejs/node/issues/24284

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
