### PR TITLE
net: always invoke after-write callback

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -776,6 +776,8 @@ function afterWrite(status, handle, err) {
   // callback may come after call to destroy.
   if (self.destroyed) {
     debug('afterWrite destroyed');
+    if (this.callback)
+      this.callback(null);
     return;
   }
 

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -41,7 +41,7 @@ const server = tls.createServer({
       c.destroy();
     }));
     // Data on next _write() will be written but callback will not be invoked
-    c.write(' gosh', null, common.mustNotCall());
+    c.write(' gosh', null, common.mustCall());
   }));
 
   server.close();

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -40,7 +40,7 @@ const server = tls.createServer({
     c.write('world!', null, common.mustCall(function() {
       c.destroy();
     }));
-    // Data on next _write() will be written but callback will not be invoked
+    // Data on next _write() will be written, and the cb will still be invoked
     c.write(' gosh', null, common.mustCall());
   }));
 


### PR DESCRIPTION
This is part of the streams API contract, and aligns
network sockets with other streams in this respect.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
