### PR TITLE
test: fix flaky test-vm-timeout-escape-queuemicrotask

### DIFF
--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -10,7 +10,6 @@ prefix known_issues
 
 [$system==linux]
 test-vm-timeout-escape-promise: PASS,FLAKY
-test-vm-timeout-escape-queuemicrotask: PASS,FLAKY
 
 [$system==macos]
 

--- a/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
+++ b/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
@@ -4,7 +4,7 @@
 // Promises, nextTick, and queueMicrotask allow code to escape the timeout
 // set for runInContext, runInNewContext, and runInThisContext
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
@@ -32,7 +32,7 @@ assert.throws(() => {
       queueMicrotask,
       loop
     },
-    { timeout: 5 }
+    { timeout: common.platformTimeout(5) }
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',


### PR DESCRIPTION
Use a larger timeout on slower platforms so that the timeout doesn't
fire before the error condition occurs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
