### PR TITLE
events: extract listener check as a function

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -48,6 +48,13 @@ function lazyErrors() {
   return errors;
 }
 
+function checkListener(listener) {
+  if (typeof listener !== 'function') {
+    const errors = lazyErrors();
+    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
+  }
+}
+
 Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   enumerable: true,
   get: function() {
@@ -195,10 +202,7 @@ function _addListener(target, type, listener, prepend) {
   var events;
   var existing;
 
-  if (typeof listener !== 'function') {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
-  }
+  checkListener(listener);
 
   events = target._events;
   if (events === undefined) {
@@ -283,20 +287,16 @@ function _onceWrap(target, type, listener) {
 }
 
 EventEmitter.prototype.once = function once(type, listener) {
-  if (typeof listener !== 'function') {
-    const errors = lazyErrors();
-    throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
-  }
+  checkListener(listener);
+
   this.on(type, _onceWrap(this, type, listener));
   return this;
 };
 
 EventEmitter.prototype.prependOnceListener =
     function prependOnceListener(type, listener) {
-      if (typeof listener !== 'function') {
-        const errors = lazyErrors();
-        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
-      }
+      checkListener(listener);
+
       this.prependListener(type, _onceWrap(this, type, listener));
       return this;
     };
@@ -306,10 +306,7 @@ EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       var list, events, position, i, originalListener;
 
-      if (typeof listener !== 'function') {
-        const errors = lazyErrors();
-        throw new errors.ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
-      }
+      checkListener(listener);
 
       events = this._events;
       if (events === undefined)


### PR DESCRIPTION
As there are multiple funcions checking the argument `listener`,so extract `listener` check as a separate function.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
