### PR TITLE
http2: add test for head request is not finished

### DIFF
--- a/test/known_issues/test-http2-compat-head-finished.js
+++ b/test/known_issues/test-http2-compat-head-finished.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+// The purpose of this test is to ensure that res.finished is
+// not true before res.end() is called or the request is aborted
+// for HEAD requests.
+
+const server = h2
+  .createServer()
+  .listen(0, common.mustCall(function() {
+    const port = server.address().port;
+    server.once('request', common.mustCall((req, res) => {
+      assert.ok(!res.finished); // This fails.
+      res.end();
+    }));
+
+    const url = `http://localhost:${port}`;
+    const client = h2.connect(url, common.mustCall(function() {
+      const headers = {
+        ':path': '/',
+        ':method': 'HEAD',
+        ':scheme': 'http',
+        ':authority': `localhost:${port}`
+      };
+      const request = client.request(headers);
+      request.on('end', common.mustCall(function() {
+        client.close();
+      }));
+      request.end();
+      request.resume();
+    }));
+  }))


### PR DESCRIPTION
Adds test for https://github.com/nodejs/node/issues/24283. Not actually fixed. Just test.

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)