### PR TITLE
doc: buffer.from will return internal pool buffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -788,7 +788,7 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 A `TypeError` will be thrown if `array` is not an `Array`.
 
-`Buffer.from(array)` may also use the internal `Buffer` pool just like
+`Buffer.from(array)` may also use the internal `Buffer` pool like
 [`Buffer.allocUnsafe()`] does.
 
 ```js

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -788,12 +788,11 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 A `TypeError` will be thrown if `array` is not an `Array`.
 
-`Buffer.from(array)` will also use the internal `Buffer` pool if `array.length`
-is less than or equal to half [`Buffer.poolSize`] just like
+`Buffer.from(array)` may also use the internal `Buffer` pool just like
 [`Buffer.allocUnsafe()`] does.
 
 ```js
-const nodeBuffers = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const nodeBuffers = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 console.log(nodeBuffers.offset);
 // prints: 344
@@ -805,7 +804,7 @@ console.log(Buffer.poolSize);
 // But you can change it
 Buffer.poolSize = 5;
 
-const buf = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const buf = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 console.log(buf.offset);
 // prints: 0

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -788,6 +788,27 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 A `TypeError` will be thrown if `array` is not an `Array`.
 
+`Buffer.from(array)` will also use the internal `Buffer` pool if `array.length` is less than or equal to half [`Buffer.poolSize`] just like [`Buffer.allocUnsafe()`] does.
+
+```js
+const nodeBuffers = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7,8, 9]);
+
+console.log(nodeBuffers.offset);
+// prints: 344
+
+// Default Buffer.poolsize is 8192
+console.log(Buffer.poolSize);
+// prints: 8192
+
+// But you can change it
+Buffer.poolSize=5;
+
+const buf = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7,8, 9]);
+
+console.log(buf.offset);
+// prints: 0
+```
+
 ### Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])
 <!-- YAML
 added: v5.10.0

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -788,10 +788,12 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 A `TypeError` will be thrown if `array` is not an `Array`.
 
-`Buffer.from(array)` will also use the internal `Buffer` pool if `array.length` is less than or equal to half [`Buffer.poolSize`] just like [`Buffer.allocUnsafe()`] does.
+`Buffer.from(array)` will also use the internal `Buffer` pool if `array.length`
+is less than or equal to half [`Buffer.poolSize`] just like
+[`Buffer.allocUnsafe()`] does.
 
 ```js
-const nodeBuffers = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7,8, 9]);
+const nodeBuffers = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 console.log(nodeBuffers.offset);
 // prints: 344
@@ -801,9 +803,9 @@ console.log(Buffer.poolSize);
 // prints: 8192
 
 // But you can change it
-Buffer.poolSize=5;
+Buffer.poolSize = 5;
 
-const buf = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7,8, 9]);
+const buf = new Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 console.log(buf.offset);
 // prints: 0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

#22139
Buffer.from will also use internal ```Buffer``` pool if it's size is less then ```Buffer.poolSize```.
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
