### PR TITLE
lib: fix - invalid timer priority queue order

### DIFF
--- a/lib/internal/priority_queue.js
+++ b/lib/internal/priority_queue.js
@@ -77,6 +77,25 @@ module.exports = class PriorityQueue {
       setPosition(item, pos);
   }
 
+  updateAt(pos) {
+    const heap = this[kHeap];
+    const item = heap[pos];
+    const compare = this[kCompare];
+    this.removeAt(pos);
+    this.insert(item);
+  }
+
+  update(value) {
+    const heap = this[kHeap];
+    const pos = heap.indexOf(value);
+    if (pos < 1)
+      return false;
+
+    this.updateAt(pos);
+
+    return true;
+  }
+
   removeAt(pos) {
     const heap = this[kHeap];
     const size = --this[kSize];

--- a/lib/internal/priority_queue.js
+++ b/lib/internal/priority_queue.js
@@ -80,7 +80,6 @@ module.exports = class PriorityQueue {
   updateAt(pos) {
     const heap = this[kHeap];
     const item = heap[pos];
-    const compare = this[kCompare];
     this.removeAt(pos);
     this.insert(item);
   }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -1,4 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
+﻿// Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the
@@ -285,7 +285,7 @@ function listOnTimeout(list, now) {
     if (diff < msecs) {
       list.expiry = timer._idleStart + msecs;
       list.id = timerListId++;
-      queue.percolateDown(1);
+      queue.updateAt(list.priorityQueuePosition);
       debug('%d list wait because diff is %d', msecs, diff);
       return;
     }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -1,4 +1,4 @@
-﻿// Copyright Joyent, Inc. and other Node contributors.
+// Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the


### PR DESCRIPTION
- in lib/timers.js PriorityQueue.percolateDown cannot be used for rescheduling list,
  because it does not work in all cases
  - updated item does not have to be root of the heap when new timers are created
    in runNextTicks and then percolateDown does not solve all binary heap
    inconsistencies
  - old behavior could cause infinite loop timers in some cases

- added PriorityQueue.updateAt and PriorityQueue.update methods
  - simple implementation by remove & insert, could be improved...
  - rescheduling list uses updateAt method

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
