### PR TITLE
doc: adjusting formatting when printing

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -533,12 +533,51 @@ th > *:last-child, td > *:last-child {
 @media print {
   html {
     height: auto;
+    font-size: 0.75em;
   }
   #column2.interior {
     display: none;
   }
   #column1.interior {
-    margin-left: auto;
+    margin-left: 0px;
+    padding: 0px;
     overflow-y: auto;
+  }
+  .api_metadata,
+  #toc,
+  .srclink,
+  #gtoc,
+  .mark {
+    display: none;
+  }
+  h1 {
+    font-size: 2rem;
+  }
+  h2 {
+    font-size: 1.75rem;
+  }
+  h3 {
+    font-size: 1.5rem;
+  }
+  h4 {
+    font-size: 1.3rem;
+  }
+  h5 {
+    font-size: 1.2rem;
+  }
+  h6 {
+    font-size: 1.1rem;
+  }
+  .api_stability {
+    display: inline-block;
+  }
+  .api_stability a {
+    text-decoration: none;
+  }
+  a {
+    color: inherit;
+  }
+  #apicontent {
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
As a weekend project I built a PDF generator for the Node.js docs. This project required making small changes to the documentation CSS for aesthetics. Take a look at [these PDF files](https://thomashunter.name/nodejs-documentation-pdf) to view the CSS changes in action.

Here's an overview of these changes:

- reduce page margin
- remove emphasis from links as they're unclickable
  - i.e. color, and underlines when in deprecated block
- hides expandable `> history` items since they're collapsed and unreadable
  - alternative: I can make these always expanded instead
- removes horizontal scrollbar from bottom of print output
- reduce stability rectangle sizes
  - normally they're full width, now they're as wide as the text
- shrink all text and headlines slightly
  - they're now closer to what you'd find in a book
- hide ToC
  - it takes up many many pages and is ultimately unclickable

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)