### PR TITLE
tools: make mkssldef ignore DEPRECATEDIN

### DIFF
--- a/tools/mkssldef.py
+++ b/tools/mkssldef.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
       assert meta[2] in ('FUNCTION', 'VARIABLE')
       if meta[0] != 'EXIST': continue
       if meta[2] != 'FUNCTION': continue
+      # In cases where meta[3] is 'DEPRECATEDIN_X_Y,CATEGORY'
+      meta[3] = meta[3].split(',')[-1]
       def satisfy(expr, rules):
         def test(expr):
           if expr.startswith('!'): return not expr[1:] in rules


### PR DESCRIPTION
Make `mkssldef` ignore deprecation. e.g. `TLSv1_2_*` that were deprecated in openSSL_1_1:
https://github.com/nodejs/node/blob/49b0f7fa19ce4b8fc3930124e58496894d4ea932/deps/openssl/openssl/util/libssl.num#L157

Fixes: https://github.com/nodejs/node/issues/20369
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
