### PR TITLE
tools: update remark version to v10 from v8

### DIFF
--- a/tools/node-lint-md-cli-rollup/package-lock.json
+++ b/tools/node-lint-md-cli-rollup/package-lock.json
@@ -1951,13 +1951,13 @@
       }
     },
     "remark": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
-      "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.0.tgz",
+      "integrity": "sha512-0fZvVmd9CgDi1qHGsRTyhpJShw60r3/4OSdRpAx+I7CmE8/Jmt829T9KWHpw2Ygw3chRZ26sMorqb8aIolU9tQ==",
       "requires": {
-        "remark-parse": "^4.0.0",
-        "remark-stringify": "^4.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "^6.0.0",
+        "remark-stringify": "^6.0.0",
+        "unified": "^7.0.0"
       }
     },
     "remark-lint": {
@@ -2341,9 +2341,9 @@
       }
     },
     "remark-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
-      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.2.tgz",
+      "integrity": "sha512-cBbst7OG/pH+VHYggWRabpVn9EP6CUb2hAtSg9cPysRvf+NE1v2cRdXC+TfXumJCar/wpPDK833zPu1fwVanZw==",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -2351,7 +2351,7 @@
         "is-whitespace-character": "^1.0.0",
         "is-word-character": "^1.0.0",
         "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
+        "parse-entities": "^1.1.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
         "trim": "0.0.1",
@@ -2405,9 +2405,9 @@
       }
     },
     "remark-stringify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
-      "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.3.tgz",
+      "integrity": "sha512-/x4EsH7uiqmTAe6/s1HmwaIeJm5Gq8pI+TpGB+t/uwrfSJW0x+ZuXezSLQ0z8bT7vhrR31yUkHwm3qkkVuo/5Q==",
       "requires": {
         "ccount": "^1.0.0",
         "is-alphanumeric": "^1.0.0",
@@ -2958,16 +2958,34 @@
       }
     },
     "unified": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.0.1.tgz",
+      "integrity": "sha512-8bUzPn/gVVkLgZKKjmGMjFDi7tg/y+KmGcvbzdvkIP+9q77AZvg7u1jNLKlsXr6rrOzppFWzNpduumn8jLKOsg==",
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
-        "vfile": "^2.0.0",
+        "vfile": "^3.0.0",
         "x-is-string": "^0.1.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          }
+        }
       }
     },
     "unified-args": {

--- a/tools/node-lint-md-cli-rollup/package.json
+++ b/tools/node-lint-md-cli-rollup/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "markdown-extensions": "^1.1.0",
-    "remark": "^8.0.0",
+    "remark": "^10.0.0",
     "remark-lint": "^6.0.2",
     "remark-preset-lint-node": "^1.1.0",
     "unified-args": "^6.0.0",


### PR DESCRIPTION
Including the below two updates:
+ https://github.com/remarkjs/remark/releases/tag/9.0.0
+ https://github.com/remarkjs/remark/releases/tag/10.0.0

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
