### PR TITLE
readline: add reverse search

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -52,6 +52,10 @@ const {
   kClearScreenDown
 } = CSI;
 
+// stuff used for reverse search
+const kReverseSearchPrompt = "(reverse-i-search)`':";
+const kFailedReverseSearchPrompt = '(failed-reverse-i-search)`';
+
 // Lazy load StringDecoder for startup performance.
 let StringDecoder;
 
@@ -75,6 +79,13 @@ function createInterface(input, output, completer, terminal) {
   return new Interface(input, output, completer, terminal);
 }
 
+function buildReverseSearchPrompt(text, match) {
+  if (text === undefined)
+    return kReverseSearchPrompt;
+  if (match === '')
+    return `${kFailedReverseSearchPrompt}${text}':`;
+  return `(reverse-i-search)\`${text}': ${match}`;
+}
 
 function Interface(input, output, completer, terminal) {
   if (!(this instanceof Interface)) {
@@ -89,6 +100,9 @@ function Interface(input, output, completer, terminal) {
   this._sawKeyPress = false;
   this._previousKey = null;
   this.escapeCodeTimeout = ESCAPE_CODE_TIMEOUT;
+
+  this.inReverseSearch = false;
+  this.reverseSearchIndex = 0;
 
   EventEmitter.call(this);
   var historySize;
@@ -347,7 +361,8 @@ Interface.prototype._addHistory = function() {
 
 Interface.prototype._refreshLine = function() {
   // line length
-  var line = this._prompt + this.line;
+  const line = this._prompt + this.line;
+
   var dispPos = this._getDisplayPos(line);
   var lineCols = dispPos.cols;
   var lineRows = dispPos.rows;
@@ -383,6 +398,8 @@ Interface.prototype._refreshLine = function() {
   }
 
   this.prevRows = cursorPos.rows;
+
+  searchHistory.call(this);
 };
 
 
@@ -474,7 +491,59 @@ Interface.prototype._insertString = function(c) {
     // a hack to get the line refreshed if it's needed
     this._moveCursor(0);
   }
+
+  searchHistory.call(this);
 };
+
+function appendSearchResult(result) {
+  // this.previewResult = result;
+
+  // Cursor to left edge.
+  cursorTo(this.output, 0);
+  clearScreenDown(this.output);
+
+  // Based on the line and match result
+  // write the data
+  if (result !== '') {
+    this.output.write(buildReverseSearchPrompt(this.line, result));
+    cursorTo(this.output, this.cursor + kReverseSearchPrompt.length - 2);
+  } else if (this.line === '') {
+    this.output.write(buildReverseSearchPrompt());
+    cursorTo(this.output, this.cursor + kReverseSearchPrompt.length - 2);
+  } else {
+    this.output.write(buildReverseSearchPrompt(this.line, ''));
+    cursorTo(this.output, this.cursor + kFailedReverseSearchPrompt.length);
+  }
+
+}
+
+function searchText() {
+  let result = '';
+  const historySet = new Set(this.history);
+  for (;this.reverseSearchIndex < [...historySet].length;
+    this.reverseSearchIndex++) {
+    if (this.line.trim() !== '' &&
+        this.history[this.reverseSearchIndex].includes(this.line)) {
+      result = this.history[this.reverseSearchIndex++];
+      break;
+    }
+  }
+
+  return result;
+}
+
+function searchHistory() {
+  if (this.inReverseSearch) {
+    let result = searchText.call(this);
+    const historySet = new Set(this.history);
+    if (this.reverseSearchIndex >= [...historySet].length) {
+      this.reverseSearchIndex = 0;
+
+      result = searchText.call(this);
+    }
+    appendSearchResult.call(this, result);
+  }
+}
 
 Interface.prototype._tabComplete = function(lastKeypressWasTab) {
   var self = this;
@@ -768,6 +837,10 @@ Interface.prototype._moveCursor = function(dx) {
   }
 };
 
+function breakOutOfReverseSearch() {
+  this.inReverseSearch = false;
+  this._refreshLine();
+}
 
 // handle a write from the tty
 Interface.prototype._ttyWrite = function(s, key) {
@@ -775,9 +848,14 @@ Interface.prototype._ttyWrite = function(s, key) {
   key = key || {};
   this._previousKey = key;
 
-  // Ignore escape key, fixes
-  // https://github.com/nodejs/node-v0.x-archive/issues/2876.
-  if (key.name === 'escape') return;
+  if (key.name === 'escape') {
+    if (this.inReverseSearch) {
+      breakOutOfReverseSearch.call(this);
+    }
+    // Else, ignore escape key. Fixes:
+    // https://github.com/nodejs/node-v0.x-archive/issues/2876.
+    return;
+  }
 
   if (key.ctrl && key.shift) {
     /* Control and shift pressed */
@@ -802,6 +880,11 @@ Interface.prototype._ttyWrite = function(s, key) {
           // This readline instance is finished
           this.close();
         }
+
+        if (this.inReverseSearch) {
+          breakOutOfReverseSearch.call(this);
+        }
+
         break;
 
       case 'h': // delete left
@@ -897,6 +980,11 @@ Interface.prototype._ttyWrite = function(s, key) {
       case 'right':
         this._wordRight();
         break;
+
+      case 'r':
+        if (!this.inReverseSearch)
+          this.inReverseSearch = true;
+        searchHistory.call(this);
     }
 
   } else if (key.meta) {
@@ -931,6 +1019,11 @@ Interface.prototype._ttyWrite = function(s, key) {
     switch (key.name) {
       case 'return':  // carriage return, i.e. \r
         this._sawReturnAt = Date.now();
+        if (this.inReverseSearch) {
+          this.line = this.history[this.reverseSearchIndex - 1];
+          this.inReverseSearch = false;
+          this.reverseSearchIndex = 0;
+        }
         this._line();
         break;
 

--- a/test/parallel/test-repl-reverse-search.js
+++ b/test/parallel/test-repl-reverse-search.js
@@ -1,0 +1,156 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const common = require('../common');
+const stream = require('stream');
+const REPL = require('internal/repl');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const defaultHistoryPath = path.join(tmpdir.path, '.node_repl_history');
+
+// Create an input stream specialized for testing an array of actions
+class ActionStream extends stream.Stream {
+  run(data) {
+    const _iter = data[Symbol.iterator]();
+    const doAction = () => {
+      const next = _iter.next();
+      if (next.done) {
+        // Close the repl. Note that it must have a clean prompt to do so.
+        this.emit('keypress', '', { ctrl: true, name: 'd' });
+        return;
+      }
+      const action = next.value;
+
+      if (typeof action === 'object') {
+        this.emit('keypress', '', action);
+      } else {
+        this.emit('data', `${action}`);
+      }
+      setImmediate(doAction);
+    };
+    setImmediate(doAction);
+  }
+  resume() {}
+  pause() {}
+}
+ActionStream.prototype.readable = true;
+
+
+// Mock keys
+const ENTER = { name: 'enter' };
+const CLEAR = { ctrl: true, name: 'u' };
+const ESCAPE = { name: 'escape' };
+const SEARCH = { ctrl: true, name: 'r' };
+
+const prompt = '> ';
+const reverseSearchPrompt = '(reverse-i-search)`\':';
+
+
+const wrapWithSearchTexts = (code, result) => {
+  return `(reverse-i-search)\`${code}': ${result}`;
+};
+const tests = [
+  { // creates few history to search for
+    env: { NODE_REPL_HISTORY: defaultHistoryPath },
+    test: ['\' search\'.trim()', ENTER, 'let ab = 45', ENTER,
+           '555 + 909', ENTER, '{key : {key2 :[] }}', ENTER],
+    expected: [],
+    clean: false
+  },
+  {
+    env: { NODE_REPL_HISTORY: defaultHistoryPath },
+    test: [SEARCH, 's', ESCAPE, CLEAR],
+    expected: [reverseSearchPrompt,
+               wrapWithSearchTexts('s', '\' search\'.trim()')]
+  },
+  {
+    env: { NODE_REPL_HISTORY: defaultHistoryPath },
+    test: ['s', SEARCH, ESCAPE, CLEAR],
+    expected: [wrapWithSearchTexts('s', '\' search\'.trim()')]
+  },
+  {
+    env: { NODE_REPL_HISTORY: defaultHistoryPath },
+    test: ['5', SEARCH, SEARCH, ESCAPE, CLEAR],
+    expected: [wrapWithSearchTexts('5', '555 + 909'),
+               wrapWithSearchTexts('5', 'let ab = 45')]
+  },
+  {
+    env: { NODE_REPL_HISTORY: defaultHistoryPath },
+    test: ['*', SEARCH, ESCAPE, CLEAR],
+    expected: ['(failed-reverse-i-search)`*\':'],
+    clean: true
+  }
+];
+
+function cleanupTmpFile() {
+  try {
+    // Write over the file, clearing any history
+    fs.writeFileSync(defaultHistoryPath, '');
+  } catch (err) {
+    if (err.code === 'ENOENT') return true;
+    throw err;
+  }
+  return true;
+}
+
+const numtests = tests.length;
+
+const runTestWrap = common.mustCall(runTest, numtests);
+
+function runTest() {
+  const opts = tests.shift();
+  if (!opts) return; // All done
+
+  const env = opts.env;
+  const test = opts.test;
+  const expected = opts.expected;
+
+  REPL.createInternalRepl(env, {
+    input: new ActionStream(),
+    output: new stream.Writable({
+      write(chunk, _, next) {
+        const output = chunk.toString();
+
+        if (!output.includes('reverse-i-search')) {
+          return next();
+        }
+
+        if (expected.length) {
+          assert.strictEqual(output, expected[0]);
+          expected.shift();
+        }
+
+        next();
+      }
+    }),
+    prompt: prompt,
+    useColors: false,
+    terminal: true
+  }, function(err, repl) {
+    if (err) {
+      console.error(`Failed test # ${numtests - tests.length}`);
+      throw err;
+    }
+
+    repl.once('close', () => {
+      if (opts.clean)
+        cleanupTmpFile();
+
+      if (expected.length !== 0) {
+        throw new Error(`Failed test # ${numtests - tests.length}`);
+      }
+      setImmediate(runTestWrap, true);
+    });
+
+    repl.inputStream.run(test);
+  });
+}
+
+// run the tests
+runTest();


### PR DESCRIPTION
Hello Team, 

I wanted to add reverse search to repl:

1. Reverse search is supported in linux and unix terminals. 
2. User can press `ctrl+r` to search their history 
3. When user types in text, we search through `node_repl_history` and show off the matching results. 
4. When user press enter we run the matching command on our `repl`. 
5. When more results found for a string, pressing `ctrl+r` again will navigate the search results one by one in a circular fashion (if we reach end of the search result). 


It's a work in progress need tests, doc etc. 

Initial mode of working is ready. 

![repl-search](https://user-images.githubusercontent.com/1241511/48406108-b2a40780-e759-11e8-8c64-7b076aaab69e.gif)


Need thoughts from community on the idea. But I would love to land this on repl 😍 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
