### PR TITLE
http: compat head request should not start finished

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -436,9 +436,10 @@ class Http2ServerResponse extends Stream {
 
   get finished() {
     const stream = this[kStream];
+    const state = this[kState];
     return stream.destroyed ||
-           stream._writableState.ended ||
-           this[kState].closed;
+           state.closed ||
+           (stream.headRequest ? state.ending : stream._writableState.ended);
   }
 
   get socket() {
@@ -630,7 +631,7 @@ class Http2ServerResponse extends Stream {
     if (chunk !== null && chunk !== undefined)
       this.write(chunk, encoding);
 
-    const isFinished = this.finished;
+    const isFinished = stream._writableState.ended;
     state.headRequest = stream.headRequest;
     state.ending = true;
 

--- a/test/parallel/test-http2-compat-head-finished.js
+++ b/test/parallel/test-http2-compat-head-finished.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const { strictEqual } = require('assert');
+const h2 = require('http2');
+
+// Http2ServerResponse.finished cannot be true before res.end() is
+// called or the request is aborted.
+const server = h2
+  .createServer()
+  .listen(0, common.mustCall(function() {
+    const port = server.address().port;
+    server.once('request', common.mustCall((req, res) => {
+      strictEqual(res.finished, false);
+      res.writeHead(400);
+      strictEqual(res.finished, false);
+      strictEqual(res.headersSent, true);
+      res.end();
+      strictEqual(res.finished, true);
+    }));
+
+    const url = `http://localhost:${port}`;
+    const client = h2.connect(url, common.mustCall(function() {
+      const headers = {
+        ':path': '/',
+        ':method': 'HEAD',
+        ':scheme': 'http',
+        ':authority': `localhost:${port}`
+      };
+      const request = client.request(headers);
+      request.on('end', common.mustCall(function() {
+        client.close();
+        server.close();
+      }));
+      request.end();
+      request.resume();
+    }));
+  }));

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -121,7 +121,7 @@ const {
   // Http2ServerResponse.end is necessary on HEAD requests in compat
   // for http1 compatibility
   const server = createServer(mustCall((request, response) => {
-    strictEqual(response.finished, true);
+    strictEqual(response.finished, false);
     response.writeHead(HTTP_STATUS_OK, { foo: 'bar' });
     response.end('data', mustCall());
   }));


### PR DESCRIPTION
http2 streams for HEAD requests are never writable, thus writableState is not interesting for checking whether a response is ended or aborted.

Refs: https://github.com/nodejs/node/issues/24283

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)