### PR TITLE
added text regarding alternate user elevation.

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -1,7 +1,6 @@
 @echo off
 
 setlocal
-
 cls
 echo ====================================================
 echo Tools for Node.js Native Modules Installation Script

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -57,7 +57,7 @@ echo -----------------
 echo Use of Boxstarter may reboot your computer automatically multiple times.
 echo When performing a reboot, Boxstarter will need to disable User Account
 echo Control (UAC) to allow the script to run immediately after the reboot.
-echo If you are installing Node under an alternate user account from your GUI
+echo If you are installing Node.js under an alternate user account from your GUI
 echo (i.e. you elevate to a separate admin account to perform installs), you
 echo may need to log in directly to the GUI interface of that user after reboots.
 echo When the scripts have completed, Boxstarter will re-enable UAC and you can

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -58,7 +58,7 @@ echo Use of Boxstarter may reboot your computer automatically multiple times.
 echo When performing a reboot, Boxstarter will need to disable User Account
 echo Control (UAC) to allow the script to run immediately after the reboot.
 echo If you are installing Node under an alternate user account from your GUI
-echo (i.e. you elevate to a seperate admin account to perform installs), you
+echo (i.e. you elevate to a separate admin account to perform installs), you
 echo may need to log in directly to the GUI interface of that user after reboots.
 echo When the scripts have completed, Boxstarter will re-enable UAC and you can
 echo log in under your current user account again.

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -56,9 +56,12 @@ echo !!!!!WARNING!!!!!
 echo -----------------
 echo Use of Boxstarter may reboot your computer automatically multiple times.
 echo When performing a reboot, Boxstarter will need to disable User Account
-echo Control (UAC) to allow the script to run immediately after the reboot. When
-echo the scripts have completed, Boxstarter will re-enable UAC. If you prematurely
-echo stop the process, UAC will need to be re-enabled manually.
+echo Control (UAC) to allow the script to run immediately after the reboot.
+echo If you are installing Node under an alternate user account from your GUI
+echo (i.e. you elevate to a seperate admin account to perform installs), you
+echo may need to log in directly to the GUI interface of that user after reboots.
+echo When the scripts have completed, Boxstarter will re-enable UAC and you can
+echo log in under your current user account again.
 echo.
 echo Sometimes the scripts may install all necessary Windows Updates which
 echo could cause a high number of reboots that appear to be a reboot loop when

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -7,17 +7,17 @@ echo ====================================================
 echo Tools for Node.js Native Modules Installation Script
 echo ====================================================
 echo.
-echo This Boxstarter script will install Python and the Visual Studio Build Tools,
-echo necessary to compile Node.js native modules. Note that Boxstarter,
+echo This Boxstarter script will install Python and the Visual Studio Build
+echo Tools, needed to compile Node.js native modules. Note that Boxstarter,
 echo Chocolatey and required Windows updates will also be installed.
 echo.
-echo This will require about 3 Gb of free disk space, plus any space necessary to
-echo install Windows updates.
+echo This will require about 3 Gb of free disk space, plus any space
+echo necessary to install Windows updates.
 echo.
-echo This will take a while to run. Your computer may reboot during the
-echo installation, and will resume automatically.
+echo This will take a while to run. Please close all open programs for the
+echo duration of the installation as your computer may reboot multiple times
+echo while the applicable installations are proceeding.
 echo.
-echo Please close all open programs for the duration of the installation.
 echo.
 echo You can close this window to stop now. This script can be invoked from the
 echo Start menu. Detailed instructions to install these tools manually are
@@ -31,10 +31,10 @@ echo Using this script downloads third party software
 echo ------------------------------------------------
 echo This script will direct to Chocolatey to install packages. By using
 echo Chocolatey to install a package, you are accepting the license for the
-echo application, executable(s), or other artifacts delivered to your machine as a
-echo result of a Chocolatey install. This acceptance occurs whether you know the
-echo license terms or not. Read and understand the license terms of the packages
-echo being installed and their dependencies prior to installation:
+echo application, executable(s), or other artifacts delivered to your machine
+echo as a result of the install(s). This acceptance occurs whether you know
+echo the license terms or not. Read and understand the license terms of the
+echo packages being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
 echo - https://chocolatey.org/packages/boxstarter
 echo - https://chocolatey.org/packages/python2
@@ -44,10 +44,10 @@ echo.
 echo This script is provided AS-IS without any warranties of any kind
 echo ----------------------------------------------------------------
 echo Chocolatey has implemented security safeguards in their process to help
-echo protect the community from malicious or pirated software, but any use of this
-echo script is at your own risk. Please read the Chocolatey's legal terms of use
-echo and the Boxstarter project license as well as how the community repository
-echo for Chocolatey.org is maintained.
+echo protect the community from malicious or pirated software, but any use of
+echo this script is at your own risk. Please read the Chocolatey's legal
+echo terms of use and the Boxstarter project license as well as how the
+echo community repository for Chocolatey.org is maintained.
 echo.
 pause
 
@@ -57,20 +57,20 @@ echo -----------------
 echo Use of Boxstarter may reboot your computer automatically multiple times.
 echo When performing a reboot, Boxstarter will need to disable User Account
 echo Control (UAC) to allow the script to run immediately after the reboot.
-echo If you are installing Node.js under an alternate user account from your GUI
-echo (i.e. you elevate to a separate admin account to perform installs), you
-echo may need to log in directly to the GUI interface of that user after reboots.
-echo When the scripts have completed, Boxstarter will re-enable UAC and you can
-echo log in under your current user account again.
+echo If you are installing Node.js under an alternate user account from your
+echo GUI (i.e. you elevate to a separate admin account to perform installs),
+echo you may need to log in directly to the GUI interface of that user after
+echo reboots. When the scripts have completed, Boxstarter will re-enable UAC
+echo and you can log in under your current user account again.
 echo.
 echo Sometimes the scripts may install all necessary Windows Updates which
-echo could cause a high number of reboots that appear to be a reboot loop when
-echo in fact it is just a normal Windows Updates reboot cycle.
+echo could cause a high number of reboots that appear to be a reboot loop
+echo when in fact it is just a normal Windows Updates reboot cycle.
 :acceptretry
 echo.
 echo Your computer may REBOOT SEVERAL TIMES WITHOUT FURTHER WARNING.
-echo Please type YES followed by enter to confirm that you have saved all your
-set /p "ACCEPT_PROMPT=work and closed all open programs: "
+echo Please type YES followed by enter to confirm that you have saved all
+set /p "ACCEPT_PROMPT=your open documents and other work and closed all open programs: "
 if /i not "%ACCEPT_PROMPT%"=="yes" (
   echo Please type YES to confirm, or close the window to exit.
   goto acceptretry


### PR DESCRIPTION
Added instructions for alternate user elevation for UAC system.

Struck "If you prematurely stop the process, UAC will need to be re-
enabled manually." When UAC is disabled the user account ironically
may not have access to re-enable it, so manual re-enabling is a non-
trivial matter. Unless instructions are given, this "help" will just
lead to confusion.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
