### PR TITLE
http2: make Http2ServerResponse#end() always return this

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -616,7 +616,7 @@ class Http2ServerResponse extends Stream {
 
     if ((state.closed || state.ending) &&
         state.headRequest === stream.headRequest) {
-      return false;
+      return this;
     }
 
     if (typeof chunk === 'function') {

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -61,6 +61,34 @@ const {
 }
 
 {
+  // Http2ServerResponse.end should return self after end
+  const server = createServer(mustCall((request, response) => {
+    strictEqual(response, response.end());
+    strictEqual(response, response.end());
+    server.close();
+  }));
+  server.listen(0, mustCall(() => {
+    const { port } = server.address();
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const headers = {
+        ':path': '/',
+        ':method': 'GET',
+        ':scheme': 'http',
+        ':authority': `localhost:${port}`
+      };
+      const request = client.request(headers);
+      request.setEncoding('utf8');
+      request.on('end', mustCall(() => {
+        client.close();
+      }));
+      request.end();
+      request.resume();
+    }));
+  }));
+}
+
+{
   // Http2ServerResponse.end can omit encoding arg, sets it to utf-8
   const server = createServer(mustCall((request, response) => {
     response.end('test\uD83D\uDE00', mustCall(() => {


### PR DESCRIPTION
Http2Response.end can return `false` instead of `this`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
