### PR TITLE
http2: make compat finished match http/1

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -471,10 +471,8 @@ class Http2ServerResponse extends Stream {
   }
 
   get finished() {
-    const stream = this[kStream];
-    return stream.destroyed ||
-           stream._writableState.ended ||
-           this[kState].closed;
+    const state = this[kState];
+    return state.ending;
   }
 
   get socket() {
@@ -700,12 +698,11 @@ class Http2ServerResponse extends Stream {
     if (chunk !== null && chunk !== undefined)
       this.write(chunk, encoding);
 
-    const isFinished = this.finished;
     state.headRequest = stream.headRequest;
     state.ending = true;
 
     if (typeof cb === 'function') {
-      if (isFinished)
+      if (stream.writableEnded)
         this.once('finish', cb);
       else
         stream.once('finish', cb);
@@ -714,7 +711,7 @@ class Http2ServerResponse extends Stream {
     if (!stream.headersSent)
       this.writeHead(this[kState].statusCode);
 
-    if (isFinished)
+    if (this[kState].closed || stream.destroyed)
       onStreamCloseResponse.call(stream);
     else
       stream.end();

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -149,11 +149,13 @@ const {
   // Http2ServerResponse.end is necessary on HEAD requests in compat
   // for http1 compatibility
   const server = createServer(mustCall((request, response) => {
-    strictEqual(response.finished, true);
     strictEqual(response.writableEnded, false);
+    strictEqual(response.finished, false);
     response.writeHead(HTTP_STATUS_OK, { foo: 'bar' });
+    strictEqual(response.finished, false);
     response.end('data', mustCall());
     strictEqual(response.writableEnded, true);
+    strictEqual(response.finished, true);
   }));
   server.listen(0, mustCall(() => {
     const { port } = server.address();


### PR DESCRIPTION
Looking at the http1 semantic the current http2 compat implementation of `finished` seems rather complicated and fragile? Also it doesn't match the semantics of http1.

I have one http2 compat test failing which I don't quite undertand the purpose of. Am I missing something critical here?

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Refs: https://github.com/nodejs/node/issues/24743

NOTE TO SELF: review cb behaviour when ending and destroyed. Is ´onStreamCloseResponse` required?