### PR TITLE
win: add customization warning to tools script

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -54,6 +54,14 @@ pause
 cls
 echo !!!!!WARNING!!!!!
 echo -----------------
+echo This script should make installing the tools as easy as possible. Hence, it
+echo WILL NOT OFFER ANY CUSTOMIZATION. If there's any parameter you'd like to
+echo customize (like installation directory or features), or if there's any
+echo special rule or policy that your computer should comply to (like not being
+echo able to log in as the user with administrative privileges), please follow the
+echo instructions to download and execute the installers directly:
+echo https://github.com/nodejs/node-gyp#on-windows
+echo.
 echo Use of Boxstarter may reboot your computer automatically multiple times.
 echo When performing a reboot, Boxstarter will need to disable User Account
 echo Control (UAC) to allow the script to run immediately after the reboot. When


### PR DESCRIPTION
The script introduced in https://github.com/nodejs/node/pull/22645 to install Visual Studio and Python on Windows should work reliably in most scenarios. But it can only go so far, if a user wants to customize the installation or has custom policies in place, the alternative installation methods should be used. The script is designed to be as simple as possible, because for other options and customization there are already detailed instructions that the users can follow.

This PR adds a warning about that.

cc @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
