### PR TITLE
src: remove unused variables

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1291,7 +1291,6 @@ void Http2Session::HandleHeadersFrame(const nghttp2_frame* frame) {
   Local<String> name_str;
   Local<String> value_str;
 
-  Local<Array> holder = Array::New(isolate);
   // The headers are passed in above as a queue of nghttp2_header structs.
   // The following converts that into a JS array with the structure:
   // [name1, value1, name2, value2, name3, value3, name3, value4] and so on.

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -796,7 +796,6 @@ void GetParentProcessId(Local<Name> property,
 void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  Local<Array> ary = Array::New(args.GetIsolate());
   std::vector<Local<Value>> request_v;
   for (auto w : *env->req_wrap_queue()) {
     if (w->persistent().IsEmpty())


### PR DESCRIPTION
Currently the following compiler warnings are generated:
```console
../src/node_process.cc:799:16:
warning: unused variable 'ary' [-Wunused-variable]
  Local<Array> ary = Array::New(args.GetIsolate());
               ^
1 warning generated.
```
```console
../src/node_http2.cc:1294:16:
warning: unused variable 'holder' [-Wunused-variable]
  Local<Array> holder = Array::New(isolate);
               ^
1 warning generated.
```
This commit removes these unused variables.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
