### PR TITLE
src: fix compiler warning in node_os

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -163,7 +163,7 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
   // The array is in the format
   // [model, speed, (5 entries of cpu_times), model2, speed2, ...]
   std::vector<Local<Value>> result(count * 7);
-  for (size_t i = 0; i < count; i++) {
+  for (int i = 0; i < count; i++) {
     uv_cpu_info_t* ci = cpu_infos + i;
     result[i * 7] = OneByteString(isolate, ci->model);
     result[i * 7 + 1] = Number::New(isolate, ci->speed);


### PR DESCRIPTION
Currently the following compiler warnings is generated:
```console
../src/node_os.cc:167:24:
warning: comparison of integers of different signs: 'size_t'
(aka 'unsigned long') and 'int' [-Wsign-compare]
  for (size_t i = 0; i < count; i++) {
                     ~ ^ ~~~~~
1 warning generated.
```
This commit changes the type of `i` to int.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
