### PR TITLE
test: fix test-vm-timeout-escape-nextick on slow platforms

### DIFF
--- a/test/known_issues/test-vm-timeout-escape-nexttick.js
+++ b/test/known_issues/test-vm-timeout-escape-nexttick.js
@@ -35,7 +35,7 @@ assert.throws(() => {
       nextTick,
       loop
     },
-    { timeout: common.platformTimeout(10) }
+    { timeout: 10 }
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT'


### PR DESCRIPTION
Continuing to ratchet up robustness (such as it is) in
test-vm-timeout-escape-nexttick: The VM timeout does not need to be
large on slow platforms. The wait time in the loop does. Remove
common.platformTImeout() multiplier function from vm timeout property.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
