### PR TITLE
test: remove unused function arguments in async-hooks tests

### DIFF
--- a/test/async-hooks/test-getaddrinforeqwrap.js
+++ b/test/async-hooks/test-getaddrinforeqwrap.js
@@ -14,7 +14,7 @@ const hooks = initHooks();
 
 hooks.enable();
 dns.lookup('www.google.com', 4, common.mustCall(onlookup));
-function onlookup(err_, ip, family) {
+function onlookup() {
   // we don't care about the error here in order to allow
   // tests to run offline (lookup will fail in that case and the err be set);
 

--- a/test/async-hooks/test-getnameinforeqwrap.js
+++ b/test/async-hooks/test-getnameinforeqwrap.js
@@ -14,7 +14,7 @@ const hooks = initHooks();
 
 hooks.enable();
 dns.lookupService('127.0.0.1', 80, common.mustCall(onlookupService));
-function onlookupService(err_, ip, family) {
+function onlookupService() {
   // we don't care about the error here in order to allow
   // tests to run offline (lookup will fail in that case and the err be set)
 


### PR DESCRIPTION
Remove unused function arguments in two async-hooks tests.

(This actually started as a bigger change but then I realized the bigger change was wrong. Oops.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
