### PR TITLE
doc: better linkaged to node-addon-api

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -75,9 +75,6 @@ if (status != napi_ok) {
 
 The end result is that the addon only uses the exported C APIs. As a result,
 it still gets the benefits of the ABI stability provided by the C API.
-Detailed API documentation for `node-addon-api` is available
-[here](https://github.com/nodejs/node-addon-api#api-documentation).
-
 
 When using `node-addon-api` instead of the C APIs, start with the API
 [docs](https://github.com/nodejs/node-addon-api#api-documentation)

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -34,8 +34,8 @@ properties:
   handling section [Error Handling][].
 
 The N-API is a C API that ensures ABI stability across Node.js versions
-and different compiler levels. **A C++ API can be easier to use
-.** To support using C++, the project maintains a
+and different compiler levels. A C++ API can be easier to use
+. To support using C++, the project maintains a
 C++ wrapper module called
 [node-addon-api](https://github.com/nodejs/node-addon-api).
 This wrapper provides an inlineable C++ API. Binaries built

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -34,8 +34,8 @@ properties:
   handling section [Error Handling][].
 
 The N-API is a C API that ensures ABI stability across Node.js versions
-and different compiler levels. A C++ API can be easier to use
-. To support using C++, the project maintains a
+and different compiler levels. A C++ API can be easier to use.
+To support using C++, the project maintains a
 C++ wrapper module called
 [node-addon-api](https://github.com/nodejs/node-addon-api).
 This wrapper provides an inlineable C++ API. Binaries built
@@ -43,7 +43,7 @@ with `node-addon-api` will depend on the symbols for the N-API C-based
 functions exported by Node.js. `node-addon-api` is a more
 efficient way to write code that calls N-API. Take, for example, the 
 following `node-addon-api` code. The first section shows the
-`node-add-api` code and the section section shows what actually gets
+`node-addon-api` code and the second section shows what actually gets
 used in the addon.
 
 ```C++
@@ -79,7 +79,8 @@ Detailed API documentation for `node-addon-api` is available
 [here](https://github.com/nodejs/node-addon-api#api-documentation).
 
 
-When using `node-addon-api` instead of the C APIs, start with the API docs
+When using `node-addon-api` instead of the C APIs, start with the API
+[docs](https://github.com/nodejs/node-addon-api#api-documentation)
 for `node-addon-api`.
 
 ## Implications of ABI Stability

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -34,13 +34,53 @@ properties:
   handling section [Error Handling][].
 
 The N-API is a C API that ensures ABI stability across Node.js versions
-and different compiler levels. However, we also understand that a C++
-API can be easier to use in many cases. To support these cases we expect
-there to be one or more C++ wrapper modules that provide an inlineable C++
-API. Binaries built with these wrapper modules will depend on the symbols
-for the N-API C based functions exported by Node.js. These wrappers are not
-part of N-API, nor will they be maintained as part of Node.js. One such
-example is: [node-addon-api](https://github.com/nodejs/node-addon-api).
+and different compiler levels. **A C++ API can be easier to use
+.** To support using C++, the project maintains a
+C++ wrapper module called
+[node-addon-api](https://github.com/nodejs/node-addon-api).
+This wrapper provides an inlineable C++ API. Binaries built
+with `node-addon-api` will depend on the symbols for the N-API C-based
+functions exported by Node.js. `node-addon-api` is a more
+efficient way to write code that calls N-API. Take, for example, the 
+following `node-addon-api` code. The first section shows the
+`node-add-api` code and the section section shows what actually gets
+used in the addon.
+
+```C++
+Object obj = Object::New(env);
+obj["foo"] = String::New(env, "bar");
+```
+
+```C++
+napi_status status;
+napi_value object, string;
+status = napi_create_object(env, &object);
+if (status != napi_ok) {
+  napi_throw_error(env, ...);
+  return;
+}
+
+status = napi_crate_string_utf8(env, "bar", NAPI_AUTO_LENGTH, &string);
+if (status != napi_ok) {
+  napi_throw_error(env, ...);
+  return;
+}
+
+status = napi_set_named_property(env, object, "foo", string);
+if (status != napi_ok) {
+  napi_throw_error(env, ...);
+  return;
+}
+```
+
+The end result is that the addon only uses the exported C APIs. As a result,
+it still gets the benefits of the ABI stability provided by the C API.
+Detailed API documentation for `node-addon-api` is available
+[here](https://github.com/nodejs/node-addon-api#api-documentation).
+
+
+When using `node-addon-api` instead of the C APIs, start with the API docs
+for `node-addon-api`.
 
 ## Implications of ABI Stability
 


### PR DESCRIPTION
One of the comments we got at the N-API workshop
at NodeConfEU was that we should have a better link to
node-addon-api and the docs in the main API docs for
N-API. The goal being to help people find node-addon-api
and potentially start with the node-addon-api docs
instead if they are using C++.

This expands and strengthens the link along with a
recommendation that starting with the node-addon-api
docs might make sense.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
