### PR TITLE
doc: add help on fixing IPv6 test failures

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -253,6 +253,14 @@ $ ./node ./test/parallel/test-stream2-transform.js
 Remember to recompile with `make -j4` in between test runs if you change code in
 the `lib` or `src` directories.
 
+The tests attempt to detect support for IPv6 and exclude IPv6 tests if
+appropriate. However, if your main interface has IPv6 addresess then your
+loopback interface must also have '::1' enabled. For some default installations
+on ubuntu that does not seem to be the case. '::1' can be enabled on the
+loopback interface on ubuntu using:
+
+`sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0`
+
 #### Running Coverage
 
 It's good practice to ensure any code you add or change is covered by tests.


### PR DESCRIPTION
It took me a while to figure out the problem and
then some googling to find the right answer.  I think
it is worth adding this to help other people in the
future and to have an easy place to point people to
for the solution if their test run fails with IPv6
failures.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
