### PR TITLE
test: remove argument and fix import

### DIFF
--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const tick = require('../common/tick');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
-const spawn = require('child_process').spawn;
+const { spawn } = require('child_process').spawn;
 
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -45,7 +45,7 @@ checkInvocations(processwrap, { init: 1 },
   checkInvocations(x, { init: 1 }, 'pipe wrap when sleep.spawn was called');
 });
 
-function onsleepExit(code) {
+function onsleepExit() {
   checkInvocations(processwrap, { init: 1, before: 1 },
                    'processwrap while in onsleepExit callback');
 }

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const tick = require('../common/tick');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
-const { spawn } = require('child_process').spawn;
+const { spawn } = require('child_process');
 
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');


### PR DESCRIPTION
Removes unused argument and uses destructuring for spawn import in `test-pipewrap.js`.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
