### PR TITLE
test: skip test that use --tls-v1.x flags

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -73,7 +73,7 @@ class SimpleTestCase(test.TestCase):
       # failure so such tests are also skipped.
       if (any(flag.startswith('--inspect') for flag in flags) and
           not self.context.v8_enable_inspector):
-        print('Skipping as node was configured --without-inspector')
+        print('Skipping as node was configured without inspector support')
       elif (('--use-bundled-ca' in flags or
           '--use-openssl-ca' in flags or
           '--tls-v1.0' in flags or

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -73,13 +73,13 @@ class SimpleTestCase(test.TestCase):
       # failure so such tests are also skipped.
       if (any(flag.startswith('--inspect') for flag in flags) and
           not self.context.v8_enable_inspector):
-        print('Skipping as node was configured without inspector support')
+        print('Skipping as node was compiled witout inspector support')
       elif (('--use-bundled-ca' in flags or
           '--use-openssl-ca' in flags or
           '--tls-v1.0' in flags or
           '--tls-v1.1' in flags) and
           not self.context.node_has_crypto):
-        print('Skipping as node was configured --without-ssl')
+        print('Skipping as node was compiled without crypto support')
       else:
         result += flags
     files_match = FILES_PATTERN.search(source);

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -73,7 +73,7 @@ class SimpleTestCase(test.TestCase):
       # failure so such tests are also skipped.
       if (any(flag.startswith('--inspect') for flag in flags) and
           not self.context.v8_enable_inspector):
-        print('Skipping as node was compiled witout inspector support')
+        print('Skipping as node was compiled without inspector support')
       elif (('--use-bundled-ca' in flags or
           '--use-openssl-ca' in flags or
           '--tls-v1.0' in flags or

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -71,12 +71,14 @@ class SimpleTestCase(test.TestCase):
       # inspector related tests). Also, if there is no ssl support the options
       # '--use-bundled-ca' and '--use-openssl-ca' will also cause a similar
       # failure so such tests are also skipped.
-      if ((any(flag.startswith('--inspect') for flag in flags) or
-          '--use-bundled-ca' in flags or
+      if (any(flag.startswith('--inspect') for flag in flags) and
+          not self.context.v8_enable_inspector):
+        print('Skipping as node was configured --without-inspector')
+      elif (('--use-bundled-ca' in flags or
           '--use-openssl-ca' in flags or
           '--tls-v1.0' in flags or
           '--tls-v1.1' in flags) and
-          self.context.v8_enable_inspector == 0):
+          not self.context.node_has_crypto):
         print('Skipping as node was configured --without-ssl')
       else:
         result += flags

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -61,7 +61,7 @@ class SimpleTestCase(test.TestCase):
     source = open(self.file).read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:
-      flag = flags_match.group(1).strip().split()
+      flags = flags_match.group(1).strip().split()
       # The following block reads config.gypi to extract the v8_enable_inspector
       # value. This is done to check if the inspector is disabled in which case
       # the '--inspect' flag cannot be passed to the node process as it will
@@ -71,15 +71,15 @@ class SimpleTestCase(test.TestCase):
       # inspector related tests). Also, if there is no ssl support the options
       # '--use-bundled-ca' and '--use-openssl-ca' will also cause a similar
       # failure so such tests are also skipped.
-      if ('--inspect' in flag[0] or \
-          '--use-bundled-ca' in flag[0] or \
-          '--use-openssl-ca' in flag[0] or \
-          '--tls-v1.0' in flag[0] or \
-          '--tls-v1.1' in flag[0]) and \
-          self.context.v8_enable_inspector == 0:
+      if ((any(flag.startswith('--inspect') for flag in flags) or
+          '--use-bundled-ca' in flags or
+          '--use-openssl-ca' in flags or
+          '--tls-v1.0' in flags or
+          '--tls-v1.1' in flags) and
+          self.context.v8_enable_inspector == 0):
         print('Skipping as node was configured --without-ssl')
       else:
-        result += flag
+        result += flags
     files_match = FILES_PATTERN.search(source);
     additional_files = []
     if files_match:

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -73,7 +73,9 @@ class SimpleTestCase(test.TestCase):
       # failure so such tests are also skipped.
       if ('--inspect' in flag[0] or \
           '--use-bundled-ca' in flag[0] or \
-          '--use-openssl-ca' in flag[0]) and \
+          '--use-openssl-ca' in flag[0] or \
+          '--tls-v1.0' in flag[0] or \
+          '--tls-v1.1' in flag[0]) and \
           self.context.v8_enable_inspector == 0:
         print('Skipping as node was configured --without-ssl')
       else:

--- a/tools/test.py
+++ b/tools/test.py
@@ -1633,14 +1633,14 @@ def Main():
 
   # We want to skip the inspector tests if node was built without the inspector.
   has_inspector = Execute([vm,
-      "-p", "process.config.variables.v8_enable_inspector"], context)
-  if has_inspector.stdout.rstrip() == "0":
-      context.v8_enable_inspector = False
+      '-p', 'process.config.variables.v8_enable_inspector'], context)
+  if has_inspector.stdout.rstrip() == '0':
+    context.v8_enable_inspector = False
 
   has_crypto = Execute([vm,
-      "-p", "process.versions.openssl"], context)
-  if has_crypto.stdout.rstrip() == "undefined":
-      context.node_has_crypto = False
+      '-p', 'process.versions.openssl'], context)
+  if has_crypto.stdout.rstrip() == 'undefined':
+    context.node_has_crypto = False
 
   if options.cat:
     visited = set()

--- a/tools/test.py
+++ b/tools/test.py
@@ -907,6 +907,7 @@ class Context(object):
     self.repeat = repeat
     self.abort_on_timeout = abort_on_timeout
     self.v8_enable_inspector = True
+    self.node_has_crypto = True
 
   def GetVm(self, arch, mode):
     if arch == 'none':
@@ -1635,6 +1636,11 @@ def Main():
       "-p", "process.config.variables.v8_enable_inspector"], context)
   if has_inspector.stdout.rstrip() == "0":
       context.v8_enable_inspector = False
+
+  has_crypto = Execute([vm,
+      "-p", "process.versions.openssl"], context)
+  if has_crypto.stdout.rstrip() == "undefined":
+      context.node_has_crypto = False
 
   if options.cat:
     visited = set()


### PR DESCRIPTION
Currently, configuring `--without-ssl` will cause the following test to
fail:
```console
=== release test-https-agent-additional-options ===
Path: parallel/test-https-agent-additional-options
out/Release/node: bad option: --tls-v1.1
Command: out/Release/node --tls-v1.1
  /node/test/parallel/test-https-agent-additional-options.js
```
```console
=== release test-https-agent-session-eviction ===
Path: parallel/test-https-agent-session-eviction
out/Release/node: bad option: --tls-v1.0

Command: out/Release/node --tls-v1.0
  /node/test/parallel/test-https-agent-session-eviction.js
```
This commit adds a check for the `--tls-v.x` flags and skips them if node
was built without crypto support.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
