### PR TITLE
repl: handle buffered string logic on finish

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -348,9 +348,9 @@ Interface.prototype.undoHistory = function() {
 
 // If it's a multiline code, then add history
 // accordingly.
-Interface.prototype.multilineHistory = function() {
-  // check if we got a multiline code
-  if (this.multiline !== '' && this.terminal) {
+Interface.prototype.multilineHistory = function(clearBuffer) {
+  // if not clear buffer, add multiline history
+  if (!clearBuffer && this.terminal) {
     const dupIndex = this.history.indexOf(this.multiline);
     if (dupIndex !== -1) this.history.splice(dupIndex, 1);
     // Remove the last entered line as multiline

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -668,6 +668,13 @@ function REPLServer(prompt,
         }
       }
 
+      // handle multiline history
+      if (self[kBufferedCommandSymbol].length)
+        REPLServer.super_.prototype.multilineHistory.call(self, false);
+      else {
+        REPLServer.super_.prototype.multilineHistory.call(self, true);
+      }
+
       // Clear buffer if no SyntaxErrors
       self.clearBufferedCommand();
       sawCtrlD = false;
@@ -774,7 +781,6 @@ exports.start = function(prompt,
 
 REPLServer.prototype.clearBufferedCommand = function clearBufferedCommand() {
   this[kBufferedCommandSymbol] = '';
-  REPLServer.super_.prototype.multilineHistory.call(this);
 };
 
 REPLServer.prototype.close = function close() {


### PR DESCRIPTION
Fixes : https://github.com/nodejs/node/issues/24385

Looks like `clearBufferedCommand` will be called on almost all flows. Hence history was broken. Sorry about that, but I take this as learning and see why history test cases didn't catch up this in first place. I will spend some time this weekend to add few more test cases on to repl history which caused this regression. 

Can some one ping repl team to make it land faster? 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
