### PR TITLE
fs: flip value of isOpen

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -204,8 +204,7 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
-  const isOpen = typeof this.fd === 'number';
-  if (!isOpen) {
+  if (typeof this.fd !== 'number') {
     this.once('open', closeFsStream.bind(null, this, cb, err));
     return;
   }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -204,8 +204,8 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
-  const isOpen = typeof this.fd !== 'number';
-  if (isOpen) {
+  const isOpen = typeof this.fd === 'number';
+  if (!isOpen) {
     this.once('open', closeFsStream.bind(null, this, cb, err));
     return;
   }


### PR DESCRIPTION
The `open` event is emitted after `this.fd` is assigned a number in `ReadStream.prototype.open`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
