### PR TITLE
stream: do not use crypto.DEFAULT_ENCODING in lazy_transform.js

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -5,7 +5,10 @@
 
 const stream = require('stream');
 const util = require('util');
-const crypto = require('crypto');
+
+const {
+  getDefaultEncoding
+} = require('internal/crypto/util');
 
 module.exports = LazyTransform;
 
@@ -22,7 +25,7 @@ function makeGetter(name) {
     this._writableState.decodeStrings = false;
 
     if (!this._options || !this._options.defaultEncoding) {
-      this._writableState.defaultEncoding = crypto.DEFAULT_ENCODING;
+      this._writableState.defaultEncoding = getDefaultEncoding();
     }
 
     return this[name];


### PR DESCRIPTION
The default encoding can be retrieved via
`require('internal/crypto/util').getDefaultEncoding` instead of
the deprecated crypto.DEFAULT_ENCODING which triggers a warning.

Background:

The require chain goes like this:

```
internal/streams/lazy_transform.js
  -> crypto.js
  -> internal/crypto/cipher.js (uses LazyTransform in the global scope)
  -> internal/streams/lazy_transform.js
```

So when `internal/streams/lazy_transform.js` is required before
`lib/crypto.js`, we have a circular dependency and since
`internal/crypto/cipher.js` uses destructuring to use LazyTransform
we will get an error. And it can also trigger a warning if
lazy_transform.js is the first file that touches
crypto.DEFAULT_ENCODING.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
