### PR TITLE
lib: set stderr._destroy to dummyDestroy

### DIFF
--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -32,7 +32,7 @@ function getMainThreadStdio() {
     stderr = createWritableStdioStream(2);
     stderr.destroySoon = stderr.destroy;
     // Override _destroy so that the fd is never actually closed.
-    stdout._destroy = dummyDestroy;
+    stderr._destroy = dummyDestroy;
     if (stderr.isTTY) {
       process.on('SIGWINCH', () => stderr._refreshSize());
     }


### PR DESCRIPTION
This seems to be typo: we are setting stdout._destroy instead of
stderr._destroy in the getter of stderr.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
