### PR TITLE
test: add typeerror test for EC crypto keygen

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -625,6 +625,22 @@ function convertDERToPEM(label, der) {
     message: 'Invalid ECDH curve name'
   });
 
+  // Test error type when curve is not a string
+  for (const namedCurve of [true, {}, [], 123]) {
+    common.expectsError(() => {
+      generateKeyPairSync('ec', {
+        namedCurve,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'sec1', format: 'pem' }
+      });
+    }, {
+      type: TypeError,
+      code: 'ERR_INVALID_OPT_VALUE',
+      message: `The value "${namedCurve}" is invalid for option ` +
+               '"namedCurve"'
+    });
+  }
+
   // It should recognize both NIST and standard curve names.
   generateKeyPair('ec', {
     namedCurve: 'P-192',


### PR DESCRIPTION
Added test for type error on generate EC crypto keygen when curve is not a string.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
