### PR TITLE
test: add a test to make sure the modules can be required independently

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -5,7 +5,10 @@
 
 const stream = require('stream');
 const util = require('util');
-const crypto = require('crypto');
+
+const {
+  getDefaultEncoding
+} = require('internal/crypto/util');
 
 module.exports = LazyTransform;
 
@@ -22,7 +25,7 @@ function makeGetter(name) {
     this._writableState.decodeStrings = false;
 
     if (!this._options || !this._options.defaultEncoding) {
-      this._writableState.defaultEncoding = crypto.DEFAULT_ENCODING;
+      this._writableState.defaultEncoding = getDefaultEncoding();
     }
 
     return this[name];

--- a/test/sequential/test-native-module-deps.js
+++ b/test/sequential/test-native-module-deps.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// This tests that all the native modules can be loaded independently
+// Flags: --expose-internals
+
+if (process.argv[3]) {
+  require(process.argv[3]);
+  return;
+}
+
+require('../common');
+const {
+  cachableBuiltins
+} = require('internal/bootstrap/cache');
+const { fork } = require('child_process');
+const assert = require('assert');
+
+for (const key of cachableBuiltins) {
+  run(key);
+}
+
+function run(key) {
+  const child = fork(__filename,
+    [ '--expose-internals', key ],
+    { silent: true }
+  );
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (data) => (stdout += data.toString()));
+  child.stderr.on('data', (data) => (stderr += data.toString()));
+  child.on('close', (code) => {
+    if (code === 0) {
+      return;
+    }
+    console.log(`Failed to require ${key}`)
+    console.log('----- stderr ----')
+    console.log(stderr);
+    console.log('----- stdout ----')
+    console.log(stdout);
+    assert.strictEqual(code, 0);
+  });
+}

--- a/test/sequential/test-native-module-deps.js
+++ b/test/sequential/test-native-module-deps.js
@@ -21,8 +21,8 @@ for (const key of cachableBuiltins) {
 
 function run(key) {
   const child = fork(__filename,
-    [ '--expose-internals', key ],
-    { silent: true }
+                     [ '--expose-internals', key ],
+                     { silent: true }
   );
 
   let stdout = '';
@@ -33,10 +33,10 @@ function run(key) {
     if (code === 0) {
       return;
     }
-    console.log(`Failed to require ${key}`)
-    console.log('----- stderr ----')
+    console.log(`Failed to require ${key}`);
+    console.log('----- stderr ----');
     console.log(stderr);
-    console.log('----- stdout ----')
+    console.log('----- stdout ----');
     console.log(stdout);
     assert.strictEqual(code, 0);
   });


### PR DESCRIPTION
The first patch comes from https://github.com/nodejs/node/pull/24396

So, I am not entirely sure if it's worth adding a test that launches ~75 child processes just to make sure we have a cleaner dependency graph in the internal modules..so just open this to see what others think.


#### test: add a test to make sure the modules can be required

This patch adds a test that makes sure all the modules (internal
or not) can be independently required - that is, when there is
circular dependency, one module does not rely on another module
being loaded first to initialize, instead it should lazily load
that dependency after initialization.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
