### PR TITLE
test: remove unused function arguments in async-hooks tests

### DIFF
--- a/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
@@ -8,11 +8,11 @@ const { checkInvocations } = require('./hook-checks');
 if (!common.isMainThread)
   common.skip('Worker bootstrapping works differently -> different async IDs');
 
-const p = new Promise(common.mustCall(function executor(resolve, reject) {
+const p = new Promise(common.mustCall(function executor(resolve) {
   resolve(5);
 }));
 
-p.then(function afterresolution(val) {
+p.then(function afterResolution(val) {
   assert.strictEqual(val, 5);
   return val;
 });

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -13,24 +13,22 @@ const hooks = initHooks();
 
 hooks.enable();
 
-const p = (new Promise(common.mustCall(executor)));
-p.then(afterresolution);
-
-function executor(resolve, reject) {
-  const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 1);
-  const a = as[0];
-  checkInvocations(a, { init: 1 }, 'while in promise executor');
-  resolve(5);
-}
-
-function afterresolution(val) {
+const p = new Promise(common.mustCall(executor));
+p.then(function afterResolution(val) {
   assert.strictEqual(val, 5);
   const as = hooks.activitiesOfTypes('PROMISE');
   assert.strictEqual(as.length, 2);
   checkInvocations(as[0], { init: 1 }, 'after resolution parent promise');
   checkInvocations(as[1], { init: 1, before: 1 },
                    'after resolution child promise');
+});
+
+function executor(resolve) {
+  const as = hooks.activitiesOfTypes('PROMISE');
+  assert.strictEqual(as.length, 1);
+  const a = as[0];
+  checkInvocations(a, { init: 1 }, 'while in promise executor');
+  resolve(5);
 }
 
 process.on('exit', onexit);

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
 
-const p = new Promise(common.mustCall(function executor(resolve, reject) {
+const p = new Promise(common.mustCall(function executor(resolve) {
   resolve(5);
 }));
 
@@ -13,7 +13,7 @@ const p = new Promise(common.mustCall(function executor(resolve, reject) {
 const hooks = initHooks({ allowNoInit: true });
 hooks.enable();
 
-p.then(function afterresolution(val) {
+p.then(function afterResolution(val) {
   assert.strictEqual(val, 5);
   const as = hooks.activitiesOfTypes('PROMISE');
   assert.strictEqual(as.length, 1);


### PR DESCRIPTION
Remove unused function arguments in three async-hooks tests and improve test consistency.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

