### PR TITLE
http2: replace unreachable error with assertion

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const Stream = require('stream');
 const Readable = Stream.Readable;
 const binding = internalBinding('http2');
@@ -331,15 +332,12 @@ class Http2ServerRequest extends Readable {
 
   _read(nread) {
     const state = this[kState];
-    if (!state.closed) {
-      if (!state.didRead) {
-        state.didRead = true;
-        this[kStream].on('data', onStreamData);
-      } else {
-        process.nextTick(resumeStream, this[kStream]);
-      }
+    assert(!state.closed);
+    if (!state.didRead) {
+      state.didRead = true;
+      this[kStream].on('data', onStreamData);
     } else {
-      this.emit('error', new ERR_HTTP2_INVALID_STREAM());
+      process.nextTick(resumeStream, this[kStream]);
     }
   }
 


### PR DESCRIPTION
"That particular `emit('error', ...)` is largely defensively coded and
should not ever actually happen." Sounds like an assertion rather than
an error event. The code in question has no test coverage because it is
believed to be unreachable.

Fixes: https://github.com/nodejs/node/issues/20673

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
