### PR TITLE
doc: include undefined in os.cpus() return values

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -54,10 +54,10 @@ defined are described in [OS Constants](#os_os_constants_1).
 added: v0.3.3
 -->
 
-* Returns: {Object[]}
+* Returns: {Object[]|undefined}
 
-The `os.cpus()` method returns an array of objects containing information about
-each logical CPU core.
+Returns an array of objects containing information about each logical CPU core.
+If the information is not available, `os.cpus()` will return `undefined`.
 
 The properties included on each object include:
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -57,7 +57,7 @@ added: v0.3.3
 * Returns: {Object[]|undefined}
 
 Returns an array of objects containing information about each logical CPU core.
-If the information is not available, `os.cpus()` will return `undefined`.
+On unsupported platforms such as Android, `os.cpus()` may return `undefined`.
 
 The properties included on each object include:
 


### PR DESCRIPTION
Document that `os.cpus()` can return `undefined` if information about
cores is not available. This can happen particularly on unsupported
platforms like Android.

Fixes: https://github.com/nodejs/node/issues/19022

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
