### PR TITLE
console: improve code readability

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -97,23 +97,26 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     throw new ERR_CONSOLE_WRITABLE_STREAM('stderr');
   }
 
-  var prop = {
+  const prop = {
     writable: true,
     enumerable: false,
     configurable: true
   };
-  prop.value = stdout;
-  Object.defineProperty(this, '_stdout', prop);
-  prop.value = stderr;
-  Object.defineProperty(this, '_stderr', prop);
-  prop.value = Boolean(ignoreErrors);
-  Object.defineProperty(this, '_ignoreErrors', prop);
-  prop.value = new Map();
-  Object.defineProperty(this, '_times', prop);
-  prop.value = createWriteErrorHandler(stdout);
-  Object.defineProperty(this, '_stdoutErrorHandler', prop);
-  prop.value = createWriteErrorHandler(stderr);
-  Object.defineProperty(this, '_stderrErrorHandler', prop);
+  Object.defineProperty(this, '_stdout', { ...prop, value: stdout });
+  Object.defineProperty(this, '_stderr', { ...prop, value: stderr });
+  Object.defineProperty(this, '_ignoreErrors', {
+    ...prop,
+    value: Boolean(ignoreErrors),
+  });
+  Object.defineProperty(this, '_times', { ...prop, value: new Map() });
+  Object.defineProperty(this, '_stdoutErrorHandler', {
+    ...prop,
+    value: createWriteErrorHandler(stdout),
+  });
+  Object.defineProperty(this, '_stderrErrorHandler', {
+    ...prop,
+    value: createWriteErrorHandler(stderr),
+  });
 
   if (typeof colorMode !== 'boolean' && colorMode !== 'auto')
     throw new ERR_INVALID_ARG_VALUE('colorMode', colorMode);


### PR DESCRIPTION
use object spread to make console code more readable

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

