### PR TITLE
test: assertion equality fix

### DIFF
--- a/test/pummel/test-net-write-callbacks.js
+++ b/test/pummel/test-net-write-callbacks.js
@@ -67,5 +67,5 @@ server.listen(common.PORT, function() {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(N, cbcount);
+  assert.strictEqual(cbcount, N);
 });


### PR DESCRIPTION
In test-net-write-callback.js, when the process exits, we check of callback
count with the expected value. written assert.strictEqual(N, cbcount),
which expects N to equal to cbcount, instead we should expect cbcount to be equal to cbcount.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
