### PR TITLE
test: fix actual parameter order for 'assert.strictEqual'

### DIFF
--- a/test/pummel/test-net-throttle.js
+++ b/test/pummel/test-net-throttle.js
@@ -58,7 +58,7 @@ server.listen(common.PORT, function() {
       console.log('pause');
       const x = chars_recved;
       setTimeout(function() {
-        assert.strictEqual(x, chars_recved);
+        assert.strictEqual(chars_recved, x);
         client.resume();
         console.log('resume');
         paused = false;


### PR DESCRIPTION

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit   @@guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This commit is initiated from Code&Learn meetup

@ryzokuken @thefourtheye 