### PR TITLE
doc,meta: add issue template for flaky tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/5-flaky-test.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F4AB Found a flaky test?"
+about: Please provide information about the failure.
+
+---
+<!--
+Thank you for reporting a possible flaky test in Node.js.
+
+Please fill in as much of the template below as you can.
+
+-->
+* test file - [NAME_OF_TEST_WITH_SUITE (e.g. parallel/test-https)](https://github.com/nodejs/node/blob/master/test/NAME_OF_TEST_WITH_SUITE.js)
+* ci job  - [CI_JOB_DESCRIPTOR (e.g. aix/21613)](https://ci.nodejs.org/job/node-test-CI_JOB_DESCRIPTOR)
+* ci worker - [CI_WORKER_NAME](https://ci.nodejs.org/computer/CI_WORKER_NAME/)
+* output:
+  ```
+  CI console output for the failing test.
+  Or content of JUnit test details page.
+  Note: should be indented with 2 spaces to align with * bullet point.
+  ```

--- a/.github/ISSUE_TEMPLATE/5-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/5-flaky-test.md
@@ -12,9 +12,9 @@ Please fill in as much of the template below as you can.
 * test file - [NAME_OF_TEST_WITH_SUITE (e.g. parallel/test-https)](https://github.com/nodejs/node/blob/master/test/NAME_OF_TEST_WITH_SUITE.js)
 * ci job  - [CI_JOB_DESCRIPTOR (e.g. aix/21613)](https://ci.nodejs.org/job/node-test-CI_JOB_DESCRIPTOR)
 * ci worker - [CI_WORKER_NAME](https://ci.nodejs.org/computer/CI_WORKER_NAME/)
-* output:
-  ```
-  CI console output for the failing test.
-  Or content of JUnit test details page.
-  Note: should be indented with 2 spaces to align with * bullet point.
-  ```
+
+output:
+```
+CI console output for the failing test.
+Or content of JUnit test details page.
+```


### PR DESCRIPTION
New template for reporting flaky tests. Lists the data point relevant to later investigate the issue (i.e. CI-job, CI-worker, link to test code, console output).
Examples:
https://github.com/nodejs/node/issues/24449
https://github.com/nodejs/node/issues/24403
https://github.com/nodejs/node/issues/24397

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
