### PR TITLE
deps,src: don't warn on V8 self-deprecation

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -31,7 +31,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -171,9 +171,17 @@
       #  'defines': ['ENABLE_HANDLE_ZAPPING',],
       # }],
 
+
       # Node.js specific switch
       ['node_use_bundled_v8=="true"', {
+        # Eliminate V8 self deprecation.
+        # Refs: https://github.com/nodejs/node/pull/24454
         'defines!': [ 'V8_DEPRECATION_WARNINGS', 'V8_IMMINENT_DEPRECATION_WARNINGS' ],
+        # A few hundreds of these are emitted from 'src/objects-inl.h'.
+        # warning: comparison is always true due to limited range of data type [-Wtype-limits]
+        # This is irrelevant for an embedding project.
+        # warning: 'foo' may be used uninitialized in this function [-Wmaybe-uninitialized]
+        'cflags': [ '-Wno-type-limits', '-Wno-maybe-uninitialized', ],
       }],
     ],  # conditions
     'defines': [

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -170,6 +170,11 @@
       # ['v8_enable_handle_zapping==1', {
       #  'defines': ['ENABLE_HANDLE_ZAPPING',],
       # }],
+
+      # Node.js specific switch
+      ['node_use_bundled_v8=="true"', {
+        'defines!': [ 'V8_DEPRECATION_WARNINGS', 'V8_IMMINENT_DEPRECATION_WARNINGS' ],
+      }],
     ],  # conditions
     'defines': [
       'V8_GYP_BUILD',

--- a/node.gyp
+++ b/node.gyp
@@ -7,7 +7,6 @@
     'node_no_browser_globals%': 'false',
     'node_code_cache_path%': '',
     'node_use_v8_platform%': 'true',
-    'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,
     'node_module_version%': '',

--- a/node.gyp
+++ b/node.gyp
@@ -465,6 +465,7 @@
         'src/udp_wrap.h',
         'src/util.h',
         'src/util-inl.h',
+        'src/vm.h',
         # Dependency headers
         'deps/http_parser/http_parser.h',
         'deps/v8/include/v8.h',

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "v8.h"
+#include "vm.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -26,7 +26,7 @@
 #include "tracing/traced_value.h"
 #include "util-inl.h"
 
-#include "v8.h"
+#include "vm.h"
 #include "v8-profiler.h"
 
 using v8::Context;

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -25,7 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "base_object.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <stdint.h>
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -27,7 +27,7 @@
 #include "base_object.h"
 #include "env-inl.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -26,7 +26,7 @@
 
 #include "node_persistent.h"
 #include "memory_tracker-inl.h"
-#include "v8.h"
+#include "vm.h"
 #include <type_traits>  // std::remove_reference
 
 namespace node {

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -1,7 +1,7 @@
 #include "node.h"
 #include "env-inl.h"
 #include "node_internals.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <atomic>
 

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -1,7 +1,7 @@
 #include "node.h"
 #include "async_wrap-inl.h"
 #include "env-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/connect_wrap.h
+++ b/src/connect_wrap.h
@@ -6,7 +6,7 @@
 #include "env.h"
 #include "req_wrap-inl.h"
 #include "async_wrap.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -5,7 +5,7 @@
 
 #include "env.h"
 #include "stream_wrap.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -29,7 +29,7 @@
 #include "node.h"
 #include "util-inl.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 #include "node_perf_common.h"
 #include "node_context_data.h"
 #include "node_worker.h"

--- a/src/env.h
+++ b/src/env.h
@@ -35,7 +35,7 @@
 #include "req_wrap.h"
 #include "util.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <list>
 #include <stdint.h>

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -2,7 +2,7 @@
 #include "node_internals.h"
 #include "env-inl.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 #include "uv.h"
 
 #include <string.h>

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -27,7 +27,7 @@
 #include "async_wrap.h"
 #include "util.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -2,7 +2,7 @@
 #include "node_internals.h"
 
 #include "env-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <set>
 #include <sstream>

--- a/src/inspector/tracing_agent.h
+++ b/src/inspector/tracing_agent.h
@@ -3,7 +3,7 @@
 
 #include "node/inspector/protocol/NodeTracing.h"
 #include "tracing/agent.h"
-#include "v8.h"
+#include "vm.h"
 
 
 namespace node {

--- a/src/inspector/worker_agent.h
+++ b/src/inspector/worker_agent.h
@@ -2,7 +2,7 @@
 #define SRC_INSPECTOR_WORKER_AGENT_H_
 
 #include "node/inspector/protocol/NodeWorker.h"
-#include "v8.h"
+#include "vm.h"
 
 
 namespace node {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -13,7 +13,7 @@
 
 #include "node_options.h"
 #include "node_persistent.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace v8_inspector {
 class StringView;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -2,7 +2,7 @@
 #include "inspector_agent.h"
 #include "inspector_io.h"
 #include "node_internals.h"
-#include "v8.h"
+#include "vm.h"
 #include "v8-inspector.h"
 
 namespace node {

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -5,7 +5,7 @@
 #include "node_buffer.h"
 #include "node_internals.h"
 #include "stream_base-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -6,7 +6,7 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "stream_base.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node.h
+++ b/src/node.h
@@ -60,7 +60,7 @@
 # define SIGKILL         9
 #endif
 
-#include "v8.h"  // NOLINT(build/include_order)
+#include "vm.h"  // NOLINT(build/include_order)
 #include "v8-platform.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -28,7 +28,7 @@
 #include "string_search.h"
 #include "util-inl.h"
 #include "v8-profiler.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <string.h>
 #include <limits.h>

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -23,7 +23,7 @@
 #define SRC_NODE_BUFFER_H_
 
 #include "node.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -25,7 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "v8.h"
+#include "vm.h"
 
 #if HAVE_OPENSSL
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -35,7 +35,7 @@
 #include "env-inl.h"
 #include "string_bytes.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <errno.h>
 #include <limits.h>  // INT_MAX

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -34,7 +34,7 @@
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
 
-#include "v8.h"
+#include "vm.h"
 
 #include <openssl/ssl.h>
 #include <openssl/ec.h>

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -28,7 +28,7 @@
 #include "openssl/bio.h"
 #include "env-inl.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 namespace crypto {

--- a/src/node_domain.cc
+++ b/src/node_domain.cc
@@ -1,4 +1,4 @@
-#include "v8.h"
+#include "vm.h"
 #include "node_internals.h"
 
 namespace node {

--- a/src/node_encoding.cc
+++ b/src/node_encoding.cc
@@ -2,7 +2,7 @@
 #include "env-inl.h"
 #include "string_bytes.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -6,7 +6,7 @@
 #include "node.h"
 #include "util-inl.h"
 #include "env-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 // Use ostringstream to print exact-width integer types
 // because the format specifiers are not available on AIX.

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -27,7 +27,7 @@
 #include "env-inl.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <stdlib.h>  // free()
 #include <string.h>  // strdup(), strchr()

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -50,7 +50,7 @@
 #include "env-inl.h"
 #include "util-inl.h"
 #include "base_object-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <unicode/utypes.h>
 #include <unicode/putil.h>

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -30,7 +30,7 @@
 #include "util-inl.h"
 #include "env-inl.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 #include "tracing/trace_event.h"
 #include "node_api.h"
 

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -22,7 +22,7 @@
 #ifndef SRC_NODE_OBJECT_WRAP_H_
 #define SRC_NODE_OBJECT_WRAP_H_
 
-#include "v8.h"
+#include "vm.h"
 #include <assert.h>
 
 

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -9,7 +9,7 @@
 #include "env.h"
 #include "base_object-inl.h"
 
-#include "v8.h"
+#include "vm.h"
 #include "uv.h"
 
 #include <string>

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -4,7 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <algorithm>
 #include <map>

--- a/src/node_persistent.h
+++ b/src/node_persistent.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -6,7 +6,7 @@
 #include "env-inl.h"
 #include "util-inl.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 
 #if HAVE_INSPECTOR
 #include "inspector_io.h"

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -28,7 +28,7 @@
 #include "handle_wrap.h"
 #include "env.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -23,7 +23,7 @@
 #include "node_internals.h"
 #include "env-inl.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -24,7 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "v8.h"
+#include "vm.h"
 #include "uv.h"
 #include "node_mutex.h"
 #include <vector>

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -27,7 +27,7 @@
 #include "env-inl.h"
 #include "util-inl.h"
 
-#include "v8.h"
+#include "vm.h"
 #include "zlib.h"
 
 #include <errno.h>

--- a/src/req_wrap.h
+++ b/src/req_wrap.h
@@ -6,7 +6,7 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "util.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -23,7 +23,7 @@
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -7,7 +7,7 @@
 
 #include "node.h"
 #include "env-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -10,7 +10,7 @@
 #include "string_bytes.h"
 #include "util.h"
 #include "util-inl.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <limits.h>  // INT_MAX
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -8,7 +8,7 @@
 #include "node.h"
 #include "util.h"
 
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -29,7 +29,7 @@
 #include "env.h"
 #include "handle_wrap.h"
 #include "string_bytes.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -26,7 +26,7 @@
 
 // Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
-#include "v8.h"
+#include "vm.h"
 #include "env.h"
 
 namespace node {

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -30,7 +30,7 @@
 #include "async_wrap.h"
 #include "env.h"
 #include "stream_wrap.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <openssl/ssl.h>
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -3,7 +3,7 @@
 
 #include "libplatform/v8-tracing.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 #include "util.h"
 #include "node_mutex.h"
 

--- a/src/tracing/traced_value.h
+++ b/src/tracing/traced_value.h
@@ -6,7 +6,7 @@
 #define SRC_TRACING_TRACED_VALUE_H_
 
 #include "node_internals.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <stddef.h>
 #include <memory>

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -28,7 +28,7 @@
 #include "env.h"
 #include "handle_wrap.h"
 #include "uv.h"
-#include "v8.h"
+#include "vm.h"
 
 namespace node {
 

--- a/src/util.h
+++ b/src/util.h
@@ -25,7 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node_persistent.h"
-#include "v8.h"
+#include "vm.h"
 
 #include <assert.h>
 #include <signal.h>

--- a/src/vm.h
+++ b/src/vm.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)  // deprecated declaration
+#endif  // _MSC_VER
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // __GNUC__
+#include "v8.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-v8/issues/88
Don't trigger V8 deprecation warnings while compiling V8 itself.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
