### PR TITLE
test: use destructuring on require

### DIFF
--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -17,9 +17,9 @@ if (isCPPSymbolsNotMapped) {
 
 
 const assert = require('assert');
-const cp = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const path = require('path');
-const fs = require('fs');
+const { writeFileSync } = require('fs');
 
 const LOG_FILE = path.join(tmpdir.path, 'tick-processor.log');
 const RETRY_TIMEOUT = 150;
@@ -33,7 +33,7 @@ const code = `function f() {
          };
          f();`;
 
-const proc = cp.spawn(process.execPath, [
+const proc = spawn(process.execPath, [
   '--no_logfile_per_isolate',
   '--logfile=-',
   '--prof',
@@ -49,8 +49,8 @@ proc.stdout.on('data', (chunk) => ticks += chunk);
 function runPolyfill(content) {
   proc.kill();
   content += BROKEN_PART;
-  fs.writeFileSync(LOG_FILE, content);
-  const child = cp.spawnSync(
+  writeFileSync(LOG_FILE, content);
+  const child = spawnSync(
     `${process.execPath}`,
     [
       '--prof-process', LOG_FILE


### PR DESCRIPTION
Uses destructuring for `spawn`, `spawnSync` and `writeFileSync` require in`test-tick-processor-polyfill-brokenfile.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
