### PR TITLE
net: emit "write after end" errors in the next tick

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -396,8 +396,7 @@ function writeAfterFIN(chunk, encoding, cb) {
   // eslint-disable-next-line no-restricted-syntax
   var er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  // TODO: defer error events consistently everywhere, not just the cb
-  this.emit('error', er);
+  process.nextTick(emitErrorNT, this, er);
   if (typeof cb === 'function') {
     defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, cb, er);
   }

--- a/test/parallel/test-net-write-after-end-nt.js
+++ b/test/parallel/test-net-write-after-end-nt.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const net = require('net');
+
+const { mustCall } = common;
+
+// This test ensures those errors caused by calling `net.Socket.write()`
+// after sockets ending will be emitted in the next tick.
+const server = net.createServer(mustCall((socket) => {
+  socket.end();
+})).listen(() => {
+  const client = net.connect(server.address().port, () => {
+    let hasError = false;
+    client.on('error', mustCall((err) => {
+      hasError = true;
+      server.close();
+    }));
+    client.on('end', mustCall(() => {
+      client.write('hello', mustCall());
+      assert(!hasError, 'The error should be emitted in the next tick.');
+    }));
+    client.end();
+  });
+});


### PR DESCRIPTION
This commit makes those errors caused by calling `net.Socket.write()` after sockets ending be emitted in the next tick.

This should be "semver-major".

Partially fixes: https://github.com/nodejs/node/issues/24111

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
