### PR TITLE
doc: updating vs cpp build tool installation steps in building

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -385,11 +385,12 @@ $ backtrace
 Prerequisites:
 
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
-* The "Desktop development with C++" workload from
-  [Visual Studio 2017](https://www.visualstudio.com/downloads/) or the
-  "Build Tools for Visual Studio 2017" workload from the
+* The "Build Tools for Visual Studio 2017" workload from the
   [Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017),
-  with the default optional components.  Once you click on the downloaded installer, choose 'Visual C++ build tools' and proceed.  It will install the necessary build tools to compile c++ files in this source.
+  with the default optional components. Once the "Build Tools for Visual Studio
+  2017" downloaded, install it by choosing "Visual C++ build tools" from the
+  installer and proceed. It will install the necessary build tools to compile
+  the C++ files.
 * Basic Unix tools required for some tests,
   [Git for Windows](http://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -387,9 +387,9 @@ Prerequisites:
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
 * The "Desktop development with C++" workload from
   [Visual Studio 2017](https://www.visualstudio.com/downloads/) or the
-  "Visual C++ build tools" workload from the
+  "Build Tools for Visual Studio 2017" workload from the
   [Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017),
-  with the default optional components.
+  with the default optional components.  Once you click on the downloaded installer, choose 'Visual C++ build tools' and proceed.  It will install the necessary build tools to compile c++ files in this source.
 * Basic Unix tools required for some tests,
   [Git for Windows](http://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]

I have set up the source code in windows.  It seems the installation steps for visual c++ build tools have changed a little recently.   Previously it might be 'build tools for visual c++' installer directly available in the visual studio website.  Now the steps are to download 'Build Tools for visual studio 2017' and choose 'visual c++ build tools'.  

Please refer the screenshot for more information
![buildtools](https://user-images.githubusercontent.com/9303047/48672687-039f6b80-eb5f-11e8-891e-19b43ec49a06.png)

![vs2017](https://user-images.githubusercontent.com/9303047/48672695-1a45c280-eb5f-11e8-88d3-3f7481bcb0d7.png)


This is my first commit.  Let me know for any changes.  Willing to contribute more in the coming days :)

Thanks
Krishnanand Sivaraj

