### PR TITLE
test: replace anonymous closure functions with arrow functions

### DIFF
--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -16,12 +16,12 @@ const msg = 'Using fs.truncate with a file descriptor is deprecated.' +
 
 
 common.expectWarning('DeprecationWarning', msg, 'DEP0081');
-fs.truncate(fd, 5, common.mustCall(function(err) {
+fs.truncate(fd, 5, common.mustCall((err) => {
   assert.ok(!err);
   assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');
 }));
 
-process.on('exit', function() {
+process.on('exit', () => {
   fs.closeSync(fd);
   fs.unlinkSync(filename);
   console.log('ok');


### PR DESCRIPTION
In `test/parallel/test-fs-truncate-fd.js`, callbacks use anonymous
closure functions. It is safe to replace them with arrow functions since
these callbacks don't alter their context (`this`). This results in
shorter functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
