### PR TITLE
test: refactor test-cluster-send-deadlock to use arrow functions

### DIFF
--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -30,31 +30,31 @@ const net = require('net');
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
-  worker.on('exit', function(code, signal) {
+  worker.on('exit', (code, signal) => {
     assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
     assert(!signal, `Worker exited by a signal: ${signal}`);
     server.close();
   });
 
-  const server = net.createServer(function(socket) {
+  const server = net.createServer((socket) => {
     worker.send('handle', socket);
   });
 
-  server.listen(0, function() {
+  server.listen(0, () => {
     worker.send({ message: 'listen', port: server.address().port });
   });
 } else {
-  process.on('message', function(msg, handle) {
+  process.on('message', (msg, handle) => {
     if (msg.message && msg.message === 'listen') {
       assert(msg.port);
       const client1 = net.connect({
         host: 'localhost',
         port: msg.port
-      }, function() {
+      }, () => {
         const client2 = net.connect({
           host: 'localhost',
           port: msg.port
-        }, function() {
+        }, () => {
           client1.on('close', onclose);
           client2.on('close', onclose);
           client1.end();
@@ -62,10 +62,10 @@ if (cluster.isMaster) {
         });
       });
       let waiting = 2;
-      function onclose() {
+      const onclose = () => {
         if (--waiting === 0)
           cluster.worker.disconnect();
-      }
+      };
     } else {
       process.send('reply', handle);
     }

--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -23,18 +23,18 @@
 // Testing mutual send of handles: from master to worker, and from worker to
 // master.
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
-  worker.on('exit', (code, signal) => {
+  worker.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
     assert(!signal, `Worker exited by a signal: ${signal}`);
     server.close();
-  });
+  }));
 
   const server = net.createServer((socket) => {
     worker.send('handle', socket);
@@ -44,7 +44,7 @@ if (cluster.isMaster) {
     worker.send({ message: 'listen', port: server.address().port });
   });
 } else {
-  process.on('message', (msg, handle) => {
+  process.on('message', common.mustCall((msg, handle) => {
     if (msg.message && msg.message === 'listen') {
       assert(msg.port);
       const client1 = net.connect({
@@ -69,5 +69,5 @@ if (cluster.isMaster) {
     } else {
       process.send('reply', handle);
     }
-  });
+  }));
 }

--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -23,7 +23,7 @@
 // Testing mutual send of handles: from master to worker, and from worker to
 // master.
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -44,7 +44,7 @@ if (cluster.isMaster) {
     worker.send({ message: 'listen', port: server.address().port });
   });
 } else {
-  process.on('message', common.mustCall((msg, handle) => {
+  process.on('message', (msg, handle) => {
     if (msg.message && msg.message === 'listen') {
       assert(msg.port);
       const client1 = net.connect({
@@ -69,5 +69,5 @@ if (cluster.isMaster) {
     } else {
       process.send('reply', handle);
     }
-  }));
+  });
 }

--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -30,11 +30,11 @@ const net = require('net');
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
-  worker.on('exit', common.mustCall((code, signal) => {
+  worker.on('exit', (code, signal) => {
     assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
     assert(!signal, `Worker exited by a signal: ${signal}`);
     server.close();
-  }));
+  });
 
   const server = net.createServer((socket) => {
     worker.send('handle', socket);


### PR DESCRIPTION
In `test/parallel/test-cluster-send-deadlock.js`, callbacks use
anonymous closure functions. It is safe to replace them with arrow
functions since these callbacks don't contain references to `this`,
`super` or `arguments`. This results in shorter functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
