### PR TITLE
test: refactor test-child-process-env to use arrow functions

### DIFF
--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -48,12 +48,12 @@ let response = '';
 
 child.stdout.setEncoding('utf8');
 
-child.stdout.on('data', function(chunk) {
+child.stdout.on('data', (chunk) => {
   console.log(`stdout: ${chunk}`);
   response += chunk;
 });
 
-process.on('exit', function() {
+process.on('exit', () => {
   assert.ok(response.includes('HELLO=WORLD'));
   assert.ok(response.includes('FOO=BAR'));
   assert.ok(!response.includes('UNDEFINED=undefined'));

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -53,10 +53,10 @@ child.stdout.on('data', (chunk) => {
   response += chunk;
 });
 
-process.on('exit', common.mustCall(() => {
+process.on('exit', () => {
   assert.ok(response.includes('HELLO=WORLD'));
   assert.ok(response.includes('FOO=BAR'));
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
   assert.ok(response.includes(`EMPTY=${os.EOL}`));
-}));
+});

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -53,10 +53,10 @@ child.stdout.on('data', (chunk) => {
   response += chunk;
 });
 
-process.on('exit', () => {
+process.on('exit', common.mustCall(() => {
   assert.ok(response.includes('HELLO=WORLD'));
   assert.ok(response.includes('FOO=BAR'));
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
   assert.ok(response.includes(`EMPTY=${os.EOL}`));
-});
+}));


### PR DESCRIPTION
In `test/parallel/test-child-process-env.js`, callbacks use
anonymous closure functions. It is safe to replace them with arrow
functions since these callbacks don't contain references to `this`,
`super` or `arguments`. This results in shorter functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
