### PR TITLE
test: refactor test-http-write-empty-string to use arrow functions

### DIFF
--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 
 const http = require('http');
 
-const server = http.createServer((request, response) => {
+const server = http.createServer(function (request, response) {
   console.log(`responding to ${request.url}`);
 
   response.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -39,7 +39,7 @@ const server = http.createServer((request, response) => {
 });
 
 server.listen(0, common.mustCall(() => {
-  http.get({ port: this.address().port }, common.mustCall((res) => {
+  http.get({ port: server.address().port }, common.mustCall((res) => {
     let response = '';
 
     assert.strictEqual(res.statusCode, 200);

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 
 const http = require('http');
 
-const server = http.createServer(function (request, response) {
+const server = http.createServer(function(request, response) {
   console.log(`responding to ${request.url}`);
 
   response.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 
 const http = require('http');
 
-const server = http.createServer(function(request, response) {
+const server = http.createServer((request, response) => {
   console.log(`responding to ${request.url}`);
 
   response.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -38,16 +38,16 @@ const server = http.createServer(function(request, response) {
   this.close();
 });
 
-server.listen(0, common.mustCall(function() {
-  http.get({ port: this.address().port }, common.mustCall(function(res) {
+server.listen(0, common.mustCall(() => {
+  http.get({ port: this.address().port }, common.mustCall((res) => {
     let response = '';
 
     assert.strictEqual(res.statusCode, 200);
     res.setEncoding('ascii');
-    res.on('data', function(chunk) {
+    res.on('data', (chunk) => {
       response += chunk;
     });
-    res.on('end', common.mustCall(function() {
+    res.on('end', common.mustCall(() => {
       assert.strictEqual(response, '1\n2\n3\n');
     }));
   }));


### PR DESCRIPTION
In `test/parallel/test-http-write-empty-string.js`, callbacks use
anonymous closure functions. It is safe to replace them with arrow
functions since these callbacks don't contain references to `this`,
`super` or `arguments`. This results in shorter functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
