### PR TITLE
[v8.x] Fix abi break

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 71
+#define V8_PATCH_LEVEL 72
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 70
+#define V8_PATCH_LEVEL 71
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -10247,27 +10247,14 @@ uint32_t Isolate::GetNumberOfDataSlots() {
 
 int64_t Isolate::AdjustAmountOfExternalAllocatedMemory(
     int64_t change_in_bytes) {
-  const int64_t kMemoryReducerActivationLimit = 1024 * 1024;
   typedef internal::Internals I;
   int64_t* external_memory = reinterpret_cast<int64_t*>(
       reinterpret_cast<uint8_t*>(this) + I::kExternalMemoryOffset);
   int64_t* external_memory_limit = reinterpret_cast<int64_t*>(
       reinterpret_cast<uint8_t*>(this) + I::kExternalMemoryLimitOffset);
-  int64_t* external_memory_at_last_mc =
-      reinterpret_cast<int64_t*>(reinterpret_cast<uint8_t*>(this) +
-                                 I::kExternalMemoryAtLastMarkCompactOffset);
   const int64_t amount = *external_memory + change_in_bytes;
 
   *external_memory = amount;
-
-  int64_t allocation_diff_since_last_mc =
-      *external_memory_at_last_mc - *external_memory;
-  allocation_diff_since_last_mc = allocation_diff_since_last_mc < 0
-                                      ? -allocation_diff_since_last_mc
-                                      : allocation_diff_since_last_mc;
-  if (allocation_diff_since_last_mc > kMemoryReducerActivationLimit) {
-    CheckMemoryPressure();
-  }
 
   if (change_in_bytes < 0) {
     *external_memory_limit += change_in_bytes;

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -7208,6 +7208,12 @@ class V8_EXPORT Isolate {
       AdjustAmountOfExternalAllocatedMemory(int64_t change_in_bytes);
 
   /**
+   * This is a Node.js 8.x specific version of the function that uses
+   * CheckMemoryPressure.
+   */
+  int64_t AdjustAmountOfExternalAllocatedMemoryCustom(int64_t change_in_bytes);
+
+  /**
    * Returns the number of phantom handles without callbacks that were reset
    * by the garbage collector since the last call to this function.
    */

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -8879,6 +8879,40 @@ void Isolate::GetStackSample(const RegisterState& state, void** frames,
   sample_info->external_callback_entry = nullptr;
 }
 
+int64_t Isolate::AdjustAmountOfExternalAllocatedMemoryCustom(
+    int64_t change_in_bytes) {
+  const int64_t kMemoryReducerActivationLimit = 1024 * 1024;
+  typedef internal::Internals I;
+  int64_t* external_memory = reinterpret_cast<int64_t*>(
+      reinterpret_cast<uint8_t*>(this) + I::kExternalMemoryOffset);
+  int64_t* external_memory_limit = reinterpret_cast<int64_t*>(
+      reinterpret_cast<uint8_t*>(this) + I::kExternalMemoryLimitOffset);
+  int64_t* external_memory_at_last_mc =
+      reinterpret_cast<int64_t*>(reinterpret_cast<uint8_t*>(this) +
+                                 I::kExternalMemoryAtLastMarkCompactOffset);
+  const int64_t amount = *external_memory + change_in_bytes;
+
+  *external_memory = amount;
+
+  int64_t allocation_diff_since_last_mc =
+      *external_memory_at_last_mc - *external_memory;
+  allocation_diff_since_last_mc = allocation_diff_since_last_mc < 0
+                                      ? -allocation_diff_since_last_mc
+                                      : allocation_diff_since_last_mc;
+  if (allocation_diff_since_last_mc > kMemoryReducerActivationLimit) {
+    CheckMemoryPressure();
+  }
+
+  if (change_in_bytes < 0) {
+    *external_memory_limit += change_in_bytes;
+  }
+
+  if (change_in_bytes > 0 && amount > *external_memory_limit) {
+    ReportExternalAllocationLimitReached();
+  }
+  return *external_memory;
+}
+
 size_t Isolate::NumberOfPhantomHandleResetsSinceLastCall() {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
   size_t result = isolate->global_handles()->NumberOfPhantomHandleResets();

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3326,7 +3326,7 @@ napi_status napi_adjust_external_memory(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, adjusted_value);
 
-  *adjusted_value = env->isolate->AdjustAmountOfExternalAllocatedMemory(
+  *adjusted_value = env->isolate->AdjustAmountOfExternalAllocatedMemoryCustom(
       change_in_bytes);
 
   return napi_clear_last_error(env);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -143,7 +143,7 @@ CallbackInfo::CallbackInfo(Isolate* isolate,
   persistent_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
   persistent_.SetWrapperClassId(BUFFER_ID);
   persistent_.MarkIndependent();
-  isolate->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
+  isolate->AdjustAmountOfExternalAllocatedMemoryCustom(sizeof(*this));
 }
 
 
@@ -163,7 +163,7 @@ void CallbackInfo::WeakCallback(
 void CallbackInfo::WeakCallback(Isolate* isolate) {
   callback_(data_, hint_);
   int64_t change_in_bytes = -static_cast<int64_t>(sizeof(*this));
-  isolate->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+  isolate->AdjustAmountOfExternalAllocatedMemoryCustom(change_in_bytes);
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2789,7 +2789,7 @@ void SSLWrap<Base>::DestroySSL() {
     return;
 
   SSL_free(ssl_);
-  env_->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+  env_->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(-kExternalSize);
   ssl_ = nullptr;
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -168,7 +168,7 @@ class SecureContext : public BaseObject {
         cert_(nullptr),
         issuer_(nullptr) {
     MakeWeak<SecureContext>(this);
-    env->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
+    env->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(kExternalSize);
   }
 
   void FreeCTXMem() {
@@ -176,7 +176,8 @@ class SecureContext : public BaseObject {
       return;
     }
 
-    env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+    env()->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(
+        -kExternalSize);
     SSL_CTX_free(ctx_);
     if (cert_ != nullptr)
       X509_free(cert_);
@@ -208,7 +209,7 @@ class SSLWrap {
         cert_cb_arg_(nullptr),
         cert_cb_running_(false) {
     ssl_ = SSL_new(sc->ctx_);
-    env_->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
+    env_->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(kExternalSize);
     CHECK_NE(ssl_, nullptr);
   }
 

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -135,14 +135,14 @@ class NodeBIO {
                                            next_(nullptr) {
       data_ = new char[len];
       if (env_ != nullptr)
-        env_->isolate()->AdjustAmountOfExternalAllocatedMemory(len);
+        env_->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(len);
     }
 
     ~Buffer() {
       delete[] data_;
       if (env_ != nullptr) {
         const int64_t len = static_cast<int64_t>(len_);
-        env_->isolate()->AdjustAmountOfExternalAllocatedMemory(-len);
+        env_->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(-len);
       }
     }
 

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -168,7 +168,7 @@ void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   fields[0] = rss;
   fields[1] = v8_heap_stats.total_heap_size();
   fields[2] = v8_heap_stats.used_heap_size();
-  fields[3] = isolate->AdjustAmountOfExternalAllocatedMemory(0);
+  fields[3] = isolate->AdjustAmountOfExternalAllocatedMemoryCustom(0);
 }
 
 // Most of the time, it's best to use `console.error` to write

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -109,12 +109,14 @@ class ZCtx : public AsyncWrap {
     if (mode_ == DEFLATE || mode_ == GZIP || mode_ == DEFLATERAW) {
       (void)deflateEnd(&strm_);
       int64_t change_in_bytes = -static_cast<int64_t>(kDeflateContextSize);
-      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+      env()->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(
+          change_in_bytes);
     } else if (mode_ == INFLATE || mode_ == GUNZIP || mode_ == INFLATERAW ||
                mode_ == UNZIP) {
       (void)inflateEnd(&strm_);
       int64_t change_in_bytes = -static_cast<int64_t>(kInflateContextSize);
-      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+      env()->isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(
+          change_in_bytes);
     }
     mode_ = NONE;
 
@@ -536,7 +538,7 @@ class ZCtx : public AsyncWrap {
                                  ctx->memLevel_,
                                  ctx->strategy_);
         ctx->env()->isolate()
-            ->AdjustAmountOfExternalAllocatedMemory(kDeflateContextSize);
+            ->AdjustAmountOfExternalAllocatedMemoryCustom(kDeflateContextSize);
         break;
       case INFLATE:
       case GUNZIP:
@@ -544,7 +546,7 @@ class ZCtx : public AsyncWrap {
       case UNZIP:
         ctx->err_ = inflateInit2(&ctx->strm_, ctx->windowBits_);
         ctx->env()->isolate()
-            ->AdjustAmountOfExternalAllocatedMemory(kInflateContextSize);
+            ->AdjustAmountOfExternalAllocatedMemoryCustom(kInflateContextSize);
         break;
       default:
         UNREACHABLE();

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -66,7 +66,7 @@ class ExternString: public ResourceType {
  public:
   ~ExternString() override {
     free(const_cast<TypeName*>(data_));
-    isolate()->AdjustAmountOfExternalAllocatedMemory(-byte_length());
+    isolate()->AdjustAmountOfExternalAllocatedMemoryCustom(-byte_length());
   }
 
   const TypeName* data() const override {
@@ -122,7 +122,7 @@ class ExternString: public ResourceType {
                                                                    data,
                                                                    length);
     MaybeLocal<Value> str = NewExternal(isolate, h_str);
-    isolate->AdjustAmountOfExternalAllocatedMemory(h_str->byte_length());
+    isolate->AdjustAmountOfExternalAllocatedMemoryCustom(h_str->byte_length());
 
     if (str.IsEmpty()) {
       delete h_str;


### PR DESCRIPTION
This addresses the inadvertent ABI-incompatible change in #21269. The first commit reverts the ABI breaking part of d868eb784c94176d0bf1a240e89818d0e30394b7. Unfortunately doing so ~~will~~ may reintroduce a memory bug (#21021). This is where the second commit adds back the functionality in an ABI-safe way and then uses it from within core.

Native modules that use `AdjustAmountOfExternalAllocatedMemory` may still miss the `CheckMemoryPressure` path. This is unfortunate, but there is no easy way to do so in an ABI compatible way. Going forward, it would be good if V8 was to avoid implementation in the `v8.h` file as that can lead to ABI issues like this where we can't fix the memory issue in an ABI compatible way. Such modules can use the 8.x specific `AdjustAmountOfExternalAllocatedMemoryCustom`, but would require a recompilation.

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: https://ci.nodejs.org/job/node-test-pull-request/18778/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1887/
