### PR TITLE
src: enable detailed source positions in V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -31,7 +31,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/include/v8-profiler.h
+++ b/deps/v8/include/v8-profiler.h
@@ -341,6 +341,12 @@ class V8_EXPORT CpuProfiler {
   V8_DEPRECATED("Use Isolate::SetIdle(bool) instead.",
                 void SetIdle(bool is_idle));
 
+  /**
+   * Generate more detailed source positions to code objects. This results in
+   * better results when mapping profiling samples to script source.
+   */
+  static void UseDetailedSourcePositionsForProfiling(Isolate* isolate);
+
  private:
   CpuProfiler();
   ~CpuProfiler();

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -10132,6 +10132,11 @@ void CpuProfiler::SetIdle(bool is_idle) {
   isolate->SetIdle(is_idle);
 }
 
+void CpuProfiler::UseDetailedSourcePositionsForProfiling(Isolate* isolate) {
+  reinterpret_cast<i::Isolate*>(isolate)
+      ->set_detailed_source_positions_for_profiling(true);
+}
+
 uintptr_t CodeEvent::GetCodeStartAddress() {
   return reinterpret_cast<i::CodeEvent*>(this)->code_start_address;
 }

--- a/deps/v8/src/isolate.cc
+++ b/deps/v8/src/isolate.cc
@@ -3257,7 +3257,8 @@ bool Isolate::use_optimizer() {
 }
 
 bool Isolate::NeedsDetailedOptimizedCodeLineInfo() const {
-  return NeedsSourcePositionsForProfiling() || FLAG_detailed_line_info;
+  return NeedsSourcePositionsForProfiling() ||
+         detailed_source_positions_for_profiling();
 }
 
 bool Isolate::NeedsSourcePositionsForProfiling() const {

--- a/deps/v8/src/isolate.h
+++ b/deps/v8/src/isolate.h
@@ -553,7 +553,8 @@ typedef std::vector<HeapObject*> DebugObjectCache;
   V(int, last_console_context_id, 0)                                          \
   V(v8_inspector::V8Inspector*, inspector, nullptr)                           \
   V(bool, next_v8_call_is_safe_for_termination, false)                        \
-  V(bool, only_terminate_in_safe_scope, false)
+  V(bool, only_terminate_in_safe_scope, false)                                \
+  V(bool, detailed_source_positions_for_profiling, FLAG_detailed_line_info)
 
 #define THREAD_LOCAL_TOP_ACCESSOR(type, name)                        \
   inline void set_##name(type v) { thread_local_top_.name##_ = v; }  \

--- a/deps/v8/test/cctest/test-cpu-profiler.cc
+++ b/deps/v8/test/cctest/test-cpu-profiler.cc
@@ -40,6 +40,7 @@
 #include "src/objects-inl.h"
 #include "src/profiler/cpu-profiler-inl.h"
 #include "src/profiler/profiler-listener.h"
+#include "src/source-position-table.h"
 #include "src/utils.h"
 #include "test/cctest/cctest.h"
 #include "test/cctest/profiler-extension.h"
@@ -2542,6 +2543,61 @@ TEST(MultipleProfilers) {
   profiler2->StartProfiling("2");
   profiler1->StopProfiling("1");
   profiler2->StopProfiling("2");
+}
+
+int GetSourcePositionEntryCount(i::Isolate* isolate, const char* source) {
+  i::Handle<i::JSFunction> function = i::Handle<i::JSFunction>::cast(
+      v8::Utils::OpenHandle(*CompileRun(source)));
+  if (function->IsInterpreted()) return -1;
+  i::Handle<i::Code> code(function->code(), isolate);
+  i::SourcePositionTableIterator iterator(
+      ByteArray::cast(code->source_position_table()));
+  int count = 0;
+  while (!iterator.done()) {
+    count++;
+    iterator.Advance();
+  }
+  return count;
+}
+
+UNINITIALIZED_TEST(DetailedSourcePositionAPI) {
+  i::FLAG_detailed_line_info = false;
+  i::FLAG_allow_natives_syntax = true;
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+
+  const char* source =
+      "function fib(i) {"
+      "  if (i <= 1) return 1; "
+      "  return fib(i - 1) +"
+      "         fib(i - 2);"
+      "}"
+      "fib(5);"
+      "%OptimizeFunctionOnNextCall(fib);"
+      "fib(5);"
+      "fib";
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+    i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+
+    CHECK(!i_isolate->NeedsDetailedOptimizedCodeLineInfo());
+
+    int non_detailed_positions = GetSourcePositionEntryCount(i_isolate, source);
+
+    v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(isolate);
+    CHECK(i_isolate->NeedsDetailedOptimizedCodeLineInfo());
+
+    int detailed_positions = GetSourcePositionEntryCount(i_isolate, source);
+
+    CHECK((non_detailed_positions == -1 && detailed_positions == -1) ||
+          non_detailed_positions < detailed_positions);
+  }
+
+  isolate->Dispose();
 }
 
 }  // namespace test_cpu_profiler

--- a/src/node.cc
+++ b/src/node.cc
@@ -2613,6 +2613,7 @@ Isolate* NewIsolate(ArrayBufferAllocator* allocator, uv_loop_t* event_loop) {
   isolate->SetMicrotasksPolicy(MicrotasksPolicy::kExplicit);
   isolate->SetFatalErrorHandler(OnFatalError);
   isolate->SetAllowWasmCodeGenerationCallback(AllowWasmCodeGenerationCallback);
+  v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(isolate);
 
   return isolate;
 }


### PR DESCRIPTION
Enable detailed source positions in generated code. When profiling, this gives a better mapping between profile samples to source text.

This is a second attempt. The previous one was reverted due to a small mistake when floating the related V8 patch.

Refs: https://github.com/nodejs/node/pull/24274
Refs: https://github.com/nodejs/node/pull/24394
Refs: https://github.com/nodejs/node/issues/24393

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] `make -j4 test-v8` passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
