### PR TITLE
src: fix process.pid for daemon process

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1525,8 +1525,10 @@ void SetupProcessObject(Environment* env,
                FIXED_ONE_BYTE_STRING(env->isolate(), "env"),
                process_env).FromJust();
 
-  READONLY_PROPERTY(process, "pid",
-                    Integer::New(env->isolate(), uv_os_getpid()));
+  CHECK(process->SetAccessor(env->context(),
+                             FIXED_ONE_BYTE_STRING(env->isolate(), "pid"),
+                             GetProcessId).FromJust());
+
   READONLY_PROPERTY(process, "features", GetFeatures(env));
 
   CHECK(process->SetAccessor(env->context(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -832,7 +832,8 @@ void DebugPortSetter(v8::Local<v8::Name> property,
 
 void GetParentProcessId(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value>& info);
-
+void GetProcessId(v8::Local<v8::Name> property,
+                  const v8::PropertyCallbackInfo<v8::Value>& info);
 void ProcessTitleGetter(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value>& info);
 void ProcessTitleSetter(v8::Local<v8::Name> property,

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -587,6 +587,11 @@ void InitGroups(const FunctionCallbackInfo<Value>& args) {
 
 #endif  // __POSIX__ && !defined(__ANDROID__) && !defined(__CloudABI__)
 
+void GetProcessId(v8::Local<v8::Name> property,
+                  const v8::PropertyCallbackInfo<v8::Value>& info) {
+  info.GetReturnValue().Set(uv_os_getpid());
+}
+
 void ProcessTitleGetter(Local<Name> property,
                         const PropertyCallbackInfo<Value>& info) {
   char buffer[512];
@@ -790,7 +795,7 @@ void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
 
 void GetParentProcessId(Local<Name> property,
                         const PropertyCallbackInfo<Value>& info) {
-  info.GetReturnValue().Set(Integer::New(info.GetIsolate(), uv_os_getppid()));
+  info.GetReturnValue().Set(uv_os_getppid());
 }
 
 void GetActiveRequests(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
The `process.pid` was initialized in the `SetupProcessObject` method.
so we change the implementation via getter method.

Fix: https://github.com/nodejs/node/issues/24539

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
