### PR TITLE
build: make .tar.xz creation opt-out, fail if no xz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -813,6 +813,7 @@ BINARYTAR=$(BINARYNAME).tar
 HAS_XZ ?= $(shell which xz > /dev/null 2>&1; [[ $$? = 0 ]] && echo 1 || echo 0)
 # Supply SKIP_XZ=1 to explicitly skip .tar.xz creation
 SKIP_XZ ?= 0
+XZ = $(shell [[ $(HAS_XZ) = 1 && $(SKIP_XZ) = 0 ]] && echo 1 || echo 0)
 XZ_COMPRESSION ?= 9e
 PKG=$(TARNAME).pkg
 MACOSOUTDIR=out/macos
@@ -957,7 +958,7 @@ $(TARBALL): release-only $(NODE_EXE) doc
 	tar -cf $(TARNAME).tar $(TARNAME)
 	$(RM) -r $(TARNAME)
 	gzip -c -f -9 $(TARNAME).tar > $(TARNAME).tar.gz
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	xz -c -f -$(XZ_COMPRESSION) $(TARNAME).tar > $(TARNAME).tar.xz
 endif
 	$(RM) $(TARNAME).tar
@@ -971,7 +972,7 @@ tar-upload: tar
 	chmod 664 $(TARNAME).tar.gz
 	scp -p $(TARNAME).tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).tar.gz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).tar.gz.done"
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	chmod 664 $(TARNAME).tar.xz
 	scp -p $(TARNAME).tar.xz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).tar.xz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).tar.xz.done"
@@ -997,7 +998,7 @@ $(TARBALL)-headers: release-only
 	tar -cf $(TARNAME)-headers.tar $(TARNAME)
 	$(RM) -r $(TARNAME)
 	gzip -c -f -9 $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.gz
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	xz -c -f -$(XZ_COMPRESSION) $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.xz
 endif
 	$(RM) $(TARNAME)-headers.tar
@@ -1009,7 +1010,7 @@ tar-headers-upload: tar-headers
 	chmod 664 $(TARNAME)-headers.tar.gz
 	scp -p $(TARNAME)-headers.tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.gz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.gz.done"
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	chmod 664 $(TARNAME)-headers.tar.xz
 	scp -p $(TARNAME)-headers.tar.xz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.xz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.xz.done"
@@ -1034,7 +1035,7 @@ endif
 	tar -cf $(BINARYNAME).tar $(BINARYNAME)
 	$(RM) -r $(BINARYNAME)
 	gzip -c -f -9 $(BINARYNAME).tar > $(BINARYNAME).tar.gz
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	xz -c -f -$(XZ_COMPRESSION) $(BINARYNAME).tar > $(BINARYNAME).tar.xz
 endif
 	$(RM) $(BINARYNAME).tar
@@ -1049,7 +1050,7 @@ binary-upload: binary
 	chmod 664 $(TARNAME)-$(OSTYPE)-$(ARCH).tar.gz
 	scp -p $(TARNAME)-$(OSTYPE)-$(ARCH).tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-$(OSTYPE)-$(ARCH).tar.gz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-$(OSTYPE)-$(ARCH).tar.gz.done"
-ifeq ($(HAS_XZ) $(SKIP_XZ), 1 0)
+ifeq ($(XZ), 1)
 	chmod 664 $(TARNAME)-$(OSTYPE)-$(ARCH).tar.xz
 	scp -p $(TARNAME)-$(OSTYPE)-$(ARCH).tar.xz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-$(OSTYPE)-$(ARCH).tar.xz
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-$(OSTYPE)-$(ARCH).tar.xz.done"


### PR DESCRIPTION
During a recent release, the 8.x before last I think, we discovered belatedly that the macos release machine didn't have `xz` installed on it. This change was discussed (somewhere, but I know @MylesBorins was involved) to help resolve such oversights in future.

* Change `XZ` to `HAS_XZ` and make it 0=no and 1=yes
* Introduce `SKIP_XZ` as a possible user-supplied value, defaulting to 0=no
* Check for either `HAS_XZ=1` or `SKIP_XZ=1` on any release build that produces a tarball of some kind and fail if the system doesn't have `xz` and `SKIP_XZ=1` hasn't been supplied.
* Only produce a .tar.xz if both `HAS_XZ=1` and `SKIP_XZ=0` (i.e. we have `xz` and haven't explicitly opted to skip)

This would get backported to active lines and we'd have to put a `SKIP_XZ=1` for AIX builds (only).

I've tested the main permutations of this and it seems to work fine. I'd appreciate some experienced Makefile eyes though, @nodejs/build @bnoordhuis @joyeecheung?