### PR TITLE
https: add missing localPort while create socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1248,6 +1248,7 @@ exports.connect = function connect(...args) {
       host: options.host,
       family: options.family,
       localAddress: options.localAddress,
+      localPort: options.localPort,
       lookup: options.lookup
     };
     socket.connect(connectOpt, socket._start);

--- a/test/parallel/test-https-connect-localport.js
+++ b/test/parallel/test-https-connect-localport.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const https = require('https');
+const assert = require('assert');
+
+{
+  https.createServer({
+    cert: fixtures.readKey('agent1-cert.pem'),
+    key: fixtures.readKey('agent1-key.pem'),
+  }, common.mustCall(function(req, res) {
+    this.close();
+    res.end();
+  })).listen(0, common.localhostIPv4, common.mustCall(function() {
+    const port = this.address().port;
+    const req = https.get({
+      host: common.localhostIPv4,
+      pathname: '/',
+      port,
+      family: 4,
+      localPort: 34567,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      assert.strictEqual(req.socket.localPort, 34567);
+      assert.strictEqual(req.socket.remotePort, port);
+    }));
+  }));
+}


### PR DESCRIPTION
In `_tls_wrap.js` while calling `socket.connect` the `localPort` was
missing, restore it.

Fix: https://github.com/nodejs/node/issues/24543

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
