### PR TITLE
lib: suppress crypto related env vars in help msg

### DIFF
--- a/lib/internal/print_help.js
+++ b/lib/internal/print_help.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { types } = internalBinding('options');
+const hasCrypto = Boolean(process.versions.openssl);
 
 const typeLookup = [];
 for (const key of Object.keys(types))
@@ -33,11 +34,6 @@ const envVars = new Map([
     'certificate validation' }],
   ['NODE_V8_COVERAGE', { helpText: 'directory to output v8 coverage JSON ' +
     'to' }],
-  ['OPENSSL_CONF', { helpText: 'load OpenSSL configuration from file' }],
-  ['SSL_CERT_DIR', { helpText: 'sets OpenSSL\'s directory of trusted ' +
-    'certificates when used in conjunction with --use-openssl-ca' }],
-  ['SSL_CERT_FILE', { helpText: 'sets OpenSSL\'s trusted certificate file ' +
-    'when used in conjunction with --use-openssl-ca' }],
   ['UV_THREADPOOL_SIZE', { helpText: 'sets the number of threads used in ' +
     'libuv\'s threadpool' }]
 ].concat(hasIntl ? [
@@ -46,6 +42,12 @@ const envVars = new Map([
 ] : []).concat(hasNodeOptions ? [
   ['NODE_OPTIONS', { helpText: 'set CLI options in the environment via a ' +
     'space-separated list' }]
+] : []).concat(hasCrypto ? [
+  ['OPENSSL_CONF', { helpText: 'load OpenSSL configuration from file' }],
+  ['SSL_CERT_DIR', { helpText: 'sets OpenSSL\'s directory of trusted ' +
+    'certificates when used in conjunction with --use-openssl-ca' }],
+  ['SSL_CERT_FILE', { helpText: 'sets OpenSSL\'s trusted certificate file ' +
+    'when used in conjunction with --use-openssl-ca' }],
 ] : []));
 
 


### PR DESCRIPTION
This commit adds a crypto check to suppress the crypto related
environment variables introduced in Commit 399bb3c95af821350774c18f469ab700387f38e1 ("doc: add NODE_DEBUG_NATIVE to API docs").

Without this check, `test/parallel/test-cli-node-print-help.js` will fail
when configured --without-ssl, as it some of the descriptions for these environment variables contain
flags that the test is not expecting to find.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
