### PR TITLE
src: add DCHECK macros

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -292,22 +292,19 @@ void StreamBase::CallJSOnreadMethod(ssize_t nread,
                                     size_t offset) {
   Environment* env = env_;
 
-#ifdef DEBUG
-  CHECK_EQ(static_cast<int32_t>(nread), nread);
-  CHECK_LE(offset, INT32_MAX);
+  DCHECK_EQ(static_cast<int32_t>(nread), nread);
+  DCHECK_LE(offset, INT32_MAX);
 
-  if (ab.IsEmpty()) {
-    CHECK_EQ(offset, 0);
-    CHECK_LE(nread, 0);
-  } else {
-    CHECK_GE(nread, 0);
-  }
-#endif
+  const bool ab_is_empty = ab.IsEmpty();
+  DCHECK_IMPLIES(ab_is_empty, offset == 0);
+  DCHECK_IMPLIES(ab_is_empty, nread <= 0);
+  DCHECK_IMPLIES(!ab_is_empty, nread >= 0);
+
   env->stream_base_state()[kReadBytesOrError] = nread;
   env->stream_base_state()[kArrayBufferOffset] = offset;
 
   Local<Value> argv[] = {
-    ab.IsEmpty() ? Undefined(env->isolate()).As<Value>() : ab.As<Value>()
+    ab_is_empty ? Undefined(env->isolate()).As<Value>() : ab.As<Value>()
   };
 
   AsyncWrap* wrap = GetAsyncWrap();

--- a/src/util.h
+++ b/src/util.h
@@ -128,6 +128,30 @@ void DumpBacktrace(FILE* fp);
 #define CHECK_NOT_NULL(val) CHECK((val) != nullptr)
 #define CHECK_IMPLIES(a, b) CHECK(!(a) || (b))
 
+#ifdef DEBUG
+#define DCHECK(condition)    CHECK(condition)
+#define DCHECK_EQ(a, b)      CHECK_EQ(a, b)
+#define DCHECK_GE(a, b)      CHECK_GE(a, b)
+#define DCHECK_GT(a, b)      CHECK_GT(a, b)
+#define DCHECK_LE(a, b)      CHECK_LE(a, b)
+#define DCHECK_LT(a, b)      CHECK_LT(a, b)
+#define DCHECK_NE(a, b)      CHECK_NE(a, b)
+#define DCHECK_NULL(val)     CHECK_NULL(val)
+#define DCHECK_NOT_NULL(val) CHECK_NOT_NULL(val)
+#define DCHECK_IMPLIES(a, b) CHECK_IMPLIES(a, b)
+#else
+#define DCHECK(condition)      ((void) 0)
+#define DCHECK_EQ(a, b)        ((void) 0)
+#define DCHECK_NE(a, b)        ((void) 0)
+#define DCHECK_GT(a, b)        ((void) 0)
+#define DCHECK_GE(a, b)        ((void) 0)
+#define DCHECK_LT(a, b)        ((void) 0)
+#define DCHECK_LE(a, b)        ((void) 0)
+#define DCHECK_NULL(val)       ((void) 0)
+#define DCHECK_NOT_NULL(val)   ((void) 0)
+#define DCHECK_IMPLIES(a, b)   ((void) 0)
+#endif
+
 #define UNREACHABLE() ABORT()
 
 // TAILQ-style intrusive list node.


### PR DESCRIPTION
The first commit adds DCHECK macros that are only enabled in debug build and are noops in release buidls.

The second commit refactors `StreamBase::CallJSOnreadMethod` to use DCHECK instead of a `ifdef DEBUG` switch.

Reasoning: IMO it's slightly more readable to use `DCHECK` and it's a utility commonly used in V8 - we can be more generous about adding checks for the debug builds as general assertions to help finding subtle bugs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
(https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
