### PR TITLE
test: add information to assertion

### DIFF
--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -7,6 +7,7 @@ const promiseFs = require('fs').promises;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const { isDate } = require('util').types;
+const { inspect } = require('util');
 
 tmpdir.refresh();
 
@@ -62,7 +63,11 @@ function verifyStats(bigintStats, numStats) {
       assert.strictEqual(bigintStats[key], undefined);
       assert.strictEqual(numStats[key], undefined);
     } else if (Number.isSafeInteger(val)) {
-      assert.strictEqual(bigintStats[key], BigInt(val));
+      assert.strictEqual(
+        bigintStats[key], BigInt(val),
+        `${inspect(bigintStats[key])} !== ${inspect(BigInt(val))}\n` +
+        `key=${key}, val=${val}`
+      );
     } else {
       assert(
         Math.abs(Number(bigintStats[key]) - val) < 1,


### PR DESCRIPTION
test-fs-stat-bigint.js failed once in CI but there wasn't enough
information to know what was giong on. Adding a bit of information to
the assertion that failed in case it fails again.

Refs: https://github.com/nodejs/node/issues/24565

Collaborators 👍 here to fast-track.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
