### PR TITLE
timers: extract type checking into a helper

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -32,6 +32,7 @@ module.exports = {
   kRefed,
   initAsyncResource,
   setUnrefTimeout,
+  validateTimerArguments,
   validateTimerDuration
 };
 
@@ -104,35 +105,42 @@ Timeout.prototype.refresh = function() {
 
 function setUnrefTimeout(callback, after, arg1, arg2, arg3) {
   // Type checking identical to setTimeout()
-  if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
-  }
-
-  let i, args;
-  switch (arguments.length) {
-    // fast cases
-    case 1:
-    case 2:
-      break;
-    case 3:
-      args = [arg1];
-      break;
-    case 4:
-      args = [arg1, arg2];
-      break;
-    default:
-      args = [arg1, arg2, arg3];
-      for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
-        args[i - 2] = arguments[i];
-      }
-      break;
-  }
+  const args = validateTimerArguments(callback, arg1, arg2, arg3, arguments);
 
   const timer = new Timeout(callback, after, args, false);
   getTimers()._unrefActive(timer);
 
   return timer;
+}
+
+// Type checking used by setTimeout(), setInterval() and setUnrefTimeout()
+function validateTimerArguments(callback, arg1, arg2, arg3, args) {
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_CALLBACK();
+  }
+
+  let i, newArgs;
+  switch (args.length) {
+    // fast cases
+    case 1:
+    case 2:
+      break;
+    case 3:
+      newArgs = [arg1];
+      break;
+    case 4:
+      newArgs = [arg1, arg2];
+      break;
+    default:
+      newArgs = [arg1, arg2, arg3];
+      for (i = 5; i < args.length; i++) {
+        // extend array dynamically, makes .apply run much faster in v6.0.0
+        newArgs[i - 2] = args[i];
+      }
+      break;
+  }
+
+  return newArgs;
 }
 
 // Type checking used by timers.enroll() and Socket#setTimeout()

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -37,6 +37,7 @@ const {
   Timeout,
   kRefed,
   initAsyncResource,
+  validateTimerArguments,
   validateTimerDuration
 } = require('internal/timers');
 const internalUtil = require('internal/util');
@@ -425,30 +426,7 @@ exports.enroll = util.deprecate(enroll,
 
 
 function setTimeout(callback, after, arg1, arg2, arg3) {
-  if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
-  }
-
-  var i, args;
-  switch (arguments.length) {
-    // fast cases
-    case 1:
-    case 2:
-      break;
-    case 3:
-      args = [arg1];
-      break;
-    case 4:
-      args = [arg1, arg2];
-      break;
-    default:
-      args = [arg1, arg2, arg3];
-      for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
-        args[i - 2] = arguments[i];
-      }
-      break;
-  }
+  const args = validateTimerArguments(callback, arg1, arg2, arg3, arguments);
 
   const timeout = new Timeout(callback, after, args, false);
   active(timeout);
@@ -474,30 +452,7 @@ const clearTimeout = exports.clearTimeout = function clearTimeout(timer) {
 
 
 exports.setInterval = function setInterval(callback, repeat, arg1, arg2, arg3) {
-  if (typeof callback !== 'function') {
-    throw new ERR_INVALID_CALLBACK();
-  }
-
-  var i, args;
-  switch (arguments.length) {
-    // fast cases
-    case 1:
-    case 2:
-      break;
-    case 3:
-      args = [arg1];
-      break;
-    case 4:
-      args = [arg1, arg2];
-      break;
-    default:
-      args = [arg1, arg2, arg3];
-      for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
-        args[i - 2] = arguments[i];
-      }
-      break;
-  }
+  const args = validateTimerArguments(callback, arg1, arg2, arg3, arguments);
 
   const timeout = new Timeout(callback, repeat, args, true);
   active(timeout);


### PR DESCRIPTION
Extract type checking used by `setTimeout()`, `setInterval` and `setUnrefTimeout` into a helper.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
