### PR TITLE
test: cover path empty string case

### DIFF
--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -43,6 +43,7 @@ if (common.isWindows) {
                      '\\\\.\\pipe\\somepipe');
 }
 
+assert.strictEqual(path.toNamespacedPath(''), '');
 assert.strictEqual(path.toNamespacedPath(null), null);
 assert.strictEqual(path.toNamespacedPath(100), 100);
 assert.strictEqual(path.toNamespacedPath(path), path);
@@ -60,6 +61,7 @@ assert.strictEqual(path.posix.toNamespacedPath(emptyObj), emptyObj);
 if (common.isWindows) {
   // These tests cause resolve() to insert the cwd, so we cannot test them from
   // non-Windows platforms (easily)
+  assert.strictEqual(path.toNamespacedPath(''), '');
   assert.strictEqual(path.win32.toNamespacedPath('foo\\bar').toLowerCase(),
                      `\\\\?\\${process.cwd().toLowerCase()}\\foo\\bar`);
   assert.strictEqual(path.win32.toNamespacedPath('foo/bar').toLowerCase(),


### PR DESCRIPTION
In path.toNamespacePath was a case when the path
was empty string and it wasn't covered in the tests.

I covered this case both in Windows and Unix environments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
