### PR TITLE
test: cover path.basename when path and ext are the same

### DIFF
--- a/test/parallel/test-path-basename.js
+++ b/test/parallel/test-path-basename.js
@@ -29,6 +29,7 @@ assert.strictEqual(path.basename('/aaa/'), 'aaa');
 assert.strictEqual(path.basename('/aaa/b'), 'b');
 assert.strictEqual(path.basename('/a/b'), 'b');
 assert.strictEqual(path.basename('//a'), 'a');
+assert.strictEqual(path.basename('a', 'a'), '');
 
 // On Windows a backslash acts as a path separator.
 assert.strictEqual(path.win32.basename('\\dir\\basename.ext'), 'basename.ext');
@@ -53,6 +54,7 @@ assert.strictEqual(path.win32.basename('C:basename.ext\\'), 'basename.ext');
 assert.strictEqual(path.win32.basename('C:basename.ext\\\\'), 'basename.ext');
 assert.strictEqual(path.win32.basename('C:foo'), 'foo');
 assert.strictEqual(path.win32.basename('file:stream'), 'file:stream');
+assert.strictEqual(path.win32.basename('a', 'a'), '');
 
 // On unix a backslash is just treated as any other character.
 assert.strictEqual(path.posix.basename('\\dir\\basename.ext'),


### PR DESCRIPTION
In path.basename was a case when the path
and the extension is the same and this wasn't
covered with tests.

I covered this case both in Windows and Unix environments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
