### PR TITLE
doc: document fs.write limitation with TTY

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3530,7 +3530,7 @@ the end of the file.
 
 On Windows, if the file descriptor is connected to the console (e.g. `fd == 1`
 or `stdout`) a string containing non-ASCII characters will not be rendered
-properly by default.
+properly by default, regardless of the encoding used.
 It is possible to configure the console to render UTF-8 properly by changing the
 active codepage with the `chcp 65001` command. See the [chcp][] docs for more
 details.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3528,6 +3528,13 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
+On Windows, if the file descriptor is connected to the console (e.g. `fd == 1`
+or `stdout`) a string encoded as UTF-8 or Unicode (`ucs2`) will not be rendered
+properly by default.
+It is possible to configure the console to render UTF-8 properly by changing the
+active codepage with the `chcp 65001` command. See the [chcp][] docs for more
+details.
+
 ## fs.writeFile(file, data[, options], callback)
 <!-- YAML
 added: v0.1.29
@@ -4926,3 +4933,4 @@ the file contents.
 [MSDN-Using-Streams]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams
 [support of file system `flags`]: #fs_file_system_flags
 [File Access Constants]: #fs_file_access_constants
+[chcp]: https://ss64.com/nt/chcp.html

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3529,7 +3529,7 @@ The kernel ignores the position argument and always appends the data to
 the end of the file.
 
 On Windows, if the file descriptor is connected to the console (e.g. `fd == 1`
-or `stdout`) a string encoded as UTF-8 or Unicode (`ucs2`) will not be rendered
+or `stdout`) a string containing non-ASCII characters will not be rendered
 properly by default.
 It is possible to configure the console to render UTF-8 properly by changing the
 active codepage with the `chcp 65001` command. See the [chcp][] docs for more


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24550

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
