### PR TITLE
tools: don't use GH API for commit message checks

### DIFF
--- a/tools/lint-pr-commit-message.sh
+++ b/tools/lint-pr-commit-message.sh
@@ -25,21 +25,15 @@ if [ -z "${PR_ID}" ]; then
   echo " e.g. $0 <PR_NUMBER>"
   exit 1
 fi
-# Retrieve the first commit of the pull request via GitHub API
-# TODO: If we teach core-validate-commit to ignore "fixup!" and "squash!"
-#       commits and lint messages for all commits in the pull request
-#       we could simplify the following to:
-#         npx -q core-validate-commit --no-validate-metadata ${GH_API_URL}/repos/nodejs/node/pulls/${PR_ID}/commits
-if PR_COMMITS="$( curl -s ${GH_API_URL}/repos/nodejs/node/pulls/${PR_ID}/commits )"; then
-  if FIRST_COMMIT="$( node -p 'JSON.parse(process.argv[1])[0].url' "${PR_COMMITS}" 2> /dev/null )"; then
-    echo "Linting the first commit message for pull request ${PR_ID}"
-    echo "according to the guidelines at https://goo.gl/p2fr5Q."
-    # Print the commit message to make it more obvious what is being checked.
-    echo "Commit message for ${FIRST_COMMIT##*/} is:"
-    node -p 'JSON.parse(process.argv[1])[0].commit.message' "${PR_COMMITS}" 2> /dev/null
-    npx -q core-validate-commit --no-validate-metadata "${FIRST_COMMIT}"
-  else
-    echo "Unable to determine the first commit for pull request ${PR_ID}."
-    exit 1
-  fi
+
+PATCH=$( curl -sL https://github.com/nodejs/node/pull/${PR_ID}.patch | grep '^From \|^Subject: ' )
+if FIRST_COMMIT="$( echo "$PATCH" | awk '/^From [0-9a-f]{40} / { if (count++ == 0) print $2 }' )"; then
+  MESSAGE=$( echo "$PATCH" | awk '/^Subject: \[PATCH 1/ { gsub(/^Subject: \[PATCH[^\]]*\] /, ""); print }' )
+  echo "
+*** Linting the first commit message for pull request ${PR_ID}
+*** according to the guidelines at https://goo.gl/p2fr5Q.
+*** Commit message for $(echo $FIRST_COMMIT | cut -c 1-10) is:
+      ${MESSAGE}
+"
+  npx -q core-validate-commit --no-validate-metadata "${FIRST_COMMIT}"
 fi

--- a/tools/lint-pr-commit-message.sh
+++ b/tools/lint-pr-commit-message.sh
@@ -26,7 +26,7 @@ if [ -z "${PR_ID}" ]; then
   exit 1
 fi
 
-PATCH=$( curl -sL https://github.com/nodejs/node/pull/${PR_ID}.patch | grep '^From \|^Subject: ' )
+PATCH=$( curl -sL https://github.com/nodejs/node/pull/${PR_ID}.patch | grep '^From ' )
 if FIRST_COMMIT="$( echo "$PATCH" | awk '/^From [0-9a-f]{40} / { if (count++ == 0) print $2 }' )"; then
   MESSAGE=$( git show --quiet --format='format:%B' $FIRST_COMMIT )
   echo "

--- a/tools/lint-pr-commit-message.sh
+++ b/tools/lint-pr-commit-message.sh
@@ -28,12 +28,12 @@ fi
 
 PATCH=$( curl -sL https://github.com/nodejs/node/pull/${PR_ID}.patch | grep '^From \|^Subject: ' )
 if FIRST_COMMIT="$( echo "$PATCH" | awk '/^From [0-9a-f]{40} / { if (count++ == 0) print $2 }' )"; then
-  MESSAGE=$( echo "$PATCH" | awk '/^Subject: \[PATCH 1/ { gsub(/^Subject: \[PATCH[^\]]*\] /, ""); print }' )
+  MESSAGE=$( git show --quiet --format='format:%B' $FIRST_COMMIT )
   echo "
 *** Linting the first commit message for pull request ${PR_ID}
 *** according to the guidelines at https://goo.gl/p2fr5Q.
 *** Commit message for $(echo $FIRST_COMMIT | cut -c 1-10) is:
-      ${MESSAGE}
+${MESSAGE}
 "
   npx -q core-validate-commit --no-validate-metadata "${FIRST_COMMIT}"
 fi


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24567

.patch URLs contain enough predictable and usable data to make this work without the API

