### PR TITLE
build: only check REPLACEME & DEP...X for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -817,12 +817,11 @@ MACOSOUTDIR=out/macos
 
 .PHONY: release-only
 release-only:
-	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
-		`grep -q REPLACEME doc/api/*.md`; then \
+	@if [ "$(DISTTYPE)" = "release" ] && `grep -q REPLACEME doc/api/*.md`; then \
 		echo 'Please update REPLACEME in Added: tags in doc/api/*.md (See doc/releases.md)' ; \
 		exit 1 ; \
 	fi
-	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
+	@if [ "$(DISTTYPE)" = "release" ] && \
 		`grep -q DEP...X doc/api/deprecations.md`; then \
 		echo 'Please update DEP...X in doc/api/deprecations.md (See doc/releases.md)' ; \
 		exit 1 ; \


### PR DESCRIPTION
A rehash of #12958.

Summary: the introduction of the checks for `REPLACEME` and later `DEP...X` in the `release-only` Makefile target screwed up "test" and "rc" builds. There are exclusions for "nightly" and "next-nightly" because those are automatic and IIRC we noticed those builds stopped working shortly after the `REPLACEME` check was instituted. However, "test" and "rc" builds are manual and don't work with this check. Now we also have "v8-canary" in the mix too. These extras make use of the "custom" DISTTYPE.

This got held up because there was disagreement about how exclusive to be. The original change proposed in #8325 was similar to this one but it was then made exclusive by switching to the "nightly" and "next-nightly" builds.

For the last ~18 months we've had this in ci-release:

```bash
if [[ "X${disttype}" != "Xrelease" ]]; then
  perl -pi -e "s/: release-only/:/g" Makefile
fi
```

i.e. overriding the `release-only` target in Makefile for everything but "release" builds.

This PR aims to put that logic into Makefile so we can remove that check.

Ref: https://github.com/nodejs/node/pull/24551
Ref: https://github.com/nodejs/node/pull/12958
Ref: https://github.com/nodejs/node/pull/12957
Ref: https://github.com/nodejs/node/pull/8325
