### PR TITLE
lib: simplify own keys retrieval

### DIFF
--- a/lib/internal/safe_globals.js
+++ b/lib/internal/safe_globals.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const copyProps = (unsafe, safe) => {
-  for (const key of [...Object.getOwnPropertyNames(unsafe),
-                     ...Object.getOwnPropertySymbols(unsafe)
-  ]) {
+  for (const key of Reflect.ownKeys(unsafe)) {
     if (!Object.getOwnPropertyDescriptor(safe, key)) {
       Object.defineProperty(
         safe,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This replacement can save us a function call, two array spreadings, and an array concatenation.

Refs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys#Description