### PR TITLE
test: removed third argument in assert.strictEqual() in test/addons-napi/test_env_sharing/test.js

### DIFF
--- a/test/addons-napi/test_env_sharing/test.js
+++ b/test/addons-napi/test_env_sharing/test.js
@@ -5,6 +5,5 @@ const storeEnv = require(`./build/${common.buildType}/store_env`);
 const compareEnv = require(`./build/${common.buildType}/compare_env`);
 const assert = require('assert');
 
-assert.strictEqual(compareEnv(storeEnv), true,
-                   'N-API environment pointers in two different modules have ' +
-                   'the same value');
+// N-API environment pointers in two different modules have the same value
+assert.strictEqual(compareEnv(storeEnv), true);


### PR DESCRIPTION
I am new to Node. I followed this [Node Todo](https://www.nodetodo.org/) to start working on this nodejs project. Also, I followed the instruction [Building Node.js on supported platforms](https://github.com/nodejs/node/blob/master/BUILDING.md#building-nodejs-on-supported-platforms) to build and run the test before submitting this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
