### PR TITLE
test: fix the arguments order in assert.strictEqual

### DIFF
--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -54,7 +54,7 @@ function testHelper(stream, args, expectedOutput, cmd, env) {
       assert.ok(response.includes(expectedOutput));
     } else {
       // Normal path where we expect either FIPS enabled or disabled.
-      assert.strictEqual(expectedOutput, Number(response));
+      assert.strictEqual(Number(response), expectedOutput);
     }
     childOk(child);
   }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
