### PR TITLE
test: fix arguments order in `assert.strictEqual`

### DIFF
--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -43,7 +43,7 @@ function testCwd(options, expectCode = 0, expectData) {
   // Can't assert callback, as stayed in to API:
   // _The 'exit' event may or may not fire after an error has occurred._
   child.on('exit', function(code, signal) {
-    assert.strictEqual(expectCode, code);
+    assert.strictEqual(code, expectCode);
   });
 
   child.on('close', common.mustCall(function() {


### PR DESCRIPTION
fix arguments order to be `assert.strictEqual(actual, expected)`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
