### PR TITLE
crypto: convert to arrow function in `lib/internal/crypto/cipher.js`

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -39,7 +39,7 @@ const { deprecate, normalizeEncoding } = require('internal/util');
 let StringDecoder;
 
 function rsaFunctionFor(method, defaultPadding) {
-  return function(options, buffer) {
+  return (options, buffer) => {
     const key = options.key || options;
     const padding = options.padding || defaultPadding;
     const passphrase = options.passphrase || null;


### PR DESCRIPTION
Changed function expression to arrow function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
