### PR TITLE
switch lib/readline to arrow functions

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -71,9 +71,9 @@ const ESCAPE_DECODER = Symbol('escape-decoder');
 // GNU readline library - keyseq-timeout is 500ms (default)
 const ESCAPE_CODE_TIMEOUT = 500;
 
-function createInterface(input, output, completer, terminal) {
+const createInterface = (input, output, completer, terminal) => {
   return new Interface(input, output, completer, terminal);
-}
+};
 
 
 function Interface(input, output, completer, terminal) {
@@ -152,7 +152,7 @@ function Interface(input, output, completer, terminal) {
   if (typeof completer === 'function') {
     this.completer = completer.length === 2 ?
       completer :
-      function completerWrapper(v, cb) {
+      (v, cb) => {
         cb(null, completer(v));
       };
   }
@@ -161,26 +161,26 @@ function Interface(input, output, completer, terminal) {
 
   this.terminal = !!terminal;
 
-  function ondata(data) {
+  const ondata = (data) => {
     self._normalWrite(data);
-  }
+  };
 
-  function onend() {
+  const onend = () => {
     if (typeof self._line_buffer === 'string' &&
         self._line_buffer.length > 0) {
       self.emit('line', self._line_buffer);
     }
     self.close();
-  }
+  };
 
-  function ontermend() {
+  const ontermend = () => {
     if (typeof self.line === 'string' && self.line.length > 0) {
       self.emit('line', self.line);
     }
     self.close();
-  }
+  };
 
-  function onkeypress(s, key) {
+  const onkeypress = (s, key) => {
     self._ttyWrite(s, key);
     if (key && key.sequence) {
       // if the key.sequence is half of a surrogate pair
@@ -190,32 +190,32 @@ function Interface(input, output, completer, terminal) {
       if (ch >= 0xd800 && ch <= 0xdfff)
         self._refreshLine();
     }
-  }
+  };
 
-  function onresize() {
+  const onresize = () => {
     self._refreshLine();
-  }
+  };
 
   this[kLineObjectStream] = undefined;
 
   if (!this.terminal) {
-    function onSelfCloseWithoutTerminal() {
+    const onSelfCloseWithoutTerminal = () => {
       input.removeListener('data', ondata);
       input.removeListener('end', onend);
-    }
+    };
 
     input.on('data', ondata);
     input.on('end', onend);
     self.once('close', onSelfCloseWithoutTerminal);
     this._decoder = new StringDecoder('utf8');
   } else {
-    function onSelfCloseWithTerminal() {
+    const onSelfCloseWithTerminal = () => {
       input.removeListener('keypress', onkeypress);
       input.removeListener('end', ontermend);
       if (output !== null && output !== undefined) {
         output.removeListener('resize', onresize);
       }
-    }
+    };
 
     emitKeypressEvents(input, this);
 
@@ -553,7 +553,7 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
 };
 
 // this = Interface instance
-function handleGroup(self, group, width, maxColumns) {
+const handleGroup = (self, group, width, maxColumns) => {
   if (group.length === 0) {
     return;
   }
@@ -575,9 +575,9 @@ function handleGroup(self, group, width, maxColumns) {
     self._writeToOutput('\r\n');
   }
   self._writeToOutput('\r\n');
-}
+};
 
-function commonPrefix(strings) {
+const commonPrefix = (strings) => {
   if (!strings || strings.length === 0) {
     return '';
   }
@@ -591,7 +591,7 @@ function commonPrefix(strings) {
     }
   }
   return min;
-}
+};
 
 
 Interface.prototype._wordLeft = function() {
@@ -887,7 +887,7 @@ Interface.prototype._ttyWrite = function(s, key) {
           this.emit('SIGTSTP');
         } else {
           process.once('SIGCONT', (function continueProcess(self) {
-            return function() {
+            return () => {
               // Don't raise events if stream has already been abandoned.
               if (!self.paused) {
                 // Stream must be paused and resumed after SIGCONT to catch
@@ -1066,7 +1066,7 @@ Interface.prototype[Symbol.asyncIterator] = function() {
  * accepts a readable Stream instance and makes it emit "keypress" events
  */
 
-function emitKeypressEvents(stream, iface) {
+const emitKeypressEvents = (stream, iface) => {
   if (stream[KEYPRESS_DECODER]) return;
 
   if (StringDecoder === undefined)
@@ -1079,7 +1079,7 @@ function emitKeypressEvents(stream, iface) {
   const escapeCodeTimeout = () => stream[ESCAPE_DECODER].next('');
   let timeoutId;
 
-  function onData(b) {
+  const onData = (b) => {
     if (stream.listenerCount('keypress') > 0) {
       var r = stream[KEYPRESS_DECODER].write(b);
       if (r) {
@@ -1121,27 +1121,27 @@ function emitKeypressEvents(stream, iface) {
       stream.removeListener('data', onData);
       stream.on('newListener', onNewListener);
     }
-  }
+  };
 
-  function onNewListener(event) {
+  const onNewListener = (event) => {
     if (event === 'keypress') {
       stream.on('data', onData);
       stream.removeListener('newListener', onNewListener);
     }
-  }
+  };
 
   if (stream.listenerCount('keypress') > 0) {
     stream.on('data', onData);
   } else {
     stream.on('newListener', onNewListener);
   }
-}
+};
 
 /**
  * moves the cursor to the x and y coordinate on the given stream
  */
 
-function cursorTo(stream, x, y) {
+const cursorTo = (stream, x, y) => {
   if (stream === null || stream === undefined)
     return;
 
@@ -1156,13 +1156,13 @@ function cursorTo(stream, x, y) {
   } else {
     stream.write(CSI`${y + 1};${x + 1}H`);
   }
-}
+};
 
 /**
  * moves the cursor relative to its current location
  */
 
-function moveCursor(stream, dx, dy) {
+const moveCursor = (stream, dx, dy) => {
   if (stream === null || stream === undefined)
     return;
 
@@ -1177,7 +1177,7 @@ function moveCursor(stream, dx, dy) {
   } else if (dy > 0) {
     stream.write(CSI`${dy}B`);
   }
-}
+};
 
 /**
  * clears the current line the cursor is on:
@@ -1186,7 +1186,7 @@ function moveCursor(stream, dx, dy) {
  *    0 for the entire line
  */
 
-function clearLine(stream, dir) {
+const clearLine = (stream, dir) => {
   if (stream === null || stream === undefined)
     return;
 
@@ -1200,18 +1200,18 @@ function clearLine(stream, dir) {
     // entire line
     stream.write(kClearLine);
   }
-}
+};
 
 /**
  * clears the screen from the current position of the cursor down
  */
 
-function clearScreenDown(stream) {
+const clearScreenDown = (stream) => {
   if (stream === null || stream === undefined)
     return;
 
   stream.write(kClearScreenDown);
-}
+};
 
 module.exports = {
   Interface,


### PR DESCRIPTION
Refs: https://github.com/nodejsjp/node-1/issues/1

fix function declarations to arrow functions inside of lib/readline.js where possible

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
