### PR TITLE
switch lib/readline.js to arrow functions

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -887,7 +887,7 @@ Interface.prototype._ttyWrite = function(s, key) {
           this.emit('SIGTSTP');
         } else {
           process.once('SIGCONT', (function continueProcess(self) {
-            return function() {
+            return () => {
               // Don't raise events if stream has already been abandoned.
               if (!self.paused) {
                 // Stream must be paused and resumed after SIGCONT to catch


### PR DESCRIPTION
Refs: https://github.com/nodejsjp/node-1/issues/1

fix function declarations to arrow functions inside of lib/readline.js where possible

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
