### PR TITLE
lib: convert to arrow function in fs.js

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -144,7 +144,7 @@ function makeCallback(cb) {
     throw new ERR_INVALID_CALLBACK();
   }
 
-  return function(...args) {
+  return (...args) => {
     return Reflect.apply(cb, undefined, args);
   };
 }
@@ -157,7 +157,7 @@ function makeStatsCallback(cb) {
     throw new ERR_INVALID_CALLBACK();
   }
 
-  return function(err, stats) {
+  return (err, stats) => {
     if (err) return cb(err);
     cb(err, getStatsFromBinding(stats));
   };
@@ -631,11 +631,11 @@ function truncate(path, len, callback) {
 
   validateInteger(len, 'len');
   callback = maybeCallback(callback);
-  fs.open(path, 'r+', function(er, fd) {
+  fs.open(path, 'r+', (er, fd) => {
     if (er) return callback(er);
     const req = new FSReqCallback();
     req.oncomplete = function oncomplete(er) {
-      fs.close(fd, function(er2) {
+      fs.close(fd, (er2) => {
         callback(er || er2);
       });
     };
@@ -995,15 +995,15 @@ function fchmodSync(fd, mode) {
 
 function lchmod(path, mode, callback) {
   callback = maybeCallback(callback);
-  fs.open(path, O_WRONLY | O_SYMLINK, function(err, fd) {
+  fs.open(path, O_WRONLY | O_SYMLINK, (err, fd) => {
     if (err) {
       callback(err);
       return;
     }
     // Prefer to return the chmod error, if one occurs,
     // but still try to close, and report closing errors if they occur.
-    fs.fchmod(fd, mode, function(err) {
-      fs.close(fd, function(err2) {
+    fs.fchmod(fd, mode, (err) => {
+      fs.close(fd, (err2) => {
         callback(err || err2);
       });
     });
@@ -1152,7 +1152,7 @@ function futimesSync(fd, atime, mtime) {
 
 function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {
   // write(fd, buffer, offset, length, position, callback)
-  fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
+  fs.write(fd, buffer, offset, length, position, (writeErr, written) => {
     if (writeErr) {
       if (isUserFd) {
         callback(writeErr);
@@ -1188,7 +1188,7 @@ function writeFile(path, data, options, callback) {
     return;
   }
 
-  fs.open(path, flag, options.mode, function(openErr, fd) {
+  fs.open(path, flag, options.mode, (openErr, fd) => {
     if (openErr) {
       callback(openErr);
     } else {
@@ -1531,7 +1531,7 @@ function realpathSync(p, options) {
 }
 
 
-realpathSync.native = function(path, options) {
+realpathSync.native = (path, options) => {
   options = getOptions(options, {});
   path = toPathIfFileURL(path);
   validatePath(path);
@@ -1572,7 +1572,7 @@ function realpath(p, options, callback) {
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
-    fs.lstat(base, function(err, stats) {
+    fs.lstat(base, (err, stats) => {
       if (err) return callback(err);
       knownHard[base] = true;
       LOOP();
@@ -1636,10 +1636,10 @@ function realpath(p, options, callback) {
         return gotTarget(null, seenLinks[id], base);
       }
     }
-    fs.stat(base, function(err) {
+    fs.stat(base, (err) => {
       if (err) return callback(err);
 
-      fs.readlink(base, function(err, target) {
+      fs.readlink(base, (err, target) => {
         if (!isWindows) seenLinks[id] = target;
         gotTarget(err, target);
       });
@@ -1660,7 +1660,7 @@ function realpath(p, options, callback) {
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
-      fs.lstat(base, function(err) {
+      fs.lstat(base, (err) => {
         if (err) return callback(err);
         knownHard[base] = true;
         LOOP();
@@ -1672,7 +1672,7 @@ function realpath(p, options, callback) {
 }
 
 
-realpath.native = function(path, options, callback) {
+realpath.native = (path, options, callback) => {
   callback = makeCallback(callback || options);
   options = getOptions(options, {});
   path = toPathIfFileURL(path);


### PR DESCRIPTION
As far as I look, there are no `this` reference in the converted functions.

Named functions like `function tick` and `function oncomplete` are left untouched to preserve stack traces.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)