### PR TITLE
test: fix the arguments order in assert.strictEqual

### DIFF
--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -43,7 +43,7 @@ function testCwd(options, expectCode = 0, expectData) {
   // Can't assert callback, as stayed in to API:
   // _The 'exit' event may or may not fire after an error has occurred._
   child.on('exit', function(code, signal) {
-    assert.strictEqual(expectCode, code);
+    assert.strictEqual(code, expectCode);
   });
 
   child.on('close', common.mustCall(function() {


### PR DESCRIPTION
I working at "Code and Learn" on Node fest 2018 in Japan.

Refs: https://github.com/nodejs/node/pull/24431

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
