### PR TITLE
src: migrate to new V8 array API

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -64,13 +64,15 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   auto isolate = args.GetIsolate();
 
   Local<Promise> promise = args[0].As<Promise>();
-  Local<Array> ret = Array::New(isolate, 2);
 
   int state = promise->State();
-  ret->Set(env->context(), 0, Integer::New(isolate, state)).FromJust();
+  std::vector<Local<Value>> values;
+  values.push_back(Integer::New(isolate, state));
   if (state != Promise::PromiseState::kPending)
-    ret->Set(env->context(), 1, promise->Result()).FromJust();
+    values.push_back(promise->Result());
 
+  Local<Array> ret = Array::New(
+    isolate, values.data(), values.size());
   args.GetReturnValue().Set(ret);
 }
 
@@ -82,11 +84,13 @@ static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
 
   Local<Proxy> proxy = args[0].As<Proxy>();
 
-  Local<Array> ret = Array::New(args.GetIsolate(), 2);
-  ret->Set(env->context(), 0, proxy->GetTarget()).FromJust();
-  ret->Set(env->context(), 1, proxy->GetHandler()).FromJust();
+  Local<Value> ret[] = {
+    proxy->GetTarget(),
+    proxy->GetHandler()
+  };
 
-  args.GetReturnValue().Set(ret);
+  args.GetReturnValue().Set(
+      Array::New(args.GetIsolate(), ret, arraysize(ret)));
 }
 
 static void PreviewEntries(const FunctionCallbackInfo<Value>& args) {
@@ -101,11 +105,13 @@ static void PreviewEntries(const FunctionCallbackInfo<Value>& args) {
   // Fast path for WeakMap, WeakSet and Set iterators.
   if (args.Length() == 1)
     return args.GetReturnValue().Set(entries);
-  Local<Array> ret = Array::New(env->isolate(), 2);
-  ret->Set(env->context(), 0, entries).FromJust();
-  ret->Set(env->context(), 1, Boolean::New(env->isolate(), is_key_value))
-      .FromJust();
-  return args.GetReturnValue().Set(ret);
+
+  Local<Value> ret[] = {
+    entries,
+    Boolean::New(env->isolate(), is_key_value)
+  };
+  return args.GetReturnValue().Set(
+      Array::New(env->isolate(), ret, arraysize(ret)));
 }
 
 // Side effect-free stringification that will never throw exceptions.

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -66,7 +66,7 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   Local<Promise> promise = args[0].As<Promise>();
 
   int state = promise->State();
-  std::vector<Local<Value>> values;
+  std::vector<Local<Value>> values(2);
   values.push_back(Integer::New(isolate, state));
   if (state != Promise::PromiseState::kPending)
     values.push_back(promise->Result());

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -66,13 +66,11 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   Local<Promise> promise = args[0].As<Promise>();
 
   int state = promise->State();
-  std::vector<Local<Value>> values(2);
-  values.push_back(Integer::New(isolate, state));
+  Local<Value> values[2] = { Integer::New(isolate, state) };
+  size_t number_of_values = 1;
   if (state != Promise::PromiseState::kPending)
-    values.push_back(promise->Result());
-
-  Local<Array> ret = Array::New(
-    isolate, values.data(), values.size());
+    values[number_of_values++] = promise->Result();
+  Local<Array> ret = Array::New(isolate, values, number_of_values);
   args.GetReturnValue().Set(ret);
 }
 


### PR DESCRIPTION
This PR uses new V8 API for array creation, instead of old one.

related PR: https://github.com/nodejs/node/pull/24125

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
