### PR TITLE
test: fix http2-binding strictEqual order

### DIFF
--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -233,16 +233,16 @@ const defaultSettings = {
 
 for (const name of Object.keys(constants)) {
   if (name.startsWith('HTTP_STATUS_')) {
-    assert.strictEqual(expectedStatusCodes[name], constants[name],
+    assert.strictEqual(constants[name], expectedStatusCodes[name],
                        `Expected status code match for ${name}`);
   } else if (name.startsWith('HTTP2_HEADER_')) {
-    assert.strictEqual(expectedHeaderNames[name], constants[name],
+    assert.strictEqual(constants[name], expectedHeaderNames[name],
                        `Expected header name match for ${name}`);
   } else if (name.startsWith('NGHTTP2_')) {
-    assert.strictEqual(expectedNGConstants[name], constants[name],
+    assert.strictEqual(constants[name], expectedNGConstants[name],
                        `Expected ng constant match for ${name}`);
   } else if (name.startsWith('DEFAULT_SETTINGS_')) {
-    assert.strictEqual(defaultSettings[name], constants[name],
+    assert.strictEqual(constants[name], defaultSettings[name],
                        `Expected default setting match for ${name}`);
   }
 }


### PR DESCRIPTION
Refs: https://github.com/nodejsjp/node-1/issues/1

Switched the order of arguments for strictEqual checks inside of test/paralell/test-http2-binding.js

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
