### PR TITLE
test: fix `assert.strictEqual`

### DIFF
--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -115,7 +115,7 @@ function test(decode, uncork, multi, next) {
   w.on('finish', function() {
     // make sure finish comes after all the write cb
     cnt('finish')();
-    assert.deepStrictEqual(expectChunks, actualChunks);
+    assert.deepStrictEqual(actualChunks, expectChunks);
     next();
   });
 }


### PR DESCRIPTION
test: fix `assert.strictEqual`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
