### PR TITLE
test: fix the arguments order in assert.strictEqual

### DIFF
--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -17,12 +17,12 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   fs.write(fd, data, 0, 'utf8', common.mustCall(function(err, written) {
     console.log('write done');
     assert.ifError(err);
-    assert.strictEqual(Buffer.byteLength(expected), written);
+    assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
     const found = fs.readFileSync(fn, 'utf8');
     console.log(`expected: "${expected}"`);
     console.log(`found: "${found}"`);
     fs.unlinkSync(fn);
-    assert.strictEqual(expected, found);
+    assert.strictEqual(found, expected);
   }));
 }));


### PR DESCRIPTION
I working at "Code and Learn" on Node fest 2018 in Japan.

Refs: https://github.com/nodejs/node/pull/24431

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
