### PR TITLE
lib: changed bootstrap/node.js to arrow function

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -332,7 +332,7 @@
             code += d;
           });
 
-          process.stdin.on('end', () => {
+          process.stdin.on('end', function() {
             if (process._syntax_check_only != null) {
               checkScriptSyntax(code, '[stdin]');
             } else {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -389,7 +389,7 @@
     const util = NativeModule.require('util');
 
     function makeGetter(name) {
-      return util.deprecate(() => {
+      return util.deprecate(function() {
         return this;
       }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
     }

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -240,7 +240,7 @@
       // To allow people to extend Node in different ways, this hook allows
       // one to drop a file lib/_third_party_main.js into the build
       // directory which will be executed instead of Node's normal loading.
-      process.nextTick(function() {
+      process.nextTick(() => {
         NativeModule.require('_third_party_main');
       });
     } else if (process.argv[1] === 'inspect' || process.argv[1] === 'debug') {
@@ -251,7 +251,7 @@
       }
 
       // Start the debugger agent.
-      process.nextTick(function() {
+      process.nextTick(() => {
         NativeModule.require('internal/deps/node-inspect/lib/_inspect').start();
       });
 
@@ -304,14 +304,14 @@
         if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
           // REPL
           const cliRepl = NativeModule.require('internal/repl');
-          cliRepl.createInternalRepl(process.env, function(err, repl) {
+          cliRepl.createInternalRepl(process.env, (err, repl) => {
             if (err) {
               throw err;
             }
-            repl.on('exit', function() {
+            repl.on('exit', () => {
               if (repl._flushing) {
                 repl.pause();
-                return repl.once('flushHistory', function() {
+                return repl.once('flushHistory', () => {
                   process.exit();
                 });
               }
@@ -328,11 +328,11 @@
           process.stdin.setEncoding('utf8');
 
           let code = '';
-          process.stdin.on('data', function(d) {
+          process.stdin.on('data', (d) => {
             code += d;
           });
 
-          process.stdin.on('end', function() {
+          process.stdin.on('end', () => {
             if (process._syntax_check_only != null) {
               checkScriptSyntax(code, '[stdin]');
             } else {
@@ -389,13 +389,13 @@
     const util = NativeModule.require('util');
 
     function makeGetter(name) {
-      return util.deprecate(function() {
+      return util.deprecate(() => {
         return this;
       }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
     }
 
     function makeSetter(name) {
-      return util.deprecate(function(value) {
+      return util.deprecate((value) => {
         Object.defineProperty(this, name, {
           configurable: true,
           writable: true,
@@ -567,7 +567,7 @@
       emitAfter
     } = NativeModule.require('internal/async_hooks');
 
-    process._fatalException = function(er) {
+    process._fatalException = (er) => {
       // It's possible that defaultTriggerAsyncId was set for a constructor
       // call that threw and was never cleared. So clear it now.
       clearDefaultTriggerAsyncId();

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -395,7 +395,7 @@
     }
 
     function makeSetter(name) {
-      return util.deprecate((value) => {
+      return util.deprecate(function(value) {
         Object.defineProperty(this, name, {
           configurable: true,
           writable: true,


### PR DESCRIPTION
##### Checklist
fix function declarations to arrow functions in lib/internal/bootstrap/node.js

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
