### PR TITLE
test: fix the arguments order in `assert.strictEqual`

### DIFF
--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -35,7 +35,7 @@ const server = http.Server(function(req, res) {
   });
 
   req.on('end', function() {
-    assert.strictEqual(expected, result);
+    assert.strictEqual(result, expected);
     server.close();
     res.writeHead(200);
     res.end('hello world\n');


### PR DESCRIPTION
Update `strictEqual` arguments order

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)