### PR TITLE
doc: remove duplicate whitespaces in doc/api

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -617,8 +617,8 @@ pipes between the parent and child. The value is one of the following:
    `'ignore'` will cause Node.js to open `/dev/null` and attach it to the
    child's fd.
 4. `'inherit'` - Pass through the corresponding stdio stream to/from the
-   parent process.  In the first three positions, this is equivalent to
-   `process.stdin`, `process.stdout`, and `process.stderr`, respectively.  In
+   parent process. In the first three positions, this is equivalent to
+   `process.stdin`, `process.stdout`, and `process.stderr`, respectively. In
    any other position, equivalent to `'ignore'`.
 5. {Stream} object - Share a readable or writable stream that refers to a tty,
    file, socket, or a pipe with the child process. The stream's underlying

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -274,7 +274,7 @@ see those as two separate modules and would attempt to load the module multiple
 times, causing an exception to be thrown).
 
 The `--preserve-symlinks` flag does not apply to the main module, which allows
-`node --preserve-symlinks node_module/.bin/<foo>` to work.  To apply the same
+`node --preserve-symlinks node_module/.bin/<foo>` to work. To apply the same
 behavior for the main module, also use `--preserve-symlinks-main`.
 
 ### `--preserve-symlinks-main`

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -92,7 +92,7 @@ Node.js process and a cluster worker differs:
    the worker to use the supplied handle, rather than talk to the master
    process.
 3. `server.listen(0)` Normally, this will cause servers to listen on a
-   random port.  However, in a cluster, each worker will receive the
+   random port. However, in a cluster, each worker will receive the
    same "random" port each time they do `listen(0)`. In essence, the
    port is random the first time, but predictable thereafter. To listen
    on a unique port, generate a port number based on the cluster worker ID.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1486,7 +1486,7 @@ closing naturally.
 
 ```js
 const fs = require('fs');
-// Create a stream from some character  device.
+// Create a stream from some character device.
 const stream = fs.createReadStream('/dev/input/event0');
 setTimeout(() => {
   stream.close(); // This may not close the stream.
@@ -4641,7 +4641,7 @@ The following constants are meant for use with `fs.open()`.
   <td><code>O_NOATIME</code></td>
     <td>Flag indicating reading accesses to the file system will no longer
     result in an update to the <code>atime</code> information associated with
-    the file.  This flag is available on Linux operating systems only.</td>
+    the file. This flag is available on Linux operating systems only.</td>
   </tr>
   <tr>
     <td><code>O_NOFOLLOW</code></td>

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -769,7 +769,7 @@ added: v10.12.0
 
 * `origins` {string[]}
 
-The `'origin'`  event is emitted whenever an `ORIGIN` frame is received by
+The `'origin'` event is emitted whenever an `ORIGIN` frame is received by
 the client. The event is emitted with an array of `origin` strings. The
 `http2session.originSet` will be updated to include the received
 origins.
@@ -1193,7 +1193,7 @@ added: v10.0.0
 
 Sends a trailing `HEADERS` frame to the connected HTTP/2 peer. This method
 will cause the `Http2Stream` to be immediately closed and must only be
-called after the `'wantTrailers'`  event has been emitted. When sending a
+called after the `'wantTrailers'` event has been emitted. When sending a
 request or sending a response, the `options.waitForTrailers` option must be set
 in order to keep the `Http2Stream` open after the final `DATA` frame so that
 trailers can be sent.
@@ -1729,7 +1729,7 @@ added: v8.4.0
 -->
 * `callback` {Function}
 
-Stops the server from accepting new connections.  See [`net.Server.close()`][].
+Stops the server from accepting new connections. See [`net.Server.close()`][].
 
 Note that this is not analogous to restricting new requests since HTTP/2
 connections are persistent. To achieve a similar graceful shutdown behavior,
@@ -1871,7 +1871,7 @@ added: v8.4.0
 -->
 * `callback` {Function}
 
-Stops the server from accepting new connections.  See [`tls.Server.close()`][].
+Stops the server from accepting new connections. See [`tls.Server.close()`][].
 
 Note that this is not analogous to restricting new requests since HTTP/2
 connections are persistent. To achieve a similar graceful shutdown behavior,
@@ -2531,7 +2531,7 @@ const server = http2.createServer({ settings });
 
 Once the client receives the `SETTINGS` frame from the server indicating that
 the extended CONNECT may be used, it may send `CONNECT` requests that use the
-`':protocol'`  HTTP/2 pseudo-header:
+`':protocol'` HTTP/2 pseudo-header:
 
 ```js
 const http2 = require('http2');

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -891,7 +891,7 @@ The following error constants are exported by `os.constants.errno`:
   </tr>
   <tr>
     <td><code>EOPNOTSUPP</code></td>
-    <td>Indicates that an operation is not supported on the socket.  Note that
+    <td>Indicates that an operation is not supported on the socket. Note that
     while <code>ENOTSUP</code> and <code>EOPNOTSUPP</code> have the same value
     on Linux, according to POSIX.1 these error values should be distinct.)</td>
   </tr>

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -690,7 +690,7 @@ the key type.
 For RSA keys, the following properties may be defined:
 * `bits` {number} The RSA bit size. Example: `1024`.
 * `exponent` {string} The RSA exponent, as a string in hexadecimal number
-  notation.  Example: `'0x010001'`.
+  notation. Example: `'0x010001'`.
 * `modulus` {string} The RSA modulus, as a hexadecimal string. Example:
    `'B56CE45CB7...'`.
 * `pubkey` {Buffer} The public key.
@@ -1139,7 +1139,7 @@ changes:
     `secureProtocol` option, use one or the other.  **Default:** `'TLSv1.2'`.
   * `minVersion` {string} Optionally set the minimum TLS version to allow. One
     of `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified along with the
-    `secureProtocol` option, use one or the other.  It is not recommended to use
+    `secureProtocol` option, use one or the other. It is not recommended to use
     less than TLSv1.2, but it may be required for interoperability.
     **Default:** `'TLSv1.2'`, unless changed using CLI options. Using
     `--tls-v1.0` changes the default to `'TLSv1'`. Using `--tls-v1.1` changes


### PR DESCRIPTION
This PR removes duplicate white spaces found in documents.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)