### PR TITLE
test: split out http2 from test-stream-pipeline

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,6 +12,8 @@ test-net-connect-options-port: PASS,FLAKY
 test-http2-pipe: PASS,FLAKY
 test-worker-syntax-error: PASS,FLAKY
 test-worker-syntax-error-file: PASS,FLAKY
+# https://github.com/nodejs/node/issues/24456
+test-stream-pipeline-http2: PASS,FLAKY
 
 [$system==linux]
 

--- a/test/parallel/test-stream-pipeline-http2.js
+++ b/test/parallel/test-stream-pipeline-http2.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const { Readable, pipeline } = require('stream');
+const http2 = require('http2');
+
+{
+  const server = http2.createServer((req, res) => {
+    pipeline(req, res, common.mustCall());
+  });
+
+  server.listen(0, () => {
+    const url = `http://localhost:${server.address().port}`;
+    const client = http2.connect(url);
+    const req = client.request({ ':method': 'POST' });
+
+    const rs = new Readable({
+      read() {
+        rs.push('hello');
+      }
+    });
+
+    pipeline(rs, req, common.mustCall((err) => {
+      server.close();
+      client.close();
+    }));
+
+    let cnt = 10;
+    req.on('data', (data) => {
+      cnt--;
+      if (cnt === 0) rs.destroy();
+    });
+  });
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1,12 +1,9 @@
 'use strict';
 
 const common = require('../common');
-if (!common.hasCrypto)
-  common.skip('missing crypto');
 const { Stream, Writable, Readable, Transform, pipeline } = require('stream');
 const assert = require('assert');
 const http = require('http');
-const http2 = require('http2');
 const { promisify } = require('util');
 
 {
@@ -271,35 +268,6 @@ const { promisify } = require('util');
         cnt--;
         if (cnt === 0) rs.destroy();
       });
-    });
-  });
-}
-
-{
-  const server = http2.createServer((req, res) => {
-    pipeline(req, res, common.mustCall());
-  });
-
-  server.listen(0, () => {
-    const url = `http://localhost:${server.address().port}`;
-    const client = http2.connect(url);
-    const req = client.request({ ':method': 'POST' });
-
-    const rs = new Readable({
-      read() {
-        rs.push('hello');
-      }
-    });
-
-    pipeline(rs, req, common.mustCall((err) => {
-      server.close();
-      client.close();
-    }));
-
-    let cnt = 10;
-    req.on('data', (data) => {
-      cnt--;
-      if (cnt === 0) rs.destroy();
     });
   });
 }


### PR DESCRIPTION
Splitting out the http2 portion of the test has a few benfits:

* We don't skip the rest of the tests if `node` is compiled without
  crypto.
* We can find out if the http2 portion of the test is responsible for
  the timeouts reported in issue 24456.

Refs: https://github.com/nodejs/node/issues/24456

/ping @nodejs/testing @refack 

Collaborators, 👍 here for fast-tracking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
