### PR TITLE
build: replace `-not` with `!` in `find`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1084,7 +1084,7 @@ tools/.docmdlintstamp: $(LINT_MD_DOC_FILES)
 LINT_MD_TARGETS = src lib benchmark test tools/doc tools/icu
 LINT_MD_ROOT_DOCS := $(wildcard *.md)
 LINT_MD_MISC_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
-  -not -path '*node_modules*' -not -path 'test/fixtures/*' -name '*.md') \
+  ! -path '*node_modules*' ! -path 'test/fixtures/*' -name '*.md') \
   $(LINT_MD_ROOT_DOCS)
 run-lint-misc-md = tools/lint-md.js -q -f $(LINT_MD_MISC_FILES)
 # Lint other changed markdown files maintained by us


### PR DESCRIPTION
Replace `find -not` usage with `find !` as `-not` is not universally
supported.

Fixes: https://github.com/nodejs/node/issues/24634

@nodejs/build-files @rvagg @nodejs/platform-aix 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
