### PR TITLE
tools,doc: fix version picker bug in html.js

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -97,7 +97,7 @@ const testData = [
   },
   {
     file: fixtures.path('altdocs.md'),
-    html: '<li><ahref="https://nodejs.org/docs/latest-v8.x/api/foo.html">8.x',
+    html: '<li><a href="https://nodejs.org/docs/latest-v8.x/api/foo.html">8.x',
   },
 ];
 

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -95,6 +95,10 @@ const testData = [
     html: '<ol><li>fish</li><li>fish</li></ol>' +
       '<ul><li>Red fish</li><li>Blue fish</li></ul>',
   },
+  {
+    file: fixtures.path('altdocs.md'),
+    html: '<li><ahref="https://nodejs.org/docs/latest-v8.x/api/foo.html">8.x',
+  },
 ];
 
 const spaces = /\s/g;
@@ -117,7 +121,8 @@ testData.forEach(({ file, html }) => {
         const actual = output.replace(spaces, '');
         // Assert that the input stripped of all whitespace contains the
         // expected markup.
-        assert(actual.includes(expected));
+        assert(actual.includes(expected),
+               `ACTUAL: ${actual}\nEXPECTED: ${expected}`);
       })
     );
   }));

--- a/test/fixtures/altdocs.md
+++ b/test/fixtures/altdocs.md
@@ -1,0 +1,3 @@
+# ALTDOCS
+<!--introduced_in=v8.4.0-->
+

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -427,6 +427,7 @@ function altDocs(filename, docCreated) {
     const [versionMajor, versionMinor] = version.num.split('.').map(Number);
     if (docCreatedMajor > versionMajor) return false;
     if (docCreatedMajor < versionMajor) return true;
+    if (Number.isNaN(versionMinor)) return true;
     return docCreatedMinor <= versionMinor;
   }
 


### PR DESCRIPTION
The processing of strings like `8.x` into a major version number and a
minor version number results in minor versions that are `NaN`. In that
situation, since the picker will link to the latest docs in the
major version, include the version in the version picker.

Fixes: https://github.com/nodejs/node/issues/23979

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
