### PR TITLE
lib: rearm pre-existing signal event registrations

### DIFF
--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -154,6 +154,13 @@ function setupSignalHandlers(internalBinding) {
       delete signalWraps[type];
     }
   });
+
+  // re-arm pre-existing signal event registrations
+  // with this signal wrap capabilities.
+  process.eventNames().forEach((ev) => {
+    if (isSignal(ev))
+      process.emit('newListener', ev);
+  });
 }
 
 function setupChildProcessIpcChannel() {


### PR DESCRIPTION
process.on('somesignal', ...) semantics expect the process to catch the signal and invoke the associated handler. `setupSignalHandlers` perform the additional task of preparing the libuv signal handler and associate it with the event handler. It is possible that by the time this is setup there could be pre-existing registrations that pre-date this setup in the boot sequence.

So rearm pre-existing signal event registrations to get those upto speed.

This is required by node-report; however given its independent existence 
raising is a separate one.

I wish I could add a test for this, but realize it might not be possible, as the logic is exercised within the boot sequence that is not influenced / intercepted by any test cases.

Ref: https://github.com/nodejs/node/pull/22712#discussion_r232457318

/cc @addaleax 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
