### PR TITLE
cli: fix omitting `--` from `process.execArgv`

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -253,7 +253,7 @@ struct ArgsInfo {
       // on the command line (i.e. not generated through alias expansion).
       // '--' is a special case here since its purpose is to end `exec_argv`,
       // which is why we do not include it.
-      if (exec_args != nullptr && first() != "--")
+      if (exec_args != nullptr && ret != "--")
         exec_args->push_back(ret);
       underlying->erase(underlying->begin() + 1);
     } else {

--- a/test/parallel/test-process-exec-argv.js
+++ b/test/parallel/test-process-exec-argv.js
@@ -27,16 +27,19 @@ const spawn = require('child_process').spawn;
 if (process.argv[2] === 'child') {
   process.stdout.write(JSON.stringify(process.execArgv));
 } else {
-  const execArgv = ['--stack-size=256'];
-  const args = [__filename, 'child', 'arg0'];
-  const child = spawn(process.execPath, execArgv.concat(args));
-  let out = '';
+  for (const extra of [ [], [ '--' ] ]) {
+    const execArgv = ['--stack-size=256'];
+    const args = [__filename, 'child', 'arg0'];
+    const child = spawn(process.execPath, [...execArgv, ...extra, ...args]);
+    let out = '';
 
-  child.stdout.on('data', function(chunk) {
-    out += chunk;
-  });
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', function(chunk) {
+      out += chunk;
+    });
 
-  child.on('close', function() {
-    assert.deepStrictEqual(JSON.parse(out), execArgv);
-  });
+    child.on('close', function() {
+      assert.deepStrictEqual(JSON.parse(out), execArgv);
+    });
+  }
 }


### PR DESCRIPTION
This was essentially a typo that went unnoticed because we
didn’t have tests for this particular situation.

Fixes: https://github.com/nodejs/node/issues/24647

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
