### PR TITLE
src: use NativeModuleLoader to compile per_context.js

### DIFF
--- a/lib/internal/per_context.js
+++ b/lib/internal/per_context.js
@@ -1,44 +1,44 @@
+// arguments: global
+
 'use strict';
 
 // node::NewContext calls this script
 
-(function(global) {
-  // https://github.com/nodejs/node/issues/14909
-  if (global.Intl) delete global.Intl.v8BreakIterator;
+// https://github.com/nodejs/node/issues/14909
+if (global.Intl) delete global.Intl.v8BreakIterator;
 
-  // https://github.com/nodejs/node/issues/21219
-  // Adds Atomics.notify and warns on first usage of Atomics.wake
-  // https://github.com/v8/v8/commit/c79206b363 adds Atomics.notify so
-  // now we alias Atomics.wake to notify so that we can remove it
-  // semver major without worrying about V8.
+// https://github.com/nodejs/node/issues/21219
+// Adds Atomics.notify and warns on first usage of Atomics.wake
+// https://github.com/v8/v8/commit/c79206b363 adds Atomics.notify so
+// now we alias Atomics.wake to notify so that we can remove it
+// semver major without worrying about V8.
 
-  const AtomicsNotify = global.Atomics.notify;
-  const ReflectApply = global.Reflect.apply;
+const AtomicsNotify = global.Atomics.notify;
+const ReflectApply = global.Reflect.apply;
 
-  const warning = 'Atomics.wake will be removed in a future version, ' +
-    'use Atomics.notify instead.';
+const warning = 'Atomics.wake will be removed in a future version, ' +
+  'use Atomics.notify instead.';
 
-  let wakeWarned = false;
-  function wake(typedArray, index, count) {
-    if (!wakeWarned) {
-      wakeWarned = true;
+let wakeWarned = false;
+function wake(typedArray, index, count) {
+  if (!wakeWarned) {
+    wakeWarned = true;
 
-      if (global.process !== undefined) {
-        global.process.emitWarning(warning, 'Atomics');
-      } else {
-        global.console.error(`Atomics: ${warning}`);
-      }
+    if (global.process !== undefined) {
+      global.process.emitWarning(warning, 'Atomics');
+    } else {
+      global.console.error(`Atomics: ${warning}`);
     }
-
-    return ReflectApply(AtomicsNotify, this, arguments);
   }
 
-  global.Object.defineProperties(global.Atomics, {
-    wake: {
-      value: wake,
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-  });
-}(this));
+  return ReflectApply(AtomicsNotify, this, arguments);
+}
+
+global.Object.defineProperties(global.Atomics, {
+  wake: {
+    value: wake,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  },
+});

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -103,29 +103,53 @@ void NativeModuleLoader::CompileCodeCache(
 
   // TODO(joyeecheung): allow compiling cache for bootstrapper by
   // switching on id
-  Local<Value> result = CompileAsModule(env, *id, true);
+  MaybeLocal<Value> result = CompileAsModule(env, *id, true);
   if (!result.IsEmpty()) {
-    args.GetReturnValue().Set(result);
+    args.GetReturnValue().Set(result.ToLocalChecked());
   }
 }
 
 void NativeModuleLoader::CompileFunction(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-
   CHECK(args[0]->IsString());
   node::Utf8Value id(env->isolate(), args[0].As<String>());
-  Local<Value> result = CompileAsModule(env, *id, false);
+
+  MaybeLocal<Value> result = CompileAsModule(env, *id, false);
   if (!result.IsEmpty()) {
-    args.GetReturnValue().Set(result);
+    args.GetReturnValue().Set(result.ToLocalChecked());
   }
 }
 
-Local<Value> NativeModuleLoader::CompileAsModule(Environment* env,
-                                                 const char* id,
-                                                 bool produce_code_cache) {
+// TODO(joyeecheung): it should be possible to generate the argument names
+// from some special comments for the bootstrapper case.
+MaybeLocal<Value> NativeModuleLoader::CompileAndCall(
+    Local<Context> context,
+    const char* id,
+    std::vector<Local<String>>* parameters,
+    std::vector<Local<Value>>* arguments,
+    Environment* optional_env) {
+  Isolate* isolate = context->GetIsolate();
+  MaybeLocal<Value> compiled = per_process_loader.LookupAndCompile(
+      context, id, parameters, false, nullptr);
+  if (compiled.IsEmpty()) {
+    return compiled;
+  }
+  Local<Function> fn = compiled.ToLocalChecked().As<Function>();
+  return fn->Call(
+      context, v8::Null(isolate), arguments->size(), arguments->data());
+}
+
+MaybeLocal<Value> NativeModuleLoader::CompileAsModule(Environment* env,
+                                                      const char* id,
+                                                      bool return_code_cache) {
+  std::vector<Local<String>> parameters = {env->exports_string(),
+                                           env->require_string(),
+                                           env->module_string(),
+                                           env->process_string(),
+                                           env->internal_binding_string()};
   return per_process_loader.LookupAndCompile(
-      env->context(), id, produce_code_cache, env);
+      env->context(), id, &parameters, return_code_cache, env);
 }
 
 // Currently V8 only checks that the length of the source code is the
@@ -183,15 +207,18 @@ ScriptCompiler::CachedData* NativeModuleLoader::GetCachedData(
   return new ScriptCompiler::CachedData(code_cache_value, code_cache_length);
 }
 
-// Returns Local<Function> of the compiled module if produce_code_cache
+// Returns Local<Function> of the compiled module if return_code_cache
 // is false (we are only compiling the function).
 // Otherwise return a Local<Object> containing the cache.
-Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
-                                                  const char* id,
-                                                  bool produce_code_cache,
-                                                  Environment* optional_env) {
+MaybeLocal<Value> NativeModuleLoader::LookupAndCompile(
+    Local<Context> context,
+    const char* id,
+    std::vector<Local<String>>* parameters,
+    bool return_code_cache,
+    Environment* optional_env) {
   Isolate* isolate = context->GetIsolate();
   EscapableHandleScope scope(isolate);
+  Local<Value> ret;  // Used to convert to MaybeLocal before return
 
   Local<String> source = GetSource(isolate, id);
 
@@ -209,7 +236,7 @@ Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
   //    built with them.
   // 2. If we are generating code cache for tools/general_code_cache.js, we
   //    are not going to use any cache ourselves.
-  if (has_code_cache_ && !produce_code_cache) {
+  if (has_code_cache_ && !return_code_cache) {
     cached_data = GetCachedData(id);
     if (cached_data != nullptr) {
       use_cache = true;
@@ -219,7 +246,7 @@ Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
   ScriptCompiler::Source script_source(source, origin, cached_data);
 
   ScriptCompiler::CompileOptions options;
-  if (produce_code_cache) {
+  if (return_code_cache) {
     options = ScriptCompiler::kEagerCompile;
   } else if (use_cache) {
     options = ScriptCompiler::kConsumeCodeCache;
@@ -227,42 +254,25 @@ Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
     options = ScriptCompiler::kNoCompileOptions;
   }
 
-  MaybeLocal<Function> maybe_fun;
-  // Currently we assume if Environment is ready, then we must be compiling
-  // native modules instead of bootstrappers.
-  if (optional_env != nullptr) {
-    Local<String> parameters[] = {optional_env->exports_string(),
-                                  optional_env->require_string(),
-                                  optional_env->module_string(),
-                                  optional_env->process_string(),
-                                  optional_env->internal_binding_string()};
-    maybe_fun = ScriptCompiler::CompileFunctionInContext(context,
-                                                         &script_source,
-                                                         arraysize(parameters),
-                                                         parameters,
-                                                         0,
-                                                         nullptr,
-                                                         options);
-  } else {
-    // Until we migrate bootstrappers compilations here this is unreachable
-    // TODO(joyeecheung): it should be possible to generate the argument names
-    // from some special comments for the bootstrapper case.
-    // Note that for bootstrappers we may not be able to get the argument
-    // names as env->some_string() because we might be compiling before
-    // those strings are initialized.
-    UNREACHABLE();
-  }
+  MaybeLocal<Function> maybe_fun =
+      ScriptCompiler::CompileFunctionInContext(context,
+                                               &script_source,
+                                               parameters->size(),
+                                               parameters->data(),
+                                               0,
+                                               nullptr,
+                                               options);
 
-  Local<Function> fun;
   // This could fail when there are early errors in the native modules,
   // e.g. the syntax errors
-  if (maybe_fun.IsEmpty() || !maybe_fun.ToLocal(&fun)) {
+  if (maybe_fun.IsEmpty()) {
     // In the case of early errors, v8 is already capable of
     // decorating the stack for us - note that we use CompileFunctionInContext
     // so there is no need to worry about wrappers.
-    return scope.Escape(Local<Value>());
+    return scope.EscapeMaybe(MaybeLocal<Value>());
   }
 
+  Local<Function> fun = maybe_fun.ToLocalChecked();
   if (use_cache) {
     if (optional_env != nullptr) {
       // This could happen when Node is run with any v8 flag, but
@@ -279,7 +289,7 @@ Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
     }
   }
 
-  if (produce_code_cache) {
+  if (return_code_cache) {
     std::unique_ptr<ScriptCompiler::CachedData> cached_data(
         ScriptCompiler::CreateCodeCacheForFunction(fun));
     CHECK_NE(cached_data, nullptr);
@@ -296,10 +306,12 @@ Local<Value> NativeModuleLoader::LookupAndCompile(Local<Context> context,
                          copied.release(),
                          cached_data_length,
                          ArrayBufferCreationMode::kInternalized);
-    return scope.Escape(Uint8Array::New(buf, 0, cached_data_length));
+    ret = Uint8Array::New(buf, 0, cached_data_length);
   } else {
-    return scope.Escape(fun);
+    ret = fun;
   }
+
+  return scope.EscapeMaybe(MaybeLocal<Value>(ret));
 }
 
 void NativeModuleLoader::Initialize(Local<Object> target,


### PR DESCRIPTION
This patch introduces a NativeModuleLoader::CompileAndCall that
can run a JS script under `lib/` as a function called
with a null receiver and arguments specified from the C++ layer.
Since all our bootstrappers are wrapped in functions in the
source to avoid leaking variables into the global scope anyway,
this allows us to remove that extra indentation in the JS source code.

As a start we move the compilation and execution of per_context.js
to NativeModuleLoader::CompileAndCall(). This patch also changes the return
value of NativeModuleLoader::LookupAndCompile() to a MaybeLocal
since the caller has to take care of the result being empty
anyway.

This patch reverts the previous design of having the
NativeModuleLoader::Compile() method magically know about the
parameters of the function - until we have tooling
in-place to guess the parameter names in the source with some
annotation, it's more readable to allow the caller to specify
the parameters along with the arguments values.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
