### PR TITLE
test: fixed the arguments order in assert.strictEqual

### DIFF
--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -237,7 +237,7 @@ function runTest(assertCleaned) {
 
       try {
         // Ensure everything that we expected was output
-        assert.strictEqual(expected.length, 0);
+        assert.strictEqual(0, expected.length);
         setImmediate(runTestWrap, cleaned);
       } catch (err) {
         console.error(`Failed test # ${numtests - tests.length}`);


### PR DESCRIPTION
fixed the arguments order in `assert.strictEqual` to (actual, expected) for `test-repl-persistent-history.js`

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
