### PR TITLE
http2: compat support for nested array headers

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -574,10 +574,16 @@ class Http2ServerResponse extends Stream {
     if (headers === undefined && typeof statusMessage === 'object')
       headers = statusMessage;
 
-    if (typeof headers === 'object') {
+    var i;
+    if (Array.isArray(headers)) {
+      for (i = 0; i < headers.length; i++) {
+        const header = headers[i];
+        this[kSetHeader](header[0], header[1]);
+      }
+    } else if (typeof headers === 'object') {
       const keys = Object.keys(headers);
       let key = '';
-      for (var i = 0; i < keys.length; i++) {
+      for (i = 0; i < keys.length; i++) {
         key = keys[i];
         this[kSetHeader](key, headers[key]);
       }

--- a/test/parallel/test-http2-compat-serverresponse-writehead-array.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead-array.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Http2ServerResponse.writeHead should support nested arrays
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  server.once('request', common.mustCall((request, response) => {
+    response.writeHead(200, [
+      ['foo', 'bar'],
+      ['ABC', 123]
+    ]);
+    response.end(common.mustCall(() => { server.close(); }));
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(() => {
+    const headers = {
+      ':path': '/',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers.foo, 'bar');
+      assert.strictEqual(headers.abc, '123');
+      assert.strictEqual(headers[':status'], 200);
+    }, 1));
+    request.on('end', common.mustCall(() => {
+      client.close();
+    }));
+    request.end();
+    request.resume();
+  }));
+}));


### PR DESCRIPTION
writeHead supports an array of arrays containing header name and values.

Compatibility between http2 & http1 even though this is not documented.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
