### PR TITLE
test: make test-uv-binding-constant JS engine neutral

### DIFF
--- a/test/parallel/test-uv-binding-constant.js
+++ b/test/parallel/test-uv-binding-constant.js
@@ -13,8 +13,7 @@ const keys = Object.keys(uv);
 keys.forEach((key) => {
   if (key.startsWith('UV_')) {
     const val = uv[key];
-    assert.throws(() => uv[key] = 1,
-                  /^TypeError: Cannot assign to read only property/);
+    assert.throws(() => uv[key] = 1, TypeError);
     assert.strictEqual(uv[key], val);
   }
 });


### PR DESCRIPTION
The error message validation in test-uv-binding-constant depends on the
JS engine. The text will be different in node-chakracore than in
V8-based versions of Node.js. Remove the message validation. Test that
it is a TypeError only. We should only validate error messages when we
control the contents of that error message (and not even necessarily
then, but that is a minimum requirement). V8 and other underlying
engines can change the error message at any time and that should not
require us to change our tests (as changing tests suggests a
semver-major change).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
