### PR TITLE
stream: make async iterator .next() always resolve

### DIFF
--- a/lib/internal/streams/async_iterator.js
+++ b/lib/internal/streams/async_iterator.js
@@ -39,6 +39,11 @@ function onReadable(iter) {
 function wrapForNext(lastPromise, iter) {
   return (resolve, reject) => {
     lastPromise.then(() => {
+      if (iter[kEnded]) {
+        resolve(createIterResult(undefined, true));
+        return;
+      }
+
       iter[kHandlePromise](resolve, reject);
     }, reject);
   };
@@ -61,7 +66,7 @@ const ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf({
     }
 
     if (this[kEnded]) {
-      return Promise.resolve(createIterResult(null, true));
+      return Promise.resolve(createIterResult(undefined, true));
     }
 
     if (this[kStream].destroyed) {
@@ -74,7 +79,7 @@ const ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf({
           if (this[kError]) {
             reject(this[kError]);
           } else {
-            resolve(createIterResult(null, true));
+            resolve(createIterResult(undefined, true));
           }
         });
       });
@@ -115,7 +120,7 @@ const ReadableStreamAsyncIteratorPrototype = Object.setPrototypeOf({
           reject(err);
           return;
         }
-        resolve(createIterResult(null, true));
+        resolve(createIterResult(undefined, true));
       });
     });
   },
@@ -131,7 +136,6 @@ const createReadableStreamAsyncIterator = (stream) => {
       value: stream._readableState.endEmitted,
       writable: true
     },
-    [kLastPromise]: { value: null, writable: true },
     // the function passed to new Promise
     // is cached so we avoid allocating a new
     // closure at every run
@@ -151,6 +155,7 @@ const createReadableStreamAsyncIterator = (stream) => {
       writable: true,
     },
   });
+  iterator[kLastPromise] = null;
 
   finished(stream, (err) => {
     if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
@@ -172,7 +177,7 @@ const createReadableStreamAsyncIterator = (stream) => {
       iterator[kLastPromise] = null;
       iterator[kLastResolve] = null;
       iterator[kLastReject] = null;
-      resolve(createIterResult(null, true));
+      resolve(createIterResult(undefined, true));
     }
     iterator[kEnded] = true;
   });


### PR DESCRIPTION
See: https://github.com/nodejs/readable-stream/issues/387

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
