### PR TITLE
tools: only sign release if promotion successful

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -196,7 +196,9 @@ for version in $versions; do
 
     ssh ${customsshkey} ${webuser}@${webhost} $promotecmd nodejs $version
 
-    sign $version
+    if [ $? -eq 0 ];then
+      sign $version
+    fi
 
     break
   done


### PR DESCRIPTION
To support https://github.com/nodejs/build/pull/1596, but good practice regardless

@nodejs/releasers @nodejs/build 
