### PR TITLE
win: do not use Boxstarter to install tools

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
+title Install Additional Tools for Node.js
 
 cls
 

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -15,12 +15,13 @@ echo.
 echo This will require about 3 Gb of free disk space, plus any space necessary to
 echo install Windows updates. This will take a while to run.
 echo.
-echo If the installation fails, please ensure Windows is fully updated and reboot
-echo your computer before trying again.
+echo Please close all open programs for the duration of the installation. If the
+echo installation fails, please ensure Windows is fully updated, reboot your
+echo computer and try to run this again. This script can be found in the
+echo Start menu under Node.js.
 echo.
-echo You can close this window to stop now. This script can be invoked from the
-echo Start menu. Detailed instructions to install these tools manually are
-echo available at https://github.com/nodejs/node-gyp#on-windows
+echo You can close this window to stop now. Detailed instructions to install these
+echo tools manually are available at https://github.com/nodejs/node-gyp#on-windows
 echo.
 pause
 
@@ -37,7 +38,6 @@ echo license terms or not. Read and understand the license terms of the packages
 echo being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
 echo - https://chocolatey.org/packages/python2
-echo - https://chocolatey.org/packages/visualstudio2017buildtools
 echo - https://chocolatey.org/packages/visualstudio2017-workload-vctools
 echo.
 echo This script is provided AS-IS without any warranties of any kind

--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -3,21 +3,20 @@
 setlocal
 
 cls
+
 echo ====================================================
 echo Tools for Node.js Native Modules Installation Script
 echo ====================================================
 echo.
-echo This Boxstarter script will install Python and the Visual Studio Build Tools,
-echo necessary to compile Node.js native modules. Note that Boxstarter,
-echo Chocolatey and required Windows updates will also be installed.
+echo This script will install Python and the Visual Studio Build Tools, necessary
+echo to compile Node.js native modules. Note that Chocolatey and required Windows
+echo updates will also be installed.
 echo.
 echo This will require about 3 Gb of free disk space, plus any space necessary to
-echo install Windows updates.
+echo install Windows updates. This will take a while to run.
 echo.
-echo This will take a while to run. Your computer may reboot during the
-echo installation, and will resume automatically.
-echo.
-echo Please close all open programs for the duration of the installation.
+echo If the installation fails, please ensure Windows is fully updated and reboot
+echo your computer before trying again.
 echo.
 echo You can close this window to stop now. This script can be invoked from the
 echo Start menu. Detailed instructions to install these tools manually are
@@ -26,6 +25,7 @@ echo.
 pause
 
 cls
+
 REM Adapted from https://github.com/Microsoft/windows-dev-box-setup-scripts/blob/79bbe5bdc4867088b3e074f9610932f8e4e192c2/README.md#legal
 echo Using this script downloads third party software
 echo ------------------------------------------------
@@ -36,7 +36,6 @@ echo result of a Chocolatey install. This acceptance occurs whether you know the
 echo license terms or not. Read and understand the license terms of the packages
 echo being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
-echo - https://chocolatey.org/packages/boxstarter
 echo - https://chocolatey.org/packages/python2
 echo - https://chocolatey.org/packages/visualstudio2017buildtools
 echo - https://chocolatey.org/packages/visualstudio2017-workload-vctools
@@ -46,39 +45,10 @@ echo ----------------------------------------------------------------
 echo Chocolatey has implemented security safeguards in their process to help
 echo protect the community from malicious or pirated software, but any use of this
 echo script is at your own risk. Please read the Chocolatey's legal terms of use
-echo and the Boxstarter project license as well as how the community repository
-echo for Chocolatey.org is maintained.
+echo as well as how the community repository for Chocolatey.org is maintained.
 echo.
 pause
 
 cls
-echo !!!!!WARNING!!!!!
-echo -----------------
-echo This script should make installing the tools as easy as possible. Hence, it
-echo WILL NOT OFFER ANY CUSTOMIZATION. If there's any parameter you'd like to
-echo customize (like installation directory or features), or if there's any
-echo special rule or policy that your computer should comply to (like not being
-echo able to log in as the user with administrative privileges), please follow the
-echo instructions to download and execute the installers directly:
-echo https://github.com/nodejs/node-gyp#on-windows
-echo.
-echo Use of Boxstarter may reboot your computer automatically multiple times.
-echo When performing a reboot, Boxstarter will need to disable User Account
-echo Control (UAC) to allow the script to run immediately after the reboot. When
-echo the scripts have completed, Boxstarter will re-enable UAC. If you prematurely
-echo stop the process, UAC will need to be re-enabled manually.
-echo.
-echo Sometimes the scripts may install all necessary Windows Updates which
-echo could cause a high number of reboots that appear to be a reboot loop when
-echo in fact it is just a normal Windows Updates reboot cycle.
-:acceptretry
-echo.
-echo Your computer may REBOOT SEVERAL TIMES WITHOUT FURTHER WARNING.
-echo Please type YES followed by enter to confirm that you have saved all your
-set /p "ACCEPT_PROMPT=work and closed all open programs: "
-if /i not "%ACCEPT_PROMPT%"=="yes" (
-  echo Please type YES to confirm, or close the window to exit.
-  goto acceptretry
-)
 
-"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://boxstarter.org/bootstrapper.ps1'')); get-boxstarter -Force; Install-BoxstarterPackage -PackageName ''%~dp0\install_tools.txt''; Read-Host ''Type ENTER to exit'' ' -Verb RunAs
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command Start-Process '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe' -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command iex ((New-Object System.Net.WebClient).DownloadString(''https://chocolatey.org/install.ps1'')); choco upgrade -y python2 visualstudio2017-workload-vctools; Read-Host ''Type ENTER to exit'' ' -Verb RunAs

--- a/tools/msvs/install_tools/install_tools.txt
+++ b/tools/msvs/install_tools/install_tools.txt
@@ -1,3 +1,0 @@
-choco upgrade -y python2
-choco upgrade -y visualstudio2017buildtools
-choco upgrade -y visualstudio2017-workload-vctools

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -13,7 +13,7 @@
     <String Id="NativeToolsDlgDescription">Optionally install the tools necessary to compile native modules.</String>
     <String Id="NativeToolsDlgBannerBitmap">WixUI_Bmp_Banner</String>
     <String Id="NativeToolsDlgIntro">Some npm modules need to be compiled from C/C++ when installing. If you want to be able to install such modules, some tools (Python 2 and Visual Studio Build Tools) need to be installed.</String>
-    <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. Note that this will also install Boxstarter and Chocolatey. The script will pop-up in a new window after the installation completes.</String>
+    <String Id="NativeToolsDlgInstallCheckbox">Automatically install the necessary tools. Note that this will also install Chocolatey. The script will pop-up in a new window after the installation completes.</String>
     <String Id="NativeToolsDlgManualDetails">Alternatively, follow the instructions at <![CDATA[<a href="https://github.com/nodejs/node-gyp#on-windows">https://github.com/nodejs/node-gyp#on-windows</a>]]> to install the dependencies yourself.</String>
 
     <!-- References like [ProductName] or $(var.ProductName) don't seem to work in Title attributes -->

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -73,7 +73,6 @@
       <ComponentRef Id="NodeStartMenu"/>
       <ComponentRef Id="AppData" />
       <ComponentRef Id="InstallToolsBat" />
-      <ComponentRef Id="InstallToolsTxt" />
       <ComponentGroupRef Id="Product.Generated"/>
 
       <Feature Id="NodeEtwSupport"
@@ -159,10 +158,6 @@
 
       <Component Id="InstallToolsBat">
         <File Id="InstallToolsBat" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\install_tools\install_tools.bat"/>
-      </Component>
-
-      <Component Id="InstallToolsTxt">
-        <File Id="InstallToolsTxt" Source="$(var.RepoDir)\tools\msvs\install_tools\install_tools.txt"/>
       </Component>
 
       <?if $(var.NoETW) != 1 ?>


### PR DESCRIPTION
The script to install Python and Visual Studio on Windows uses Boxstarter to reboot the machine whenever a reboot is pending and disable some Windows features that can make the installation fail. This has been causing issues for some users, leaving the machine in an unexpected state when the installation is cancelled.

This PR removes Boxstarter, changing the script to use Chocolatey directly, thus not changing machine configuration. This makes it possible for the installation to fail because of interference from updates or previous installations, but I could not make this happen in my tests with the packages installed here. Hence, I believe this is a good trade-off to fix the issues that have been happening.

Fixes: https://github.com/nodejs/node/issues/23838
Refs: https://github.com/nodejs/node/issues/24637

cc @nodejs/platform-windows @gep13

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
