### PR TITLE
test: verify order of error in h2 server stream

### DIFF
--- a/test/parallel/test-http2-error-order.js
+++ b/test/parallel/test-http2-error-order.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { createServer, connect } = require('http2');
+
+const messages = [];
+const expected = [
+  'Stream:created',
+  'Stream:error',
+  'Stream:close',
+  'Request:error'
+];
+
+const server = createServer();
+
+server.on('stream', (stream) => {
+  messages.push('Stream:created');
+  stream
+    .on('close', () => messages.push('Stream:close'))
+    .on('error', (err) => messages.push('Stream:error'))
+    .respondWithFile('dont exist');
+});
+
+server.listen(8000);
+
+const client = connect('http://localhost:8000');
+const req = client.request();
+
+req.on('response', common.mustNotCall());
+
+req.on('error', () => {
+  messages.push('Request:error');
+  client.close();
+});
+
+client.on('close', () => {
+  assert.deepStrictEqual(messages, expected);
+  server.close();
+});

--- a/test/parallel/test-http2-error-order.js
+++ b/test/parallel/test-http2-error-order.js
@@ -25,9 +25,9 @@ server.on('stream', (stream) => {
     .respondWithFile('dont exist');
 });
 
-server.listen(8000);
+server.listen(0);
 
-const client = connect('http://localhost:8000');
+const client = connect(`http://localhost:${server.address().port}`);
 const req = client.request();
 
 req.on('response', common.mustNotCall());
@@ -37,7 +37,7 @@ req.on('error', () => {
   client.close();
 });
 
-client.on('close', () => {
+client.on('close', common.mustCall(() => {
   assert.deepStrictEqual(messages, expected);
   server.close();
-});
+}));


### PR DESCRIPTION
Currently the order of error / closing of an h2 stream is consistent
in 10.x, 11.x, and master. There appears to be an unexpected behavior
difference in 8.x. This test will be used to bisect the commit that will
fix this behavior change and ensure there are no future regressions.