### PR TITLE
test: replace anonymous functions with arrows

### DIFF
--- a/test/parallel/test-net-persistent-ref-unref.js
+++ b/test/parallel/test-net-persistent-ref-unref.js
@@ -29,7 +29,7 @@ TCPWrap.prototype.unref = function() {
 
 echoServer.listen(0);
 
-echoServer.on('listening', () => {
+echoServer.on('listening', function() {
   const sock = new net.Socket();
   sock.unref();
   sock.ref();

--- a/test/parallel/test-net-persistent-ref-unref.js
+++ b/test/parallel/test-net-persistent-ref-unref.js
@@ -6,7 +6,7 @@ const net = require('net');
 const { internalBinding } = require('internal/test/binding');
 const TCPWrap = internalBinding('tcp_wrap').TCP;
 
-const echoServer = net.createServer(function(conn) {
+const echoServer = net.createServer((conn) => {
   conn.end();
 });
 
@@ -29,12 +29,12 @@ TCPWrap.prototype.unref = function() {
 
 echoServer.listen(0);
 
-echoServer.on('listening', function() {
+echoServer.on('listening', () => {
   const sock = new net.Socket();
   sock.unref();
   sock.ref();
   sock.connect(this.address().port);
-  sock.on('end', function() {
+  sock.on('end', () => {
     assert.strictEqual(refCount, 0);
     echoServer.close();
   });


### PR DESCRIPTION
Modified the file test-net-persistent-ref-unref.js to replace anonymous closure functions with arrow functions.
