### PR TITLE
tls: extract setOptions function to reduce duplication

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -842,17 +842,6 @@ function Server(options, listener) {
   }
 
   this._contexts = [];
-  this.requestCert = options.requestCert === true;
-  this.rejectUnauthorized = options.rejectUnauthorized !== false;
-
-  if (options.sessionTimeout)
-    this.sessionTimeout = options.sessionTimeout;
-
-  if (options.ticketKeys)
-    this.ticketKeys = options.ticketKeys;
-
-  if (options.ALPNProtocols)
-    tls.convertALPNProtocols(options.ALPNProtocols, this);
 
   this.setSecureContext(options);
 
@@ -888,91 +877,7 @@ Server.prototype.setSecureContext = function(options) {
   if (options === null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
 
-  if (options.pfx)
-    this.pfx = options.pfx;
-  else
-    this.pfx = undefined;
-
-  if (options.key)
-    this.key = options.key;
-  else
-    this.key = undefined;
-
-  if (options.passphrase)
-    this.passphrase = options.passphrase;
-  else
-    this.passphrase = undefined;
-
-  if (options.cert)
-    this.cert = options.cert;
-  else
-    this.cert = undefined;
-
-  if (options.clientCertEngine)
-    this.clientCertEngine = options.clientCertEngine;
-  else
-    this.clientCertEngine = undefined;
-
-  if (options.ca)
-    this.ca = options.ca;
-  else
-    this.ca = undefined;
-
-  if (options.minVersion)
-    this.minVersion = options.minVersion;
-  else
-    this.minVersion = undefined;
-
-  if (options.maxVersion)
-    this.maxVersion = options.maxVersion;
-  else
-    this.maxVersion = undefined;
-
-  if (options.secureProtocol)
-    this.secureProtocol = options.secureProtocol;
-  else
-    this.secureProtocol = undefined;
-
-  if (options.crl)
-    this.crl = options.crl;
-  else
-    this.crl = undefined;
-
-  if (options.ciphers)
-    this.ciphers = options.ciphers;
-  else
-    this.ciphers = undefined;
-
-  if (options.ecdhCurve !== undefined)
-    this.ecdhCurve = options.ecdhCurve;
-  else
-    this.ecdhCurve = undefined;
-
-  if (options.dhparam)
-    this.dhparam = options.dhparam;
-  else
-    this.dhparam = undefined;
-
-  if (options.honorCipherOrder !== undefined)
-    this.honorCipherOrder = !!options.honorCipherOrder;
-  else
-    this.honorCipherOrder = true;
-
-  const secureOptions = options.secureOptions || 0;
-
-  if (secureOptions)
-    this.secureOptions = secureOptions;
-  else
-    this.secureOptions = undefined;
-
-  if (options.sessionIdContext) {
-    this.sessionIdContext = options.sessionIdContext;
-  } else {
-    this.sessionIdContext = crypto.createHash('sha1')
-                                  .update(process.argv.join(' '))
-                                  .digest('hex')
-                                  .slice(0, 32);
-  }
+  setOptions.call(this, options);
 
   this._sharedCreds = tls.createSecureContext({
     pfx: this.pfx,
@@ -1027,7 +932,26 @@ Server.prototype.setTicketKeys = function setTicketKeys(keys) {
 };
 
 
-Server.prototype.setOptions = util.deprecate(function(options) {
+Server.prototype.setOptions = util.deprecate(
+  setOptions,
+  'Server.prototype.setOptions() is deprecated',
+  'DEP0122'
+);
+
+// SNI Contexts High-Level API
+Server.prototype.addContext = function(servername, context) {
+  if (!servername) {
+    throw new ERR_TLS_REQUIRED_SERVER_NAME();
+  }
+
+  var re = new RegExp('^' +
+                      servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
+                                .replace(/\*/g, '[^.]*') +
+                      '$');
+  this._contexts.push([re, tls.createSecureContext(context).context]);
+};
+
+function setOptions(options) {
   this.requestCert = options.requestCert === true;
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
 
@@ -1064,20 +988,7 @@ Server.prototype.setOptions = util.deprecate(function(options) {
                                   .digest('hex')
                                   .slice(0, 32);
   }
-}, 'Server.prototype.setOptions() is deprecated', 'DEP0122');
-
-// SNI Contexts High-Level API
-Server.prototype.addContext = function(servername, context) {
-  if (!servername) {
-    throw new ERR_TLS_REQUIRED_SERVER_NAME();
-  }
-
-  var re = new RegExp('^' +
-                      servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
-                                .replace(/\*/g, '[^.]*') +
-                      '$');
-  this._contexts.push([re, tls.createSecureContext(context).context]);
-};
+}
 
 function SNICallback(servername, callback) {
   const contexts = this.server._contexts;


### PR DESCRIPTION
Since we have deprecate `setOptions` function, we can just extract it and reuse it in the `setSecureContext` function, reduce duplication.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
