### PR TITLE
doc: http module clarify header limits

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -51,7 +51,8 @@ list like the following:
 <!-- YAML
 added: v0.3.4
 changes:
-  - version: v11.3.0
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
     description: The maximum size of HTTP/1 headers is now 8KB.
 -->
 
@@ -956,7 +957,8 @@ added: v5.7.0
 <!-- YAML
 added: v0.7.0
 changes:
-  - version: v11.3.0
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
     description: The maximum size of HTTP/1 headers is now 8KB.
 -->
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -108,12 +108,10 @@ http.get({
 ```
 
 <!-- YAML
-added: v10.14.0
+added: v11.3.0
 -->
 
-The maximum size of HTTP/1 headers is 8KB and the maximum time that the HTTP/1
-headers could be received is limited to 40 seconds.
-
+The maximum size of HTTP/1 headers is 8KB.
 
 ### new Agent([options])
 <!-- YAML
@@ -965,6 +963,12 @@ added: v0.7.0
 * {number} **Default:** `2000`
 
 Limits maximum incoming headers count. If set to 0, no limit will be applied.
+
+<!-- YAML
+added: v11.3.0
+-->
+
+The maximum size of HTTP/1 headers is 8KB.
 
 ### server.headersTimeout
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -111,7 +111,8 @@ http.get({
 added: v10.14.0
 -->
 
-The maximum size of HTTP/1 headers is 8KB and the maximum time that the HTTP/1 headers could be received is limited to 40 seconds.
+The maximum size of HTTP/1 headers is 8KB and the maximum time that the HTTP/1
+headers could be received is limited to 40 seconds.
 
 
 ### new Agent([options])

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -50,10 +50,6 @@ list like the following:
 ## Class: http.Agent
 <!-- YAML
 added: v0.3.4
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
-    description: The maximum size of HTTP/1 headers is now 8KB.
 -->
 
 An `Agent` is responsible for managing connection persistence
@@ -630,6 +626,12 @@ const cookie = request.getHeader('Cookie');
 ```
 
 ### request.maxHeadersCount
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
+    description: The maximum size of HTTP/1 headers is now 8KB.
+-->
 
 * {number} **Default:** `2000`
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -107,6 +107,13 @@ http.get({
 });
 ```
 
+<!-- YAML
+added: v10.14.0
+-->
+
+The maximum size of HTTP/1 headers is 8KB and the maximum time that the HTTP/1 headers could be received is limited to 40 seconds.
+
+
 ### new Agent([options])
 <!-- YAML
 added: v0.3.4

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -50,6 +50,9 @@ list like the following:
 ## Class: http.Agent
 <!-- YAML
 added: v0.3.4
+changes:
+  - version: v11.3.0
+    description: The maximum size of HTTP/1 headers is now 8KB.
 -->
 
 An `Agent` is responsible for managing connection persistence
@@ -106,12 +109,6 @@ http.get({
   // Do stuff with response
 });
 ```
-
-<!-- YAML
-added: v11.3.0
--->
-
-The maximum size of HTTP/1 headers is 8KB.
 
 ### new Agent([options])
 <!-- YAML
@@ -958,17 +955,14 @@ added: v5.7.0
 ### server.maxHeadersCount
 <!-- YAML
 added: v0.7.0
+changes:
+  - version: v11.3.0
+    description: The maximum size of HTTP/1 headers is now 8KB.
 -->
 
 * {number} **Default:** `2000`
 
 Limits maximum incoming headers count. If set to 0, no limit will be applied.
-
-<!-- YAML
-added: v11.3.0
--->
-
-The maximum size of HTTP/1 headers is 8KB.
 
 ### server.headersTimeout
 <!-- YAML


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/24693

Updates the API docs for the HTTP module to clarify header limitations such as size and processing time.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
