### PR TITLE
doc: describe current HTTP header size limit

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1884,7 +1884,7 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
-    description: deps,http: http_parser set max header size to 8KB
+    description: Max header size in `http_parser` was set to 8KB.
 -->
 
 Too much HTTP header data was received. In order to protect against malicious or

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1880,9 +1880,15 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 
 <a id="HPE_HEADER_OVERFLOW"></a>
 ### HPE_HEADER_OVERFLOW
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
+    description: deps,http: http_parser set max header size to 8KB
+-->
 
 Too much HTTP header data was received. In order to protect against malicious or
-malconfigured clients, if more than 80KB of HTTP header data is received then
+malconfigured clients, if more than 8KB of HTTP header data is received then
 HTTP parsing will abort without a request or response object being created, and
 an `Error` with this code will be emitted.
 


### PR DESCRIPTION
Document that the limit was changed from 80KB to 8KB in 186035243.

Fixes: https://github.com/nodejs/node/issues/24693

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
