### PR TITLE
lib: move setupAllowedFlags() into per_thread.js

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -226,7 +226,7 @@
 
     perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
 
-    setupAllowedFlags();
+    perThreadSetup.setupAllowedFlags();
 
     // There are various modes that Node can run in. The most common two
     // are running from a script and running the REPL - but there are a few
@@ -698,129 +698,6 @@
     source = CJSModule.wrap(source);
     // Compile the script, this will throw if it fails.
     new vm.Script(source, { displayErrors: true, filename });
-  }
-
-  function setupAllowedFlags() {
-    // This builds process.allowedNodeEnvironmentFlags
-    // from data in the config binding
-
-    const replaceUnderscoresRegex = /_/g;
-    const leadingDashesRegex = /^--?/;
-    const trailingValuesRegex = /=.*$/;
-
-    // Save references so user code does not interfere
-    const replace = Function.call.bind(String.prototype.replace);
-    const has = Function.call.bind(Set.prototype.has);
-    const test = Function.call.bind(RegExp.prototype.test);
-
-    const get = () => {
-      const {
-        envSettings: { kAllowedInEnvironment }
-      } = internalBinding('options');
-      const { options, aliases } = NativeModule.require('internal/options');
-
-      const allowedNodeEnvironmentFlags = [];
-      for (const [name, info] of options) {
-        if (info.envVarSettings === kAllowedInEnvironment) {
-          allowedNodeEnvironmentFlags.push(name);
-        }
-      }
-
-      for (const [ from, expansion ] of aliases) {
-        let isAccepted = true;
-        for (const to of expansion) {
-          if (!to.startsWith('-') || to === '--') continue;
-          const recursiveExpansion = aliases.get(to);
-          if (recursiveExpansion) {
-            if (recursiveExpansion[0] === to)
-              recursiveExpansion.splice(0, 1);
-            expansion.push(...recursiveExpansion);
-            continue;
-          }
-          isAccepted = options.get(to).envVarSettings === kAllowedInEnvironment;
-          if (!isAccepted) break;
-        }
-        if (isAccepted) {
-          let canonical = from;
-          if (canonical.endsWith('='))
-            canonical = canonical.substr(0, canonical.length - 1);
-          if (canonical.endsWith(' <arg>'))
-            canonical = canonical.substr(0, canonical.length - 4);
-          allowedNodeEnvironmentFlags.push(canonical);
-        }
-      }
-
-      const trimLeadingDashes = (flag) => replace(flag, leadingDashesRegex, '');
-
-      // Save these for comparison against flags provided to
-      // process.allowedNodeEnvironmentFlags.has() which lack leading dashes.
-      // Avoid interference w/ user code by flattening `Set.prototype` into
-      // each object.
-      const nodeFlags = Object.defineProperties(
-        new Set(allowedNodeEnvironmentFlags.map(trimLeadingDashes)),
-        Object.getOwnPropertyDescriptors(Set.prototype)
-      );
-
-      class NodeEnvironmentFlagsSet extends Set {
-        constructor(...args) {
-          super(...args);
-
-          // the super constructor consumes `add`, but
-          // disallow any future adds.
-          this.add = () => this;
-        }
-
-        delete() {
-          // noop, `Set` API compatible
-          return false;
-        }
-
-        clear() {
-          // noop
-        }
-
-        has(key) {
-          // This will return `true` based on various possible
-          // permutations of a flag, including present/missing leading
-          // dash(es) and/or underscores-for-dashes.
-          // Strips any values after `=`, inclusive.
-          // TODO(addaleax): It might be more flexible to run the option parser
-          // on a dummy option set and see whether it rejects the argument or
-          // not.
-          if (typeof key === 'string') {
-            key = replace(key, replaceUnderscoresRegex, '-');
-            if (test(leadingDashesRegex, key)) {
-              key = replace(key, trailingValuesRegex, '');
-              return has(this, key);
-            }
-            return has(nodeFlags, key);
-          }
-          return false;
-        }
-      }
-
-      Object.freeze(NodeEnvironmentFlagsSet.prototype.constructor);
-      Object.freeze(NodeEnvironmentFlagsSet.prototype);
-
-      return process.allowedNodeEnvironmentFlags = Object.freeze(
-        new NodeEnvironmentFlagsSet(
-          allowedNodeEnvironmentFlags
-        ));
-    };
-
-    Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
-      get,
-      set(value) {
-        Object.defineProperty(this, 'allowedNodeEnvironmentFlags', {
-          value,
-          configurable: true,
-          enumerable: true,
-          writable: true
-        });
-      },
-      enumerable: true,
-      configurable: true
-    });
   }
 
   startup();

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -234,7 +234,132 @@ function setupUncaughtExceptionCapture(exceptionHandlerState,
   };
 }
 
+const replaceUnderscoresRegex = /_/g;
+const leadingDashesRegex = /^--?/;
+const trailingValuesRegex = /=.*$/;
+
+// Save references so user code does not interfere
+const replace = Function.call.bind(String.prototype.replace);
+const has = Function.call.bind(Set.prototype.has);
+const test = Function.call.bind(RegExp.prototype.test);
+
+// This builds the initial process.allowedNodeEnvironmentFlags
+// from data in the config binding.
+function buildAllowedFlags() {
+  const {
+    envSettings: { kAllowedInEnvironment }
+  } = internalBinding('options');
+  const { options, aliases } = require('internal/options');
+
+  const allowedNodeEnvironmentFlags = [];
+  for (const [name, info] of options) {
+    if (info.envVarSettings === kAllowedInEnvironment) {
+      allowedNodeEnvironmentFlags.push(name);
+    }
+  }
+
+  for (const [ from, expansion ] of aliases) {
+    let isAccepted = true;
+    for (const to of expansion) {
+      if (!to.startsWith('-') || to === '--') continue;
+      const recursiveExpansion = aliases.get(to);
+      if (recursiveExpansion) {
+        if (recursiveExpansion[0] === to)
+          recursiveExpansion.splice(0, 1);
+        expansion.push(...recursiveExpansion);
+        continue;
+      }
+      isAccepted = options.get(to).envVarSettings === kAllowedInEnvironment;
+      if (!isAccepted) break;
+    }
+    if (isAccepted) {
+      let canonical = from;
+      if (canonical.endsWith('='))
+        canonical = canonical.substr(0, canonical.length - 1);
+      if (canonical.endsWith(' <arg>'))
+        canonical = canonical.substr(0, canonical.length - 4);
+      allowedNodeEnvironmentFlags.push(canonical);
+    }
+  }
+
+  const trimLeadingDashes = (flag) => replace(flag, leadingDashesRegex, '');
+
+  // Save these for comparison against flags provided to
+  // process.allowedNodeEnvironmentFlags.has() which lack leading dashes.
+  // Avoid interference w/ user code by flattening `Set.prototype` into
+  // each object.
+  const nodeFlags = Object.defineProperties(
+    new Set(allowedNodeEnvironmentFlags.map(trimLeadingDashes)),
+    Object.getOwnPropertyDescriptors(Set.prototype)
+  );
+
+  class NodeEnvironmentFlagsSet extends Set {
+    constructor(...args) {
+      super(...args);
+
+      // the super constructor consumes `add`, but
+      // disallow any future adds.
+      this.add = () => this;
+    }
+
+    delete() {
+      // noop, `Set` API compatible
+      return false;
+    }
+
+    clear() {
+      // noop
+    }
+
+    has(key) {
+      // This will return `true` based on various possible
+      // permutations of a flag, including present/missing leading
+      // dash(es) and/or underscores-for-dashes.
+      // Strips any values after `=`, inclusive.
+      // TODO(addaleax): It might be more flexible to run the option parser
+      // on a dummy option set and see whether it rejects the argument or
+      // not.
+      if (typeof key === 'string') {
+        key = replace(key, replaceUnderscoresRegex, '-');
+        if (test(leadingDashesRegex, key)) {
+          key = replace(key, trailingValuesRegex, '');
+          return has(this, key);
+        }
+        return has(nodeFlags, key);
+      }
+      return false;
+    }
+  }
+
+  Object.freeze(NodeEnvironmentFlagsSet.prototype.constructor);
+  Object.freeze(NodeEnvironmentFlagsSet.prototype);
+
+  return process.allowedNodeEnvironmentFlags = Object.freeze(
+    new NodeEnvironmentFlagsSet(
+      allowedNodeEnvironmentFlags
+    ));
+}
+
+function setupAllowedFlags() {
+  Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
+    get: buildAllowedFlags,
+    set(value) {
+      // If the user tries to set this to another value, override
+      // this completely to that value.
+      Object.defineProperty(this, 'allowedNodeEnvironmentFlags', {
+        value,
+        configurable: true,
+        enumerable: true,
+        writable: true
+      });
+    },
+    enumerable: true,
+    configurable: true
+  });
+}
+
 module.exports = {
+  setupAllowedFlags,
   setupAssert,
   setupCpuUsage,
   setupHrtime,


### PR DESCRIPTION
Because most of its code (the getter) has nothing to do with
the actual bootstrapping and it is run per-thread.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
