### PR TITLE
test: validate fs.rename() when NODE_TEST_DIR on separate mount

### DIFF
--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -299,10 +299,11 @@ function re(literals, ...values) {
     return true;
   };
 
-  fs.rename(nonexistentFile, 'foo', common.mustCall(validateError));
+  const destFile = path.join(tmpdir.path, 'foo');
+  fs.rename(nonexistentFile, destFile, common.mustCall(validateError));
 
   assert.throws(
-    () => fs.renameSync(nonexistentFile, 'foo'),
+    () => fs.renameSync(nonexistentFile, destFile),
     validateError
   );
 }


### PR DESCRIPTION
When testing fs.rename() of an non-existent file, use a destination path
which is in the same directory. Otherwise we might trigger an `EXDEV`
error if NODE_TEST_DIR is a separate device than the current working
directory.

Fixes: https://github.com/nodejs/node/issues/21669

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
