### PR TITLE
lib: do not register DOMException in a module

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -517,7 +517,9 @@
 
   function setupDOMException() {
     // Registers the constructor with C++.
-    NativeModule.require('internal/domexception');
+    const DOMException = NativeModule.require('internal/domexception');
+    const { registerDOMException } = internalBinding('messaging');
+    registerDOMException(DOMException);
   }
 
   function setupInspector(originalConsole, wrappedConsole) {

--- a/lib/internal/domexception.js
+++ b/lib/internal/domexception.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { registerDOMException } = internalBinding('messaging');
 const { ERR_INVALID_THIS } = require('internal/errors').codes;
 
 const internalsMap = new WeakMap();
@@ -85,5 +84,3 @@ for (const [name, codeName, value] of [
 }
 
 module.exports = DOMException;
-
-registerDOMException(DOMException);


### PR DESCRIPTION
Instead of registering it in a global scope of a native module
and expecting that it only gets evaluated when the module is actually
compiled and run and will not be evaluated because the module can
be cached, directly register the DOMException constructor
onto Environment during bootstrap for clarity, since this is
a side effect that has to happen during bootstrap.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
