### PR TITLE
src: remove unused context variable in node_serdes

### DIFF
--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -397,7 +397,6 @@ void DeserializerContext::ReadUint64(const FunctionCallbackInfo<Value>& args) {
   uint32_t lo = static_cast<uint32_t>(value);
 
   Isolate* isolate = ctx->env()->isolate();
-  Local<Context> context = ctx->env()->context();
 
   Local<Value> ret[] = {
     Integer::NewFromUnsigned(isolate, hi),


### PR DESCRIPTION
Currently the following compiler warnings is generated:
```console
../src/node_serdes.cc:400:18:
warning: unused variable 'context' [-Wunused-variable]
  Local<Context> context = ctx->env()->context();
                 ^
1 warning generated.
```
This commit removes the unused variable.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
