### PR TITLE
tls: use for loop instead of forEach

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -689,12 +689,15 @@ function makeSocketMethodProxy(name) {
   };
 }
 
-[
+const socketProxiedMethods = [
   'getFinished', 'getPeerFinished', 'getSession', 'isSessionReused',
   'getEphemeralKeyInfo', 'getProtocol', 'getTLSTicket'
-].forEach((method) => {
-  TLSSocket.prototype[method] = makeSocketMethodProxy(method);
-});
+];
+
+for (n = 0; n < socketProxiedMethods.length; n++) {
+  TLSSocket.prototype[socketProxiedMethods[n]] =
+    makeSocketMethodProxy(socketProxiedMethods[n]);
+}
 
 TLSSocket.prototype.getCipher = function(err) {
   if (this._handle)


### PR DESCRIPTION
Using native `for loop` instead of `forEach` may make the performance a bit of better ?

On the other hand, it's for consistency with [proxiedMethods](https://github.com/nodejs/node/blob/c481799d72cb1fd496c0747fba870afb275d36b0/lib/_tls_wrap.js#L349)

Refs: #11582


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
