### PR TITLE
build: make HTTP_MAX_HEADER_SIZE configurable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -189,6 +189,11 @@ parser.add_option('--experimental-http-parser',
     dest='experimental_http_parser',
     help='use llhttp instead of http_parser')
 
+parser.add_option('--http-max-header-size',
+    action='store',
+    default='8192',
+    help='set the max size of HTTP headers [default: %default]')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -1594,7 +1599,11 @@ flavor = GetFlavor(flavor_params)
 
 configure_node(output)
 configure_library('zlib', output)
+
+# configure http_parser
 configure_library('http_parser', output)
+output['variables']['http_max_header_size'] = options.http_max_header_size
+
 configure_library('libuv', output)
 configure_library('libcares', output)
 configure_library('nghttp2', output)

--- a/deps/http_parser/http_parser.gyp
+++ b/deps/http_parser/http_parser.gyp
@@ -47,6 +47,10 @@
     ],
   },
 
+  'variables': {
+    'http_max_header_size%': '8192'
+  },
+
   'targets': [
     {
       'target_name': 'http_parser',
@@ -56,7 +60,7 @@
         'defines': [ 'HTTP_PARSER_STRICT=0' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_MAX_HEADER_SIZE=8192', 'HTTP_PARSER_STRICT=0' ],
+      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=0' ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {
@@ -79,7 +83,7 @@
         'defines': [ 'HTTP_PARSER_STRICT=1' ],
         'include_dirs': [ '.' ],
       },
-      'defines': [ 'HTTP_MAX_HEADER_SIZE=8192', 'HTTP_PARSER_STRICT=1' ],
+      'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)', 'HTTP_PARSER_STRICT=1' ],
       'sources': [ './http_parser.c', ],
       'conditions': [
         ['OS=="win"', {

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1888,9 +1888,13 @@ changes:
 -->
 
 Too much HTTP header data was received. In order to protect against malicious or
-malconfigured clients, if more than 8KB of HTTP header data is received then
+malconfigured clients, if more than 8KB of HTTP/1 header data is received then
 HTTP parsing will abort without a request or response object being created, and
 an `Error` with this code will be emitted.
+
+The maximum amount of HTTP/1 header data could be configured and changed
+when building node by using `./configure --http-max-header-size=MAX`
+for example.
 
 <a id="MODULE_NOT_FOUND"></a>
 ### MODULE_NOT_FOUND

--- a/node.gypi
+++ b/node.gypi
@@ -8,6 +8,7 @@
   # all obj files in static libs into the executable or shared lib.
   'variables': {
     'variables': {
+      'http_max_header_size%': 8192,
       'variables': {
         'force_load%': 'true',
         'current_type%': '<(_type)',
@@ -168,6 +169,7 @@
       'dependencies': [ 'deps/llhttp/llhttp.gyp:llhttp' ],
     }, {
       'conditions': [ [ 'node_shared_http_parser=="false"', {
+        'defines': [ 'HTTP_MAX_HEADER_SIZE=<(http_max_header_size)' ],
         'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
       } ] ],
     } ],


### PR DESCRIPTION
The maximum size of headers introduced in the security release of
2018/11/27 is not configurable. This change adds a
--http-max-header-size option to ./configure.

See: https://github.com/nodejs/node/issues/24693

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
