### PR TITLE
test: show stdout and stderr in test-cli-syntax when it fails

### DIFF
--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -34,6 +34,12 @@ const notFoundRE = /^Error: Cannot find module/m;
 
     const cmd = [node, ..._args].join(' ');
     exec(cmd, common.mustCall((err, stdout, stderr) => {
+      if (err) {
+        console.log('-- stdout --');
+        console.log(stdout);
+        console.log('-- stderr --');
+        console.log(stderr);
+      }
       assert.ifError(err);
       assert.strictEqual(stdout, '');
       assert.strictEqual(stderr, '');


### PR DESCRIPTION
To help debugging the flake with the log from the CI.

Refs: https://github.com/nodejs/node/issues/24403

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
