### PR TITLE
http2: make compat writeHead not crash if the stream is destroyed

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -568,6 +568,11 @@ class Http2ServerResponse extends Stream {
     if (this[kStream].headersSent)
       throw new ERR_HTTP2_HEADERS_SENT();
 
+    // If the stream is destroyed, we return false,
+    // like require('http').
+    if (this.stream.destroyed)
+      return false;
+
     if (typeof statusMessage === 'string')
       statusMessageWarn();
 

--- a/test/parallel/test-http2-compat-write-head-destroyed.js
+++ b/test/parallel/test-http2-compat-write-head-destroyed.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Check that writeHead, write and end do not crash in compatibikity mode
+
+const server = http2.createServer(common.mustCall((req, res) => {
+  // destroy the stream first
+  req.stream.destroy();
+
+  res.writeHead(200);
+  res.write('hello ');
+  res.end('world');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request();
+  req.on('response', common.mustNotCall());
+  req.on('close', common.mustCall((arg) => {
+    client.close();
+    server.close();
+  }));
+  req.resume();
+}));

--- a/test/parallel/test-http2-compat-write-head-destroyed.js
+++ b/test/parallel/test-http2-compat-write-head-destroyed.js
@@ -5,7 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
 
-// Check that writeHead, write and end do not crash in compatibikity mode
+// Check that writeHead, write and end do not crash in compatibility mode
 
 const server = http2.createServer(common.mustCall((req, res) => {
   // destroy the stream first


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24470

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
