### PR TITLE
doc: document AliasedBuffers usage scope in style guide

### DIFF
--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -262,7 +262,7 @@ class ExampleClass {
 
 When working with typed arrays that involve direct data modification
 from C++, use an `AliasedBuffer` when possible. The API abstraction and
-the usage scope of `AliasedBuffer` is documented in [aliased_buffer.h][].
+the usage scope of `AliasedBuffer` are documented in [aliased_buffer.h][].
 
 ```c++
 // Create an AliasedBuffer.


### PR DESCRIPTION
Expose AliasedBuffer API and its function through the C++ style guide, and also differentiate it with
TypedArrays.

Fixes: https://github.com/nodejs/node/issues/22977

A draft attempt to follow @joyeecheung 's thought, open to iterate over the verbiage.

/cc @joyeecheung @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)