### PR TITLE
tls: add code for ERR_TLS_INVALID_PROTOCOL_METHOD

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1655,6 +1655,12 @@ recommended to use 2048 bits or larger for stronger security.
 A TLS/SSL handshake timed out. In this case, the server must also abort the
 connection.
 
+<a id="ERR_TLS_INVALID_PROTOCOL_METHOD"></a>
+### ERR_TLS_INVALID_PROTOCOL_METHOD
+
+The specified  `secureProtocol` method is invalid. It is  either unknown, or
+disabled because it is insecure.
+
 <a id="ERR_TLS_INVALID_PROTOCOL_VERSION"></a>
 ### ERR_TLS_INVALID_PROTOCOL_VERSION
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -63,6 +63,8 @@ v8::MaybeLocal<v8::Object> New(Environment* env, unsigned char* udata,
 
 namespace crypto {
 
+using node::THROW_ERR_TLS_INVALID_PROTOCOL_METHOD;
+
 using v8::Array;
 using v8::Boolean;
 using v8::ConstructorBehavior;
@@ -421,17 +423,23 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
     // protocols are supported unless explicitly disabled (which we do below
     // for SSLv2 and SSLv3.)
     if (strcmp(*sslmethod, "SSLv2_method") == 0) {
-      return env->ThrowError("SSLv2 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv2_server_method") == 0) {
-      return env->ThrowError("SSLv2 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv2_client_method") == 0) {
-      return env->ThrowError("SSLv2 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv3_method") == 0) {
-      return env->ThrowError("SSLv3 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv3_server_method") == 0) {
-      return env->ThrowError("SSLv3 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv3_client_method") == 0) {
-      return env->ThrowError("SSLv3 methods disabled");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
+      return;
     } else if (strcmp(*sslmethod, "SSLv23_method") == 0) {
       // noop
     } else if (strcmp(*sslmethod, "SSLv23_server_method") == 0) {
@@ -483,7 +491,8 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       max_version = TLS1_2_VERSION;
       method = TLS_client_method();
     } else {
-      return env->ThrowError("Unknown method");
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "Unknown method");
+      return;
     }
   }
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -71,6 +71,7 @@ void FatalException(const v8::FunctionCallbackInfo<v8::Value>& args);
   V(ERR_SCRIPT_EXECUTION_INTERRUPTED, Error)                                 \
   V(ERR_SCRIPT_EXECUTION_TIMEOUT, Error)                                     \
   V(ERR_STRING_TOO_LONG, Error)                                              \
+  V(ERR_TLS_INVALID_PROTOCOL_METHOD, TypeError)                              \
   V(ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER, TypeError)              \
 
 #define V(code, type)                                                         \

--- a/test/parallel/test-tls-min-max-version.js
+++ b/test/parallel/test-tls-min-max-version.js
@@ -26,8 +26,8 @@ function test(cmin, cmax, cprot, smin, smax, sprot, expect) {
       secureProtocol: sprot,
     },
   }, common.mustCall((err, pair, cleanup) => {
-    if (expect && !expect.match(/^TLS/)) {
-      assert(err.message.match(expect));
+    if (expect && expect.match(/^ERR/)) {
+      assert.strictEqual(err.code, expect);
       return cleanup();
     }
 
@@ -53,18 +53,22 @@ const U = undefined;
 test(U, U, U, U, U, U, 'TLSv1.2');
 
 // Insecure or invalid protocols cannot be enabled.
-test(U, U, U, U, U, 'SSLv2_method', 'SSLv2 methods disabled');
-test(U, U, U, U, U, 'SSLv3_method', 'SSLv3 methods disabled');
-test(U, U, 'SSLv2_method', U, U, U, 'SSLv2 methods disabled');
-test(U, U, 'SSLv3_method', U, U, U, 'SSLv3 methods disabled');
-test(U, U, 'hokey-pokey', U, U, U, 'Unknown method');
-test(U, U, U, U, U, 'hokey-pokey', 'Unknown method');
+test(U, U, U, U, U, 'SSLv2_method', 'ERR_TLS_INVALID_PROTOCOL_METHOD');
+test(U, U, U, U, U, 'SSLv3_method', 'ERR_TLS_INVALID_PROTOCOL_METHOD');
+test(U, U, 'SSLv2_method', U, U, U, 'ERR_TLS_INVALID_PROTOCOL_METHOD');
+test(U, U, 'SSLv3_method', U, U, U, 'ERR_TLS_INVALID_PROTOCOL_METHOD');
+test(U, U, 'hokey-pokey', U, U, U, 'ERR_TLS_INVALID_PROTOCOL_METHOD');
+test(U, U, U, U, U, 'hokey-pokey', 'ERR_TLS_INVALID_PROTOCOL_METHOD');
 
 // Cannot use secureProtocol and min/max versions simultaneously.
-test(U, U, U, U, 'TLSv1.2', 'TLS1_2_method', 'conflicts with secureProtocol');
-test(U, U, U, 'TLSv1.2', U, 'TLS1_2_method', 'conflicts with secureProtocol');
-test(U, 'TLSv1.2', 'TLS1_2_method', U, U, U, 'conflicts with secureProtocol');
-test('TLSv1.2', U, 'TLS1_2_method', U, U, U, 'conflicts with secureProtocol');
+test(U, U, U, U, 'TLSv1.2', 'TLS1_2_method',
+     'ERR_TLS_PROTOCOL_VERSION_CONFLICT');
+test(U, U, U, 'TLSv1.2', U, 'TLS1_2_method',
+     'ERR_TLS_PROTOCOL_VERSION_CONFLICT');
+test(U, 'TLSv1.2', 'TLS1_2_method', U, U, U,
+     'ERR_TLS_PROTOCOL_VERSION_CONFLICT');
+test('TLSv1.2', U, 'TLS1_2_method', U, U, U,
+     'ERR_TLS_PROTOCOL_VERSION_CONFLICT');
 
 // TLS_method means "any supported protocol".
 test(U, U, 'TLSv1_2_method', U, U, 'TLS_method', 'TLSv1.2');


### PR DESCRIPTION
Add an error code property to invalid `secureProtocol` method
exceptions.

Node errors are supposed to have a .code property, so use the new C++ errors framework.

@joyeecheung Its not clear to me whether this has to be semver-major. I changed the error type from `Error` (`env->ThrowError()`) to `TypeError`, which would be semver-major. The `.message` should not have changed. If its possible to make this semver-minor by changing the error type, I will.... then introduce a tiny semver-major PR to change the type to `TypeError` for future releases.

If any kind of change like this to the errors is semver-major by definition, then I won't bother splitting it up.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
