### PR TITLE
test: check invalid argument error for option

### DIFF
--- a/test/parallel/test-whatwg-encoding-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder.js
@@ -233,6 +233,16 @@ testDecodeSample(
   ]
 );
 
+{
+  common.expectsError(
+    () => new TextDecoder('utf-8', 1),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+}
+
 // From: https://github.com/w3c/web-platform-tests/blob/master/encoding/api-invalid-label.html
 [
   'utf-8',


### PR DESCRIPTION
this adds a test for the validateArguments function in TextDecoder

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

As another note I would like to test the function `makeTextDecoderJS` in encoding.js but I do not know how to force hasIntl to be false without rebuilding node with the option `--without-intl`. Is there a way to do this at runtime? (Maybe it could be providing a icu-data-dir that has it disabled? I just don't know what that file would look like if that is the case)

If anyone knows a way to set hasIntl to off let me know because I can just include those tests and get the coverage of encoding.js up even more!
