### PR TITLE
src: fix type mismatch warnings from missing priv

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -433,7 +433,8 @@ Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(Environment* env) {
 
 void AsyncWrap::Initialize(Local<Object> target,
                            Local<Value> unused,
-                           Local<Context> context) {
+                           Local<Context> context,
+                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -116,7 +116,8 @@ class AsyncWrap : public BaseObject {
 
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   static void GetAsyncId(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PushAsyncIds(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -171,7 +171,8 @@ namespace symbols {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 #define V(PropertyName, StringValue)                                        \
     target->Set(env->context(),                                             \

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2172,7 +2172,8 @@ void StrError(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "getaddrinfo", GetAddrInfo);

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -52,7 +52,8 @@ class FSEventWrap: public HandleWrap {
  public:
   static void Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context);
+                         Local<Context> context,
+                         void* priv);
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void GetInitialized(const FunctionCallbackInfo<Value>& args);
@@ -95,7 +96,8 @@ void FSEventWrap::GetInitialized(const FunctionCallbackInfo<Value>& args) {
 
 void FSEventWrap::Initialize(Local<Object> target,
                              Local<Value> unused,
-                             Local<Context> context) {
+                             Local<Context> context,
+                             void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   auto fsevent_string = FIXED_ONE_BYTE_STRING(env->isolate(), "FSEvent");

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -247,7 +247,8 @@ void CreateHeapDump(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethodNoSideEffect(target, "buildEmbedderGraph", BuildEmbedderGraph);

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -194,7 +194,8 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
 
 void JSStream::Initialize(Local<Object> target,
                           Local<Value> unused,
-                          Local<Context> context) {
+                          Local<Context> context,
+                          void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -14,7 +14,8 @@ class JSStream : public AsyncWrap, public StreamBase {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   bool IsAlive() override;
   bool IsClosing() override;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -820,7 +820,8 @@ void ModuleWrap::SetInitializeImportMetaObjectCallback(
 
 void ModuleWrap::Initialize(Local<Object> target,
                             Local<Value> unused,
-                            Local<Context> context) {
+                            Local<Context> context,
+                            void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -38,7 +38,8 @@ class ModuleWrap : public BaseObject {
   static const std::string EXTENSIONS[];
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
   static void HostInitializeImportMetaObjectCallback(
       v8::Local<v8::Context> context,
       v8::Local<v8::Module> module,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1085,7 +1085,8 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "setupBufferJS", SetupBufferJS);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1074,7 +1074,8 @@ void ContextifyContext::CompileFunction(
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);

--- a/src/node_domain.cc
+++ b/src/node_domain.cc
@@ -22,7 +22,8 @@ void Enable(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "enable", Enable);

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -317,7 +317,8 @@ MaybeLocal<Value> NativeModuleLoader::LookupAndCompile(
 
 void NativeModuleLoader::Initialize(Local<Object> target,
                                     Local<Value> unused,
-                                    Local<Context> context) {
+                                    Local<Context> context,
+                                    void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(

--- a/src/node_native_module.h
+++ b/src/node_native_module.h
@@ -37,7 +37,8 @@ class NativeModuleLoader {
   NativeModuleLoader();
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
   v8::Local<v8::Object> GetSourceObject(v8::Local<v8::Context> context) const;
   v8::Local<v8::String> GetSource(v8::Isolate* isolate, const char* id) const;
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -483,7 +483,8 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   env->SetMethodNoSideEffect(target, "getOptions", GetOptions);

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -445,7 +445,8 @@ static void GetPriority(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHostname", GetHostname);
   env->SetMethod(target, "getLoadAvg", GetLoadAvg);

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -376,7 +376,8 @@ void Timerify(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   performance_state* state = env->performance_state();

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -441,7 +441,8 @@ void DeserializerContext::ReadRawBytes(
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> ser =
       env->NewFunctionTemplate(SerializerContext::New);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -21,6 +21,11 @@ using v8::Value;
 
 class NodeCategorySet : public BaseObject {
  public:
+  static void Initialize(Local<Object> target,
+                  Local<Value> unused,
+                  Local<Context> context,
+                  void* priv);
+
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Enable(const FunctionCallbackInfo<Value>& args);
   static void Disable(const FunctionCallbackInfo<Value>& args);
@@ -97,7 +102,7 @@ void GetEnabledCategories(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void Initialize(Local<Object> target,
+void NodeCategorySet::Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
                 void* priv) {
@@ -136,4 +141,5 @@ void Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(trace_events, node::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(trace_events,
+                                   node::NodeCategorySet::Initialize)

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -62,7 +62,8 @@ static void IsBoxedPrimitive(const FunctionCallbackInfo<Value>& args) {
 
 void InitializeTypes(Local<Object> target,
                      Local<Value> unused,
-                     Local<Context> context) {
+                     Local<Context> context,
+                     void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
 #define V(type) env->SetMethodNoSideEffect(target,     \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -56,6 +56,7 @@ static void GetOwnNonIndexProperties(
 }
 
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
     return;
@@ -74,6 +75,7 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -56,7 +56,6 @@ static void GetOwnNonIndexProperties(
 }
 
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
     return;
@@ -75,7 +74,6 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;
@@ -196,7 +194,8 @@ void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
 #define V(name, _)                                                            \

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -119,7 +119,8 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -69,7 +69,8 @@ Local<Object> PipeWrap::Instantiate(Environment* env,
 
 void PipeWrap::Initialize(Local<Object> target,
                           Local<Value> unused,
-                          Local<Context> context) {
+                          Local<Context> context,
+                          void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -43,7 +43,8 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
                                            SocketType type);
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(PipeWrap)

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -49,7 +49,8 @@ class ProcessWrap : public HandleWrap {
  public:
   static void Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -43,7 +43,8 @@ class SignalWrap : public HandleWrap {
  public:
   static void Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -365,7 +365,8 @@ void SyncProcessStdioPipe::CloseCallback(uv_handle_t* handle) {
 
 void SyncProcessRunner::Initialize(Local<Object> target,
                                    Local<Value> unused,
-                                   Local<Context> context) {
+                                   Local<Context> context,
+                                   void* priv) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "spawn", Spawn);
 }

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -141,7 +141,8 @@ class SyncProcessRunner {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
   static void Spawn(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -248,7 +248,8 @@ namespace {
 
 void InitializeStreamPipe(Local<Object> target,
                           Local<Value> unused,
-                          Local<Context> context) {
+                          Local<Context> context,
+                          void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   // Create FunctionTemplate for FileHandle::CloseReq

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -52,7 +52,8 @@ using v8::Value;
 
 void LibuvStreamWrap::Initialize(Local<Object> target,
                                  Local<Value> unused,
-                                 Local<Context> context) {
+                                 Local<Context> context,
+                                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   auto is_construct_call_callback =

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -37,7 +37,8 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   int GetFD() override;
   bool IsAlive() override;

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -276,7 +276,8 @@ void FlushData(const FunctionCallbackInfo<Value>& args) {
 
 void InitializeStringDecoder(Local<Object> target,
                              Local<Value> unused,
-                             Local<Context> context) {
+                             Local<Context> context,
+                             void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -73,7 +73,8 @@ Local<Object> TCPWrap::Instantiate(Environment* env,
 
 void TCPWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -42,7 +42,8 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
                                            SocketType type);
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   SET_NO_MEMORY_INFO()
   SET_SELF_SIZE(TCPWrap)

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -43,7 +43,8 @@ void ToggleImmediateRef(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                        Local<Value> unused,
-                       Local<Context> context) {
+                       Local<Context> context,
+                       void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "getLibuvNow", GetLibuvNow);

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -871,7 +871,8 @@ void TLSWrap::MemoryInfo(MemoryTracker* tracker) const {
 
 void TLSWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -54,7 +54,8 @@ class TLSWrap : public AsyncWrap,
 
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   int GetFD() override;
   bool IsAlive() override;

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -43,7 +43,8 @@ using v8::Value;
 
 void TTYWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<String> ttyString = FIXED_ONE_BYTE_STRING(env->isolate(), "TTY");

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -34,7 +34,8 @@ class TTYWrap : public LibuvStreamWrap {
  public:
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
 
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(TTYWrap)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -88,7 +88,8 @@ UDPWrap::UDPWrap(Environment* env, Local<Object> object)
 
 void UDPWrap::Initialize(Local<Object> target,
                          Local<Value> unused,
-                         Local<Context> context) {
+                         Local<Context> context,
+                         void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -39,7 +39,8 @@ class UDPWrap: public HandleWrap {
   };
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context);
+                         v8::Local<v8::Context> context,
+                         void* priv);
   static void GetFD(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -60,7 +60,8 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
-                Local<Context> context) {
+                Local<Context> context,
+                void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   target->Set(env->context(),


### PR DESCRIPTION
Registration initialization functions are expected to have a 4th
argument, a void*, so add them where necessary to fix the warnings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
