### PR TITLE
http_parser: fix error return in `Finish()`

### DIFF
--- a/test/parallel/test-http-parser-finish-error.js
+++ b/test/parallel/test-http-parser-finish-error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const http = require('http');
+const assert = require('assert');
+
+const str = 'GET / HTTP/1.1\r\n' +
+            'Content-Length:';
+
+
+const server = http.createServer(common.mustNotCall());
+server.on('clientError', common.mustCall((err, socket) => {
+  assert(/^Parse Error/.test(err.message));
+  assert.strictEqual(err.code, 'HPE_INVALID_EOF_STATE');
+  server.close();
+  socket.destroy();
+}, 1));
+server.listen(0, () => {
+  const client = net.connect({ port: server.address().port }, () => {
+    client.on('data', common.mustNotCall());
+    client.on('end', common.mustCall(() => {
+      server.close();
+    }));
+    client.write(str);
+    client.end();
+  });
+});

--- a/test/parallel/test-http-parser-finish-error.js
+++ b/test/parallel/test-http-parser-finish-error.js
@@ -13,7 +13,6 @@ const server = http.createServer(common.mustNotCall());
 server.on('clientError', common.mustCall((err, socket) => {
   assert(/^Parse Error/.test(err.message));
   assert.strictEqual(err.code, 'HPE_INVALID_EOF_STATE');
-  server.close();
   socket.destroy();
 }, 1));
 server.listen(0, () => {


### PR DESCRIPTION
`http_parser_execute(..., nullptr, 0)` returns either `0` or `1`. The
expectation is that no error must be returned if it is `0`, and if
it is `1` - a `Error` object must be returned back to user.

The introduction of `llhttp` and the refactor that happened during it
accidentally removed the error-returning code. This commit reverts it
back to its original state.

Fix: #24585

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)