### PR TITLE
util: improve internal `isError()` validation

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -12,6 +12,9 @@ const {
   arrow_message_private_symbol: kArrowMessagePrivateSymbolIndex,
   decorated_private_symbol: kDecoratedPrivateSymbolIndex
 } = internalBinding('util');
+const {
+  isNativeError
+} = internalBinding('types');
 
 const { errmap } = internalBinding('uv');
 
@@ -26,7 +29,8 @@ function removeColors(str) {
 }
 
 function isError(e) {
-  return objectToString(e) === '[object Error]' || e instanceof Error;
+  // An error could be an instance of Error while not being a native error.
+  return isNativeError(e) || e instanceof Error;
 }
 
 function objectToString(o) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -29,7 +29,9 @@ function removeColors(str) {
 }
 
 function isError(e) {
-  // An error could be an instance of Error while not being a native error.
+  // An error could be an instance of Error while not being a native error
+  // or could be from a different realm and not be instance of Error but still
+  // be a native error.
   return isNativeError(e) || e instanceof Error;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -42,9 +42,15 @@ const {
 const {
   deprecate,
   getSystemErrorName: internalErrorName,
-  isError,
   promisify,
 } = require('internal/util');
+
+const ReflectApply = Reflect.apply;
+
+function uncurryThis(func) {
+  return (thisArg, ...args) => ReflectApply(func, thisArg, args);
+}
+const objectToString = uncurryThis(Object.prototype.toString);
 
 let CIRCULAR_ERROR_MESSAGE;
 let internalDeepEqual;
@@ -434,7 +440,9 @@ module.exports = exports = {
   isRegExp,
   isObject,
   isDate,
-  isError,
+  isError(e) {
+    return objectToString(e) === '[object Error]' || e instanceof Error;
+  },
   isFunction,
   isPrimitive,
   log,

--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -1,0 +1,25 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { types } = require('util');
+const { isError } = require('internal/util');
+
+// Special cased errors.
+{
+  const fake = { [Symbol.toStringTag]: 'Error' };
+  assert(!types.isNativeError(fake));
+  assert(!(fake instanceof Error));
+  assert(!isError(fake));
+
+  const err = new Error('test');
+  const newErr = Object.create(
+    Object.getPrototypeOf(err),
+    Object.getOwnPropertyDescriptors(err));
+  Object.defineProperty(err, 'message', { value: err.message });
+  assert(types.isNativeError(err));
+  assert(!types.isNativeError(newErr));
+  assert(newErr instanceof Error);
+  assert(isError(newErr));
+}

--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -5,6 +5,7 @@ require('../common');
 const assert = require('assert');
 const { types } = require('util');
 const { isError } = require('internal/util');
+const vm = require('vm');
 
 // Special cased errors.
 {
@@ -22,4 +23,10 @@ const { isError } = require('internal/util');
   assert(!types.isNativeError(newErr));
   assert(newErr instanceof Error);
   assert(isError(newErr));
+
+  const context = vm.createContext({});
+  const differentRealmErr = vm.runInContext('new Error()', context);
+  assert(types.isNativeError(differentRealmErr));
+  assert(!(differentRealmErr instanceof Error));
+  assert(isError(differentRealmErr));
 }

--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -7,7 +7,12 @@ const { types } = require('util');
 const { isError } = require('internal/util');
 const vm = require('vm');
 
-// Special cased errors.
+// Special cased errors. Test the internal function which is used in
+// `util.inspect()`, the `repl` and maybe more. This verifies that errors from
+// different realms, and non native instances of error are properly detected as
+// error while definitely false ones are not detected. This is different than
+// the public `util.isError()` function which falsy detects the fake errors as
+// actual errors.
 {
   const fake = { [Symbol.toStringTag]: 'Error' };
   assert(!types.isNativeError(fake));


### PR DESCRIPTION
The current internal isError function checked the toString value
instead of using the more precise `util.types.isNativeError()` check.
The `instanceof` check is not removed due to possible errors that
are not native but still an instance of Error.

The internal `isError` function is only used in `util.inspect()` and the `repl`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
