### PR TITLE
test: fix `common.mustNotCall()` usage in HTTP test

### DIFF
--- a/test/sequential/test-http-max-http-headers.js
+++ b/test/sequential/test-http-max-http-headers.js
@@ -94,7 +94,7 @@ function test1() {
 
   server.listen(0, common.mustCall(() => {
     const port = server.address().port;
-    const client = http.get({ port: port }, common.mustNotCall(() => {}));
+    const client = http.get({ port: port }, common.mustNotCall());
 
     client.on('error', common.mustCall((err) => {
       assert.strictEqual(err.code, 'HPE_HEADER_OVERFLOW');


### PR DESCRIPTION
The argument to `common.mustNotCall()` is a message, not a function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
