### PR TITLE
test: check for the correct strict equal arguments order

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -48,9 +48,8 @@ rules:
       message: "The first argument should be the `actual`, not the `expected` value."
     - selector: "CallExpression[callee.object.name='assert'][callee.property.name='deepStrictEqual'][arguments.0.type='Literal']:not([arguments.1.type='Literal']):not([arguments.1.type='ObjectExpression']):not([arguments.1.type='ArrayExpression'])"
       message: "The first argument should be the `actual`, not the `expected` value."
-    # TODO: Activate the `strictEqual` rule as soon as it produces less churn.
-    # - selector: "CallExpression[callee.object.name='assert'][callee.property.name='strictEqual'][arguments.0.type='Literal']:not([arguments.1.type='Literal']):not([arguments.1.type='ObjectExpression']):not([arguments.1.type='ArrayExpression'])"
-    #   message: "The first argument should be the `actual`, not the `expected` value."
+    - selector: "CallExpression[callee.object.name='assert'][callee.property.name='strictEqual'][arguments.0.type='Literal']:not([arguments.1.type='Literal']):not([arguments.1.type='ObjectExpression']):not([arguments.1.type='ArrayExpression'])"
+      message: "The first argument should be the `actual`, not the `expected` value."
 # Global scoped methods and vars
 globals:
   WebAssembly: false

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -28,11 +28,11 @@ const net = require('net');
 const server = http.createServer(common.mustCall((req, res) => {
   assert.strictEqual(req.method, 'GET');
   assert.strictEqual(req.url, '/blah');
-  assert.deepStrictEqual({
+  assert.deepStrictEqual(req.headers, {
     host: 'example.org:443',
     origin: 'http://example.org',
     cookie: ''
-  }, req.headers);
+  });
 }));
 
 
@@ -52,7 +52,7 @@ server.listen(0, common.mustCall(() => {
     received += data.toString();
   }));
   c.on('end', common.mustCall(() => {
-    assert.strictEqual('HTTP/1.1 400 Bad Request\r\n\r\n', received);
+    assert.strictEqual(received, 'HTTP/1.1 400 Bad Request\r\n\r\n');
     c.end();
   }));
   c.on('close', common.mustCall(() => server.close()));

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -68,7 +68,7 @@ if (process.argv[2] === 'you-are-the-child') {
 // delete should return true except for non-configurable properties
 // https://github.com/nodejs/node/issues/7960
 delete process.env.NON_EXISTING_VARIABLE;
-assert.strictEqual(true, delete process.env.NON_EXISTING_VARIABLE);
+assert(delete process.env.NON_EXISTING_VARIABLE);
 
 /* For the moment we are not going to support setting the timezone via the
  * environment variables. The problem is that various V8 platform backends


### PR DESCRIPTION
This activates a eslint rule to verify that the `assert.strictEqual()`
arguments are in the correct order.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
