### PR TITLE
tools: fix eslint usage for Node.js 8 and before

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,10 @@ Module._findPath = (request, paths, isMain) => {
   if (!r && hacks.includes(request)) {
     try {
       return require.resolve(`./tools/node_modules/${request}`);
-    } catch {
+    // Keep the variable in place to ensure that eslint started by older Node.js
+    // versions work as expected.
+    // eslint-disable-next-line no-unused-vars
+    } catch (e) {
       return require.resolve(
         `./tools/node_modules/eslint/node_modules/${request}`);
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ Module._findPath = (request, paths, isMain) => {
   if (!r && hacks.includes(request)) {
     try {
       return require.resolve(`./tools/node_modules/${request}`);
-    // Keep the variable in place to ensure that eslint started by older Node.js
+    // Keep the variable in place to ensure that ESLint started by older Node.js
     // versions work as expected.
     // eslint-disable-next-line no-unused-vars
     } catch (e) {


### PR DESCRIPTION
IDEs like vscode use older Node.js versions that do not yet support
the new try catch syntax. This makes sure eslint continues to work
in these IDEs as before.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
