### PR TITLE
lib: remove `inherits()` usage

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -325,6 +325,8 @@ Inherit the prototype methods from one [constructor][] into another. The
 prototype of `constructor` will be set to a new object created from
 `superConstructor`.
 
+This mainly adds some input validation on top of
+`Object.setPrototypeOf(constructor.prototype, superConstructor.prototype)`.
 As an additional convenience, `superConstructor` will be accessible
 through the `constructor.super_` property.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -106,6 +106,7 @@ function Agent(options) {
   });
 }
 Object.setPrototypeOf(Agent.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Agent, EventEmitter);
 
 Agent.defaultMaxSockets = Infinity;
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -105,8 +105,7 @@ function Agent(options) {
     }
   });
 }
-
-util.inherits(Agent, EventEmitter);
+Object.setPrototypeOf(Agent.prototype, EventEmitter.prototype);
 
 Agent.defaultMaxSockets = Infinity;
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -279,9 +279,7 @@ function ClientRequest(input, options, cb) {
 
   this._deferToConnect(null, null, () => this._flush());
 }
-
-util.inherits(ClientRequest, OutgoingMessage);
-
+Object.setPrototypeOf(ClientRequest.prototype, OutgoingMessage.prototype);
 
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -280,6 +280,7 @@ function ClientRequest(input, options, cb) {
   this._deferToConnect(null, null, () => this._flush());
 }
 Object.setPrototypeOf(ClientRequest.prototype, OutgoingMessage.prototype);
+Object.setPrototypeOf(ClientRequest, OutgoingMessage);
 
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -72,6 +72,7 @@ function IncomingMessage(socket) {
   this._dumped = false;
 }
 Object.setPrototypeOf(IncomingMessage.prototype, Stream.Readable.prototype);
+Object.setPrototypeOf(IncomingMessage, Stream.Readable);
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
   if (callback)

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -21,7 +21,6 @@
 
 'use strict';
 
-const util = require('util');
 const Stream = require('stream');
 
 function readStart(socket) {
@@ -72,8 +71,7 @@ function IncomingMessage(socket) {
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
 }
-util.inherits(IncomingMessage, Stream.Readable);
-
+Object.setPrototypeOf(IncomingMessage.prototype, Stream.Readable.prototype);
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
   if (callback)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -107,6 +107,7 @@ function OutgoingMessage() {
   this._onPendingData = noopPendingOutput;
 }
 Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
+Object.setPrototypeOf(OutgoingMessage, Stream);
 
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -106,7 +106,7 @@ function OutgoingMessage() {
 
   this._onPendingData = noopPendingOutput;
 }
-util.inherits(OutgoingMessage, Stream);
+Object.setPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -138,6 +138,7 @@ function ServerResponse(req) {
   }
 }
 Object.setPrototypeOf(ServerResponse.prototype, OutgoingMessage.prototype);
+Object.setPrototypeOf(ServerResponse, OutgoingMessage);
 
 ServerResponse.prototype._finish = function _finish() {
   DTRACE_HTTP_SERVER_RESPONSE(this.connection);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -137,7 +137,7 @@ function ServerResponse(req) {
     this.shouldKeepAlive = false;
   }
 }
-util.inherits(ServerResponse, OutgoingMessage);
+Object.setPrototypeOf(ServerResponse.prototype, OutgoingMessage.prototype);
 
 ServerResponse.prototype._finish = function _finish() {
   DTRACE_HTTP_SERVER_RESPONSE(this.connection);

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -28,11 +28,10 @@
 
 module.exports = Duplex;
 
-const util = require('util');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
 
-util.inherits(Duplex, Readable);
+Object.setPrototypeOf(Duplex.prototype, Readable.prototype);
 
 {
   // Allow the keys array to be GC'ed.

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -32,6 +32,7 @@ const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
 
 Object.setPrototypeOf(Duplex.prototype, Readable.prototype);
+Object.setPrototypeOf(Duplex, Readable);
 
 {
   // Allow the keys array to be GC'ed.

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -28,8 +28,7 @@
 module.exports = PassThrough;
 
 const Transform = require('_stream_transform');
-const util = require('util');
-util.inherits(PassThrough, Transform);
+Object.setPrototypeOf(PassThrough.prototype, Transform.prototype);
 
 function PassThrough(options) {
   if (!(this instanceof PassThrough))

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -29,6 +29,7 @@ module.exports = PassThrough;
 
 const Transform = require('_stream_transform');
 Object.setPrototypeOf(PassThrough.prototype, Transform.prototype);
+Object.setPrototypeOf(PassThrough, Transform);
 
 function PassThrough(options) {
   if (!(this instanceof PassThrough))

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -44,7 +44,7 @@ const { emitExperimentalWarning } = require('internal/util');
 let StringDecoder;
 let createReadableStreamAsyncIterator;
 
-util.inherits(Readable, Stream);
+Object.setPrototypeOf(Readable.prototype, Stream.prototype);
 
 const { errorOrDestroy } = destroyImpl;
 const kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -45,6 +45,7 @@ let StringDecoder;
 let createReadableStreamAsyncIterator;
 
 Object.setPrototypeOf(Readable.prototype, Stream.prototype);
+Object.setPrototypeOf(Readable, Stream);
 
 const { errorOrDestroy } = destroyImpl;
 const kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -72,6 +72,7 @@ const {
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
 Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
+Object.setPrototypeOf(Transform, Duplex);
 
 
 function afterTransform(er, data) {

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -71,8 +71,7 @@ const {
   ERR_TRANSFORM_WITH_LENGTH_0
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
-const util = require('util');
-util.inherits(Transform, Duplex);
+Object.setPrototypeOf(Transform.prototype, Duplex.prototype);
 
 
 function afterTransform(er, data) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -47,6 +47,7 @@ const {
 const { errorOrDestroy } = destroyImpl;
 
 Object.setPrototypeOf(Writable.prototype, Stream.prototype);
+Object.setPrototypeOf(Writable, Stream);
 
 function nop() {}
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -28,7 +28,6 @@
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
-const util = require('util');
 const internalUtil = require('internal/util');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
@@ -47,7 +46,7 @@ const {
 
 const { errorOrDestroy } = destroyImpl;
 
-util.inherits(Writable, Stream);
+Object.setPrototypeOf(Writable.prototype, Stream.prototype);
 
 function nop() {}
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -109,6 +109,7 @@ function Socket(type, listener) {
   };
 }
 Object.setPrototypeOf(Socket.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Socket, EventEmitter);
 
 
 function createSocket(type, listener) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -108,7 +108,7 @@ function Socket(type, listener) {
     sendBufferSize
   };
 }
-util.inherits(Socket, EventEmitter);
+Object.setPrototypeOf(Socket.prototype, EventEmitter.prototype);
 
 
 function createSocket(type, listener) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -149,7 +149,7 @@ function Agent(options) {
     list: []
   };
 }
-inherits(Agent, HttpAgent);
+Object.setPrototypeOf(Agent.prototype, HttpAgent.prototype);
 Agent.prototype.createConnection = createConnection;
 
 Agent.prototype.getName = function getName(options) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -150,6 +150,7 @@ function Agent(options) {
   };
 }
 Object.setPrototypeOf(Agent.prototype, HttpAgent.prototype);
+Object.setPrototypeOf(Agent, HttpAgent);
 Agent.prototype.createConnection = createConnection;
 
 Agent.prototype.getName = function getName(options) {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -266,6 +266,7 @@ function ChildProcess() {
   };
 }
 Object.setPrototypeOf(ChildProcess.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(ChildProcess, EventEmitter);
 
 
 function flushStdio(subprocess) {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -265,7 +265,7 @@ function ChildProcess() {
     maybeClose(this);
   };
 }
-util.inherits(ChildProcess, EventEmitter);
+Object.setPrototypeOf(ChildProcess.prototype, EventEmitter.prototype);
 
 
 function flushStdio(subprocess) {

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -30,6 +30,7 @@ function Worker(options) {
 }
 
 Object.setPrototypeOf(Worker.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Worker, EventEmitter);
 
 Worker.prototype.kill = function() {
   this.destroy.apply(this, arguments);

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -1,6 +1,5 @@
 'use strict';
 const EventEmitter = require('events');
-const util = require('util');
 
 module.exports = Worker;
 
@@ -30,7 +29,7 @@ function Worker(options) {
   }
 }
 
-util.inherits(Worker, EventEmitter);
+Object.setPrototypeOf(Worker.prototype, EventEmitter.prototype);
 
 Worker.prototype.kill = function() {
   this.destroy.apply(this, arguments);

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -124,6 +124,7 @@ function Cipher(cipher, password, options) {
 }
 
 Object.setPrototypeOf(Cipher.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Cipher, LazyTransform);
 
 Cipher.prototype._transform = function _transform(chunk, encoding, callback) {
   this.push(this[kHandle].update(chunk, encoding));
@@ -254,6 +255,7 @@ function addCipherPrototypeFunctions(constructor) {
 }
 
 Object.setPrototypeOf(Cipheriv.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Cipheriv, LazyTransform);
 addCipherPrototypeFunctions(Cipheriv);
 legacyNativeHandle(Cipheriv);
 
@@ -265,6 +267,7 @@ function Decipher(cipher, password, options) {
 }
 
 Object.setPrototypeOf(Decipher.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Decipher, LazyTransform);
 addCipherPrototypeFunctions(Decipher);
 legacyNativeHandle(Decipher);
 
@@ -277,6 +280,7 @@ function Decipheriv(cipher, key, iv, options) {
 }
 
 Object.setPrototypeOf(Decipheriv.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Decipheriv, LazyTransform);
 addCipherPrototypeFunctions(Decipheriv);
 legacyNativeHandle(Decipheriv);
 

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -32,7 +32,6 @@ const {
 const assert = require('assert');
 const LazyTransform = require('internal/streams/lazy_transform');
 
-const { inherits } = require('util');
 const { deprecate, normalizeEncoding } = require('internal/util');
 
 // Lazy loaded for startup performance.
@@ -124,7 +123,7 @@ function Cipher(cipher, password, options) {
   createCipher.call(this, cipher, password, options, true);
 }
 
-inherits(Cipher, LazyTransform);
+Object.setPrototypeOf(Cipher.prototype, LazyTransform.prototype);
 
 Cipher.prototype._transform = function _transform(chunk, encoding, callback) {
   this.push(this[kHandle].update(chunk, encoding));
@@ -254,7 +253,7 @@ function addCipherPrototypeFunctions(constructor) {
   constructor.prototype.setAAD = Cipher.prototype.setAAD;
 }
 
-inherits(Cipheriv, LazyTransform);
+Object.setPrototypeOf(Cipheriv.prototype, LazyTransform.prototype);
 addCipherPrototypeFunctions(Cipheriv);
 legacyNativeHandle(Cipheriv);
 
@@ -265,7 +264,7 @@ function Decipher(cipher, password, options) {
   createCipher.call(this, cipher, password, options, false);
 }
 
-inherits(Decipher, LazyTransform);
+Object.setPrototypeOf(Decipher.prototype, LazyTransform.prototype);
 addCipherPrototypeFunctions(Decipher);
 legacyNativeHandle(Decipher);
 
@@ -277,7 +276,7 @@ function Decipheriv(cipher, key, iv, options) {
   createCipherWithIV.call(this, cipher, key, options, false, iv);
 }
 
-inherits(Decipheriv, LazyTransform);
+Object.setPrototypeOf(Decipheriv.prototype, LazyTransform.prototype);
 addCipherPrototypeFunctions(Decipheriv);
 legacyNativeHandle(Decipheriv);
 

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -39,6 +39,7 @@ function Hash(algorithm, options) {
 }
 
 Object.setPrototypeOf(Hash.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Hash, LazyTransform);
 
 Hash.prototype._transform = function _transform(chunk, encoding, callback) {
   this[kHandle].update(chunk, encoding);
@@ -100,6 +101,7 @@ function Hmac(hmac, key, options) {
 }
 
 Object.setPrototypeOf(Hmac.prototype, LazyTransform.prototype);
+Object.setPrototypeOf(Hmac, LazyTransform);
 
 Hmac.prototype.update = Hash.prototype.update;
 

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -21,7 +21,6 @@ const {
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
-const { inherits } = require('util');
 const { normalizeEncoding } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const LazyTransform = require('internal/streams/lazy_transform');
@@ -39,7 +38,7 @@ function Hash(algorithm, options) {
   LazyTransform.call(this, options);
 }
 
-inherits(Hash, LazyTransform);
+Object.setPrototypeOf(Hash.prototype, LazyTransform.prototype);
 
 Hash.prototype._transform = function _transform(chunk, encoding, callback) {
   this[kHandle].update(chunk, encoding);
@@ -100,7 +99,7 @@ function Hmac(hmac, key, options) {
   LazyTransform.call(this, options);
 }
 
-inherits(Hmac, LazyTransform);
+Object.setPrototypeOf(Hmac.prototype, LazyTransform.prototype);
 
 Hmac.prototype.update = Hash.prototype.update;
 

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -18,7 +18,6 @@ const {
   validateArrayBufferView,
 } = require('internal/crypto/util');
 const { Writable } = require('stream');
-const { inherits } = require('util');
 
 function Sign(algorithm, options) {
   if (!(this instanceof Sign))
@@ -30,7 +29,7 @@ function Sign(algorithm, options) {
   Writable.call(this, options);
 }
 
-inherits(Sign, Writable);
+Object.setPrototypeOf(Sign.prototype, Writable.prototype);
 
 Sign.prototype._write = function _write(chunk, encoding, callback) {
   this.update(chunk, encoding);
@@ -101,7 +100,7 @@ function Verify(algorithm, options) {
   Writable.call(this, options);
 }
 
-inherits(Verify, Writable);
+Object.setPrototypeOf(Verify.prototype, Writable.prototype);
 
 Verify.prototype._write = Sign.prototype._write;
 Verify.prototype.update = Sign.prototype.update;

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -30,6 +30,7 @@ function Sign(algorithm, options) {
 }
 
 Object.setPrototypeOf(Sign.prototype, Writable.prototype);
+Object.setPrototypeOf(Sign, Writable);
 
 Sign.prototype._write = function _write(chunk, encoding, callback) {
   this.update(chunk, encoding);
@@ -101,6 +102,7 @@ function Verify(algorithm, options) {
 }
 
 Object.setPrototypeOf(Verify.prototype, Writable.prototype);
+Object.setPrototypeOf(Verify, Writable);
 
 Verify.prototype._write = Sign.prototype._write;
 Verify.prototype.update = Sign.prototype.update;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -119,6 +119,7 @@ function ReadStream(path, options) {
   });
 }
 Object.setPrototypeOf(ReadStream.prototype, Readable.prototype);
+Object.setPrototypeOf(ReadStream, Readable);
 
 ReadStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
@@ -273,6 +274,7 @@ function WriteStream(path, options) {
     this.open();
 }
 Object.setPrototypeOf(WriteStream.prototype, Writable.prototype);
+Object.setPrototypeOf(WriteStream, Writable);
 
 WriteStream.prototype._final = function(callback) {
   if (this.autoClose) {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -17,7 +17,6 @@ const {
 } = require('internal/fs/utils');
 const { Readable, Writable } = require('stream');
 const { toPathIfFileURL } = require('internal/url');
-const util = require('util');
 
 const kMinPoolSpace = 128;
 
@@ -119,7 +118,7 @@ function ReadStream(path, options) {
     }
   });
 }
-util.inherits(ReadStream, Readable);
+Object.setPrototypeOf(ReadStream.prototype, Readable.prototype);
 
 ReadStream.prototype.open = function() {
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
@@ -273,7 +272,7 @@ function WriteStream(path, options) {
   if (typeof this.fd !== 'number')
     this.open();
 }
-util.inherits(WriteStream, Writable);
+Object.setPrototypeOf(WriteStream.prototype, Writable.prototype);
 
 WriteStream.prototype._final = function(callback) {
   if (this.autoClose) {

--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Writable } = require('stream');
-const { inherits } = require('util');
 const { closeSync, writeSync } = require('fs');
 
 function SyncWriteStream(fd, options) {
@@ -16,7 +15,7 @@ function SyncWriteStream(fd, options) {
   this.on('end', () => this._destroy());
 }
 
-inherits(SyncWriteStream, Writable);
+Object.setPrototypeOf(SyncWriteStream.prototype, Writable.prototype);
 
 SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
   writeSync(this.fd, chunk, 0, chunk.length);

--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -16,6 +16,7 @@ function SyncWriteStream(fd, options) {
 }
 
 Object.setPrototypeOf(SyncWriteStream.prototype, Writable.prototype);
+Object.setPrototypeOf(SyncWriteStream, Writable);
 
 SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
   writeSync(this.fd, chunk, 0, chunk.length);

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -36,6 +36,7 @@ function StatWatcher(bigint) {
   this[kUseBigint] = bigint;
 }
 Object.setPrototypeOf(StatWatcher.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(StatWatcher, EventEmitter);
 
 function onchange(newStatus, stats) {
   const self = this[owner_symbol];
@@ -132,6 +133,7 @@ function FSWatcher() {
   };
 }
 Object.setPrototypeOf(FSWatcher.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(FSWatcher, EventEmitter);
 
 
 // FIXME(joyeecheung): this method is not documented.

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -19,7 +19,6 @@ const {
 const { toNamespacedPath } = require('path');
 const { validateUint32 } = require('internal/validators');
 const { toPathIfFileURL } = require('internal/url');
-const util = require('util');
 const assert = require('assert');
 
 const kOldStatus = Symbol('kOldStatus');
@@ -36,7 +35,7 @@ function StatWatcher(bigint) {
   this[kOldStatus] = -1;
   this[kUseBigint] = bigint;
 }
-util.inherits(StatWatcher, EventEmitter);
+Object.setPrototypeOf(StatWatcher.prototype, EventEmitter.prototype);
 
 function onchange(newStatus, stats) {
   const self = this[owner_symbol];
@@ -132,7 +131,7 @@ function FSWatcher() {
     }
   };
 }
-util.inherits(FSWatcher, EventEmitter);
+Object.setPrototypeOf(FSWatcher.prototype, EventEmitter.prototype);
 
 
 // FIXME(joyeecheung): this method is not documented.

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const EE = require('events');
-const util = require('util');
 
 function Stream() {
   EE.call(this);
 }
-util.inherits(Stream, EE);
+Object.setPrototypeOf(Stream.prototype, EE.prototype);
 
 Stream.prototype.pipe = function(dest, options) {
   var source = this;

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -6,6 +6,7 @@ function Stream() {
   EE.call(this);
 }
 Object.setPrototypeOf(Stream.prototype, EE.prototype);
+Object.setPrototypeOf(Stream, EE);
 
 Stream.prototype.pipe = function(dest, options) {
   var source = this;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1145,7 +1145,7 @@ function Server(options, connectionListener) {
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
-util.inherits(Server, EventEmitter);
+Object.setPrototypeOf(Server.prototype, EventEmitter.prototype);
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1146,6 +1146,7 @@ function Server(options, connectionListener) {
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
 Object.setPrototypeOf(Server.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Server, EventEmitter);
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -33,7 +33,6 @@ const {
 const { AsyncResource } = require('async_hooks');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
-const { inherits } = require('util');
 
 const kCallback = Symbol('callback');
 const kTypes = Symbol('types');
@@ -208,10 +207,8 @@ class PerformanceNodeTiming {
     };
   }
 }
-// Use this instead of Extends because we want PerformanceEntry in the
-// prototype chain but we do not want to use the PerformanceEntry
-// constructor for this.
-inherits(PerformanceNodeTiming, PerformanceEntry);
+Object.setPrototypeOf(
+  PerformanceNodeTiming.prototype, PerformanceEntry.prototype);
 
 const nodeTiming = new PerformanceNodeTiming();
 

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -209,6 +209,7 @@ class PerformanceNodeTiming {
 }
 Object.setPrototypeOf(
   PerformanceNodeTiming.prototype, PerformanceEntry.prototype);
+Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
 
 const nodeTiming = new PerformanceNodeTiming();
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -32,7 +32,7 @@ const {
   ERR_INVALID_CURSOR_POS,
   ERR_INVALID_OPT_VALUE
 } = require('internal/errors').codes;
-const { debug, inherits } = require('util');
+const { debug } = require('util');
 const { emitExperimentalWarning } = require('internal/util');
 const { Buffer } = require('buffer');
 const EventEmitter = require('events');
@@ -245,7 +245,7 @@ function Interface(input, output, completer, terminal) {
   input.resume();
 }
 
-inherits(Interface, EventEmitter);
+Object.setPrototypeOf(Interface.prototype, EventEmitter.prototype);
 
 Object.defineProperty(Interface.prototype, 'columns', {
   configurable: true,

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -246,6 +246,7 @@ function Interface(input, output, completer, terminal) {
 }
 
 Object.setPrototypeOf(Interface.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(Interface, EventEmitter);
 
 Object.defineProperty(Interface.prototype, 'columns', {
   configurable: true,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -753,6 +753,8 @@ function REPLServer(prompt,
   self.displayPrompt();
 }
 Object.setPrototypeOf(REPLServer.prototype, Interface.prototype);
+Object.setPrototypeOf(REPLServer, Interface);
+
 exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
@@ -923,6 +925,7 @@ function ArrayStream() {
   };
 }
 Object.setPrototypeOf(ArrayStream.prototype, Stream.prototype);
+Object.setPrototypeOf(ArrayStream, Stream);
 ArrayStream.prototype.readable = true;
 ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
@@ -1514,4 +1517,5 @@ function Recoverable(err) {
   this.err = err;
 }
 Object.setPrototypeOf(Recoverable.prototype, SyntaxError.prototype);
+Object.setPrototypeOf(Recoverable, SyntaxError);
 exports.Recoverable = Recoverable;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -53,7 +53,6 @@ const {
 } = require('internal/deps/acorn/dist/acorn');
 const internalUtil = require('internal/util');
 const util = require('util');
-const { inherits } = util;
 const Stream = require('stream');
 const vm = require('vm');
 const path = require('path');
@@ -669,9 +668,9 @@ function REPLServer(prompt,
 
       // handle multiline history
       if (self[kBufferedCommandSymbol].length)
-        REPLServer.super_.prototype.multilineHistory.call(self, false);
+        Interface.prototype.multilineHistory.call(self, false);
       else {
-        REPLServer.super_.prototype.multilineHistory.call(self, true);
+        Interface.prototype.multilineHistory.call(self, true);
       }
 
       // Clear buffer if no SyntaxErrors
@@ -753,7 +752,7 @@ function REPLServer(prompt,
 
   self.displayPrompt();
 }
-inherits(REPLServer, Interface);
+Object.setPrototypeOf(REPLServer.prototype, Interface.prototype);
 exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
@@ -894,18 +893,18 @@ REPLServer.prototype.displayPrompt = function(preserveCursor) {
     const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
     const levelInd = '..'.repeat(len);
     prompt += levelInd + ' ';
-    REPLServer.super_.prototype.undoHistory.call(this);
+    Interface.prototype.undoHistory.call(this);
   }
 
   // Do not overwrite `_initialPrompt` here
-  REPLServer.super_.prototype.setPrompt.call(this, prompt);
+  Interface.prototype.setPrompt.call(this, prompt);
   this.prompt(preserveCursor);
 };
 
 // When invoked as an API method, overwrite _initialPrompt
 REPLServer.prototype.setPrompt = function setPrompt(prompt) {
   this._initialPrompt = prompt;
-  REPLServer.super_.prototype.setPrompt.call(this, prompt);
+  Interface.prototype.setPrompt.call(this, prompt);
 };
 
 REPLServer.prototype.turnOffEditorMode = util.deprecate(
@@ -923,7 +922,7 @@ function ArrayStream() {
       this.emit('data', `${data[n]}\n`);
   };
 }
-util.inherits(ArrayStream, Stream);
+Object.setPrototypeOf(ArrayStream.prototype, Stream.prototype);
 ArrayStream.prototype.readable = true;
 ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
@@ -1396,7 +1395,7 @@ function addStandardGlobals(completionGroups, filter) {
 
 function _turnOnEditorMode(repl) {
   repl.editorMode = true;
-  REPLServer.super_.prototype.setPrompt.call(repl, '');
+  Interface.prototype.setPrompt.call(repl, '');
 }
 
 function _turnOffEditorMode(repl) {
@@ -1514,5 +1513,5 @@ function regexpEscape(s) {
 function Recoverable(err) {
   this.err = err;
 }
-inherits(Recoverable, SyntaxError);
+Object.setPrototypeOf(Recoverable.prototype, SyntaxError.prototype);
 exports.Recoverable = Recoverable;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -318,6 +318,7 @@ function Zlib(opts, mode) {
   this.once('end', this.close);
 }
 Object.setPrototypeOf(Zlib.prototype, Transform.prototype);
+Object.setPrototypeOf(Zlib, Transform);
 
 Object.defineProperty(Zlib.prototype, '_closed', {
   configurable: true,
@@ -648,6 +649,7 @@ function Deflate(opts) {
   Zlib.call(this, opts, DEFLATE);
 }
 Object.setPrototypeOf(Deflate.prototype, Zlib.prototype);
+Object.setPrototypeOf(Deflate, Zlib);
 
 function Inflate(opts) {
   if (!(this instanceof Inflate))
@@ -655,6 +657,7 @@ function Inflate(opts) {
   Zlib.call(this, opts, INFLATE);
 }
 Object.setPrototypeOf(Inflate.prototype, Zlib.prototype);
+Object.setPrototypeOf(Inflate, Zlib);
 
 function Gzip(opts) {
   if (!(this instanceof Gzip))
@@ -662,6 +665,7 @@ function Gzip(opts) {
   Zlib.call(this, opts, GZIP);
 }
 Object.setPrototypeOf(Gzip.prototype, Zlib.prototype);
+Object.setPrototypeOf(Gzip, Zlib);
 
 function Gunzip(opts) {
   if (!(this instanceof Gunzip))
@@ -669,6 +673,7 @@ function Gunzip(opts) {
   Zlib.call(this, opts, GUNZIP);
 }
 Object.setPrototypeOf(Gunzip.prototype, Zlib.prototype);
+Object.setPrototypeOf(Gunzip, Zlib);
 
 function DeflateRaw(opts) {
   if (opts && opts.windowBits === 8) opts.windowBits = 9;
@@ -677,6 +682,7 @@ function DeflateRaw(opts) {
   Zlib.call(this, opts, DEFLATERAW);
 }
 Object.setPrototypeOf(DeflateRaw.prototype, Zlib.prototype);
+Object.setPrototypeOf(DeflateRaw, Zlib);
 
 function InflateRaw(opts) {
   if (!(this instanceof InflateRaw))
@@ -684,6 +690,7 @@ function InflateRaw(opts) {
   Zlib.call(this, opts, INFLATERAW);
 }
 Object.setPrototypeOf(InflateRaw.prototype, Zlib.prototype);
+Object.setPrototypeOf(InflateRaw, Zlib);
 
 function Unzip(opts) {
   if (!(this instanceof Unzip))
@@ -691,6 +698,7 @@ function Unzip(opts) {
   Zlib.call(this, opts, UNZIP);
 }
 Object.setPrototypeOf(Unzip.prototype, Zlib.prototype);
+Object.setPrototypeOf(Unzip, Zlib);
 
 function createConvenienceMethod(ctor, sync) {
   if (sync) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -31,7 +31,6 @@ const Transform = require('_stream_transform');
 const {
   deprecate,
   _extend,
-  inherits,
   types: {
     isAnyArrayBuffer,
     isArrayBufferView
@@ -318,7 +317,7 @@ function Zlib(opts, mode) {
   this._info = opts && opts.info;
   this.once('end', this.close);
 }
-inherits(Zlib, Transform);
+Object.setPrototypeOf(Zlib.prototype, Transform.prototype);
 
 Object.defineProperty(Zlib.prototype, '_closed', {
   configurable: true,
@@ -648,28 +647,28 @@ function Deflate(opts) {
     return new Deflate(opts);
   Zlib.call(this, opts, DEFLATE);
 }
-inherits(Deflate, Zlib);
+Object.setPrototypeOf(Deflate.prototype, Zlib.prototype);
 
 function Inflate(opts) {
   if (!(this instanceof Inflate))
     return new Inflate(opts);
   Zlib.call(this, opts, INFLATE);
 }
-inherits(Inflate, Zlib);
+Object.setPrototypeOf(Inflate.prototype, Zlib.prototype);
 
 function Gzip(opts) {
   if (!(this instanceof Gzip))
     return new Gzip(opts);
   Zlib.call(this, opts, GZIP);
 }
-inherits(Gzip, Zlib);
+Object.setPrototypeOf(Gzip.prototype, Zlib.prototype);
 
 function Gunzip(opts) {
   if (!(this instanceof Gunzip))
     return new Gunzip(opts);
   Zlib.call(this, opts, GUNZIP);
 }
-inherits(Gunzip, Zlib);
+Object.setPrototypeOf(Gunzip.prototype, Zlib.prototype);
 
 function DeflateRaw(opts) {
   if (opts && opts.windowBits === 8) opts.windowBits = 9;
@@ -677,21 +676,21 @@ function DeflateRaw(opts) {
     return new DeflateRaw(opts);
   Zlib.call(this, opts, DEFLATERAW);
 }
-inherits(DeflateRaw, Zlib);
+Object.setPrototypeOf(DeflateRaw.prototype, Zlib.prototype);
 
 function InflateRaw(opts) {
   if (!(this instanceof InflateRaw))
     return new InflateRaw(opts);
   Zlib.call(this, opts, INFLATERAW);
 }
-inherits(InflateRaw, Zlib);
+Object.setPrototypeOf(InflateRaw.prototype, Zlib.prototype);
 
 function Unzip(opts) {
   if (!(this instanceof Unzip))
     return new Unzip(opts);
   Zlib.call(this, opts, UNZIP);
 }
-inherits(Unzip, Zlib);
+Object.setPrototypeOf(Unzip.prototype, Zlib.prototype);
 
 function createConvenienceMethod(ctor, sync) {
   if (sync) {


### PR DESCRIPTION
This switches all `util.inherits()` calls to use
`Object.setPrototypeOf()` instead. In fact, `util.inherits()` is
mainly a small wrapper around exactly this function while adding
the `_super` property on the object as well.

Refs: #24395

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
