### PR TITLE
test: fix `common.isAlive()`

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -460,7 +460,7 @@ function busyLoop(time) {
 
 function isAlive(pid) {
   try {
-    process.kill(pid, 'SIGCONT');
+    process.kill(pid, 0);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Use signal value `0` rather than `'SIGCONT'` as the latter appears to
behave unexpectedly on Alpine 3.8.

Fixes: https://github.com/nodejs/node/issues/22308

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
