### PR TITLE
http: destroy the socket on parse error

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -512,7 +512,8 @@ function socketOnError(e) {
 
   if (!this.server.emit('clientError', e, this)) {
     if (this.writable) {
-      this.end(badRequestResponse);
+      this.write(badRequestResponse);
+      this.destroy(e);
       return;
     }
     this.destroy(e);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -513,8 +513,6 @@ function socketOnError(e) {
   if (!this.server.emit('clientError', e, this)) {
     if (this.writable) {
       this.write(badRequestResponse);
-      this.destroy(e);
-      return;
     }
     this.destroy(e);
   }

--- a/test/parallel/test-http-server-destroy-socket-on-client-error.js
+++ b/test/parallel/test-http-server-destroy-socket-on-client-error.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { expectsError, mustCall } = require('../common');
+
+// Test that the request socket is destroyed if the `'clientError'` event is
+// emitted and there is no listener for it.
+
+const assert = require('assert');
+const { createServer } = require('http');
+const { createConnection } = require('net');
+
+const server = createServer();
+
+server.on('connection', mustCall((socket) => {
+  socket.on('error', expectsError({
+    type: Error,
+    message: 'Parse Error',
+    code: 'HPE_INVALID_METHOD',
+    bytesParsed: 0,
+    rawPacket: Buffer.from('FOO /\r\n')
+  }));
+}));
+
+server.listen(0, () => {
+  const chunks = [];
+  const socket = createConnection({
+    allowHalfOpen: true,
+    port: server.address().port
+  });
+
+  socket.on('connect', mustCall(() => {
+    socket.write('FOO /\r\n');
+  }));
+
+  socket.on('data', (chunk) => {
+    chunks.push(chunk);
+  });
+
+  socket.on('end', mustCall(() => {
+    const expected = Buffer.from('HTTP/1.1 400 Bad Request\r\n\r\n');
+    assert(Buffer.concat(chunks).equals(expected));
+
+    server.close();
+  }));
+});


### PR DESCRIPTION
Destroy the socket if the `'clientError'` event is emitted and there is
no listener for it.

Fixes: https://github.com/nodejs/node/issues/24586

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
