### PR TITLE
doc: fix REPLACEME for tls min/max protocol option

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1054,6 +1054,10 @@ argument.
 <!-- YAML
 added: v0.11.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/24405
+    description: The `minVersion` and `maxVersion` can be used to restrict
+                 the allowed TLS protocol versions.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/19794
     description: The `ecdhCurve` cannot be set to `false` anymore due to a
@@ -1070,10 +1074,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/4099
     description: The `ca` option can now be a single string containing multiple
                  CA certificates.
-  - version: REPLACEME
-    pr-url: REPLACEME
-    description: The `minVersion` and `maxVersion` can be used to restrict
-                 the allowed TLS protocol versions.
 -->
 
 * `options` {Object}


### PR DESCRIPTION
Fill in correct pr-url: value in the YAML changelog that was missing
from
https://github.com/nodejs/node/commit/f512f5ea138fe86e47c0179d5733044daf6f4fe6

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
