### PR TITLE
test: add a missing (flag param) scenario in test-fs-write-file-sync

### DIFF
--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -96,3 +96,12 @@ function closeSync() {
   openCount--;
   return fs._closeSync.apply(fs, arguments);
 }
+
+// Test writeFileSync with flags
+const file4 = path.join(tmpdir.path, 'testWriteFileSyncFlags.txt');
+
+fs.writeFileSync(file4, 'hello ', { encoding: 'utf8', flag: 'a' });
+fs.writeFileSync(file4, 'world!', { encoding: 'utf8', flag: 'a' });
+
+content = fs.readFileSync(file4, { encoding: 'utf8' });
+assert.strictEqual(content, 'hello world!');


### PR DESCRIPTION
(came across this while working on some thing). `fs.writeFileSync` takes flag param to define the file opening semantics. Add a scenario that covers flags as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)