### PR TITLE
lib: remove duplicated noop function

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -200,7 +200,6 @@ function startup() {
   // so these are now deprecated non-ops that can be removed after one
   // major release cycle.
   if (process.platform === 'win32') {
-    function noop() {}
     const names = [
       'NET_SERVER_CONNECTION',
       'NET_SERVER_CONNECTION_CLOSE',


### PR DESCRIPTION
We have a `noop` function outside the `if` statement in the line 609 :)
https://github.com/nodejs/node/blob/eb6741b15ebd93ffdd71e87cbc1350b9e94ef222/lib/internal/bootstrap/node.js#L609
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
