### PR TITLE
inspector: split the HostPort being used and the one parsed from CLI

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -585,6 +585,10 @@ inline std::shared_ptr<EnvironmentOptions> Environment::options() {
   return options_;
 }
 
+inline std::shared_ptr<HostPort> Environment::inspector_host_port() {
+  return inspector_host_port_;
+}
+
 inline std::shared_ptr<PerIsolateOptions> IsolateData::options() {
   return options_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -5,6 +5,7 @@
 #include "node_file.h"
 #include "node_internals.h"
 #include "node_native_module.h"
+#include "node_options-inl.h"
 #include "node_platform.h"
 #include "node_worker.h"
 #include "tracing/agent.h"
@@ -192,7 +193,7 @@ Environment::Environment(IsolateData* isolate_data,
   // part of the per-Isolate option set, for which in turn the defaults are
   // part of the per-process option set.
   options_.reset(new EnvironmentOptions(*isolate_data->options()->per_env));
-  options_->debug_options.reset(new DebugOptions(*options_->debug_options));
+  inspector_host_port_.reset(new HostPort(options_->debug_options().host_port));
 
 #if HAVE_INSPECTOR
   // We can only create the inspector agent after having cloned the options.

--- a/src/env.h
+++ b/src/env.h
@@ -911,6 +911,7 @@ class Environment {
                                  void* data);
 
   inline std::shared_ptr<EnvironmentOptions> options();
+  inline std::shared_ptr<HostPort> inspector_host_port();
 
  private:
   inline void CreateImmediate(native_immediate_callback cb,
@@ -942,6 +943,14 @@ class Environment {
   std::vector<double> destroy_async_id_list_;
 
   std::shared_ptr<EnvironmentOptions> options_;
+  // options_ contains debug options parsed from CLI arguments,
+  // while inspector_host_port_ stores the actual inspector host
+  // and port being used. For example the port is -1 by default
+  // and can be specified as 0 (meaning any port allocated when the
+  // server starts listening), but when the inspector server starts
+  // the inspector_host_port_->port() will be the actual port being
+  // used.
+  std::shared_ptr<HostPort> inspector_host_port_;
 
   uint32_t module_id_counter_ = 0;
   uint32_t script_id_counter_ = 0;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -667,8 +667,9 @@ class NodeInspectorClient : public V8InspectorClient {
 };
 
 Agent::Agent(Environment* env)
-  : parent_env_(env),
-    debug_options_(env->options()->debug_options) {}
+    : parent_env_(env),
+      debug_options_(env->options()->debug_options()),
+      host_port_(env->inspector_host_port()) {}
 
 Agent::~Agent() {
   if (start_io_thread_async.data == this) {
@@ -679,13 +680,14 @@ Agent::~Agent() {
 }
 
 bool Agent::Start(const std::string& path,
-                  std::shared_ptr<DebugOptions> options,
+                  const DebugOptions& options,
+                  std::shared_ptr<HostPort> host_port,
                   bool is_main) {
-  if (options == nullptr) {
-    options = std::make_shared<DebugOptions>();
-  }
   path_ = path;
   debug_options_ = options;
+  CHECK_NE(host_port, nullptr);
+  host_port_ = host_port;
+
   client_ = std::make_shared<NodeInspectorClient>(parent_env_, is_main);
   if (parent_env_->is_main_thread()) {
     CHECK_EQ(0, uv_async_init(parent_env_->event_loop(),
@@ -697,13 +699,18 @@ bool Agent::Start(const std::string& path,
     StartDebugSignalHandler();
   }
 
-  bool wait_for_connect = options->wait_for_connect();
+  bool wait_for_connect = options.wait_for_connect();
   if (parent_handle_) {
     wait_for_connect = parent_handle_->WaitForConnect();
     parent_handle_->WorkerStarted(client_->getThreadHandle(), wait_for_connect);
-  } else if (!options->inspector_enabled || !StartIoThread()) {
+  } else if (!options.inspector_enabled || !StartIoThread()) {
     return false;
   }
+
+  // TODO(joyeecheung): we should not be using process as a global object
+  // to transport --inspect-brk. Instead, the JS land can get this through
+  // require('internal/options') since it should be set once CLI parsing
+  // is done.
   if (wait_for_connect) {
     HandleScope scope(parent_env_->isolate());
     parent_env_->process_object()->DefineOwnProperty(
@@ -723,8 +730,7 @@ bool Agent::StartIoThread() {
 
   CHECK_NOT_NULL(client_);
 
-  io_ = InspectorIo::Start(
-      client_->getThreadHandle(), path_, debug_options_);
+  io_ = InspectorIo::Start(client_->getThreadHandle(), path_, host_port_);
   if (io_ == nullptr) {
     return false;
   }
@@ -865,8 +871,7 @@ void Agent::ContextCreated(Local<Context> context, const ContextInfo& info) {
 }
 
 bool Agent::WillWaitForConnect() {
-  if (debug_options_->wait_for_connect())
-    return true;
+  if (debug_options_.wait_for_connect()) return true;
   if (parent_handle_)
     return parent_handle_->WaitForConnect();
   return false;

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -46,21 +46,22 @@ class InspectorIo {
   // bool Start();
   // Returns empty pointer if thread was not started
   static std::unique_ptr<InspectorIo> Start(
-      std::shared_ptr<MainThreadHandle> main_thread, const std::string& path,
-      std::shared_ptr<DebugOptions> options);
+      std::shared_ptr<MainThreadHandle> main_thread,
+      const std::string& path,
+      std::shared_ptr<HostPort> host_port);
 
   // Will block till the transport thread shuts down
   ~InspectorIo();
 
   void StopAcceptingNewConnections();
-  const std::string& host() const { return options_->host(); }
-  int port() const { return port_; }
+  const std::string& host() const { return host_port_->host(); }
+  int port() const { return host_port_->port(); }
   std::vector<std::string> GetTargetIds() const;
 
  private:
   InspectorIo(std::shared_ptr<MainThreadHandle> handle,
               const std::string& path,
-              std::shared_ptr<DebugOptions> options);
+              std::shared_ptr<HostPort> host_port);
 
   // Wrapper for agent->ThreadMain()
   static void ThreadMain(void* agent);
@@ -74,7 +75,7 @@ class InspectorIo {
   // Used to post on a frontend interface thread, lives while the server is
   // running
   std::shared_ptr<RequestQueue> request_queue_;
-  std::shared_ptr<DebugOptions> options_;
+  std::shared_ptr<HostPort> host_port_;
 
   // The IO thread runs its own uv_loop to implement the TCP server off
   // the main thread.
@@ -84,7 +85,6 @@ class InspectorIo {
   Mutex thread_start_lock_;
   ConditionVariable thread_start_condition_;
   std::string script_name_;
-  int port_ = -1;
   // May be accessed from any thread
   const std::string id_;
 };

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -243,12 +243,12 @@ void Open(const FunctionCallbackInfo<Value>& args) {
 
   if (args.Length() > 0 && args[0]->IsUint32()) {
     uint32_t port = args[0].As<Uint32>()->Value();
-    agent->options()->host_port.port = port;
+    agent->host_port()->set_port(static_cast<int>(port));
   }
 
   if (args.Length() > 1 && args[1]->IsString()) {
     Utf8Value host(env->isolate(), args[1].As<String>());
-    agent->options()->host_port.host_name = *host;
+    agent->host_port()->set_host(*host);
   }
 
   if (args.Length() > 2 && args[2]->IsBoolean()) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,5 +1,6 @@
 #include "node.h"
 #include "node_i18n.h"
+#include "node_options-inl.h"
 #include "env-inl.h"
 #include "util-inl.h"
 
@@ -94,20 +95,18 @@ static void Initialize(Local<Object> target,
     READONLY_STRING_PROPERTY(target, "warningFile", warning_file);
   }
 
-  std::shared_ptr<DebugOptions> debug_options = env->options()->debug_options;
   Local<Object> debug_options_obj = Object::New(isolate);
   READONLY_PROPERTY(target, "debugOptions", debug_options_obj);
 
-  READONLY_STRING_PROPERTY(debug_options_obj, "host",
-                           debug_options->host());
-
-  READONLY_PROPERTY(debug_options_obj,
-                    "port",
-                    Integer::New(isolate, debug_options->port()));
-
+  const DebugOptions& debug_options = env->options()->debug_options();
   READONLY_PROPERTY(debug_options_obj,
                     "inspectorEnabled",
-                    Boolean::New(isolate, debug_options->inspector_enabled));
+                    Boolean::New(isolate, debug_options.inspector_enabled));
+  READONLY_STRING_PROPERTY(
+      debug_options_obj, "host", debug_options.host_port.host());
+  READONLY_PROPERTY(debug_options_obj,
+                    "port",
+                    Integer::New(isolate, debug_options.host_port.port()));
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -14,7 +14,11 @@ PerIsolateOptions* PerProcessOptions::get_per_isolate_options() {
 }
 
 DebugOptions* EnvironmentOptions::get_debug_options() {
-  return debug_options.get();
+  return &debug_options_;
+}
+
+const DebugOptions& EnvironmentOptions::debug_options() const {
+  return debug_options_;
 }
 
 EnvironmentOptions* PerIsolateOptions::get_per_env_options() {

--- a/src/node_process.cc
+++ b/src/node_process.cc
@@ -825,14 +825,7 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
 void DebugPortGetter(Local<Name> property,
                      const PropertyCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
-  Mutex::ScopedLock lock(process_mutex);
-  int port = env->options()->debug_options->port();
-#if HAVE_INSPECTOR
-  if (port == 0) {
-    if (auto io = env->inspector_agent()->io())
-      port = io->port();
-  }
-#endif  // HAVE_INSPECTOR
+  int port = env->inspector_host_port()->port();
   info.GetReturnValue().Set(port);
 }
 
@@ -841,9 +834,8 @@ void DebugPortSetter(Local<Name> property,
                      Local<Value> value,
                      const PropertyCallbackInfo<void>& info) {
   Environment* env = Environment::GetCurrent(info);
-  Mutex::ScopedLock lock(process_mutex);
-  env->options()->debug_options->host_port.port =
-      value->Int32Value(env->context()).FromMaybe(0);
+  int32_t port = value->Int32Value(env->context()).FromMaybe(0);
+  env->inspector_host_port()->set_port(static_cast<int>(port));
 }
 
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -37,7 +37,10 @@ Mutex next_thread_id_mutex;
 
 #if NODE_USE_V8_PLATFORM && HAVE_INSPECTOR
 void StartWorkerInspector(Environment* child, const std::string& url) {
-  child->inspector_agent()->Start(url, nullptr, false);
+  child->inspector_agent()->Start(url,
+                                  child->options()->debug_options(),
+                                  child->inspector_host_port(),
+                                  false);
 }
 
 void AddWorkerInspector(Environment* parent,


### PR DESCRIPTION
Instead of using a shared pointer of the entire debug option set,
pass the parsed debug option to inspector classes by value because
they are set once the CLI argument parsing is done. Add another shared
pointer to HostPort being used by the inspector server, which is copied
from the one in the debug options initially. The port of the shared
HostPort is 9229 by default and can be specified as 0 initially but
will be set to the actual port of the server once it starts listening.

This makes the shared state clearer and makes it possible to use
`require('internal/options')` in JS land to query the CLI options
instead of using `process._breakFirstLine` and other underscored
properties of `process` since we are now certain that these
values should not be altered once the parsing is done and can be
passed around in copies without locks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
