### PR TITLE
src: use NativeModuleLoader to compile all the bootstrappers

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -39,335 +39,336 @@
 
 'use strict';
 
-(function bootstrapInternalLoaders(process, getBinding, getLinkedBinding,
-                                   getInternalBinding, debugBreak) {
-  if (debugBreak)
-    debugger; // eslint-disable-line no-debugger
+// This file is compiled as if it's wrapped in a function with arguments
+// passed by node::LoadEnvironment()
+/* global process, getBinding, getLinkedBinding, getInternalBinding */
+/* global debugBreak */
 
-  const {
-    apply: ReflectApply,
-    deleteProperty: ReflectDeleteProperty,
-    get: ReflectGet,
-    getOwnPropertyDescriptor: ReflectGetOwnPropertyDescriptor,
-    has: ReflectHas,
-    set: ReflectSet,
-  } = Reflect;
-  const {
-    prototype: {
-      hasOwnProperty: ObjectHasOwnProperty,
+if (debugBreak)
+  debugger; // eslint-disable-line no-debugger
+
+const {
+  apply: ReflectApply,
+  deleteProperty: ReflectDeleteProperty,
+  get: ReflectGet,
+  getOwnPropertyDescriptor: ReflectGetOwnPropertyDescriptor,
+  has: ReflectHas,
+  set: ReflectSet,
+} = Reflect;
+const {
+  prototype: {
+    hasOwnProperty: ObjectHasOwnProperty,
+  },
+  create: ObjectCreate,
+  defineProperty: ObjectDefineProperty,
+  keys: ObjectKeys,
+} = Object;
+
+// Set up process.moduleLoadList.
+const moduleLoadList = [];
+ObjectDefineProperty(process, 'moduleLoadList', {
+  value: moduleLoadList,
+  configurable: true,
+  enumerable: true,
+  writable: false
+});
+
+// internalBindingWhitelist contains the name of internalBinding modules
+// that are whitelisted for access via process.binding()... This is used
+// to provide a transition path for modules that are being moved over to
+// internalBinding.
+const internalBindingWhitelist = [
+  'async_wrap',
+  'buffer',
+  'cares_wrap',
+  'constants',
+  'contextify',
+  'crypto',
+  'fs',
+  'fs_event_wrap',
+  'http_parser',
+  'icu',
+  'js_stream',
+  'natives',
+  'pipe_wrap',
+  'process_wrap',
+  'signal_wrap',
+  'spawn_sync',
+  'stream_wrap',
+  'tcp_wrap',
+  'tls_wrap',
+  'tty_wrap',
+  'udp_wrap',
+  'url',
+  'util',
+  'uv',
+  'v8',
+  'zlib'
+];
+// We will use a lazy loaded SafeSet in internalBindingWhitelistHas
+// for checking existence in this list.
+let internalBindingWhitelistSet;
+
+// Set up process.binding() and process._linkedBinding().
+{
+  const bindingObj = ObjectCreate(null);
+
+  process.binding = function binding(module) {
+    module = String(module);
+    // Deprecated specific process.binding() modules, but not all, allow
+    // selective fallback to internalBinding for the deprecated ones.
+    if (internalBindingWhitelistHas(module)) {
+      return internalBinding(module);
+    }
+    let mod = bindingObj[module];
+    if (typeof mod !== 'object') {
+      mod = bindingObj[module] = getBinding(module);
+      moduleLoadList.push(`Binding ${module}`);
+    }
+    return mod;
+  };
+
+  process._linkedBinding = function _linkedBinding(module) {
+    module = String(module);
+    let mod = bindingObj[module];
+    if (typeof mod !== 'object')
+      mod = bindingObj[module] = getLinkedBinding(module);
+    return mod;
+  };
+}
+
+// Set up internalBinding() in the closure.
+let internalBinding;
+{
+  const bindingObj = ObjectCreate(null);
+  internalBinding = function internalBinding(module) {
+    let mod = bindingObj[module];
+    if (typeof mod !== 'object') {
+      mod = bindingObj[module] = getInternalBinding(module);
+      moduleLoadList.push(`Internal Binding ${module}`);
+    }
+    return mod;
+  };
+}
+
+// Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
+internalBinding('module_wrap').callbackMap = new WeakMap();
+
+// Set up NativeModule.
+function NativeModule(id) {
+  this.filename = `${id}.js`;
+  this.id = id;
+  this.exports = {};
+  this.reflect = undefined;
+  this.exportKeys = undefined;
+  this.loaded = false;
+  this.loading = false;
+}
+
+NativeModule._source = getInternalBinding('natives');
+NativeModule._cache = {};
+
+const config = getBinding('config');
+
+// Think of this as module.exports in this file even though it is not
+// written in CommonJS style.
+const loaderExports = { internalBinding, NativeModule };
+const loaderId = 'internal/bootstrap/loaders';
+
+NativeModule.require = function(id) {
+  if (id === loaderId) {
+    return loaderExports;
+  }
+
+  const cached = NativeModule.getCached(id);
+  if (cached && (cached.loaded || cached.loading)) {
+    return cached.exports;
+  }
+
+  if (!NativeModule.exists(id)) {
+    // Model the error off the internal/errors.js model, but
+    // do not use that module given that it could actually be
+    // the one causing the error if there's a bug in Node.js.
+    // eslint-disable-next-line no-restricted-syntax
+    const err = new Error(`No such built-in module: ${id}`);
+    err.code = 'ERR_UNKNOWN_BUILTIN_MODULE';
+    err.name = 'Error [ERR_UNKNOWN_BUILTIN_MODULE]';
+    throw err;
+  }
+
+  moduleLoadList.push(`NativeModule ${id}`);
+
+  const nativeModule = new NativeModule(id);
+
+  nativeModule.cache();
+  nativeModule.compile();
+
+  return nativeModule.exports;
+};
+
+NativeModule.isDepsModule = function(id) {
+  return id.startsWith('node-inspect/') || id.startsWith('v8/');
+};
+
+NativeModule.requireForDeps = function(id) {
+  if (!NativeModule.exists(id) ||
+      // TODO(TimothyGu): remove when DEP0084 reaches end of life.
+      NativeModule.isDepsModule(id)) {
+    id = `internal/deps/${id}`;
+  }
+  return NativeModule.require(id);
+};
+
+NativeModule.getCached = function(id) {
+  return NativeModule._cache[id];
+};
+
+NativeModule.exists = function(id) {
+  return NativeModule._source.hasOwnProperty(id);
+};
+
+if (config.exposeInternals) {
+  NativeModule.nonInternalExists = function(id) {
+    // Do not expose this to user land even with --expose-internals.
+    if (id === loaderId) {
+      return false;
+    }
+    return NativeModule.exists(id);
+  };
+
+  NativeModule.isInternal = function(id) {
+    // Do not expose this to user land even with --expose-internals.
+    return id === loaderId;
+  };
+} else {
+  NativeModule.nonInternalExists = function(id) {
+    return NativeModule.exists(id) && !NativeModule.isInternal(id);
+  };
+
+  NativeModule.isInternal = function(id) {
+    return id.startsWith('internal/') ||
+        (id === 'worker_threads' && !config.experimentalWorker);
+  };
+}
+
+NativeModule.getSource = function(id) {
+  return NativeModule._source[id];
+};
+
+NativeModule.wrap = function(script) {
+  return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
+};
+
+NativeModule.wrapper = [
+  '(function (exports, require, module, process, internalBinding) {',
+  '\n});'
+];
+
+const getOwn = (target, property, receiver) => {
+  return ReflectApply(ObjectHasOwnProperty, target, [property]) ?
+    ReflectGet(target, property, receiver) :
+    undefined;
+};
+
+// Provide named exports for all builtin libraries so that the libraries
+// may be imported in a nicer way for ESM users. The default export is left
+// as the entire namespace (module.exports) and wrapped in a proxy such
+// that APMs and other behavior are still left intact.
+NativeModule.prototype.proxifyExports = function() {
+  this.exportKeys = ObjectKeys(this.exports);
+
+  const update = (property, value) => {
+    if (this.reflect !== undefined &&
+        ReflectApply(ObjectHasOwnProperty,
+                     this.reflect.exports, [property]))
+      this.reflect.exports[property].set(value);
+  };
+
+  const handler = {
+    __proto__: null,
+    defineProperty: (target, prop, descriptor) => {
+      // Use `Object.defineProperty` instead of `Reflect.defineProperty`
+      // to throw the appropriate error if something goes wrong.
+      ObjectDefineProperty(target, prop, descriptor);
+      if (typeof descriptor.get === 'function' &&
+          !ReflectHas(handler, 'get')) {
+        handler.get = (target, prop, receiver) => {
+          const value = ReflectGet(target, prop, receiver);
+          if (ReflectApply(ObjectHasOwnProperty, target, [prop]))
+            update(prop, value);
+          return value;
+        };
+      }
+      update(prop, getOwn(target, prop));
+      return true;
     },
-    create: ObjectCreate,
-    defineProperty: ObjectDefineProperty,
-    keys: ObjectKeys,
-  } = Object;
-
-  // Set up process.moduleLoadList.
-  const moduleLoadList = [];
-  ObjectDefineProperty(process, 'moduleLoadList', {
-    value: moduleLoadList,
-    configurable: true,
-    enumerable: true,
-    writable: false
-  });
-
-  // internalBindingWhitelist contains the name of internalBinding modules
-  // that are whitelisted for access via process.binding()... This is used
-  // to provide a transition path for modules that are being moved over to
-  // internalBinding.
-  const internalBindingWhitelist = [
-    'async_wrap',
-    'buffer',
-    'cares_wrap',
-    'constants',
-    'contextify',
-    'crypto',
-    'fs',
-    'fs_event_wrap',
-    'http_parser',
-    'icu',
-    'js_stream',
-    'natives',
-    'pipe_wrap',
-    'process_wrap',
-    'signal_wrap',
-    'spawn_sync',
-    'stream_wrap',
-    'tcp_wrap',
-    'tls_wrap',
-    'tty_wrap',
-    'udp_wrap',
-    'url',
-    'util',
-    'uv',
-    'v8',
-    'zlib'
-  ];
-  // We will use a lazy loaded SafeSet in internalBindingWhitelistHas
-  // for checking existence in this list.
-  let internalBindingWhitelistSet;
-
-  // Set up process.binding() and process._linkedBinding().
-  {
-    const bindingObj = ObjectCreate(null);
-
-    process.binding = function binding(module) {
-      module = String(module);
-      // Deprecated specific process.binding() modules, but not all, allow
-      // selective fallback to internalBinding for the deprecated ones.
-      if (internalBindingWhitelistHas(module)) {
-        return internalBinding(module);
+    deleteProperty: (target, prop) => {
+      if (ReflectDeleteProperty(target, prop)) {
+        update(prop, undefined);
+        return true;
       }
-      let mod = bindingObj[module];
-      if (typeof mod !== 'object') {
-        mod = bindingObj[module] = getBinding(module);
-        moduleLoadList.push(`Binding ${module}`);
+      return false;
+    },
+    set: (target, prop, value, receiver) => {
+      const descriptor = ReflectGetOwnPropertyDescriptor(target, prop);
+      if (ReflectSet(target, prop, value, receiver)) {
+        if (descriptor && typeof descriptor.set === 'function') {
+          for (const key of this.exportKeys) {
+            update(key, getOwn(target, key, receiver));
+          }
+        } else {
+          update(prop, getOwn(target, prop, receiver));
+        }
+        return true;
       }
-      return mod;
-    };
+      return false;
+    }
+  };
 
-    process._linkedBinding = function _linkedBinding(module) {
-      module = String(module);
-      let mod = bindingObj[module];
-      if (typeof mod !== 'object')
-        mod = bindingObj[module] = getLinkedBinding(module);
-      return mod;
-    };
-  }
+  this.exports = new Proxy(this.exports, handler);
+};
 
-  // Set up internalBinding() in the closure.
-  let internalBinding;
-  {
-    const bindingObj = ObjectCreate(null);
-    internalBinding = function internalBinding(module) {
-      let mod = bindingObj[module];
-      if (typeof mod !== 'object') {
-        mod = bindingObj[module] = getInternalBinding(module);
-        moduleLoadList.push(`Internal Binding ${module}`);
-      }
-      return mod;
-    };
-  }
+const { compileFunction } = getInternalBinding('native_module');
+NativeModule.prototype.compile = function() {
+  const id = this.id;
 
-  // Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
-  internalBinding('module_wrap').callbackMap = new WeakMap();
+  this.loading = true;
 
-  // Set up NativeModule.
-  function NativeModule(id) {
-    this.filename = `${id}.js`;
-    this.id = id;
-    this.exports = {};
-    this.reflect = undefined;
-    this.exportKeys = undefined;
-    this.loaded = false;
+  try {
+    const requireFn = this.id.startsWith('internal/deps/') ?
+      NativeModule.requireForDeps :
+      NativeModule.require;
+
+    const fn = compileFunction(id);
+    fn(this.exports, requireFn, this, process, internalBinding);
+
+    if (config.experimentalModules && !NativeModule.isInternal(this.id)) {
+      this.proxifyExports();
+    }
+
+    this.loaded = true;
+  } finally {
     this.loading = false;
   }
+};
 
-  NativeModule._source = getInternalBinding('natives');
-  NativeModule._cache = {};
+NativeModule.prototype.cache = function() {
+  NativeModule._cache[this.id] = this;
+};
 
-  const config = getBinding('config');
+// Coverage must be turned on early, so that we can collect
+// it for Node.js' own internal libraries.
+if (process.env.NODE_V8_COVERAGE) {
+  NativeModule.require('internal/process/coverage').setup();
+}
 
-  // Think of this as module.exports in this file even though it is not
-  // written in CommonJS style.
-  const loaderExports = { internalBinding, NativeModule };
-  const loaderId = 'internal/bootstrap/loaders';
-
-  NativeModule.require = function(id) {
-    if (id === loaderId) {
-      return loaderExports;
-    }
-
-    const cached = NativeModule.getCached(id);
-    if (cached && (cached.loaded || cached.loading)) {
-      return cached.exports;
-    }
-
-    if (!NativeModule.exists(id)) {
-      // Model the error off the internal/errors.js model, but
-      // do not use that module given that it could actually be
-      // the one causing the error if there's a bug in Node.js.
-      // eslint-disable-next-line no-restricted-syntax
-      const err = new Error(`No such built-in module: ${id}`);
-      err.code = 'ERR_UNKNOWN_BUILTIN_MODULE';
-      err.name = 'Error [ERR_UNKNOWN_BUILTIN_MODULE]';
-      throw err;
-    }
-
-    moduleLoadList.push(`NativeModule ${id}`);
-
-    const nativeModule = new NativeModule(id);
-
-    nativeModule.cache();
-    nativeModule.compile();
-
-    return nativeModule.exports;
-  };
-
-  NativeModule.isDepsModule = function(id) {
-    return id.startsWith('node-inspect/') || id.startsWith('v8/');
-  };
-
-  NativeModule.requireForDeps = function(id) {
-    if (!NativeModule.exists(id) ||
-        // TODO(TimothyGu): remove when DEP0084 reaches end of life.
-        NativeModule.isDepsModule(id)) {
-      id = `internal/deps/${id}`;
-    }
-    return NativeModule.require(id);
-  };
-
-  NativeModule.getCached = function(id) {
-    return NativeModule._cache[id];
-  };
-
-  NativeModule.exists = function(id) {
-    return NativeModule._source.hasOwnProperty(id);
-  };
-
-  if (config.exposeInternals) {
-    NativeModule.nonInternalExists = function(id) {
-      // Do not expose this to user land even with --expose-internals.
-      if (id === loaderId) {
-        return false;
-      }
-      return NativeModule.exists(id);
-    };
-
-    NativeModule.isInternal = function(id) {
-      // Do not expose this to user land even with --expose-internals.
-      return id === loaderId;
-    };
-  } else {
-    NativeModule.nonInternalExists = function(id) {
-      return NativeModule.exists(id) && !NativeModule.isInternal(id);
-    };
-
-    NativeModule.isInternal = function(id) {
-      return id.startsWith('internal/') ||
-          (id === 'worker_threads' && !config.experimentalWorker);
-    };
+function internalBindingWhitelistHas(name) {
+  if (!internalBindingWhitelistSet) {
+    const { SafeSet } = NativeModule.require('internal/safe_globals');
+    internalBindingWhitelistSet = new SafeSet(internalBindingWhitelist);
   }
+  return internalBindingWhitelistSet.has(name);
+}
 
-  NativeModule.getSource = function(id) {
-    return NativeModule._source[id];
-  };
-
-  NativeModule.wrap = function(script) {
-    return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
-  };
-
-  NativeModule.wrapper = [
-    '(function (exports, require, module, process, internalBinding) {',
-    '\n});'
-  ];
-
-  const getOwn = (target, property, receiver) => {
-    return ReflectApply(ObjectHasOwnProperty, target, [property]) ?
-      ReflectGet(target, property, receiver) :
-      undefined;
-  };
-
-  // Provide named exports for all builtin libraries so that the libraries
-  // may be imported in a nicer way for ESM users. The default export is left
-  // as the entire namespace (module.exports) and wrapped in a proxy such
-  // that APMs and other behavior are still left intact.
-  NativeModule.prototype.proxifyExports = function() {
-    this.exportKeys = ObjectKeys(this.exports);
-
-    const update = (property, value) => {
-      if (this.reflect !== undefined &&
-          ReflectApply(ObjectHasOwnProperty,
-                       this.reflect.exports, [property]))
-        this.reflect.exports[property].set(value);
-    };
-
-    const handler = {
-      __proto__: null,
-      defineProperty: (target, prop, descriptor) => {
-        // Use `Object.defineProperty` instead of `Reflect.defineProperty`
-        // to throw the appropriate error if something goes wrong.
-        ObjectDefineProperty(target, prop, descriptor);
-        if (typeof descriptor.get === 'function' &&
-            !ReflectHas(handler, 'get')) {
-          handler.get = (target, prop, receiver) => {
-            const value = ReflectGet(target, prop, receiver);
-            if (ReflectApply(ObjectHasOwnProperty, target, [prop]))
-              update(prop, value);
-            return value;
-          };
-        }
-        update(prop, getOwn(target, prop));
-        return true;
-      },
-      deleteProperty: (target, prop) => {
-        if (ReflectDeleteProperty(target, prop)) {
-          update(prop, undefined);
-          return true;
-        }
-        return false;
-      },
-      set: (target, prop, value, receiver) => {
-        const descriptor = ReflectGetOwnPropertyDescriptor(target, prop);
-        if (ReflectSet(target, prop, value, receiver)) {
-          if (descriptor && typeof descriptor.set === 'function') {
-            for (const key of this.exportKeys) {
-              update(key, getOwn(target, key, receiver));
-            }
-          } else {
-            update(prop, getOwn(target, prop, receiver));
-          }
-          return true;
-        }
-        return false;
-      }
-    };
-
-    this.exports = new Proxy(this.exports, handler);
-  };
-
-  const { compileFunction } = getInternalBinding('native_module');
-  NativeModule.prototype.compile = function() {
-    const id = this.id;
-
-    this.loading = true;
-
-    try {
-      const requireFn = this.id.startsWith('internal/deps/') ?
-        NativeModule.requireForDeps :
-        NativeModule.require;
-
-      const fn = compileFunction(id);
-      fn(this.exports, requireFn, this, process, internalBinding);
-
-      if (config.experimentalModules && !NativeModule.isInternal(this.id)) {
-        this.proxifyExports();
-      }
-
-      this.loaded = true;
-    } finally {
-      this.loading = false;
-    }
-  };
-
-  NativeModule.prototype.cache = function() {
-    NativeModule._cache[this.id] = this;
-  };
-
-  // Coverage must be turned on early, so that we can collect
-  // it for Node.js' own internal libraries.
-  if (process.env.NODE_V8_COVERAGE) {
-    NativeModule.require('internal/process/coverage').setup();
-  }
-
-  function internalBindingWhitelistHas(name) {
-    if (!internalBindingWhitelistSet) {
-      const { SafeSet } = NativeModule.require('internal/safe_globals');
-      internalBindingWhitelistSet = new SafeSet(internalBindingWhitelist);
-    }
-    return internalBindingWhitelistSet.has(name);
-  }
-
-  // This will be passed to the bootstrapNodeJSCore function in
-  // bootstrap/node.js.
-  return loaderExports;
-});
+// This will be passed to internal/bootstrap/node.js.
+return loaderExports;

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -12,696 +12,696 @@
 // into this bootstrapper to bootstrap Node.js core.
 'use strict';
 
-(function bootstrapNodeJSCore(process,
-                              // bootstrapper properties... destructured to
-                              // avoid retaining a reference to the bootstrap
-                              // object.
-                              { _setupTraceCategoryState,
-                                _setupNextTick,
-                                _setupPromises, _chdir, _cpuUsage,
-                                _hrtime, _hrtimeBigInt,
-                                _memoryUsage, _rawDebug,
-                                _umask, _initgroups, _setegid, _seteuid,
-                                _setgid, _setuid, _setgroups,
-                                _shouldAbortOnUncaughtToggle },
-                              { internalBinding, NativeModule },
-                              triggerFatalException) {
-  const exceptionHandlerState = { captureFn: null };
-  const isMainThread = internalBinding('worker').threadId === 0;
+// This file is compiled as if it's wrapped in a function with arguments
+// passed by node::LoadEnvironment()
+/* global process, bootstrappers, loaderExports, triggerFatalException */
+const {
+  _setupTraceCategoryState,
+  _setupNextTick,
+  _setupPromises, _chdir, _cpuUsage,
+  _hrtime, _hrtimeBigInt,
+  _memoryUsage, _rawDebug,
+  _umask, _initgroups, _setegid, _seteuid,
+  _setgid, _setuid, _setgroups,
+  _shouldAbortOnUncaughtToggle
+} = bootstrappers;
+const { internalBinding, NativeModule } = loaderExports;
 
-  function startup() {
-    setupTraceCategoryState();
+const exceptionHandlerState = { captureFn: null };
+const isMainThread = internalBinding('worker').threadId === 0;
 
-    setupProcessObject();
+function startup() {
+  setupTraceCategoryState();
 
-    // Do this good and early, since it handles errors.
-    setupProcessFatal();
+  setupProcessObject();
 
-    setupProcessICUVersions();
+  // Do this good and early, since it handles errors.
+  setupProcessFatal();
 
-    setupGlobalVariables();
+  setupProcessICUVersions();
 
-    // Bootstrappers for all threads, including worker threads and main thread
-    const perThreadSetup = NativeModule.require('internal/process/per_thread');
-    // Bootstrappers for the main thread only
-    let mainThreadSetup;
-    // Bootstrappers for the worker threads only
-    let workerThreadSetup;
-    if (isMainThread) {
-      mainThreadSetup = NativeModule.require(
-        'internal/process/main_thread_only'
-      );
-    } else {
-      workerThreadSetup = NativeModule.require(
-        'internal/process/worker_thread_only'
-      );
-    }
+  setupGlobalVariables();
 
-    perThreadSetup.setupAssert();
-    perThreadSetup.setupConfig(NativeModule._source);
+  // Bootstrappers for all threads, including worker threads and main thread
+  const perThreadSetup = NativeModule.require('internal/process/per_thread');
+  // Bootstrappers for the main thread only
+  let mainThreadSetup;
+  // Bootstrappers for the worker threads only
+  let workerThreadSetup;
+  if (isMainThread) {
+    mainThreadSetup = NativeModule.require(
+      'internal/process/main_thread_only'
+    );
+  } else {
+    workerThreadSetup = NativeModule.require(
+      'internal/process/worker_thread_only'
+    );
+  }
 
-    if (isMainThread) {
-      mainThreadSetup.setupSignalHandlers(internalBinding);
-    }
+  perThreadSetup.setupAssert();
+  perThreadSetup.setupConfig(NativeModule._source);
 
-    perThreadSetup.setupUncaughtExceptionCapture(exceptionHandlerState,
-                                                 _shouldAbortOnUncaughtToggle);
+  if (isMainThread) {
+    mainThreadSetup.setupSignalHandlers(internalBinding);
+  }
 
-    NativeModule.require('internal/process/warning').setup();
-    NativeModule.require('internal/process/next_tick').setup(_setupNextTick,
-                                                             _setupPromises);
+  perThreadSetup.setupUncaughtExceptionCapture(exceptionHandlerState,
+                                               _shouldAbortOnUncaughtToggle);
 
-    if (isMainThread) {
-      mainThreadSetup.setupStdio();
-      mainThreadSetup.setupProcessMethods(
-        _chdir, _umask, _initgroups, _setegid, _seteuid,
-        _setgid, _setuid, _setgroups
-      );
-    } else {
-      workerThreadSetup.setupStdio();
-    }
+  NativeModule.require('internal/process/warning').setup();
+  NativeModule.require('internal/process/next_tick').setup(_setupNextTick,
+                                                           _setupPromises);
 
-    const perf = internalBinding('performance');
-    const {
-      NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE,
-    } = perf.constants;
+  if (isMainThread) {
+    mainThreadSetup.setupStdio();
+    mainThreadSetup.setupProcessMethods(
+      _chdir, _umask, _initgroups, _setegid, _seteuid,
+      _setgid, _setuid, _setgroups
+    );
+  } else {
+    workerThreadSetup.setupStdio();
+  }
 
-    perThreadSetup.setupRawDebug(_rawDebug);
-    perThreadSetup.setupHrtime(_hrtime, _hrtimeBigInt);
-    perThreadSetup.setupCpuUsage(_cpuUsage);
-    perThreadSetup.setupMemoryUsage(_memoryUsage);
-    perThreadSetup.setupKillAndExit();
+  const perf = internalBinding('performance');
+  const {
+    NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE,
+  } = perf.constants;
 
-    if (global.__coverage__)
-      NativeModule.require('internal/process/write-coverage').setup();
+  perThreadSetup.setupRawDebug(_rawDebug);
+  perThreadSetup.setupHrtime(_hrtime, _hrtimeBigInt);
+  perThreadSetup.setupCpuUsage(_cpuUsage);
+  perThreadSetup.setupMemoryUsage(_memoryUsage);
+  perThreadSetup.setupKillAndExit();
 
-    if (process.env.NODE_V8_COVERAGE) {
-      NativeModule.require('internal/process/coverage').setupExitHooks();
-    }
+  if (global.__coverage__)
+    NativeModule.require('internal/process/write-coverage').setup();
 
-    if (process.config.variables.v8_enable_inspector) {
-      NativeModule.require('internal/inspector_async_hook').setup();
-    }
+  if (process.env.NODE_V8_COVERAGE) {
+    NativeModule.require('internal/process/coverage').setupExitHooks();
+  }
 
-    const { getOptionValue } = NativeModule.require('internal/options');
+  if (process.config.variables.v8_enable_inspector) {
+    NativeModule.require('internal/inspector_async_hook').setup();
+  }
 
-    if (getOptionValue('--help')) {
-      NativeModule.require('internal/print_help').print(process.stdout);
-      return;
-    }
+  const { getOptionValue } = NativeModule.require('internal/options');
 
-    if (getOptionValue('--completion-bash')) {
-      NativeModule.require('internal/bash_completion').print(process.stdout);
-      return;
-    }
+  if (getOptionValue('--help')) {
+    NativeModule.require('internal/print_help').print(process.stdout);
+    return;
+  }
 
-    if (isMainThread) {
-      mainThreadSetup.setupChildProcessIpcChannel();
-    }
+  if (getOptionValue('--completion-bash')) {
+    NativeModule.require('internal/bash_completion').print(process.stdout);
+    return;
+  }
 
-    const browserGlobals = !process._noBrowserGlobals;
-    if (browserGlobals) {
-      setupGlobalTimeouts();
-      setupGlobalConsole();
-      setupGlobalURL();
-      setupGlobalEncoding();
-      setupQueueMicrotask();
-    }
+  if (isMainThread) {
+    mainThreadSetup.setupChildProcessIpcChannel();
+  }
 
-    if (getOptionValue('--experimental-worker')) {
-      setupDOMException();
-    }
+  const browserGlobals = !process._noBrowserGlobals;
+  if (browserGlobals) {
+    setupGlobalTimeouts();
+    setupGlobalConsole();
+    setupGlobalURL();
+    setupGlobalEncoding();
+    setupQueueMicrotask();
+  }
 
-    // On OpenBSD process.execPath will be relative unless we
-    // get the full path before process.execPath is used.
-    if (process.platform === 'openbsd') {
-      const { realpathSync } = NativeModule.require('fs');
-      process.execPath = realpathSync.native(process.execPath);
-    }
+  if (getOptionValue('--experimental-worker')) {
+    setupDOMException();
+  }
 
-    Object.defineProperty(process, 'argv0', {
-      enumerable: true,
-      configurable: false,
-      value: process.argv[0]
-    });
-    process.argv[0] = process.execPath;
+  // On OpenBSD process.execPath will be relative unless we
+  // get the full path before process.execPath is used.
+  if (process.platform === 'openbsd') {
+    const { realpathSync } = NativeModule.require('fs');
+    process.execPath = realpathSync.native(process.execPath);
+  }
 
-    // Handle `--debug*` deprecation and invalidation.
-    if (process._invalidDebug) {
+  Object.defineProperty(process, 'argv0', {
+    enumerable: true,
+    configurable: false,
+    value: process.argv[0]
+  });
+  process.argv[0] = process.execPath;
+
+  // Handle `--debug*` deprecation and invalidation.
+  if (process._invalidDebug) {
+    process.emitWarning(
+      '`node --debug` and `node --debug-brk` are invalid. ' +
+      'Please use `node --inspect` or `node --inspect-brk` instead.',
+      'DeprecationWarning', 'DEP0062', startup, true);
+    process.exit(9);
+  } else if (process._deprecatedDebugBrk) {
+    process.emitWarning(
+      '`node --inspect --debug-brk` is deprecated. ' +
+      'Please use `node --inspect-brk` instead.',
+      'DeprecationWarning', 'DEP0062', startup, true);
+  }
+
+  const experimentalModules = getOptionValue('--experimental-modules');
+  const experimentalVMModules = getOptionValue('--experimental-vm-modules');
+  if (experimentalModules || experimentalVMModules) {
+    if (experimentalModules) {
       process.emitWarning(
-        '`node --debug` and `node --debug-brk` are invalid. ' +
-        'Please use `node --inspect` or `node --inspect-brk` instead.',
-        'DeprecationWarning', 'DEP0062', startup, true);
-      process.exit(9);
-    } else if (process._deprecatedDebugBrk) {
+        'The ESM module loader is experimental.',
+        'ExperimentalWarning', undefined);
+    }
+    NativeModule.require('internal/process/esm_loader').setup();
+  }
+
+  const { deprecate } = NativeModule.require('internal/util');
+  {
+    // Install legacy getters on the `util` binding for typechecking.
+    // TODO(addaleax): Turn into a full runtime deprecation.
+    const { pendingDeprecation } = process.binding('config');
+    const utilBinding = internalBinding('util');
+    const types = internalBinding('types');
+    for (const name of [
+      'isArrayBuffer', 'isArrayBufferView', 'isAsyncFunction',
+      'isDataView', 'isDate', 'isExternal', 'isMap', 'isMapIterator',
+      'isNativeError', 'isPromise', 'isRegExp', 'isSet', 'isSetIterator',
+      'isTypedArray', 'isUint8Array', 'isAnyArrayBuffer'
+    ]) {
+      utilBinding[name] = pendingDeprecation ?
+        deprecate(types[name],
+                  'Accessing native typechecking bindings of Node ' +
+                  'directly is deprecated. ' +
+                  `Please use \`util.types.${name}\` instead.`,
+                  'DEP0103') :
+        types[name];
+    }
+  }
+
+  // TODO(jasnell): The following have been globals since around 2012.
+  // That's just silly. The underlying perfctr support has been removed
+  // so these are now deprecated non-ops that can be removed after one
+  // major release cycle.
+  if (process.platform === 'win32') {
+    function noop() {}
+    const names = [
+      'NET_SERVER_CONNECTION',
+      'NET_SERVER_CONNECTION_CLOSE',
+      'HTTP_SERVER_REQUEST',
+      'HTTP_SERVER_RESPONSE',
+      'HTTP_CLIENT_REQUEST',
+      'HTTP_CLIENT_RESPONSE'
+    ];
+    for (var n = 0; n < names.length; n++) {
+      Object.defineProperty(global, `COUNTER_${names[n]}`, {
+        configurable: true,
+        enumerable: false,
+        value: deprecate(noop,
+                         `COUNTER_${names[n]}() is deprecated.`,
+                         'DEP0120')
+      });
+    }
+  }
+
+  perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
+
+  perThreadSetup.setupAllowedFlags();
+
+  startExecution();
+}
+
+// There are various modes that Node can run in. The most common two
+// are running from a script and running the REPL - but there are a few
+// others like the debugger or running --eval arguments. Here we decide
+// which mode we run in.
+function startExecution() {
+  // This means we are in a Worker context, and any script execution
+  // will be directed by the worker module.
+  if (internalBinding('worker').getEnvMessagePort() !== undefined) {
+    NativeModule.require('internal/worker').setupChild(evalScript);
+    return;
+  }
+
+  // To allow people to extend Node in different ways, this hook allows
+  // one to drop a file lib/_third_party_main.js into the build
+  // directory which will be executed instead of Node's normal loading.
+  if (NativeModule.exists('_third_party_main')) {
+    process.nextTick(() => {
+      NativeModule.require('_third_party_main');
+    });
+    return;
+  }
+
+  // `node inspect ...` or `node debug ...`
+  if (process.argv[1] === 'inspect' || process.argv[1] === 'debug') {
+    if (process.argv[1] === 'debug') {
       process.emitWarning(
-        '`node --inspect --debug-brk` is deprecated. ' +
-        'Please use `node --inspect-brk` instead.',
-        'DeprecationWarning', 'DEP0062', startup, true);
+        '`node debug` is deprecated. Please use `node inspect` instead.',
+        'DeprecationWarning', 'DEP0068');
     }
 
-    const experimentalModules = getOptionValue('--experimental-modules');
-    const experimentalVMModules = getOptionValue('--experimental-vm-modules');
-    if (experimentalModules || experimentalVMModules) {
-      if (experimentalModules) {
-        process.emitWarning(
-          'The ESM module loader is experimental.',
-          'ExperimentalWarning', undefined);
-      }
-      NativeModule.require('internal/process/esm_loader').setup();
-    }
-
-    const { deprecate } = NativeModule.require('internal/util');
-    {
-      // Install legacy getters on the `util` binding for typechecking.
-      // TODO(addaleax): Turn into a full runtime deprecation.
-      const { pendingDeprecation } = process.binding('config');
-      const utilBinding = internalBinding('util');
-      const types = internalBinding('types');
-      for (const name of [
-        'isArrayBuffer', 'isArrayBufferView', 'isAsyncFunction',
-        'isDataView', 'isDate', 'isExternal', 'isMap', 'isMapIterator',
-        'isNativeError', 'isPromise', 'isRegExp', 'isSet', 'isSetIterator',
-        'isTypedArray', 'isUint8Array', 'isAnyArrayBuffer'
-      ]) {
-        utilBinding[name] = pendingDeprecation ?
-          deprecate(types[name],
-                    'Accessing native typechecking bindings of Node ' +
-                    'directly is deprecated. ' +
-                    `Please use \`util.types.${name}\` instead.`,
-                    'DEP0103') :
-          types[name];
-      }
-    }
-
-    // TODO(jasnell): The following have been globals since around 2012.
-    // That's just silly. The underlying perfctr support has been removed
-    // so these are now deprecated non-ops that can be removed after one
-    // major release cycle.
-    if (process.platform === 'win32') {
-      function noop() {}
-      const names = [
-        'NET_SERVER_CONNECTION',
-        'NET_SERVER_CONNECTION_CLOSE',
-        'HTTP_SERVER_REQUEST',
-        'HTTP_SERVER_RESPONSE',
-        'HTTP_CLIENT_REQUEST',
-        'HTTP_CLIENT_RESPONSE'
-      ];
-      for (var n = 0; n < names.length; n++) {
-        Object.defineProperty(global, `COUNTER_${names[n]}`, {
-          configurable: true,
-          enumerable: false,
-          value: deprecate(noop,
-                           `COUNTER_${names[n]}() is deprecated.`,
-                           'DEP0120')
-        });
-      }
-    }
-
-    perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
-
-    perThreadSetup.setupAllowedFlags();
-
-    startExecution();
-  }
-
-  // There are various modes that Node can run in. The most common two
-  // are running from a script and running the REPL - but there are a few
-  // others like the debugger or running --eval arguments. Here we decide
-  // which mode we run in.
-  function startExecution() {
-    // This means we are in a Worker context, and any script execution
-    // will be directed by the worker module.
-    if (internalBinding('worker').getEnvMessagePort() !== undefined) {
-      NativeModule.require('internal/worker').setupChild(evalScript);
-      return;
-    }
-
-    // To allow people to extend Node in different ways, this hook allows
-    // one to drop a file lib/_third_party_main.js into the build
-    // directory which will be executed instead of Node's normal loading.
-    if (NativeModule.exists('_third_party_main')) {
-      process.nextTick(() => {
-        NativeModule.require('_third_party_main');
-      });
-      return;
-    }
-
-    // `node inspect ...` or `node debug ...`
-    if (process.argv[1] === 'inspect' || process.argv[1] === 'debug') {
-      if (process.argv[1] === 'debug') {
-        process.emitWarning(
-          '`node debug` is deprecated. Please use `node inspect` instead.',
-          'DeprecationWarning', 'DEP0068');
-      }
-
-      // Start the debugger agent.
-      process.nextTick(() => {
-        NativeModule.require('internal/deps/node-inspect/lib/_inspect').start();
-      });
-      return;
-    }
-
-    // `node --prof-process`
-    // TODO(joyeecheung): use internal/options instead of process.profProcess
-    if (process.profProcess) {
-      NativeModule.require('internal/v8_prof_processor');
-      return;
-    }
-
-    // There is user code to be run.
-    prepareUserCodeExecution();
-    executeUserCode();
-  }
-
-  function prepareUserCodeExecution() {
-    // If this is a worker in cluster mode, start up the communication
-    // channel. This needs to be done before any user code gets executed
-    // (including preload modules).
-    if (process.argv[1] && process.env.NODE_UNIQUE_ID) {
-      const cluster = NativeModule.require('cluster');
-      cluster._setupWorker();
-      // Make sure it's not accidentally inherited by child processes.
-      delete process.env.NODE_UNIQUE_ID;
-    }
-
-    // For user code, we preload modules if `-r` is passed
-    // TODO(joyeecheung): use internal/options instead of
-    // process._preload_modules
-    if (process._preload_modules) {
-      const {
-        _preloadModules
-      } = NativeModule.require('internal/modules/cjs/loader');
-      _preloadModules(process._preload_modules);
-    }
-  }
-
-  function executeUserCode() {
-    // User passed `-e` or `--eval` arguments to Node without `-i` or
-    // `--interactive`.
-    // Note that the name `forceRepl` is merely an alias of `interactive`
-    // in code.
-    // TODO(joyeecheung): use internal/options instead of
-    // process._eval/process._forceRepl
-    if (process._eval != null && !process._forceRepl) {
-      const {
-        addBuiltinLibsToObject
-      } = NativeModule.require('internal/modules/cjs/helpers');
-      addBuiltinLibsToObject(global);
-      evalScript('[eval]', wrapForBreakOnFirstLine(process._eval));
-      return;
-    }
-
-    // If the first argument is a file name, run it as a main script
-    if (process.argv[1] && process.argv[1] !== '-') {
-      // Expand process.argv[1] into a full path.
-      const path = NativeModule.require('path');
-      process.argv[1] = path.resolve(process.argv[1]);
-
-      const CJSModule = NativeModule.require('internal/modules/cjs/loader');
-
-      // If user passed `-c` or `--check` arguments to Node, check its syntax
-      // instead of actually running the file.
-      // TODO(joyeecheung): use internal/options instead of
-      // process._syntax_check_only
-      if (process._syntax_check_only != null) {
-        const fs = NativeModule.require('fs');
-        // Read the source.
-        const filename = CJSModule._resolveFilename(process.argv[1]);
-        const source = fs.readFileSync(filename, 'utf-8');
-        checkScriptSyntax(source, filename);
-        process.exit(0);
-      }
-
-      // Note: this actually tries to run the module as a ESM first if
-      // --experimental-modules is on.
-      // TODO(joyeecheung): can we move that logic to here? Note that this
-      // is an undocumented method available via `require('module').runMain`
-      CJSModule.runMain();
-      return;
-    }
-
-    // Create the REPL if `-i` or `--interactive` is passed, or if
-    // stdin is a TTY.
-    // Note that the name `forceRepl` is merely an alias of `interactive`
-    // in code.
-    if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
-      const cliRepl = NativeModule.require('internal/repl');
-      cliRepl.createInternalRepl(process.env, (err, repl) => {
-        if (err) {
-          throw err;
-        }
-        repl.on('exit', () => {
-          if (repl._flushing) {
-            repl.pause();
-            return repl.once('flushHistory', () => {
-              process.exit();
-            });
-          }
-          process.exit();
-        });
-      });
-
-      // User passed '-e' or '--eval' along with `-i` or `--interactive`
-      if (process._eval != null) {
-        evalScript('[eval]', wrapForBreakOnFirstLine(process._eval));
-      }
-      return;
-    }
-
-    // Stdin is not a TTY, we will read it and execute it.
-    readAndExecuteStdin();
-  }
-
-  function readAndExecuteStdin() {
-    process.stdin.setEncoding('utf8');
-
-    let code = '';
-    process.stdin.on('data', (d) => {
-      code += d;
+    // Start the debugger agent.
+    process.nextTick(() => {
+      NativeModule.require('internal/deps/node-inspect/lib/_inspect').start();
     });
-
-    process.stdin.on('end', () => {
-      if (process._syntax_check_only != null) {
-        checkScriptSyntax(code, '[stdin]');
-      } else {
-        process._eval = code;
-        evalScript('[stdin]', wrapForBreakOnFirstLine(process._eval));
-      }
-    });
+    return;
   }
 
-  function setupTraceCategoryState() {
-    const { traceCategoryState } = internalBinding('trace_events');
-    const kCategoryAsyncHooks = 0;
-    let traceEventsAsyncHook;
-
-    function toggleTraceCategoryState() {
-      // Dynamically enable/disable the traceEventsAsyncHook
-      const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
-
-      if (asyncHooksEnabled) {
-        // Lazy load internal/trace_events_async_hooks only if the async_hooks
-        // trace event category is enabled.
-        if (!traceEventsAsyncHook) {
-          traceEventsAsyncHook =
-            NativeModule.require('internal/trace_events_async_hooks');
-        }
-        traceEventsAsyncHook.enable();
-      } else if (traceEventsAsyncHook) {
-        traceEventsAsyncHook.disable();
-      }
-    }
-
-    toggleTraceCategoryState();
-    _setupTraceCategoryState(toggleTraceCategoryState);
+  // `node --prof-process`
+  // TODO(joyeecheung): use internal/options instead of process.profProcess
+  if (process.profProcess) {
+    NativeModule.require('internal/v8_prof_processor');
+    return;
   }
 
-  function setupProcessObject() {
-    const EventEmitter = NativeModule.require('events');
-    const origProcProto = Object.getPrototypeOf(process);
-    Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
-    EventEmitter.call(process);
+  // There is user code to be run.
+  prepareUserCodeExecution();
+  executeUserCode();
+}
+
+function prepareUserCodeExecution() {
+  // If this is a worker in cluster mode, start up the communication
+  // channel. This needs to be done before any user code gets executed
+  // (including preload modules).
+  if (process.argv[1] && process.env.NODE_UNIQUE_ID) {
+    const cluster = NativeModule.require('cluster');
+    cluster._setupWorker();
+    // Make sure it's not accidentally inherited by child processes.
+    delete process.env.NODE_UNIQUE_ID;
   }
 
-  function setupGlobalVariables() {
-    Object.defineProperty(global, Symbol.toStringTag, {
-      value: 'global',
-      writable: false,
-      enumerable: false,
-      configurable: true
-    });
-    global.process = process;
-    const util = NativeModule.require('util');
-
-    function makeGetter(name) {
-      return util.deprecate(function() {
-        return this;
-      }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
-    }
-
-    function makeSetter(name) {
-      return util.deprecate(function(value) {
-        Object.defineProperty(this, name, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: value
-        });
-      }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
-    }
-
-    Object.defineProperties(global, {
-      GLOBAL: {
-        configurable: true,
-        get: makeGetter('GLOBAL'),
-        set: makeSetter('GLOBAL')
-      },
-      root: {
-        configurable: true,
-        get: makeGetter('root'),
-        set: makeSetter('root')
-      }
-    });
-
-    // This, as side effect, removes `setupBufferJS` from the buffer binding,
-    // and exposes it on `internal/buffer`.
-    NativeModule.require('internal/buffer');
-
-    global.Buffer = NativeModule.require('buffer').Buffer;
-    process.domain = null;
-    process._exiting = false;
-  }
-
-  function setupGlobalTimeouts() {
-    const timers = NativeModule.require('timers');
-    global.clearImmediate = timers.clearImmediate;
-    global.clearInterval = timers.clearInterval;
-    global.clearTimeout = timers.clearTimeout;
-    global.setImmediate = timers.setImmediate;
-    global.setInterval = timers.setInterval;
-    global.setTimeout = timers.setTimeout;
-  }
-
-  function setupGlobalConsole() {
-    const consoleFromVM = global.console;
-    const consoleFromNode =
-      NativeModule.require('internal/console/global');
-    // Override global console from the one provided by the VM
-    // to the one implemented by Node.js
-    Object.defineProperty(global, 'console', {
-      configurable: true,
-      enumerable: false,
-      value: consoleFromNode,
-      writable: true
-    });
-    // TODO(joyeecheung): can we skip this if inspector is not active?
-    if (process.config.variables.v8_enable_inspector) {
-      const inspector =
-        NativeModule.require('internal/console/inspector');
-      inspector.addInspectorApis(consoleFromNode, consoleFromVM);
-      // This will be exposed by `require('inspector').console` later.
-      inspector.consoleFromVM = consoleFromVM;
-    }
-  }
-
-  function setupGlobalURL() {
-    const { URL, URLSearchParams } = NativeModule.require('internal/url');
-    Object.defineProperties(global, {
-      URL: {
-        value: URL,
-        writable: true,
-        configurable: true,
-        enumerable: false
-      },
-      URLSearchParams: {
-        value: URLSearchParams,
-        writable: true,
-        configurable: true,
-        enumerable: false
-      }
-    });
-  }
-
-  function setupGlobalEncoding() {
-    const { TextEncoder, TextDecoder } = NativeModule.require('util');
-    Object.defineProperties(global, {
-      TextEncoder: {
-        value: TextEncoder,
-        writable: true,
-        configurable: true,
-        enumerable: false
-      },
-      TextDecoder: {
-        value: TextDecoder,
-        writable: true,
-        configurable: true,
-        enumerable: false
-      }
-    });
-  }
-
-  function setupQueueMicrotask() {
-    Object.defineProperty(global, 'queueMicrotask', {
-      get: () => {
-        process.emitWarning('queueMicrotask() is experimental.',
-                            'ExperimentalWarning');
-        const { setupQueueMicrotask } =
-          NativeModule.require('internal/queue_microtask');
-        const queueMicrotask = setupQueueMicrotask(triggerFatalException);
-        Object.defineProperty(global, 'queueMicrotask', {
-          value: queueMicrotask,
-          writable: true,
-          enumerable: false,
-          configurable: true,
-        });
-        return queueMicrotask;
-      },
-      set: (v) => {
-        Object.defineProperty(global, 'queueMicrotask', {
-          value: v,
-          writable: true,
-          enumerable: false,
-          configurable: true,
-        });
-      },
-      enumerable: false,
-      configurable: true,
-    });
-  }
-
-  function setupDOMException() {
-    // Registers the constructor with C++.
-    const DOMException = NativeModule.require('internal/domexception');
-    const { registerDOMException } = internalBinding('messaging');
-    registerDOMException(DOMException);
-  }
-
-  function noop() {}
-
-  function setupProcessFatal() {
+  // For user code, we preload modules if `-r` is passed
+  // TODO(joyeecheung): use internal/options instead of
+  // process._preload_modules
+  if (process._preload_modules) {
     const {
-      executionAsyncId,
-      clearDefaultTriggerAsyncId,
-      clearAsyncIdStack,
-      hasAsyncIdStack,
-      afterHooksExist,
-      emitAfter
-    } = NativeModule.require('internal/async_hooks');
-
-    process._fatalException = (er) => {
-      // It's possible that defaultTriggerAsyncId was set for a constructor
-      // call that threw and was never cleared. So clear it now.
-      clearDefaultTriggerAsyncId();
-
-      if (exceptionHandlerState.captureFn !== null) {
-        exceptionHandlerState.captureFn(er);
-      } else if (!process.emit('uncaughtException', er)) {
-        // If someone handled it, then great.  otherwise, die in C++ land
-        // since that means that we'll exit the process, emit the 'exit' event.
-        try {
-          if (!process._exiting) {
-            process._exiting = true;
-            process.exitCode = 1;
-            process.emit('exit', 1);
-          }
-        } catch {
-          // Nothing to be done about it at this point.
-        }
-        try {
-          const { kExpandStackSymbol } = NativeModule.require('internal/util');
-          if (typeof er[kExpandStackSymbol] === 'function')
-            er[kExpandStackSymbol]();
-        } catch {
-          // Nothing to be done about it at this point.
-        }
-        return false;
-      }
-
-      // If we handled an error, then make sure any ticks get processed
-      // by ensuring that the next Immediate cycle isn't empty.
-      NativeModule.require('timers').setImmediate(noop);
-
-      // Emit the after() hooks now that the exception has been handled.
-      if (afterHooksExist()) {
-        do {
-          emitAfter(executionAsyncId());
-        } while (hasAsyncIdStack());
-      // Or completely empty the id stack.
-      } else {
-        clearAsyncIdStack();
-      }
-
-      return true;
-    };
+      _preloadModules
+    } = NativeModule.require('internal/modules/cjs/loader');
+    _preloadModules(process._preload_modules);
   }
+}
 
-  function setupProcessICUVersions() {
-    const icu = process.binding('config').hasIntl ?
-      internalBinding('icu') : undefined;
-    if (!icu) return;  // no Intl/ICU: nothing to add here.
-    // With no argument, getVersion() returns a comma separated list
-    // of possible types.
-    const versionTypes = icu.getVersion().split(',');
-
-    for (var n = 0; n < versionTypes.length; n++) {
-      const name = versionTypes[n];
-      const version = icu.getVersion(name);
-      Object.defineProperty(process.versions, name, {
-        writable: false,
-        enumerable: true,
-        value: version
-      });
-    }
-  }
-
-  function wrapForBreakOnFirstLine(source) {
-    if (!process._breakFirstLine)
-      return source;
-    const fn = `function() {\n\n${source};\n\n}`;
-    return `process.binding('inspector').callAndPauseOnStart(${fn}, {})`;
-  }
-
-  function evalScript(name, body) {
-    const CJSModule = NativeModule.require('internal/modules/cjs/loader');
-    const path = NativeModule.require('path');
-    const { tryGetCwd } = NativeModule.require('internal/util');
-    const cwd = tryGetCwd(path);
-
-    const module = new CJSModule(name);
-    module.filename = path.join(cwd, name);
-    module.paths = CJSModule._nodeModulePaths(cwd);
-    const script = `global.__filename = ${JSON.stringify(name)};\n` +
-                   'global.exports = exports;\n' +
-                   'global.module = module;\n' +
-                   'global.__dirname = __dirname;\n' +
-                   'global.require = require;\n' +
-                   'return require("vm").runInThisContext(' +
-                   `${JSON.stringify(body)}, { filename: ` +
-                   `${JSON.stringify(name)}, displayErrors: true });\n`;
-    const result = module._compile(script, `${name}-wrapper`);
-    if (process._print_eval) console.log(result);
-    // Handle any nextTicks added in the first tick of the program.
-    process._tickCallback();
-  }
-
-  function checkScriptSyntax(source, filename) {
-    const CJSModule = NativeModule.require('internal/modules/cjs/loader');
-    const vm = NativeModule.require('vm');
+function executeUserCode() {
+  // User passed `-e` or `--eval` arguments to Node without `-i` or
+  // `--interactive`.
+  // Note that the name `forceRepl` is merely an alias of `interactive`
+  // in code.
+  // TODO(joyeecheung): use internal/options instead of
+  // process._eval/process._forceRepl
+  if (process._eval != null && !process._forceRepl) {
     const {
-      stripShebang, stripBOM
+      addBuiltinLibsToObject
     } = NativeModule.require('internal/modules/cjs/helpers');
-
-    // Remove Shebang.
-    source = stripShebang(source);
-    // Remove BOM.
-    source = stripBOM(source);
-    // Wrap it.
-    source = CJSModule.wrap(source);
-    // Compile the script, this will throw if it fails.
-    new vm.Script(source, { displayErrors: true, filename });
+    addBuiltinLibsToObject(global);
+    evalScript('[eval]', wrapForBreakOnFirstLine(process._eval));
+    return;
   }
 
-  startup();
-});
+  // If the first argument is a file name, run it as a main script
+  if (process.argv[1] && process.argv[1] !== '-') {
+    // Expand process.argv[1] into a full path.
+    const path = NativeModule.require('path');
+    process.argv[1] = path.resolve(process.argv[1]);
+
+    const CJSModule = NativeModule.require('internal/modules/cjs/loader');
+
+    // If user passed `-c` or `--check` arguments to Node, check its syntax
+    // instead of actually running the file.
+    // TODO(joyeecheung): use internal/options instead of
+    // process._syntax_check_only
+    if (process._syntax_check_only != null) {
+      const fs = NativeModule.require('fs');
+      // Read the source.
+      const filename = CJSModule._resolveFilename(process.argv[1]);
+      const source = fs.readFileSync(filename, 'utf-8');
+      checkScriptSyntax(source, filename);
+      process.exit(0);
+    }
+
+    // Note: this actually tries to run the module as a ESM first if
+    // --experimental-modules is on.
+    // TODO(joyeecheung): can we move that logic to here? Note that this
+    // is an undocumented method available via `require('module').runMain`
+    CJSModule.runMain();
+    return;
+  }
+
+  // Create the REPL if `-i` or `--interactive` is passed, or if
+  // stdin is a TTY.
+  // Note that the name `forceRepl` is merely an alias of `interactive`
+  // in code.
+  if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
+    const cliRepl = NativeModule.require('internal/repl');
+    cliRepl.createInternalRepl(process.env, (err, repl) => {
+      if (err) {
+        throw err;
+      }
+      repl.on('exit', () => {
+        if (repl._flushing) {
+          repl.pause();
+          return repl.once('flushHistory', () => {
+            process.exit();
+          });
+        }
+        process.exit();
+      });
+    });
+
+    // User passed '-e' or '--eval' along with `-i` or `--interactive`
+    if (process._eval != null) {
+      evalScript('[eval]', wrapForBreakOnFirstLine(process._eval));
+    }
+    return;
+  }
+
+  // Stdin is not a TTY, we will read it and execute it.
+  readAndExecuteStdin();
+}
+
+function readAndExecuteStdin() {
+  process.stdin.setEncoding('utf8');
+
+  let code = '';
+  process.stdin.on('data', (d) => {
+    code += d;
+  });
+
+  process.stdin.on('end', () => {
+    if (process._syntax_check_only != null) {
+      checkScriptSyntax(code, '[stdin]');
+    } else {
+      process._eval = code;
+      evalScript('[stdin]', wrapForBreakOnFirstLine(process._eval));
+    }
+  });
+}
+
+function setupTraceCategoryState() {
+  const { traceCategoryState } = internalBinding('trace_events');
+  const kCategoryAsyncHooks = 0;
+  let traceEventsAsyncHook;
+
+  function toggleTraceCategoryState() {
+    // Dynamically enable/disable the traceEventsAsyncHook
+    const asyncHooksEnabled = !!traceCategoryState[kCategoryAsyncHooks];
+
+    if (asyncHooksEnabled) {
+      // Lazy load internal/trace_events_async_hooks only if the async_hooks
+      // trace event category is enabled.
+      if (!traceEventsAsyncHook) {
+        traceEventsAsyncHook =
+          NativeModule.require('internal/trace_events_async_hooks');
+      }
+      traceEventsAsyncHook.enable();
+    } else if (traceEventsAsyncHook) {
+      traceEventsAsyncHook.disable();
+    }
+  }
+
+  toggleTraceCategoryState();
+  _setupTraceCategoryState(toggleTraceCategoryState);
+}
+
+function setupProcessObject() {
+  const EventEmitter = NativeModule.require('events');
+  const origProcProto = Object.getPrototypeOf(process);
+  Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
+  EventEmitter.call(process);
+}
+
+function setupGlobalVariables() {
+  Object.defineProperty(global, Symbol.toStringTag, {
+    value: 'global',
+    writable: false,
+    enumerable: false,
+    configurable: true
+  });
+  global.process = process;
+  const util = NativeModule.require('util');
+
+  function makeGetter(name) {
+    return util.deprecate(function() {
+      return this;
+    }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
+  }
+
+  function makeSetter(name) {
+    return util.deprecate(function(value) {
+      Object.defineProperty(this, name, {
+        configurable: true,
+        writable: true,
+        enumerable: true,
+        value: value
+      });
+    }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
+  }
+
+  Object.defineProperties(global, {
+    GLOBAL: {
+      configurable: true,
+      get: makeGetter('GLOBAL'),
+      set: makeSetter('GLOBAL')
+    },
+    root: {
+      configurable: true,
+      get: makeGetter('root'),
+      set: makeSetter('root')
+    }
+  });
+
+  // This, as side effect, removes `setupBufferJS` from the buffer binding,
+  // and exposes it on `internal/buffer`.
+  NativeModule.require('internal/buffer');
+
+  global.Buffer = NativeModule.require('buffer').Buffer;
+  process.domain = null;
+  process._exiting = false;
+}
+
+function setupGlobalTimeouts() {
+  const timers = NativeModule.require('timers');
+  global.clearImmediate = timers.clearImmediate;
+  global.clearInterval = timers.clearInterval;
+  global.clearTimeout = timers.clearTimeout;
+  global.setImmediate = timers.setImmediate;
+  global.setInterval = timers.setInterval;
+  global.setTimeout = timers.setTimeout;
+}
+
+function setupGlobalConsole() {
+  const consoleFromVM = global.console;
+  const consoleFromNode =
+    NativeModule.require('internal/console/global');
+  // Override global console from the one provided by the VM
+  // to the one implemented by Node.js
+  Object.defineProperty(global, 'console', {
+    configurable: true,
+    enumerable: false,
+    value: consoleFromNode,
+    writable: true
+  });
+  // TODO(joyeecheung): can we skip this if inspector is not active?
+  if (process.config.variables.v8_enable_inspector) {
+    const inspector =
+      NativeModule.require('internal/console/inspector');
+    inspector.addInspectorApis(consoleFromNode, consoleFromVM);
+    // This will be exposed by `require('inspector').console` later.
+    inspector.consoleFromVM = consoleFromVM;
+  }
+}
+
+function setupGlobalURL() {
+  const { URL, URLSearchParams } = NativeModule.require('internal/url');
+  Object.defineProperties(global, {
+    URL: {
+      value: URL,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    },
+    URLSearchParams: {
+      value: URLSearchParams,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    }
+  });
+}
+
+function setupGlobalEncoding() {
+  const { TextEncoder, TextDecoder } = NativeModule.require('util');
+  Object.defineProperties(global, {
+    TextEncoder: {
+      value: TextEncoder,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    },
+    TextDecoder: {
+      value: TextDecoder,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    }
+  });
+}
+
+function setupQueueMicrotask() {
+  Object.defineProperty(global, 'queueMicrotask', {
+    get: () => {
+      process.emitWarning('queueMicrotask() is experimental.',
+                          'ExperimentalWarning');
+      const { setupQueueMicrotask } =
+        NativeModule.require('internal/queue_microtask');
+      const queueMicrotask = setupQueueMicrotask(triggerFatalException);
+      Object.defineProperty(global, 'queueMicrotask', {
+        value: queueMicrotask,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+      return queueMicrotask;
+    },
+    set: (v) => {
+      Object.defineProperty(global, 'queueMicrotask', {
+        value: v,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    },
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+function setupDOMException() {
+  // Registers the constructor with C++.
+  const DOMException = NativeModule.require('internal/domexception');
+  const { registerDOMException } = internalBinding('messaging');
+  registerDOMException(DOMException);
+}
+
+function noop() {}
+
+function setupProcessFatal() {
+  const {
+    executionAsyncId,
+    clearDefaultTriggerAsyncId,
+    clearAsyncIdStack,
+    hasAsyncIdStack,
+    afterHooksExist,
+    emitAfter
+  } = NativeModule.require('internal/async_hooks');
+
+  process._fatalException = (er) => {
+    // It's possible that defaultTriggerAsyncId was set for a constructor
+    // call that threw and was never cleared. So clear it now.
+    clearDefaultTriggerAsyncId();
+
+    if (exceptionHandlerState.captureFn !== null) {
+      exceptionHandlerState.captureFn(er);
+    } else if (!process.emit('uncaughtException', er)) {
+      // If someone handled it, then great.  otherwise, die in C++ land
+      // since that means that we'll exit the process, emit the 'exit' event.
+      try {
+        if (!process._exiting) {
+          process._exiting = true;
+          process.exitCode = 1;
+          process.emit('exit', 1);
+        }
+      } catch {
+        // Nothing to be done about it at this point.
+      }
+      try {
+        const { kExpandStackSymbol } = NativeModule.require('internal/util');
+        if (typeof er[kExpandStackSymbol] === 'function')
+          er[kExpandStackSymbol]();
+      } catch {
+        // Nothing to be done about it at this point.
+      }
+      return false;
+    }
+
+    // If we handled an error, then make sure any ticks get processed
+    // by ensuring that the next Immediate cycle isn't empty.
+    NativeModule.require('timers').setImmediate(noop);
+
+    // Emit the after() hooks now that the exception has been handled.
+    if (afterHooksExist()) {
+      do {
+        emitAfter(executionAsyncId());
+      } while (hasAsyncIdStack());
+    // Or completely empty the id stack.
+    } else {
+      clearAsyncIdStack();
+    }
+
+    return true;
+  };
+}
+
+function setupProcessICUVersions() {
+  const icu = process.binding('config').hasIntl ?
+    internalBinding('icu') : undefined;
+  if (!icu) return;  // no Intl/ICU: nothing to add here.
+  // With no argument, getVersion() returns a comma separated list
+  // of possible types.
+  const versionTypes = icu.getVersion().split(',');
+
+  for (var n = 0; n < versionTypes.length; n++) {
+    const name = versionTypes[n];
+    const version = icu.getVersion(name);
+    Object.defineProperty(process.versions, name, {
+      writable: false,
+      enumerable: true,
+      value: version
+    });
+  }
+}
+
+function wrapForBreakOnFirstLine(source) {
+  if (!process._breakFirstLine)
+    return source;
+  const fn = `function() {\n\n${source};\n\n}`;
+  return `process.binding('inspector').callAndPauseOnStart(${fn}, {})`;
+}
+
+function evalScript(name, body) {
+  const CJSModule = NativeModule.require('internal/modules/cjs/loader');
+  const path = NativeModule.require('path');
+  const { tryGetCwd } = NativeModule.require('internal/util');
+  const cwd = tryGetCwd(path);
+
+  const module = new CJSModule(name);
+  module.filename = path.join(cwd, name);
+  module.paths = CJSModule._nodeModulePaths(cwd);
+  const script = `global.__filename = ${JSON.stringify(name)};\n` +
+                  'global.exports = exports;\n' +
+                  'global.module = module;\n' +
+                  'global.__dirname = __dirname;\n' +
+                  'global.require = require;\n' +
+                  'return require("vm").runInThisContext(' +
+                  `${JSON.stringify(body)}, { filename: ` +
+                  `${JSON.stringify(name)}, displayErrors: true });\n`;
+  const result = module._compile(script, `${name}-wrapper`);
+  if (process._print_eval) console.log(result);
+  // Handle any nextTicks added in the first tick of the program.
+  process._tickCallback();
+}
+
+function checkScriptSyntax(source, filename) {
+  const CJSModule = NativeModule.require('internal/modules/cjs/loader');
+  const vm = NativeModule.require('vm');
+  const {
+    stripShebang, stripBOM
+  } = NativeModule.require('internal/modules/cjs/helpers');
+
+  // Remove Shebang.
+  source = stripShebang(source);
+  // Remove BOM.
+  source = stripBOM(source);
+  // Wrap it.
+  source = CJSModule.wrap(source);
+  // Compile the script, this will throw if it fails.
+  new vm.Script(source, { displayErrors: true, filename });
+}
+
+startup();

--- a/lib/internal/per_context.js
+++ b/lib/internal/per_context.js
@@ -1,8 +1,8 @@
-// arguments: global
+// This file is compiled as if it's wrapped in a function with arguments
+// passed by node::NewContext()
+/* global global */
 
 'use strict';
-
-// node::NewContext calls this script
 
 // https://github.com/nodejs/node/issues/14909
 if (global.Intl) delete global.Intl.v8BreakIterator;

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -12,7 +12,7 @@ SyntaxError: Strict mode code may not include a with statement
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*
 42
 42
 [eval]:1
@@ -29,7 +29,7 @@ Error: hello
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*
 
 [eval]:1
 throw new Error("hello")
@@ -45,7 +45,7 @@ Error: hello
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*
 100
 [eval]:1
 var x = 100; y = x;
@@ -61,7 +61,7 @@ ReferenceError: y is not defined
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*
 
 [eval]:1
 var ______________________________________________; throw 10

--- a/test/message/events_unhandled_error_nexttick.out
+++ b/test/message/events_unhandled_error_nexttick.out
@@ -21,4 +21,4 @@ Emitted 'error' event at:
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -10,4 +10,4 @@ ReferenceError: undefined_reference_error_maker is not defined
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)
     at startup (internal/bootstrap/node.js:*:*)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:*:*)
+    at internal/bootstrap/node.js:*:*


### PR DESCRIPTION
This patch moves all the bootstrapper compilation to use
NativeModuleLoader::CompileAndCall(). With this we no longer
need to mess with the error decoration and handling any more -
there is no point in handling the JS error occurred during bootstrapping
by ourselves, we should just crash or let the VM handle it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
