### PR TITLE
doc: add authority and scheme psuedo headers

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2723,6 +2723,26 @@ added: v8.4.0
 
 The request method as a string. Read-only. Examples: `'GET'`, `'DELETE'`.
 
+#### request.authority
+<!-- YAML
+added: v8.4.0
+-->
+
+* {string}
+
+The request authority psuedo header field. It can also be accessed via
+`req.headers[':authority']`
+
+#### request.scheme
+<!-- YAML
+added: v8.4.0
+-->
+
+* {string}
+
+The request schem psuedo header field indicating the scheme
+portion of the target URI.
+
 #### request.rawHeaders
 <!-- YAML
 added: v8.4.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2654,6 +2654,16 @@ added: v10.1.0
 The `request.aborted` property will be `true` if the request has
 been aborted.
 
+#### request.authority
+<!-- YAML
+added: v8.4.0
+-->
+
+* {string}
+
+The request authority pseudo header field. It can also be accessed via
+`req.headers[':authority']`.
+
 #### request.destroy([error])
 <!-- YAML
 added: v8.4.0
@@ -2723,26 +2733,6 @@ added: v8.4.0
 
 The request method as a string. Read-only. Examples: `'GET'`, `'DELETE'`.
 
-#### request.authority
-<!-- YAML
-added: v8.4.0
--->
-
-* {string}
-
-The request authority psuedo header field. It can also be accessed via
-`req.headers[':authority']`
-
-#### request.scheme
-<!-- YAML
-added: v8.4.0
--->
-
-* {string}
-
-The request scheme psuedo header field indicating the scheme
-portion of the target URL.
-
 #### request.rawHeaders
 <!-- YAML
 added: v8.4.0
@@ -2781,6 +2771,16 @@ added: v8.4.0
 
 The raw request/response trailer keys and values exactly as they were
 received. Only populated at the `'end'` event.
+
+#### request.scheme
+<!-- YAML
+added: v8.4.0
+-->
+
+* {string}
+
+The request scheme pseudo header field indicating the scheme
+portion of the target URL.
 
 #### request.setTimeout(msecs, callback)
 <!-- YAML

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2740,8 +2740,8 @@ added: v8.4.0
 
 * {string}
 
-The request schem psuedo header field indicating the scheme
-portion of the target URI.
+The request scheme psuedo header field indicating the scheme
+portion of the target URL.
 
 #### request.rawHeaders
 <!-- YAML


### PR DESCRIPTION
doc: add authority and scheme psuedo headers to http2.md

This pull request adds the request psuedo headers authority
and scheme to the http2 documentation

Fixes: https://github.com/nodejs/node/issues/23825

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]
