### PR TITLE
src: remove icuDataDir from node config

### DIFF
--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -76,10 +76,6 @@ static void Initialize(Local<Object> target,
   READONLY_BOOLEAN_PROPERTY("hasNodeOptions");
 #endif
 
-  // TODO(addaleax): This seems to be an unused, private API. Remove it?
-  READONLY_STRING_PROPERTY(target, "icuDataDir",
-      per_process_opts->icu_data_dir);
-
 #endif  // NODE_HAVE_I18N_SUPPORT
 
   if (env->options()->preserve_symlinks)


### PR DESCRIPTION
icuDataDir seems to be redundant as it is not used anywhere.
Hence removing it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
