### PR TITLE
[8.x] assert: revert breaking change

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -782,7 +782,7 @@ function expectsNoError(stackStartFn, actual, error, message) {
       actual,
       expected: error,
       operator: stackStartFn.name,
-      message: `Got unwanted ${fnType}${details}\n${actual.message}`,
+      message: `Got unwanted ${fnType}${details}`,
       stackStartFn
     });
   }

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -34,7 +34,7 @@ common.crashOnUnhandledRejection();
         assert(err instanceof assert.AssertionError,
                `${err.name} is not instance of AssertionError`);
         assert.strictEqual(err.code, 'ERR_ASSERTION');
-        assert(/^Got unwanted rejection\.\n$/.test(err.message));
+        assert(/^Got unwanted rejection\.$/.test(err.message));
         assert.strictEqual(err.operator, 'doesNotReject');
         assert.ok(!err.stack.includes('at Function.doesNotReject'));
         return true;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -460,7 +460,7 @@ common.expectsError(
     type: a.AssertionError,
     code: 'ERR_ASSERTION',
     operator: 'doesNotThrow',
-    message: 'Got unwanted exception: user message\n[object Object]'
+    message: 'Got unwanted exception: user message'
   }
 );
 


### PR DESCRIPTION
It was not intended to change the `assert.doesNotThrow()` message
with https://github.com/nodejs/node/pull/23223. This reverts the
breaking behavior to the one before.

Refs: https://github.com/nodejs/node/pull/23223#issuecomment-443493425

I guess it won't hurt much if we keep this change in 8.x but it was not meant to be
in 8 and therefore I opened this revert.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
