### PR TITLE
child_process: ensure message sanity at send source

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -665,6 +665,18 @@ function setupChannel(target, channel) {
     if (message === undefined)
       throw new ERR_MISSING_ARGS('message');
 
+    // Non-serializable messages should not reach the remote
+    // end point; as any failure in the stringification there
+    // will result in error message that is weakly consumable.
+    // So perform a sanity check on message prior to sending.
+    if (typeof message !== 'string' &&
+        typeof message !== 'object' &&
+        typeof message !== 'number' &&
+        typeof message !== 'boolean') {
+      throw new ERR_INVALID_ARG_TYPE(
+        'message', ['string', 'object', 'number', 'boolean'], message);
+    }
+
     // Support legacy function signature
     if (typeof options === 'boolean') {
       options = { swallowErrors: options };

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -49,6 +49,12 @@ assert.throws(() => n.send(), {
   code: 'ERR_MISSING_ARGS'
 });
 
+assert.throws(() => n.send(Symbol()), {
+  name: 'TypeError [ERR_INVALID_ARG_TYPE]',
+  message: 'The "message" argument must be one of type string,' +
+           ' object, number, or boolean. Received type symbol',
+  code: 'ERR_INVALID_ARG_TYPE'
+});
 n.send({ hello: 'world' });
 
 n.on('exit', common.mustCall((c) => {


### PR DESCRIPTION
Error messages coming out of de-serialization at the send target is not consumable. So detect the scenario and fix it at the send source.

Ref: https://github.com/nodejs/node/issues/20314


existing error message (sample code in the linked issue):
```
SUBPROCESS error: SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at Pipe.channel.onread (internal/child_process.js:492:28)
```

with this change:
```
PARENT error: TypeError [ERR_INVALID_ARG_TYPE]: The "message" argument must be of type serializable objects. Received type symbol
    at ChildProcess.target._send (internal/child_process.js:664:13)
    at ChildProcess.target.send (internal/child_process.js:641:19)
    at Object.<anonymous> (/home/gireesh/node/parent.js:6:14)
    at Module._compile (internal/modules/cjs/loader.js:723:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:734:10)
    at Module.load (internal/modules/cjs/loader.js:620:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
    at Function.Module._load (internal/modules/cjs/loader.js:552:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:776:12)
    at executeUserCode (internal/bootstrap/node.js:343:17)
```

/cc @vsemozhetbyt @joyeecheung @nodejs/child_process 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)