### PR TITLE
[v8.x] http2: fix sequence of error/close events

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1997,9 +1997,8 @@ class Http2Stream extends Duplex {
     // will destroy if it has been closed and there are no other open or
     // pending streams.
     session[kMaybeDestroy]();
-    process.nextTick(emit, this, 'close', code);
     callback(err);
-
+    process.nextTick(emit, this, 'close', code);
   }
   // The Http2Stream can be destroyed if it has closed and if the readable
   // side has received the final chunk.

--- a/test/parallel/test-http2-error-order.js
+++ b/test/parallel/test-http2-error-order.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { createServer, connect } = require('http2');
+
+const messages = [];
+const expected = [
+  'Stream:created',
+  'Stream:error',
+  'Stream:close',
+  'Request:error'
+];
+
+const server = createServer();
+
+server.on('stream', (stream) => {
+  messages.push('Stream:created');
+  stream
+    .on('close', () => messages.push('Stream:close'))
+    .on('error', (err) => messages.push('Stream:error'))
+    .respondWithFile('dont exist');
+});
+
+server.listen(0);
+
+const client = connect(`http://localhost:${server.address().port}`);
+const req = client.request();
+
+req.on('response', common.mustNotCall());
+
+req.on('error', () => {
+  messages.push('Request:error');
+  client.close();
+});
+
+client.on('close', common.mustCall(() => {
+  assert.deepStrictEqual(messages, expected);
+  server.close();
+}));

--- a/test/parallel/test-http2-stream-destroy-event-order.js
+++ b/test/parallel/test-http2-stream-destroy-event-order.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');
@@ -10,8 +9,8 @@ let client;
 let req;
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
-  stream.on('close', common.mustCall(() => {
-    stream.on('error', common.mustCall(() => {
+  stream.on('error', common.mustCall(() => {
+    stream.on('close', common.mustCall(() => {
       server.close();
     }));
   }));
@@ -22,8 +21,8 @@ server.listen(0, common.mustCall(() => {
   client = http2.connect(`http://localhost:${server.address().port}`);
   req = client.request();
   req.resume();
-  req.on('close', common.mustCall(() => {
-    req.on('error', common.mustCall(() => {
+  req.on('error', common.mustCall(() => {
+    req.on('close', common.mustCall(() => {
       client.close();
     }));
   }));


### PR DESCRIPTION
Correct sequence of emitting `error` and `close` events for a
`Http2Stream`.

Refs: https://github.com/nodejs/node/pull/22850
Refs: https://github.com/nodejs/node/pull/24685
Fixes: https://github.com/nodejs/node/issues/24559

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
