### PR TITLE
http2: compat always return this on .end()

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -625,7 +625,7 @@ class Http2ServerResponse extends Stream {
 
     if ((state.closed || state.ending) &&
         state.headRequest === stream.headRequest) {
-      return false;
+      return this;
     }
 
     if (typeof chunk === 'function') {


### PR DESCRIPTION
Always return `this`. Looks like a typo?

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
