### PR TITLE
build: add '.git' to 'make lint-py' exclude list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1227,7 +1227,7 @@ ifneq ("","$(wildcard tools/pip/site-packages)")
 lint-py:
 	PYTHONPATH=tools/pip $(PYTHON) -m flake8 . \
 		--count --show-source --statistics --select=E901,E999,F821,F822,F823 \
-		--exclude=deps,lib,src,tools/*_macros.py,tools/gyp,tools/jinja2,tools/pip
+		--exclude=.git,deps,lib,src,tools/*_macros.py,tools/gyp,tools/jinja2,tools/pip
 else
 lint-py:
 	@echo "Python linting with flake8 is not avalible"


### PR DESCRIPTION
When run locally [flake8](http://flake8.pycqa.org) is currently creating false positives by scanning the __.git__ directory.  This PR prevents that behavior.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
