### PR TITLE
repl: revert multiline history

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -225,7 +225,6 @@ function Interface(input, output, completer, terminal) {
 
     // Current line
     this.line = '';
-    this.multiline = '';
 
     this._setRawMode(true);
     this.terminal = true;
@@ -337,7 +336,6 @@ Interface.prototype._addHistory = function() {
       if (dupIndex !== -1) this.history.splice(dupIndex, 1);
     }
 
-    this.multiline += this.line;
     this.history.unshift(this.line);
 
     // Only store so many
@@ -348,29 +346,6 @@ Interface.prototype._addHistory = function() {
   return this.history[0];
 };
 
-// Called when a multiline is seen by the repl
-Interface.prototype.undoHistory = function() {
-  if (this.terminal) {
-    this.history.shift();
-  }
-};
-
-// If it's a multiline code, then add history
-// accordingly.
-Interface.prototype.multilineHistory = function() {
-  // check if we got a multiline code
-  if (this.multiline !== '' && this.terminal) {
-    const dupIndex = this.history.indexOf(this.multiline);
-    if (dupIndex !== -1) this.history.splice(dupIndex, 1);
-    // Remove the last entered line as multiline
-    // already contains them.
-    this.history.shift();
-    this.history.unshift(this.multiline);
-  }
-
-  // clear the multiline buffer
-  this.multiline = '';
-};
 
 Interface.prototype._refreshLine = function() {
   // line length

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -357,9 +357,9 @@ Interface.prototype.undoHistory = function() {
 
 // If it's a multiline code, then add history
 // accordingly.
-Interface.prototype.multilineHistory = function(clearBuffer) {
-  // if not clear buffer, add multiline history
-  if (!clearBuffer && this.terminal) {
+Interface.prototype.multilineHistory = function() {
+  // check if we got a multiline code
+  if (this.multiline !== '' && this.terminal) {
     const dupIndex = this.history.indexOf(this.multiline);
     if (dupIndex !== -1) this.history.splice(dupIndex, 1);
     // Remove the last entered line as multiline

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -774,7 +774,6 @@ exports.start = function(prompt,
 
 REPLServer.prototype.clearBufferedCommand = function clearBufferedCommand() {
   this[kBufferedCommandSymbol] = '';
-  REPLServer.super_.prototype.multilineHistory.call(this);
 };
 
 REPLServer.prototype.close = function close() {
@@ -889,7 +888,6 @@ REPLServer.prototype.displayPrompt = function(preserveCursor) {
     const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
     const levelInd = '..'.repeat(len);
     prompt += levelInd + ' ';
-    Interface.prototype.undoHistory.call(this);
   }
 
   // Do not overwrite `_initialPrompt` here

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -666,13 +666,6 @@ function REPLServer(prompt,
         }
       }
 
-      // handle multiline history
-      if (self[kBufferedCommandSymbol].length)
-        Interface.prototype.multilineHistory.call(self, false);
-      else {
-        Interface.prototype.multilineHistory.call(self, true);
-      }
-
       // Clear buffer if no SyntaxErrors
       self.clearBufferedCommand();
       sawCtrlD = false;
@@ -781,6 +774,7 @@ exports.start = function(prompt,
 
 REPLServer.prototype.clearBufferedCommand = function clearBufferedCommand() {
   this[kBufferedCommandSymbol] = '';
+  REPLServer.super_.prototype.multilineHistory.call(this);
 };
 
 REPLServer.prototype.close = function close() {

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -111,13 +111,6 @@ const tests = [
     test: [UP],
     expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
   },
-  { // Tests multiline history
-    env: {},
-    test: ['{', '}', UP, CLEAR],
-    expected: [prompt, '{', '... ', '}', '{}\n',
-               prompt, `${prompt}{}`, prompt],
-    clean: false
-  },
   {
     before: function before() {
       if (common.isWindows) {


### PR DESCRIPTION
So far the multiline history caused a lot of problems and the current logic is not suitable at all as such. It changes the actual content of the history and should not be used at all.

I struggle a lot with my history at the moment as it often forgets entries and similar and until a proper solution is found this should be reverted.

We discussed some possibilities how to properly implement this feature in #24231.

Refs: #24231

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
