### PR TITLE
doc: mention util depth default change

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -384,6 +384,9 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `depth` default changed back to `2`.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22846
     description: The `depth` default changed to `20`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -385,7 +385,7 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/24326
     description: The `depth` default changed back to `2`.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22846


### PR DESCRIPTION
This was missed when reverting a former commit. To make sure the
history is kept in place, this just adds a new entry to state the
revert.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
