### PR TITLE
[v11.x] Revert "util: change %o depth default"

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -183,6 +183,9 @@ property take precedence over `--trace-deprecation` and
 <!-- YAML
 added: v0.5.3
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `%o` specifier's `depth` has default depth of 4 again.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/17907
     description: The `%o` specifier's `depth` option will now fall back to the

--- a/lib/util.js
+++ b/lib/util.js
@@ -117,7 +117,8 @@ function formatWithOptions(inspectOptions, f) {
           {
             const opts = Object.assign({}, inspectOptions, {
               showHidden: true,
-              showProxy: true
+              showProxy: true,
+              depth: 4
             });
             tempStr = inspect(arguments[a++], opts);
             break;


### PR DESCRIPTION
This reverts commit 1a1fe53e3dbd0042807b75caac94dcae0abe4dc1.

This was part of another PR of which the first commit was reverted. This change alone was however not intended. Since this change was done by accident on master already (a faulty rebase in a different PR) this is only here as a backport for v11.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
