### PR TITLE
tools: capitalize sentences

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,18 @@ module.exports = {
     'arrow-spacing': ['error', { before: true, after: true }],
     'block-spacing': 'error',
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
+    'capitalized-comments': ['error', 'always', {
+      line: {
+        // Ignore all lines that have less characters than 62 and all lines that
+        // start with something that looks like a variable name or code.
+        ignorePattern: '^.{0,62}$|^ [a-z]+ ?[0-9A-Z_.(/=:-]',
+        ignoreInlineComments: true,
+        ignoreConsecutiveComments: true
+      },
+      block: {
+        ignorePattern: '.*'
+      }
+    }],
     'comma-dangle': ['error', 'only-multiline'],
     'comma-spacing': 'error',
     'comma-style': 'error',

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -49,7 +49,7 @@ function CLI(usage, settings) {
         this.optional[currentOptional] = true;
         mode = 'both';
       } else {
-        // expect the next value to be option related (either -- or the value)
+        // Expect the next value to be option related (either -- or the value)
         mode = 'option';
       }
     } else if (mode === 'option') {

--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -31,7 +31,7 @@ function childProcessExecStdout({ dur, len }) {
       try {
         execSync(`taskkill /f /t /pid ${child.pid}`);
       } catch {
-        // this is a best effort kill. stderr is piped to parent for tracing.
+        // This is a best effort kill. stderr is piped to parent for tracing.
       }
     } else {
       child.kill();

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -146,7 +146,7 @@ Benchmark.prototype._run = function() {
   (function recursive(queueIndex) {
     const config = self.queue[queueIndex];
 
-    // set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't construct
+    // Set NODE_RUN_BENCHMARK_FN to indicate that the child shouldn't construct
     // a configuration queue, but just execute the benchmark function.
     const childEnv = Object.assign({}, process.env);
     childEnv.NODE_RUN_BENCHMARK_FN = '';
@@ -187,7 +187,7 @@ Benchmark.prototype.start = function() {
 };
 
 Benchmark.prototype.end = function(operations) {
-  // get elapsed time now and do error checking later for accuracy.
+  // Get elapsed time now and do error checking later for accuracy.
   const elapsed = process.hrtime(this._time);
 
   if (!this._started) {

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -58,7 +58,7 @@ function main({ api, cipher, type, len, writes }) {
 
   const fn = api === 'stream' ? streamWrite : legacyWrite;
 
-  // write data as fast as possible to alice, and have bob decrypt.
+  // Write data as fast as possible to alice, and have bob decrypt.
   // use old API for comparison to v0.8
   bench.start();
   fn(alice_cipher, bob_cipher, message, encoding, writes);

--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -1,4 +1,4 @@
-// test UDP send throughput with the multi buffer API against Buffer.concat
+// Test UDP send throughput with the multi buffer API against Buffer.concat
 'use strict';
 
 const common = require('../common.js');

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -1,4 +1,4 @@
-// test UDP send/recv throughput with the "old" offset/length API
+// Test UDP send/recv throughput with the "old" offset/length API
 'use strict';
 
 const common = require('../common.js');

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -7,7 +7,7 @@
 const assert = require('assert');
 const common = require('../../common.js');
 
-// this fails when we try to open with a different version of node,
+// This fails when we try to open with a different version of node,
 // which is quite common for benchmarks.  so in that case, just
 // abort quietly.
 

--- a/benchmark/net/net-wrap-js-stream-passthrough.js
+++ b/benchmark/net/net-wrap-js-stream-passthrough.js
@@ -1,4 +1,4 @@
-// test the speed of .pipe() with JSStream wrapping for PassThrough streams
+// Test the speed of .pipe() with JSStream wrapping for PassThrough streams
 'use strict';
 
 const common = require('../common.js');

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -61,12 +61,12 @@ asyncHook.disable();
 // resource referenced by "asyncId" may not have been populated.
 function init(asyncId, type, triggerAsyncId, resource) { }
 
-// before is called just before the resource's callback is called. It can be
+// Before is called just before the resource's callback is called. It can be
 // called 0-N times for handles (e.g. TCPWrap), and will be called exactly 1
 // time for requests (e.g. FSReqCallback).
 function before(asyncId) { }
 
-// after is called just after the resource's callback has finished.
+// After is called just after the resource's callback has finished.
 function after(asyncId) { }
 
 // destroy is called when an AsyncWrap instance is destroyed.
@@ -159,7 +159,7 @@ const fs = require('fs');
 const util = require('util');
 
 function debug(...args) {
-  // use a function like this one when debugging inside an AsyncHooks callback
+  // Use a function like this one when debugging inside an AsyncHooks callback
   fs.writeFileSync('log.out', `${util.format(...args)}\n`, { flag: 'a' });
 }
 ```

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -772,7 +772,7 @@ const uncompressedKey = ECDH.convertKey(compressedKey,
                                         'hex',
                                         'uncompressed');
 
-// the converted key and the uncompressed public key should be the same
+// The converted key and the uncompressed public key should be the same
 console.log(uncompressedKey === ecdh.getPublicKey('hex'));
 ```
 

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -143,7 +143,7 @@ if (cluster.isMaster) {
         // a new worker.
         cluster.worker.disconnect();
 
-        // try to send an error to the request that triggered the problem
+        // Try to send an error to the request that triggered the problem
         res.statusCode = 500;
         res.setHeader('content-type', 'text/plain');
         res.end('Oops, there was a problem!\n');

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -371,7 +371,7 @@ range, or outside the set of options for a given function parameter.
 
 ```js
 require('net').connect(-1);
-// throws "RangeError: "port" option should be >= 0 and < 65536: -1"
+// Throws "RangeError: "port" option should be >= 0 and < 65536: -1"
 ```
 
 Node.js will generate and throw `RangeError` instances *immediately* as a form
@@ -388,7 +388,7 @@ will do so.
 
 ```js
 doesNotExist;
-// throws ReferenceError, doesNotExist is not a variable in this program.
+// Throws ReferenceError, doesNotExist is not a variable in this program.
 ```
 
 Unless an application is dynamically generating and running code,

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -638,14 +638,14 @@ emitter.once('log', () => console.log('log once'));
 const listeners = emitter.rawListeners('log');
 const logFnWrapper = listeners[0];
 
-// logs "log once" to the console and does not unbind the `once` event
+// Logs "log once" to the console and does not unbind the `once` event
 logFnWrapper.listener();
 
 // logs "log once" to the console and removes the listener
 logFnWrapper();
 
 emitter.on('log', () => console.log('log persistently'));
-// will return a new Array with a single function bound by `.on()` above
+// Will return a new Array with a single function bound by `.on()` above
 const newListeners = emitter.rawListeners('log');
 
 // logs "log persistently" twice

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1926,7 +1926,7 @@ console.log(fs.readFileSync('temp.txt', 'utf8'));
 // get the file descriptor of the file to be truncated
 const fd = fs.openSync('temp.txt', 'r+');
 
-// truncate the file to 10 bytes, whereas the actual size is 7 bytes
+// Truncate the file to 10 bytes, whereas the actual size is 7 bytes
 fs.ftruncate(fd, 10, (err) => {
   assert.ifError(err);
   console.log(fs.readFileSync('temp.txt'));

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -49,7 +49,7 @@ console.log(`The area of mySquare is ${mySquare.area()}`);
 The `square` module is defined in `square.js`:
 
 ```js
-// assigning to exports will not modify module, must use module.exports
+// Assigning to exports will not modify module, must use module.exports
 module.exports = class Square {
   constructor(width) {
     this.width = width;

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -286,7 +286,7 @@ The listener function is called with the following arguments:
 ```js
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at:', p, 'reason:', reason);
-  // application specific logging, throwing an error, or other logic here
+  // Application specific logging, throwing an error, or other logic here
 });
 
 somePromise.then((res) => {

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -131,7 +131,7 @@ const server = http.createServer((req, res) => {
     body += chunk;
   });
 
-  // the 'end' event indicates that the entire body has been received
+  // The 'end' event indicates that the entire body has been received
   req.on('end', () => {
     try {
       const data = JSON.parse(body);

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -159,7 +159,7 @@ const util = require('util');
 const fn1 = util.deprecate(someFunction, someMessage, 'DEP0001');
 const fn2 = util.deprecate(someOtherFunction, someOtherMessage, 'DEP0001');
 fn1(); // emits a deprecation warning with code DEP0001
-fn2(); // does not emit a deprecation warning because it has the same code
+fn2(); // Does not emit a deprecation warning because it has the same code
 ```
 
 If either the `--no-deprecation` or `--no-warnings` command line flags are

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -109,7 +109,7 @@ const { MessageChannel } = require('worker_threads');
 const { port1, port2 } = new MessageChannel();
 port1.on('message', (message) => console.log('received', message));
 port2.postMessage({ foo: 'bar' });
-// prints: received { foo: 'bar' } from the `port1.on('message')` listener
+// Prints: received { foo: 'bar' } from the `port1.on('message')` listener
 ```
 
 ## Class: MessagePort

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -50,7 +50,7 @@ function Agent(options) {
 
   this.options = util._extend({}, options);
 
-  // don't confuse net and make it think that we're connecting to a pipe
+  // Don't confuse net and make it think that we're connecting to a pipe
   this.options.path = null;
   this.requests = {};
   this.sockets = {};

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -388,7 +388,7 @@ function _storeHeader(firstLine, headers) {
   this._header = header + CRLF;
   this._headerSent = false;
 
-  // wait until the first body chunk, or close(), is sent to flush,
+  // Wait until the first body chunk, or close(), is sent to flush,
   // UNLESS we're sending Expect: 100-continue.
   if (state.expect) this._send('');
 }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -263,7 +263,7 @@ function writeHead(statusCode, reason, obj) {
     this._hasBody = false;
   }
 
-  // don't keep alive connections where the client expects 100 Continue
+  // Don't keep alive connections where the client expects 100 Continue
   // but we sent a final status; they may put extra bytes on the wire.
   if (this._expect_continue && !this._sent100) {
     this.shouldKeepAlive = false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -86,7 +86,7 @@ function ReadableState(options, stream, isDuplex) {
   if (isDuplex)
     this.objectMode = this.objectMode || !!options.readableObjectMode;
 
-  // the point at which it stops calling _read() to fill the buffer
+  // The point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   this.highWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark',
                                         isDuplex);
@@ -103,7 +103,7 @@ function ReadableState(options, stream, isDuplex) {
   this.endEmitted = false;
   this.reading = false;
 
-  // a flag to be able to tell if the event 'readable'/'data' is emitted
+  // A flag to be able to tell if the event 'readable'/'data' is emitted
   // immediately, or on a later tick.  We set this to true at first, because
   // any actions that shouldn't happen until "later" should generally also
   // not happen before the first read call.
@@ -131,7 +131,7 @@ function ReadableState(options, stream, isDuplex) {
   // Everything else in the universe uses 'utf8', though.
   this.defaultEncoding = options.defaultEncoding || 'utf8';
 
-  // the number of writers that are awaiting a drain event in .pipe()s
+  // The number of writers that are awaiting a drain event in .pipe()s
   this.awaitDrain = 0;
 
   // if true, a maybeReadMore has been scheduled
@@ -374,7 +374,7 @@ function howMuchToRead(n, state) {
   return state.length;
 }
 
-// you can override either this method, or the async _read(n) below.
+// You can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
   debug('read', n);
   n = parseInt(n, 10);
@@ -436,13 +436,13 @@ Readable.prototype.read = function(n) {
   var doRead = state.needReadable;
   debug('need readable', doRead);
 
-  // if we currently have less than the highWaterMark, then also read some
+  // If we currently have less than the highWaterMark, then also read some
   if (state.length === 0 || state.length - n < state.highWaterMark) {
     doRead = true;
     debug('length less than watermark', doRead);
   }
 
-  // however, if we've ended, then there's no point, and if we're already
+  // However, if we've ended, then there's no point, and if we're already
   // reading, then it's unnecessary.
   if (state.ended || state.reading) {
     doRead = false;
@@ -451,7 +451,7 @@ Readable.prototype.read = function(n) {
     debug('do read');
     state.reading = true;
     state.sync = true;
-    // if the length is currently zero, then we *need* a readable event.
+    // If the length is currently zero, then we *need* a readable event.
     if (state.length === 0)
       state.needReadable = true;
     // call internal read method
@@ -554,7 +554,7 @@ function emitReadable_(stream) {
 }
 
 
-// at this point, the user has presumably seen the 'readable' event,
+// At this point, the user has presumably seen the 'readable' event,
 // and called read() to consume some data.  that may have triggered
 // in turn another _read(n) call, in which case reading = true if
 // it's in progress.
@@ -582,7 +582,7 @@ function maybeReadMore_(stream, state) {
   state.readingMore = false;
 }
 
-// abstract method.  to be overridden in specific implementation classes.
+// Abstract method.  to be overridden in specific implementation classes.
 // call cb(er, data) where data is <= n in length.
 // for virtual (non-string, non-buffer) streams, "length" is somewhat
 // arbitrary, and perhaps not very meaningful.

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -116,10 +116,10 @@ function Transform(options) {
     writeencoding: null
   };
 
-  // start out asking for a readable event once data is transformed.
+  // Start out asking for a readable event once data is transformed.
   this._readableState.needReadable = true;
 
-  // we have implemented the _read method, and done the other things
+  // We have implemented the _read method, and done the other things
   // that Readable wants before the first _read call, so unset the
   // sync guard flag.
   this._readableState.sync = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -90,7 +90,7 @@ function WritableState(options, stream, isDuplex) {
   // has it been destroyed
   this.destroyed = false;
 
-  // should we decode strings into buffers before passing to _write?
+  // Should we decode strings into buffers before passing to _write?
   // this is here so that some node-core streams can optimize string
   // handling at a lower level.
   var noDecode = options.decodeStrings === false;
@@ -112,13 +112,13 @@ function WritableState(options, stream, isDuplex) {
   // when true all writes will be buffered until .uncork() call
   this.corked = 0;
 
-  // a flag to be able to tell if the onwrite cb is called immediately,
+  // A flag to be able to tell if the onwrite cb is called immediately,
   // or on a later tick.  We set this to true at first, because any
   // actions that shouldn't happen until "later" should generally also
   // not happen before the first write call.
   this.sync = true;
 
-  // a flag to know if we're processing previously buffered items, which
+  // A flag to know if we're processing previously buffered items, which
   // may call the _write() callback in the same tick, so that we don't
   // end up in an overlapped onwrite situation.
   this.bufferProcessing = false;
@@ -126,7 +126,7 @@ function WritableState(options, stream, isDuplex) {
   // the callback that's passed to _write(chunk,cb)
   this.onwrite = onwrite.bind(undefined, stream);
 
-  // the callback that the user supplies to write(chunk,encoding,cb)
+  // The callback that the user supplies to write(chunk,encoding,cb)
   this.writecb = null;
 
   // the amount that is being written when _write is called.
@@ -139,7 +139,7 @@ function WritableState(options, stream, isDuplex) {
   // this must be 0 before 'finish' can be emitted
   this.pendingcb = 0;
 
-  // emit prefinish if the only thing we're waiting for is _write cbs
+  // Emit prefinish if the only thing we're waiting for is _write cbs
   // This is relevant for synchronous Transform streams
   this.prefinished = false;
 
@@ -376,7 +376,7 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
   state.length += len;
 
   var ret = state.length < state.highWaterMark;
-  // we must ensure that previous needDrain will not be reset to false.
+  // We must ensure that previous needDrain will not be reset to false.
   if (!ret)
     state.needDrain = true;
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -916,7 +916,7 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
     if (string.length > 0 && (length < 0 || offset < 0))
       throw new ERR_BUFFER_OUT_OF_BOUNDS();
   } else {
-    // if someone is still calling the obsolete form of write(), tell them.
+    // If someone is still calling the obsolete form of write(), tell them.
     // we don't want eg buf.write("foo", "utf8", 10) to silently turn into
     // buf.write("foo", "utf8"), so we can't ignore extra args
     throw new ERR_NO_LONGER_SUPPORTED(

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -313,7 +313,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
 };
 
 
-// thin wrapper around `send`, here for compatibility with dgram_legacy.js
+// Thin wrapper around `send`, here for compatibility with dgram_legacy.js
 Socket.prototype.sendto = function(buffer,
                                    offset,
                                    length,

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -35,7 +35,7 @@ const {
 } = require('internal/errors').codes;
 const { createHook } = require('async_hooks');
 
-// overwrite process.domain with a getter/setter that will allow for more
+// Overwrite process.domain with a getter/setter that will allow for more
 // effective optimizations
 var _domain = [null];
 Object.defineProperty(process, 'domain', {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1452,7 +1452,7 @@ function realpathSync(p, options) {
   let pos;
   // the partial path so far, including a trailing slash if any
   let current;
-  // the partial path without a trailing slash (except when pointing at a root)
+  // The partial path without a trailing slash (except when pointing at a root)
   let base;
   // the partial path scanned in the previous round, with slash
   let previous;
@@ -1469,7 +1469,7 @@ function realpathSync(p, options) {
     knownHard[base] = true;
   }
 
-  // walk down the path, swapping out linked path parts for their real
+  // Walk down the path, swapping out linked path parts for their real
   // values
   // NB: p.length changes.
   while (pos < p.length) {
@@ -1592,7 +1592,7 @@ function realpath(p, options, callback) {
   let pos;
   // the partial path so far, including a trailing slash if any
   let current;
-  // the partial path without a trailing slash (except when pointing at a root)
+  // The partial path without a trailing slash (except when pointing at a root)
   let base;
   // the partial path scanned in the previous round, with slash
   let previous;
@@ -1611,7 +1611,7 @@ function realpath(p, options, callback) {
     process.nextTick(LOOP);
   }
 
-  // walk down the path, swapping out linked path parts for their real
+  // Walk down the path, swapping out linked path parts for their real
   // values
   function LOOP() {
     // stop if scanned past end of path

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -62,7 +62,7 @@ let HTTPParser;
 
 const MAX_HANDLE_RETRANSMISSIONS = 3;
 
-// this object contain function to convert TCP objects to native handle objects
+// This object contain function to convert TCP objects to native handle objects
 // and back again.
 const handleConversion = {
   'net.Native': {
@@ -117,7 +117,7 @@ const handleConversion = {
 
       var handle = socket._handle;
 
-      // remove handle from socket object, it will be closed when the socket
+      // Remove handle from socket object, it will be closed when the socket
       // will be sent
       if (!options.keepOpen) {
         handle.onread = nop;
@@ -166,7 +166,7 @@ const handleConversion = {
         writable: true
       });
 
-      // if the socket was created by net.Server we will track the socket
+      // If the socket was created by net.Server we will track the socket
       if (message.key) {
 
         // add socket to connections list
@@ -663,7 +663,7 @@ function setupChannel(target, channel) {
 
     // package messages with a handle object
     if (handle) {
-      // this message will be handled by an internalMessage event handler
+      // This message will be handled by an internalMessage event handler
       message = {
         cmd: 'NODE_HANDLE',
         type: null,
@@ -768,7 +768,7 @@ function setupChannel(target, channel) {
     return channel.writeQueueSize < (65536 * 2);
   };
 
-  // connected will be set to false immediately when a disconnect() is
+  // Connected will be set to false immediately when a disconnect() is
   // requested, even though the channel might still be alive internally to
   // process queued messages. The three states are distinguished as follows:
   // - disconnect() never requested: channel is not null and connected

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -223,7 +223,7 @@ Console.prototype[kWriteToConsole] = function(streamSymbol, string) {
 
     stream.write(string, errorHandler);
   } catch (e) {
-    // console is a debugging utility, so it swallowing errors is not desirable
+    // Console is a debugging utility, so it swallowing errors is not desirable
     // even in edge cases such as low stack space.
     if (isStackOverflowError(e))
       throw e;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -231,7 +231,7 @@ function onStreamCloseRequest() {
   state.closed = true;
 
   req.push(null);
-  // if the user didn't interact with incoming data and didn't pipe it,
+  // If the user didn't interact with incoming data and didn't pipe it,
   // dump it for compatibility with http1
   if (!state.didRead && !req._readableState.resumeScheduled)
     req.resume();

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -266,7 +266,7 @@ function onSessionHeaders(handle, id, cat, flags, headers) {
 
   if (stream === undefined) {
     if (session.closed) {
-      // we are not accepting any new streams at this point. This callback
+      // We are not accepting any new streams at this point. This callback
       // should not be invoked at this point in time, but just in case it is,
       // refuse the stream using an RST_STREAM and destroy the handle.
       handle.rstStream(NGHTTP2_REFUSED_STREAM);
@@ -1112,7 +1112,7 @@ class Http2Session extends EventEmitter {
     return this[kState].goawayLastStreamID || 0;
   }
 
-  // true if the Http2Session is waiting for a settings acknowledgement
+  // True if the Http2Session is waiting for a settings acknowledgement
   get pendingSettingsAck() {
     return this[kState].pendingAck > 0;
   }
@@ -2235,7 +2235,7 @@ class ServerHttp2Stream extends Http2Stream {
            this[kSession].remoteSettings.enablePush;
   }
 
-  // create a push stream, call the given callback with the created
+  // Create a push stream, call the given callback with the created
   // Http2Stream for the push stream.
   pushStream(headers, options, callback) {
     if (!this.pushAllowed)

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -290,7 +290,7 @@ function getDefaultSettings() {
   return holder;
 }
 
-// remote is a boolean. true to fetch remote settings, false to fetch local.
+// Remote is a boolean. true to fetch remote settings, false to fetch local.
 // this is only called internally
 function getSettings(session, remote) {
   if (remote)

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -138,7 +138,7 @@ const debug = util.debuglog('module');
 Module._debug = util.deprecate(debug, 'Module._debug is deprecated.',
                                'DEP0077');
 
-// given a module name, and a list of paths to test, returns the first
+// Given a module name, and a list of paths to test, returns the first
 // matching file in the following precedence.
 //
 // require("a.<ext>")
@@ -207,7 +207,7 @@ function toRealPath(requestPath) {
   });
 }
 
-// given a path, check if the file exists with any of the set extensions
+// Given a path, check if the file exists with any of the set extensions
 function tryExtensions(p, exts, isMain) {
   for (var i = 0; i < exts.length; i++) {
     const filename = tryFile(p + exts[i], isMain);
@@ -452,7 +452,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
 
   // with --eval, parent.id is not set and parent.filename is null
   if (!parent || !parent.id || !parent.filename) {
-    // make require('./path/to/foo') work - normally the path is taken
+    // Make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename
     var mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
 
@@ -498,7 +498,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
   }
   var id = path.resolve(parentIdPath, request);
 
-  // make sure require('./path') and require('path') get distinct ids, even
+  // Make sure require('./path') and require('path') get distinct ids, even
   // when called from the toplevel js file
   if (parentIdPath === '.' &&
       id.indexOf('/') === -1 &&
@@ -625,7 +625,7 @@ Module.prototype.load = function(filename) {
     const ESMLoader = asyncESM.ESMLoader;
     const url = `${pathToFileURL(filename)}`;
     const module = ESMLoader.moduleMap.get(url);
-    // create module entry at load time to snapshot exports correctly
+    // Create module entry at load time to snapshot exports correctly
     const exports = this.exports;
     if (module !== undefined) { // called from cjs translator
       module.reflect.onReady((reflect) => {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -67,7 +67,7 @@ translators.set('cjs', async (url, isMain) => {
   }
   return createDynamicModule(['default'], url, () => {
     debug(`Loading CJSModule ${url}`);
-    // we don't care about the return val of _load here because Module#load
+    // We don't care about the return val of _load here because Module#load
     // will handle it for us by checking the loader registry and filling the
     // exports like above
     CJSModule._load(pathname, undefined, isMain);

--- a/lib/internal/repl/recoverable.js
+++ b/lib/internal/repl/recoverable.js
@@ -45,7 +45,7 @@ function isRecoverableError(e, code) {
 
           case 'Unterminated string constant':
             const token = this.input.slice(this.lastTokStart, this.pos);
-            // see https://www.ecma-international.org/ecma-262/#sec-line-terminators
+            // See https://www.ecma-international.org/ecma-262/#sec-line-terminators
             recoverable = /\\(?:\r\n?|\n|\u2028|\u2029)$/.test(token);
         }
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -17,14 +17,14 @@ function destroy(err, cb) {
     return this;
   }
 
-  // we set destroyed to true before firing error callbacks in order
+  // We set destroyed to true before firing error callbacks in order
   // to make it re-entrance safe in case destroy() is called within callbacks
 
   if (this._readableState) {
     this._readableState.destroyed = true;
   }
 
-  // if this is a duplex stream mark the writable part as destroyed as well
+  // If this is a duplex stream mark the writable part as destroyed as well
   if (this._writableState) {
     this._writableState.destroyed = true;
   }

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -123,7 +123,7 @@ function setUnrefTimeout(callback, after, arg1, arg2, arg3) {
     default:
       args = [arg1, arg2, arg3];
       for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
+        // Extend array dynamically, makes .apply run much faster in v6.0.0
         args[i - 2] = arguments[i];
       }
       break;

--- a/lib/net.js
+++ b/lib/net.js
@@ -209,7 +209,7 @@ function normalizeArgs(args) {
 }
 
 
-// called when creating new Socket, or when re-using a closed Socket
+// Called when creating new Socket, or when re-using a closed Socket
 function initSocketHandle(self) {
   self._undestroy();
   self._sockname = null;
@@ -1266,10 +1266,10 @@ function setupListenHandle(address, port, addressType, backlog, fd, flags) {
     return;
   }
 
-  // generate connection key, this should be unique to the connection
+  // Generate connection key, this should be unique to the connection
   this._connectionKey = addressType + ':' + address + ':' + port;
 
-  // unref the handle if the server was unref'ed prior to listening
+  // Unref the handle if the server was unref'ed prior to listening
   if (this._unref)
     this.unref();
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -357,7 +357,7 @@ Interface.prototype._refreshLine = function() {
   // cursor position
   var cursorPos = this._getCursorPos();
 
-  // first move to the bottom of the current line, based on cursor pos
+  // First move to the bottom of the current line, based on cursor pos
   var prevRows = this.prevRows || 0;
   if (prevRows > 0) {
     moveCursor(this.output, 0, -prevRows);
@@ -445,7 +445,7 @@ Interface.prototype._normalWrite = function(b) {
 
     // got one or more newlines; process into "line" events
     var lines = string.split(lineEnding);
-    // either '' or (conceivably) the unfinished portion of the next line
+    // Either '' or (conceivably) the unfinished portion of the next line
     string = lines.pop();
     this._line_buffer = string;
     for (var n = 0; n < lines.length; n++)

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -389,7 +389,7 @@ function unenroll(item) {
   }
   item[kRefed] = null;
 
-  // if active is called later, then we want to make sure not to insert again
+  // If active is called later, then we want to make sure not to insert again
   item._idleTimeout = -1;
 }
 
@@ -444,7 +444,7 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
     default:
       args = [arg1, arg2, arg3];
       for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
+        // Extend array dynamically, makes .apply run much faster in v6.0.0
         args[i - 2] = arguments[i];
       }
       break;
@@ -493,7 +493,7 @@ exports.setInterval = function setInterval(callback, repeat, arg1, arg2, arg3) {
     default:
       args = [arg1, arg2, arg3];
       for (i = 5; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
+        // Extend array dynamically, makes .apply run much faster in v6.0.0
         args[i - 2] = arguments[i];
       }
       break;
@@ -712,7 +712,7 @@ function setImmediate(callback, arg1, arg2, arg3) {
     default:
       args = [arg1, arg2, arg3];
       for (i = 4; i < arguments.length; i++) {
-        // extend array dynamically, makes .apply run much faster in v6.0.0
+        // Extend array dynamically, makes .apply run much faster in v6.0.0
         args[i - 1] = arguments[i];
       }
       break;

--- a/lib/url.js
+++ b/lib/url.js
@@ -461,7 +461,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     this.path = p + s;
   }
 
-  // finally, reconstruct the href based on what has been validated.
+  // Finally, reconstruct the href based on what has been validated.
   this.href = this.format();
   return this;
 };
@@ -629,7 +629,7 @@ Url.prototype.format = function format() {
       pathname = newPathname;
   }
 
-  // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
+  // Only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
   // unless they had them to begin with.
   if (this.slashes || slashedProtocol.has(protocol)) {
     if (this.slashes || host) {
@@ -686,7 +686,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // even href="" will remove it.
   result.hash = relative.hash;
 
-  // if the relative url is empty, then there's nothing left to do here.
+  // If the relative url is empty, then there's nothing left to do here.
   if (relative.href === '') {
     result.href = result.format();
     return result;
@@ -888,7 +888,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     }
   }
 
-  // if the path is allowed to go above the root, restore leading ..s
+  // If the path is allowed to go above the root, restore leading ..s
   if (!mustEndAbs && !removeAllDots) {
     while (up--) {
       srcPath.unshift('..');

--- a/lib/util.js
+++ b/lib/util.js
@@ -292,7 +292,7 @@ function timestamp() {
   return [d.getDate(), months[d.getMonth()], time].join(' ');
 }
 
-// log is just a thin wrapper to console.log that prepends a timestamp
+// Log is just a thin wrapper to console.log that prepends a timestamp
 function log() {
   console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
 }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -510,7 +510,7 @@ function processChunkSync(self, chunk, flushFlag) {
       assert(have === 0, 'have should not go down');
     }
 
-    // exhausted the output buffer, or used all the input create a new one.
+    // Exhausted the output buffer, or used all the input create a new one.
     if (availOutAfter === 0 || offset >= chunkSize) {
       availOutBefore = chunkSize;
       offset = 0;
@@ -599,7 +599,7 @@ function processCallback() {
     return;
   }
 
-  // exhausted the output buffer, or used all the input create a new one.
+  // Exhausted the output buffer, or used all the input create a new one.
   if (availOutAfter === 0 || self._outOffset >= self._chunkSize) {
     handle.availOutBefore = self._chunkSize;
     self._outOffset = 0;

--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -10,7 +10,7 @@ if (process.argv[2] === 'child') {
   const stderr = child.stderr.toString();
 
   assert.strictEqual(child.stdout.toString(), '');
-  // stderr will be empty for systems that don't support backtraces.
+  // Stderr will be empty for systems that don't support backtraces.
   if (stderr !== '') {
     const frames = stderr.trimRight().split('\n').map((s) => s.trim());
 

--- a/test/async-hooks/test-async-await.js
+++ b/test/async-hooks/test-async-await.js
@@ -14,7 +14,7 @@ const util = require('util');
 const sleep = util.promisify(setTimeout);
 // either 'inited' or 'resolved'
 const promisesInitState = new Map();
-// either 'before' or 'after' AND asyncId must be present in the other map
+// Either 'before' or 'after' AND asyncId must be present in the other map
 const promisesExecutionState = new Map();
 
 const hooks = initHooks({

--- a/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'child') {
   const hooks = initHooks();
   hooks.enable();
 
-  // once 'destroy' has been emitted, we can no longer emit 'after'
+  // Once 'destroy' has been emitted, we can no longer emit 'after'
 
   // Emitting 'before', 'after' and then 'destroy'
   const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());

--- a/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'child') {
   const hooks = initHooks();
   hooks.enable();
 
-  // once 'destroy' has been emitted, we can no longer emit 'before'
+  // Once 'destroy' has been emitted, we can no longer emit 'before'
 
   // Emitting 'before', 'after' and then 'destroy'
   const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());

--- a/test/async-hooks/test-embedder.api.async-resource.improper-order.js
+++ b/test/async-hooks/test-embedder.api.async-resource.improper-order.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'child') {
   const hooks = initHooks();
   hooks.enable();
 
-  // async hooks enforce proper order of 'before' and 'after' invocations
+  // Async hooks enforce proper order of 'before' and 'after' invocations
 
   // Proper ordering
   const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -29,13 +29,13 @@ assert.strictEqual(
   async_hooks.executionAsyncId()
 );
 
-// create first custom event 'alcazares' with triggerAsyncId derived
+// Create first custom event 'alcazares' with triggerAsyncId derived
 // from async_hooks executionAsyncId
 const alcaTriggerId = async_hooks.executionAsyncId();
 const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
 const alcazaresActivities = hooks.activitiesOfTypes([ 'alcazares' ]);
 
-// alcazares event was constructed and thus only has an `init` call
+// Alcazares event was constructed and thus only has an `init` call
 assert.strictEqual(alcazaresActivities.length, 1);
 const alcazares = alcazaresActivities[0];
 assert.strictEqual(alcazares.type, 'alcazares');
@@ -83,7 +83,7 @@ function tick1() {
   checkInvocations(poblado, { init: 1, before: 1, after: 1 },
                    'poblado emitted after');
 
-  // after we disable the hooks we shouldn't receive any events anymore
+  // After we disable the hooks we shouldn't receive any events anymore
   hooks.disable();
   alcaEvent.emitDestroy();
   tick(1, common.mustCall(tick2));

--- a/test/async-hooks/test-enable-disable.js
+++ b/test/async-hooks/test-enable-disable.js
@@ -261,7 +261,7 @@ function onexit() {
                    'hook2Second: when process exits');
   checkInvocations(hook3First, { init: 1, before: 1, after: 1, destroy: 1 },
                    'hook3First: when process exits');
-  // we don't see a "destroy" invocation here since hook3 disabled itself
+  // We don't see a "destroy" invocation here since hook3 disabled itself
   // during its "after" invocation
   checkInvocations(hook3Second, { init: 1, before: 1, after: 1 },
                    'hook3Second: when process exits');

--- a/test/async-hooks/test-fsreqcallback-readFile.js
+++ b/test/async-hooks/test-fsreqcallback-readFile.js
@@ -32,7 +32,7 @@ function onread() {
   checkInvocations(as[2], { init: 1, before: 1, after: 1, destroy: 1 },
                    'reqwrap[2]: while in onread callback');
 
-  // this callback is called from within the last fs req callback therefore
+  // This callback is called from within the last fs req callback therefore
   // the last req is still going and after/destroy haven't been called yet
   checkInvocations(as[3], { init: 1, before: 1 },
                    'reqwrap[3]: while in onread callback');

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -53,7 +53,7 @@ function onlisten() {
 
 const awaitOnconnectCalls = new Set(['server', 'client']);
 function maybeOnconnect(source) {
-  // both server and client must call onconnect. On most OS's waiting for
+  // Both server and client must call onconnect. On most OS's waiting for
   // the client is sufficient, but on CentOS 5 the sever needs to respond too.
   assert.ok(awaitOnconnectCalls.size > 0);
   awaitOnconnectCalls.delete(source);

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -22,7 +22,7 @@ nodeVersionSpawn
   .on('exit', common.mustCall(onsleepExit))
   .on('close', common.mustCall(onsleepClose));
 
-// a process wrap and 3 pipe wraps for std{in,out,err} are initialized
+// A process wrap and 3 pipe wraps for std{in,out,err} are initialized
 // synchronously
 const processes = hooks.activitiesOfTypes('PROCESSWRAP');
 const pipes = hooks.activitiesOfTypes('PIPEWRAP');

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -32,7 +32,7 @@ process.on('exit', function onexit() {
   const a0 = as[0];
   assert.strictEqual(a0.type, 'PROMISE');
   assert.strictEqual(typeof a0.uid, 'number');
-  // we can't get the asyncId from the parent dynamically, since init was
+  // We can't get the asyncId from the parent dynamically, since init was
   // never called. However, it is known that the parent promise was created
   // immediately before the child promise, thus there should only be one
   // difference in id.

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -92,7 +92,7 @@ function onexit() {
   checkInvocations(
     signal1, { init: 1, before: 2, after: 2, destroy: 1 },
     'signal1: when second SIGUSR2 process exits');
-  // second signal not destroyed yet since its event listener is still active
+  // Second signal not destroyed yet since its event listener is still active
   checkInvocations(
     signal2, { init: 1, before: 1, after: 1 },
     'signal2: when second SIGUSR2 process exits');

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -336,7 +336,7 @@ function _mustCallInner(fn, criteria = 1, field) {
     name: fn.name || '<anonymous>'
   };
 
-  // add the exit listener only once to avoid listener leak warnings
+  // Add the exit listener only once to avoid listener leak warnings
   if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
 
   mustCallChecks.push(context);
@@ -392,7 +392,7 @@ function getCallSite(top) {
     `${stack[0].getFileName()}:${stack[0].getLineNumber()}`;
   const err = new Error();
   Error.captureStackTrace(err, top);
-  // with the V8 Error API, the stack is not formatted until it is accessed
+  // With the V8 Error API, the stack is not formatted until it is accessed
   err.stack;
   Error.prepareStackTrace = originalStackFormatter;
   return err.stack;
@@ -507,7 +507,7 @@ function expectWarningByMap(warningMap) {
   process.on('warning', (warning) => catchWarning[warning.name](warning));
 }
 
-// accepts a warning name and description or array of descriptions or a map
+// Accepts a warning name and description or array of descriptions or a map
 // of warning names to description(s)
 // ensures a warning is generated for each name/description pair
 function expectWarning(nameOrMap, expected, code) {

--- a/test/es-module/test-esm-preserve-symlinks-main.js
+++ b/test/es-module/test-esm-preserve-symlinks-main.js
@@ -35,7 +35,7 @@ try {
 }
 
 function doTest(flags, done) {
-  // invoke the main file via a symlink.  In this case --preserve-symlinks-main
+  // Invoke the main file via a symlink.  In this case --preserve-symlinks-main
   // dictates that it'll resolve relative imports in the main file relative to
   // the symlink, and not relative to the symlink target; the file structure set
   // up above requires this to not crash when loading ./submodule_link.js

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -48,7 +48,7 @@ assert.strictEqual(test_general.testGetVersion(), 3);
   assert.strictEqual(test_general.testNapiTypeof(val), typeof val);
 });
 
-// since typeof in js return object need to validate specific case
+// Since typeof in js return object need to validate specific case
 // for null
 assert.strictEqual(test_general.testNapiTypeof(null), 'null');
 

--- a/test/js-native-api/test_number/test.js
+++ b/test/js-native-api/test_number/test.js
@@ -49,7 +49,7 @@ testUint32(4294967296, 0);
 testUint32(4294967297, 1);
 testUint32(17 * 4294967296 + 1, 1);
 
-// validate documented behavior when value is retrieved as 32-bit integer with
+// Validate documented behavior when value is retrieved as 32-bit integer with
 // `napi_get_value_int32`
 function testInt32(input, expected = input) {
   assert.strictEqual(expected, test_number.TestInt32Truncation(input));
@@ -92,7 +92,7 @@ testInt32(Number.POSITIVE_INFINITY, 0);
 testInt32(Number.NEGATIVE_INFINITY, 0);
 testInt32(Number.NaN, 0);
 
-// validate documented behavior when value is retrieved as 64-bit integer with
+// Validate documented behavior when value is retrieved as 64-bit integer with
 // `napi_get_value_int64`
 function testInt64(input, expected = input) {
   assert.strictEqual(expected, test_number.TestInt64Truncation(input));

--- a/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
+++ b/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
@@ -45,7 +45,7 @@ if (cluster.isMaster) {
   // worker code
   process.on('message', (msg) => msg === BYE && process.exit(0));
 
-  // first worker will bind to '0', second will try the assigned port and fail
+  // First worker will bind to '0', second will try the assigned port and fail
   const PRT1 = process.env.PRT1 || 0;
   const socket1 = dgram.createSocket('udp4', () => {});
   socket1.on('error', PRT1 === 0 ? () => {} : assert.fail);

--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -36,7 +36,7 @@ const keepAliveAgent = new http.Agent({
 
 const countdown = new Countdown(N, () => {
   server.close(() => {
-    // give the server sockets time to close (which will also free their
+    // Give the server sockets time to close (which will also free their
     // associated parser objects) after the server has been closed.
     setTimeout(() => {
       createdIds.forEach((createdAsyncId) => {

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -106,7 +106,7 @@ b.copy(Buffer.alloc(1), 1, 1, 1);
 // try to copy 0 bytes from past the end of the source buffer
 b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
-// testing for smart defaults and ability to pass string values as offset
+// Testing for smart defaults and ability to pass string values as offset
 {
   const writeTest = Buffer.from('abcdes');
   writeTest.write('n', 'ascii');
@@ -799,7 +799,7 @@ common.expectsError(
   outOfRangeError
 );
 
-// attempt to overflow buffers, similar to previous bug in array buffers
+// Attempt to overflow buffers, similar to previous bug in array buffers
 common.expectsError(
   () => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
   outOfRangeError

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -54,7 +54,7 @@ assert.strictEqual(a.compare(b, 0, { valueOf: () => 5 }), -1);
 // zero length target
 assert.strictEqual(a.compare(b, Infinity, -Infinity), 1);
 
-// zero length target because default for targetEnd <= targetSource
+// Zero length target because default for targetEnd <= targetSource
 assert.strictEqual(a.compare(b, '0xff'), 1);
 
 const oor = common.expectsError({ code: 'ERR_OUT_OF_RANGE' }, 7);

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -108,7 +108,7 @@ common.expectsError(
   errorProperty);
 
 {
-  // check sourceEnd resets to targetEnd if former is greater than the latter
+  // Check sourceEnd resets to targetEnd if former is greater than the latter
   b.fill(++cntr);
   c.fill(++cntr);
   b.copy(c, 0, 0, 1025);

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -13,22 +13,22 @@ function read(buff, funx, args, expected) {
   );
 }
 
-// testing basic functionality of readDoubleBE() and readDoubleLE()
+// Testing basic functionality of readDoubleBE() and readDoubleLE()
 read(buf, 'readDoubleBE', [1], -3.1827727774563287e+295);
 read(buf, 'readDoubleLE', [1], -6.966010051009108e+144);
 
-// testing basic functionality of readFloatBE() and readFloatLE()
+// Testing basic functionality of readFloatBE() and readFloatLE()
 read(buf, 'readFloatBE', [1], -1.6691549692541768e+37);
 read(buf, 'readFloatLE', [1], -7861303808);
 
 // testing basic functionality of readInt8()
 read(buf, 'readInt8', [1], -3);
 
-// testing basic functionality of readInt16BE() and readInt16LE()
+// Testing basic functionality of readInt16BE() and readInt16LE()
 read(buf, 'readInt16BE', [1], -696);
 read(buf, 'readInt16LE', [1], 0x48fd);
 
-// testing basic functionality of readInt32BE() and readInt32LE()
+// Testing basic functionality of readInt32BE() and readInt32LE()
 read(buf, 'readInt32BE', [1], -45552945);
 read(buf, 'readInt32LE', [1], -806729475);
 
@@ -39,11 +39,11 @@ read(buf, 'readIntLE', [2, 1], 0x48);
 // testing basic functionality of readUInt8()
 read(buf, 'readUInt8', [1], 0xfd);
 
-// testing basic functionality of readUInt16BE() and readUInt16LE()
+// Testing basic functionality of readUInt16BE() and readUInt16LE()
 read(buf, 'readUInt16BE', [2], 0x48ea);
 read(buf, 'readUInt16LE', [2], 0xea48);
 
-// testing basic functionality of readUInt32BE() and readUInt32LE()
+// Testing basic functionality of readUInt32BE() and readUInt32LE()
 read(buf, 'readUInt32BE', [1], 0xfd48eacf);
 read(buf, 'readUInt32LE', [1], 0xcfea48fd);
 

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -35,7 +35,7 @@ assert.strictEqual(rangeBuffer.toString('ascii', undefined, 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', false, 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', '', 3), 'abc');
 
-// but, if start is an integer when coerced, then it will be coerced and used.
+// But, if start is an integer when coerced, then it will be coerced and used.
 assert.strictEqual(rangeBuffer.toString('ascii', '-1', 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', '1', 3), 'bc');
 assert.strictEqual(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
@@ -47,7 +47,7 @@ assert.strictEqual(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', 1.99, 3), 'bc');
 assert.strictEqual(rangeBuffer.toString('ascii', true, 3), 'bc');
 
-// if end > buffer's length, end will be taken as buffer's length
+// If end > buffer's length, end will be taken as buffer's length
 assert.strictEqual(rangeBuffer.toString('ascii', 0, 5), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, 6.99), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, Infinity), 'abc');
@@ -55,7 +55,7 @@ assert.strictEqual(rangeBuffer.toString('ascii', 0, '5'), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, '6.99'), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, 'Infinity'), 'abc');
 
-// if end is an invalid integer, end will be taken as buffer's length
+// If end is an invalid integer, end will be taken as buffer's length
 assert.strictEqual(rangeBuffer.toString('ascii', 0, 'node.js'), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, {}), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, NaN), '');
@@ -66,7 +66,7 @@ assert.strictEqual(rangeBuffer.toString('ascii', 0, []), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, false), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, ''), '');
 
-// but, if end is an integer when coerced, then it will be coerced and used.
+// But, if end is an integer when coerced, then it will be coerced and used.
 assert.strictEqual(rangeBuffer.toString('ascii', 0, '-1'), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, '1'), 'a');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, '-Infinity'), '');

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -91,7 +91,7 @@ const s = 'string';
 const u = undefined;
 const n = null;
 
-// function spawn(file=f [,args=a] [, options=o]) has valid combinations:
+// Function spawn(file=f [,args=a] [, options=o]) has valid combinations:
 //   (f)
 //   (f, a)
 //   (f, a, o)

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -45,7 +45,7 @@ if (process.argv[2] === 'child') {
     assert.fail(`Unexpected parent stderr: ${data}`);
   });
 
-  // check if we receive both 'hello' at start and 'goodbye' at end
+  // Check if we receive both 'hello' at start and 'goodbye' at end
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(data) {
     stdout += data;

--- a/test/parallel/test-cluster-setup-master-multiple.js
+++ b/test/parallel/test-cluster-setup-master-multiple.js
@@ -62,7 +62,7 @@ execs.forEach((v, i) => {
   }, i * 100);
 });
 
-// cluster emits 'setup' asynchronously, so we must stay alive long
+// Cluster emits 'setup' asynchronously, so we must stay alive long
 // enough for that to happen
 setTimeout(() => {
   console.log('cluster setup complete');

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -26,7 +26,7 @@ const cluster = require('cluster');
 
 const SENTINEL = 42;
 
-// workers forcibly exit when control channel is disconnected, if
+// Workers forcibly exit when control channel is disconnected, if
 // their .exitedAfterDisconnect flag isn't set
 //
 // test this by:

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -30,7 +30,7 @@ let success;
 let worker;
 let server;
 
-// workers do not exit on disconnect, they exit under normal node rules: when
+// Workers do not exit on disconnect, they exit under normal node rules: when
 // they have nothing keeping their loop alive, like an active connection
 //
 // test this by:

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -174,7 +174,7 @@ console.timeEnd();
 console.time(NaN);
 console.timeEnd(NaN);
 
-// make sure calling time twice without timeEnd doesn't reset the timer.
+// Make sure calling time twice without timeEnd doesn't reset the timer.
 console.time('test');
 const time = console._times.get('test');
 setTimeout(() => {
@@ -248,7 +248,7 @@ assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^constructor: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^hasOwnProperty: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 
-// verify that console.time() coerces label values to strings as expected
+// Verify that console.time() coerces label values to strings as expected
 assert.ok(/^: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^\[object Object\]: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^\[object Object\]: \d+\.\d{3}ms$/.test(strings.shift().trim()));

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -122,7 +122,7 @@ for (const test of TEST_CASES) {
     hex += encrypt.final('hex');
 
     const auth_tag = encrypt.getAuthTag();
-    // only test basic encryption run if output is marked as tampered.
+    // Only test basic encryption run if output is marked as tampered.
     if (!test.tampered) {
       assert.strictEqual(hex, test.ct);
       assert.strictEqual(auth_tag.toString('hex'), test.tag);
@@ -170,7 +170,7 @@ for (const test of TEST_CASES) {
       let hex = encrypt.update(test.plain, 'ascii', 'hex');
       hex += encrypt.final('hex');
       const auth_tag = encrypt.getAuthTag();
-      // only test basic encryption run if output is marked as tampered.
+      // Only test basic encryption run if output is marked as tampered.
       if (!test.tampered) {
         assert.strictEqual(hex, test.ct);
         assert.strictEqual(auth_tag.toString('hex'), test.tag);

--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-// skip test in FreeBSD jails since 0.0.0.0 will resolve to default interface
+// Skip test in FreeBSD jails since 0.0.0.0 will resolve to default interface
 if (common.inFreeBSDJail)
   common.skip('In a FreeBSD jail');
 

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -92,7 +92,7 @@ source.on('close', function() {
 if (process.env.BOUND === 'y') {
   source.bind(0);
 } else {
-  // cluster doesn't know about exclusive sockets, so it won't close them. This
+  // Cluster doesn't know about exclusive sockets, so it won't close them. This
   // is expected, its the same situation for timers, outgoing tcp connections,
   // etc, which also keep workers alive after disconnect was requested.
   source.unref();

--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const dgram = require('dgram');
 
-// should not hang, see https://github.com/nodejs/node-v0.x-archive/issues/1282
+// Should not hang, see https://github.com/nodejs/node-v0.x-archive/issues/1282
 dgram.createSocket('udp4');
 dgram.createSocket('udp6');
 

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -33,7 +33,7 @@ common.allowGlobals(require('domain'));
 // See https://github.com/nodejs/node/commit/d1eff9ab
 global.domain = require('domain');
 
-// should not throw a 'TypeError: undefined is not a function' exception
+// Should not throw a 'TypeError: undefined is not a function' exception
 crypto.randomBytes(8);
 crypto.randomBytes(8, common.mustCall());
 const buf = Buffer.alloc(8);

--- a/test/parallel/test-domain-from-timer.js
+++ b/test/parallel/test-domain-from-timer.js
@@ -25,7 +25,7 @@
 require('../common');
 const assert = require('assert');
 
-// timeouts call the callback directly from cc, so need to make sure the
+// Timeouts call the callback directly from cc, so need to make sure the
 // domain will be used regardless
 setTimeout(() => {
   const domain = require('domain');

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -88,7 +88,7 @@ const events = require('events');
   assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
 }
 
-// but _maxListeners still has precedence over defaultMaxListeners
+// But _maxListeners still has precedence over defaultMaxListeners
 {
   events.EventEmitter.defaultMaxListeners = 42;
   const e = new events.EventEmitter();

--- a/test/parallel/test-force-repl-with-eval.js
+++ b/test/parallel/test-force-repl-with-eval.js
@@ -3,7 +3,7 @@ require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-// spawn a node child process in "interactive" mode (force the repl) and eval
+// Spawn a node child process in "interactive" mode (force the repl) and eval
 const cp = spawn(process.execPath, ['-i', '-e', 'console.log("42")']);
 let gotToEnd = false;
 

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -42,7 +42,7 @@ tmpdir.refresh();
 
 const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 
-// test that empty file will be created and have content added (callback API)
+// Test that empty file will be created and have content added (callback API)
 {
   const filename = join(tmpdir.path, 'append.txt');
 
@@ -56,7 +56,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   }));
 }
 
-// test that empty file will be created and have content added (promise API)
+// Test that empty file will be created and have content added (promise API)
 {
   const filename = join(tmpdir.path, 'append-promise.txt');
 

--- a/test/parallel/test-fs-read-stream-double-close.js
+++ b/test/parallel/test-fs-read-stream-double-close.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 {
   const s = fs.createReadStream(__filename);
 
-  // this is a private API, but it is worth testing. close calls this
+  // This is a private API, but it is worth testing. close calls this
   s.destroy(null, common.mustCall());
   s.destroy(null, common.mustCall());
 }

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -251,7 +251,7 @@ function test_relative_input_cwd(realpath, realpathSync, callback) {
     return callback();
   }
 
-  // we need to calculate the relative path to the tmp dir from cwd
+  // We need to calculate the relative path to the tmp dir from cwd
   const entrydir = process.cwd();
   const entry = path.relative(entrydir,
                               path.join(`${tmpDir}/cycles/realpath-3a`));

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -27,7 +27,7 @@ const fs = require('fs');
 const { internalBinding } = require('internal/test/binding');
 const { UV_EBADF } = internalBinding('uv');
 
-// ensure that (read|write|append)FileSync() closes the file descriptor
+// Ensure that (read|write|append)FileSync() closes the file descriptor
 fs.openSync = function() {
   return 42;
 };

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -186,7 +186,7 @@ process.on('exit', () => {
 const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
-// test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
+// Test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
 if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
   // because 2 ** 31 doesn't look right
   // eslint-disable-next-line space-infix-ops

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -35,7 +35,7 @@ const stream = fs.WriteStream(file);
 const _fs_close = fs.close;
 const _fs_open = fs.open;
 
-// change the fs.open with an identical function after the WriteStream
+// Change the fs.open with an identical function after the WriteStream
 // has pushed it onto its internal action queue, but before it's
 // returned.  This simulates AOP-style extension of the fs lib.
 fs.open = function() {

--- a/test/parallel/test-heapdump-inspector.js
+++ b/test/parallel/test-heapdump-inspector.js
@@ -13,7 +13,7 @@ const snapshotNode = {
   ]
 };
 
-// starts with no JSBindingsConnection (or 1 if coverage enabled).
+// Starts with no JSBindingsConnection (or 1 if coverage enabled).
 {
   const expected = [];
   if (process.env.NODE_V8_COVERAGE) {

--- a/test/parallel/test-http-agent-false.js
+++ b/test/parallel/test-http-agent-false.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const http = require('http');
 
-// sending `agent: false` when `port: null` is also passed in (i.e. the result
+// Sending `agent: false` when `port: null` is also passed in (i.e. the result
 // of a `url.parse()` call with the default port used, 80 or 443), should not
 // result in an assertion error...
 const opts = {
@@ -34,7 +34,7 @@ const opts = {
   agent: false
 };
 
-// we just want an "error" (no local HTTP server on port 80) or "response"
+// We just want an "error" (no local HTTP server on port 80) or "response"
 // to happen (user happens ot have HTTP server running on port 80).
 // As long as the process doesn't crash from a C++ assertion then we're good.
 const req = http.request(opts);

--- a/test/parallel/test-http-agent-no-protocol.js
+++ b/test/parallel/test-http-agent-no-protocol.js
@@ -29,7 +29,7 @@ const server = http.createServer(common.mustCall((req, res) => {
 })).listen(0, '127.0.0.1', common.mustCall(() => {
   const opts = url.parse(`http://127.0.0.1:${server.address().port}/`);
 
-  // remove the `protocol` field… the `http` module should fall back
+  // Remove the `protocol` field… the `http` module should fall back
   // to "http:", as defined by the global, default `http.Agent` instance.
   opts.agent = new http.Agent();
   opts.agent.protocol = null;

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -39,7 +39,7 @@ function execute(options) {
   });
 }
 
-// should be the same except for implicit Host header on the first two
+// Should be the same except for implicit Host header on the first two
 execute({ headers: { 'x-foo': 'boom', 'cookie': 'a=1; b=2; c=3' } });
 execute({ headers: { 'x-foo': 'boom', 'cookie': [ 'a=1', 'b=2', 'c=3' ] } });
 execute({ headers: [[ 'x-foo', 'boom' ], [ 'cookie', 'a=1; b=2; c=3' ]] });

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -31,7 +31,7 @@ const options = {
 };
 
 process.env.NODE_DEBUG = 'http';
-// start a tcp server that closes incoming connections immediately
+// Start a tcp server that closes incoming connections immediately
 const server = net.createServer(function(client) {
   client.destroy();
   server.close();

--- a/test/parallel/test-http-outgoing-message-inheritance.js
+++ b/test/parallel/test-http-outgoing-message-inheritance.js
@@ -5,7 +5,7 @@ const { OutgoingMessage } = require('http');
 const { Writable } = require('stream');
 const assert = require('assert');
 
-// check that OutgoingMessage can be used without a proper Socket
+// Check that OutgoingMessage can be used without a proper Socket
 // Fixes: https://github.com/nodejs/node/issues/14386
 // Fixes: https://github.com/nodejs/node/issues/14381
 

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -26,7 +26,7 @@ const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(function(request, response) {
-  // removed headers should stay removed, even if node automatically adds them
+  // Removed headers should stay removed, even if node automatically adds them
   // to the output:
   response.removeHeader('connection');
   response.removeHeader('transfer-encoding');

--- a/test/parallel/test-http-url.parse-auth-with-header-in-request.js
+++ b/test/parallel/test-http-url.parse-auth-with-header-in-request.js
@@ -41,7 +41,7 @@ const server = http.createServer(function(request, response) {
 server.listen(0, function() {
   const testURL =
     url.parse(`http://asdf:qwer@localhost:${this.address().port}`);
-  // the test here is if you set a specific authorization header in the
+  // The test here is if you set a specific authorization header in the
   // request we should not override that with basic auth
   testURL.headers = {
     Authorization: 'NoAuthForYOU'

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -65,7 +65,7 @@ const tests = specificTests.concat(genericTests);
 
 let currentError;
 
-// mock submitRequest because we only care about testing error handling
+// Mock submitRequest because we only care about testing error handling
 Http2Session.prototype.request = () => currentError;
 
 const server = http2.createServer(common.mustNotCall());

--- a/test/parallel/test-http2-client-setNextStreamID-errors.js
+++ b/test/parallel/test-http2-client-setNextStreamID-errors.js
@@ -37,7 +37,7 @@ server.listen(0, common.mustCall(() => {
       }
     );
 
-    // should throw if something other than number is passed to setNextStreamID
+    // Should throw if something other than number is passed to setNextStreamID
     Object.entries(types).forEach(([type, value]) => {
       if (type === 'number') {
         return;

--- a/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const h2 = require('http2');
 
-// makes sure that Http2ServerResponse setHeader & removeHeader, do not throw
+// Makes sure that Http2ServerResponse setHeader & removeHeader, do not throw
 // any errors if the stream was destroyed before headers were sent
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -62,7 +62,7 @@ server.on('request', common.mustCall(function(request, response) {
     });
   }));
 
-  // properties that do not exist on the proxy are retrieved from the socket
+  // Properties that do not exist on the proxy are retrieved from the socket
   assert.ok(request.socket._server);
   assert.strictEqual(request.socket.connecting, false);
 

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -55,7 +55,7 @@ server.listen(0, common.mustCall(() => {
   proxy.listen(0, () => {
     const client = http2.connect(`http://localhost:${proxy.address().port}`);
 
-    // confirm that :authority is required and :scheme & :path are forbidden
+    // Confirm that :authority is required and :scheme & :path are forbidden
     common.expectsError(
       () => client.request({
         [HTTP2_HEADER_METHOD]: 'CONNECT'

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -33,7 +33,7 @@ const { connect: netConnect } = require('net');
   }));
 }
 
-// check for session connect callback on already connected socket
+// Check for session connect callback on already connected socket
 {
   const server = createServer();
   server.listen(0, mustCall(() => {

--- a/test/parallel/test-http2-info-headers-errors.js
+++ b/test/parallel/test-http2-info-headers-errors.js
@@ -39,7 +39,7 @@ const tests = specificTests.concat(genericTests);
 
 let currentError;
 
-// mock sendHeaders because we only care about testing error handling
+// Mock sendHeaders because we only care about testing error handling
 Http2Stream.prototype.info = () => currentError.ngError;
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -40,7 +40,7 @@ const tests = specificTests.concat(genericTests);
 
 let currentError;
 
-// mock submitResponse because we only care about testing error handling
+// Mock submitResponse because we only care about testing error handling
 Http2Stream.prototype.respond = () => currentError.ngError;
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -47,7 +47,7 @@ const tests = specificTests.concat(genericTests);
 
 let currentError;
 
-// mock `respond` because we only care about testing error handling
+// Mock `respond` because we only care about testing error handling
 Http2Stream.prototype.respond = () => currentError.ngError;
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-server-push-stream-errors.js
+++ b/test/parallel/test-http2-server-push-stream-errors.js
@@ -64,7 +64,7 @@ const tests = specificTests.concat(genericTests);
 
 let currentError;
 
-// mock submitPushPromise because we only care about testing error handling
+// Mock submitPushPromise because we only care about testing error handling
 Http2Stream.prototype.pushPromise = () => currentError.ngError;
 
 const server = http2.createServer();

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -22,7 +22,7 @@ const dftProtocol = {};
 }
 
 
-// validate that `createServer` can work with the only argument requestListener
+// Validate that `createServer` can work with the only argument requestListener
 {
   const mustNotCall = common.mustNotCall();
   const server = https.createServer(mustNotCall);

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -47,14 +47,14 @@ process.on('exit', function() {
   assert.ok(ok);
 });
 
-// spawn the parent, and listen for it to tell us the pid of the cluster.
+// Spawn the parent, and listen for it to tell us the pid of the cluster.
 // WARNING: This is an example of listening on some arbitrary FD number
 // that has already been bound elsewhere in advance.  However, binding
 // server handles to stdio fd's is NOT a good or reliable way to do
 // concurrency in HTTP servers!  Use the cluster module, or if you want
 // a more low-level approach, use child process IPC manually.
 test(function(parent, port) {
-  // now make sure that we can request to the worker, then kill it.
+  // Now make sure that we can request to the worker, then kill it.
   http.get({
     server: 'localhost',
     port: port,

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -35,7 +35,7 @@ switch (process.argv[2]) {
   default: return test();
 }
 
-// spawn the parent, and listen for it to tell us the pid of the child.
+// Spawn the parent, and listen for it to tell us the pid of the child.
 // WARNING: This is an example of listening on some arbitrary FD number
 // that has already been bound elsewhere in advance.  However, binding
 // server handles to stdio fd's is NOT a good or reliable way to do
@@ -53,7 +53,7 @@ function test() {
   function next() {
     console.error('output from parent = %s', json);
     const child = JSON.parse(json);
-    // now make sure that we can request to the subprocess, then kill it.
+    // Now make sure that we can request to the subprocess, then kill it.
     http.get({
       server: 'localhost',
       port: child.port,

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -35,7 +35,7 @@ switch (process.argv[2]) {
   default: return test();
 }
 
-// spawn the parent, and listen for it to tell us the pid of the child.
+// Spawn the parent, and listen for it to tell us the pid of the child.
 // WARNING: This is an example of listening on some arbitrary FD number
 // that has already been bound elsewhere in advance.  However, binding
 // server handles to stdio fd's is NOT a good or reliable way to do
@@ -53,7 +53,7 @@ function test() {
   function next() {
     console.error('output from parent = %s', json);
     const child = JSON.parse(json);
-    // now make sure that we can request to the subprocess, then kill it.
+    // Now make sure that we can request to the subprocess, then kill it.
     http.get({
       server: 'localhost',
       port: child.port,

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -44,7 +44,7 @@ process.on('exit', function() {
 // concurrency in HTTP servers!  Use the cluster module, or if you want
 // a more low-level approach, use child process IPC manually.
 test(function(child, port) {
-  // now make sure that we can request to the subprocess, then kill it.
+  // Now make sure that we can request to the subprocess, then kill it.
   http.get({
     server: 'localhost',
     port: port,

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -32,7 +32,7 @@ const assert = require('assert');
 let emptyTxt;
 
 if (common.isWindows) {
-  // on Win, common.PIPE will be a named pipe, so we use an existing empty
+  // On Win, common.PIPE will be a named pipe, so we use an existing empty
   // file instead
   emptyTxt = fixtures.path('empty.txt');
 } else {

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -32,7 +32,7 @@ const expectedWarning = 'Server.connections property is deprecated. ' +
 
 common.expectWarning('DeprecationWarning', expectedWarning, 'DEP0020');
 
-// test that server.connections property is no longer enumerable now that it
+// Test that server.connections property is no longer enumerable now that it
 // has been marked as deprecated
 assert.strictEqual(Object.keys(server).includes('connections'), false);
 

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -32,7 +32,7 @@ socket = new net.Socket({
 });
 falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
-// if a handler doesn't have a setNoDelay function it shouldn't be called.
+// If a handler doesn't have a setNoDelay function it shouldn't be called.
 // In the case below, if it is called an exception will be thrown
 socket = new net.Socket({
   handle: {

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -27,7 +27,7 @@ const net = require('net');
 
 const s = new net.Stream();
 
-// test that destroy called on a stream with a server only ever decrements the
+// Test that destroy called on a stream with a server only ever decrements the
 // server connection count once
 
 s.server = new net.Server();

--- a/test/parallel/test-path-zero-length-strings.js
+++ b/test/parallel/test-path-zero-length-strings.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const path = require('path');
 const pwd = process.cwd();
 
-// join will internally ignore all the zero-length strings and it will return
+// Join will internally ignore all the zero-length strings and it will return
 // '.' if the joined string is a zero-length string.
 assert.strictEqual(path.posix.join(''), '.');
 assert.strictEqual(path.posix.join('', ''), '.');
@@ -19,7 +19,7 @@ assert.strictEqual(path.win32.join('', ''), '.');
 assert.strictEqual(path.join(pwd), pwd);
 assert.strictEqual(path.join(pwd, ''), pwd);
 
-// normalize will return '.' if the input is a zero-length string
+// Normalize will return '.' if the input is a zero-length string
 assert.strictEqual(path.posix.normalize(''), '.');
 assert.strictEqual(path.win32.normalize(''), '.');
 assert.strictEqual(path.normalize(pwd), pwd);
@@ -28,12 +28,12 @@ assert.strictEqual(path.normalize(pwd), pwd);
 assert.strictEqual(path.posix.isAbsolute(''), false);
 assert.strictEqual(path.win32.isAbsolute(''), false);
 
-// resolve, internally ignores all the zero-length strings and returns the
+// Resolve, internally ignores all the zero-length strings and returns the
 // current working directory
 assert.strictEqual(path.resolve(''), pwd);
 assert.strictEqual(path.resolve('', ''), pwd);
 
-// relative, internally calls resolve. So, '' is actually the current directory
+// Relative, internally calls resolve. So, '' is actually the current directory
 assert.strictEqual(path.relative('', pwd), '');
 assert.strictEqual(path.relative(pwd, ''), '');
 assert.strictEqual(path.relative(pwd, pwd), '');

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -46,7 +46,7 @@ function tryListen() {
     }));
 }
 
-// test that a function invoked from the beforeExit handler can use a timer
+// Test that a function invoked from the beforeExit handler can use a timer
 // to keep the event loop open, which can use another timer to keep the event
 // loop open, etc.
 function tryRepeatedTimer() {

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 require('../common');
 
-// assert legit flags are allowed, and bogus flags are disallowed
+// Assert legit flags are allowed, and bogus flags are disallowed
 {
   const goodFlags = [
     '--perf_basic_prof',

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -65,7 +65,7 @@ if (process.argv[2] === 'you-are-the-child') {
 }
 
 
-// delete should return true except for non-configurable properties
+// Delete should return true except for non-configurable properties
 // https://github.com/nodejs/node/issues/7960
 delete process.env.NON_EXISTING_VARIABLE;
 assert(delete process.env.NON_EXISTING_VARIABLE);

--- a/test/parallel/test-process-exit-recursive.js
+++ b/test/parallel/test-process-exit-recursive.js
@@ -23,14 +23,14 @@
 require('../common');
 const assert = require('assert');
 
-// recursively calling .exit() should not overflow the call stack
+// Recursively calling .exit() should not overflow the call stack
 let nexits = 0;
 
 process.on('exit', function(code) {
   assert.strictEqual(nexits++, 0);
   assert.strictEqual(code, 1);
 
-  // now override the exit code of 1 with 0 so that the test passes
+  // Now override the exit code of 1 with 0 so that the test passes
   process.exit(0);
 });
 

--- a/test/parallel/test-process-exit.js
+++ b/test/parallel/test-process-exit.js
@@ -23,7 +23,7 @@
 require('../common');
 const assert = require('assert');
 
-// calling .exit() from within "exit" should not overflow the call stack
+// Calling .exit() from within "exit" should not overflow the call stack
 let nexits = 0;
 
 process.on('exit', function(code) {

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -7,7 +7,7 @@ const versionParts = process.versions.node.split('.');
 
 assert.strictEqual(process.release.name, 'node');
 
-// it's expected that future LTS release lines will have additional
+// It's expected that future LTS release lines will have additional
 // branches in here
 if (versionParts[0] === '4' && versionParts[1] >= 2) {
   assert.strictEqual(process.release.lts, 'Argon');

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -189,7 +189,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // sending multiple newlines at once that does not end with a new line
+  // Sending multiple newlines at once that does not end with a new line
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(
@@ -206,7 +206,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // sending multiple newlines at once that does not end with a new(empty)
+  // Sending multiple newlines at once that does not end with a new(empty)
   // line and a `end` event
   {
     const fi = new FakeInput();
@@ -228,7 +228,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // sending multiple newlines at once that does not end with a new line
+  // Sending multiple newlines at once that does not end with a new line
   // and a `end` event(last line is)
 
   // \r should behave like \n when alone
@@ -354,7 +354,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // constructor throws if completer is not a function or undefined
+  // Constructor throws if completer is not a function or undefined
   {
     const fi = new FakeInput();
     common.expectsError(function() {
@@ -979,7 +979,7 @@ function isWarned(emitter) {
     assert.strictEqual(isWarned(process.stdout._events), false);
   }
 
-  // can create a new readline Interface with a null output argument
+  // Can create a new readline Interface with a null output argument
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(
@@ -1037,7 +1037,7 @@ function isWarned(emitter) {
 const crlfDelay = Infinity;
 
 [ true, false ].forEach(function(terminal) {
-  // sending multiple newlines at once that does not end with a new line
+  // Sending multiple newlines at once that does not end with a new line
   // and a `end` event(last line is)
 
   // \r\n should emit one line event, not two

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -97,7 +97,7 @@ let loadFile = join(tmpdir.path, 'file.does.not.exist');
 
 // should not break
 putIn.write = function(data) {
-  // make sure I get a failed to load message and not some crazy error
+  // Make sure I get a failed to load message and not some crazy error
   assert.strictEqual(data, `Failed to load:${loadFile}\n`);
   // eat me to avoid work
   putIn.write = () => {};
@@ -121,7 +121,7 @@ const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
 
 // should not break
 putIn.write = function(data) {
-  // make sure I get a failed to save message and not some other error
+  // Make sure I get a failed to save message and not some other error
   assert.strictEqual(data, `Failed to save:${invalidFileName}\n`);
   // reset to no-op
   putIn.write = () => {};

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -207,7 +207,7 @@ testMe.complete(' ', common.mustCall(function(error, data) {
   clearTimeout(spaceTimeout);
 }));
 
-// tab completion should pick up the global "toString" object, and
+// Tab completion should pick up the global "toString" object, and
 // any other properties up the "global" object's prototype chain
 testMe.complete('toSt', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['toString'], 'toSt']);

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -6,7 +6,7 @@ require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
-// use -i to force node into interactive mode, despite stdout not being a TTY
+// Use -i to force node into interactive mode, despite stdout not being a TTY
 const args = [ '-i' ];
 const child = spawn(process.execPath, args);
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -204,13 +204,13 @@ const errorTests = [
     send: 'JSON.parse(\'{"valid": "json"}\');',
     expect: '{ valid: \'json\' }'
   },
-  // invalid input to JSON.parse error is special case of syntax error,
+  // Invalid input to JSON.parse error is special case of syntax error,
   // should throw
   {
     send: 'JSON.parse(\'{invalid: \\\'json\\\'}\');',
     expect: [/^SyntaxError: /, '']
   },
-  // end of input to JSON.parse error is special case of syntax error,
+  // End of input to JSON.parse error is special case of syntax error,
   // should throw
   {
     send: 'JSON.parse(\'066\');',
@@ -380,19 +380,19 @@ const errorTests = [
     send: 'var path = 42; path',
     expect: '42'
   },
-  // this makes sure that we don't print `undefined` when we actually print
+  // This makes sure that we don't print `undefined` when we actually print
   // the error message
   {
     send: '.invalid_repl_command',
     expect: 'Invalid REPL keyword'
   },
-  // this makes sure that we don't crash when we use an inherited property as
+  // This makes sure that we don't crash when we use an inherited property as
   // a REPL command
   {
     send: '.toString',
     expect: 'Invalid REPL keyword'
   },
-  // fail when we are not inside a String and a line continuation is used
+  // Fail when we are not inside a String and a line continuation is used
   {
     send: '[] \\',
     expect: [
@@ -421,7 +421,7 @@ const errorTests = [
     send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
     expect: '... ... \'the    fourth\\t\\t  eye  \''
   },
-  // more than one multiline strings also should preserve whitespace chars
+  // More than one multiline strings also should preserve whitespace chars
   {
     send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
     expect: '... ... \'the    fourth\\t\\t  eye  \''
@@ -431,7 +431,7 @@ const errorTests = [
     send: '\'\\\n.break',
     expect: '... ' + prompt_unix
   },
-  // using REPL command "help" within a string literal should still work
+  // Using REPL command "help" within a string literal should still work
   {
     send: '\'thefourth\\\n.help\neye\'',
     expect: [
@@ -450,7 +450,7 @@ const errorTests = [
     send: '\n\r\n\r\n',
     expect: ''
   },
-  // empty lines in the string literals should not affect the string
+  // Empty lines in the string literals should not affect the string
   {
     send: '\'the\\\n\\\nfourtheye\'\n',
     expect: '... ... \'thefourtheye\''
@@ -460,14 +460,14 @@ const errorTests = [
     send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
     expect: 'true'
   },
-  // the following test's result depends on the RegExp's match from the above
+  // The following test's result depends on the RegExp's match from the above
   {
     send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
           'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
     expect: ['\'1\'', '\'2\'', '\'3\'', '\'4\'', '\'5\'', '\'6\'',
              '\'7\'', '\'8\'', '\'9\'']
   },
-  // regression tests for https://github.com/nodejs/node/issues/2749
+  // Regression tests for https://github.com/nodejs/node/issues/2749
   {
     send: 'function x() {\nreturn \'\\n\';\n }',
     expect: '... ... undefined'
@@ -476,7 +476,7 @@ const errorTests = [
     send: 'function x() {\nreturn \'\\\\\';\n }',
     expect: '... ... undefined'
   },
-  // regression tests for https://github.com/nodejs/node/issues/3421
+  // Regression tests for https://github.com/nodejs/node/issues/3421
   {
     send: 'function x() {\n//\'\n }',
     expect: '... ... undefined'

--- a/test/parallel/test-stream-readable-hwm-0.js
+++ b/test/parallel/test-stream-readable-hwm-0.js
@@ -16,7 +16,7 @@ const r = new Readable({
 });
 
 let pushedNull = false;
-// this will trigger read(0) but must only be called after push(null)
+// This will trigger read(0) but must only be called after push(null)
 // because the we haven't pushed any data
 r.on('readable', common.mustCall(() => {
   assert.strictEqual(r.read(), null);

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -143,7 +143,7 @@ const Readable = require('stream').Readable;
   readable.on('end', common.mustCall(onStreamEnd));
   readable.push('pushed');
 
-  // we are still not flowing, we will be resuming in the next tick
+  // We are still not flowing, we will be resuming in the next tick
   assert.strictEqual(state.flowing, false);
 
   // wait for nextTick, so the readableListener flag resets

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -106,7 +106,7 @@ r.on('readable', function() {
 });
 
 w.on('finish', common.mustCall(function() {
-  // each chunk should start with 1234, and then be asfdasdfasdf...
+  // Each chunk should start with 1234, and then be asfdasdfasdf...
   // The first got pulled out before the first unshift('1234'), so it's
   // lacking that piece.
   assert.strictEqual(written[0], 'asdfasdfas');

--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -35,7 +35,7 @@ assert.strictEqual(writable._writableState.bufferedRequestCount, 1);
 
 process.nextTick(uncork);
 
-// the second chunk is buffered, because we uncork at the end of tick
+// The second chunk is buffered, because we uncork at the end of tick
 writable.write('second chunk');
 assert.strictEqual(writable._writableState.corked, 1);
 assert.strictEqual(writable._writableState.bufferedRequestCount, 2);

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -40,7 +40,7 @@ class TestReader extends R {
     n = Math.max(n, 0);
     const toRead = Math.min(n, max);
     if (toRead === 0) {
-      // simulate the read buffer filling up with some more bytes some time
+      // Simulate the read buffer filling up with some more bytes some time
       // in the future.
       setTimeout(() => {
         this._pos = 0;

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -27,7 +27,7 @@ const { Readable, Writable } = require('stream');
 const EE = require('events').EventEmitter;
 
 
-// a mock thing a bit like the net.Socket/tcp_wrap.handle interaction
+// A mock thing a bit like the net.Socket/tcp_wrap.handle interaction
 
 const stream = new Readable({
   highWaterMark: 16,

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -31,7 +31,7 @@ test2();
 function test1() {
   const r = new Readable();
 
-  // should not end when we get a Buffer.alloc(0) or '' as the _read
+  // Should not end when we get a Buffer.alloc(0) or '' as the _read
   // result that just means that there is *temporarily* no data, but to
   // go ahead and try again later.
   //

--- a/test/parallel/test-string-decoder-end.js
+++ b/test/parallel/test-string-decoder-end.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// verify that the string decoder works getting 1 byte at a time,
+// Verify that the string decoder works getting 1 byte at a time,
 // the whole buffer at once, and that both match the .toString(enc)
 // result of the entire buffer.
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -201,7 +201,7 @@ common.expectsError(
   }
 );
 
-// test verifies that StringDecoder will correctly decode the given input
+// Test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all
 // possible ways to write() the input buffer, see writeSequences(). The
 // singleSequence allows for easy debugging of a specific sequence which is

--- a/test/parallel/test-timers-api-refs.js
+++ b/test/parallel/test-timers-api-refs.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const timers = require('timers');
 
-// delete global APIs to make sure they're not relied on by the internal timers
+// Delete global APIs to make sure they're not relied on by the internal timers
 // code
 delete global.setTimeout;
 delete global.clearTimeout;

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -38,7 +38,7 @@ function f(i) {
     assert.strictEqual(i, last_i + 1, `order is broken: ${i} != ${last_i} + 1`);
     last_i = i;
 
-    // check that this iteration is fired at least 1ms later than the previous
+    // Check that this iteration is fired at least 1ms later than the previous
     const now = getLibuvNow();
     assert(now >= last_ts + 1,
            `current ts ${now} < prev ts ${last_ts} + 1`);

--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -19,7 +19,7 @@ const pair = tls.createSecurePair(sslcontext, true, false, false, {
   })
 });
 
-// captured traffic from browser's request to https://www.google.com
+// Captured traffic from browser's request to https://www.google.com
 const sslHello = fixtures.readSync('google_ssl_hello.bin');
 
 pair.encrypted.write(sslHello);

--- a/test/parallel/test-tls-socket-snicallback-without-server.js
+++ b/test/parallel/test-tls-socket-snicallback-without-server.js
@@ -20,7 +20,7 @@ new tls.TLSSocket(serverSide, {
   })
 });
 
-// captured traffic from browser's request to https://www.google.com
+// Captured traffic from browser's request to https://www.google.com
 const sslHello = fixtures.readSync('google_ssl_hello.bin');
 
 clientSide.write(sslHello);

--- a/test/parallel/test-url-relative.js
+++ b/test/parallel/test-url-relative.js
@@ -234,7 +234,7 @@ const relativeTests2 = [
   // may change to http:///s//a/../../../g
   ['../../../../g', bases[4], 'http:///g'],
 
-  // from Dan Connelly's tests in http://www.w3.org/2000/10/swap/uripath.py
+  // From Dan Connelly's tests in http://www.w3.org/2000/10/swap/uripath.py
   ['bar:abc', 'foo:xyz', 'bar:abc'],
   ['../abc', 'http://example/x/y/z', 'http://example/x/abc'],
   ['http://example/x/abc', 'http://example2/x/y/z', 'http://example/x/abc'],

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -16,7 +16,7 @@ function nextdir() {
   return `cov_${++dirc}`;
 }
 
-// outputs coverage when event loop is drained, with no async logic.
+// Outputs coverage when event loop is drained, with no async logic.
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [
@@ -46,7 +46,7 @@ function nextdir() {
   assert.strictEqual(fixtureCoverage.functions[1].ranges[1].count, 0);
 }
 
-// outputs coverage when process.kill(process.pid, "SIGINT"); exits process.
+// Outputs coverage when process.kill(process.pid, "SIGINT"); exits process.
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [

--- a/test/parallel/test-whatwg-encoding-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder.js
@@ -177,7 +177,7 @@ function testDecodeSample(encoding, string, bytes) {
     string);
 }
 
-// z (ASCII U+007A), cent (Latin-1 U+00A2), CJK water (BMP U+6C34),
+// `z` (ASCII U+007A), cent (Latin-1 U+00A2), CJK water (BMP U+6C34),
 // G-Clef (non-BMP U+1D11E), PUA (BMP U+F8FF), PUA (non-BMP U+10FFFD)
 // byte-swapped BOM (non-character U+FFFE)
 const sample = 'z\xA2\u6C34\uD834\uDD1E\uF8FF\uDBFF\uDFFD\uFFFE';

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -39,7 +39,7 @@ zlib.unzip(Buffer.concat([
   assert.strictEqual(result.toString(), abc);
 }));
 
-// files that have the "right" magic bytes for starting a new gzip member
+// Files that have the "right" magic bytes for starting a new gzip member
 // in the middle of themselves, even if they are part of a single
 // regularly compressed member
 const pmmFileZlib = fixtures.path('pseudo-multimember-gzip.z');
@@ -59,7 +59,7 @@ fs.createReadStream(pmmFileGz)
     assert.deepStrictEqual(Buffer.concat(pmmResultBuffers), pmmExpected);
   }));
 
-// test that the next gzip member can wrap around the input buffer boundary
+// Test that the next gzip member can wrap around the input buffer boundary
 [0, 1, 2, 3, 4, defEncoded.length].forEach((offset) => {
   const resultBuffers = [];
 

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -23,7 +23,7 @@ zlib.gunzip(data, common.mustCall((err, result) => {
   );
 }));
 
-// if the trailing garbage happens to look like a gzip header, it should
+// If the trailing garbage happens to look like a gzip header, it should
 // throw an error.
 data = Buffer.concat([
   zlib.gzipSync('abc'),

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// test unzipping a file that was created with a non-node gzip lib,
+// Test unzipping a file that was created with a non-node gzip lib,
 // piped in as fast as possible.
 
 const common = require('../common');

--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -72,7 +72,7 @@ function test(next) {
     child.stdout.resume();
     child.stderr.resume();
 
-    // count handshakes, start the attack after the initial handshake is done
+    // Count handshakes, start the attack after the initial handshake is done
     let handshakes = 0;
     let renegs = 0;
 

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -103,7 +103,7 @@ const interval4 = setInterval(function() {
 }, 0);
 
 
-// we should be able to clearTimeout multiple times without breakage.
+// We should be able to clearTimeout multiple times without breakage.
 let expectedTimeouts = 3;
 
 function t() {

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -70,7 +70,7 @@ function test(next) {
     child.stdout.resume();
     child.stderr.resume();
 
-    // count handshakes, start the attack after the initial handshake is done
+    // Count handshakes, start the attack after the initial handshake is done
     let handshakes = 0;
     let renegs = 0;
 

--- a/test/sequential/test-cli-syntax.js
+++ b/test/sequential/test-cli-syntax.js
@@ -112,7 +112,7 @@ syntaxArgs.forEach(function(args) {
   assert.strictEqual(c.status, 0);
 });
 
-// should throw if code piped from stdin with --check has bad syntax
+// Should throw if code piped from stdin with --check has bad syntax
 // loop each possible option, `-c` or `--check`
 syntaxArgs.forEach(function(args) {
   const stdin = 'var foo bar;';

--- a/test/sequential/test-http-max-http-headers.js
+++ b/test/sequential/test-http-max-http-headers.js
@@ -27,8 +27,8 @@ function finished(client, callback) {
 }
 
 function fillHeaders(headers, currentSize, valid = false) {
-  // llhttp counts actual header name/value sizes, excluding the whitespace and
-  // stripped chars.
+  // `llhttp` counts actual header name/value sizes, excluding the whitespace
+  // and stripped chars.
   if (getOptionValue('--http-parser') === 'llhttp') {
     // OK, Content-Length, 0, X-CRASH, aaa...
     headers += 'a'.repeat(MAX - currentSize);

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -43,7 +43,7 @@ function test(file, expected) {
 }
 
 {
-  // change CWD as we do this test so it's not dependent on current CWD
+  // Change CWD as we do this test so it's not dependent on current CWD
   // being in the test folder
   process.chdir(__dirname);
   test('test-init', 'Loaded successfully!');
@@ -57,7 +57,7 @@ function test(file, expected) {
 }
 
 {
-  // ensures that `node fs` does not mistakenly load the native 'fs' module
+  // Ensures that `node fs` does not mistakenly load the native 'fs' module
   // instead of the desired file and that the fs module loads as
   // expected in node
   process.chdir(fixtures.path('test-init-native'));

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -171,7 +171,7 @@ async function testCommandLineAPI(session) {
   const printBModulePath = require.resolve('../fixtures/printB.js');
   const printBModuleStr = JSON.stringify(printBModulePath);
 
-  // we can use `require` outside of a callframe with require in scope
+  // We can use `require` outside of a callframe with require in scope
   let result = await session.send(
     {
       'method': 'Runtime.evaluate', 'params': {
@@ -182,7 +182,7 @@ async function testCommandLineAPI(session) {
   checkException(result);
   assert.strictEqual(result.result.value, true);
 
-  // the global require has the same properties as a normal `require`
+  // The global require has the same properties as a normal `require`
   result = await session.send(
     {
       'method': 'Runtime.evaluate', 'params': {
@@ -273,7 +273,7 @@ async function testCommandLineAPI(session) {
     parentsEqual: true,
     parentId: '<inspector console>'
   });
-  // the `require` in the module shadows the command line API's `require`
+  // The `require` in the module shadows the command line API's `require`
   result = await session.send(
     {
       'method': 'Debugger.evaluateOnCallFrame', 'params': {

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
 
   const foundModules = [];
 
-  // if no modules are required we don't need to check the CallExpressions
+  // If no modules are required we don't need to check the CallExpressions
   if (requiredModules.length === 0) {
     return {};
   }


### PR DESCRIPTION
This adds the `capitalized-comments` eslint rule to verify that
actual sentences use capital letters as starting letters. It ignores
special words and all lines below 62 characters. That way it will
mainly detect sentences. This way the code changes are kept low.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
