### PR TITLE
cli: add --max-http-header-size flag

### DIFF
--- a/deps/http_parser/http_parser.c
+++ b/deps/http_parser/http_parser.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <limits.h>
 
+static uint32_t max_header_size = HTTP_MAX_HEADER_SIZE;
+
 #ifndef ULLONG_MAX
 # define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
 #endif
@@ -137,20 +139,20 @@ do {                                                                 \
 } while (0)
 
 /* Don't allow the total size of the HTTP headers (including the status
- * line) to exceed HTTP_MAX_HEADER_SIZE.  This check is here to protect
+ * line) to exceed max_header_size.  This check is here to protect
  * embedders against denial-of-service attacks where the attacker feeds
  * us a never-ending header that the embedder keeps buffering.
  *
  * This check is arguably the responsibility of embedders but we're doing
  * it on the embedder's behalf because most won't bother and this way we
- * make the web a little safer.  HTTP_MAX_HEADER_SIZE is still far bigger
+ * make the web a little safer.  max_header_size is still far bigger
  * than any reasonable request or response so this should never affect
  * day-to-day operation.
  */
 #define COUNT_HEADER_SIZE(V)                                         \
 do {                                                                 \
   parser->nread += (V);                                              \
-  if (UNLIKELY(parser->nread > (HTTP_MAX_HEADER_SIZE))) {            \
+  if (UNLIKELY(parser->nread > max_header_size)) {                   \
     SET_ERRNO(HPE_HEADER_OVERFLOW);                                  \
     goto error;                                                      \
   }                                                                  \
@@ -1471,7 +1473,7 @@ reexecute:
               const char* p_lf;
               size_t limit = data + len - p;
 
-              limit = MIN(limit, HTTP_MAX_HEADER_SIZE);
+              limit = MIN(limit, max_header_size);
 
               p_cr = (const char*) memchr(p, CR, limit);
               p_lf = (const char*) memchr(p, LF, limit);
@@ -2436,4 +2438,9 @@ http_parser_version(void) {
   return HTTP_PARSER_VERSION_MAJOR * 0x10000 |
          HTTP_PARSER_VERSION_MINOR * 0x00100 |
          HTTP_PARSER_VERSION_PATCH * 0x00001;
+}
+
+void
+http_parser_set_max_header_size(uint32_t size) {
+  max_header_size = size;
 }

--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -427,6 +427,9 @@ void http_parser_pause(http_parser *parser, int paused);
 /* Checks if this is the final chunk of the body. */
 int http_body_is_final(const http_parser *parser);
 
+/* Change the maximum header size provided at compile time. */
+void http_parser_set_max_header_size(uint32_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -197,6 +197,13 @@ added: v9.0.0
 
 Specify the `file` of the custom [experimental ECMAScript Module][] loader.
 
+### `--max-http-header-size=size`
+<!-- YAML
+added: REPLACEME
+-->
+
+Specify the maximum size, in bytes, of HTTP headers. Defaults to 8KB.
+
 ### `--napi-modules`
 <!-- YAML
 added: v7.10.0
@@ -620,6 +627,7 @@ Node.js options that are allowed are:
 - `--inspect-brk`
 - `--inspect-port`
 - `--loader`
+- `--max-http-header-size`
 - `--napi-modules`
 - `--no-deprecation`
 - `--no-force-async-hooks-checks`

--- a/doc/node.1
+++ b/doc/node.1
@@ -139,6 +139,9 @@ Specify the
 as a custom loader, to load
 .Fl -experimental-modules .
 .
+.It Fl -max-http-header-size Ns = Ns Ar size
+Specify the maximum size of HTTP headers in bytes. Defaults to 8KB.
+.
 .It Fl -napi-modules
 This option is a no-op.
 It is kept for compatibility.

--- a/lib/internal/print_help.js
+++ b/lib/internal/print_help.js
@@ -69,6 +69,7 @@ function getArgDescription(type) {
     case 'kHostPort':
       return '[host:]port';
     case 'kInteger':
+    case 'kUInteger':
     case 'kString':
     case 'kStringList':
       return '...';

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -42,6 +42,19 @@ void OptionsParser<Options>::AddOption(const std::string& name,
 template <typename Options>
 void OptionsParser<Options>::AddOption(const std::string& name,
                                        const std::string& help_text,
+                                       uint64_t Options::* field,
+                                       OptionEnvvarSettings env_setting) {
+  options_.emplace(
+      name,
+      OptionInfo{kUInteger,
+                 std::make_shared<SimpleOptionField<uint64_t>>(field),
+                 env_setting,
+                 help_text});
+}
+
+template <typename Options>
+void OptionsParser<Options>::AddOption(const std::string& name,
+                                       const std::string& help_text,
                                        int64_t Options::* field,
                                        OptionEnvvarSettings env_setting) {
   options_.emplace(
@@ -400,6 +413,9 @@ void OptionsParser<Options>::Parse(
         break;
       case kInteger:
         *Lookup<int64_t>(info.field, options) = std::atoll(value.c_str());
+        break;
+      case kUInteger:
+        *Lookup<uint64_t>(info.field, options) = std::stoull(value.c_str());
         break;
       case kString:
         *Lookup<std::string>(info.field, options) = value;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -429,6 +429,9 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
       case kInteger:
         value = Number::New(isolate, *parser.Lookup<int64_t>(field, opts));
         break;
+      case kUInteger:
+        value = Number::New(isolate, *parser.Lookup<uint64_t>(field, opts));
+        break;
       case kString:
         if (!ToV8Value(context, *parser.Lookup<std::string>(field, opts))
                  .ToLocal(&value)) {
@@ -516,6 +519,7 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(types, kV8Option);
   NODE_DEFINE_CONSTANT(types, kBoolean);
   NODE_DEFINE_CONSTANT(types, kInteger);
+  NODE_DEFINE_CONSTANT(types, kUInteger);
   NODE_DEFINE_CONSTANT(types, kString);
   NODE_DEFINE_CONSTANT(types, kHostPort);
   NODE_DEFINE_CONSTANT(types, kStringList);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -259,6 +259,10 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {
     "--trace-event-categories", "v8,node,node.async_hooks" });
+  AddOption("--max-http-header-size",
+            "set the maximum size of HTTP headers (default: 8KB)",
+            &PerProcessOptions::max_http_header_size,
+            kAllowedInEnvironment);
   AddOption("--v8-pool-size",
             "set V8's thread pool size",
             &PerProcessOptions::v8_thread_pool_size,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -203,6 +203,7 @@ enum OptionType {
   kV8Option,
   kBoolean,
   kInteger,
+  kUInteger,
   kString,
   kHostPort,
   kStringList,
@@ -228,6 +229,10 @@ class OptionsParser {
   void AddOption(const std::string& name,
                  const std::string& help_text,
                  bool Options::* field,
+                 OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
+  void AddOption(const std::string& name,
+                 const std::string& help_text,
+                 uint64_t Options::* field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvironment);
   void AddOption(const std::string& name,
                  const std::string& help_text,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -151,6 +151,7 @@ class PerProcessOptions : public Options {
   std::string title;
   std::string trace_event_categories;
   std::string trace_event_file_pattern = "node_trace.${rotation}.log";
+  uint64_t max_http_header_size = 8 * 1024;
   int64_t v8_thread_pool_size = 4;
   bool zero_fill_all_buffers = false;
 

--- a/test/sequential/test-set-http-max-http-headers.js
+++ b/test/sequential/test-set-http-max-http-headers.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const path = require('path');
+const testName = path.join(__dirname, 'test-http-max-http-headers.js');
+const parsers = ['legacy', 'llhttp'];
+
+const timeout = common.platformTimeout(100);
+
+const tests = [];
+
+function test(fn) {
+  tests.push(fn);
+}
+
+parsers.forEach((parser) => {
+  test(function(cb) {
+    console.log('running subtest expecting failure');
+
+    // Validate that the test fails if the max header size is too small.
+    const args = ['--expose-internals',
+                  `--http-parser=${parser}`,
+                  '--max-http-header-size=1024',
+                  testName];
+    const cp = spawn(process.execPath, args, { stdio: 'inherit' });
+
+    cp.on('close', common.mustCall((code, signal) => {
+      assert.strictEqual(code, 1);
+      assert.strictEqual(signal, null);
+      cb();
+    }));
+  });
+
+  test(function(cb) {
+    console.log('running subtest expecting success');
+
+    const env = Object.assign({}, process.env, {
+      NODE_DEBUG: 'http'
+    });
+
+    // Validate that the test fails if the max header size is too small.
+    // Validate that the test now passes if the same limit becomes large enough.
+    const args = ['--expose-internals',
+                  `--http-parser=${parser}`,
+                  '--max-http-header-size=1024',
+                  testName,
+                  '1024'];
+    const cp = spawn(process.execPath, args, {
+      env,
+      stdio: 'inherit'
+    });
+
+    cp.on('close', common.mustCall((code, signal) => {
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+      cb();
+    }));
+  });
+
+  // Next, repeat the same checks using NODE_OPTIONS if it is supported.
+  if (process.config.variables.node_without_node_options) {
+    const env = Object.assign({}, process.env, {
+      NODE_OPTIONS: `--http-parser=${parser} --max-http-header-size=1024`
+    });
+
+    test(function(cb) {
+      console.log('running subtest expecting failure');
+
+      // Validate that the test fails if the max header size is too small.
+      const args = ['--expose-internals', testName];
+      const cp = spawn(process.execPath, args, { env, stdio: 'inherit' });
+
+      cp.on('close', common.mustCall((code, signal) => {
+        assert.strictEqual(code, 1);
+        assert.strictEqual(signal, null);
+        cb();
+      }));
+    });
+
+    test(function(cb) {
+      // Validate that the test now passes if the same limit
+      // becomes large enough.
+      const args = ['--expose-internals', testName, '1024'];
+      const cp = spawn(process.execPath, args, { env, stdio: 'inherit' });
+
+      cp.on('close', common.mustCall((code, signal) => {
+        assert.strictEqual(code, 0);
+        assert.strictEqual(signal, null);
+        cb();
+      }));
+    });
+  }
+});
+
+function runTest() {
+  const fn = tests.shift();
+
+  if (!fn) {
+    return;
+  }
+
+  fn(() => {
+    setTimeout(runTest, timeout);
+  });
+}
+
+runTest();


### PR DESCRIPTION
Allow the maximum size of HTTP headers to be overridden from the command line.

Refs: https://github.com/nodejs/http-parser/pull/453
Fixes: https://github.com/nodejs/node/issues/24692

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
