### PR TITLE
doc: fix added version of randomFill+randomFillSync

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2204,7 +2204,9 @@ request.
 
 ### crypto.randomFillSync(buffer[, offset][, size])
 <!-- YAML
-added: v7.10.0
+added:
+  - v7.10.0
+  - v6.13.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231
@@ -2248,7 +2250,9 @@ console.log(Buffer.from(crypto.randomFillSync(c).buffer,
 
 ### crypto.randomFill(buffer[, offset][, size], callback)
 <!-- YAML
-added: v7.10.0
+added:
+  - v7.10.0
+  - v6.13.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231


### PR DESCRIPTION
`crypto.randomFill` and `crypto.randomFillSync` was [backported](https://github.com/nodejs/node/pull/18342) to Node.js 6.13.0 but the documentation wasn't updated. So the documentation still says that this was added in v7.10.0.

~~This PR updates that to say v6.13.0, but I'm honestly not really sure if that's the best solution. Because it of course means that it wasn't there between version 7.0.0 and 7.9.0.~~

~~Possible solutions:~~

- ~~Don't care because 7.x isn't EoL~~
- ~~Add a row to the `changes:` section saying that it wasn't there between 7.0.0 and 7.9.0~~
- ~~Update the yaml parser to support that a function be added in more than one different major~~

~~@nodejs/documentation What do you think?~~

**Update:** Changed the PR according to https://github.com/nodejs/node/pull/24812#issuecomment-443806932

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
