### PR TITLE
buffer: remove checkNumberType()

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -26,7 +26,7 @@ float32Array[0] = -1; // 0xBF800000
 const bigEndian = uInt8Float32Array[3] === 0;
 
 function checkBounds(buf, offset, byteLength) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   if (buf[offset] === undefined || buf[offset + byteLength] === undefined)
     boundsError(offset, buf.length - (byteLength + 1));
 }
@@ -38,13 +38,9 @@ function checkInt(value, min, max, buf, offset, byteLength) {
   checkBounds(buf, offset, byteLength);
 }
 
-function checkNumberType(value, type) {
-  validateNumber(value, type || 'offset');
-}
-
 function boundsError(value, length, type) {
   if (Math.floor(value) !== value) {
-    checkNumberType(value, type);
+    validateNumber(value, type);
     throw new ERR_OUT_OF_RANGE(type || 'offset', 'an integer', value);
   }
 
@@ -77,7 +73,7 @@ function readUIntLE(offset, byteLength) {
 }
 
 function readUInt48LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 5];
   if (first === undefined || last === undefined)
@@ -91,7 +87,7 @@ function readUInt48LE(buf, offset = 0) {
 }
 
 function readUInt40LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 4];
   if (first === undefined || last === undefined)
@@ -105,7 +101,7 @@ function readUInt40LE(buf, offset = 0) {
 }
 
 function readUInt32LE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -118,7 +114,7 @@ function readUInt32LE(offset = 0) {
 }
 
 function readUInt24LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 2];
   if (first === undefined || last === undefined)
@@ -128,7 +124,7 @@ function readUInt24LE(buf, offset = 0) {
 }
 
 function readUInt16LE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 1];
   if (first === undefined || last === undefined)
@@ -138,7 +134,7 @@ function readUInt16LE(offset = 0) {
 }
 
 function readUInt8(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const val = this[offset];
   if (val === undefined)
     boundsError(offset, this.length - 1);
@@ -166,7 +162,7 @@ function readUIntBE(offset, byteLength) {
 }
 
 function readUInt48BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 5];
   if (first === undefined || last === undefined)
@@ -180,7 +176,7 @@ function readUInt48BE(buf, offset = 0) {
 }
 
 function readUInt40BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 4];
   if (first === undefined || last === undefined)
@@ -194,7 +190,7 @@ function readUInt40BE(buf, offset = 0) {
 }
 
 function readUInt32BE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -207,7 +203,7 @@ function readUInt32BE(offset = 0) {
 }
 
 function readUInt24BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 2];
   if (first === undefined || last === undefined)
@@ -217,7 +213,7 @@ function readUInt24BE(buf, offset = 0) {
 }
 
 function readUInt16BE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 1];
   if (first === undefined || last === undefined)
@@ -246,7 +242,7 @@ function readIntLE(offset, byteLength) {
 }
 
 function readInt48LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 5];
   if (first === undefined || last === undefined)
@@ -261,7 +257,7 @@ function readInt48LE(buf, offset = 0) {
 }
 
 function readInt40LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 4];
   if (first === undefined || last === undefined)
@@ -275,7 +271,7 @@ function readInt40LE(buf, offset = 0) {
 }
 
 function readInt32LE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -288,7 +284,7 @@ function readInt32LE(offset = 0) {
 }
 
 function readInt24LE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 2];
   if (first === undefined || last === undefined)
@@ -299,7 +295,7 @@ function readInt24LE(buf, offset = 0) {
 }
 
 function readInt16LE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 1];
   if (first === undefined || last === undefined)
@@ -310,7 +306,7 @@ function readInt16LE(offset = 0) {
 }
 
 function readInt8(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const val = this[offset];
   if (val === undefined)
     boundsError(offset, this.length - 1);
@@ -338,7 +334,7 @@ function readIntBE(offset, byteLength) {
 }
 
 function readInt48BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 5];
   if (first === undefined || last === undefined)
@@ -353,7 +349,7 @@ function readInt48BE(buf, offset = 0) {
 }
 
 function readInt40BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 4];
   if (first === undefined || last === undefined)
@@ -367,7 +363,7 @@ function readInt40BE(buf, offset = 0) {
 }
 
 function readInt32BE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -380,7 +376,7 @@ function readInt32BE(offset = 0) {
 }
 
 function readInt24BE(buf, offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = buf[offset];
   const last = buf[offset + 2];
   if (first === undefined || last === undefined)
@@ -391,7 +387,7 @@ function readInt24BE(buf, offset = 0) {
 }
 
 function readInt16BE(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 1];
   if (first === undefined || last === undefined)
@@ -403,7 +399,7 @@ function readInt16BE(offset = 0) {
 
 // Read floats
 function readFloatBackwards(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -417,7 +413,7 @@ function readFloatBackwards(offset = 0) {
 }
 
 function readFloatForwards(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 3];
   if (first === undefined || last === undefined)
@@ -431,7 +427,7 @@ function readFloatForwards(offset = 0) {
 }
 
 function readDoubleBackwards(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -449,7 +445,7 @@ function readDoubleBackwards(offset = 0) {
 }
 
 function readDoubleForwards(offset = 0) {
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   const first = this[offset];
   const last = this[offset + 7];
   if (first === undefined || last === undefined)
@@ -563,7 +559,7 @@ function writeUInt16LE(value, offset = 0) {
 function writeU_Int8(buf, value, offset, min, max) {
   value = +value;
   // `checkInt()` can not be used here because it checks two entries.
-  checkNumberType(offset);
+  validateNumber(offset, 'offset');
   if (value > max || value < min) {
     throw new ERR_OUT_OF_RANGE('value', `>= ${min} and <= ${max}`, value);
   }


### PR DESCRIPTION
`checkNumberType()` was a very thin wrapper around `validateNumber()`. This commit removes `checkNumberType()` and used `validateNumber()` directly instead.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
