### PR TITLE
src: remove unused env variables in node_util

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -56,7 +56,6 @@ static void GetOwnNonIndexProperties(
 }
 
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a Promise.
   if (!args[0]->IsPromise())
     return;
@@ -75,7 +74,6 @@ static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;


### PR DESCRIPTION
Currently the following compiler warnings are generated:
```console
../src/node_util.cc:59:16:
warning: unused variable 'env' [-Wunused-variable]
  Environment* env = Environment::GetCurrent(args);
               ^
../src/node_util.cc:78:16:
warning: unused variable 'env' [-Wunused-variable]
  Environment* env = Environment::GetCurrent(args);
               ^
2 warnings generated.
```
This commit removes the two unused variables.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
