### PR TITLE
src: remove finalized_ member from Hash class

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3458,7 +3458,6 @@ bool Hash::HashInit(const char* hash_type) {
     mdctx_.reset();
     return false;
   }
-  finalized_ = false;
   return true;
 }
 
@@ -3512,7 +3511,6 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
   unsigned int md_len;
 
   EVP_DigestFinal_ex(hash->mdctx_.get(), md_value, &md_len);
-  hash->finalized_ = true;
 
   Local<Value> error;
   MaybeLocal<Value> rc =

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -476,14 +476,12 @@ class Hash : public BaseObject {
 
   Hash(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
-        mdctx_(nullptr),
-        finalized_(false) {
+        mdctx_(nullptr) {
     MakeWeak();
   }
 
  private:
   EVPMDPointer mdctx_;
-  bool finalized_;
 };
 
 class SignBase : public BaseObject {


### PR DESCRIPTION
This commit removes the finalized_ member from the Hash class as it does
not seem to be used in any valuable way. Commit c75f87cc4c8 ("crypto:
refactor the crypto module") removed the check where it was previously
used.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
