### PR TITLE
zlib: make “bare” constants un-enumerable

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -779,6 +779,6 @@ const bkeys = Object.keys(constants);
 for (var bk = 0; bk < bkeys.length; bk++) {
   var bkey = bkeys[bk];
   Object.defineProperty(module.exports, bkey, {
-    enumerable: true, value: constants[bkey], writable: false
+    enumerable: false, value: constants[bkey], writable: false
   });
 }


### PR DESCRIPTION
We prefer for users to use `zlib.constants.XXX` instead of `zlib.XXX`.
Having both enumerable means that inspecting the `zlib` module
shows both variants, making the output significantly longer and
redundant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
