### PR TITLE
src: dispose of V8 platform in `process.exit()`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -849,10 +849,12 @@ void Environment::AsyncHooks::grow_async_ids_stack() {
 uv_key_t Environment::thread_local_env = {};
 
 void Environment::Exit(int exit_code) {
-  if (is_main_thread())
+  if (is_main_thread()) {
+    DisposePlatform();
     exit(exit_code);
-  else
+  } else {
     worker_context_->Exit(exit_code);
+  }
 }
 
 void Environment::stop_sub_worker_contexts() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -338,6 +338,10 @@ tracing::AgentWriterHandle* GetTracingAgentWriter() {
   return v8_platform.GetTracingAgentWriter();
 }
 
+void DisposePlatform() {
+  v8_platform.Dispose();
+}
+
 #ifdef __POSIX__
 static const unsigned kMaxSignal = 32;
 #endif

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -357,6 +357,7 @@ int ThreadPoolWork::CancelWork() {
 }
 
 tracing::AgentWriterHandle* GetTracingAgentWriter();
+void DisposePlatform();
 
 static inline const char* errno_string(int errorno) {
 #define ERRNO_CASE(e)  case e: return #e;


### PR DESCRIPTION
Calling `process.exit()` calls the C `exit()` function, which in turn
calls the destructors of static C++ objects. This can lead to race
conditions with other concurrently executing threads; disposing of the
V8 platform instance helps with this (although it might not be a full
solution for all problems of this kind).

Fixes: https://github.com/nodejs/node/issues/24403

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
