### PR TITLE
process: simplify check in previousValueIsValid()

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -85,7 +85,7 @@ function setupCpuUsage(_cpuUsage) {
   // Ensure that a previously passed in value is valid. Currently, the native
   // implementation always returns numbers <= Number.MAX_SAFE_INTEGER.
   function previousValueIsValid(num) {
-    return Number.isFinite(num) &&
+    return typeof num === 'number' &&
         num <= Number.MAX_SAFE_INTEGER &&
         num >= 0;
   }


### PR DESCRIPTION
This commit replaces a call to `Number.isFinite()` with a cheaper `typeof` check. The subsequent range checks ensure that the checked value is finite.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
