### PR TITLE
Align fs.ReadStream buffer pool writes to 8-byte boundary

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -49,6 +49,10 @@ function checkPosition(pos, name) {
   }
 }
 
+function roundUpToMultipleOf8(n) {
+  return (n + 7) & ~7;  // Align to 8 byte boundary.
+}
+
 function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
@@ -170,10 +174,18 @@ ReadStream.prototype._read = function(n) {
       // Now that we know how much data we have actually read, re-wind the
       // 'used' field if we can, and otherwise allow the remainder of our
       // reservation to be used as a new pool later.
-      if (start + toRead === thisPool.used && thisPool === pool)
-        thisPool.used += bytesRead - toRead;
-      else if (toRead - bytesRead > kMinPoolSpace)
-        poolFragments.push(thisPool.slice(start + bytesRead, start + toRead));
+      if (start + toRead === thisPool.used && thisPool === pool) {
+        const newUsed = thisPool.used + bytesRead - toRead;
+        thisPool.used = roundUpToMultipleOf8(newUsed);
+      } else {
+        // Round down to the next lowest multiple of 8 to ensure the new pool
+        // fragment start and end positions are aligned to an 8 byte boundary.
+        const alignedEnd = (start + toRead) & ~7;
+        const alignedStart = roundUpToMultipleOf8(start + bytesRead);
+        if (alignedEnd - alignedStart >= kMinPoolSpace) {
+          poolFragments.push(thisPool.slice(alignedStart, alignedEnd));
+        }
+      }
 
       if (bytesRead > 0) {
         this.bytesRead += bytesRead;
@@ -187,7 +199,8 @@ ReadStream.prototype._read = function(n) {
   // Move the pool positions, and internal position for reading.
   if (this.pos !== undefined)
     this.pos += toRead;
-  pool.used += toRead;
+
+  pool.used = roundUpToMultipleOf8(pool.used + toRead);
 };
 
 ReadStream.prototype._destroy = function(err, cb) {

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -55,6 +55,7 @@ const rangeFile = fixtures.path('x.txt');
 
   file.on('data', function(data) {
     assert.ok(data instanceof Buffer);
+    assert.ok(data.byteOffset % 8 === 0);
     assert.ok(!paused);
     file.length += data.length;
 


### PR DESCRIPTION
fs: align fs.ReadStream buffer pool writes to 8-byte boundary
   
Prevents alignment issues when people create a typed array from a chunk buffer, similar to https://github.com/nodejs/node/commit/285d8c658914d43cb39bacbde1ae62d8f6be25cf.

Fixes https://github.com/nodejs/node/issues/24817

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
