### PR TITLE
path: replace assertPath() with validator

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -33,12 +33,7 @@ const {
   CHAR_COLON,
   CHAR_QUESTION_MARK,
 } = require('internal/constants');
-
-function assertPath(path) {
-  if (typeof path !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('path', 'string', path);
-  }
-}
+const { validateString } = require('internal/validators');
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -163,7 +158,7 @@ const win32 = {
         }
       }
 
-      assertPath(path);
+      validateString(path, 'path');
 
       // Skip empty entries
       if (path.length === 0) {
@@ -282,7 +277,7 @@ const win32 = {
   },
 
   normalize: function normalize(path) {
-    assertPath(path);
+    validateString(path, 'path');
     const len = path.length;
     if (len === 0)
       return '.';
@@ -401,7 +396,7 @@ const win32 = {
 
 
   isAbsolute: function isAbsolute(path) {
-    assertPath(path);
+    validateString(path, 'path');
     const len = path.length;
     if (len === 0)
       return false;
@@ -429,7 +424,7 @@ const win32 = {
     var firstPart;
     for (var i = 0; i < arguments.length; ++i) {
       var arg = arguments[i];
-      assertPath(arg);
+      validateString(arg, 'path');
       if (arg.length > 0) {
         if (joined === undefined)
           joined = firstPart = arg;
@@ -494,8 +489,8 @@ const win32 = {
   //  to = 'C:\\orandea\\impl\\bbb'
   // The output of the function should be: '..\\..\\impl\\bbb'
   relative: function relative(from, to) {
-    assertPath(from);
-    assertPath(to);
+    validateString(from, 'from');
+    validateString(to, 'to');
 
     if (from === to)
       return '';
@@ -648,7 +643,7 @@ const win32 = {
   },
 
   dirname: function dirname(path) {
-    assertPath(path);
+    validateString(path, 'path');
     const len = path.length;
     if (len === 0)
       return '.';
@@ -744,9 +739,9 @@ const win32 = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('ext', 'string', ext);
-    assertPath(path);
+    if (ext !== undefined)
+      validateString(ext, 'ext');
+    validateString(path, 'path');
     var start = 0;
     var end = -1;
     var matchedSlash = true;
@@ -832,7 +827,7 @@ const win32 = {
 
 
   extname: function extname(path) {
-    assertPath(path);
+    validateString(path, 'path');
     var start = 0;
     var startDot = -1;
     var startPart = 0;
@@ -905,7 +900,7 @@ const win32 = {
 
 
   parse: function parse(path) {
-    assertPath(path);
+    validateString(path, 'path');
 
     var ret = { root: '', dir: '', base: '', ext: '', name: '' };
     if (path.length === 0)
@@ -1082,7 +1077,7 @@ const posix = {
         path = process.cwd();
       }
 
-      assertPath(path);
+      validateString(path, 'path');
 
       // Skip empty entries
       if (path.length === 0) {
@@ -1114,7 +1109,7 @@ const posix = {
 
 
   normalize: function normalize(path) {
-    assertPath(path);
+    validateString(path, 'path');
 
     if (path.length === 0)
       return '.';
@@ -1138,7 +1133,7 @@ const posix = {
 
 
   isAbsolute: function isAbsolute(path) {
-    assertPath(path);
+    validateString(path, 'path');
     return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
   },
 
@@ -1149,7 +1144,7 @@ const posix = {
     var joined;
     for (var i = 0; i < arguments.length; ++i) {
       var arg = arguments[i];
-      assertPath(arg);
+      validateString(arg, 'path');
       if (arg.length > 0) {
         if (joined === undefined)
           joined = arg;
@@ -1164,8 +1159,8 @@ const posix = {
 
 
   relative: function relative(from, to) {
-    assertPath(from);
-    assertPath(to);
+    validateString(from, 'from');
+    validateString(to, 'to');
 
     if (from === to)
       return '';
@@ -1262,7 +1257,7 @@ const posix = {
   },
 
   dirname: function dirname(path) {
-    assertPath(path);
+    validateString(path, 'path');
     if (path.length === 0)
       return '.';
     const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
@@ -1289,9 +1284,9 @@ const posix = {
 
 
   basename: function basename(path, ext) {
-    if (ext !== undefined && typeof ext !== 'string')
-      throw new ERR_INVALID_ARG_TYPE('ext', 'string', ext);
-    assertPath(path);
+    if (ext !== undefined)
+      validateString(ext, 'ext');
+    validateString(path, 'path');
 
     var start = 0;
     var end = -1;
@@ -1367,7 +1362,7 @@ const posix = {
 
 
   extname: function extname(path) {
-    assertPath(path);
+    validateString(path, 'path');
     var startDot = -1;
     var startPart = 0;
     var end = -1;
@@ -1428,7 +1423,7 @@ const posix = {
 
 
   parse: function parse(path) {
-    assertPath(path);
+    validateString(path, 'path');
 
     var ret = { root: '', dir: '', base: '', ext: '', name: '' };
     if (path.length === 0)


### PR DESCRIPTION
The `path` module's `assertPath()` does exactly what the `validateString()` validator does, so this commit updates `path` to use `validateString()` instead. A couple drive by updates to `validateString()` outside of `assertPath()` are also included.

Technically, the `validateString(from, 'from');` and `validateString(to, 'to');` changes make the error message different (changes 'path' to 'to'/'from'), but these are already using the new error system, so they shouldn't be considered semver major IMO.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
