### PR TITLE
build: fix check-xz for platforms defaulting to sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -851,10 +851,10 @@ BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
 endif
 BINARYTAR=$(BINARYNAME).tar
 # OSX doesn't have xz installed by default, http://macpkg.sourceforge.net/
-HAS_XZ ?= $(shell which xz > /dev/null 2>&1; [[ $$? = 0 ]] && echo 1 || echo 0)
+HAS_XZ ?= $(shell which xz > /dev/null 2>&1; [ $$? -eq 0 ] && echo 1 || echo 0)
 # Supply SKIP_XZ=1 to explicitly skip .tar.xz creation
 SKIP_XZ ?= 0
-XZ = $(shell [[ $(HAS_XZ) = 1 && $(SKIP_XZ) = 0 ]] && echo 1 || echo 0)
+XZ = $(shell [ $(HAS_XZ) -eq 1 -a $(SKIP_XZ) -eq 0 ] && echo 1 || echo 0)
 XZ_COMPRESSION ?= 9e
 PKG=$(TARNAME).pkg
 MACOSOUTDIR=out/macos


### PR DESCRIPTION
5e80a9a160 introduced check-xz, using `[[ .. ]]` syntax, but this is a bash builtin and some platforms default to `sh` when doing `$(shell ...)` in Makefiles.

Fix is to make it `sh` friendly.

Ref: https://github.com/nodejs/node/pull/24551

I'm not sure why this didn't show up in test builds during the preparation of #24551, but it's broken on the ARM cross compilers and ppcle-ubuntu1404 because of this (I haven't figured out why those platforms, and passing `SHELL=/bin/bash` doesn't help at all). See <https://ci-release.nodejs.org/job/iojs+release/4008/>. Best route is to make it work on all platforms anyway so users don't get caught by this.

It's working as expected with this commit: https://ci-release.nodejs.org/job/iojs+release/4013/ coming out @ https://nodejs.org/download/test/v12.0.0-test201812040ba0e0fd89/ (still building but only early failure is AIX as expected, it needs `SKIP_XZ`).