### PR TITLE
test: fix wrong parameter

### DIFF
--- a/test/parallel/test-path-join.js
+++ b/test/parallel/test-path-join.js
@@ -90,7 +90,7 @@ joinTests.push([
       [['//', 'foo/bar'], '\\foo\\bar'],
       [['//', '/foo/bar'], '\\foo\\bar'],
       [['\\\\', '/', '/foo/bar'], '\\foo\\bar'],
-      [['//'], '/'],
+      [['//'], '\\'],
       // No UNC path expected (share name missing - questionable).
       [['//foo'], '\\foo'],
       [['//foo/'], '\\foo\\'],


### PR DESCRIPTION
the expected result should be \
