### PR TITLE
doc: update http doc for new Agent()/support options in socket.connect()

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -128,9 +128,8 @@ added: v0.3.4
     **Default:** `256`.
   * `timeout` {number} Socket timeout in milliseconds.
     This will set the timeout after the socket is connected.
-  * `options` in
-    [`socket.connect()`](net.html#net_socket_connect_options_connectlistener)
-    are also supported.
+
+`options` in [`socket.connect()`][] are also supported.
 
 The default [`http.globalAgent`][] that is used by [`http.request()`][] has all
 of these values set to their respective defaults.
@@ -2142,6 +2141,7 @@ not abort the request or do anything besides add a `'timeout'` event.
 [`server.listen()`]: net.html#net_server_listen
 [`server.timeout`]: #http_server_timeout
 [`setHeader(name, value)`]: #http_request_setheader_name_value
+[`socket.connect()`]: net.html#net_socket_connect_options_connectlistener
 [`socket.setKeepAlive()`]: net.html#net_socket_setkeepalive_enable_initialdelay
 [`socket.setNoDelay()`]: net.html#net_socket_setnodelay_nodelay
 [`socket.setTimeout()`]: net.html#net_socket_settimeout_timeout_callback

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -128,6 +128,9 @@ added: v0.3.4
     **Default:** `256`.
   * `timeout` {number} Socket timeout in milliseconds.
     This will set the timeout after the socket is connected.
+  * `options` in
+    [`socket.connect()`](net.html#net_socket_connect_options_connectlistener)
+    are also supported.
 
 The default [`http.globalAgent`][] that is used by [`http.request()`][] has all
 of these values set to their respective defaults.


### PR DESCRIPTION
Refs #24098, list the supported `options` in `socket.connect()` for `new Agent()` signature in `http` doc.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
