### PR TITLE
doc: add class worker documentation

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -235,7 +235,8 @@ added: v10.5.0
 -->
 
 The `Worker` class represents an independent JavaScript execution thread.
-Most Node.js APIs are available inside of it.
+This class inherits from `EventEmitter`, and most Node.js APIs are available
+inside of it.
 
 Notable differences inside a Worker environment are:
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -234,9 +234,10 @@ listeners for the event exist.
 added: v10.5.0
 -->
 
+* Extends: {EventEmitter}
+
 The `Worker` class represents an independent JavaScript execution thread.
-This class inherits from `EventEmitter`, and most Node.js APIs are available
-inside of it.
+Most Node.js APIs are available inside of it.
 
 Notable differences inside a Worker environment are:
 


### PR DESCRIPTION
This PR is repullrequest(#24809) because I did not read the document carefully and conflict occurred trying to fix. sorry, I am not used to git.

Add documentation about Worker class inherits from EventEmitter.

related #24732

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]
