### PR TITLE
doc: fix http.createServer for versions before v9.6.0

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1808,13 +1808,22 @@ A collection of all the standard HTTP response status codes, and the
 short description of each. For example, `http.STATUS_CODES[404] === 'Not
 Found'`.
 
-## http.createServer([options][, requestListener])
+## http.createServer([requestListener])
 <!-- YAML
 added: v0.1.13
-changes:
-  - version: v9.6.0
-    pr-url: https://github.com/nodejs/node/pull/15752
-    description: The `options` argument is supported now.
+-->
+- `requestListener` {Function}
+
+* Returns: {http.Server}
+
+Returns a new instance of [`http.Server`][].
+
+The `requestListener` is a function which is automatically
+added to the [`'request'`][] event.
+
+## http.createServer([options][, requestListener])
+<!-- YAML
+added: v9.6.0
 -->
 * `options` {Object}
   * `IncomingMessage` {http.IncomingMessage} Specifies the `IncomingMessage`


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24105

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
