### PR TITLE
http: add maxHeaderSize property

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1912,6 +1912,16 @@ added: v0.5.9
 Global instance of `Agent` which is used as the default for all HTTP client
 requests.
 
+## http.maxHeaderSize
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Read-only property specifying the maximum allowed size of HTTP headers in bytes.
+Defaults to 8KB. Configurable using the [`--max-http-header-size`][] CLI option.
+
 ## http.request(options[, callback])
 ## http.request(url[, options][, callback])
 <!-- YAML
@@ -2097,6 +2107,7 @@ will be emitted in the following order:
 Note that setting the `timeout` option or using the `setTimeout()` function will
 not abort the request or do anything besides add a `'timeout'` event.
 
+[`--max-http-header-size`]: cli.html#cli_max_http_header_size_size
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'request'`]: #http_event_request
 [`'response'`]: #http_event_response

--- a/lib/http.js
+++ b/lib/http.js
@@ -32,6 +32,7 @@ const {
   Server,
   ServerResponse
 } = require('_http_server');
+let maxHeaderSize;
 
 function createServer(opts, requestListener) {
   return new Server(opts, requestListener);
@@ -62,3 +63,16 @@ module.exports = {
   get,
   request
 };
+
+Object.defineProperty(module.exports, 'maxHeaderSize', {
+  configurable: true,
+  enumerable: true,
+  get() {
+    if (maxHeaderSize === undefined) {
+      const { getOptionValue } = require('internal/options');
+      maxHeaderSize = getOptionValue('--max-http-header-size');
+    }
+
+    return maxHeaderSize;
+  }
+});

--- a/test/parallel/test-http-max-header-size.js
+++ b/test/parallel/test-http-max-header-size.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const http = require('http');
+
+assert.strictEqual(http.maxHeaderSize, 8 * 1024);
+const child = spawnSync(process.execPath, ['--max-http-header-size=10', '-p',
+                                           'http.maxHeaderSize']);
+assert.strictEqual(+child.stdout.toString().trim(), 10);


### PR DESCRIPTION
Requested by @mcollina in #24811 ~~, but I didn't want to stall that out. Ignore the commits to `deps` and `cli`, which are just #24811.~~

This PR exposes the value of `--max-http-header-size` as a property of the `http` module.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
