### PR TITLE
module: use validateString in modules/cjs

### DIFF
--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+const { validateString } = require('internal/validators');
 
 const {
   CHAR_LINE_FEED,
@@ -26,18 +26,14 @@ function makeRequireFunction(mod) {
   }
 
   function resolve(request, options) {
-    if (typeof request !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('request', 'string', request);
-    }
+    validateString(request, 'request');
     return Module._resolveFilename(request, mod, false, options);
   }
 
   require.resolve = resolve;
 
   function paths(request) {
-    if (typeof request !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('request', 'string', request);
-    }
+    validateString(request, 'request');
     return Module._resolveLookupPaths(request, mod, true);
   }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -47,10 +47,10 @@ const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalModules = getOptionValue('--experimental-modules');
 
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
+const { validateString } = require('internal/validators');
 
 module.exports = Module;
 
@@ -649,9 +649,7 @@ Module.prototype.load = function(filename) {
 // Loads a module at the given file path. Returns that module's
 // `exports` property.
 Module.prototype.require = function(id) {
-  if (typeof id !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('id', 'string', id);
-  }
+  validateString(id, 'id');
   if (id === '') {
     throw new ERR_INVALID_ARG_VALUE('id', id,
                                     'must be a non-empty string');


### PR DESCRIPTION
Simply use `validateString` in modules/cjs.

Refs: #22101
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
