### PR TITLE
doc: fix api documentation of http.createServer

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1720,21 +1720,10 @@ A collection of all the standard HTTP response status codes, and the
 short description of each. For example, `http.STATUS_CODES[404] === 'Not
 Found'`.
 
-## http.createServer([options][, requestListener])
+## http.createServer([requestListener])
 <!-- YAML
 added: v0.1.13
-changes:
-  - version: v8.12.0
-    pr-url: https://github.com/nodejs/node/pull/15752
-    description: The `options` argument is supported now.
 -->
-- `options` {Object}
-  * `IncomingMessage` {http.IncomingMessage} Specifies the IncomingMessage class
-    to be used. Useful for extending the original `IncomingMessage`.
-    **Default:** `IncomingMessage`.
-  * `ServerResponse` {http.ServerResponse} Specifies the ServerResponse class to
-    be used. Useful for extending the original `ServerResponse`. **Default:**
-    `ServerResponse`.
 - `requestListener` {Function}
 
 * Returns: {http.Server}


### PR DESCRIPTION
Fixes: #24105

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
