### PR TITLE
bootstrap: make Buffer and process non-enumerable

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -432,7 +432,12 @@ function setupGlobalVariables() {
     enumerable: false,
     configurable: true
   });
-  global.process = process;
+  Object.defineProperty(global, 'process', {
+    value: process,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  });
   const util = NativeModule.require('util');
 
   function makeGetter(name) {
@@ -469,7 +474,12 @@ function setupGlobalVariables() {
   // and exposes it on `internal/buffer`.
   NativeModule.require('internal/buffer');
 
-  global.Buffer = NativeModule.require('buffer').Buffer;
+  Object.defineProperty(global, 'Buffer', {
+    value: NativeModule.require('buffer').Buffer,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  });
   process.domain = null;
   process._exiting = false;
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -217,12 +217,10 @@ function platformTimeout(ms) {
 }
 
 let knownGlobals = [
-  Buffer,
   clearImmediate,
   clearInterval,
   clearTimeout,
   global,
-  process,
   setImmediate,
   setInterval,
   setTimeout

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -27,6 +27,31 @@ const common = require('../common');
 const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
+const { builtinModules } = require('module');
+
+// Load all modules to actually cover most code parts.
+builtinModules.forEach((moduleName) => {
+  if (!moduleName.includes('/')) {
+    try {
+      // This could throw for e.g., crypto if the binary is not compiled
+      // accordingly.
+      require(moduleName);
+    } catch {}
+  }
+});
+
+assert.deepStrictEqual(
+  Object.keys(global),
+  [
+    'global',
+    'clearImmediate',
+    'clearInterval',
+    'clearTimeout',
+    'setImmediate',
+    'setInterval',
+    'setTimeout'
+  ]
+);
 
 common.allowGlobals('bar', 'foo');
 

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -52,12 +52,12 @@ builtinModules.forEach((moduleName) => {
   ];
   if (global.DTRACE_HTTP_SERVER_RESPONSE) {
     expected.unshift(
-      DTRACE_HTTP_SERVER_RESPONSE,
-      DTRACE_HTTP_SERVER_REQUEST,
-      DTRACE_HTTP_CLIENT_RESPONSE,
-      DTRACE_HTTP_CLIENT_REQUEST,
-      DTRACE_NET_STREAM_END,
-      DTRACE_NET_SERVER_CONNECTION
+      'DTRACE_HTTP_SERVER_RESPONSE',
+      'DTRACE_HTTP_SERVER_REQUEST',
+      'DTRACE_HTTP_CLIENT_RESPONSE',
+      'DTRACE_HTTP_CLIENT_REQUEST',
+      'DTRACE_NET_STREAM_END',
+      'DTRACE_NET_SERVER_CONNECTION'
     );
   }
   assert.deepStrictEqual(Object.keys(global), expected);

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -60,7 +60,7 @@ builtinModules.forEach((moduleName) => {
       'DTRACE_NET_SERVER_CONNECTION'
     );
   }
-  assert.deepStrictEqual(Object.keys(global), expected);
+  assert.deepStrictEqual(new Set(Object.keys(global)), new Set(expected));
 }
 
 common.allowGlobals('bar', 'foo');

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -40,9 +40,8 @@ builtinModules.forEach((moduleName) => {
   }
 });
 
-assert.deepStrictEqual(
-  Object.keys(global),
-  [
+{
+  const expected = [
     'global',
     'clearImmediate',
     'clearInterval',
@@ -50,8 +49,19 @@ assert.deepStrictEqual(
     'setImmediate',
     'setInterval',
     'setTimeout'
-  ]
-);
+  ];
+  if (global.DTRACE_HTTP_SERVER_RESPONSE) {
+    expected.unshift(
+      DTRACE_HTTP_SERVER_RESPONSE,
+      DTRACE_HTTP_SERVER_REQUEST,
+      DTRACE_HTTP_CLIENT_RESPONSE,
+      DTRACE_HTTP_CLIENT_REQUEST,
+      DTRACE_NET_STREAM_END,
+      DTRACE_NET_SERVER_CONNECTION
+    );
+  }
+  assert.deepStrictEqual(Object.keys(global), expected);
+}
 
 common.allowGlobals('bar', 'foo');
 


### PR DESCRIPTION
This makes sure these two properties are non-enumerable. This aligns
them with all other globals that are not enumerable by spec.

Refs: https://github.com/nodejs/node/issues/20565

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
