### PR TITLE
test: verify input flags

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -45,6 +45,44 @@ const isMainThread = (() => {
   }
 })();
 
+// Check for flags. Skip this for workers (both, the `cluster` module and
+// `worker_threads`) and child processes.
+if (process.argv.length === 2 &&
+    isMainThread &&
+    module.parent &&
+    require('cluster').isMaster) {
+  // The copyright notice is relatively big and the flags could come afterwards.
+  const bytesToRead = 1500;
+  const buffer = Buffer.allocUnsafe(bytesToRead);
+  const fd = fs.openSync(module.parent.filename, 'r');
+  fs.readSync(fd, buffer, 0, bytesToRead);
+  fs.closeSync(fd);
+  const source = buffer.toString();
+
+  const flagStart = source.indexOf('// Flags: --') + 10;
+  if (flagStart !== 9) {
+    let flagEnd = source.indexOf('\n', flagStart);
+    // Normalize different EOL.
+    if (source[flagEnd - 1] === '\r') {
+      flagEnd--;
+    }
+    const flags = source
+      .substring(flagStart, flagEnd)
+      .replace(/_/g, '-')
+      .split(' ');
+    const args = process.execArgv.map((arg) => arg.replace(/_/g, '-'));
+    for (const flag of flags) {
+      if (!args.includes(flag) &&
+          // If the binary is build without `intl` the inspect option is
+          // invalid. The test itself should handle this case.
+          (process.config.variables.v8_enable_inspector !== 0 ||
+            !flag.startsWith('--inspect'))) {
+        throw new Error(`Test has to be started with the flag: '${flag}'`);
+      }
+    }
+  }
+}
+
 const isWindows = process.platform === 'win32';
 const isAIX = process.platform === 'aix';
 const isLinuxPPCBE = (process.platform === 'linux') &&


### PR DESCRIPTION
This makes sure all required flags are passed through to the test.
If that's not the case an error is thrown to inform the user what
flag is missing.

This is especially helpful for people new to Node core who start some
tests and don't know why they fail.

I actually intend to improve this further to automatically starting a child_process
with the correct flags without any further user interaction necessary (the main
process would just end as soon as the child_process is done).
In that case we could likely improve our instrumentation as well by stop reading
the source in python and to parse the flags there.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
