### PR TITLE
build: fix compiler version detection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -655,8 +655,8 @@ def try_check_compiler(cc, lang):
 
   values = (proc.communicate()[0].split() + ['0'] * 7)[0:7]
   is_clang = values[0] == '1'
-  gcc_version = tuple(values[1:1+3])
-  clang_version = tuple(values[4:4+3])
+  gcc_version = tuple(map(int, values[1:1+3]))
+  clang_version = tuple(map(int, values[4:4+3])) if is_clang else None
 
   return (True, is_clang, clang_version, gcc_version)
 
@@ -921,8 +921,7 @@ def gcc_version_ge(version_checked):
   for compiler in [(CC, 'c'), (CXX, 'c++')]:
     ok, is_clang, clang_version, compiler_version = \
       try_check_compiler(compiler[0], compiler[1])
-    compiler_version_num = tuple(map(int, compiler_version))
-    if is_clang or compiler_version_num < version_checked:
+    if is_clang or compiler_version < version_checked:
       return False
   return True
 


### PR DESCRIPTION
Compiler version tuples should be numeric for tuple comparisons
to work.

Before:
```
-bash-4.2$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

-bash-4.2$ ./configure
-bash-4.2$
```

After:
```
-bash-4.2$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

-bash-4.2$ ./configure
WARNING: C++ compiler too old, need g++ 4.9.4 or clang++ 3.4.2 (CXX=g++)
WARNING: warnings were emitted in the configure phase
-bash-4.2$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
