### PR TITLE
test: do not lint macros files

### DIFF
--- a/deps/v8/src/js/macros.py
+++ b/deps/v8/src/js/macros.py
@@ -28,6 +28,8 @@
 # Dictionary that is passed as defines for js2c.py.
 # Used for defines that must be defined for all native JS files.
 
+# flake8: noqa
+
 define NONE        = 0;
 define READ_ONLY   = 1;
 define DONT_ENUM   = 2;

--- a/src/notrace_macros.py
+++ b/src/notrace_macros.py
@@ -1,6 +1,9 @@
 # This file is used by tools/js2c.py to preprocess out the DTRACE symbols in
 # builds that don't support DTrace. This is not used in builds that support
 # DTrace.
+
+# flake8: noqa
+
 macro DTRACE_HTTP_CLIENT_REQUEST(x) = ;
 macro DTRACE_HTTP_CLIENT_RESPONSE(x) = ;
 macro DTRACE_HTTP_SERVER_REQUEST(x) = ;

--- a/tools/dcheck_macros.py
+++ b/tools/dcheck_macros.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 macro DCHECK(x) = do { if (!(x)) (process._rawDebug("DCHECK: x == true"), process.abort()) } while (0);
 macro DCHECK_EQ(a, b) = DCHECK((a) === (b));
 macro DCHECK_GE(a, b) = DCHECK((a) >= (b));

--- a/tools/nodcheck_macros.py
+++ b/tools/nodcheck_macros.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 macro DCHECK(x) = void(x);
 macro DCHECK_EQ(a, b) = void(a, b);
 macro DCHECK_GE(a, b) = void(a, b);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

These four __.py__ files do not contain _any_ Python code.  Instead they contain "__macros__" which are processed by __js2c.py__.  Our Python linter (make lint-py) will properly flag these files as containing Python syntax errors.  One solution would be to change the filename suffixes (.py -->.js2c) or we could add a linter directive (# noqa) to the comments of each file to tell our linter to ignore those files.  This PR implements the latter.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
