### PR TITLE
tools: prepare tools/icu/icutrim.py for Python 3

### DIFF
--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -12,16 +12,25 @@
 #  Use "-h" to get help options.
 
 from __future__ import print_function
-import sys
-import shutil
-# for utf-8
-reload(sys)
-sys.setdefaultencoding("utf-8")
 
+import json
 import optparse
 import os
-import json
 import re
+import shutil
+import sys
+
+try:
+    # for utf-8 on Python 2
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
+except NameError:
+    pass  # Python 3 already defaults to utf-8
+
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
 
 endian=sys.byteorder
 
@@ -214,7 +223,7 @@ def queueForRemoval(tree):
     if(options.verbose>0):
         print("* %s: %d items" % (tree, len(mytree["locs"])))
     # do varible substitution for this tree here
-    if type(config["trees"][tree]) == str or type(config["trees"][tree]) == unicode:
+    if isinstance(config["trees"][tree], basestring):
         treeStr = config["trees"][tree]
         if(options.verbose>5):
             print(" Substituting $%s for tree %s" % (treeStr, tree))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
* __reload()__ was moved and __sys.setdefaultencoding()__ was removed in Python 3 because the default encoding is already utf-8
* use __isinstance()__ instead of directly comparing types as recommended in PEP8
* use __basestring__ instead of __str__ and __unicode__ as is the Python 2 convention
* define __basestring__ in Python 3 where it has been removed because all __str__ are Unicode.
* run __isort__ on the imports for readability

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
