### PR TITLE
src: allow adjusting trace events per file in cli

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -273,7 +273,7 @@ static struct {
           std::unique_ptr<tracing::AsyncTraceWriter>(
               new tracing::NodeTraceWriter(
                   per_process_opts->trace_event_file_pattern,
-                  per_process_opts->trace_event_traces_per_file)),
+                  per_process_opts->trace_event_file_trace_count)),
           tracing::Agent::kUseDefaultCategories);
     }
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -272,7 +272,8 @@ static struct {
           ParseCommaSeparatedSet(per_process_opts->trace_event_categories),
           std::unique_ptr<tracing::AsyncTraceWriter>(
               new tracing::NodeTraceWriter(
-                  per_process_opts->trace_event_file_pattern)),
+                  per_process_opts->trace_event_file_pattern,
+                  per_process_opts->trace_event_traces_per_file)),
           tracing::Agent::kUseDefaultCategories);
     }
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -257,6 +257,13 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             "data, it supports ${rotation} and ${pid}.",
             &PerProcessOptions::trace_event_file_pattern,
             kAllowedInEnvironment);
+  AddOption("--trace-event-traces-per-file",
+            "The minimum number of trace events to be written to a single file "
+            "before rotating to the next file. "
+            "Defaults to 524288 (2^19) traces; minimum 65536 (2^16). "
+            "Specify 0 for unlimited (aka disable rotation).",
+            &PerProcessOptions::trace_event_traces_per_file,
+            kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {
     "--trace-event-categories", "v8,node,node.async_hooks" });
   AddOption("--max-http-header-size",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -257,12 +257,12 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             "data, it supports ${rotation} and ${pid}.",
             &PerProcessOptions::trace_event_file_pattern,
             kAllowedInEnvironment);
-  AddOption("--trace-event-traces-per-file",
+  AddOption("--trace-event-file-trace-count",
             "The minimum number of trace events to be written to a single file "
             "before rotating to the next file. "
             "Defaults to 524288 (2^19) traces; minimum 65536 (2^16). "
             "Specify 0 for unlimited (aka disable rotation).",
-            &PerProcessOptions::trace_event_traces_per_file,
+            &PerProcessOptions::trace_event_file_trace_count,
             kAllowedInEnvironment);
   AddAlias("--trace-events-enabled", {
     "--trace-event-categories", "v8,node,node.async_hooks" });

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -152,7 +152,7 @@ class PerProcessOptions : public Options {
   std::string trace_event_categories;
   std::string trace_event_file_pattern = "node_trace.${rotation}.log";
   uint64_t max_http_header_size = 8 * 1024;
-  int64_t trace_event_traces_per_file = 1 << 19;
+  uint64_t trace_event_file_trace_count = 1 << 19;
   int64_t v8_thread_pool_size = 4;
   bool zero_fill_all_buffers = false;
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -152,6 +152,7 @@ class PerProcessOptions : public Options {
   std::string trace_event_categories;
   std::string trace_event_file_pattern = "node_trace.${rotation}.log";
   uint64_t max_http_header_size = 8 * 1024;
+  int64_t trace_event_traces_per_file = 1 << 19;
   int64_t v8_thread_pool_size = 4;
   bool zero_fill_all_buffers = false;
 

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -10,7 +10,7 @@ namespace node {
 namespace tracing {
 
 NodeTraceWriter::NodeTraceWriter(const std::string& log_file_pattern,
-                                 int64_t min_traces_per_file)
+                                 uint64_t min_traces_per_file)
     : log_file_pattern_(log_file_pattern),
       min_traces_per_file_(min_traces_per_file) {}
 
@@ -124,7 +124,7 @@ void NodeTraceWriter::FlushPrivate() {
   int highest_request_id;
   {
     Mutex::ScopedLock stream_scoped_lock(stream_mutex_);
-    if (min_traces_per_file_ > 0 && total_traces_ >= min_traces_per_file_) {
+    if (min_traces_per_file_ != 0 && total_traces_ >= min_traces_per_file_) {
       total_traces_ = 0;
       // Destroying the member JSONTraceWriter object appends "]}" to
       // stream_ - in other words, ending a JSON file.

--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -17,7 +17,7 @@ using v8::platform::tracing::TraceWriter;
 class NodeTraceWriter : public AsyncTraceWriter {
  public:
   explicit NodeTraceWriter(const std::string& log_file_pattern,
-                           int64_t min_traces_per_file);
+                           uint64_t min_traces_per_file);
   ~NodeTraceWriter();
 
   void InitializeOnThread(uv_loop_t* loop) override;
@@ -62,10 +62,10 @@ class NodeTraceWriter : public AsyncTraceWriter {
   std::string log_file_pattern_;
   // Keeps track of the total number of traces written to the currently open
   // file.
-  int64_t total_traces_ = 0;
+  uint64_t total_traces_ = 0;
   // The minimum number of traces to allow in a single file before closing it
   // and rotating to a new file.
-  int64_t min_traces_per_file_;
+  uint64_t min_traces_per_file_;
   std::ostringstream stream_;
   std::unique_ptr<TraceWriter> json_trace_writer_;
   bool exited_ = false;

--- a/test/parallel/test-trace-events-traces-per-file.js
+++ b/test/parallel/test-trace-events-traces-per-file.js
@@ -16,7 +16,7 @@ const spawn = common.mustCall((numTraces) => new Promise((resolve, reject) => {
     '--trace-events-enabled',
     '--trace-event-file-pattern',
     `trace-${numTraces}-\${pid}-\${rotation}.log`,
-    '--trace-event-traces-per-file', numTraces,
+    '--trace-event-file-trace-count', numTraces,
     '-e', CODE
   ], { cwd: tmpdir.path, stdio: 'inherit' });
 
@@ -32,10 +32,16 @@ const spawn = common.mustCall((numTraces) => new Promise((resolve, reject) => {
 }), 2);
 
 // spawn(x) creates a new process where the value for
-// --trace-event-traces-per-file is set to x.
+// --trace-event-file-trace-count is set to x.
 Promise.all([spawn(1 << 16), spawn(1 << 17)])
   .then(([numTraces16, numTraces17]) => {
-    assert.ok(numTraces16 >= (1 << 16));
-    assert.ok(numTraces16 < (1 << 17));
-    assert.ok(numTraces17 >= (1 << 17));
-  });
+    const prefix = (fileTraceCount) =>
+        `\`node --trace-event-file-trace-count=${fileTraceCount}\``;
+    assert.ok(numTraces16 >= (1 << 16), `Expected >= ${1 << 16} traces from ${
+              prefix(1 << 16)}, got ${numTraces16} instead`);
+    assert.ok(numTraces16 < (1 << 17), `Expected < ${1 << 17} traces from ${
+              prefix(1 << 16)}, got ${numTraces16} instead`);
+    assert.ok(numTraces17 >= (1 << 17), `Expected >= ${1 << 17} traces from ${
+              prefix(1 << 17)}, got ${numTraces17} instead`);
+  })
+  .then(common.mustCall());

--- a/test/parallel/test-trace-events-traces-per-file.js
+++ b/test/parallel/test-trace-events-traces-per-file.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+tmpdir.refresh();
+
+// Needs to produce more than 1 << 17 traces.
+const CODE = 'for (let i = 0; i < 20000; i++) (async ()=>{})()';
+
+const spawn = common.mustCall((numTraces) => new Promise((resolve, reject) => {
+  const proc = cp.spawn(process.execPath, [
+    '--trace-events-enabled',
+    '--trace-event-file-pattern',
+    `trace-${numTraces}-\${pid}-\${rotation}.log`,
+    '--trace-event-traces-per-file', numTraces,
+    '-e', CODE
+  ], { cwd: tmpdir.path, stdio: 'inherit' });
+
+  proc.once('exit', common.mustCall(() => {
+    const expectedFilename = path.join(tmpdir.path,
+                                       `trace-${numTraces}-${proc.pid}-1.log`);
+    assert(fs.existsSync(expectedFilename));
+    fs.readFile(expectedFilename, common.mustCall((err, data) => {
+      const traces = JSON.parse(data.toString()).traceEvents;
+      resolve(traces.length);
+    }));
+  }));
+}), 2);
+
+// spawn(x) creates a new process where the value for
+// --trace-event-traces-per-file is set to x.
+Promise.all([spawn(1 << 16), spawn(1 << 17)])
+  .then(([numTraces16, numTraces17]) => {
+    assert.ok(numTraces16 >= (1 << 16));
+    assert.ok(numTraces16 < (1 << 17));
+    assert.ok(numTraces17 >= (1 << 17));
+  });


### PR DESCRIPTION
This change proposes a new CLI flag `--trace-event-traces-per-file` that can be used to adjust the number of traces written to a file before rotating the file number. This is currently a hardcoded number (`kTracesPerFile` = 524288). I've added the ability to turn off rotation by specifying 0 as an argument -- it acts more like "infinity" in this case.

We still currently have the number of traces buffered before writing to disk hardcoded at 65536 (1024 chunks * 16 traces per chunk), so it's not really effective for the number of traces to be lower than this. Allowing users to adjust # of buffered traces might also be worthwhile, though I haven't included it yet.

The primary motivation for this is to disable file rotation -- which allows us to write continuously to a file pipe without ever closing the file for rotation purposes. But there might be merit in having smaller/larger trace files for other use cases.

Note that this is the _minimum_ number of traces written to a file, rather than the maximum. It's possible that we could use this PR to also discuss whether that makes sense to users. (I believe in practice the number of written traces will be only a little more than the specified number, and definitely not more than 2 * the specified number, as long as the specified number is greater than 65536 as mentioned above.)

/cc @nodejs/diagnostics

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
