### PR TITLE
lib: remove unused NativeModule.wrap and NativeModule.wrapper

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -257,15 +257,6 @@ NativeModule.getSource = function(id) {
   return NativeModule._source[id];
 };
 
-NativeModule.wrap = function(script) {
-  return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
-};
-
-NativeModule.wrapper = [
-  '(function (exports, require, module, process, internalBinding) {',
-  '\n});'
-];
-
 const getOwn = (target, property, receiver) => {
   return ReflectApply(ObjectHasOwnProperty, target, [property]) ?
     ReflectGet(target, property, receiver) :


### PR DESCRIPTION
We now compile the native modules in C++ so these are no longer
used.

Refs: https://github.com/nodejs/node/commit/bd765d61d7425d82e80bdf2f4f27c0424221837b

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
