### PR TITLE
src: create env->inspector_console_api_object earlier

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -340,6 +340,13 @@ void Environment::Start(const std::vector<std::string>& args,
   static uv_once_t init_once = UV_ONCE_INIT;
   uv_once(&init_once, InitThreadLocalOnce);
   uv_key_set(&thread_local_env, this);
+
+#if HAVE_INSPECTOR
+  // This needs to be set before we start the inspector
+  Local<Object> obj = Object::New(isolate());
+  CHECK(obj->SetPrototype(context(), Null(isolate())).FromJust());
+  set_inspector_console_api_object(obj);
+#endif  // HAVE_INSPECTOR
 }
 
 void Environment::RegisterHandleCleanups() {

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -502,6 +502,7 @@ class NodeInspectorClient : public V8InspectorClient {
   void installAdditionalCommandLineAPI(Local<Context> context,
                                        Local<Object> target) override {
     Local<Object> console_api = env_->inspector_console_api_object();
+    CHECK(!console_api.IsEmpty());
 
     Local<Array> properties =
         console_api->GetOwnPropertyNames(context).ToLocalChecked();

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -277,12 +277,6 @@ void Url(const FunctionCallbackInfo<Value>& args) {
 void Initialize(Local<Object> target, Local<Value> unused,
                 Local<Context> context, void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  {
-    auto obj = Object::New(env->isolate());
-    auto null = Null(env->isolate());
-    CHECK(obj->SetPrototype(context, null).FromJust());
-    env->set_inspector_console_api_object(obj);
-  }
 
   Agent* agent = env->inspector_agent();
   env->SetMethod(target, "consoleCall", InspectorConsoleCall);


### PR DESCRIPTION
Previously we create env->inspector_console_api_object() when
`process.binding('inspector')` is called, which may be too late
if the inspector console is used before the first call to
`process.binding('inspector')` - that is possible when
using `--inspect-brk-node`. Setting a breakpoint and using the
inspector console before that would crash the process.

This patch moves the initialization of the console API object to
the point when Environment is initialized so that
`installAdditionalCommandLineAPI()` can be essentially a noop
if we use the inspector console before the inspector binding
is initialized instead of crashing on an empty object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
