### PR TITLE
lib: ensure readable stream flows to end

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -570,7 +570,8 @@ function maybeReadMore(stream, state) {
 function maybeReadMore_(stream, state) {
   var len = state.length;
   while (!state.reading && !state.ended &&
-         state.length < state.highWaterMark) {
+         (state.length < state.highWaterMark ||
+         state.flowing && state.length === 0)) {
     debug('maybeReadMore read 0');
     stream.read(0);
     if (len === state.length)

--- a/test/parallel/test-stream-readable-hwm-0-async.js
+++ b/test/parallel/test-stream-readable-hwm-0-async.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that Readable stream will call _read() for streams
+// with highWaterMark === 0 upon .read(0) instead of just trying to
+// emit 'readable' event.
+
+const { Readable } = require('stream');
+
+let count = 5;
+
+const r = new Readable({
+  // Called 6 times: First 5 return data, last one signals end of stream.
+  read: common.mustCall(() => {
+    process.nextTick(common.mustCall(() => {
+      if (count--)
+        r.push('a');
+      else
+        r.push(null);
+    }));
+  }, 6),
+  highWaterMark: 0,
+});
+
+r.on('end', common.mustCall());
+r.on('data', common.mustCall(5));


### PR DESCRIPTION
If a readable stream was set up with `highWaterMark 0`, the while-loop in `maybeReadMore_` function would never execute.

The while loop now has an extra or-condition for the case where the stream is flowing and there are no items. The or-condition is adapted from the emit-condition of the `addChunk` function.

The `addChunk` also contains a check for `state.sync`. However that part of the check was omitted here because the `maybeReadMore_` is executed using `process.nextTick`. `state.sync` is set and then unset  within the `read()` function so it should never be in effect in `maybeReadMore_`.

Fixes: https://github.com/nodejs/node/issues/24915

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
