### PR TITLE
lib: extract validateObject validator

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -49,7 +49,7 @@ const {
   ERR_TLS_SESSION_ATTACK,
   ERR_TLS_SNI_FROM_SERVER
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateObject, validateString } = require('internal/validators');
 const kConnectOptions = Symbol('connect-options');
 const kDisableRenegotiation = Symbol('disable-renegotiation');
 const kErrorEmitted = Symbol('error-emitted');
@@ -885,8 +885,7 @@ exports.createServer = function createServer(options, listener) {
 
 
 Server.prototype.setSecureContext = function(options) {
-  if (options === null || typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+  validateObject(options, 'options');
 
   if (options.pfx)
     this.pfx = options.pfx;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -37,7 +37,11 @@ const {
   ERR_INVALID_OPT_VALUE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
-const { validateString, isInt32 } = require('internal/validators');
+const {
+  validateString,
+  isInt32,
+  validateObject
+} = require('internal/validators');
 const child_process = require('internal/child_process');
 const {
   _validateStdio,
@@ -417,8 +421,8 @@ function normalizeSpawnArguments(file, args, options) {
 
   if (options === undefined)
     options = {};
-  else if (options === null || typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+  else
+    validateObject(options, 'options');
 
   // Validate the cwd, if present.
   if (options.cwd != null &&

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -6,10 +6,9 @@ const {
   ERR_INSPECTOR_CLOSED,
   ERR_INSPECTOR_NOT_AVAILABLE,
   ERR_INSPECTOR_NOT_CONNECTED,
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CALLBACK
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const { validateObject, validateString } = require('internal/validators');
 const util = require('util');
 const { Connection, open, url } = internalBinding('inspector');
 
@@ -63,9 +62,7 @@ class Session extends EventEmitter {
       callback = params;
       params = null;
     }
-    if (params && typeof params !== 'object') {
-      throw new ERR_INVALID_ARG_TYPE('params', 'Object', params);
-    }
+    if (params) validateObject(params, 'params');
     if (callback && typeof callback !== 'function') {
       throw new ERR_INVALID_CALLBACK();
     }

--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const { inspect } = require('util');
-const { codes: {
-  ERR_INVALID_ARG_TYPE
-} } = require('internal/errors');
+const { validateObject } = require('internal/validators');
 
 let blue = '';
 let green = '';
@@ -289,9 +287,7 @@ function createErrDiff(actual, expected, operator) {
 
 class AssertionError extends Error {
   constructor(options) {
-    if (typeof options !== 'object' || options === null) {
-      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
-    }
+    validateObject(options, 'options');
     var {
       actual,
       expected,

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -14,7 +14,7 @@ const {
     ERR_MISSING_ARGS
   }
 } = require('internal/errors');
-const { validateString } = require('internal/validators');
+const { validateObject, validateString } = require('internal/validators');
 const EventEmitter = require('events');
 const net = require('net');
 const dgram = require('dgram');
@@ -308,9 +308,7 @@ ChildProcess.prototype.spawn = function(options) {
   var ipcFd;
   var i;
 
-  if (options === null || typeof options !== 'object') {
-    throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
-  }
+  validateObject(options, 'options');
 
   // If no `stdio` option was given - use default
   var stdio = options.stdio || 'pipe';

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -16,7 +16,8 @@ const {
   PrivateKeyObject
 } = require('internal/crypto/keys');
 const { customPromisifyArgs } = require('internal/util');
-const { isUint32, validateString } = require('internal/validators');
+const { isUint32, validateObject, validateString } = require('internal/validators');
+
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
@@ -115,8 +116,7 @@ function parseKeyEncoding(keyType, options) {
 
 function check(type, options, callback) {
   validateString(type, 'type');
-  if (options == null || typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+  validateObject(options, 'options');
 
   // These will be set after parsing the type and type-specific options to make
   // the order a bit more intuitive.

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -16,10 +16,13 @@ const {
   PrivateKeyObject
 } = require('internal/crypto/keys');
 const { customPromisifyArgs } = require('internal/util');
-const { isUint32, validateObject, validateString } = require('internal/validators');
+const {
+  isUint32,
+  validateObject,
+  validateString
+} = require('internal/validators');
 
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
   ERR_INVALID_OPT_VALUE

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -7,6 +7,7 @@ const {
   isHexTable
 } = require('internal/querystring');
 
+const { validateObject } = require('internal/validators');
 const { getConstructorOf, removeColors } = require('internal/util');
 const {
   ERR_ARG_NOT_ITERABLE,
@@ -380,8 +381,7 @@ Object.defineProperties(URL.prototype, {
     configurable: false,
     // eslint-disable-next-line func-name-matching
     value: function format(options) {
-      if (options && typeof options !== 'object')
-        throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+      if (options) validateObject(options, 'options');
       options = {
         fragment: true,
         unicode: false,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -20,12 +20,8 @@ const {
   removeColors
 } = require('internal/util');
 
-const {
-  codes: {
-    ERR_INVALID_ARG_TYPE
-  },
-  isStackOverflowError
-} = require('internal/errors');
+const { isStackOverflowError } = require('internal/errors');
+const { validateObject } = require('internal/validators');
 
 const types = internalBinding('types');
 Object.assign(types, require('internal/util/types'));
@@ -200,9 +196,7 @@ Object.defineProperty(inspect, 'defaultOptions', {
     return inspectDefaultOptions;
   },
   set(options) {
-    if (options === null || typeof options !== 'object') {
-      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
-    }
+    validateObject(options, 'options');
     return Object.assign(inspectDefaultOptions, options);
   }
 });

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -130,6 +130,12 @@ function validateNumber(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 }
 
+function validateObject(value, name) {
+  if (typeof value !== 'object' || value === null) {
+    throw new ERR_INVALID_ARG_TYPE(name, 'object', value);
+  }
+}
+
 module.exports = {
   isInt32,
   isUint32,
@@ -138,5 +144,6 @@ module.exports = {
   validateInt32,
   validateUint32,
   validateString,
-  validateNumber
+  validateNumber,
+  validateObject
 };

--- a/lib/internal/vm/source_text_module.js
+++ b/lib/internal/vm/source_text_module.js
@@ -21,6 +21,7 @@ const { SafePromise } = require('internal/safe_globals');
 const {
   validateInt32,
   validateUint32,
+  validateObject,
   validateString
 } = require('internal/validators');
 
@@ -59,8 +60,7 @@ class SourceTextModule {
     emitExperimentalWarning('vm.SourceTextModule');
 
     validateString(src, 'src');
-    if (typeof options !== 'object' || options === null)
-      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
+    validateObject(options, 'options');
 
     const {
       context,
@@ -71,9 +71,7 @@ class SourceTextModule {
     } = options;
 
     if (context !== undefined) {
-      if (typeof context !== 'object' || context === null) {
-        throw new ERR_INVALID_ARG_TYPE('options.context', 'Object', context);
-      }
+      validateObject(context, 'options.context');
       if (!isContext(context)) {
         throw new ERR_INVALID_ARG_TYPE('options.context', 'vm.Context',
                                        context);
@@ -218,9 +216,7 @@ class SourceTextModule {
   }
 
   async evaluate(options = {}) {
-    if (typeof options !== 'object' || options === null) {
-      throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
-    }
+    validateObject(options, 'options');
 
     let timeout = options.timeout;
     if (timeout === undefined) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -21,7 +21,6 @@
 
 'use strict';
 
-const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const {
   CHAR_UPPERCASE_A,
   CHAR_LOWERCASE_A,
@@ -33,7 +32,7 @@ const {
   CHAR_COLON,
   CHAR_QUESTION_MARK,
 } = require('internal/constants');
-const { validateString } = require('internal/validators');
+const { validateObject, validateString } = require('internal/validators');
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -892,9 +891,7 @@ const win32 = {
 
 
   format: function format(pathObject) {
-    if (pathObject === null || typeof pathObject !== 'object') {
-      throw new ERR_INVALID_ARG_TYPE('pathObject', 'Object', pathObject);
-    }
+    validateObject(pathObject, 'pathObject');
     return _format('\\', pathObject);
   },
 
@@ -1415,9 +1412,7 @@ const posix = {
 
 
   format: function format(pathObject) {
-    if (pathObject === null || typeof pathObject !== 'object') {
-      throw new ERR_INVALID_ARG_TYPE('pathObject', 'Object', pathObject);
-    }
+    validateObject(pathObject, 'pathObject');
     return _format('/', pathObject);
   },
 

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -33,6 +33,7 @@ const {
 const { AsyncResource } = require('async_hooks');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
+const { validateObject } = require('internal/validators');
 
 const kCallback = Symbol('callback');
 const kTypes = Symbol('types');
@@ -324,9 +325,7 @@ class PerformanceObserver extends AsyncResource {
 
   observe(options) {
     const errors = lazyErrors();
-    if (typeof options !== 'object' || options == null) {
-      throw new errors.ERR_INVALID_ARG_TYPE('options', 'Object', options);
-    }
+    validateObject(options, 'options');
     if (!Array.isArray(options.entryTypes)) {
       throw new errors.ERR_INVALID_OPT_VALUE('entryTypes', options);
     }

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -12,6 +12,7 @@ const {
   ERR_TRACE_EVENTS_UNAVAILABLE,
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
+const { validateObject } = require('internal/validators');
 
 const { isMainThread } = require('internal/worker');
 if (!hasTracing || !isMainThread)
@@ -70,8 +71,7 @@ class Tracing {
 }
 
 function createTracing(options) {
-  if (typeof options !== 'object' || options == null)
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+  validateObject(options, 'options');
 
   if (!Array.isArray(options.categories)) {
     throw new ERR_INVALID_ARG_TYPE('options.categories', 'string[]',

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -404,7 +404,7 @@ assert.throws(() => {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "options" argument must be of type Object. ' +
+        message: 'The "options" argument must be of type object. ' +
                  `Received type ${typeof input}`
       });
   });

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -19,7 +19,7 @@ function typeName(value) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "options" argument must be of type Object. ' +
+      message: 'The "options" argument must be of type object. ' +
                `Received type ${typeName(options)}`
     });
   });

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -226,7 +226,7 @@ function checkFormat(path, testCases) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "pathObject" argument must be of type Object. ' +
+      message: 'The "pathObject" argument must be of type object. ' +
                `Received type ${typeof pathObject}`
     });
   });

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -45,7 +45,7 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
       {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "options" argument must be of type Object. ' +
+        message: 'The "options" argument must be of type object. ' +
                  `Received type ${typeof input}`
       });
   });

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -27,7 +27,7 @@ assert.strictEqual(
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError [ERR_INVALID_ARG_TYPE]',
-        message: 'The "options" argument must be of type Object. ' +
+        message: 'The "options" argument must be of type object. ' +
                  `Received type ${typeof value}`
       }
     );

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1186,7 +1186,7 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type Object. ' +
+    message: 'The "options" argument must be of type object. ' +
              'Received type object'
   }
   );
@@ -1196,7 +1196,7 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type Object. ' +
+    message: 'The "options" argument must be of type object. ' +
              'Received type string'
   }
   );

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -137,7 +137,7 @@ async function checkModuleState() {
     await m.evaluate(false);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options" argument must be of type Object. ' +
+    message: 'The "options" argument must be of type object. ' +
              'Received type boolean'
   });
 

--- a/test/sequential/test-inspector-module.js
+++ b/test/sequential/test-inspector-module.js
@@ -40,7 +40,7 @@ session.post('Runtime.evaluate', { expression: '2 + 2' });
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message:
-        'The "params" argument must be of type Object. ' +
+        'The "params" argument must be of type object. ' +
         `Received type ${typeof i}`
     }
   );


### PR DESCRIPTION
Pulls out the common argument `validateObject` validator to internal/validators.

BTW, there is inconsistent `ERR_INVALID_ARG_TYPE` via the `object` validation: `object` or `Object`, do we need to unify this error message ? Although this is so trivial :)

https://github.com/nodejs/node/blob/951b1c3e09bae8395dde0d4f5cecb1fde117fa94/lib/path.js#L896

https://github.com/nodejs/node/blob/951b1c3e09bae8395dde0d4f5cecb1fde117fa94/lib/child_process.js#L408

Update: unify the error message by lowercase `object`(should be semver-major?)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
