### PR TITLE
src: remove use of CallOnForegroundThread()

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -257,8 +257,7 @@ void MainThreadInterface::Post(std::unique_ptr<Request> request) {
     if (isolate_ != nullptr && platform_ != nullptr) {
       std::shared_ptr<v8::TaskRunner> taskrunner =
         platform_->GetForegroundTaskRunner(isolate_);
-      taskrunner->PostTask(std::unique_ptr<v8::Task>(
-        new DispatchMessagesTask(this)));
+      taskrunner->PostTask(std::make_unique<DispatchMessagesTask>(this));
       isolate_->RequestInterrupt([](v8::Isolate* isolate, void* thread) {
         static_cast<MainThreadInterface*>(thread)->DispatchMessages();
       }, this);

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -255,8 +255,10 @@ void MainThreadInterface::Post(std::unique_ptr<Request> request) {
   if (needs_notify) {
     CHECK_EQ(0, uv_async_send(&main_thread_request_->first));
     if (isolate_ != nullptr && platform_ != nullptr) {
-      platform_->CallOnForegroundThread(isolate_,
-                                        new DispatchMessagesTask(this));
+      std::shared_ptr<v8::TaskRunner> taskrunner =
+        platform_->GetForegroundTaskRunner(isolate_);
+      taskrunner->PostTask(std::unique_ptr<v8::Task>(
+        new DispatchMessagesTask(this)));
       isolate_->RequestInterrupt([](v8::Isolate* isolate, void* thread) {
         static_cast<MainThreadInterface*>(thread)->DispatchMessages();
       }, this);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -865,7 +865,7 @@ void Agent::RequestIoThreadStart() {
   v8::Platform* platform = parent_env_->isolate_data()->platform();
   std::shared_ptr<TaskRunner> taskrunner =
     platform->GetForegroundTaskRunner(isolate);
-  taskrunner->PostTask(std::unique_ptr<Task>(new StartIoTask(this)));
+  taskrunner->PostTask(std::make_unique<StartIoTask>(this));
   isolate->RequestInterrupt(StartIoInterrupt, this);
   uv_async_send(&start_io_thread_async);
 }

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -40,6 +40,8 @@ using v8::Local;
 using v8::Message;
 using v8::Object;
 using v8::String;
+using v8::Task;
+using v8::TaskRunner;
 using v8::Value;
 
 using v8_inspector::StringBuffer;
@@ -50,7 +52,7 @@ using v8_inspector::V8InspectorClient;
 static uv_sem_t start_io_thread_semaphore;
 static uv_async_t start_io_thread_async;
 
-class StartIoTask : public v8::Task {
+class StartIoTask : public Task {
  public:
   explicit StartIoTask(Agent* agent) : agent(agent) {}
 
@@ -861,7 +863,9 @@ void Agent::RequestIoThreadStart() {
   uv_async_send(&start_io_thread_async);
   Isolate* isolate = parent_env_->isolate();
   v8::Platform* platform = parent_env_->isolate_data()->platform();
-  platform->CallOnForegroundThread(isolate, new StartIoTask(this));
+  std::shared_ptr<TaskRunner> taskrunner =
+    platform->GetForegroundTaskRunner(isolate);
+  taskrunner->PostTask(std::unique_ptr<Task>(new StartIoTask(this)));
   isolate->RequestInterrupt(StartIoInterrupt, this);
   uv_async_send(&start_io_thread_async);
 }


### PR DESCRIPTION
The V8 platform's `CallOnForegroundThread()` method is deprecated. This commit replaces its use with `GetForegroundTaskRunner()` functionality instead.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
