### PR TITLE
test: code improvements of internet/test-dns

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -84,7 +84,6 @@ TEST(async function test_resolve4_ttl(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-      assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
       assert.strictEqual(typeof item.address, 'string');
@@ -113,7 +112,6 @@ TEST(async function test_resolve6_ttl(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-      assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
       assert.strictEqual(typeof item.address, 'string');
@@ -142,7 +140,6 @@ TEST(async function test_resolveMx(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-      assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.ok(item.exchange);
       assert.strictEqual(typeof item.exchange, 'string');
@@ -183,7 +180,6 @@ TEST(async function test_resolveNs(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-
       assert.ok(item);
       assert.strictEqual(typeof item, 'string');
     }
@@ -222,12 +218,9 @@ TEST(async function test_resolveSrv(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-      assert.ok(item);
       assert.strictEqual(typeof item, 'object');
-
       assert.ok(item.name);
       assert.strictEqual(typeof item.name, 'string');
-
       assert.strictEqual(typeof item.port, 'number');
       assert.strictEqual(typeof item.priority, 'number');
       assert.strictEqual(typeof item.weight, 'number');
@@ -305,7 +298,6 @@ TEST(async function test_resolveNaptr(done) {
     assert.ok(result.length > 0);
 
     for (const item of result) {
-      assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.flags, 'string');
       assert.strictEqual(typeof item.service, 'string');
@@ -346,7 +338,6 @@ TEST(function test_resolveNaptr_failure(done) {
 
 TEST(async function test_resolveSoa(done) {
   function validateResult(result) {
-    assert.ok(result);
     assert.strictEqual(typeof result, 'object');
     assert.strictEqual(typeof result.nsname, 'string');
     assert.ok(result.nsname.length > 0);

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -83,8 +83,7 @@ TEST(async function test_resolve4_ttl(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
@@ -113,8 +112,7 @@ TEST(async function test_resolve6_ttl(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
@@ -143,8 +141,7 @@ TEST(async function test_resolveMx(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.ok(item.exchange);
@@ -185,8 +182,7 @@ TEST(async function test_resolveNs(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
 
       assert.ok(item);
       assert.strictEqual(typeof item, 'string');
@@ -225,8 +221,7 @@ TEST(async function test_resolveSrv(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'object');
 
@@ -271,8 +266,7 @@ TEST(async function test_resolvePtr(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'string');
     }
@@ -310,8 +304,7 @@ TEST(async function test_resolveNaptr(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const item = result[i];
+    for (const item of result) {
       assert.ok(item);
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.flags, 'string');
@@ -403,10 +396,9 @@ TEST(async function test_resolveCname(done) {
   function validateResult(result) {
     assert.ok(result.length > 0);
 
-    for (let i = 0; i < result.length; i++) {
-      const name = result[i];
-      assert.ok(name);
-      assert.strictEqual(typeof name, 'string');
+    for (const item of result) {
+      assert.ok(item);
+      assert.strictEqual(typeof item, 'string');
     }
   }
 

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -472,7 +472,7 @@ TEST(function test_lookup_failure(done) {
     .then(common.mustNotCall())
     .catch(common.expectsError({ errno: dns.NOTFOUND }));
 
-  const req = dns.lookup(addresses.INVALID_HOST, 4, (err, ip, family) => {
+  const req = dns.lookup(addresses.INVALID_HOST, 4, (err) => {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, dns.NOTFOUND);
     assert.strictEqual(err.errno, 'ENOTFOUND');
@@ -540,7 +540,7 @@ TEST(function test_lookup_ip_promise(done) {
 TEST(async function test_lookup_null_all(done) {
   assert.deepStrictEqual(await dnsPromises.lookup(null, { all: true }), []);
 
-  const req = dns.lookup(null, { all: true }, function(err, ips, family) {
+  const req = dns.lookup(null, { all: true }, (err, ips) => {
     assert.ifError(err);
     assert.ok(Array.isArray(ips));
     assert.strictEqual(ips.length, 0);
@@ -586,7 +586,7 @@ TEST(function test_lookupservice_invalid(done) {
     .then(common.mustNotCall())
     .catch(common.expectsError({ code: 'ENOTFOUND' }));
 
-  const req = dns.lookupService('1.2.3.4', 80, function(err, host, service) {
+  const req = dns.lookupService('1.2.3.4', 80, (err) => {
     assert(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
     assert.ok(/1\.2\.3\.4/.test(err.message));


### PR DESCRIPTION
Generally changed usual 'for' loops to 'for of' loops for
reducing amount of lines that provides better readability.

Removed unused parameters passed to functions.

Removed unnecessary 'assert.ok' after which there is
an assert that the variable is an 'object' and object
asserted with 'assert.ok' always passes the check.

- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
