### PR TITLE
zlib: throw TypeError if callback is missing

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -73,6 +73,8 @@ for (var ck = 0; ck < ckeys.length; ck++) {
 }
 
 function zlibBuffer(engine, buffer, callback) {
+  if (typeof callback !== 'function')
+    throw new ERR_INVALID_ARG_TYPE('callback', 'function', callback);
   // Streams do not support non-Buffer ArrayBufferViews yet. Convert it to a
   // Buffer without copying.
   if (isArrayBufferView(buffer) &&

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -119,3 +119,13 @@ for (const [type, expect] of [
     }
   }
 }
+
+common.expectsError(
+  () => zlib.gzip('abc'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "callback" argument must be of type function. ' +
+             'Received type undefined'
+  }
+);


### PR DESCRIPTION
Get a proper stack trace when no callback is passed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
