### PR TITLE
inspector: migrate process.binding to internalBinding

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -11,7 +11,7 @@ const {
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
 const util = require('util');
-const { Connection, open, url } = process.binding('inspector');
+const { Connection, open, url } = internalBinding('inspector');
 
 if (!Connection)
   throw new ERR_INSPECTOR_NOT_AVAILABLE();

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -90,6 +90,7 @@ const internalBindingWhitelist = [
   'fs_event_wrap',
   'http_parser',
   'icu',
+  'inspector',
   'js_stream',
   'natives',
   'pipe_wrap',

--- a/lib/internal/console/inspector.js
+++ b/lib/internal/console/inspector.js
@@ -4,7 +4,7 @@ const path = require('path');
 const CJSModule = require('internal/modules/cjs/loader');
 const { makeRequireFunction } = require('internal/modules/cjs/helpers');
 const { tryGetCwd } = require('internal/util');
-const { addCommandLineAPI, consoleCall } = process.binding('inspector');
+const { addCommandLineAPI, consoleCall } = internalBinding('inspector');
 
 // Wrap a console implemented by Node.js with features from the VM inspector
 function addInspectorApis(consoleFromNode, consoleFromVM) {

--- a/lib/internal/inspector_async_hook.js
+++ b/lib/internal/inspector_async_hook.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const inspector = process.binding('inspector');
+const inspector = internalBinding('inspector');
 
 if (!inspector || !inspector.asyncTaskScheduled) {
   exports.setup = function() {};

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -108,7 +108,7 @@ if (getOptionValue('--experimental-worker')) {
   builtinLibs.sort();
 }
 
-if (typeof process.binding('inspector').open === 'function') {
+if (typeof internalBinding('inspector').open === 'function') {
   builtinLibs.push('inspector');
   builtinLibs.sort();
 }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -706,7 +706,7 @@ Module.prototype._compile = function(content, filename) {
     // Set breakpoint on module start
     if (filename === resolvedArgv) {
       delete process._breakFirstLine;
-      inspectorWrapper = process.binding('inspector').callAndPauseOnStart;
+      inspectorWrapper = internalBinding('inspector').callAndPauseOnStart;
     }
   }
   var dirname = path.dirname(filename);

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -73,7 +73,7 @@ class ModuleJob {
     try {
       if (this.isMain && process._breakFirstLine) {
         delete process._breakFirstLine;
-        const initWrapper = process.binding('inspector').callAndPauseOnStart;
+        const initWrapper = internalBinding('inspector').callAndPauseOnStart;
         initWrapper(this.module.instantiate, this.module);
       } else {
         this.module.instantiate();

--- a/lib/internal/process/coverage.js
+++ b/lib/internal/process/coverage.js
@@ -51,7 +51,7 @@ function disableAllAsyncHooks() {
 exports.writeCoverage = writeCoverage;
 
 function setup() {
-  const { Connection } = process.binding('inspector');
+  const { Connection } = internalBinding('inspector');
   if (!Connection) {
     console.warn('inspector not enabled');
     return;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -321,5 +321,5 @@ void Initialize(Local<Object> target, Local<Value> unused,
 }  // namespace inspector
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector,
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(inspector,
                                   node::inspector::Initialize);

--- a/src/node.cc
+++ b/src/node.cc
@@ -2145,5 +2145,5 @@ int Start(int argc, char** argv) {
 #if !HAVE_INSPECTOR
 void Initialize() {}
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector, Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(inspector, Initialize)
 #endif  // !HAVE_INSPECTOR

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -17,3 +17,4 @@ assert(process.binding('spawn_sync'));
 assert(process.binding('js_stream'));
 assert(process.binding('buffer'));
 assert(process.binding('fs'));
+assert(process.binding('inspector'));

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -291,7 +291,7 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
 
 if (process.config.variables.v8_enable_inspector !== 0 &&
     common.isMainThread) {
-  const binding = process.binding('inspector');
+  const binding = internalBinding('inspector');
   const handle = new binding.Connection(() => {});
   testInitialized(handle, 'Connection');
   handle.disconnect();


### PR DESCRIPTION
Refs #22160, this PR attempts to migrate `process.binding('inspector')` to `internalBinding('inspector')`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
