### PR TITLE
worker: drain the messages from the internal message port

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -317,6 +317,7 @@ class Worker extends EventEmitter {
   [kOnExit](code) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
     MessagePortPrototype.drain.call(this[kPublicPort]);
+    MessagePortPrototype.drain.call(this[kPort]);
     this[kDispose]();
     this.emit('exit', code);
     this.removeAllListeners();

--- a/test/parallel/test-worker-message-port-drain.js
+++ b/test/parallel/test-worker-message-port-drain.js
@@ -1,0 +1,41 @@
+// Flags: --experimental-worker
+'use strict';
+require('../common');
+
+// This test ensures that the messages from the internal
+// message port are drained before the call to 'kDispose',
+// and so all the stdio messages from the worker are processed
+// in the parent and are pushed to their target streams.
+
+const assert = require('assert');
+const {
+  Worker,
+  isMainThread,
+  parentPort,
+  threadId,
+} = require('worker_threads');
+
+if (isMainThread) {
+  const workerIdsToOutput = new Map();
+
+  for (let i = 0; i < 2; i++) {
+    const worker = new Worker(__filename, { stdout: true });
+    const workerOutput = [];
+    workerIdsToOutput.set(worker.threadId, workerOutput);
+    worker.on('message', console.log);
+    worker.stdout.on('data', (chunk) => {
+      workerOutput.push(chunk.toString().trim());
+    });
+  }
+
+  process.on('exit', () => {
+    for (const [threadId, workerOutput] of workerIdsToOutput) {
+      assert.ok(workerOutput.includes(`1 threadId: ${threadId}`));
+      assert.ok(workerOutput.includes(`2 threadId: ${threadId}`));
+    }
+  });
+} else {
+  console.log(`1 threadId: ${threadId}`);
+  console.log(`2 threadId: ${threadId}`);
+  parentPort.postMessage(Array(100).fill(1));
+}


### PR DESCRIPTION
When the worker thread exits, drain the messages also from the internal
message port so that the call to 'kDispose' will occur only after all
the messages from the worker were processed in the parent, so stdio
messages from the worker will be successfully pushed to their target
streams in the parent.

Thanks to @addaleax for the actual solution :)

Fixes: https://github.com/nodejs/node/issues/24636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
