### PR TITLE
src: include node_internals.h in node_metadata.cc

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -2,6 +2,7 @@
 #include "ares.h"
 #include "nghttp2/nghttp2ver.h"
 #include "node.h"
+#include "node_internals.h"
 #include "util.h"
 #include "uv.h"
 #include "v8.h"


### PR DESCRIPTION
Currently, if configured `--without-ssl` the following compiler error will
be generated:
```console
../src/node_metadata.cc:29:12:
error: use of undeclared identifier 'llhttp_version'
  llhttp = llhttp_version;
           ^
../src/node_metadata.cc:30:17:
error: use of undeclared identifier 'http_parser_version'
  http_parser = http_parser_version;
```
This commit includes the node_internals.h header so that
llhttp_version and http_parser_versions are always available.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
