### PR TITLE
test: remove magic numbers in test-gc-http-client-onerror

### DIFF
--- a/test/parallel/test-gc-http-client-onerror.js
+++ b/test/parallel/test-gc-http-client-onerror.js
@@ -6,6 +6,8 @@
 const common = require('../common');
 const onGC = require('../common/ongc');
 
+const cpus = require('os').cpus().length;
+
 function serverHandler(req, res) {
   req.resume();
   res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -13,38 +15,35 @@ function serverHandler(req, res) {
 }
 
 const http = require('http');
-const todo = 500;
+let createClients = true;
 let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log(`We should do ${todo} requests`);
-
 const server = http.createServer(serverHandler);
 server.listen(0, common.mustCall(() => {
-  for (let i = 0; i < 10; i++)
-    getall();
+  for (let i = 0; i < cpus; i++)
+    getAll();
 }));
 
-function getall() {
-  if (count >= todo)
-    return;
+function getAll() {
+  if (createClients) {
+    const req = http.get({
+      hostname: 'localhost',
+      pathname: '/',
+      port: server.address().port
+    }, cb).on('error', onerror);
 
-  const req = http.get({
-    hostname: 'localhost',
-    pathname: '/',
-    port: server.address().port
-  }, cb).on('error', onerror);
+    count++;
+    onGC(req, { ongc });
 
-  count++;
-  onGC(req, { ongc });
-
-  setImmediate(getall);
+    setImmediate(getAll);
+  }
 }
 
 function cb(res) {
   res.resume();
-  done += 1;
+  done++;
 }
 
 function onerror(err) {
@@ -55,11 +54,19 @@ function ongc() {
   countGC++;
 }
 
-setInterval(status, 100).unref();
+setImmediate(status);
 
 function status() {
-  global.gc();
-  console.log('Done: %d/%d', done, todo);
-  console.log('Collected: %d/%d', countGC, count);
-  if (countGC === todo) server.close();
+  if (done > 0) {
+    createClients = false;
+    global.gc();
+    console.log(`done/collected/total: ${done}/${countGC}/${count}`);
+    if (countGC === count) {
+      server.close();
+    } else {
+      setImmediate(status);
+    }
+  } else {
+    setImmediate(status);
+  }
 }


### PR DESCRIPTION
Remove magic numbers 500 and 10 from the test. Instead, detect when GC
has started and stop sending requests at that point.

On my laptop, this results in 68 or 72 requests per run instead of 500.

Fixes: https://github.com/nodejs/node/issues/23089

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
