### PR TITLE
trace_events: fix trace events JS API not writing traces

### DIFF
--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -74,6 +74,9 @@ void NodeCategorySet::Enable(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(category_set);
   const auto& categories = category_set->GetCategories();
   if (!category_set->enabled_ && !categories.empty()) {
+    // Starts the Tracing Agent if it wasn't started already (e.g. through
+    // a command line flag.)
+    StartTracingAgent();
     GetTracingAgentWriter()->Enable(categories);
     category_set->enabled_ = true;
   }

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -59,6 +59,8 @@ class AgentWriterHandle {
   inline void Enable(const std::set<std::string>& categories);
   inline void Disable(const std::set<std::string>& categories);
 
+  inline bool IsDefaultHandle();
+
   inline Agent* agent() { return agent_; }
 
   inline v8::TracingController* GetTracingController();
@@ -172,6 +174,10 @@ void AgentWriterHandle::Enable(const std::set<std::string>& categories) {
 
 void AgentWriterHandle::Disable(const std::set<std::string>& categories) {
   if (agent_ != nullptr) agent_->Disable(id_, categories);
+}
+
+bool AgentWriterHandle::IsDefaultHandle() {
+  return agent_ != nullptr && id_ == Agent::kDefaultHandleId;
 }
 
 inline v8::TracingController* AgentWriterHandle::GetTracingController() {


### PR DESCRIPTION
Fixes #24944

~~I believe Inspector-based tracing probably faces the same issue, but I wasn't yet able to verify it because of a possibly unrelated V8 issue. So this PR only fixes the JS API.~~ (edit: it seems that this does not affect inspector as it uses its own trace writer)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
