### PR TITLE
lib: use debugger statement to break scripts in -e --inspect-brk

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -659,8 +659,7 @@ function setupProcessICUVersions() {
 function wrapForBreakOnFirstLine(source) {
   if (!process._breakFirstLine)
     return source;
-  const fn = `function() {\n\n${source};\n\n}`;
-  return `process.binding('inspector').callAndPauseOnStart(${fn}, {})`;
+  return `debugger;\n${source}`;
 }
 
 function evalScript(name, body) {

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -503,6 +503,39 @@ function fires(promise, error, timeoutMs) {
   ]);
 }
 
+const firstBreakIndex = {
+  // -e will wrap the source with `debugger;\n${source}`
+  eval: 0,
+  // CJS module will be wrapped with `require('module').wrapper`
+  cjs: -1,
+  // The following are not wrapped
+  esm: -1,
+  vm: -1
+};
+
+const firstBreakOffset = {
+  eval: firstBreakIndex.eval + 1,
+  cjs: firstBreakIndex.cjs + 1,
+  esm: firstBreakIndex.esm + 1,
+  vm: firstBreakIndex.vm + 1,
+  none: 0
+};
+
+function getDebuggerStatementIndices(script, mode = 'none') {
+  const lines = script.split('\n');
+  const result = [];
+  for (let i = 0; i < lines.length; ++i) {
+    const line = lines[i];
+    if (/\bdebugger\b/.test(line)) {
+      result.push(firstBreakOffset[mode] + i);
+    }
+  }
+  return result;
+}
+
 module.exports = {
-  NodeInstance
+  NodeInstance,
+  getDebuggerStatementIndices,
+  firstBreakIndex,
+  firstBreakOffset
 };

--- a/test/sequential/test-inspector-break-e.js
+++ b/test/sequential/test-inspector-break-e.js
@@ -4,7 +4,12 @@ const common = require('../common');
 common.skipIfInspectorDisabled();
 
 const assert = require('assert');
-const { NodeInstance } = require('../common/inspector-helper.js');
+const {
+  NodeInstance,
+  firstBreakIndex: {
+    eval: evalDebugBreakIndex
+  }
+} = require('../common/inspector-helper.js');
 
 async function runTests() {
   const instance = new NodeInstance(undefined, 'console.log(10)');
@@ -14,7 +19,7 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(2, '[eval]');
+  await session.waitForBreakOnLine(evalDebugBreakIndex, '[eval]');
   await session.runToCompletion();
   assert.strictEqual((await instance.expectShutdown()).exitCode, 0);
 }

--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -2,9 +2,16 @@
 'use strict';
 const common = require('../common');
 common.skipIfInspectorDisabled();
-const { NodeInstance } = require('../common/inspector-helper.js');
+const {
+  NodeInstance,
+  firstBreakIndex: {
+    eval: evalDebugBreakIndex
+  },
+  getDebuggerStatementIndices
+} = require('../common/inspector-helper.js');
 const assert = require('assert');
 
+const vmDebugScript = 'debugger';
 const script = `
   'use strict';
   const assert = require('assert');
@@ -28,8 +35,11 @@ const script = `
   vm.runInNewContext('Array', {});
   debugger;
 
-  vm.runInNewContext('debugger', {});
+  vm.runInNewContext('${vmDebugScript}', {});
 `;
+
+const breakIndices = getDebuggerStatementIndices(script, 'eval');
+const [ vmDebugIndex ] = getDebuggerStatementIndices(vmDebugScript, 'vm');
 
 async function getContext(session) {
   const created =
@@ -51,34 +61,34 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(4, '[eval]');
+  await session.waitForBreakOnLine(evalDebugBreakIndex, '[eval]');
 
   await session.send({ 'method': 'Runtime.enable' });
   await getContext(session);
   await session.send({ 'method': 'Debugger.resume' });
   const childContext = await getContext(session);
-  await session.waitForBreakOnLine(13, '[eval]');
+  await session.waitForBreakOnLine(breakIndices[0], '[eval]');
 
   console.error('[test]', 'Script is unbound');
   await session.send({ 'method': 'Debugger.resume' });
-  await session.waitForBreakOnLine(17, '[eval]');
+  await session.waitForBreakOnLine(breakIndices[1], '[eval]');
 
   console.error('[test]', 'vm.runInContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   await checkScriptContext(session, childContext);
-  await session.waitForBreakOnLine(20, '[eval]');
+  await session.waitForBreakOnLine(breakIndices[2], '[eval]');
 
   console.error('[test]', 'vm.runInNewContext associates script with context');
   await session.send({ 'method': 'Debugger.resume' });
   const thirdContext = await getContext(session);
   await checkScriptContext(session, thirdContext);
-  await session.waitForBreakOnLine(23, '[eval]');
+  await session.waitForBreakOnLine(breakIndices[3], '[eval]');
 
   console.error('[test]', 'vm.runInNewContext can contain debugger statements');
   await session.send({ 'method': 'Debugger.resume' });
   const fourthContext = await getContext(session);
   await checkScriptContext(session, fourthContext);
-  await session.waitForBreakOnLine(0, 'evalmachine.<anonymous>');
+  await session.waitForBreakOnLine(vmDebugIndex, 'evalmachine.<anonymous>');
 
   await session.runToCompletion();
   assert.strictEqual((await instance.expectShutdown()).exitCode, 0);


### PR DESCRIPTION
When wrapping scripts being evaluated with `-e` and `--inspect-brk`,
instead of wrapping it with an internal binding:

```
process.binding('inspector').callAndPauseOnStart(function() {

${source};

}, {})
```

simply insert a debugger statement:

```
debugger;
${source}
```

so that the wrapped script do not rely on any internal magic
since we should treat it as a normal user land script. In addition,
if the source starts with declarations, it now breaks before the
declarations instead of skipping through the declarations and jumping
to the first statement.

This patch also introduces helpers for the inspector tests to calculate
debug break line numbers programmatically, instead of hard-coding the
numbers, since these numbers can change when the way we wrap different
kinds of scripts change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
