### PR TITLE
src: emit 'params' instead of 'data' for NodeTracing.dataCollected

### DIFF
--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -31,7 +31,7 @@ class InspectorTraceWriter : public node::tracing::AsyncTraceWriter {
       return;
     json_writer_.reset();
     std::ostringstream result(
-        "{\"method\":\"NodeTracing.dataCollected\",\"data\":",
+        "{\"method\":\"NodeTracing.dataCollected\",\"params\":",
         std::ostringstream::ate);
     result << stream_.str();
     result << "}";

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -60,7 +60,7 @@ async function test() {
     await generateTrace();
   JSON.stringify(await post('NodeTracing.stop', { traceConfig }));
   session.disconnect();
-  assert(traceNotification.data.value.length > 0);
+  assert(traceNotification.params.value.length > 0);
   assert(tracingComplete);
   clearInterval(interval);
   console.log('Success');

--- a/test/parallel/test-trace-events-dynamic-enable.js
+++ b/test/parallel/test-trace-events-dynamic-enable.js
@@ -28,8 +28,8 @@ async function test() {
   const events = [];
   let tracingComplete = false;
   session.on('NodeTracing.dataCollected', (n) => {
-    assert.ok(n && n.data && n.data.value);
-    events.push(...n.data.value);  // append the events.
+    assert.ok(n && n.params && n.params.value);
+    events.push(...n.params.value);  // append the events.
   });
   session.on('NodeTracing.tracingComplete', () => tracingComplete = true);
 


### PR DESCRIPTION
All inspector event emissions emit an object of the shape `{ method: string, params: {} }` except for `NodeTracing.dataCollected`. This PR changes this event to emit an object with a `params` field instead of `data`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
