### PR TITLE
child_process: truncate output when maxBuffer is exceeded

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -147,8 +147,9 @@ changes:
     `'/bin/sh'` on UNIX, `process.env.ComSpec` on Windows.
   * `timeout` {number} **Default:** `0`
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. If exceeded, the child process is terminated. See caveat at
-    [`maxBuffer` and Unicode][]. **Default:** `200 * 1024`.
+    stderr. If exceeded, the child process is terminated and any output is
+    truncated. See caveat at [`maxBuffer` and Unicode][].
+    **Default:** `200 * 1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -245,8 +246,9 @@ changes:
   * `encoding` {string} **Default:** `'utf8'`
   * `timeout` {number} **Default:** `0`
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. If exceeded, the child process is terminated. See caveat at
-    [`maxBuffer` and Unicode][]. **Default:** `200 * 1024`.
+    stderr. If exceeded, the child process is terminated and any output is
+    truncated. See caveat at [`maxBuffer` and Unicode][].
+    **Default:** `200 * 1024`.
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -779,8 +781,9 @@ changes:
   * `killSignal` {string|integer} The signal value to be used when the spawned
     process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. If exceeded, the child process is terminated. See caveat at
-    [`maxBuffer` and Unicode][]. **Default:** `200 * 1024`.
+    stderr. If exceeded, the child process is terminated and any output is
+    truncated. See caveat at [`maxBuffer` and Unicode][].
+    **Default:** `200 * 1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
@@ -842,8 +845,9 @@ changes:
   * `killSignal` {string|integer} The signal value to be used when the spawned
     process will be killed. **Default:** `'SIGTERM'`.
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. If exceeded, the child process is terminated. See caveat at
-    [`maxBuffer` and Unicode][]. **Default:** `200 * 1024`.
+    stderr. If exceeded, the child process is terminated and any output is
+    truncated. See caveat at [`maxBuffer` and Unicode][].
+    **Default:** `200 * 1024`.
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`.
   * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -343,9 +343,15 @@ exports.execFile = function execFile(file /* , args, options, callback */) {
 
     child.stdout.on('data', function onChildStdout(chunk) {
       var encoding = child.stdout._readableState.encoding;
-      stdoutLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
+      const length = encoding ?
+        Buffer.byteLength(chunk, encoding) :
+        chunk.length;
+      stdoutLen += length;
 
       if (stdoutLen > options.maxBuffer) {
+        const truncatedLen = options.maxBuffer - (stdoutLen - length);
+        _stdout.push(chunk.slice(0, truncatedLen));
+
         ex = new ERR_CHILD_PROCESS_STDIO_MAXBUFFER('stdout');
         kill();
       } else {
@@ -360,9 +366,15 @@ exports.execFile = function execFile(file /* , args, options, callback */) {
 
     child.stderr.on('data', function onChildStderr(chunk) {
       var encoding = child.stderr._readableState.encoding;
-      stderrLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
+      const length = encoding ?
+        Buffer.byteLength(chunk, encoding) :
+        chunk.length;
+      stderrLen += length;
 
       if (stderrLen > options.maxBuffer) {
+        const truncatedLen = options.maxBuffer - (stderrLen - length);
+        _stderr.push(chunk.slice(0, truncatedLen));
+
         ex = new ERR_CHILD_PROCESS_STDIO_MAXBUFFER('stderr');
         kill();
       } else {

--- a/test/parallel/test-child-process-exec-maxBuffer.js
+++ b/test/parallel/test-child-process-exec-maxBuffer.js
@@ -22,13 +22,13 @@ function runChecks(err, stdio, streamName, expected) {
 }
 
 {
-  const cmd = 'echo "hello world"';
+  const cmd = 'echo hello world';
 
   cp.exec(
     cmd,
     { maxBuffer: 5 },
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stdout', '');
+      runChecks(err, { stdout, stderr }, 'stdout', 'hello');
     })
   );
 }
@@ -42,7 +42,7 @@ const unicode = '中文测试'; // length = 4, byte length = 12
     cmd,
     { maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stdout', '');
+      runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
     })
   );
 }
@@ -54,7 +54,7 @@ const unicode = '中文测试'; // length = 4, byte length = 12
     cmd,
     { maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stderr', '');
+      runChecks(err, { stdout, stderr }, 'stderr', '中文测');
     })
   );
 }
@@ -66,7 +66,7 @@ const unicode = '中文测试'; // length = 4, byte length = 12
     cmd,
     { encoding: null, maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stdout', '');
+      runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
     })
   );
 
@@ -80,9 +80,22 @@ const unicode = '中文测试'; // length = 4, byte length = 12
     cmd,
     { encoding: null, maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
-      runChecks(err, { stdout, stderr }, 'stderr', '');
+      runChecks(err, { stdout, stderr }, 'stderr', '中文测');
     })
   );
 
   child.stderr.setEncoding('utf-8');
+}
+
+{
+  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
+
+  cp.exec(
+    cmd,
+    { encoding: null, maxBuffer: 5 },
+    common.mustCall((err, stdout, stderr) => {
+      const buf = Buffer.from(unicode).slice(0, 5);
+      runChecks(err, { stdout, stderr }, 'stderr', buf);
+    })
+  );
 }


### PR DESCRIPTION
Preserves truncated output for `child_process.exec()` when `maxBuffer` is exceeded.

This is particularly useful for commands which have indistinguishable
error codes for what output they produce.

-----

I am presently running into this and just vendoring `exec` with a similar change into some code because... well, I need it, and don't want to re-write all of `exec` by hand.

~~Done as an added option / semver-minor because I want it sooner. IMO we should make this the default behavior but I think there's a chance something relies on the old behavior.~~
_Done as patch as per discussion._

The old behavior was also completely untested so... commit 1 fixes that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
