### PR TITLE
test: from functools import reduce in test/testpy/__init__.py

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -31,6 +31,11 @@ from os.path import join, dirname, exists, splitext
 import re
 import ast
 
+try:
+  reduce
+except NameError:
+  from functools import reduce
+
 
 FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
 FILES_PATTERN = re.compile(r"//\s+Files:(.*)")


### PR DESCRIPTION
Fixes #23659 !!!

$ __make lint-py__  # When run on Python 3
```
PYTHONPATH=tools/pip python -m flake8 . \
		--count --show-source --statistics --select=E901,E999,F821,F822,F823 \
		--exclude=.git,deps,lib,src,tools/*_macros.py,tools/gyp,tools/inspector_protocol,tools/jinja2,tools/markupsafe,tools/pip
./test/testpy/__init__.py:119:37: F821 undefined name 'reduce'
        file_path = join(self.root, reduce(join, test[1:], ""))
                                    ^
./test/testpy/__init__.py:161:37: F821 undefined name 'reduce'
        file_path = join(self.root, reduce(join, test[1:], "") + ".js")
                                    ^
2     F821 undefined name 'reduce'
2
make: *** [lint-py] Error 1
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
