### PR TITLE
src: remove internalBinding('config').warningFile

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -1,10 +1,17 @@
 'use strict';
 
-const config = internalBinding('config');
 const prefix = `(${process.release.name}:${process.pid}) `;
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 
 exports.setup = setupProcessWarnings;
+
+let options;
+function lazyOption(name) {
+  if (!options) {
+    options = require('internal/options');
+  }
+  return options.getOptionValue(name);
+}
 
 var cachedFd;
 var acquiringFd = false;
@@ -49,11 +56,11 @@ function onAcquired(message) {
   };
 }
 
-function acquireFd(cb) {
+function acquireFd(warningFile, cb) {
   if (cachedFd === undefined && !acquiringFd) {
     acquiringFd = true;
     if (fs === null) fs = require('fs');
-    fs.open(config.warningFile, 'a', onOpen(cb));
+    fs.open(warningFile, 'a', onOpen(cb));
   } else if (cachedFd !== undefined && !acquiringFd) {
     cb(null, cachedFd);
   } else {
@@ -62,8 +69,9 @@ function acquireFd(cb) {
 }
 
 function output(message) {
-  if (typeof config.warningFile === 'string') {
-    acquireFd(onAcquired(message));
+  const warningFile = lazyOption('--redirect-warnings');
+  if (warningFile) {
+    acquireFd(warningFile, onAcquired(message));
     return;
   }
   writeOut(message);

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -90,11 +90,6 @@ static void Initialize(Local<Object> target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));
 
-  const std::string& warning_file = env->options()->redirect_warnings;
-  if (!warning_file.empty()) {
-    READONLY_STRING_PROPERTY(target, "warningFile", warning_file);
-  }
-
   Local<Object> debug_options_obj = Object::New(isolate);
   READONLY_PROPERTY(target, "debugOptions", debug_options_obj);
 


### PR DESCRIPTION
Instead use `require('internal/options')` lazily. Also refactor the
call site a bit so that the option is queried only once since it's
synchronous anyway.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
