### PR TITLE
process: improve `--redirect-warnings` handling

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -5,20 +5,20 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 
 exports.setup = setupProcessWarnings;
 
-let options;
-function lazyOption(name) {
-  if (!options) {
-    options = require('internal/options');
-  }
-  return options.getOptionValue(name);
-}
-
-var cachedFd;
-var acquiringFd = false;
-function nop() {}
-
 // Lazily loaded
-var fs = null;
+let fs;
+let fd;
+let warningFile;
+
+function lazyOption() {
+  // This will load `warningFile` only once. If the flag is not set,
+  // `warningFile` will be set to an empty string.
+  if (warningFile === undefined) {
+    warningFile = require('internal/options')
+                  .getOptionValue('--redirect-warnings');
+  }
+  return warningFile;
+}
 
 function writeOut(message) {
   if (console && typeof console.error === 'function')
@@ -26,63 +26,29 @@ function writeOut(message) {
   process._rawDebug(message);
 }
 
-function onClose(fd) {
-  return () => {
-    if (fs === null) fs = require('fs');
+function writeToFile(message) {
+  if (fd === undefined) {
+    fs = require('fs');
     try {
-      fs.closeSync(fd);
-    } catch {}
-  };
-}
-
-function onOpen(cb) {
-  return (err, fd) => {
-    acquiringFd = false;
-    if (fd !== undefined) {
-      cachedFd = fd;
-      process.on('exit', onClose(fd));
-    }
-    cb(err, fd);
-    process.emit('_node_warning_fd_acquired', err, fd);
-  };
-}
-
-function onAcquired(message) {
-  // make a best effort attempt at writing the message
-  // to the fd. Errors are ignored at this point.
-  return (err, fd) => {
-    if (err)
+      fd = fs.openSync(warningFile, 'a');
+    } catch {
       return writeOut(message);
-    if (fs === null) fs = require('fs');
-    fs.appendFile(fd, `${message}\n`, nop);
-  };
-}
-
-function acquireFd(warningFile, cb) {
-  if (cachedFd === undefined && !acquiringFd) {
-    acquiringFd = true;
-    if (fs === null) fs = require('fs');
-    fs.open(warningFile, 'a', onOpen(cb));
-  } else if (cachedFd !== undefined && !acquiringFd) {
-    cb(null, cachedFd);
-  } else {
-    process.once('_node_warning_fd_acquired', cb);
+    }
+    process.on('exit', () => {
+      try {
+        fs.closeSync(fd);
+      } catch {}
+    });
   }
-}
-
-function output(message) {
-  const warningFile = lazyOption('--redirect-warnings');
-  if (warningFile) {
-    acquireFd(warningFile, onAcquired(message));
-    return;
-  }
-  writeOut(message);
+  fs.appendFile(fd, `${message}\n`, (err) => {
+    if (err) {
+      writeOut(message);
+    }
+  });
 }
 
 function doEmitWarning(warning) {
-  return () => {
-    process.emit('warning', warning);
-  };
+  return () => process.emit('warning', warning);
 }
 
 function setupProcessWarnings() {
@@ -107,7 +73,11 @@ function setupProcessWarnings() {
       if (typeof warning.detail === 'string') {
         msg += `\n${warning.detail}`;
       }
-      output(msg);
+      const warningFile = lazyOption();
+      if (warningFile) {
+        return writeToFile(msg);
+      }
+      writeOut(msg);
     });
   }
 


### PR DESCRIPTION
1) Acquiring the file descriptor is not observable anymore when using
   the `--redirect-warnings` flag.
2) If `fs.appendFile` fails, the warning is now redirected to the
   default output.
4) The code is much smaller and simpler.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
