### PR TITLE
process: properly close file descriptor on exit

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -22,7 +22,9 @@ function writeOut(message) {
 function onClose(fd) {
   return () => {
     if (fs === null) fs = require('fs');
-    fs.close(fd, nop);
+    try {
+      fs.closeSync(fd);
+    } catch {}
   };
 }
 


### PR DESCRIPTION
This makes sure the file descriptor is closed syncronously on exit
instead of using the asyncronous version which should not be used
on exit.

This is pulled out from #24965 as suggested by @addaleax.

Refs: https://github.com/nodejs/node/pull/24965/files#r240770314
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
