### PR TITLE
util: inspect all prototypes

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -322,7 +322,7 @@ function getEmptyFormatArray() {
   return [];
 }
 
-function getConstructorName(obj) {
+function getConstructorName(obj, ctx) {
   let firstProto;
   while (obj) {
     const descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
@@ -341,10 +341,11 @@ function getConstructorName(obj) {
   if (firstProto === null) {
     return null;
   }
-  // TODO(BridgeAR): Improve prototype inspection.
-  // We could use inspect on the prototype itself to improve the output.
 
-  return '';
+  return `<${inspect(firstProto, {
+    ...ctx,
+    customInspect: false
+  })}>`;
 }
 
 function getPrefix(constructor, tag, fallback) {
@@ -503,7 +504,7 @@ function formatValue(ctx, value, recurseTimes) {
   }
 
   if (ctx.stop !== undefined) {
-    const name = getConstructorName(value) || value[Symbol.toStringTag];
+    const name = getConstructorName(value, ctx) || value[Symbol.toStringTag];
     return ctx.stylize(`[${name || 'Object'}]`, 'special');
   }
 
@@ -547,7 +548,7 @@ function formatValue(ctx, value, recurseTimes) {
 function formatRaw(ctx, value, recurseTimes) {
   let keys;
 
-  const constructor = getConstructorName(value);
+  const constructor = getConstructorName(value, ctx);
   let tag = value[Symbol.toStringTag];
   if (typeof tag !== 'string')
     tag = '';

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1738,19 +1738,34 @@ assert.strictEqual(
   );
 }
 
-// Manipulate the prototype to one that we can not handle.
+// Manipulate the prototype in weird ways.
 {
   let obj = { a: true };
   let value = (function() { return function() {}; })();
   Object.setPrototypeOf(value, null);
   Object.setPrototypeOf(obj, value);
-  assert.strictEqual(util.inspect(obj), '{ a: true }');
+  assert.strictEqual(util.inspect(obj), '<[Function]> { a: true }');
+  assert.strictEqual(
+    util.inspect(obj, { colors: true }),
+    '<\u001b[36m[Function]\u001b[39m> { a: \u001b[33mtrue\u001b[39m }'
+  );
 
   obj = { a: true };
   value = [];
   Object.setPrototypeOf(value, null);
   Object.setPrototypeOf(obj, value);
-  assert.strictEqual(util.inspect(obj), '{ a: true }');
+  assert.strictEqual(
+    util.inspect(obj),
+    '<[Array: null prototype] []> { a: true }'
+  );
+
+  function StorageObject() {}
+  StorageObject.prototype = Object.create(null);
+  assert.strictEqual(
+    util.inspect(new StorageObject()),
+    '<[Object: null prototype] {}> {}'
+  );
+
 }
 
 // Check that the fallback always works.


### PR DESCRIPTION
It is currently difficult to distinguish multiple objects from each
other because the prototype is not properly inspected. From now on
all prototypes will be inspected, even if we do not fully know how
they will look like / what there shape really is.

Fixes: https://github.com/nodejs/node/issues/24917

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
