### PR TITLE
buffer: up to 2x times faster copy of buffers

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  size: [10, 1024, 2048, 4096, 8192],
+  size: [10, 1024, 2048, 8192, 64 * 1024, 256 * 1024, 1024 * 1024, 8 * 1024 * 1024, 32 * 1024 * 1024],
   n: [1024]
 });
 

--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common.js');
+const { randomFillSync } = require('crypto');
 
 const bench = common.createBenchmark(main, {
   size: [10, 1024, 2048, 8192, 64 * 1024, 256 * 1024, 1024 * 1024, 8 * 1024 * 1024, 32 * 1024 * 1024],
@@ -7,12 +8,12 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n, size }) {
-  const source = Buffer.allocUnsafe(size);
-  const target = Buffer.allocUnsafe(size);
+  const buf = Buffer.allocUnsafe(size * 2);
+  randomFillSync(buf);
 
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
-    source.copy(target);
+    buf.copy(buf, size, 0, size);
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -3,19 +3,21 @@ const common = require('../common.js');
 const { randomBytes } = require('crypto');
 
 const KB = 1024;
-const MB = KB * KB;
 
 const bench = common.createBenchmark(main, {
-  size: [10, KB, 2 * KB, 8 * KB, 64 * KB, 256 * KB, MB, 8 * MB, 32 * MB],
+  size: [10, KB, 2 * KB, 8 * KB, 64 * KB /* , 256 * KB */],
+  // This option checks edge case when target.length !== source.length.
+  targetStart: [0, 1],
   n: [1024]
 });
 
-const buf = randomBytes(32 * MB * 2);
+function main({ n, size, targetStart }) {
+  const source = randomBytes(size);
+  const target = randomBytes(size);
 
-function main({ n, size }) {
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
-    buf.copy(buf, size, 0, size);
+    source.copy(target, targetStart);
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  size: [10, 1024, 2048, 4096, 8192],
+  n: [1024]
+});
+
+function main({ n, size }) {
+  const source = Buffer.allocUnsafe(size);
+  const target = Buffer.allocUnsafe(size);
+
+  bench.start();
+  for (var i = 0; i < n * 1024; i++) {
+    source.copy(target);
+  }
+  bench.end(n);
+}

--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -1,16 +1,18 @@
 'use strict';
 const common = require('../common.js');
-const { randomFillSync } = require('crypto');
+const { randomBytes } = require('crypto');
+
+const KB = 1024;
+const MB = KB * KB;
 
 const bench = common.createBenchmark(main, {
-  size: [10, 1024, 2048, 8192, 64 * 1024, 256 * 1024, 1024 * 1024, 8 * 1024 * 1024, 32 * 1024 * 1024],
+  size: [10, KB, 2 * KB, 8 * KB, 64 * KB, 256 * KB, MB, 8 * MB, 32 * MB],
   n: [1024]
 });
 
-function main({ n, size }) {
-  const buf = Buffer.allocUnsafe(size * 2);
-  randomFillSync(buf);
+const buf = randomBytes(32 * MB * 2);
 
+function main({ n, size }) {
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
     buf.copy(buf, size, 0, size);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -473,7 +473,7 @@ Buffer.concat = function concat(list, length) {
       throw new ERR_INVALID_ARG_TYPE(
         `list[${i}]`, ['Array', 'Buffer', 'Uint8Array'], list[i]);
     }
-    _copy(buf, buffer, pos);
+    fastcopy(buf, buffer, pos);
     pos += buf.length;
   }
 
@@ -487,6 +487,59 @@ Buffer.concat = function concat(list, length) {
 
   return buffer;
 };
+
+function fastcopy(source, target, targetStart = 0, sourceStart = 0, sourceEnd) {
+  if (!isUint8Array(source)) {
+    throw new ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], source);
+  }
+
+  if (!isUint8Array(target)) {
+    throw new ERR_INVALID_ARG_TYPE('target', ['Buffer', 'Uint8Array'], target);
+  }
+
+  if (targetStart < 0)
+    throw new ERR_OUT_OF_RANGE('targetStart', '>= 0', targetStart);
+  else
+    targetStart >>>= 0;
+
+  if (sourceStart < 0)
+    throw new ERR_OUT_OF_RANGE('sourceStart', '>= 0', sourceStart);
+  else
+    sourceStart >>>= 0;
+
+  if (sourceEnd === undefined)
+    sourceEnd = source.byteLength;
+  else if (sourceEnd < 0)
+    throw new ERR_OUT_OF_RANGE('sourceEnd', '>= 0', sourceEnd);
+  else
+    sourceEnd >>>= 0;
+
+  if (targetStart >= target.byteLength || sourceStart >= sourceEnd)
+    return 0;
+
+  if (sourceStart > source.byteLength) {
+    throw new ERR_OUT_OF_RANGE(
+      'sourceStart', `<= ${source.byteLength}`, sourceStart
+    );
+  }
+
+  if (sourceEnd - sourceStart > target.byteLength - targetStart)
+    sourceEnd = sourceStart + target.byteLength - targetStart;
+
+  const to_copy = Math.min(
+    Math.min(
+      sourceEnd - sourceStart, target.byteLength - targetStart
+    ),
+    source.byteLength - sourceStart
+  );
+
+  if (sourceStart > 0 || to_copy < source.byteLength) {
+    source = source.subarray(sourceStart, sourceStart + to_copy);
+  }
+
+  target.set(source, targetStart);
+  return to_copy;
+}
 
 function base64ByteLength(str, bytes) {
   // Handle padding
@@ -626,7 +679,7 @@ function stringSlice(buf, encoding, start, end) {
 
 Buffer.prototype.copy =
   function copy(target, targetStart, sourceStart, sourceEnd) {
-    return _copy(this, target, targetStart, sourceStart, sourceEnd);
+    return fastcopy(this, target, targetStart, sourceStart, sourceEnd);
   };
 
 // No need to verify that "buf.length <= MAX_UINT32" since it's a read-only

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,7 +23,6 @@
 
 const {
   byteLengthUtf8,
-  copy: _copy,
   compare: _compare,
   compareOffset,
   createFromString,
@@ -401,7 +400,7 @@ function fromObject(obj) {
     if (b.length === 0)
       return b;
 
-    _copy(obj, b, 0, 0, obj.length);
+    fastcopy(obj, b, 0, 0, obj.length);
     return b;
   }
 
@@ -499,13 +498,11 @@ function fastcopy(source, target, targetStart = 0, sourceStart = 0, sourceEnd) {
 
   if (targetStart < 0)
     throw new ERR_OUT_OF_RANGE('targetStart', '>= 0', targetStart);
-  else
-    targetStart >>>= 0;
+  targetStart >>>= 0;
 
   if (sourceStart < 0)
     throw new ERR_OUT_OF_RANGE('sourceStart', '>= 0', sourceStart);
-  else
-    sourceStart >>>= 0;
+  sourceStart >>>= 0;
 
   if (sourceEnd === undefined)
     sourceEnd = source.byteLength;
@@ -523,22 +520,23 @@ function fastcopy(source, target, targetStart = 0, sourceStart = 0, sourceEnd) {
     );
   }
 
-  if (sourceEnd - sourceStart > target.byteLength - targetStart)
-    sourceEnd = sourceStart + target.byteLength - targetStart;
+  const targetBytesAmount = target.byteLength - targetStart;
 
-  const to_copy = Math.min(
-    Math.min(
-      sourceEnd - sourceStart, target.byteLength - targetStart
-    ),
+  if (sourceEnd - sourceStart > targetBytesAmount)
+    sourceEnd = sourceStart + targetBytesAmount;
+
+  const bytesAmount = Math.min(
+    sourceEnd - sourceStart,
+    targetBytesAmount,
     source.byteLength - sourceStart
   );
 
-  if (sourceStart > 0 || to_copy < source.byteLength) {
-    source = source.subarray(sourceStart, sourceStart + to_copy);
+  if (sourceStart > 0 || bytesAmount < source.byteLength) {
+    source = source.subarray(sourceStart, sourceStart + bytesAmount);
   }
 
   target.set(source, targetStart);
-  return to_copy;
+  return bytesAmount;
 }
 
 function base64ByteLength(str, bytes) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  copy: _copy,
   byteLengthUtf8,
   compare: _compare,
   compareOffset,
@@ -532,7 +533,8 @@ function fastcopy(source, target, targetStart = 0, sourceStart = 0, sourceEnd) {
   );
 
   if (sourceStart > 0 || bytesAmount < source.byteLength) {
-    source = source.subarray(sourceStart, sourceStart + bytesAmount);
+    sourceEnd = sourceStart + bytesAmount;
+    return _copy(source, target, targetStart, sourceStart, sourceEnd);
   }
 
   target.set(source, targetStart);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -964,7 +964,8 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'argument must be a buffer'
+    message: 'The "target" argument must be one of type Buffer or ' +
+    'Uint8Array. Received type undefined'
   });
 
 assert.throws(() => Buffer.from(), {
@@ -1008,13 +1009,6 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
   });
   assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0), errMsg);
 }
-
-// ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
-common.expectsError(() => {
-  const a = Buffer.alloc(1);
-  const b = Buffer.alloc(1);
-  a.copy(b, 0, 0x100000000, 0x100000001);
-}, outOfRangeError);
 
 // Unpooled buffer (replaces SlowBuffer)
 {

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -9,7 +9,8 @@ const c = Buffer.allocUnsafe(512);
 const errorProperty = {
   code: 'ERR_OUT_OF_RANGE',
   type: RangeError,
-  message: 'Index out of range'
+  message: 'The value of "sourceStart" is out of range. ' +
+    'It must be >= 0. Received -1'
 };
 
 let cntr = 0;


### PR DESCRIPTION
`%TypedArray%.prototype.set` is able to copy data between `ArrayBuffer` a lot faster. This allows us to speed up `Buffer.copy` and `Buffer.concat` by 2x in some cases.

#### benchmarks

##### node@master vs node@pr

```
                                         confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-copy.js n=1024 size=10          ***    117.07 %       ±2.82% ±3.76% ±4.90%
 buffers/buffer-copy.js n=1024 size=1024        ***     94.86 %       ±3.36% ±4.47% ±5.83%
 buffers/buffer-copy.js n=1024 size=2048        ***     53.33 %       ±4.03% ±5.38% ±7.06%
 buffers/buffer-copy.js n=1024 size=4096        ***     30.17 %       ±2.49% ±3.33% ±4.36%
 buffers/buffer-copy.js n=1024 size=8192        ***     21.52 %       ±2.23% ±2.97% ±3.86%
```
```
                                                                           confidence improvement accuracy (*)    (**)   (***)
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=1          ***      4.52 %       ±1.73%  ±2.31%  ±3.03%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=16         ***    144.18 %       ±1.97%  ±2.63%  ±3.46%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=4          ***    104.35 %       ±6.67%  ±8.97% ±11.88%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=1           ***      5.51 %       ±2.37%  ±3.18%  ±4.18%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=16          ***    143.85 %       ±2.21%  ±2.95%  ±3.86%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=4           ***    101.56 %       ±6.18%  ±8.31% ±10.99%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=1         ***      5.50 %       ±2.97%  ±3.99%  ±5.27%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=16        ***     45.37 %       ±2.16%  ±2.89%  ±3.81%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=4         ***     66.76 %       ±1.69%  ±2.25%  ±2.94%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=1          ***      5.70 %       ±2.81%  ±3.78%  ±4.99%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=16         ***    160.34 %       ±5.80%  ±7.81% ±10.34%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=4          ***    116.18 %       ±5.38%  ±7.23%  ±9.55%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=1           ***      5.19 %       ±1.82%  ±2.44%  ±3.20%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=16          ***    160.41 %       ±2.37%  ±3.17%  ±4.15%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=4           ***    108.86 %       ±7.55% ±10.16% ±13.47%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=1         ***      5.46 %       ±3.00%  ±4.02%  ±5.30%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=16        ***     47.44 %       ±1.57%  ±2.10%  ±2.75%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=4         ***     70.00 %       ±1.66%  ±2.22%  ±2.89%
```

##### node@v10 vs node@v10-pr

```
                                         confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-copy.js n=1024 size=10          ***    187.01 %       ±5.37% ±7.21% ±9.54%
 buffers/buffer-copy.js n=1024 size=1024        ***    129.87 %       ±3.41% ±4.57% ±6.01%
 buffers/buffer-copy.js n=1024 size=2048        ***     78.64 %       ±2.57% ±3.42% ±4.45%
 buffers/buffer-copy.js n=1024 size=4096        ***     59.96 %       ±4.00% ±5.34% ±7.00%
 buffers/buffer-copy.js n=1024 size=8192        ***     75.37 %       ±1.23% ±1.64% ±2.14%
```

```
                                                                          confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=1          ***     22.93 %       ±1.38% ±1.83% ±2.39%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=16         ***    203.86 %       ±3.10% ±4.15% ±5.45%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=4          ***    154.01 %       ±2.50% ±3.34% ±4.39%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=1           ***     26.54 %       ±1.39% ±1.86% ±2.42%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=16          ***    226.57 %       ±2.42% ±3.24% ±4.26%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=4           ***    153.34 %       ±2.78% ±3.74% ±4.94%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=1         ***     19.00 %       ±1.83% ±2.44% ±3.18%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=16        ***     72.48 %       ±1.56% ±2.08% ±2.72%
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=4         ***     89.29 %       ±2.61% ±3.50% ±4.62%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=1          ***     22.45 %       ±1.68% ±2.24% ±2.92%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=16         ***    214.20 %       ±3.17% ±4.25% ±5.58%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=4          ***    155.20 %       ±3.64% ±4.88% ±6.43%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=1           ***     23.09 %       ±1.88% ±2.51% ±3.27%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=16          ***    232.81 %       ±2.64% ±3.53% ±4.63%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=4           ***    165.25 %       ±2.23% ±2.99% ±3.92%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=1         ***     21.09 %       ±1.66% ±2.22% ±2.88%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=16        ***     71.34 %       ±1.11% ±1.47% ±1.92%
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=4         ***     91.33 %       ±2.32% ±3.10% ±4.07%

```

This PR is able to be backported to v10 branch. The main question is what to doing with error messages. Some of previous error messages are less informative.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)