### PR TITLE
console: add `inspectOptions` option

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -88,6 +88,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/19372
     description: The `Console` constructor now supports an `options` argument,
                  and the `colorMode` option was introduced.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `formatOptions` option is introduced.
 -->
 
 * `options` {Object}
@@ -98,8 +101,11 @@ changes:
   * `colorMode` {boolean|string} Set color support for this `Console` instance.
     Setting to `true` enables coloring while inspecting values, setting to
     `'auto'` will make color support depend on the value of the `isTTY` property
-    and the value returned by `getColorDepth()` on the respective stream.
+    and the value returned by `getColorDepth()` on the respective stream. This
+    option can not be used, if `inspectOptions.colors` is set as well.
     **Default:** `'auto'`.
+  * `inspectOptions` {Object} Specifies options that are passed along to
+    [`util.inspect()`][].
 
 Creates a new `Console` with one or two writable stream instances. `stdout` is a
 writable stream to print log or info output. `stderr` is used for warning or

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -90,7 +90,7 @@ changes:
                  and the `colorMode` option was introduced.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/REPLACEME
-    description: The `formatOptions` option is introduced.
+    description: The `inspectOptions` option is introduced.
 -->
 
 * `options` {Object}

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1126,6 +1126,12 @@ is set for the `Http2Stream`.
 `http2.connect()` was passed a URL that uses any protocol other than `http:` or
 `https:`.
 
+<a id="ERR_INCOMPATIBLE_KEY_OPTIONS"></a>
+### ERR_INCOMPATIBLE_KEY_OPTIONS
+
+An option pair is incompatible with each other and can not be used at the same
+time.
+
 <a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
 ### ERR_INSPECTOR_ALREADY_CONNECTED
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1126,8 +1126,8 @@ is set for the `Http2Stream`.
 `http2.connect()` was passed a URL that uses any protocol other than `http:` or
 `https:`.
 
-<a id="ERR_INCOMPATIBLE_KEY_OPTIONS"></a>
-### ERR_INCOMPATIBLE_KEY_OPTIONS
+<a id="ERR_INCOMPATIBLE_OPTION_PAIR"></a>
+### ERR_INCOMPATIBLE_OPTION_PAIR
 
 An option pair is incompatible with each other and can not be used at the same
 time.

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -10,7 +10,7 @@ const {
     ERR_CONSOLE_WRITABLE_STREAM,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_INCOMPATIBLE_KEY_OPTIONS,
+    ERR_INCOMPATIBLE_OPTION_PAIR,
   },
 } = require('internal/errors');
 const { previewEntries } = internalBinding('util');
@@ -94,7 +94,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   if (inspectOptions) {
     if (inspectOptions.colors !== undefined &&
         options.colorMode !== undefined) {
-      throw new ERR_INCOMPATIBLE_KEY_OPTIONS(
+      throw new ERR_INCOMPATIBLE_OPTION_PAIR(
         'inspectOptions.color', 'colorMode');
     }
     optionsMap.set(this, inspectOptions);

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -10,6 +10,7 @@ const {
     ERR_CONSOLE_WRITABLE_STREAM,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
+    ERR_INCOMPATIBLE_KEY_OPTIONS,
   },
 } = require('internal/errors');
 const { previewEntries } = internalBinding('util');
@@ -54,6 +55,8 @@ const kBindStreamsLazy = Symbol('kBindStreamsLazy');
 const kUseStdout = Symbol('kUseStdout');
 const kUseStderr = Symbol('kUseStderr');
 
+const optionsMap = new WeakMap();
+
 function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   // We have to test new.target here to see if this function is called
   // with new, because we need to define a custom instanceof to accommodate
@@ -74,7 +77,8 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     stdout,
     stderr = stdout,
     ignoreErrors = true,
-    colorMode = 'auto'
+    colorMode = 'auto',
+    inspectOptions
   } = options;
 
   if (!stdout || typeof stdout.write !== 'function') {
@@ -86,6 +90,15 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
 
   if (typeof colorMode !== 'boolean' && colorMode !== 'auto')
     throw new ERR_INVALID_ARG_VALUE('colorMode', colorMode);
+
+  if (inspectOptions) {
+    if (inspectOptions.colors !== undefined &&
+        options.colorMode !== undefined) {
+      throw new ERR_INCOMPATIBLE_KEY_OPTIONS(
+        'inspectOptions.color', 'colorMode');
+    }
+    optionsMap.set(this, inspectOptions);
+  }
 
   // bind the prototype functions to this Console instance
   var keys = Object.keys(Console.prototype);
@@ -241,6 +254,14 @@ Console.prototype[kGetInspectOptions] = function(stream) {
     color = stream.isTTY && (
       typeof stream.getColorDepth === 'function' ?
         stream.getColorDepth() > 2 : true);
+  }
+
+  const options = optionsMap.get(this);
+  if (options) {
+    if (options.colors === undefined) {
+      options.colors = color;
+    }
+    return options;
   }
 
   return color ? kColorInspectOptions : kNoColorInspectOptions;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -686,7 +686,7 @@ E('ERR_HTTP_INVALID_HEADER_VALUE',
 E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding', Error);
-E('ERR_INCOMPATIBLE_KEY_OPTIONS',
+E('ERR_INCOMPATIBLE_OPTION_PAIR',
   'Option "%s" can not be used in combination with option "%s"', TypeError);
 E('ERR_INSPECTOR_ALREADY_CONNECTED', '%s is already connected', Error);
 E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -686,6 +686,8 @@ E('ERR_HTTP_INVALID_HEADER_VALUE',
 E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding', Error);
+E('ERR_INCOMPATIBLE_KEY_OPTIONS',
+  'Option "%s" can not be used in combination with option "%s"', TypeError);
 E('ERR_INSPECTOR_ALREADY_CONNECTED', '%s is already connected', Error);
 E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available', Error);

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -5,7 +5,7 @@ const util = require('util');
 const { Writable } = require('stream');
 const { Console } = require('console');
 
-function check(isTTY, colorMode, expectedColorMode) {
+function check(isTTY, colorMode, expectedColorMode, inspectOptions) {
   const items = [
     1,
     { a: 2 },
@@ -18,7 +18,8 @@ function check(isTTY, colorMode, expectedColorMode) {
     write: common.mustCall((chunk, enc, cb) => {
       assert.strictEqual(chunk.trim(),
                          util.inspect(items[i++], {
-                           colors: expectedColorMode
+                           colors: expectedColorMode,
+                           ...inspectOptions
                          }));
       cb();
     }, items.length),
@@ -31,7 +32,8 @@ function check(isTTY, colorMode, expectedColorMode) {
   const testConsole = new Console({
     stdout: stream,
     ignoreErrors: false,
-    colorMode
+    colorMode,
+    inspectOptions
   });
   for (const item of items) {
     testConsole.log(item);
@@ -40,12 +42,15 @@ function check(isTTY, colorMode, expectedColorMode) {
 
 check(true, 'auto', true);
 check(false, 'auto', false);
+check(false, undefined, true, { colors: true, compact: false });
+check(true, 'auto', true, { compact: false });
+check(true, undefined, false, { colors: false });
 check(true, true, true);
 check(false, true, true);
 check(true, false, false);
 check(false, false, false);
 
-// check invalid colorMode type
+// Check invalid options.
 {
   const stream = new Writable({
     write: common.mustNotCall()
@@ -64,6 +69,26 @@ check(false, false, false);
       {
         message: `The argument 'colorMode' is invalid. Received ${received}`,
         code: 'ERR_INVALID_ARG_VALUE'
+      }
+    );
+  });
+
+  [true, false, 'auto'].forEach((colorMode) => {
+    assert.throws(
+      () => {
+        new Console({
+          stdout: stream,
+          ignoreErrors: false,
+          colorMode: colorMode,
+          inspectOptions: {
+            colors: false
+          }
+        });
+      },
+      {
+        message: 'Option "inspectOptions.color" can not be used in ' +
+                 'combination with option "colorMode"',
+        code: 'ERR_INCOMPATIBLE_KEY_OPTIONS'
       }
     );
   });

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -88,7 +88,7 @@ check(false, false, false);
       {
         message: 'Option "inspectOptions.color" can not be used in ' +
                  'combination with option "colorMode"',
-        code: 'ERR_INCOMPATIBLE_KEY_OPTIONS'
+        code: 'ERR_INCOMPATIBLE_OPTION_PAIR'
       }
     );
   });


### PR DESCRIPTION
Add an `inspectOptions` option to the `console` constructor. That
way it's possible to define all inspection defaults for each
`console` instance instead of relying on the `inspect()` defaults.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
