### PR TITLE
util: improve format performance

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -78,45 +78,32 @@ function format(...args) {
   return formatWithOptions(emptyOptions, ...args);
 }
 
-function formatValue(val, inspectOptions) {
-  const inspectTypes = ['object', 'symbol', 'function', 'number'];
-
-  if (inspectTypes.includes(typeof val)) {
-    return inspect(val, inspectOptions);
-  } else {
-    return String(val);
-  }
-}
-
 function formatWithOptions(inspectOptions, ...args) {
   const first = args[0];
-  const parts = [];
+  let a = 0;
+  let str = '';
+  let join = '';
 
-  const firstIsString = typeof first === 'string';
-
-  if (firstIsString && args.length === 1) {
-    return first;
-  }
-
-  if (firstIsString && /%[sjdOoif%]/.test(first)) {
-    let i, tempStr;
-    let str = '';
-    let a = 1;
+  if (typeof first === 'string') {
+    if (args.length === 1) {
+      return first;
+    }
+    let tempStr;
     let lastPos = 0;
 
-    for (i = 0; i < first.length - 1; i++) {
+    for (var i = 0; i < first.length - 1; i++) {
       if (first.charCodeAt(i) === 37) { // '%'
         const nextChar = first.charCodeAt(++i);
-        if (a !== args.length) {
+        if (a + 1 !== args.length) {
           switch (nextChar) {
             case 115: // 's'
-              tempStr = String(args[a++]);
+              tempStr = String(args[++a]);
               break;
             case 106: // 'j'
-              tempStr = tryStringify(args[a++]);
+              tempStr = tryStringify(args[++a]);
               break;
             case 100: // 'd'
-              const tempNum = args[a++];
+              const tempNum = args[++a];
               // eslint-disable-next-line valid-typeof
               if (typeof tempNum === 'bigint') {
                 tempStr = `${tempNum}n`;
@@ -127,20 +114,20 @@ function formatWithOptions(inspectOptions, ...args) {
               }
               break;
             case 79: // 'O'
-              tempStr = inspect(args[a++], inspectOptions);
+              tempStr = inspect(args[++a], inspectOptions);
               break;
             case 111: // 'o'
             {
-              const opts = Object.assign({}, inspectOptions, {
+              tempStr = inspect(args[++a], {
+                ...inspectOptions,
                 showHidden: true,
                 showProxy: true,
                 depth: 4
               });
-              tempStr = inspect(args[a++], opts);
               break;
             }
             case 105: // 'i'
-              const tempInteger = args[a++];
+              const tempInteger = args[++a];
               // eslint-disable-next-line valid-typeof
               if (typeof tempInteger === 'bigint') {
                 tempStr = `${tempInteger}n`;
@@ -151,7 +138,7 @@ function formatWithOptions(inspectOptions, ...args) {
               }
               break;
             case 102: // 'f'
-              const tempFloat = args[a++];
+              const tempFloat = args[++a];
               if (typeof tempFloat === 'symbol') {
                 tempStr = 'NaN';
               } else {
@@ -176,24 +163,32 @@ function formatWithOptions(inspectOptions, ...args) {
         }
       }
     }
-    if (lastPos === 0) {
-      str = first;
-    } else if (lastPos < first.length) {
-      str += first.slice(lastPos);
-    }
-
-    parts.push(str);
-    while (a < args.length) {
-      parts.push(formatValue(args[a], inspectOptions));
+    if (lastPos !== 0) {
       a++;
-    }
-  } else {
-    for (const arg of args) {
-      parts.push(formatValue(arg, inspectOptions));
+      join = ' ';
+      if (lastPos < first.length) {
+        str += first.slice(lastPos);
+      }
     }
   }
 
-  return parts.join(' ');
+  while (a < args.length) {
+    const value = args[a];
+    // TODO: This should apply for all besides strings. Especially BigInt should
+    // be properly inspected.
+    str += join;
+    if (typeof value !== 'string' &&
+        typeof value !== 'boolean' &&
+        // eslint-disable-next-line valid-typeof
+        typeof value !== 'bigint') {
+      str += inspect(value, inspectOptions);
+    } else {
+      str += value;
+    }
+    join = ' ';
+    a++;
+  }
+  return str;
 }
 
 const debugs = {};

--- a/lib/util.js
+++ b/lib/util.js
@@ -174,8 +174,8 @@ function formatWithOptions(inspectOptions, ...args) {
 
   while (a < args.length) {
     const value = args[a];
-    // TODO: This should apply for all besides strings. Especially BigInt should
-    // be properly inspected.
+    // TODO(BridgeAR): This should apply for all besides strings. Especially
+    // BigInt should be properly inspected.
     str += join;
     if (typeof value !== 'string' &&
         typeof value !== 'boolean' &&


### PR DESCRIPTION
This simplifies the `format()` code and significantly improves the
performance.

Just a few runs to verify the gain:

```
                                               confidence improvement accuracy (*)    (**)   (***)
 util/format.js type='many-%' n=600000                ***     18.98 %       ±9.60% ±13.22% ±18.15%
 util/format.js type='no-replace-2' n=600000          ***    396.74 %      ±43.42% ±60.18% ±83.52%
 util/format.js type='no-replace' n=600000            ***    166.64 %      ±32.80% ±44.98% ±61.39%
 util/format.js type='number' n=600000                ***     56.96 %      ±11.00% ±15.14% ±20.80%
 util/format.js type='only-objects' n=600000           **     19.21 %      ±13.09% ±17.82% ±24.05%
 util/format.js type='replace-object' n=600000          *     14.14 %      ±12.46% ±17.04% ±23.16%
 util/format.js type='string-2' n=600000              ***     28.66 %      ±13.20% ±18.21% ±25.07%
 util/format.js type='string' n=600000                ***     59.04 %      ±14.04% ±19.03% ±25.49%
 util/format.js type='unknown' n=600000               ***    338.50 %      ±37.78% ±52.19% ±72.06%
```

CI https://ci.nodejs.org/job/node-test-pull-request/19442/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
