### PR TITLE
fix(lib): whitelist types for internalBinding

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -100,6 +100,7 @@ const internalBindingWhitelist = [
   'tcp_wrap',
   'tls_wrap',
   'tty_wrap',
+  'types',
   'udp_wrap',
   'url',
   'util',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Added `types` to internalBinding whitelist for https://github.com/nodejs/node/blob/f194b7f6261b065726b2850582b4969059b64fa1/lib/internal/util/inspect.js

Fixes https://github.com/nodejs/node/issues/24985

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
