### PR TITLE
stream: re-use existing `once()` implementation

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -7,18 +7,10 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = require('internal/errors').codes;
+const { once } = require('internal/util');
 
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
-}
-
-function once(callback) {
-  let called = false;
-  return function(err) {
-    if (called) return;
-    called = true;
-    callback.call(this, err);
-  };
 }
 
 function eos(stream, opts, callback) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -375,7 +375,7 @@ function once(callback) {
   return function(...args) {
     if (called) return;
     called = true;
-    callback(...args);
+    callback.apply(this, args);
   };
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
