### PR TITLE
build: make lint-addon-docs run only if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1263,10 +1263,14 @@ tools/.cpplintstamp: $(LINT_CPP_FILES)
 	@$(PYTHON) tools/check-imports.py
 	@touch $@
 
-lint-addon-docs: test/addons/.docbuildstamp
+.PHONY: lint-addon-docs
+lint-addon-docs: tools/.doclintstamp
+
+tools/.doclintstamp: test/addons/.docbuildstamp
 	@echo "Running C++ linter on addon docs..."
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_QUIET) --filter=$(ADDON_DOC_LINT_FLAGS) \
 		$(LINT_CPP_ADDON_DOC_FILES_GLOB)
+	@touch $@
 
 cpplint: lint-cpp
 	@echo "Please use lint-cpp instead of cpplint"


### PR DESCRIPTION
Currently, the `lint-addon-docs` targets recipe will always be run.
This commit makes `lint-addon-docs` a phony target and adds a new target named
`tools/.doclintstamp` what will be an actual file, similar to what the `lint-cpp`
target does.

@nodejs/build-files 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
