### PR TITLE
querystring: remove eslint-disable

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -771,8 +771,7 @@ function parseParams(qs) {
       if (code === CHAR_PERCENT) {
         encodeCheck = 1;
       } else if (encodeCheck > 0) {
-        // eslint-disable-next-line no-extra-boolean-cast
-        if (!!isHexTable[code]) {
+        if (isHexTable[code] === 1) {
           if (++encodeCheck === 3) {
             querystring = require('querystring');
             encoded = true;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -318,8 +318,7 @@ function parse(qs, sep, eq, options) {
               encodeCheck = 1;
               continue;
             } else if (encodeCheck > 0) {
-              // eslint-disable-next-line no-extra-boolean-cast
-              if (!!isHexTable[code]) {
+              if (isHexTable[code] === 1) {
                 if (++encodeCheck === 3)
                   keyEncoded = true;
                 continue;
@@ -348,8 +347,7 @@ function parse(qs, sep, eq, options) {
         if (code === 37/* % */) {
           encodeCheck = 1;
         } else if (encodeCheck > 0) {
-          // eslint-disable-next-line no-extra-boolean-cast
-          if (!!isHexTable[code]) {
+          if (isHexTable[code] === 1) {
             if (++encodeCheck === 3)
               valEncoded = true;
           } else {


### PR DESCRIPTION
Remove the eslint-disable comments by using a strict comparison
instead of a Boolean cast.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
