### PR TITLE
doc,lib,test: capitalize comment sentences

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,9 +60,9 @@ module.exports = {
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
     'capitalized-comments': ['error', 'always', {
       line: {
-        // Ignore all lines that have less characters than 62 and all lines that
+        // Ignore all lines that have less characters than 50 and all lines that
         // start with something that looks like a variable name or code.
-        ignorePattern: '^.{0,62}$|^ [a-z]+ ?[0-9A-Z_.(/=:-]',
+        ignorePattern: '^.{0,50}$|^ [a-z]+ ?[0-9A-Z_.(/=:[#-]',
         ignoreInlineComments: true,
         ignoreConsecutiveComments: true
       },

--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -40,7 +40,7 @@ class BenchmarkProgress {
     this.completedConfig = 0;
     // Total number of configurations for the current file
     this.scheduledConfig = 0;
-    this.interval = 0;  // result of setInterval for updating the elapsed time
+    this.interval;  // Updates the elapsed time.
   }
 
   startQueue(index) {

--- a/benchmark/napi/function_args/index.js
+++ b/benchmark/napi/function_args/index.js
@@ -1,4 +1,4 @@
-// show the difference between calling a V8 binding C++ function
+// Show the difference between calling a V8 binding C++ function
 // relative to a comparable N-API C++ function,
 // in various types/numbers of arguments.
 // Reports n of calls per second.

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -1,4 +1,4 @@
-// show the difference between calling a short js function
+// Show the difference between calling a short js function
 // relative to a comparable C++ function.
 // Reports n of calls per second.
 // Note that JS speed goes up, while cxx speed stays about the same.

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -48,7 +48,7 @@ function main({ dur, len, type }) {
       socket.pipe(writer);
 
       setTimeout(function() {
-        // multiply by 2 since we're sending it first one way
+        // Multiply by 2 since we're sending it first one way
         // then then back again.
         const bytes = writer.received * 2;
         const gbits = (bytes * 8) / (1024 * 1024 * 1024);

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -47,12 +47,12 @@ function main({ dur, len, type }) {
     }, dur * 1000);
 
     clientHandle.onread = function(buffer) {
-      // we're not expecting to ever get an EOF from the client.
-      // just lots of data forever.
+      // We're not expecting to ever get an EOF from the client.
+      // Just lots of data forever.
       if (!buffer)
         fail('read');
 
-      // don't slice the buffer.  the point of this is to isolate, not
+      // Don't slice the buffer. The point of this is to isolate, not
       // simulate real traffic.
       bytes += buffer.byteLength;
     };

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -44,8 +44,8 @@ function main({ dur, len, type }) {
       fail(err, 'connect');
 
     clientHandle.onread = function(buffer) {
-      // we're not expecting to ever get an EOF from the client.
-      // just lots of data forever.
+      // We're not expecting to ever get an EOF from the client.
+      // Just lots of data forever.
       if (!buffer)
         fail('read');
 
@@ -105,7 +105,7 @@ function main({ dur, len, type }) {
     clientHandle.readStart();
 
     setTimeout(function() {
-      // multiply by 2 since we're sending it first one way
+      // Multiply by 2 since we're sending it first one way
       // then then back again.
       bench.end(2 * (bytes * 8) / (1024 * 1024 * 1024));
       process.exit(0);

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -110,12 +110,12 @@ function main({ dur, len, type }) {
     connectReq.oncomplete = function() {
       var bytes = 0;
       clientHandle.onread = function(buffer) {
-        // we're not expecting to ever get an EOF from the client.
-        // just lots of data forever.
+        // We're not expecting to ever get an EOF from the client.
+        // Just lots of data forever.
         if (!buffer)
           fail('read');
 
-        // don't slice the buffer.  the point of this is to isolate, not
+        // Don't slice the buffer. The point of this is to isolate, not
         // simulate real traffic.
         bytes += buffer.byteLength;
       };

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -59,7 +59,7 @@ function makeConnection() {
 
 function done() {
   running = false;
-  // it's only an established connection if they both saw it.
+  // It's only an established connection if they both saw it.
   // because we destroy the server somewhat abruptly, these
   // don't always match.  Generally, serverConn will be
   // the smaller number, but take the min just to be sure.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -69,7 +69,7 @@ function before(asyncId) { }
 // After is called just after the resource's callback has finished.
 function after(asyncId) { }
 
-// destroy is called when an AsyncWrap instance is destroyed.
+// Destroy is called when an AsyncWrap instance is destroyed.
 function destroy(asyncId) { }
 
 // promiseResolve is called only for promise resources, when the

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -322,7 +322,7 @@ if (cluster.isMaster) {
 
   process.on('message', (msg) => {
     if (msg === 'shutdown') {
-      // initiate graceful close of any connections to server
+      // Initiate graceful close of any connections to server
     }
   });
 }

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -248,7 +248,7 @@ const serverDomain = domain.create();
 serverDomain.run(() => {
   // server is created in the scope of serverDomain
   http.createServer((req, res) => {
-    // req and res are also created in the scope of serverDomain
+    // Req and res are also created in the scope of serverDomain
     // however, we'd prefer to have a separate domain for each request.
     // create it first thing, and add req and res to it.
     const reqd = domain.create();
@@ -316,7 +316,7 @@ const d = domain.create();
 
 function readSomeFile(filename, cb) {
   fs.readFile(filename, 'utf8', d.bind((er, data) => {
-    // if this throws, it will also be passed to the domain
+    // If this throws, it will also be passed to the domain
     return cb(er, data ? JSON.parse(data) : null);
   }));
 }

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -242,7 +242,7 @@ export async function dynamicInstantiate(url) {
   return {
     exports: ['customExportName'],
     execute: (exports) => {
-      // get and set functions provided for pre-allocated export names
+      // Get and set functions provided for pre-allocated export names
       exports.customExportName.set('value');
     }
   };

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -641,7 +641,7 @@ const logFnWrapper = listeners[0];
 // Logs "log once" to the console and does not unbind the `once` event
 logFnWrapper.listener();
 
-// logs "log once" to the console and removes the listener
+// Logs "log once" to the console and removes the listener
 logFnWrapper();
 
 emitter.on('log', () => console.log('log persistently'));

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -299,7 +299,7 @@ path.join('/foo', 'bar', 'baz/asdf', 'quux', '..');
 // Returns: '/foo/bar/baz/asdf'
 
 path.join('foo', {}, 'bar');
-// throws 'TypeError: Path must be a string. Received {}'
+// Throws 'TypeError: Path must be a string. Received {}'
 ```
 
 A [`TypeError`][] is thrown if any of the path segments is not a string.
@@ -495,7 +495,7 @@ path.resolve('/foo/bar', '/tmp/file/');
 // Returns: '/tmp/file'
 
 path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif');
-// if the current working directory is /home/myself/node,
+// If the current working directory is /home/myself/node,
 // this returns '/home/myself/node/wwwroot/static_files/gif/image.gif'
 ```
 

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -331,7 +331,7 @@ const {
 } = require('perf_hooks');
 
 const obs = new PerformanceObserver((list, observer) => {
-  // called three times synchronously. list contains one item
+  // Called three times synchronously. list contains one item
 });
 obs.observe({ entryTypes: ['mark'] });
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -118,8 +118,8 @@ that implements an HTTP server:
 const http = require('http');
 
 const server = http.createServer((req, res) => {
-  // req is an http.IncomingMessage, which is a Readable Stream
-  // res is an http.ServerResponse, which is a Writable Stream
+  // `req` is an http.IncomingMessage, which is a Readable Stream
+  // `res` is an http.ServerResponse, which is a Writable Stream
 
   let body = '';
   // Get the data as utf8 strings.
@@ -1195,7 +1195,7 @@ function parseHeader(stream, callback) {
         stream.removeListener('readable', onReadable);
         if (buf.length)
           stream.unshift(buf);
-        // now the body of the message can be read from the stream.
+        // Now the body of the message can be read from the stream.
         callback(null, header, stream);
       } else {
         // still reading the header.
@@ -1930,7 +1930,7 @@ pause/resume mechanism, and a data callback, the low-level source can be wrapped
 by the custom `Readable` instance:
 
 ```js
-// source is an object with readStop() and readStart() methods,
+// `_source` is an object with readStop() and readStart() methods,
 // and an `ondata` member that gets called when it has data, and
 // an `onend` member that gets called when the data is over.
 
@@ -1938,11 +1938,11 @@ class SourceWrapper extends Readable {
   constructor(options) {
     super(options);
 
-    this._source = getLowlevelSourceObject();
+    this._source = getLowLevelSourceObject();
 
     // Every time there's data, push it into the internal buffer.
     this._source.ondata = (chunk) => {
-      // if push() returns false, then stop reading from source
+      // If push() returns false, then stop reading from source
       if (!this.push(chunk))
         this._source.readStop();
     };
@@ -2391,7 +2391,7 @@ For example, consider the following code:
 // WARNING!  BROKEN!
 net.createServer((socket) => {
 
-  // we add an 'end' listener, but never consume the data
+  // We add an 'end' listener, but never consume the data
   socket.on('end', () => {
     // It will never get here.
     socket.end('The message was received but was not processed.\n');

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -133,7 +133,7 @@ t2.enable();
 // Prints 'node,node.perf,v8'
 console.log(trace_events.getEnabledCategories());
 
-t2.disable(); // will only disable emission of the 'node.perf' category
+t2.disable(); // Will only disable emission of the 'node.perf' category
 
 // Prints 'node,v8'
 console.log(trace_events.getEnabledCategories());

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -33,7 +33,7 @@ const sandbox = { x: 2 };
 vm.createContext(sandbox); // Contextify the sandbox.
 
 const code = 'x += 40; var y = 17;';
-// x and y are global variables in the sandboxed environment.
+// `x` and `y` are global variables in the sandboxed environment.
 // Initially, x has the value 2 because that is the value of sandbox.x.
 vm.runInContext(code, sandbox);
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -81,7 +81,7 @@ request.on('response', (response) => {
   const output = fs.createWriteStream('example.com_index.html');
 
   switch (response.headers['content-encoding']) {
-    // or, just use zlib.createUnzip() to handle both cases
+    // Or, just use zlib.createUnzip() to handle both cases
     case 'gzip':
       response.pipe(zlib.createGunzip()).pipe(output);
       break;

--- a/doc/guides/writing-and-running-benchmarks.md
+++ b/doc/guides/writing-and-running-benchmarks.md
@@ -397,7 +397,7 @@ const options = {
   flags: ['--zero-fill-buffers']
 };
 
-// main and configs are required, options is optional.
+// `main` and `configs` are required, `options` is optional.
 const bench = common.createBenchmark(main, configs, options);
 
 // Note that any code outside main will be run twice,

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -555,7 +555,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   req.res = res;
   res.req = req;
 
-  // add our listener first, so that we guarantee socket cleanup
+  // Add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
   req.on('prefinish', requestOnPrefinish);
   var handled = req.emit('response', res);

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -116,11 +116,11 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
 function parserOnBody(b, start, len) {
   const stream = this.incoming;
 
-  // if the stream has already been removed, then drop it.
+  // If the stream has already been removed, then drop it.
   if (stream === null)
     return;
 
-  // pretend this was the result of a stream._read call.
+  // Pretend this was the result of a stream._read call.
   if (len > 0 && !stream._dumped) {
     var slice = b.slice(start, start + len);
     var ret = stream.push(slice);

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -67,7 +67,7 @@ function IncomingMessage(socket) {
   this.client = socket;
 
   this._consuming = false;
-  // flag for when we decide that this message cannot possibly be
+  // Flag for when we decide that this message cannot possibly be
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
 }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -574,7 +574,7 @@ function resOnFinish(req, res, socket, state, server) {
 
   state.incoming.shift();
 
-  // if the user never called req.read(), and didn't pipe() or
+  // If the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the
   // bytes will be pulled off the wire.
   if (!req._consuming && !req._readableState.resumeScheduled)

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -67,7 +67,7 @@ function Duplex(options) {
 }
 
 Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -77,7 +77,7 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
 });
 
 Object.defineProperty(Duplex.prototype, 'writableBuffer', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -87,7 +87,7 @@ Object.defineProperty(Duplex.prototype, 'writableBuffer', {
 });
 
 Object.defineProperty(Duplex.prototype, 'writableLength', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -112,7 +112,7 @@ function onEndNT(self) {
 }
 
 Object.defineProperty(Duplex.prototype, 'destroyed', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -79,7 +79,7 @@ function ReadableState(options, stream, isDuplex) {
   if (typeof isDuplex !== 'boolean')
     isDuplex = stream instanceof Stream.Duplex;
 
-  // object stream flag. Used to make read(n) ignore n and to
+  // Object stream flag. Used to make read(n) ignore n and to
   // make all the buffer merging and length checks go away
   this.objectMode = !!options.objectMode;
 
@@ -109,7 +109,7 @@ function ReadableState(options, stream, isDuplex) {
   // not happen before the first read call.
   this.sync = true;
 
-  // whenever we return null, then we set a flag to say
+  // Whenever we return null, then we set a flag to say
   // that we're awaiting a 'readable' event emission.
   this.needReadable = false;
   this.emittedReadable = false;
@@ -172,7 +172,7 @@ function Readable(options) {
 }
 
 Object.defineProperty(Readable.prototype, 'destroyed', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -323,7 +323,7 @@ Readable.prototype.setEncoding = function(enc) {
   if (!StringDecoder)
     StringDecoder = require('string_decoder').StringDecoder;
   this._readableState.decoder = new StringDecoder(enc);
-  // if setEncoding(null), decoder.encoding equals utf8
+  // If setEncoding(null), decoder.encoding equals utf8
   this._readableState.encoding = this._readableState.decoder.encoding;
   return this;
 };
@@ -384,7 +384,7 @@ Readable.prototype.read = function(n) {
   if (n !== 0)
     state.emittedReadable = false;
 
-  // if we're doing read(0) to trigger a readable event, but we
+  // If we're doing read(0) to trigger a readable event, but we
   // already have a bunch of data in the buffer, then just trigger
   // the 'readable' event and move on.
   if (n === 0 &&
@@ -403,7 +403,7 @@ Readable.prototype.read = function(n) {
 
   n = howMuchToRead(n, state);
 
-  // if we've ended, and we're now clear, then finish it up.
+  // If we've ended, and we're now clear, then finish it up.
   if (n === 0 && state.ended) {
     if (state.length === 0)
       endReadable(this);
@@ -506,12 +506,12 @@ function onEofChunk(stream, state) {
   state.ended = true;
 
   if (state.sync) {
-    // if we are sync, wait until next tick to emit the data.
+    // If we are sync, wait until next tick to emit the data.
     // Otherwise we risk emitting data in the flow()
     // the readable code triggers during a read() call
     emitReadable(stream);
   } else {
-    // emit 'readable' now to make sure it gets picked up.
+    // Emit 'readable' now to make sure it gets picked up.
     state.needReadable = false;
     if (!state.emittedReadable) {
       state.emittedReadable = true;
@@ -656,7 +656,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.end();
   }
 
-  // when the dest drains, it reduces the awaitDrain counter
+  // When the dest drains, it reduces the awaitDrain counter
   // on the source.  This would be more elegant with a .once()
   // handler in flow(), but adding and removing repeatedly is
   // too slow.
@@ -678,7 +678,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
 
     cleanedUp = true;
 
-    // if the reader is waiting for a drain event from this
+    // If the reader is waiting for a drain event from this
     // specific writer, then it would cause it to never start
     // flowing again.
     // So, if this is awaiting a drain, then we just call it now.
@@ -708,8 +708,8 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     }
   }
 
-  // if the dest has an error, then stop piping into it.
-  // however, don't suppress the throwing behavior for this.
+  // If the dest has an error, then stop piping into it.
+  // However, don't suppress the throwing behavior for this.
   function onerror(er) {
     debug('onerror', er);
     unpipe();
@@ -828,7 +828,7 @@ Readable.prototype.on = function(ev, fn) {
   const state = this._readableState;
 
   if (ev === 'data') {
-    // update readableListening so that resume() may be a no-op
+    // Update readableListening so that resume() may be a no-op
     // a few lines down. This is needed to support once('readable').
     state.readableListening = this.listenerCount('readable') > 0;
 
@@ -958,7 +958,7 @@ function flow(stream) {
   while (state.flowing && stream.read() !== null);
 }
 
-// wrap an old-style stream as the async data source.
+// Wrap an old-style stream as the async data source.
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function(stream) {
@@ -1011,7 +1011,7 @@ Readable.prototype.wrap = function(stream) {
     stream.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
   }
 
-  // when we try to consume some more bytes, simply unpause the
+  // When we try to consume some more bytes, simply unpause the
   // underlying stream.
   this._read = (n) => {
     debug('wrapped _read', n);
@@ -1034,7 +1034,7 @@ Readable.prototype[Symbol.asyncIterator] = function() {
 };
 
 Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -1044,7 +1044,7 @@ Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
 });
 
 Object.defineProperty(Readable.prototype, 'readableBuffer', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -1054,7 +1054,7 @@ Object.defineProperty(Readable.prototype, 'readableBuffer', {
 });
 
 Object.defineProperty(Readable.prototype, 'readableFlowing', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -1072,7 +1072,7 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
 Readable._fromList = fromList;
 
 Object.defineProperty(Readable.prototype, 'readableLength', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -88,7 +88,7 @@ function afterTransform(er, data) {
   ts.writechunk = null;
   ts.writecb = null;
 
-  if (data != null) // single equals check for both `null` and `undefined`
+  if (data != null) // Single equals check for both `null` and `undefined`
     this.push(data);
 
   cb(er);
@@ -189,7 +189,7 @@ Transform.prototype._read = function(n) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {
-    // mark that we need a transform, so that any data that comes in
+    // Mark that we need a transform, so that any data that comes in
     // will get processed, now that we've asked for it.
     ts.needTransform = true;
   }
@@ -207,7 +207,7 @@ function done(stream, er, data) {
   if (er)
     return stream.emit('error', er);
 
-  if (data != null) // single equals check for both `null` and `undefined`
+  if (data != null) // Single equals check for both `null` and `undefined`
     stream.push(data);
 
   // TODO(BridgeAR): Write a test for these two error cases

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -62,7 +62,7 @@ function WritableState(options, stream, isDuplex) {
   if (typeof isDuplex !== 'boolean')
     isDuplex = stream instanceof Stream.Duplex;
 
-  // object stream flag to indicate whether or not this stream
+  // Object stream flag to indicate whether or not this stream
   // contains buffers or objects.
   this.objectMode = !!options.objectMode;
 
@@ -101,15 +101,15 @@ function WritableState(options, stream, isDuplex) {
   // Everything else in the universe uses 'utf8', though.
   this.defaultEncoding = options.defaultEncoding || 'utf8';
 
-  // not an actual buffer we keep track of, but a measurement
+  // Not an actual buffer we keep track of, but a measurement
   // of how much we're waiting to get pushed to some underlying
   // socket or file.
   this.length = 0;
 
-  // a flag to see when we're in the middle of a write.
+  // A flag to see when we're in the middle of a write.
   this.writing = false;
 
-  // when true all writes will be buffered until .uncork() call
+  // When true all writes will be buffered until .uncork() call
   this.corked = 0;
 
   // A flag to be able to tell if the onwrite cb is called immediately,
@@ -129,7 +129,7 @@ function WritableState(options, stream, isDuplex) {
   // The callback that the user supplies to write(chunk,encoding,cb)
   this.writecb = null;
 
-  // the amount that is being written when _write is called.
+  // The amount that is being written when _write is called.
   this.writelen = 0;
 
   this.bufferedRequest = null;
@@ -331,7 +331,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 };
 
 Object.defineProperty(Writable.prototype, 'writableBuffer', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -350,7 +350,7 @@ function decodeChunk(state, chunk, encoding) {
 }
 
 Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -359,7 +359,7 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   }
 });
 
-// if we're already writing something, then just put this
+// If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
@@ -420,7 +420,7 @@ function onwriteError(stream, state, sync, er, cb) {
   --state.pendingcb;
 
   if (sync) {
-    // defer the callback if we are being called synchronously
+    // Defer the callback if we are being called synchronously
     // to avoid piling up things on the stack
     process.nextTick(cb, er);
     // this can emit finish, and it will always happen
@@ -496,7 +496,7 @@ function onwriteDrain(stream, state) {
   }
 }
 
-// if there's something in the buffer waiting, then process it
+// If there's something in the buffer waiting, then process it
 function clearBuffer(stream, state) {
   state.bufferProcessing = true;
   var entry = state.bufferedRequest;
@@ -597,7 +597,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
 };
 
 Object.defineProperty(Writable.prototype, 'writableLength', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
@@ -686,7 +686,7 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {
-  // making it explicit this property is not enumerable
+  // Making it explicit this property is not enumerable
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -157,7 +157,7 @@ class AsyncResource {
 
     this[async_id_symbol] = newAsyncId();
     this[trigger_async_id_symbol] = triggerAsyncId;
-    // this prop name (destroyed) has to be synchronized with C++
+    // This prop name (destroyed) has to be synchronized with C++
     this[destroyedSymbol] = { destroyed: false };
 
     emitInit(

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -515,7 +515,7 @@ function doSend(ex, self, ip, list, address, port, callback) {
                               !!callback);
 
   if (err && callback) {
-    // don't emit as error, dgram_legacy.js compatibility
+    // Don't emit as error, dgram_legacy.js compatibility
     const ex = exceptionWithHostPort(err, 'send', address, port);
     process.nextTick(callback, ex);
   }

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -52,7 +52,7 @@ const pairing = new Map();
 const asyncHook = createHook({
   init(asyncId, type, triggerAsyncId, resource) {
     if (process.domain !== null && process.domain !== undefined) {
-      // if this operation is created while in a domain, let's mark it
+      // If this operation is created while in a domain, let's mark it
       pairing.set(asyncId, process.domain);
       resource.domain = process.domain;
     }
@@ -180,7 +180,7 @@ exports.create = exports.createDomain = function createDomain() {
   return new Domain();
 };
 
-// the active domain is always the one that we're currently in.
+// The active domain is always the one that we're currently in.
 exports.active = null;
 Domain.prototype.members = undefined;
 
@@ -219,7 +219,7 @@ Domain.prototype._errorHandler = function(er) {
       }
     }
   } else {
-    // wrap this in a try/catch so we don't get infinite throwing
+    // Wrap this in a try/catch so we don't get infinite throwing
     try {
       // One of three things will happen here.
       //
@@ -259,7 +259,7 @@ Domain.prototype._errorHandler = function(er) {
 
 
 Domain.prototype.enter = function() {
-  // note that this might be a no-op, but we still need
+  // Note that this might be a no-op, but we still need
   // to push it onto the stack so that we can pop it later.
   exports.active = process.domain = this;
   stack.push(this);
@@ -268,7 +268,7 @@ Domain.prototype.enter = function() {
 
 
 Domain.prototype.exit = function() {
-  // don't do anything if this domain is not on the stack.
+  // Don't do anything if this domain is not on the stack.
   var index = stack.lastIndexOf(this);
   if (index === -1) return;
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -380,7 +380,7 @@ EventEmitter.prototype.removeAllListeners =
         return this;
       }
 
-      // emit removeListener for all listeners on all events
+      // Emit removeListener for all listeners on all events
       if (arguments.length === 0) {
         var keys = Object.keys(events);
         var key;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1269,7 +1269,7 @@ function appendFile(path, data, options, callback) {
   // Don't make changes directly on options object
   options = copyObject(options);
 
-  // force append behavior when using a supplied file descriptor
+  // Force append behavior when using a supplied file descriptor
   if (!options.flag || isFd(path))
     options.flag = 'a';
 
@@ -1282,7 +1282,7 @@ function appendFileSync(path, data, options) {
   // Don't make changes directly on options object
   options = copyObject(options);
 
-  // force append behavior when using a supplied file descriptor
+  // Force append behavior when using a supplied file descriptor
   if (!options.flag || isFd(path))
     options.flag = 'a';
 
@@ -1450,11 +1450,11 @@ function realpathSync(p, options) {
 
   // current character position in p
   let pos;
-  // the partial path so far, including a trailing slash if any
+  // The partial path so far, including a trailing slash if any
   let current;
   // The partial path without a trailing slash (except when pointing at a root)
   let base;
-  // the partial path scanned in the previous round, with slash
+  // The partial path scanned in the previous round, with slash
   let previous;
 
   // Skip over roots
@@ -1590,11 +1590,11 @@ function realpath(p, options, callback) {
 
   // current character position in p
   let pos;
-  // the partial path so far, including a trailing slash if any
+  // The partial path so far, including a trailing slash if any
   let current;
   // The partial path without a trailing slash (except when pointing at a root)
   let base;
-  // the partial path scanned in the previous round, with slash
+  // The partial path scanned in the previous round, with slash
   let previous;
 
   current = base = splitRoot(p);

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -105,7 +105,7 @@ const handleConversion = {
         var firstTime = !this.channel.sockets.send[message.key];
         var socketList = getSocketList('send', this, message.key);
 
-        // the server should no longer expose a .connection property
+        // The server should no longer expose a .connection property
         // and when asked to close it should query the socket status from
         // the workers
         if (firstTime) socket.server._setupWorker(socketList);
@@ -254,7 +254,7 @@ function ChildProcess() {
       this.emit('exit', this.exitCode, this.signalCode);
     }
 
-    // if any of the stdio streams have not been touched,
+    // If any of the stdio streams have not been touched,
     // then pull all the data through so that it can get the
     // eof and emit a 'close' event.
     // Do it on nextTick so that the user has one last chance

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -100,7 +100,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     optionsMap.set(this, inspectOptions);
   }
 
-  // bind the prototype functions to this Console instance
+  // Bind the prototype functions to this Console instance
   var keys = Object.keys(Console.prototype);
   for (var v = 0; v < keys.length; v++) {
     var k = keys[v];

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -40,17 +40,17 @@ function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
 
-  // a little bit bigger buffer and water marks by default
+  // A little bit bigger buffer and water marks by default
   options = copyObject(getOptions(options, {}));
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
-  // for backwards compat do not emit close on destroy.
+  // For backwards compat do not emit close on destroy.
   options.emitClose = false;
 
   Readable.call(this, options);
 
-  // path will be ignored when fd is specified, so it can be falsy
+  // Path will be ignored when fd is specified, so it can be falsy
   this.path = toPathIfFileURL(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
@@ -197,7 +197,7 @@ ReadStream.prototype._read = function(n) {
     }
   });
 
-  // move the pool positions, and internal position for reading.
+  // Move the pool positions, and internal position for reading.
   if (this.pos !== undefined)
     this.pos += toRead;
   pool.used += toRead;
@@ -238,12 +238,12 @@ function WriteStream(path, options) {
 
   options = copyObject(getOptions(options, {}));
 
-  // for backwards compat do not emit close on destroy.
+  // For backwards compat do not emit close on destroy.
   options.emitClose = false;
 
   Writable.call(this, options);
 
-  // path will be ignored when fd is specified, so it can be falsy
+  // Path will be ignored when fd is specified, so it can be falsy
   this.path = toPathIfFileURL(path);
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -440,7 +440,7 @@ class Http2ServerResponse extends Stream {
   }
 
   get socket() {
-    // this is compatible with http1 which removes socket reference
+    // This is compatible with http1 which removes socket reference
     // only from ServerResponse but not IncomingMessage
     if (this[kState].closed)
       return;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -564,7 +564,7 @@ function requestOnConnect(headers, options) {
   if (options.waitForTrailers)
     streamOptions |= STREAM_OPTION_GET_TRAILERS;
 
-  // ret will be either the reserved stream ID (if positive)
+  // `ret` will be either the reserved stream ID (if positive)
   // or an error code (if negative)
   const ret = session[kHandle].request(headers,
                                        streamOptions,
@@ -2082,7 +2082,7 @@ function startFilePipe(self, fd, offset, length) {
   pipe.onunpipe = onFileUnpipe;
   pipe.start();
 
-  // exact length of the file doesn't matter here, since the
+  // Exact length of the file doesn't matter here, since the
   // stream is closing anyway - just use 1 to signify that
   // a write does exist
   trackWriteState(self, 1);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -219,7 +219,7 @@ function tryExtensions(p, exts, isMain) {
   return false;
 }
 
-// find the longest (possibly multi-dot) extension registered in
+// Find the longest (possibly multi-dot) extension registered in
 // Module._extensions
 function findLongestRegisteredExtension(filename) {
   const name = path.basename(filename);
@@ -593,7 +593,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     paths = Module._resolveLookupPaths(request, parent, true);
   }
 
-  // look up the filename first, since that's the cache key.
+  // Look up the filename first, since that's the cache key.
   var filename = Module._findPath(request, paths, isMain);
   if (!filename) {
     // eslint-disable-next-line no-restricted-syntax
@@ -692,7 +692,7 @@ Module.prototype._compile = function(content, filename) {
   var inspectorWrapper = null;
   if (process._breakFirstLine && process._eval == null) {
     if (!resolvedArgv) {
-      // we enter the repl if we're not given a filename argument.
+      // We enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
         resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
       } else {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -25,11 +25,11 @@ const debug = require('util').debuglog('esm');
  * the main module and everything in its dependency graph. */
 class Loader {
   constructor() {
-    // methods which translate input code or other information
+    // Methods which translate input code or other information
     // into es modules
     this.translators = translators;
 
-    // registry of loaded modules, akin to `require.cache`
+    // Registry of loaded modules, akin to `require.cache`
     this.moduleMap = new ModuleMap();
 
     // The resolver has the signature

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -81,7 +81,7 @@ function setupNextTick(_setupNextTick, _setupPromises) {
 
   class TickObject {
     constructor(callback, args, triggerAsyncId) {
-      // this must be set to null first to avoid function tracking
+      // This must be set to null first to avoid function tracking
       // on the hidden class, revisit in V8 versions after 6.2
       this.callback = null;
       this.callback = callback;

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -92,8 +92,8 @@ function getMainThreadStdio() {
     // For supporting legacy API we put the FD here.
     stdin.fd = fd;
 
-    // stdin starts out life in a paused state, but node doesn't
-    // know yet.  Explicitly to readStop() it to put it in the
+    // `stdin` starts out life in a paused state, but node doesn't
+    // know yet. Explicitly to readStop() it to put it in the
     // not-reading state.
     if (stdin._handle && stdin._handle.readStop) {
       stdin._handle.reading = false;

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// undocumented cb() API, needed for core, not for public API
+// Undocumented cb() API, needed for core, not for public API
 function destroy(err, cb) {
   const readableDestroyed = this._readableState &&
     this._readableState.destroyed;

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -69,7 +69,7 @@ function Timeout(callback, after, args, isRepeat) {
   this._idlePrev = this;
   this._idleNext = this;
   this._idleStart = null;
-  // this must be set to null first to avoid function tracking
+  // This must be set to null first to avoid function tracking
   // on the hidden class, revisit in V8 versions after 6.2
   this._onTimeout = null;
   this._onTimeout = callback;

--- a/lib/net.js
+++ b/lib/net.js
@@ -311,7 +311,7 @@ function Socket(options) {
   // handle strings directly
   this._writableState.decodeStrings = false;
 
-  // if we have a handle, then start the flow of data into the
+  // If we have a handle, then start the flow of data into the
   // buffer.  if not, then this will happen when we connect
   if (this._handle && options.readable !== false) {
     if (options.pauseOnCreate) {
@@ -343,7 +343,7 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 };
 
 
-// the user has called .end(), and all the bytes have been
+// The user has called .end(), and all the bytes have been
 // sent out to the other side.
 Socket.prototype._final = function(cb) {
   // If still connecting - defer handling `_final` until 'connect' will happen
@@ -453,7 +453,7 @@ Socket.prototype.setNoDelay = function(enable) {
     return this;
   }
 
-  // backwards compatibility: assume true when `enable` is omitted
+  // Backwards compatibility: assume true when `enable` is omitted
   if (this._handle.setNoDelay)
     this._handle.setNoDelay(enable === undefined ? true : !!enable);
 
@@ -755,7 +755,7 @@ protoGetter('bytesWritten', function bytesWritten() {
   });
 
   if (Array.isArray(data)) {
-    // was a writev, iterate over chunks to get total length
+    // Was a writev, iterate over chunks to get total length
     for (var i = 0; i < data.length; i++) {
       const chunk = data[i];
 
@@ -1147,7 +1147,7 @@ function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 // Returns handle if it can be created, or error code if it can't
 function createServerHandle(address, port, addressType, fd, flags) {
   var err = 0;
-  // assign handle in listen, and clean up if bind or listen fails
+  // Assign handle in listen, and clean up if bind or listen fails
   var handle;
 
   var isTCP = false;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -134,7 +134,7 @@ function Interface(input, output, completer, terminal) {
     throw new ERR_INVALID_OPT_VALUE.RangeError('historySize', historySize);
   }
 
-  // backwards compat; check the isTTY prop of the output stream
+  // Backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
   if (terminal === undefined && !(output === null || output === undefined)) {
     terminal = !!output.isTTY;
@@ -441,7 +441,7 @@ Interface.prototype._normalWrite = function(b) {
   if (newPartContainsEnding) {
     this._sawReturnAt = string.endsWith('\r') ? Date.now() : 0;
 
-    // got one or more newlines; process into "line" events
+    // Got one or more newlines; process into "line" events
     var lines = string.split(lineEnding);
     // Either '' or (conceivably) the unfinished portion of the next line
     string = lines.pop();
@@ -449,7 +449,7 @@ Interface.prototype._normalWrite = function(b) {
     for (var n = 0; n < lines.length; n++)
       this._onLine(lines[n]);
   } else if (string) {
-    // no newlines this time, save what we have for next time
+    // No newlines this time, save what we have for next time
     this._line_buffer = string;
   }
 };
@@ -869,7 +869,7 @@ Interface.prototype._ttyWrite = function(s, key) {
                 self.pause();
                 self.emit('SIGCONT');
               }
-              // explicitly re-enable "raw mode" and move the cursor to
+              // Explicitly re-enable "raw mode" and move the cursor to
               // the correct position.
               // See https://github.com/joyent/node/issues/3295.
               self._setRawMode(true);
@@ -1078,7 +1078,7 @@ function emitKeypressEvents(stream, iface) {
               );
             }
           } catch (err) {
-            // if the generator throws (it could happen in the `keypress`
+            // If the generator throws (it could happen in the `keypress`
             // event), we need to restart it.
             stream[ESCAPE_DECODER] = emitKeys(stream);
             stream[ESCAPE_DECODER].next();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -753,7 +753,7 @@ exports.REPLServer = REPLServer;
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
 exports.REPL_MODE_STRICT = Symbol('repl-strict');
 
-// prompt is a string to print on each line for the prompt,
+// Prompt is a string to print on each line for the prompt,
 // source is a stream to use for I/O, defaulting to stdin/stdout.
 exports.start = function(prompt,
                          source,
@@ -1359,7 +1359,7 @@ function _memory(cmd) {
       }());
     }
 
-    // it is possible to determine a syntax error at this point.
+    // It is possible to determine a syntax error at this point.
     // if the REPL still has a bufferedCommand and
     // self.lines.level.length === 0
     // TODO? keep a log of level so that any syntax breaking lines can

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -654,7 +654,7 @@ const Immediate = class Immediate {
   constructor(callback, args) {
     this._idleNext = null;
     this._idlePrev = null;
-    // this must be set to null first to avoid function tracking
+    // This must be set to null first to avoid function tracking
     // on the hidden class, revisit in V8 versions after 6.2
     this._onImmediate = null;
     this._onImmediate = callback;

--- a/lib/url.js
+++ b/lib/url.js
@@ -78,7 +78,7 @@ const hostPattern = /^\/\/[^@/]+@[^@/]+/;
 const simplePathPattern = /^(\/\/?(?!\/)[^?\s]*)(\?[^\s]*)?$/;
 
 const hostnameMaxLen = 255;
-// protocols that can allow "unsafe" and "unwise" chars.
+// Protocols that can allow "unsafe" and "unwise" chars.
 const unsafeProtocol = new SafeSet([
   'javascript',
   'javascript:'
@@ -434,7 +434,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
       this.query = querystring.parse(this.query);
     }
   } else if (parseQueryString) {
-    // no query string, but parseQueryString still requested
+    // No query string, but parseQueryString still requested
     this.search = null;
     this.query = Object.create(null);
   }
@@ -863,7 +863,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     return result;
   }
 
-  // if a url ENDs in . or .., then it must get a trailing slash.
+  // If a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
   var last = srcPath.slice(-1)[0];
@@ -871,7 +871,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     (result.host || relative.host || srcPath.length > 1) &&
     (last === '.' || last === '..') || last === '');
 
-  // strip single dots, resolve double dots to parent dir
+  // Strip single dots, resolve double dots to parent dir
   // if the path tries to go above the root, `up` ends up > 0
   var up = 0;
   for (var i = srcPath.length - 1; i >= 0; i--) {

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -80,7 +80,7 @@ assert.ok(!arg);
       assert.strictEqual(signal, null);
     } else {
       assert.strictEqual(code, null);
-      // most posix systems will show 'SIGABRT', but alpine34 does not
+      // Most posix systems will show 'SIGABRT', but alpine34 does not
       if (signal !== 'SIGABRT') {
         console.log(`parent received signal ${signal}\nchild's stderr:`);
         console.log(stderr);

--- a/test/async-hooks/test-getaddrinforeqwrap.js
+++ b/test/async-hooks/test-getaddrinforeqwrap.js
@@ -15,7 +15,7 @@ const hooks = initHooks();
 hooks.enable();
 dns.lookup('www.google.com', 4, common.mustCall(onlookup));
 function onlookup() {
-  // we don't care about the error here in order to allow
+  // We don't care about the error here in order to allow
   // tests to run offline (lookup will fail in that case and the err be set);
 
   const as = hooks.activitiesOfTypes('GETADDRINFOREQWRAP');

--- a/test/async-hooks/test-getnameinforeqwrap.js
+++ b/test/async-hooks/test-getnameinforeqwrap.js
@@ -15,7 +15,7 @@ const hooks = initHooks();
 hooks.enable();
 dns.lookupService('127.0.0.1', 80, common.mustCall(onlookupService));
 function onlookupService() {
-  // we don't care about the error here in order to allow
+  // We don't care about the error here in order to allow
   // tests to run offline (lookup will fail in that case and the err be set)
 
   const as = hooks.activitiesOfTypes('GETNAMEINFOREQWRAP');

--- a/test/async-hooks/test-querywrap.js
+++ b/test/async-hooks/test-querywrap.js
@@ -11,7 +11,7 @@ const dns = require('dns');
 const hooks = initHooks();
 
 hooks.enable();
-// uses cares for queryA which in turn uses QUERYWRAP
+// Uses cares for queryA which in turn uses QUERYWRAP
 dns.resolve('localhost', common.mustCall(onresolved));
 
 function onresolved() {

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -21,7 +21,7 @@ function onlistening() {
     Buffer.alloc(2), 0, 2, sock.address().port,
     undefined, common.mustCall(onsent));
 
-  // init not called synchronously because dns lookup always wraps
+  // Init not called synchronously because dns lookup always wraps
   // callback in a next tick even if no lookup is needed
   // TODO (trevnorris) submit patch to fix creation of tick objects and instead
   // create the send wrap synchronously.

--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -14,7 +14,7 @@ function findInGraph(graph, type, n) {
 }
 
 function pruneTickObjects(activities) {
-  // remove one TickObject on each pass until none is left anymore
+  // Remove one TickObject on each pass until none is left anymore
   // not super efficient, but simplest especially to handle
   // multiple TickObjects in a row
   let foundTickObject = true;
@@ -31,7 +31,7 @@ function pruneTickObjects(activities) {
     if (tickObjectIdx >= 0) {
       foundTickObject = true;
 
-      // point all triggerAsyncIds that point to the tickObject
+      // Point all triggerAsyncIds that point to the tickObject
       // to its triggerAsyncId and finally remove it from the activities
       const tickObject = activities[tickObjectIdx];
       const newTriggerId = tickObject.triggerAsyncId;
@@ -48,7 +48,7 @@ function pruneTickObjects(activities) {
 module.exports = function verifyGraph(hooks, graph) {
   pruneTickObjects(hooks);
 
-  // map actual ids to standin ids defined in the graph
+  // Map actual ids to standin ids defined in the graph
   const idtouid = {};
   const uidtoid = {};
   const typeSeen = {};

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -78,7 +78,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
   const async_wrap = internalBinding('async_wrap');
 
   process.on('exit', () => {
-    // iterate through handles to make sure nothing crashes
+    // Iterate through handles to make sure nothing crashes
     for (const k in initHandles)
       util.inspect(initHandles[k]);
   });
@@ -777,7 +777,7 @@ module.exports = {
       // use external command
       opensslCli = 'openssl';
     } else {
-      // use command built from sources included in Node.js repository
+      // Use command built from sources included in Node.js repository
       opensslCli = path.join(path.dirname(process.execPath), 'openssl-cli');
     }
 

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -44,7 +44,7 @@ assert.strictEqual(test_object.readonlyAccessor2, 2);
 assert.throws(() => { test_object.readonlyAccessor2 = 3; },
               /^TypeError: Cannot assign to read only property 'readonlyAccessor2' of object '#<MyObject>'$/);
 
-// validate that static properties are on the class as opposed
+// Validate that static properties are on the class as opposed
 // to the instance
 assert.strictEqual(TestConstructor.staticReadonlyAccessor1, 10);
 assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);

--- a/test/js-native-api/test_general/testInstanceOf.js
+++ b/test/js-native-api/test_general/testInstanceOf.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const common = require('../../common');
 const assert = require('assert');
 
-// addon is referenced through the eval expression in testFile
+// Addon is referenced through the eval expression in testFile
 // eslint-disable-next-line no-unused-vars
 const addon = require(`./build/${common.buildType}/test_general`);
 const path = require('path');

--- a/test/js-native-api/test_general/testNapiRun.js
+++ b/test/js-native-api/test_general/testNapiRun.js
@@ -3,7 +3,7 @@
 const common = require('../../common');
 const assert = require('assert');
 
-// addon is referenced through the eval expression in testFile
+// `addon` is referenced through the eval expression in testFile
 // eslint-disable-next-line no-unused-vars
 const addon = require(`./build/${common.buildType}/test_general`);
 

--- a/test/parallel/test-async-wrap-tlssocket-asyncreset.js
+++ b/test/parallel/test-async-wrap-tlssocket-asyncreset.js
@@ -41,7 +41,7 @@ server.listen(
         res.on('error', (err) => assert.fail(err));
         res.socket.on('error', (err) => assert.fail(err));
         res.resume();
-        // drain the socket and wait for it to be free to reuse
+        // Drain the socket and wait for it to be free to reuse
         res.socket.once('free', () => {
           // This is the pain point. Internally the Agent will call
           // `socket._handle.asyncReset()` and if the _handle does not implement

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -84,7 +84,7 @@ const outOfRangeError = {
   type: RangeError
 };
 
-// try to write a 0-length string beyond the end of b
+// Try to write a 0-length string beyond the end of b
 common.expectsError(() => b.write('', 2048), outOfBoundsError);
 
 // throw when writing to negative offset
@@ -96,14 +96,14 @@ common.expectsError(() => b.write('a', 2048), outOfBoundsError);
 // throw when writing to negative offset
 common.expectsError(() => b.write('a', -1), outOfBoundsError);
 
-// try to copy 0 bytes worth of data into an empty buffer
+// Try to copy 0 bytes worth of data into an empty buffer
 b.copy(Buffer.alloc(0), 0, 0, 0);
 
-// try to copy 0 bytes past the end of the target buffer
+// Try to copy 0 bytes past the end of the target buffer
 b.copy(Buffer.alloc(0), 1, 1, 1);
 b.copy(Buffer.alloc(1), 1, 1, 1);
 
-// try to copy 0 bytes from past the end of the source buffer
+// Try to copy 0 bytes from past the end of the source buffer
 b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
 // Testing for smart defaults and ability to pass string values as offset
@@ -183,7 +183,7 @@ Buffer.alloc(1).write('', 1, 0);
 }
 
 {
-  // make sure only top level parent propagates from allocPool
+  // Make sure only top level parent propagates from allocPool
   const b = Buffer.allocUnsafe(5);
   const c = b.slice(0, 4);
   const d = c.slice(0, 2);
@@ -331,13 +331,13 @@ assert.strictEqual((Buffer.from('Man')).toString('base64'), 'TWFu');
   assert.strictEqual(quote.length, bytesWritten);
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
-  // check that the base64 decoder on the constructor works
+  // Check that the base64 decoder on the constructor works
   // even in the presence of whitespace.
   b = Buffer.from(expectedWhite, 'base64');
   assert.strictEqual(quote.length, b.length);
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
-  // check that the base64 decoder ignores illegal chars
+  // Check that the base64 decoder ignores illegal chars
   const expectedIllegal = expected.slice(0, 60) + ' \x80' +
                           expected.slice(60, 120) + ' \xff' +
                           expected.slice(120, 180) + ' \x00' +
@@ -723,7 +723,7 @@ assert.strictEqual(x.inspect(), '<Buffer 81 a3 66 6f 6f a3 62 61 72>');
 }
 
 {
-  // test unmatched surrogates not producing invalid utf8 output
+  // Test unmatched surrogates not producing invalid utf8 output
   // ef bf bd = utf-8 representation of unicode replacement character
   // see https://codereview.chromium.org/121173009/
   const buf = Buffer.from('ab\ud800cd', 'utf8');

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -78,7 +78,7 @@ assert.strictEqual(Buffer.byteLength('𠝹𠱓𠱸', 'UTF8'), 12);
 assert.strictEqual(Buffer.byteLength('hey there'), 9);
 assert.strictEqual(Buffer.byteLength('𠱸挶νξ#xx :)'), 17);
 assert.strictEqual(Buffer.byteLength('hello world', ''), 11);
-// it should also be assumed with unrecognized encoding
+// It should also be assumed with unrecognized encoding
 assert.strictEqual(Buffer.byteLength('hello world', 'abc'), 11);
 assert.strictEqual(Buffer.byteLength('ßœ∑≈', 'unkn0wn enc0ding'), 10);
 

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -48,7 +48,7 @@ let cntr = 0;
 }
 
 {
-  // copy longer buffer b to shorter c without targetStart
+  // Copy longer buffer b to shorter c without targetStart
   b.fill(++cntr);
   c.fill(++cntr);
   const copied = b.copy(c);
@@ -73,7 +73,7 @@ let cntr = 0;
 }
 
 {
-  // try to copy 513 bytes, and check we don't overrun c
+  // Try to copy 513 bytes, and check we don't overrun c
   b.fill(++cntr);
   c.fill(++cntr);
   const copied = b.copy(c, 0, 0, 513);
@@ -94,7 +94,7 @@ let cntr = 0;
   }
 }
 
-// copy string longer than buffer length (failure will segfault)
+// Copy string longer than buffer length (failure will segfault)
 const bb = Buffer.allocUnsafe(10);
 bb.fill('hello crazy world');
 
@@ -121,7 +121,7 @@ common.expectsError(
 common.expectsError(
   () => b.copy(c, 0, -1), errorProperty);
 
-// when sourceStart is greater than sourceEnd, zero copied
+// When sourceStart is greater than sourceEnd, zero copied
 assert.strictEqual(b.copy(c, 0, 100, 10), 0);
 
 // when targetStart > targetLength, zero copied

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -193,7 +193,7 @@ for (let i = 66; i < 76; i++) {  // from 'B' to 'K'
 
 const longBufferString = Buffer.from(longString);
 
-// pattern of 15 chars, repeated every 16 chars in long
+// Pattern of 15 chars, repeated every 16 chars in long
 let pattern = 'ABACABADABACABA';
 for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
   const includes = longBufferString.includes(pattern, i);

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -248,7 +248,7 @@ for (let i = 66; i < 76; i++) {  // from 'B' to 'K'
 
 const longBufferString = Buffer.from(longString);
 
-// pattern of 15 chars, repeated every 16 chars in long
+// Pattern of 15 chars, repeated every 16 chars in long
 let pattern = 'ABACABADABACABA';
 for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
   const index = longBufferString.indexOf(pattern, i);

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -32,7 +32,7 @@ read(buf, 'readInt16LE', [1], 0x48fd);
 read(buf, 'readInt32BE', [1], -45552945);
 read(buf, 'readInt32LE', [1], -806729475);
 
-// testing basic functionality of readIntBE() and readIntLE()
+// Testing basic functionality of readIntBE() and readIntLE()
 read(buf, 'readIntBE', [1, 1], -3);
 read(buf, 'readIntLE', [2, 1], 0x48);
 
@@ -47,7 +47,7 @@ read(buf, 'readUInt16LE', [2], 0xea48);
 read(buf, 'readUInt32BE', [1], 0xfd48eacf);
 read(buf, 'readUInt32LE', [1], 0xcfea48fd);
 
-// testing basic functionality of readUIntBE() and readUIntLE()
+// Testing basic functionality of readUIntBE() and readUIntLE()
 read(buf, 'readUIntBE', [2, 2], 0x48ea);
 read(buf, 'readUIntLE', [2, 2], 0xea48);
 

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -43,7 +43,7 @@ try {
 assert.strictEqual(SlowBuffer('6').length, 6);
 assert.strictEqual(SlowBuffer(true).length, 1);
 
-// should create zero-length buffer if parameter is not a number
+// Should create zero-length buffer if parameter is not a number
 assert.strictEqual(SlowBuffer().length, 0);
 assert.strictEqual(SlowBuffer(NaN).length, 0);
 assert.strictEqual(SlowBuffer({}).length, 0);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 const rangeBuffer = Buffer.from('abc');
 
-// if start >= buffer's length, empty string will be returned
+// If start >= buffer's length, empty string will be returned
 assert.strictEqual(rangeBuffer.toString('ascii', 3), '');
 assert.strictEqual(rangeBuffer.toString('ascii', +Infinity), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 3.14, 3), '');
@@ -25,7 +25,7 @@ assert.strictEqual(rangeBuffer.toString('ascii', '-1', 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
 
-// if start is an invalid integer, start will be taken as zero
+// If start is an invalid integer, start will be taken as zero
 assert.strictEqual(rangeBuffer.toString('ascii', 'node.js', 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', {}, 3), 'abc');
 assert.strictEqual(rangeBuffer.toString('ascii', [], 3), 'abc');

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -48,7 +48,7 @@ if (process.argv[2] === 'child') {
       socket.end((process.connected).toString());
     });
 
-    // when the socket is closed, we will close the server
+    // When the socket is closed, we will close the server
     // allowing the process to self terminate
     socket.on('end', function() {
       server.close();
@@ -77,14 +77,14 @@ if (process.argv[2] === 'child') {
     parentFlag = child.connected;
   }));
 
-  // the process should also self terminate without using signals
+  // The process should also self terminate without using signals
   child.on('exit', common.mustCall());
 
   // when child is listening
   child.on('message', function(obj) {
     if (obj && obj.msg === 'ready') {
 
-      // connect to child using TCP to know if disconnect was emitted
+      // Connect to child using TCP to know if disconnect was emitted
       const socket = net.connect(obj.port);
 
       socket.on('data', function(data) {

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -8,7 +8,7 @@ const _validateStdio = require('internal/child_process')._validateStdio;
 const expectedError =
   common.expectsError({ code: 'ERR_INVALID_OPT_VALUE', type: TypeError }, 2);
 
-// should throw if string and not ignore, pipe, or inherit
+// Should throw if string and not ignore, pipe, or inherit
 assert.throws(() => _validateStdio('foo'), expectedError);
 
 // should throw if not a string or array

--- a/test/parallel/test-cli-syntax-piped-good.js
+++ b/test/parallel/test-cli-syntax-piped-good.js
@@ -12,8 +12,8 @@ const syntaxArgs = [
   ['--check']
 ];
 
-// should not execute code piped from stdin with --check
-// loop each possible option, `-c` or `--check`
+// Should not execute code piped from stdin with --check.
+// Loop each possible option, `-c` or `--check`.
 syntaxArgs.forEach(function(args) {
   const stdin = 'throw new Error("should not get run");';
   const c = spawnSync(node, args, { encoding: 'utf8', input: stdin });

--- a/test/parallel/test-cluster-disconnect.js
+++ b/test/parallel/test-cluster-disconnect.js
@@ -68,7 +68,7 @@ if (cluster.isWorker) {
     }
   };
 
-  // start two workers and execute callback when both is listening
+  // Start two workers and execute callback when both is listening
   const startCluster = (cb) => {
     const workers = 8;
     let online = 0;

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -45,7 +45,7 @@ if (cluster.isMaster && process.argv.length !== 3) {
   worker.on('online', common.mustCall());
 
   worker.on('message', common.mustCall(function(err) {
-    // disconnect first, so that we will not leave zombies
+    // Disconnect first, so that we will not leave zombies
     worker.disconnect();
     assert.strictEqual(err.code, 'EADDRINUSE');
   }));
@@ -54,7 +54,7 @@ if (cluster.isMaster && process.argv.length !== 3) {
   const PIPE_NAME = process.env.PIPE_NAME;
   const cp = fork(__filename, [PIPE_NAME], { stdio: 'inherit' });
 
-  // message from the child indicates it's ready and listening
+  // Message from the child indicates it's ready and listening
   cp.on('message', common.mustCall(function() {
     const server = net.createServer().listen(PIPE_NAME, function() {
       // message child process so that it can exit

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -68,7 +68,7 @@ if (cluster.isMaster) {
   });
 } else {
   process.on('message', function(msg) {
-    // we shouldn't exit, not while a network connection exists
+    // We shouldn't exit, not while a network connection exists
     net.connect(msg.port);
   });
 }

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -39,7 +39,7 @@ if (cluster.isWorker) {
     socket.on('connect', function() {
       socket.on('data', function() {
         console.log('got data from client');
-        // socket definitely connected to worker if we got data
+        // Socket definitely connected to worker if we got data
         worker.disconnect();
         socket.end();
       });

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -149,7 +149,7 @@ console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
 console.time('label');
 console.timeEnd('label');
 
-// verify that Object.prototype properties can be used as labels
+// Verify that Object.prototype properties can be used as labels
 console.time('__proto__');
 console.timeEnd('__proto__');
 console.time('constructor');
@@ -202,7 +202,7 @@ assert.strictEqual(errStrings.length, process.stderr.writeTimes);
 restoreStdout();
 restoreStderr();
 
-// verify that console.timeEnd() doesn't leave dead links
+// Verify that console.timeEnd() doesn't leave dead links
 const timesMapSize = console._times.size;
 console.time('label1');
 console.time('label2');
@@ -268,7 +268,7 @@ assert.strictEqual(strings.length, 0);
 assert.strictEqual(errStrings.shift().split('\n').shift(),
                    'Trace: This is a {"formatted":"trace"} 10 foo');
 
-// hijack stderr to catch `process.emitWarning` which is using
+// Hijack stderr to catch `process.emitWarning` which is using
 // `process.nextTick`
 hijackStderr(common.mustCall(function(data) {
   restoreStderr();

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -153,7 +153,7 @@ for (const test of TEST_CASES) {
         msg += decrypt.final(outputEncoding);
         assert.strictEqual(msg, test.plain);
       } else {
-        // assert that final throws if input data could not be verified!
+        // Assert that final throws if input data could not be verified!
         assert.throws(function() { decrypt.final('hex'); }, errMessages.auth);
       }
     }
@@ -192,7 +192,7 @@ for (const test of TEST_CASES) {
         msg += decrypt.final('ascii');
         assert.strictEqual(msg, test.plain);
       } else {
-        // assert that final throws if input data could not be verified!
+        // Assert that final throws if input data could not be verified!
         assert.throws(function() { decrypt.final('ascii'); }, errMessages.auth);
       }
     }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -238,7 +238,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
   assert.strictEqual(decipher.setAAD(aadbuf), decipher);
 }
 
-// error throwing in setAAD/setAuthTag/getAuthTag/setAutoPadding
+// Error throwing in setAAD/setAuthTag/getAuthTag/setAutoPadding
 {
   const key = '0123456789';
   const aadbuf = Buffer.from('aadbuf');

--- a/test/parallel/test-crypto-from-binary.js
+++ b/test/parallel/test-crypto-from-binary.js
@@ -33,7 +33,7 @@ const crypto = require('crypto');
 
 const EXTERN_APEX = 0xFBEE9;
 
-// manually controlled string for checking binary output
+// Manually controlled string for checking binary output
 let ucs2_control = 'a\u0000';
 
 // grow the strings to proper length

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -235,7 +235,7 @@ assert.throws(function() {
   //   Then open private_key.pem and change its header and footer.
   const sha1_privateKey = fixtures.readSync('test_bad_rsa_privkey.pem',
                                             'ascii');
-  // this would inject errors onto OpenSSL's error stack
+  // This would inject errors onto OpenSSL's error stack
   crypto.createSign('sha1').sign(sha1_privateKey);
 }, (err) => {
   // Throws crypto error, so there is an opensslErrorStack property.

--- a/test/parallel/test-dgram-close-in-listening.js
+++ b/test/parallel/test-dgram-close-in-listening.js
@@ -16,7 +16,7 @@ socket.on('listening', function() {
 // get a random port for send
 const portGetter = dgram.createSocket('udp4')
   .bind(0, 'localhost', common.mustCall(() => {
-    // adds a listener to 'listening' to send the data when
+    // Adds a listener to 'listening' to send the data when
     // the socket is available
     socket.send(buf, 0, buf.length,
                 portGetter.address().port,

--- a/test/parallel/test-dgram-close-is-not-callback.js
+++ b/test/parallel/test-dgram-close-is-not-callback.js
@@ -13,7 +13,7 @@ const portGetter = dgram.createSocket('udp4')
                 portGetter.address().port,
                 portGetter.address().address);
 
-    // if close callback is not function, ignore the argument.
+    // If close callback is not function, ignore the argument.
     socket.close('bad argument');
     portGetter.close();
 

--- a/test/parallel/test-domain-ee-implicit.js
+++ b/test/parallel/test-domain-ee-implicit.js
@@ -23,6 +23,6 @@ d.run(common.mustCall(() => {
 }));
 
 setTimeout(common.mustCall(() => {
-  // escape from the domain, but implicit is still bound to it.
+  // Escape from the domain, but implicit is still bound to it.
   implicit.emit('error', new Error('foobar'));
 }), 1);

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -40,7 +40,7 @@ d.on('error', common.mustCall(function(er) {
 }));
 
 
-// implicit handling of thrown errors while in a domain, via the
+// Implicit handling of thrown errors while in a domain, via the
 // single entry points of ReqWrap and MakeCallback.  Even if
 // we try very hard to escape, there should be no way to, even if
 // we go many levels deep through timeouts and multiple IO calls.

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -36,7 +36,7 @@ const server = http.createServer((req, res) => {
   const b = domain.create();
   a.add(b);
 
-  // treat these EE objects as if they are a part of the b domain
+  // Treat these EE objects as if they are a part of the b domain
   // so, an 'error' event on them propagates to the domain, rather
   // than being thrown.
   b.add(req);

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -39,7 +39,7 @@ const data = '南越国是前203年至前111年存在于岭南地区的一个国
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-// test that empty file will be created and have content added
+// Test that empty file will be created and have content added
 const filename = join(tmpdir.path, 'append-sync.txt');
 
 fs.appendFileSync(filename, data);

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -68,7 +68,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     .catch(throwNextTick);
 }
 
-// test that appends data to a non-empty file (callback API)
+// Test that appends data to a non-empty file (callback API)
 {
   const filename = join(tmpdir.path, 'append-non-empty.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -84,7 +84,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   }));
 }
 
-// test that appends data to a non-empty file (promise API)
+// Test that appends data to a non-empty file (promise API)
 {
   const filename = join(tmpdir.path, 'append-non-empty-promise.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -98,7 +98,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     .catch(throwNextTick);
 }
 
-// test that appendFile accepts buffers (callback API)
+// Test that appendFile accepts buffers (callback API)
 {
   const filename = join(tmpdir.path, 'append-buffer.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -115,7 +115,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   }));
 }
 
-// test that appendFile accepts buffers (promises API)
+// Test that appendFile accepts buffers (promises API)
 {
   const filename = join(tmpdir.path, 'append-buffer-promises.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -130,7 +130,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     .catch(throwNextTick);
 }
 
-// test that appendFile accepts numbers (callback API)
+// Test that appendFile accepts numbers (callback API)
 {
   const filename = join(tmpdir.path, 'append-numbers.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -153,7 +153,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   }));
 }
 
-// test that appendFile accepts numbers (promises API)
+// Test that appendFile accepts numbers (promises API)
 {
   const filename = join(tmpdir.path, 'append-numbers-promises.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -176,7 +176,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     .catch(throwNextTick);
 }
 
-// test that appendFile accepts file descriptors (callback API)
+// Test that appendFile accepts file descriptors (callback API)
 {
   const filename = join(tmpdir.path, 'append-descriptors.txt');
   fs.writeFileSync(filename, currentFileData);
@@ -200,7 +200,7 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   }));
 }
 
-// test that appendFile accepts file descriptors (promises API)
+// Test that appendFile accepts file descriptors (promises API)
 {
   const filename = join(tmpdir.path, 'append-descriptors-promises.txt');
   fs.writeFileSync(filename, currentFileData);

--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -10,7 +10,7 @@ const tempFile = path.join(tmpdir.path, 'fs-non-number-arguments-throw');
 tmpdir.refresh();
 fs.writeFileSync(tempFile, 'abc\ndef');
 
-// a sanity check when using numbers instead of strings
+// A sanity check when using numbers instead of strings
 const sanity = 'def';
 const saneEmitter = fs.createReadStream(tempFile, { start: 4, end: 6 });
 

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -148,8 +148,8 @@ check(null, fs.watch, fileUrl2, assert.fail);
 check(null, fs.watchFile, fileUrl2, assert.fail);
 check(fs.writeFile, fs.writeFileSync, fileUrl2, 'abc');
 
-// an 'error' for exists means that it doesn't exist.
-// one of many reasons why this file is the absolute worst.
+// An 'error' for exists means that it doesn't exist.
+// One of many reasons why this file is the absolute worst.
 fs.exists('foo\u0000bar', common.mustCall((exists) => {
   assert(!exists);
 }));

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -25,10 +25,10 @@ async function validateFilePermission() {
   const newPermissions = 0o765;
 
   if (common.isWindows) {
-    // chmod in Windows will only toggle read only/write access. the
+    // Chmod in Windows will only toggle read only/write access. The
     // fs.Stats.mode in Windows is computed using read/write
-    // bits (not exec). read only at best returns 444; r/w 666.
-    // refer: /deps/uv/src/win/fs.cfs;
+    // bits (not exec). Read-only at best returns 444; r/w 666.
+    // Refer: /deps/uv/src/win/fs.cfs;
     expectedAccess = 0o664;
   } else {
     expectedAccess = newPermissions;

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -106,7 +106,7 @@ async function getHandle(dest) {
       await handle.sync();
     }
 
-    // test fs.read promises when length to read is zero bytes
+    // Test fs.read promises when length to read is zero bytes
     {
       const dest = path.resolve(tmpDir, 'test1.js');
       const handle = await getHandle(dest);

--- a/test/parallel/test-fs-realpath-on-substed-drive.js
+++ b/test/parallel/test-fs-realpath-on-substed-drive.js
@@ -25,7 +25,7 @@ for (i = 0; i < driveLetters.length; ++i) {
 if (i === driveLetters.length)
   common.skip('Cannot create subst drive');
 
-// schedule cleanup (and check if all callbacks where called)
+// Schedule cleanup (and check if all callbacks where called)
 process.on('exit', function() {
   spawnSync('subst', ['/d', drive]);
 });

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -115,7 +115,7 @@ function test_simple_relative_symlink(realpath, realpathSync, callback) {
 function test_simple_absolute_symlink(realpath, realpathSync, callback) {
   console.log('test_simple_absolute_symlink');
 
-  // this one should still run, even if skipSymlinks is set,
+  // This one should still run, even if skipSymlinks is set,
   // because it uses a junction.
   const type = skipSymlinks ? 'junction' : 'dir';
 
@@ -418,7 +418,7 @@ function test_up_multiple(realpath, realpathSync, cb) {
 function test_abs_with_kids(realpath, realpathSync, cb) {
   console.log('test_abs_with_kids');
 
-  // this one should still run, even if skipSymlinks is set,
+  // This one should still run, even if skipSymlinks is set,
   // because it uses a junction.
   const type = skipSymlinks ? 'junction' : 'dir';
 

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -195,7 +195,7 @@ if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
 }
 
 if (common.isWindows) {
-  // this value would get converted to (double)1713037251359.9998
+  // This value would get converted to (double)1713037251359.9998
   const truncate_mtime = 1713037251360;
   fs.utimesSync(path, truncate_mtime / 1000, truncate_mtime / 1000);
   const truncate_stats = fs.statSync(path);

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -42,7 +42,7 @@ common.expectsError(
 
 // pct-encoded characters in the path will be decoded and checked
 if (common.isWindows) {
-  // encoded back and forward slashes are not permitted on windows
+  // Encoded back and forward slashes are not permitted on windows
   ['%2f', '%2F', '%5c', '%5C'].forEach((i) => {
     common.expectsError(
       () => {
@@ -67,7 +67,7 @@ if (common.isWindows) {
     }
   );
 } else {
-  // encoded forward slashes are not permitted on other platforms
+  // Encoded forward slashes are not permitted on other platforms
   ['%2f', '%2F'].forEach((i) => {
     common.expectsError(
       () => {

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -107,4 +107,4 @@ const { kStateSymbol } = require('internal/dgram');
 }
 
 
-// see also test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+// See also test/pseudo-tty/test-handle-wrap-isrefed-tty.js

--- a/test/parallel/test-http-addrequest-localaddress.js
+++ b/test/parallel/test-http-addrequest-localaddress.js
@@ -8,7 +8,7 @@ require('../common');
 const assert = require('assert');
 const agent = require('http').globalAgent;
 
-// small stub just so we can call addRequest directly
+// Small stub just so we can call addRequest directly
 const req = {
   getHeader: () => {}
 };

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -52,7 +52,7 @@ const server = http.createServer(common.mustCall((req, res) => {
         // assert request2 was removed from the queue
         assert(!agent.requests[key]);
         process.nextTick(() => {
-          // assert that the same socket was not assigned to request2,
+          // Assert that the same socket was not assigned to request2,
           // since it was destroyed.
           assert.notStrictEqual(request1.socket, request2.socket);
           assert(!request2.socket.destroyed, 'the socket is destroyed');
@@ -64,7 +64,7 @@ const server = http.createServer(common.mustCall((req, res) => {
   const request2 = http.get(requestOptions, common.mustCall((response) => {
     assert(!request2.socket.destroyed);
     assert(request1.socket.destroyed);
-    // assert not reusing the same socket, since it was destroyed.
+    // Assert not reusing the same socket, since it was destroyed.
     assert.notStrictEqual(request1.socket, request2.socket);
     const countdown = new Countdown(2, () => server.close());
     request2.socket.on('close', common.mustCall(() => countdown.dec()));

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -50,7 +50,7 @@ server.listen(common.PIPE, function() {
   sched(function() { req.end(); }, 5);
 });
 
-// schedule a callback after `ticks` event loop ticks
+// Schedule a callback after `ticks` event loop ticks
 function sched(cb, ticks) {
   function fn() {
     if (--ticks)

--- a/test/parallel/test-http-client-spurious-aborted.js
+++ b/test/parallel/test-http-client-spurious-aborted.js
@@ -52,7 +52,7 @@ function download() {
     _handle._close = res.socket._handle.close;
     _handle.close = function(callback) {
       _handle._close();
-      // set readable to true even though request is complete
+      // Set readable to true even though request is complete
       if (res.complete) res.readable = true;
       callback();
     };

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -89,6 +89,6 @@ server.listen(0, options.host, function() {
 
 process.on('exit', () => {
   console.error(`done=${requests_done} sent=${requests_sent}`);
-  // check that timeout on http request was not called too much
+  // Check that timeout on http request was not called too much
   assert.strictEqual(requests_done, requests_sent);
 });

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -51,7 +51,7 @@ server.listen(0, common.mustCall(function() {
 
     let data = firstBodyChunk.toString();
 
-    // test that the firstBodyChunk was not parsed as HTTP
+    // Test that the firstBodyChunk was not parsed as HTTP
     assert.strictEqual(data, 'Head');
 
     socket.on('data', function(buf) {

--- a/test/parallel/test-http-outgoing-finish.js
+++ b/test/parallel/test-http-outgoing-finish.js
@@ -51,7 +51,7 @@ function write(out) {
   // first, write until it gets some backpressure
   while (out.write(buf)) {}
 
-  // now end, and make sure that we don't get the 'finish' event
+  // Now end, and make sure that we don't get the 'finish' event
   // before the tick where the cb gets called.  We give it until
   // nextTick because this is added as a listener before the endcb
   // is registered.  The order is not what we're testing here, just

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -32,7 +32,7 @@ const server = http.createServer(function(request, response) {
   response.removeHeader('transfer-encoding');
   response.removeHeader('content-length');
 
-  // make sure that removing and then setting still works:
+  // Make sure that removing and then setting still works:
   response.removeHeader('date');
   response.setHeader('date', 'coffee o clock');
 

--- a/test/parallel/test-http-request-dont-override-options.js
+++ b/test/parallel/test-http-request-dont-override-options.js
@@ -14,7 +14,7 @@ server.listen(0, function() {
   const agent = new http.Agent();
   agent.defaultPort = this.address().port;
 
-  // options marked as explicitly undefined for readability
+  // Options marked as explicitly undefined for readability
   // in this test, they should STAY undefined as options should not
   // be mutable / modified
   const options = {

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -51,7 +51,7 @@ const server = http.createServer(function(req, res) {
 server.listen(0, common.mustCall(function() {
   const countdown = new Countdown(runCount, () => server.close());
   for (let n = 1; n <= runCount; n++) {
-    // this runs twice, the first time, the server will use
+    // This runs twice, the first time, the server will use
     // setHeader, the second time it uses writeHead. The
     // result on the client side should be the same in
     // either case -- only the first instance of the header

--- a/test/parallel/test-http-server-multiheaders2.js
+++ b/test/parallel/test-http-server-multiheaders2.js
@@ -47,7 +47,7 @@ const multipleAllowed = [
   // not a special case, just making sure it's parsed correctly
   'X-Forwarded-For',
 
-  // make sure that unspecified headers is treated as multiple
+  // Make sure that unspecified headers is treated as multiple
   'Some-Random-Header',
   'X-Some-Random-Header',
 ];

--- a/test/parallel/test-http-server-response-standalone.js
+++ b/test/parallel/test-http-server-response-standalone.js
@@ -5,7 +5,7 @@ const { ServerResponse } = require('http');
 const { Writable } = require('stream');
 const assert = require('assert');
 
-// check that ServerResponse can be used without a proper Socket
+// Check that ServerResponse can be used without a proper Socket
 // Fixes: https://github.com/nodejs/node/issues/14386
 // Fixes: https://github.com/nodejs/node/issues/14381
 

--- a/test/parallel/test-http-url.parse-basic.js
+++ b/test/parallel/test-http-url.parse-basic.js
@@ -31,7 +31,7 @@ let testURL;
 function check(request) {
   // default method should still be get
   assert.strictEqual(request.method, 'GET');
-  // there are no URL params, so you should not see any
+  // There are no URL params, so you should not see any
   assert.strictEqual(request.url, '/');
   // the host header should use the url.parse.hostname
   assert.strictEqual(request.headers.host,

--- a/test/parallel/test-http-wget.js
+++ b/test/parallel/test-http-wget.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const net = require('net');
 const http = require('http');
 
-// wget sends an HTTP/1.0 request with Connection: Keep-Alive
+// `wget` sends an HTTP/1.0 request with Connection: Keep-Alive
 //
 // Sending back a chunked response to an HTTP/1.0 client would be wrong,
 // so what has to happen in this case is that the connection is closed

--- a/test/parallel/test-http-write-callbacks.js
+++ b/test/parallel/test-http-write-callbacks.js
@@ -91,7 +91,7 @@ server.listen(0, function() {
     });
   });
   req.on('response', (res) => {
-    // this should not come until after the end is flushed out
+    // This should not come until after the end is flushed out
     assert(clientEndCb);
     res.setEncoding('ascii');
     res.on('data', (c) => {

--- a/test/parallel/test-http-zero-length-write.js
+++ b/test/parallel/test-http-zero-length-write.js
@@ -32,7 +32,7 @@ function getSrc() {
   // The Readable class prevents this behavior.
   const src = new Stream();
 
-  // start out paused, just so we don't miss anything yet.
+  // Start out paused, just so we don't miss anything yet.
   let paused = false;
   src.pause = function() {
     paused = true;

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -88,7 +88,7 @@ server.on('session', common.mustCall((session) => {
     );
   });
 
-  // arguments + origin are too long for an ALTSVC frame
+  // Arguments + origin are too long for an ALTSVC frame
   assert.throws(
     () => {
       session.altsvc('h2=":8000"',

--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -36,9 +36,9 @@ checkWeight(1, 1);
 checkWeight(16, 16);
 checkWeight(256, 256);
 
-// when client weight is higher than 256, weight is 256
+// When client weight is higher than 256, weight is 256
 checkWeight(257, 256);
 checkWeight(512, 256);
 
-// when client weight is undefined, weight is default 16
+// When client weight is undefined, weight is default 16
 checkWeight(undefined, 16);

--- a/test/parallel/test-http2-compat-expect-continue-check.js
+++ b/test/parallel/test-http2-compat-expect-continue-check.js
@@ -20,7 +20,7 @@ server.on('checkContinue', common.mustCall((req, res) => {
   res.writeContinue();
   res.writeHead(200, {});
   res.end(testResBody);
-  // should simply return false if already too late to write
+  // Should simply return false if already too late to write
   assert.strictEqual(res.writeContinue(), false);
   res.on('finish', common.mustCall(
     () => process.nextTick(() => assert.strictEqual(res.writeContinue(), false))

--- a/test/parallel/test-http2-compat-serverrequest-pause.js
+++ b/test/parallel/test-http2-compat-serverrequest-pause.js
@@ -26,7 +26,7 @@ server.on('request', common.mustCall((req, res) => {
     res.end();
   }));
 
-  // shouldn't throw if underlying Http2Stream no longer exists
+  // Shouldn't throw if underlying Http2Stream no longer exists
   res.on('finish', common.mustCall(() => process.nextTick(() => {
     req.pause();
     req.resume();

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -9,7 +9,7 @@ const http2 = require('http2');
 const fs = require('fs');
 const path = require('path');
 
-// piping should work as expected with createWriteStream
+// Piping should work as expected with createWriteStream
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -43,7 +43,7 @@ server.on('request', common.mustCall(function(request, response) {
   common.expectsError(() => request.socket.pause(), errMsg);
   common.expectsError(() => request.socket.resume(), errMsg);
 
-  // should have correct this context for socket methods & getters
+  // Should have correct this context for socket methods & getters
   assert.ok(request.socket.address() != null);
   assert.ok(request.socket.remotePort);
 
@@ -66,7 +66,7 @@ server.on('request', common.mustCall(function(request, response) {
   assert.ok(request.socket._server);
   assert.strictEqual(request.socket.connecting, false);
 
-  // socket events are bound and emitted on Http2Stream
+  // Socket events are bound and emitted on Http2Stream
   request.socket.on('close', common.mustCall());
   request.socket.once('close', common.mustCall());
   request.socket.on('testEvent', common.mustCall());

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -63,7 +63,7 @@ const { connect: netConnect } = require('net');
   connect(authority).on('error', () => {});
 }
 
-// check for error for an invalid protocol (not http or https)
+// Check for error for an invalid protocol (not http or https)
 {
   const authority = 'ssh://localhost';
   expectsError(() => {

--- a/test/parallel/test-http2-dont-override.js
+++ b/test/parallel/test-http2-dont-override.js
@@ -10,7 +10,7 @@ const options = {};
 
 const server = http2.createServer(options);
 
-// options are defaulted but the options are not modified
+// Options are defaulted but the options are not modified
 assert.deepStrictEqual(Object.keys(options), []);
 
 server.on('stream', common.mustCall((stream) => {

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -9,7 +9,7 @@ const http2 = require('http2');
 const fs = require('fs');
 const path = require('path');
 
-// piping should work as expected with createWriteStream
+// Piping should work as expected with createWriteStream
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();

--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -20,7 +20,7 @@ server.on('stream', (stream) => {
     [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
   }, {
     statCheck(stat, headers) {
-      // abort the send and return a 304 Not Modified instead
+      // Abort the send and return a 304 Not Modified instead
       stream.respond({ [HTTP2_HEADER_STATUS]: 304 });
       return false;
     }

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -14,7 +14,7 @@ server.on('stream', common.mustCall((stream) => {
     stream.end('hello world');
   }));
 
-  // check that expected errors are thrown with wrong args
+  // Check that expected errors are thrown with wrong args
   common.expectsError(
     () => stream.setTimeout('100'),
     {

--- a/test/parallel/test-https-agent-create-connection.js
+++ b/test/parallel/test-https-agent-create-connection.js
@@ -89,7 +89,7 @@ function createServer() {
   }));
 }
 
-// use port and host and option does not have agentKey
+// Use port and host and option does not have agentKey
 {
   const server = createServer();
   server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -35,7 +35,7 @@ const dftProtocol = {};
 }
 
 
-// validate that `createServer` can work with no arguments
+// Validate that `createServer` can work with no arguments
 {
   const server = https.createServer();
 

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -25,7 +25,7 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-// disable strict server certificate validation by the client
+// Disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const assert = require('assert');

--- a/test/parallel/test-https-slow-headers.js
+++ b/test/parallel/test-https-slow-headers.js
@@ -30,7 +30,7 @@ let sendCharEvery = 1000;
 // 40 seconds is the default
 assert.strictEqual(server.headersTimeout, 40 * 1000);
 
-// pass a REAL env variable to shortening up the default
+// Pass a REAL env variable to shortening up the default
 // value which is 40s otherwise
 // this is useful for manual testing
 if (!process.env.REAL) {

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -25,7 +25,7 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-// disable strict server certificate validation by the client
+// Disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 common.expectWarning(

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -32,7 +32,7 @@ const https = require('https');
 const key = fixtures.readKey('agent1-key.pem');
 const cert = fixtures.readKey('agent1-cert.pem');
 
-// number of bytes discovered empirically to trigger the bug
+// Number of bytes discovered empirically to trigger the bug
 const data = Buffer.alloc(1024 * 32 + 1);
 
 httpsTest();

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -64,8 +64,8 @@ function test() {
         s += c.toString();
       });
       res.on('end', function() {
-        // kill the subprocess before we start doing asserts.
-        // it's really annoying when tests leave orphans!
+        // Kill the subprocess before we start doing asserts.
+        // It's really annoying when tests leave orphans!
         process.kill(child.pid, 'SIGKILL');
         try {
           parent.kill();

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -64,7 +64,7 @@ function test() {
         s += c.toString();
       });
       res.on('end', function() {
-        // kill the subprocess before we start doing asserts.
+        // Kill the subprocess before we start doing asserts.
         // it's really annoying when tests leave orphans!
         process.kill(child.pid, 'SIGKILL');
         try {

--- a/test/parallel/test-module-version.js
+++ b/test/parallel/test-module-version.js
@@ -5,6 +5,6 @@ const assert = require('assert');
 // check for existence
 assert(process.config.variables.hasOwnProperty('node_module_version'));
 
-// ensure that `node_module_version` is an Integer > 0
+// Ensure that `node_module_version` is an Integer > 0
 assert(Number.isInteger(process.config.variables.node_module_version));
 assert(process.config.variables.node_module_version > 0);

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -38,7 +38,7 @@ const {
 
 const client = net.connect({
   host: addresses.INVALID_HOST,
-  port: 80, // port number doesn't matter because host name is invalid
+  port: 80, // Port number doesn't matter because host name is invalid
   lookup: common.mustCall(errorLookupMock())
 }, common.mustNotCall());
 

--- a/test/parallel/test-net-connect-options-allowhalfopen.js
+++ b/test/parallel/test-net-connect-options-allowhalfopen.js
@@ -67,7 +67,7 @@ const net = require('net');
       client.resume();
       client.on('end', common.mustCall(function clientOnEnd() {
         setTimeout(function closeServer() {
-          // when allowHalfOpen is true, client must still be writable
+          // When allowHalfOpen is true, client must still be writable
           // after the server closes the connections, but not readable
           console.log(`client ${index} received FIN`);
           assert(!client.readable);

--- a/test/parallel/test-net-timeout-no-handle.js
+++ b/test/parallel/test-net-timeout-no-handle.js
@@ -13,5 +13,5 @@ socket.on('timeout', common.mustCall(() => {
 
 socket.on('connect', common.mustNotCall());
 
-// since the timeout is unrefed, the code will exit without this
+// Since the timeout is unrefed, the code will exit without this
 setTimeout(() => {}, common.platformTimeout(200));

--- a/test/parallel/test-next-tick-intentional-starvation.js
+++ b/test/parallel/test-next-tick-intentional-starvation.js
@@ -23,7 +23,7 @@
 require('../common');
 const assert = require('assert');
 
-// this is the inverse of test-next-tick-starvation. it verifies
+// This is the inverse of test-next-tick-starvation. it verifies
 // that process.nextTick will *always* come before other events
 
 let ran = false;

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -48,7 +48,7 @@ typeErrorTests.forEach((test) => {
     fail(namespace.basename, test);
     fail(namespace.extname, test);
 
-    // undefined is a valid value as the second argument to basename
+    // Undefined is a valid value as the second argument to basename
     if (test !== undefined) {
       fail(namespace.basename, 'foo', test);
     }

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -100,7 +100,7 @@ replProc.on('close', function(code) {
   assert.strictEqual(replStdout, output);
 });
 
-// test that preload placement at other points in the cmdline
+// Test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
 childProcess.exec(
   `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');" ${

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -38,7 +38,7 @@ class CustomWarning extends Error {
   [testMsg, { type: testType, code: testCode }],
   [testMsg, { type: testType, code: testCode, detail: testDetail }],
   [new CustomWarning()],
-  // detail will be ignored for the following. No errors thrown
+  // Detail will be ignored for the following. No errors thrown
   [testMsg, { type: testType, code: testCode, detail: true }],
   [testMsg, { type: testType, code: testCode, detail: [] }],
   [testMsg, { type: testType, code: testCode, detail: null }],

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -56,7 +56,7 @@ require('../common');
   });
 }
 
-// assert immutability of process.allowedNodeEnvironmentFlags
+// Assert immutability of process.allowedNodeEnvironmentFlags
 {
   assert.strictEqual(Object.isFrozen(process.allowedNodeEnvironmentFlags),
                      true);

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -24,7 +24,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-// changes in environment should be visible to child processes
+// Changes in environment should be visible to child processes
 if (process.argv[2] === 'you-are-the-child') {
   assert.strictEqual('NODE_PROCESS_ENV_DELETED' in process.env, false);
   assert.strictEqual(process.env.NODE_PROCESS_ENV, '42');

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -286,7 +286,7 @@ asyncTest('While inside setImmediate, catching a rejected promise derived ' +
   onUnhandledFail(done);
 
   setImmediate(function() {
-    // reproduces on first tick and inside of setImmediate
+    // Reproduces on first tick and inside of setImmediate
     Promise
       .resolve('resolve')
       .then(function() {

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -214,7 +214,7 @@ qsColonTestCases.forEach((testCase) => {
   check(qs.parse(testCase[0], ';', ':'), testCase[2], testCase[0]);
 });
 
-// test the weird objects, that they get parsed properly
+// Test the weird objects, that they get parsed properly
 qsWeirdObjects.forEach((testCase) => {
   check(qs.parse(testCase[1]), testCase[2], testCase[1]);
 });

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -154,7 +154,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // sending a single character with no newline and then a newline
+  // Sending a single character with no newline and then a newline
   {
     const fi = new FakeInput();
     const rli = new readline.Interface(
@@ -368,7 +368,7 @@ function isWarned(emitter) {
     });
   }
 
-  // constructor throws if historySize is not a positive number
+  // Constructor throws if historySize is not a positive number
   {
     const fi = new FakeInput();
     common.expectsError(function() {
@@ -472,7 +472,7 @@ function isWarned(emitter) {
     rli.close();
   }
 
-  // sending a multi-byte utf8 char over multiple writes
+  // Sending a multi-byte utf8 char over multiple writes
   {
     const buf = Buffer.from('☮', 'utf8');
     const fi = new FakeInput();

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -160,7 +160,7 @@ testMe.complete('inner.o', common.mustCall(function(error, data) {
 
 putIn.run(['.clear']);
 
-// currently does not work, but should not break, not the {
+// Currently does not work, but should not break, not the {
 putIn.run([
   'var top = function() {',
   'r = function test ()',
@@ -213,7 +213,7 @@ testMe.complete('toSt', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['toString'], 'toSt']);
 }));
 
-// own properties should shadow properties on the prototype
+// Own properties should shadow properties on the prototype
 putIn.run(['.clear']);
 putIn.run([
   'var x = Object.create(null);',

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -149,7 +149,7 @@ function testResetContextGlobal() {
     '10',
   ]);
 
-  // delete globals leaked by REPL when `useGlobal` is `true`
+  // Delete globals leaked by REPL when `useGlobal` is `true`
   delete global.module;
   delete global.require;
 }

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -50,7 +50,7 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
   let str = '';
   output.on('data', (data) => (str += data));
 
-  // if useGlobal is false, then `let process` should work
+  // If useGlobal is false, then `let process` should work
   repl.write('let process;\n');
   repl.write('21 * 2;\n');
   repl.close();

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -53,7 +53,7 @@ async function runReplTests(socket, prompt, tests) {
     socket.write(`${send}\n`);
 
     for (let expectedLine of expectedLines) {
-      // special value: kSource refers to last sent source text
+      // Special value: kSource refers to last sent source text
       if (expectedLine === kSource)
         expectedLine = send;
 
@@ -233,7 +233,7 @@ const errorTests = [
     send: 'new RegExp("foo", "wrong modifier");',
     expect: [/^SyntaxError: /, '']
   },
-  // strict mode syntax errors should be caught (GH-5178)
+  // Strict mode syntax errors should be caught (GH-5178)
   {
     send: '(function() { "use strict"; return 0755; })()',
     expect: [
@@ -403,7 +403,7 @@ const errorTests = [
       ''
     ]
   },
-  // do not fail when a String is created with line continuation
+  // Do not fail when a String is created with line continuation
   {
     send: '\'the\\\nfourth\\\neye\'',
     expect: ['... ... \'thefourtheye\'']
@@ -416,7 +416,7 @@ const errorTests = [
     send: '  \t    .break  \t  ',
     expect: ''
   },
-  // multiline strings preserve whitespace characters in them
+  // Multiline strings preserve whitespace characters in them
   {
     send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
     expect: '... ... \'the    fourth\\t\\t  eye  \''

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -35,7 +35,7 @@ exec(cmd, common.mustCall((error, stdout, stderr) => {
   assert.ifError(error);
   assert.strictEqual(stderr, '');
 
-  // freebsd always add ' (procname)' to the process title
+  // Freebsd always add ' (procname)' to the process title
   if (common.isFreeBSD || common.isOpenBSD)
     title += ` (${path.basename(process.execPath)})`;
 

--- a/test/parallel/test-stdio-pipe-stderr.js
+++ b/test/parallel/test-stdio-pipe-stderr.js
@@ -13,10 +13,10 @@ const spawn = require('child_process').spawnSync;
 tmpdir.refresh();
 const fakeModulePath = join(tmpdir.path, 'batman.js');
 const stderrOutputPath = join(tmpdir.path, 'stderr-output.txt');
-// we need to redirect stderr to a file to produce #11257
+// We need to redirect stderr to a file to produce #11257
 const stream = fs.createWriteStream(stderrOutputPath);
 
-// the error described in #11257 only happens when we require a
+// The error described in #11257 only happens when we require a
 // non-built-in module.
 fs.writeFileSync(fakeModulePath, '', 'utf8');
 

--- a/test/parallel/test-stream-big-push.js
+++ b/test/parallel/test-stream-big-push.js
@@ -62,7 +62,7 @@ chunk = r.read();
 assert.strictEqual(chunk, null);
 
 r.once('readable', () => {
-  // this time, we'll get *all* the remaining data, because
+  // This time, we'll get *all* the remaining data, because
   // it's been added synchronously, as the read WOULD take
   // us below the hwm, and so it triggered a _read() again,
   // which synchronously added more, which we then return.

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -177,7 +177,7 @@ const { inherits } = require('util');
   duplex.destroyed = true;
   assert.strictEqual(duplex.destroyed, true);
 
-  // the internal destroy() mechanism should not be triggered
+  // The internal destroy() mechanism should not be triggered
   duplex.on('finish', common.mustNotCall());
   duplex.on('end', common.mustNotCall());
   duplex.destroy();

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -51,10 +51,10 @@ class TestWritable extends Writable {
   }
 }
 
-// this one should not emit 'end' until we read() from it later.
+// This one should not emit 'end' until we read() from it later.
 const ender = new TestReadable();
 
-// what happens when you pipe() a Readable that's already ended?
+// What happens when you pipe() a Readable that's already ended?
 const piper = new TestReadable();
 // pushes EOF null, and length=0, so this will trigger 'end'
 piper.read();

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -460,5 +460,5 @@ async function tests() {
   }
 }
 
-// to avoid missing some tests if a promise does not resolve
+// To avoid missing some tests if a promise does not resolve
 tests().then(common.mustCall());

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -148,7 +148,7 @@ const { inherits } = require('util');
   read.destroyed = true;
   assert.strictEqual(read.destroyed, true);
 
-  // the internal destroy() mechanism should not be triggered
+  // The internal destroy() mechanism should not be triggered
   read.on('end', common.mustNotCall());
   read.destroy();
 }

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -45,7 +45,7 @@ const Readable = require('stream').Readable;
 }
 
 {
-  // second test, make sure that readable is re-emitted if there's
+  // Second test, make sure that readable is re-emitted if there's
   // already a length, while it IS reading.
 
   const r = new Readable({

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -23,7 +23,7 @@
 require('../common');
 const assert = require('assert');
 
-// this test verifies that passing a huge number to read(size)
+// This test verifies that passing a huge number to read(size)
 // will push up the highWaterMark, and cause the stream to read
 // more data continuously, but without triggering a nextTick
 // warning or RangeError.
@@ -69,7 +69,7 @@ process.on('exit', function(code) {
   assert.strictEqual(reads, 2);
   // we pushed up the high water mark
   assert.strictEqual(stream.readableHighWaterMark, 8192);
-  // length is 0 right now, because we pulled it all out.
+  // Length is 0 right now, because we pulled it all out.
   assert.strictEqual(stream.readableLength, 0);
   assert(!code);
   assert.strictEqual(depth, 0);

--- a/test/parallel/test-stream-readable-hwm-0.js
+++ b/test/parallel/test-stream-readable-hwm-0.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const { Readable } = require('stream');
 
 const r = new Readable({
-  // must be called only once upon setting 'readable' listener
+  // Must be called only once upon setting 'readable' listener
   read: common.mustCall(),
   highWaterMark: 0,
 });

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -15,7 +15,7 @@ const Readable = require('stream').Readable;
   assert.strictEqual(state.readingMore, false);
 
   readable.on('data', common.mustCall((data) => {
-    // while in a flowing state with a 'readable' listener
+    // While in a flowing state with a 'readable' listener
     // we should not be reading more
     if (readable.readableFlowing)
       assert.strictEqual(state.readingMore, true);
@@ -33,7 +33,7 @@ const Readable = require('stream').Readable;
 
   const expectedReadingMore = [true, false];
   readable.on('readable', common.mustCall(() => {
-    // there is only one readingMore scheduled from on('data'),
+    // There is only one readingMore scheduled from on('data'),
     // after which everything is governed by the .read() call
     assert.strictEqual(state.readingMore, expectedReadingMore.shift());
 
@@ -73,7 +73,7 @@ const Readable = require('stream').Readable;
   assert.strictEqual(state.readingMore, false);
 
   readable.on('data', common.mustCall((data) => {
-    // while in a flowing state without a 'readable' listener
+    // While in a flowing state without a 'readable' listener
     // we should be reading more
     if (readable.readableFlowing)
       assert.strictEqual(state.readingMore, true);
@@ -146,7 +146,7 @@ const Readable = require('stream').Readable;
   // We are still not flowing, we will be resuming in the next tick
   assert.strictEqual(state.flowing, false);
 
-  // wait for nextTick, so the readableListener flag resets
+  // Wait for nextTick, so the readableListener flag resets
   process.nextTick(function() {
     readable.resume();
 

--- a/test/parallel/test-stream-readable-resumeScheduled.js
+++ b/test/parallel/test-stream-readable-resumeScheduled.js
@@ -14,7 +14,7 @@ const { Readable, Writable } = require('stream');
   // resumeScheduled should start = `false`.
   assert.strictEqual(r._readableState.resumeScheduled, false);
 
-  // calling pipe() should change the state value = true.
+  // Calling pipe() should change the state value = true.
   r.pipe(w);
   assert.strictEqual(r._readableState.resumeScheduled, true);
 
@@ -32,7 +32,7 @@ const { Readable, Writable } = require('stream');
 
   r.push(Buffer.from([1, 2, 3]));
 
-  // adding 'data' listener should change the state value
+  // Adding 'data' listener should change the state value
   r.on('data', common.mustCall(() => {
     assert.strictEqual(r._readableState.resumeScheduled, false);
   }));

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -43,7 +43,7 @@ r.on('readable', () => {
   let chunk;
   while (chunk = r.read()) {
     seen.push(chunk.toString());
-    // simulate only reading a certain amount of the data,
+    // Simulate only reading a certain amount of the data,
     // and then putting the rest of the chunk back into the
     // stream, like a parser might do.  We just fill it with
     // 'y' so that it's easy to see which bits were touched,

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -161,7 +161,7 @@ const { inherits } = require('util');
   write.destroyed = true;
   assert.strictEqual(write.destroyed, true);
 
-  // the internal destroy() mechanism should not be triggered
+  // The internal destroy() mechanism should not be triggered
   write.on('close', common.mustNotCall());
   write.destroy();
 }

--- a/test/parallel/test-stream-writable-write-writev-finish.js
+++ b/test/parallel/test-stream-writable-write-writev-finish.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const stream = require('stream');
 
-// ensure consistency between the finish event when using cork()
+// Ensure consistency between the finish event when using cork()
 // and writev and when not using them
 
 {

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -151,7 +151,7 @@ class TestWriter extends EE {
   // Verify unpipe
   const r = new TestReader(5);
 
-  // unpipe after 3 writes, then write to another stream instead.
+  // Unpipe after 3 writes, then write to another stream instead.
   let expect = [ 'xxxxx',
                  'xxxxx',
                  'xxxxx',
@@ -227,7 +227,7 @@ class TestWriter extends EE {
   // Verify multi-unpipe
   const r = new TestReader(5);
 
-  // unpipe after 3 writes, then write to another stream instead.
+  // Unpipe after 3 writes, then write to another stream instead.
   let expect = [ 'xxxxx',
                  'xxxxx',
                  'xxxxx',

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -210,7 +210,7 @@ const Transform = require('_stream_transform');
   // Verify asymmetric transform (compress)
   const pt = new Transform();
 
-  // each output is the first char of 3 consecutive chunks,
+  // Each output is the first char of 3 consecutive chunks,
   // or whatever's left.
   pt.state = '';
 
@@ -259,7 +259,7 @@ const Transform = require('_stream_transform');
   }));
 }
 
-// this tests for a stall when data is written to a full stream
+// This tests for a stall when data is written to a full stream
 // that has empty transforms.
 {
   // Verify complex transform behavior

--- a/test/parallel/test-stream3-cork-end.js
+++ b/test/parallel/test-stream3-cork-end.js
@@ -19,7 +19,7 @@ let seenEnd = false;
 const w = new Writable();
 // lets arrange to store the chunks
 w._write = function(chunk, encoding, cb) {
-  // stream end event is not seen before the last write
+  // Stream end event is not seen before the last write
   assert.ok(!seenEnd);
   // default encoding given none was specified
   assert.strictEqual(encoding, 'buffer');

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -137,7 +137,7 @@ function read1234() {
 
 function resumePause() {
   console.error('resumePause');
-  // don't read anything, just resume and re-pause a whole bunch
+  // Don't read anything, just resume and re-pause a whole bunch
   r.resume();
   r.pause();
   r.resume();

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -22,10 +22,10 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-// minimum string size to overflow into external string space
+// Minimum string size to overflow into external string space
 const EXTERN_APEX = 0xFBEE9;
 
-// manually controlled string for checking binary output
+// Manually controlled string for checking binary output
 let ucs2_control = 'a\u0000';
 let write_str = 'a';
 
@@ -56,7 +56,7 @@ for (let i = 0; i < b.length; i += 2) {
   assert.strictEqual(b[i + 1], 0);
 }
 
-// create another string to create an external string
+// Create another string to create an external string
 const b_ucs = b.toString('ucs2');
 
 // check control against external binary string

--- a/test/parallel/test-timers-immediate-unref.js
+++ b/test/parallel/test-timers-immediate-unref.js
@@ -29,7 +29,7 @@ function secondStep() {
   const immA = setImmediate(() => {
     clearImmediate(immA);
     clearImmediate(immB);
-    // this should not keep the event loop open indefinitely
+    // This should not keep the event loop open indefinitely
     // or do anything else weird
     immA.ref();
     immB.ref();

--- a/test/parallel/test-timers-reset-process-domain-on-throw.js
+++ b/test/parallel/test-timers-reset-process-domain-on-throw.js
@@ -21,7 +21,7 @@ function err() {
   d.run(err2);
 
   function err2() {
-    // this function doesn't exist, and throws an error as a result.
+    // This function doesn't exist, and throws an error as a result.
     err3(); // eslint-disable-line no-undef
   }
 

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -47,7 +47,7 @@ const inputs = [
   0.5,
   1,
   1.0,
-  2147483648,     // browser behavior: timeouts > 2^31-1 run on next tick
+  2147483648,     // Browser behavior: timeouts > 2^31-1 run on next tick
   12345678901234  // ditto
 ];
 

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -35,7 +35,7 @@ function test(size, err, next) {
   });
 
   server.listen(0, '127.0.0.1', function() {
-    // client set minimum DH parameter size to 2048 bits so that
+    // Client set minimum DH parameter size to 2048 bits so that
     // it fails when it make a connection to the tls server where
     // dhparams is 1024 bits
     const client = tls.connect({

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -44,7 +44,7 @@ function connectClient(server) {
     assert(netSocket);
     netSocket.setTimeout(1, common.mustCall(() => {
       assert(tlsSocket);
-      // this breaks if TLSSocket is already managing the socket:
+      // This breaks if TLSSocket is already managing the socket:
       netSocket.destroy();
       const interval = setInterval(() => {
         // Checking this way allows us to do the write at a time that causes a

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -216,7 +216,7 @@ const formatTests = {
     pathname: '/'
   },
 
-  // more than 255 characters in hostname which exceeds the limit
+  // More than 255 characters in hostname which exceeds the limit
   [`http://${'a'.repeat(255)}.com/node`]: {
     href: 'http:///node',
     protocol: 'http:',
@@ -227,7 +227,7 @@ const formatTests = {
     path: '/node'
   },
 
-  // greater than or equal to 63 characters after `.` in hostname
+  // Greater than or equal to 63 characters after `.` in hostname
   [`http://www.${'z'.repeat(63)}example.com/node`]: {
     href: `http://www.${'z'.repeat(63)}example.com/node`,
     protocol: 'http:',

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -194,7 +194,7 @@ const parseTests = {
     path: ';a/b/c?d=e'
   },
 
-  // make sure that we don't accidentally lcast the path parts.
+  // Make sure that we don't accidentally lcast the path parts.
   'HtTp://x.y.cOm;A/b/c?d=e#f g<h>i': {
     href: 'http://x.y.com/;A/b/c?d=e#f%20g%3Ch%3Ei',
     protocol: 'http:',

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -31,7 +31,7 @@ function nextdir() {
   assert.strictEqual(fixtureCoverage.functions[1].ranges[1].count, 0);
 }
 
-// outputs coverage when process.exit(1) exits process.
+// Outputs coverage when process.exit(1) exits process.
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [
@@ -96,7 +96,7 @@ function nextdir() {
   assert.strictEqual(fixtureCoverage.functions[2].ranges[1].count, 0);
 }
 
-// does not output coverage if NODE_V8_COVERAGE is empty.
+// Does not output coverage if NODE_V8_COVERAGE is empty.
 {
   const coverageDirectory = path.join(tmpdir.path, nextdir());
   const output = spawnSync(process.execPath, [
@@ -122,7 +122,7 @@ function nextdir() {
   assert.strictEqual(fixtureCoverage.functions[1].ranges[0].count, 1);
 }
 
-// extracts the coverage object for a given fixture name.
+// Extracts the coverage object for a given fixture name.
 function getFixtureCoverage(fixtureFile, coverageDirectory) {
   const coverageFiles = fs.readdirSync(coverageDirectory);
   for (const coverageFile of coverageFiles) {

--- a/test/parallel/test-whatwg-url-custom-properties.js
+++ b/test/parallel/test-whatwg-url-custom-properties.js
@@ -28,7 +28,7 @@ const expected = ['toString',
 
 assert.deepStrictEqual(props, expected);
 
-// href is writable (not readonly) and is stringifier
+// `href` is writable (not readonly) and is stringifier
 assert.strictEqual(url.toString(), url.href);
 url.href = 'http://user:pass@foo.bar.com:21/aaa/zzz?l=25#test';
 assert.strictEqual(url.href,

--- a/test/parallel/test-worker-uncaught-exception-async.js
+++ b/test/parallel/test-worker-uncaught-exception-async.js
@@ -18,7 +18,7 @@ if (!process.env.HAS_STARTED_WORKER) {
     assert.strictEqual(code, 1);
   }));
 } else {
-  // cannot use common.mustCall as it cannot catch this
+  // Cannot use common.mustCall as it cannot catch this
   let called = false;
   process.on('exit', (code) => {
     if (!called) {

--- a/test/parallel/test-worker-uncaught-exception.js
+++ b/test/parallel/test-worker-uncaught-exception.js
@@ -18,7 +18,7 @@ if (!process.env.HAS_STARTED_WORKER) {
     assert.strictEqual(code, 1);
   }));
 } else {
-  // cannot use common.mustCall as it cannot catch this
+  // Cannot use common.mustCall as it cannot catch this
   let called = false;
   process.on('exit', (code) => {
     if (!called) {

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// test convenience methods with and without options supplied
+// Test convenience methods with and without options supplied
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-zlib-destroy-pipe.js
+++ b/test/parallel/test-zlib-destroy-pipe.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const zlib = require('zlib');
 const { Writable } = require('stream');
 
-// verify that the zlib transform does not error in case
+// Verify that the zlib transform does not error in case
 // it is destroyed with data still in flight
 
 const ts = zlib.createGzip();

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -12,7 +12,7 @@ const opts = {
 
 const deflater = zlib.createDeflate(opts);
 
-// shim deflater.flush so we can count times executed
+// Shim deflater.flush so we can count times executed
 let flushCount = 0;
 let drainCount = 0;
 

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -76,7 +76,7 @@ fs.createReadStream(pmmFileGz)
       );
     }));
 
-  // first write: write "abc" + the first bytes of "def"
+  // First write: write "abc" + the first bytes of "def"
   unzip.write(Buffer.concat([
     abcEncoded, defEncoded.slice(0, offset)
   ]));

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -1,5 +1,5 @@
 'use strict';
-// test unzipping a gzip file that has trailing garbage
+// Test unzipping a gzip file that has trailing garbage
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// test compressing and uncompressing a string with zlib
+// Test compressing and uncompressing a string with zlib
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -1,5 +1,5 @@
 'use strict';
-// tests zlib streams with truncated compressed input
+// Tests zlib streams with truncated compressed input
 
 require('../common');
 const assert = require('assert');
@@ -50,11 +50,11 @@ const errMessage = /unexpected end of file/;
 
     const syncFlushOpt = { finishFlush: zlib.constants.Z_SYNC_FLUSH };
 
-    // sync truncated input test, finishFlush = Z_SYNC_FLUSH
+    // Sync truncated input test, finishFlush = Z_SYNC_FLUSH
     const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
     assert.strictEqual(result, inputString.substr(0, result.length));
 
-    // async truncated input test, finishFlush = Z_SYNC_FLUSH
+    // Async truncated input test, finishFlush = Z_SYNC_FLUSH
     zlib[methods.decomp](truncated, syncFlushOpt, function(err, decompressed) {
       assert.ifError(err);
       const result = toUTF8(decompressed);

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -38,7 +38,7 @@ gunz.on('end', common.mustCall(() => {
   assert.strictEqual(gzip._nextFlush, -1);
 }));
 
-// make sure that flush/write doesn't trigger an assert failure
+// Make sure that flush/write doesn't trigger an assert failure
 gzip.flush();
 gzip.write(input);
 gzip.end();

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -49,7 +49,7 @@ let windowBits = [8, 9, 10, 11, 12, 13, 14, 15];
 let memLevel = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 let strategy = [0, 1, 2, 3, 4];
 
-// it's nice in theory to test every combination, but it
+// It's nice in theory to test every combination, but it
 // takes WAY too long.  Maybe a pummel test could do this?
 if (!process.env.PUMMEL) {
   trickle = [1024];
@@ -173,7 +173,7 @@ zlib.createDeflateRaw({ windowBits: 8 });
         () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))));
 }
 
-// for each of the files, make sure that compressing and
+// For each of the files, make sure that compressing and
 // decompressing results in the same data, for every combination
 // of the options set above.
 
@@ -196,7 +196,7 @@ testKeys.forEach(common.mustCall((file) => {
                 const ss = new SlowStream(trickle);
                 const buf = new BufferStream();
 
-                // verify that the same exact buffer comes out the other end.
+                // Verify that the same exact buffer comes out the other end.
                 buf.on('data', common.mustCall((c) => {
                   const msg = `${file} ${chunkSize} ${
                     JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;

--- a/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
+++ b/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals --no-warnings
 'use strict';
 
-// see also test/sequential/test-async-wrap-getasyncid.js
+// See also test/sequential/test-async-wrap-getasyncid.js
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+++ b/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals --no-warnings
 'use strict';
 
-// see also test/parallel/test-handle-wrap-isrefed.js
+// See also test/parallel/test-handle-wrap-isrefed.js
 
 const common = require('../common');
 const strictEqual = require('assert').strictEqual;

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -95,7 +95,7 @@ const killMeTwice = exec(SLEEP3_COMMAND, { timeout: 1000 },
 
 process.nextTick(function() {
   console.log(`kill pid ${killMeTwice.pid}`);
-  // make sure there is no race condition in starting the process
+  // Make sure there is no race condition in starting the process
   // the PID SHOULD exist directly following the exec() call.
   assert.strictEqual(typeof killMeTwice._handle.pid, 'number');
   // Kill the process

--- a/test/pummel/test-process-hrtime.js
+++ b/test/pummel/test-process-hrtime.js
@@ -35,7 +35,7 @@ while (Date.now() - now < 2000);
 // get a diff reading
 const diff = process.hrtime(start);
 
-// should be at least 1 second, at most 2 seconds later
+// Should be at least 1 second, at most 2 seconds later
 // (the while loop will usually exit a few nanoseconds before 2)
 assert(diff[0] >= 1);
 assert(diff[0] <= 2);

--- a/test/sequential/test-cli-syntax-file-not-found.js
+++ b/test/sequential/test-cli-syntax-file-not-found.js
@@ -30,7 +30,7 @@ const notFoundRE = /^Error: Cannot find module/m;
       // no stdout should be produced
       assert.strictEqual(stdout, '');
 
-      // stderr should have a module not found error message
+      // `stderr` should have a module not found error message.
       assert(notFoundRE.test(stderr), `${notFoundRE} === ${stderr}`);
 
       assert.strictEqual(err.code, 1,

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -111,7 +111,7 @@ tmpdir.refresh();
   fs.watch(__filename, { persistent: false }, common.mustNotCall());
 }
 
-// whitebox test to ensure that wrapped FSEvent is safe
+// Whitebox test to ensure that wrapped FSEvent is safe
 // https://github.com/joyent/node/issues/6690
 {
   let oldhandle;

--- a/test/sequential/test-http-max-http-headers.js
+++ b/test/sequential/test-http-max-http-headers.js
@@ -49,7 +49,7 @@ const timeout = common.platformTimeout(10);
 function writeHeaders(socket, headers) {
   const array = [];
 
-  // this is off from 1024 so that \r\n does not get split
+  // This is off from 1024 so that \r\n does not get split
   const chunkSize = 1000;
   let last = 0;
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -35,11 +35,11 @@ assert.strictEqual(require.main.id, '.');
 assert.strictEqual(require.main, module);
 assert.strictEqual(process.mainModule, module);
 
-// assert that it's *not* the main module in the required module.
+// Assert that it's *not* the main module in the required module.
 require('../fixtures/not-main-module.js');
 
 {
-  // require a file with a request that includes the extension
+  // Require a file with a request that includes the extension
   const a_js = require('../fixtures/a.js');
   assert.strictEqual(a_js.number, 42);
 }
@@ -126,7 +126,7 @@ require('../fixtures/node_modules/foo');
 
 {
   console.error('test name clashes');
-  // this one exists and should import the local module
+  // This one exists and should import the local module
   const my_path = require('../fixtures/path');
   assert.ok(my_path.path_func instanceof Function);
   // this one does not exist and should throw
@@ -235,7 +235,7 @@ try {
 
 
 {
-  // now verify that module.children contains all the different
+  // Now verify that module.children contains all the different
   // modules that we've required, and that all of them contain
   // the appropriate children, and so on.
 

--- a/test/sequential/test-next-tick-error-spin.js
+++ b/test/sequential/test-next-tick-error-spin.js
@@ -40,7 +40,7 @@ if (process.argv[2] !== 'child') {
   const domain = require('domain');
   const d = domain.create();
 
-  // in the error handler, we trigger several MakeCallback events
+  // In the error handler, we trigger several MakeCallback events
   d.on('error', function() {
     console.log('a');
     console.log('b');

--- a/test/sequential/test-timers-set-interval-excludes-callback-duration.js
+++ b/test/sequential/test-timers-set-interval-excludes-callback-duration.js
@@ -8,7 +8,7 @@ const t = setInterval(() => {
   cntr++;
   if (cntr === 1) {
     common.busyLoop(100);
-    // ensure that the event loop passes before the second interval
+    // Ensure that the event loop passes before the second interval
     setImmediate(() => assert.strictEqual(cntr, 1));
     first = Date.now();
   } else if (cntr === 2) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -216,7 +216,7 @@ function preprocessElements({ filename }) {
           const noLinking = filename.includes('documentation') &&
             heading !== null && heading.children[0].value === 'Stability Index';
 
-          // collapse blockquote and paragraph into a single node
+          // Collapse blockquote and paragraph into a single node
           node.type = 'paragraph';
           node.children.shift();
           node.children.unshift(...paragraph.children);


### PR DESCRIPTION
This expands the eslint capitalize comment rule to be active for comments
above 50 characters (instead of 62) and ignores starting words which contain `#` or `[`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
