### PR TITLE
test: added test for lib/internal/util/inspector.js

### DIFF
--- a/test/sequential/test-inspector-send-inspector-command-exception.js
+++ b/test/sequential/test-inspector-send-inspector-command-exception.js
@@ -8,9 +8,9 @@ const common = require('../common');
 process.config.variables.v8_enable_inspector = 1;
 const inspector = require('internal/util/inspector');
 
-// Pass first argument as a String instead of cb() function to trigger
-// a TypeError that will be caught and onError() will be called 1 time
+// Pass first argument as a function that throws an error that will be caught
+// and onError() will be called
 inspector.sendInspectorCommand(
-  common.mustCall('String to trigger a TypeError'),
-  common.mustCall(1)
+  common.mustCall(() => { throw new Error('foo'); }),
+  common.mustCall()
 );

--- a/test/sequential/test-inspector-send-inspector-command-exception.js
+++ b/test/sequential/test-inspector-send-inspector-command-exception.js
@@ -1,0 +1,16 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+// This is to ensure that the sendInspectorCommand function calls the cb
+// function if v8_enable_inspector is enabled
+process.config.variables.v8_enable_inspector = 1;
+const inspector = require('internal/util/inspector');
+
+// Pass first argument as a String instead of cb() function to trigger
+// a TypeError that will be caught and onError() will be called 1 time
+inspector.sendInspectorCommand(
+  common.mustCall('String to trigger a TypeError'),
+  common.mustCall(1)
+);


### PR DESCRIPTION
Test for lib/internal/util/inspector.js to make 100% test coverage.
Test checks that onError on line 19 is executed when exception is thrown

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
