### PR TITLE
tls: expose openssl library version

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2071,6 +2071,7 @@ Will generate an object similar to:
   nghttp2: '1.29.0',
   napi: '2',
   openssl: '1.0.2n',
+  openssl_linked: '1.0.2n',
   icu: '60.1',
   unicode: '10.0',
   cldr: '32.0',

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5840,15 +5840,23 @@ constexpr int search(const char* s, int n, int c) {
   return *s == c ? n : search(s + 1, n + 1, c);
 }
 
-std::string GetOpenSSLVersion() {
+static const std::string GetOpenSSLVersionParsed(const char* version) {
   // sample openssl version string format
   // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
   char buf[128];
-  const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
-  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ');
+  const int start = search(version, 0, ' ') + 1;
+  const int end = search(version + start, start, ' ');
   const int len = end - start;
-  snprintf(buf, sizeof(buf), "%.*s", len, &OPENSSL_VERSION_TEXT[start]);
+  snprintf(buf, sizeof(buf), "%.*s", len, &version[start]);
   return std::string(buf);
+}
+
+const std::string GetOpenSSLVersionCompiled() {
+  return GetOpenSSLVersionParsed(OPENSSL_VERSION_TEXT);
+}
+
+const std::string GetOpenSSLVersionLinked() {
+  return GetOpenSSLVersionParsed(OpenSSL_version(OPENSSL_VERSION));
 }
 
 }  // namespace crypto

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -94,7 +94,8 @@ extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 extern void UseExtraCaCerts(const std::string& file);
 
 void InitCryptoOnce();
-std::string GetOpenSSLVersion();
+const std::string GetOpenSSLVersionCompiled();
+const std::string GetOpenSSLVersionLinked();
 
 class SecureContext : public BaseObject {
  public:

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -30,7 +30,8 @@ Metadata::Versions::Versions() {
   http_parser = http_parser_version;
 
 #if HAVE_OPENSSL
-  openssl = crypto::GetOpenSSLVersion();
+  openssl = crypto::GetOpenSSLVersionCompiled();
+  openssl_linked = crypto::GetOpenSSLVersionLinked();
 #endif
 }
 

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -20,7 +20,7 @@ namespace node {
   V(http_parser)                                                               \
 
 #if HAVE_OPENSSL
-#define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl)
+#define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl) V(openssl_linked)
 #else
 #define NODE_VERSIONS_KEY_CRYPTO(V)
 #endif

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -8,6 +8,7 @@ const expected_keys = ['ares', 'modules', 'node',
 
 if (common.hasCrypto) {
   expected_keys.push('openssl');
+  expected_keys.push('openssl_linked');
 }
 
 if (common.hasIntl) {
@@ -37,6 +38,7 @@ assert(/^\d+$/.test(process.versions.modules));
 
 if (common.hasCrypto) {
   assert(/^\d+\.\d+\.\d+[a-z]?(-fips)?$/.test(process.versions.openssl));
+  assert(/^\d+\.\d+\.\d+[a-z]?(-fips)?$/.test(process.versions.openssl_linked));
 }
 
 for (let i = 0; i < expected_keys.length; i++) {


### PR DESCRIPTION
Node can be dynamically linked against a different version of OpenSSL
than it was compiled against, so expose the actual library version.


cf. https://github.com/nodejs/node/issues/24658#issuecomment-446596338

@bnoordhuis @rvagg @nodejs/crypto I'm not sure if this is a good idea, perhaps its overkill for an exceedingly rare occurence. Has this been discussed or considered before?

Still waiting on #24658 to see if they are built against a different version of ossl than they are linked against.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
