### PR TITLE
doc: corrected version http.createServer options addition

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1814,7 +1814,7 @@ Found'`.
 <!-- YAML
 added: v0.1.13
 changes:
-  - version: v9.6.0
+  - version: v9.6.0, v8.12.0
     pr-url: https://github.com/nodejs/node/pull/15752
     description: The `options` argument is supported now.
 -->


### PR DESCRIPTION
8.12 Changelog
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.12.0

Specifically
[01dc646382] - (SEMVER-MINOR) http: add options to http.createServer() (Peter Marton) #15752

Pull
https://github.com/nodejs/node/pull/15752

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
