### PR TITLE
assert: inspect getters

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -56,7 +56,9 @@ function inspectValue(val) {
       breakLength: Infinity,
       // Assert does not detect proxies currently.
       showProxy: false,
-      sorted: true
+      sorted: true,
+      // Inspect getters as we also check them when comparing entries.
+      getters: true
     }
   );
 }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -24,7 +24,8 @@ function re(literals, ...values) {
       customInspect: false,
       maxArrayLength: Infinity,
       breakLength: Infinity,
-      sorted: true
+      sorted: true,
+      getters: true
     });
     // Need to escape special characters.
     result += str;
@@ -1048,4 +1049,25 @@ assert.throws(
     value: () => { throw new Error('failed'); }
   });
   assertDeepAndStrictEqual(a, b);
+}
+
+// Check getters.
+{
+  const a = {
+    get a() { return 5; }
+  };
+  const b = {
+    get a() { return 6; }
+  };
+  assert.throws(
+    () => assert.deepStrictEqual(a, b),
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError [ERR_ASSERTION]',
+      message: /a: \[Getter: 5]\n-   a: \[Getter: 6]\n  /
+    }
+  );
+
+  // The descriptor is not compared.
+  assertDeepAndStrictEqual(a, { a: 5 });
 }


### PR DESCRIPTION
While asserting two objects the descriptor is not taken into account.
Therefore getters will be triggered as such. This makes sure they
are also highlighted in the error message instead of potentially
looking identical while the return value of the getter is actually
different.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)