### PR TITLE
test: use global.gc() instead of gc()

### DIFF
--- a/test/parallel/test-fs-filehandle.js
+++ b/test/parallel/test-fs-filehandle.js
@@ -31,6 +31,6 @@ common.expectWarning({
   ]
 });
 
-gc();  // eslint-disable-line no-undef
+global.gc();
 
 setTimeout(() => {}, 10);


### PR DESCRIPTION
This change is made for consistency, and to remove an eslint-disable comment.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
