### PR TITLE
test: remove unnecessary linter comment

### DIFF
--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -188,9 +188,7 @@ fs.writeFileSync(path, '');
 
 // Test Y2K38 for all platforms [except 'arm', 'OpenBSD' and 'SunOS']
 if (!process.arch.includes('arm') && !common.isOpenBSD && !common.isSunOS) {
-  // because 2 ** 31 doesn't look right
-  // eslint-disable-next-line space-infix-ops
-  const Y2K38_mtime = 2**31;
+  const Y2K38_mtime = 2 ** 31;
   fs.utimesSync(path, Y2K38_mtime, Y2K38_mtime);
   const Y2K38_stats = fs.statSync(path);
   assert.strictEqual(Y2K38_mtime, Y2K38_stats.mtime.getTime() / 1000);


### PR DESCRIPTION
Some would say it's the linter's job to determine what looks right.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
