### PR TITLE
net: use strict comparisons for fd

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -281,11 +281,8 @@ function Socket(options) {
       throw errnoException(err, 'open');
 
     this[async_id_symbol] = this._handle.getAsyncId();
-    // options.fd can be string (since it is user-defined),
-    // so changing this to === would be semver-major
-    // See: https://github.com/nodejs/node/pull/11513
-    // eslint-disable-next-line eqeqeq
-    if ((fd == 1 || fd == 2) &&
+
+    if ((fd === 1 || fd === 2) &&
         (this._handle instanceof Pipe) &&
         process.platform === 'win32') {
       // Make stdout and stderr blocking on Windows


### PR DESCRIPTION
This commit removes an eslint-disable comment, and moves file descriptor checks to use strict equality. These checks were using loose equality to support numeric and string file descriptors. However, d9e95d8982ee5b409b36f09c77feccbb1040095c introduced strict validation, making the loose equality checks redundant.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
