### PR TITLE
src: pass isMainThread into bootstrap/node.js directly

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -15,6 +15,8 @@
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::LoadEnvironment()
 /* global process, bootstrappers, loaderExports, triggerFatalException */
+/* global isMainThread */
+
 const {
   _setupTraceCategoryState,
   _setupNextTick,
@@ -28,7 +30,6 @@ const {
 const { internalBinding, NativeModule } = loaderExports;
 
 const exceptionHandlerState = { captureFn: null };
-const isMainThread = internalBinding('worker').threadId === 0;
 
 function startup() {
   setupTraceCategoryState();

--- a/src/node.cc
+++ b/src/node.cc
@@ -1276,14 +1276,16 @@ void LoadEnvironment(Environment* env) {
       env->process_string(),
       FIXED_ONE_BYTE_STRING(isolate, "bootstrappers"),
       FIXED_ONE_BYTE_STRING(isolate, "loaderExports"),
-      FIXED_ONE_BYTE_STRING(isolate, "triggerFatalException")};
+      FIXED_ONE_BYTE_STRING(isolate, "triggerFatalException"),
+      FIXED_ONE_BYTE_STRING(isolate, "isMainThread")};
   std::vector<Local<Value>> node_args = {
       process,
       bootstrapper,
       loader_exports.ToLocalChecked(),
       env->NewFunctionTemplate(FatalException)
           ->GetFunction(context)
-          .ToLocalChecked()};
+          .ToLocalChecked(),
+      Boolean::New(isolate, env->is_main_thread())};
 
   if (ExecuteBootstrapper(
           env, "internal/bootstrap/node", &node_params, &node_args)

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const isMainThread = common.isMainThread;
-const kMaxModuleCount = isMainThread ? 60 : 82;
+const kMaxModuleCount = isMainThread ? 59 : 82;
 
 assert(list.length <= kMaxModuleCount,
        `Total length: ${list.length}\n` + list.join('\n')


### PR DESCRIPTION
Instead of loading the working binding for the sole purpose of
detecting whether we are inside the main thread unconditionally.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
