### PR TITLE
doc: fix typo in http 'connect' event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -331,7 +331,7 @@ emitted on the first call to `abort()`.
 added: v0.7.0
 -->
 
-* `response` {http.IncomingMessage}
+* `request` {http.IncomingMessage}
 * `socket` {net.Socket}
 * `head` {Buffer}
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Not much to say really, I just noticed this typo while reading the documentation. 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
