### PR TITLE
src: schedule destroy hooks in BeforeExit early during bootstrap

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -88,8 +88,7 @@ struct AsyncWrapObject : public AsyncWrap {
   SET_SELF_SIZE(AsyncWrapObject)
 };
 
-
-static void DestroyAsyncIdsCallback(Environment* env, void* data) {
+void AsyncWrap::DestroyAsyncIdsCallback(Environment* env, void* data) {
   Local<Function> fn = env->async_hooks_destroy_function();
 
   TryCatchScope try_catch(env, TryCatchScope::CatchMode::kFatal);
@@ -111,13 +110,6 @@ static void DestroyAsyncIdsCallback(Environment* env, void* data) {
     }
   } while (!env->destroy_async_id_list()->empty());
 }
-
-static void DestroyAsyncIdsCallback(void* arg) {
-  Environment* env = static_cast<Environment*>(arg);
-  if (!env->destroy_async_id_list()->empty())
-    DestroyAsyncIdsCallback(env, nullptr);
-}
-
 
 void Emit(Environment* env, double async_id, AsyncHooks::Fields type,
           Local<Function> fn) {
@@ -445,8 +437,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
-
-  env->BeforeExit(DestroyAsyncIdsCallback, env);
 
   env->SetMethod(target, "setupHooks", SetupHooks);
   env->SetMethod(target, "pushAsyncIds", PushAsyncIds);

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -141,6 +141,7 @@ class AsyncWrap : public BaseObject {
   static void EmitTraceEventAfter(ProviderType type, double async_id);
   void EmitTraceEventDestroy();
 
+  static void DestroyAsyncIdsCallback(Environment* env, void* data);
 
   inline ProviderType provider_type() const;
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -211,6 +211,14 @@ Environment::Environment(IsolateData* isolate_data,
   }
 
   destroy_async_id_list_.reserve(512);
+  BeforeExit(
+      [](void* arg) {
+        Environment* env = static_cast<Environment*>(arg);
+        if (!env->destroy_async_id_list()->empty())
+          AsyncWrap::DestroyAsyncIdsCallback(env, nullptr);
+      },
+      this);
+
   performance_state_.reset(new performance::performance_state(isolate()));
   performance_state_->Mark(
       performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1227,14 +1227,6 @@ void LoadEnvironment(Environment* env) {
   InitDTrace(env, global);
 #endif
 
-  env->BeforeExit(
-      [](void* arg) {
-        Environment* env = static_cast<Environment*>(arg);
-        if (!env->destroy_async_id_list()->empty())
-          AsyncWrap::DestroyAsyncIdsCallback(env, nullptr);
-      },
-      env);
-
   Local<Object> process = env->process_object();
 
   // Setting global properties for the bootstrappers to use:

--- a/src/node.cc
+++ b/src/node.cc
@@ -1227,6 +1227,14 @@ void LoadEnvironment(Environment* env) {
   InitDTrace(env, global);
 #endif
 
+  env->BeforeExit(
+      [](void* arg) {
+        Environment* env = static_cast<Environment*>(arg);
+        if (!env->destroy_async_id_list()->empty())
+          AsyncWrap::DestroyAsyncIdsCallback(env, nullptr);
+      },
+      env);
+
   Local<Object> process = env->process_object();
 
   // Setting global properties for the bootstrappers to use:


### PR DESCRIPTION
Instead of doing it in the `internalBinding('async_wrap')`
initialization whose first call is uncertain depending on how
the native modules are loaded in JS land during bootstrap.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
