### PR TITLE
tls: re-define max supported version as 1.2

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -518,6 +518,12 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
                                  SSL_SESS_CACHE_NO_AUTO_CLEAR);
 
   SSL_CTX_set_min_proto_version(sc->ctx_.get(), min_version);
+
+  if (max_version == 0) {
+    // Selecting some secureProtocol methods allows the TLS version to be "any
+    // supported", but we don't support TLSv1.3, even if OpenSSL does.
+    max_version = TLS1_2_VERSION;
+  }
   SSL_CTX_set_max_proto_version(sc->ctx_.get(), max_version);
 
   // OpenSSL 1.1.0 changed the ticket key size, but the OpenSSL 1.0.x size was


### PR DESCRIPTION
Several secureProtocol strings allow any supported TLS version as the
maximum, but our maximum supported protocol version is TLSv1.2 even if
someone configures a build against an OpenSSL that supports TLSv1.3.

Fixes: https://github.com/nodejs/node/issues/24658

Was part of the openssl 1.1.1 upgrade work, but given that distros are assuming that openssl 1.1.1 is API and ABI compatible with 1.1.0, and can be dropped in, and that node does in fact build when that happens, I  think we should apply this change to master, and likely backport through to 10.x 



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
