### PR TITLE
net: check for close on stream, not parent

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -371,8 +371,8 @@ Socket.prototype._final = function(cb) {
 };
 
 
-function afterShutdown(status, handle) {
-  var self = handle[owner_symbol];
+function afterShutdown(status) {
+  var self = this.handle[owner_symbol];
 
   debug('afterShutdown destroyed=%j', self.destroyed,
         self._readableState);

--- a/test/parallel/test-tls-close-event-after-write.js
+++ b/test/parallel/test-tls-close-event-after-write.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Issue #24984
+// 'close' event isn't emitted on a TLS connection if it's been written to
+// (but 'end' and 'finish' events are). Without a fix, this test won't exit.
+
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+let cconn = null;
+let sconn = null;
+
+function test() {
+  if (cconn && sconn) {
+    cconn.resume();
+    sconn.resume();
+    sconn.end(Buffer.alloc(1024 * 1024));
+    cconn.end();
+  }
+}
+
+const server = tls.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+}, function(c) {
+  c.on('close', function() {
+    server.close();
+  });
+  sconn = c;
+  test();
+}).listen(0, common.mustCall(function() {
+  tls.connect(this.address().port, {
+    rejectUnauthorized: false
+  }, common.mustCall(function() {
+    cconn = this;
+    test();
+  }));
+}));


### PR DESCRIPTION
`afterShutdown` was checking parent stream rather than TLS stream
Fixes #24984

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
