### PR TITLE
[v8.x] deps: V8: cherry-pick 525b396

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 75
+#define V8_PATCH_LEVEL 76
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/profiler/cpu-profiler.cc
+++ b/deps/v8/src/profiler/cpu-profiler.cc
@@ -326,8 +326,11 @@ void CpuProfiler::StartProcessorIfNotStarted() {
   // Disable logging when using the new implementation.
   saved_is_logging_ = logger->is_logging_;
   logger->is_logging_ = false;
+
+  bool codemap_needs_initialization = false;
   if (!generator_) {
     generator_.reset(new ProfileGenerator(profiles_.get()));
+    codemap_needs_initialization = true;
     CreateEntriesForRuntimeCallStats();
   }
   processor_.reset(new ProfilerEventsProcessor(isolate_, generator_.get(),
@@ -341,12 +344,14 @@ void CpuProfiler::StartProcessorIfNotStarted() {
   isolate_->set_is_profiling(true);
   // Enumerate stuff we already have in the heap.
   DCHECK(isolate_->heap()->HasBeenSetUp());
-  if (!FLAG_prof_browser_mode) {
-    logger->LogCodeObjects();
+  if (codemap_needs_initialization) {
+    if (!FLAG_prof_browser_mode) {
+      logger->LogCodeObjects();
+    }
+    logger->LogCompiledFunctions();
+    logger->LogAccessorCallbacks();
+    LogBuiltins();
   }
-  logger->LogCompiledFunctions();
-  logger->LogAccessorCallbacks();
-  LogBuiltins();
   // Enable stack sampling.
   processor_->AddCurrentStack(isolate_);
   processor_->StartSynchronously();


### PR DESCRIPTION
Original commit message:

    [cpu-profiler] Fix a leak caused by re-logging existing functions.

    Don't re-log all existing functions during StartProcessorIfNotStarted().
    They will already be in the CodeMap attached to the ProfileGenerator and
    re-logging them causes leaks. See the linked bug for more details.

    Bug: v8:8253
    Change-Id: Ibb1a1ab2431c588e8c3a3a9ff714767cdf61a88e
    Reviewed-on: https://chromium-review.googlesource.com/1256763
    Commit-Queue: Peter Marshall <petermarshall@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#56336}

Refs: https://github.com/v8/v8/commit/525b39619548b4e7fbf48934acb18d3f209321db

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
