### PR TITLE
src: enable Writev to write beyond INT_MAX

### DIFF
--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -346,6 +346,13 @@ class StreamBase : public StreamResource {
   friend class WriteWrap;
   friend class ShutdownWrap;
   friend class Environment;  // For kNumStreamBaseStateFields.
+  int WritevHelper(size_t storage_size,
+                   int index,
+                   int count,
+                   bool all_buffers,
+                   Environment* env,
+                   const v8::Local<v8::Array>& chunks,
+                   const v8::Local<v8::Object>& req_wrap_obj);
 };
 
 


### PR DESCRIPTION
Vectored writes that contain large string data (accumulated from
small strings over time due to congestion in the stream) fails
with ENOBUFS if the cumulative chunk size is more than INT_MAX.

Under backpressure situations failure is justified in JS land with heap
OOM as well as in the native land with libuv resource exhaustion etc, but
the stream wrap that sits in the middle which just facilitates the
transport between layers is not.

Detect the large data situation, and split those at right boundaries.
Carry out intermediary writes through dummy write_wrap objects to avoid
multiple callbacks to the requestor.

Fixes: https://github.com/nodejs/node/issues/24992

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
