### PR TITLE
doc: fix node.1 --http-parser sort order

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -97,17 +97,17 @@ Enable experimental ES module support in VM module.
 .It Fl -experimental-worker
 Enable experimental worker threads using worker_threads module.
 .
-.It Fl -http-parser Ns = Ns Ar library
-Chooses an HTTP parser library. Available values are
-.Sy llhttp
-or
-.Sy legacy .
-.
 .It Fl -force-fips
 Force FIPS-compliant crypto on startup
 (Cannot be disabled from script code).
 Same requirements as
 .Fl -enable-fips .
+.
+.It Fl -http-parser Ns = Ns Ar library
+Chooses an HTTP parser library. Available values are
+.Sy llhttp
+or
+.Sy legacy .
 .
 .It Fl -icu-data-dir Ns = Ns Ar file
 Specify ICU data load path.


### PR DESCRIPTION
For consistency with the API docs, switch the order of `--http-parser` and `--force-fips` in `node.1`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
