### PR TITLE
util: `format()` now formats bigint and booleans

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -245,8 +245,7 @@ util.format('%s:%s', 'foo');
 ```
 
 Values that are not part of the format string are formatted using
-`util.inspect()` if their type is either `'object'`, `'symbol'`, `'function'`
-or `'number'` and using `String()` in all other cases.
+`util.inspect()` if their type is not `string`.
 
 If there are more arguments passed to the `util.format()` method than the
 number of specifiers, the extra arguments are concatenated to the returned

--- a/lib/util.js
+++ b/lib/util.js
@@ -174,17 +174,8 @@ function formatWithOptions(inspectOptions, ...args) {
 
   while (a < args.length) {
     const value = args[a];
-    // TODO(BridgeAR): This should apply for all besides strings. Especially
-    // BigInt should be properly inspected.
     str += join;
-    if (typeof value !== 'string' &&
-        typeof value !== 'boolean' &&
-        // eslint-disable-next-line valid-typeof
-        typeof value !== 'bigint') {
-      str += inspect(value, inspectOptions);
-    } else {
-      str += value;
-    }
+    str += typeof value !== 'string' ? inspect(value, inspectOptions) : value;
     join = ' ';
     a++;
   }

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -316,10 +316,27 @@ assert.strictEqual(util.format(new BadCustomError('foo')),
 assert.strictEqual(util.format('1', '1'), '1 1');
 assert.strictEqual(util.format(1, '1'), '1 1');
 assert.strictEqual(util.format('1', 1), '1 1');
-assert.strictEqual(util.format(1, 1), '1 1');
+assert.strictEqual(util.format(1, -0), '1 -0');
 assert.strictEqual(util.format('1', () => {}), '1 [Function]');
 assert.strictEqual(util.format(1, () => {}), '1 [Function]');
 assert.strictEqual(util.format('1', "'"), "1 '");
 assert.strictEqual(util.format(1, "'"), "1 '");
 assert.strictEqual(util.format('1', 'number'), '1 number');
 assert.strictEqual(util.format(1, 'number'), '1 number');
+assert.strictEqual(util.format(5n), '5n');
+assert.strictEqual(util.format(5n, 5n), '5n 5n');
+
+// Check `formatWithOptions`.
+assert.strictEqual(
+  util.formatWithOptions(
+    { colors: true },
+    true, undefined, Symbol(), 1, 5n, null, 'foobar'
+  ),
+  '\u001b[33mtrue\u001b[39m ' +
+    '\u001b[90mundefined\u001b[39m ' +
+    '\u001b[32mSymbol()\u001b[39m ' +
+    '\u001b[33m1\u001b[39m ' +
+    '\u001b[33m5n\u001b[39m ' +
+    '\u001b[1mnull\u001b[22m ' +
+    'foobar'
+);


### PR DESCRIPTION
This is necessary to distinguish them from other data types.

I also added a test for `formatWithOptions` which was untested so far and which was necessary to actually see which types are passed through to `inspect`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
