### PR TITLE
vm: simplify Script constructor options validation

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -44,8 +44,7 @@ class Script extends ContextifyScript {
     code = `${code}`;
     if (typeof options === 'string') {
       options = { filename: options };
-    }
-    if (typeof options !== 'object' || options === null) {
+    } else if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
 


### PR DESCRIPTION
This commit combines two related `if` statements into an `if-else` statement.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
