### PR TITLE
tools: enable no-useless-constructor lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -235,6 +235,7 @@ module.exports = {
     }],
     'no-useless-call': 'error',
     'no-useless-concat': 'error',
+    'no-useless-constructor': 'error',
     'no-useless-escape': 'error',
     'no-useless-return': 'error',
     'no-void': 'error',

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1450,6 +1450,7 @@ of the four basic stream classes (`stream.Writable`, `stream.Readable`,
 `stream.Duplex`, or `stream.Transform`), making sure they call the appropriate
 parent class constructor:
 
+<!-- eslint-disable no-useless-constructor -->
 ```js
 const { Writable } = require('stream');
 
@@ -1547,6 +1548,7 @@ changes:
   * `autoDestroy` {boolean} Whether this stream should automatically call
     `.destroy()` on itself after ending. **Default:** `false`.
 
+<!-- eslint-disable no-useless-constructor -->
 ```js
 const { Writable } = require('stream');
 
@@ -1718,11 +1720,6 @@ required elements of a custom [`Writable`][] stream instance:
 const { Writable } = require('stream');
 
 class MyWritable extends Writable {
-  constructor(options) {
-    super(options);
-    // ...
-  }
-
   _write(chunk, encoding, callback) {
     if (chunk.toString().indexOf('a') >= 0) {
       callback(new Error('chunk is invalid'));
@@ -1806,6 +1803,7 @@ changes:
   * `autoDestroy` {boolean} Whether this stream should automatically call
     `.destroy()` on itself after ending. **Default:** `false`.
 
+<!-- eslint-disable no-useless-constructor -->
 ```js
 const { Readable } = require('stream');
 
@@ -2064,6 +2062,7 @@ changes:
   * `writableHighWaterMark` {number} Sets `highWaterMark` for the writable side
     of the stream. Has no effect if `highWaterMark` is provided.
 
+<!-- eslint-disable no-useless-constructor -->
 ```js
 const { Duplex } = require('stream');
 
@@ -2218,6 +2217,7 @@ output on the `Readable` side is not consumed.
   * `flush` {Function} Implementation for the [`stream._flush()`][stream-_flush]
     method.
 
+<!-- eslint-disable no-useless-constructor -->
 ```js
 const { Transform } = require('stream');
 

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -142,8 +142,6 @@ function getMilestoneTimestamp(milestoneIdx) {
 }
 
 class PerformanceNodeTiming {
-  constructor() {}
-
   get name() {
     return 'node';
   }

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -172,10 +172,6 @@ class DefaultSerializer extends Serializer {
 }
 
 class DefaultDeserializer extends Deserializer {
-  constructor(buffer) {
-    super(buffer);
-  }
-
   _readHostObject() {
     const typeIndex = this.readUint32();
     const ctor = arrayBufferViewTypes[typeIndex];

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -5,10 +5,6 @@ const assert = require('assert');
 const stream = require('stream');
 
 class MyWritable extends stream.Writable {
-  constructor(opt) {
-    super(opt);
-  }
-
   _write(chunk, encoding, callback) {
     assert.notStrictEqual(chunk, null);
     callback();


### PR DESCRIPTION
This commit enables ESLint's `no-useless-constructor` rule. Note that the documentation examples that only include constructor calls were left in tact.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
