### PR TITLE
src: dispose of V8 platform in `process.exit()`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -857,10 +857,13 @@ void Environment::AsyncHooks::grow_async_ids_stack() {
 uv_key_t Environment::thread_local_env = {};
 
 void Environment::Exit(int exit_code) {
-  if (is_main_thread())
+  if (is_main_thread()) {
+    stop_sub_worker_contexts();
+    DisposePlatform();
     exit(exit_code);
-  else
+  } else {
     worker_context_->Exit(exit_code);
+  }
 }
 
 void Environment::stop_sub_worker_contexts() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -340,6 +340,10 @@ tracing::AgentWriterHandle* GetTracingAgentWriter() {
   return v8_platform.GetTracingAgentWriter();
 }
 
+void DisposePlatform() {
+  v8_platform.Dispose();
+}
+
 #ifdef __POSIX__
 static const unsigned kMaxSignal = 32;
 #endif

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -357,6 +357,7 @@ int ThreadPoolWork::CancelWork() {
 }
 
 tracing::AgentWriterHandle* GetTracingAgentWriter();
+void DisposePlatform();
 
 static inline const char* errno_string(int errorno) {
 #define ERRNO_CASE(e)  case e: return #e;


### PR DESCRIPTION
This is essentially a re-do of #24828, with the addition of also shutting down worker threads before exiting. As pointed out by @Trott, this also is unlikely to fully resolve the issues we were seeing with `test-cli-syntax`, but even in the worse case this might help with figuring out what the root cause is.

---

Calling `process.exit()` calls the C `exit()` function, which in turn
calls the destructors of static C++ objects. This can lead to race
conditions with other concurrently executing threads; disposing of all
Worker threads and then the V8 platform instance helps with this
(although it might not be a full solution for all problems of
this kind).

Refs: https://github.com/nodejs/node/issues/24403
Refs: https://github.com/nodejs/node/issues/25007

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
