### PR TITLE
tools: better error message for failed tools/doc/generate

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -49,9 +49,15 @@ args.forEach(function(arg) {
   } else if (arg.startsWith('--output-directory=')) {
     outputDir = arg.replace(/^--output-directory=/, '');
   } else if (arg.startsWith('--apilinks=')) {
-    apilinks = JSON.parse(
-      fs.readFileSync(arg.replace(/^--apilinks=/, ''), 'utf8')
-    );
+    const filename = arg.replace(/^--apilinks=/, '');
+    try {
+      apilinks = JSON.parse(
+        fs.readFileSync(filename, 'utf8')
+      );
+    } catch (e) {
+      console.log(`Failure reading ${filename}, maybe remove it?`);
+      throw e;
+    }
   }
 });
 


### PR DESCRIPTION
When one creates a bogus `node` executable during development,
sometimes an issue that comes up is a failing invocation
of `tools/doc/generate.js --apilinks=...`, which continues
to fail afterwards. Removing the target file helps, but
there was no indication of that in the error message;
therefore, print a better one and suggest removing the file in it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
