### PR TITLE
src: use std::vector for setting up process.execPath

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1124,22 +1124,23 @@ void SetupProcessObject(Environment* env,
   SECURITY_REVERSIONS(V)
 #undef V
 
-  size_t exec_path_len = 2 * PATH_MAX;
-  char* exec_path = new char[exec_path_len];
-  Local<String> exec_path_value;
-  if (uv_exepath(exec_path, &exec_path_len) == 0) {
-    exec_path_value = String::NewFromUtf8(env->isolate(),
-                                          exec_path,
-                                          NewStringType::kInternalized,
-                                          exec_path_len).ToLocalChecked();
-  } else {
-    exec_path_value = String::NewFromUtf8(env->isolate(), args[0].c_str(),
-        NewStringType::kInternalized).ToLocalChecked();
+  {
+    size_t exec_path_len = 2 * PATH_MAX;
+    std::vector<char> exec_path(exec_path_len);
+    Local<String> exec_path_value;
+    if (uv_exepath(exec_path.data(), &exec_path_len) == 0) {
+      exec_path_value = String::NewFromUtf8(env->isolate(),
+                                            exec_path.data(),
+                                            NewStringType::kInternalized,
+                                            exec_path_len).ToLocalChecked();
+    } else {
+      exec_path_value = String::NewFromUtf8(env->isolate(), args[0].c_str(),
+          NewStringType::kInternalized).ToLocalChecked();
+    }
+    process->Set(env->context(),
+                 FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
+                 exec_path_value).FromJust();
   }
-  process->Set(env->context(),
-               FIXED_ONE_BYTE_STRING(env->isolate(), "execPath"),
-               exec_path_value).FromJust();
-  delete[] exec_path;
 
   auto debug_port_string = FIXED_ONE_BYTE_STRING(env->isolate(), "debugPort");
   CHECK(process->SetAccessor(env->context(),


### PR DESCRIPTION
Whitespace-adjusted diff for review: https://github.com/nodejs/node/pull/25069/files?w=1

Use `std::vector` as an RAII-style alternative to allocating
and deleting raw memory storage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
