### PR TITLE
vm: reuse validateString of internal/validators

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -33,7 +33,11 @@ const {
   ERR_VM_MODULE_NOT_MODULE,
 } = require('internal/errors').codes;
 const { isModuleNamespaceObject, isArrayBufferView } = require('util').types;
-const { validateInt32, validateUint32 } = require('internal/validators');
+const {
+  validateInt32,
+  validateUint32,
+  validateString
+} = require('internal/validators');
 const kParsingContext = Symbol('script parsing context');
 
 const ArrayForEach = Function.call.bind(Array.prototype.forEach);
@@ -59,9 +63,7 @@ class Script extends ContextifyScript {
       [kParsingContext]: parsingContext,
     } = options;
 
-    if (typeof filename !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('options.filename', 'string', filename);
-    }
+    validateString(filename, 'options.filename');
     validateInt32(lineOffset, 'options.lineOffset');
     validateInt32(columnOffset, 'options.columnOffset');
     if (cachedData !== undefined && !isArrayBufferView(cachedData)) {
@@ -150,11 +152,6 @@ function validateContext(sandbox) {
   }
 }
 
-function validateString(prop, propName) {
-  if (prop !== undefined && typeof prop !== 'string')
-    throw new ERR_INVALID_ARG_TYPE(propName, 'string', prop);
-}
-
 function validateBool(prop, propName) {
   if (prop !== undefined && typeof prop !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(propName, 'boolean', prop);
@@ -209,8 +206,10 @@ function getContextOptions(options) {
         wasm: options.contextCodeGeneration.wasm,
       } : undefined,
     };
-    validateString(contextOptions.name, 'options.contextName');
-    validateString(contextOptions.origin, 'options.contextOrigin');
+    if (contextOptions.name !== undefined)
+      validateString(contextOptions.name, 'options.contextName');
+    if (contextOptions.origin !== undefined)
+      validateString(contextOptions.origin, 'options.contextOrigin');
     if (contextOptions.codeGeneration) {
       validateBool(contextOptions.codeGeneration.strings,
                    'options.contextCodeGeneration.strings');
@@ -245,10 +244,9 @@ function createContext(sandbox = {}, options = {}) {
     codeGeneration
   } = options;
 
-  if (typeof name !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('options.name', 'string', options.name);
-  }
-  validateString(origin, 'options.origin');
+  validateString(name, 'options.name');
+  if (origin !== undefined)
+    validateString(origin, 'options.origin');
   validateObject(codeGeneration, 'options.codeGeneration');
 
   let strings = true;
@@ -320,18 +318,12 @@ function runInThisContext(code, options) {
 }
 
 function compileFunction(code, params, options = {}) {
-  if (typeof code !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('code', 'string', code);
-  }
+  validateString(code, 'code');
   if (params !== undefined) {
     if (!ArrayIsArray(params)) {
       throw new ERR_INVALID_ARG_TYPE('params', 'Array', params);
     }
-    ArrayForEach(params, (param, i) => {
-      if (typeof param !== 'string') {
-        throw new ERR_INVALID_ARG_TYPE(`params[${i}]`, 'string', param);
-      }
-    });
+    ArrayForEach(params, (param, i) => validateString(param, `params[${i}]`));
   }
 
   const {
@@ -344,9 +336,7 @@ function compileFunction(code, params, options = {}) {
     contextExtensions = [],
   } = options;
 
-  if (typeof filename !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('options.filename', 'string', filename);
-  }
+  validateString(filename, 'options.filename');
   validateUint32(columnOffset, 'options.columnOffset');
   validateUint32(lineOffset, 'options.lineOffset');
   if (cachedData !== undefined && !isArrayBufferView(cachedData)) {


### PR DESCRIPTION
The `validateString` function in `vm.js` is just one more judgement which validates whether `prop !== undefined` than the `validateString` function in `internal/validators`:
https://github.com/nodejs/node/blob/8f4b924f4a7b37bd16ddff65329c8e96fc5f0f2d/lib/vm.js#L153-L156

https://github.com/nodejs/node/blob/8f4b924f4a7b37bd16ddff65329c8e96fc5f0f2d/lib/internal/validators.js#L123-L126

So now just reuse the general `validateString` in `validator.js` totally.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
