### PR TITLE
worker: fix nullptr deref after MessagePort deser failure

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -90,7 +90,8 @@ MaybeLocal<Value> Message::Deserialize(Environment* env,
     if (ports[i] == nullptr) {
       for (MessagePort* port : ports) {
         // This will eventually release the MessagePort object itself.
-        port->Close();
+        if (port != nullptr)
+          port->Close();
       }
       return MaybeLocal<Value>();
     }

--- a/test/parallel/test-worker-messageport-transfer-terminate.js
+++ b/test/parallel/test-worker-messageport-transfer-terminate.js
@@ -1,0 +1,18 @@
+// Flags: --experimental-worker
+'use strict';
+require('../common');
+const { Worker, MessageChannel } = require('worker_threads');
+
+// Check the interaction of calling .terminate() while transferring
+// MessagePort objects; in particular, that it does not crash the process.
+
+for (let i = 0; i < 10; ++i) {
+  const w = new Worker(
+    "require('worker_threads').parentPort.on('message', () => {})",
+    { eval: true });
+  setImmediate(() => {
+    const port = new MessageChannel().port1;
+    w.postMessage({ port }, [ port ]);
+    w.terminate();
+  });
+}


### PR DESCRIPTION
This would previously always have crashed when deserializing
a `MessagePort` fails, because there was always at least one
`nullptr` entry in the vector.

(Caught by @gireeshpunathil in #25061)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
