### PR TITLE
src: handle empty Maybe in uv binding initialize

### DIFF
--- a/src/uv.cc
+++ b/src/uv.cc
@@ -81,9 +81,11 @@ void Initialize(Local<Object> target,
     OneByteString(isolate, #name),                                            \
     OneByteString(isolate, msg)                                               \
   };                                                                          \
-  err_map->Set(context,                                                       \
-               Integer::New(isolate, UV_##name),                              \
-               Array::New(isolate, arr, arraysize(arr))).ToLocalChecked();    \
+  if (err_map->Set(context,                                                   \
+                   Integer::New(isolate, UV_##name),                          \
+                   Array::New(isolate, arr, arraysize(arr))).IsEmpty()) {     \
+    return;                                                                   \
+  }                                                                           \
 } while (0);
   UV_ERRNO_MAP(V)
 #undef V


### PR DESCRIPTION
This can fail when terminating a Worker that loads
the `uv` binding at the same time.

Refs: https://github.com/nodejs/node/pull/25061#issuecomment-447648475

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
