### PR TITLE
doc: update behaviour of fs.writeFile

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3605,10 +3605,10 @@ recommended.
 1. Any specified file descriptor has to support writing.
 2. If a file descriptor is specified as the `file`, it will not be closed
 automatically.
-3. The writing will begin at the beginning of the file. For example, if the
-file already had `'Hello World'` and the newly written content is `'Aloha'`,
-then the contents of the file would be `'Aloha World'`, rather than just
-`'Aloha'`.
+3. The writing will begin at the current position. For example, if the string
+`'Hello'` is written to the file descriptor, and if `', World'` is written with
+`fs.writeFile()` to the same file descriptor, the contents of the file would
+become `'Hello, World'`, instead of just `', World'`.
 
 
 ## fs.writeFileSync(file, data[, options])


### PR DESCRIPTION
As per the decision in https://github.com/nodejs/node/issues/23433,
the `fs.writeFile` will always write from the current position if it
is used with file descriptors. This patch updates it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

cc @nodejs/fs @nodejs/tsc