### PR TITLE
test: exit sequence sanity tests

### DIFF
--- a/test/parallel/test-worker-cleanexit-with-moduleload.js
+++ b/test/parallel/test-worker-cleanexit-with-moduleload.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+
+// Harden the thread interactions on the exit path.
+// Ensure workers are able to bail out safe at
+// arbitrary execution points. By using a number of
+// internal modules as load candidates, the expectation
+// is that those will be at various control flow points
+// preferrably in the C++ land.
+
+const { Worker } = require('worker_threads');
+for (let i = 0; i < 10; i++) {
+  new Worker("const modules = ['fs', 'assert', 'async_hooks'," +
+    "'buffer', 'child_process', 'net', 'http', 'https', 'os'," +
+    "'path', 'v8', 'vm'];" +
+    'modules.forEach((module) => {' +
+    'const m = require(module);' +
+    '});', { eval: true });
+}
+
+// Allow workers to go live.
+setTimeout(() => {
+  process.exit(0);
+}, 200);


### PR DESCRIPTION
Execute many module loads in worker in a loop
while exiting from the main thread at arbitrary
execution points, and make sure that the workers
quiesce without crashing.

`worker_threads` are not necessarily the subject of
testing, those are used for easy simulation of
multi-thread scenarios.

Refs: https://github.com/nodejs/node/issues/25007

The current code base is not yet ready to conceive this, so please don't land this before #25007 is fully resolved.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
