### PR TITLE
test: exit sequence sanity tests [2]

### DIFF
--- a/test/parallel/test-worker-cleanexit-with-js.js
+++ b/test/parallel/test-worker-cleanexit-with-js.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+
+// Harden the thread interactions on the exit path.
+// Ensure workers are able to bail out safe at
+// arbitrary execution points. By running a lot of
+// JS code in a tight loop, the expectation
+// is that those will be at various control flow points
+// preferrably in the JS land.
+
+const { Worker } = require('worker_threads');
+const code = 'setInterval(() => {' +
+      "require('v8').deserialize(require('v8').serialize({ foo: 'bar' }));" +
+      "require('vm').runInThisContext('x = \"foo\";');" +
+      "eval('const y = \"vm\";');}, 10);";
+for (let i = 0; i < 9; i++) {
+  new Worker(code, { eval: true });
+}
+new Worker(code, { eval: true }).on('online', common.mustCall((msg) => {
+  process.exit(0);
+}));


### PR DESCRIPTION
Execute JS code in worker through same vm context
while exiting from the main thread at arbitrary
execution points, and make sure that the workers
quiesce without crashing.

`worker_threads` are not necessarily the subject of
testing, those are used for easy simulation of
multi-thread scenarios.

Refs: https://github.com/nodejs/node/issues/25007

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
