### PR TITLE
os: move process.binding('os') to internalBinding

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -93,6 +93,7 @@ const internalBindingWhitelist = [
   'inspector',
   'js_stream',
   'natives',
+  'os',
   'pipe_wrap',
   'process_wrap',
   'signal_wrap',

--- a/lib/os.js
+++ b/lib/os.js
@@ -44,7 +44,7 @@ const {
   getUptime,
   isBigEndian,
   setPriority: _setPriority
-} = process.binding('os');
+} = internalBinding('os');
 
 function getCheckedFunction(fn) {
   return function checkError(...args) {

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -470,4 +470,4 @@ void Initialize(Local<Object> target,
 }  // namespace os
 }  // namespace node
 
-NODE_BUILTIN_MODULE_CONTEXT_AWARE(os, node::os::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(os, node::os::Initialize)

--- a/test/parallel/test-os-checked-function.js
+++ b/test/parallel/test-os-checked-function.js
@@ -1,7 +1,11 @@
 'use strict';
+// Flags: --expose_internals
+
+const { internalBinding } = require('internal/test/binding');
+
 // Monkey patch the os binding before requiring any other modules, including
 // common, which requires the os module.
-process.binding('os').getHomeDirectory = function(ctx) {
+internalBinding('os').getHomeDirectory = function(ctx) {
   ctx.syscall = 'foo';
   ctx.code = 'bar';
   ctx.message = 'baz';

--- a/test/parallel/test-process-binding-internalbinding-whitelist.js
+++ b/test/parallel/test-process-binding-internalbinding-whitelist.js
@@ -18,3 +18,4 @@ assert(process.binding('js_stream'));
 assert(process.binding('buffer'));
 assert(process.binding('fs'));
 assert(process.binding('inspector'));
+assert(process.binding('os'));


### PR DESCRIPTION
see: #22160
ref: #22292

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
