### PR TITLE
test: remove obsolete eslint comments

### DIFF
--- a/test/js-native-api/test_general/testInstanceOf.js
+++ b/test/js-native-api/test_general/testInstanceOf.js
@@ -5,7 +5,6 @@ const common = require('../../common');
 const assert = require('assert');
 
 // Addon is referenced through the eval expression in testFile
-// eslint-disable-next-line no-unused-vars
 const addon = require(`./build/${common.buildType}/test_general`);
 const path = require('path');
 

--- a/test/parallel/test-require-extensions-same-filename-as-dir-trailing-slash.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir-trailing-slash.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable max-len */
 'use strict';
 require('../common');
 const assert = require('assert');


### PR DESCRIPTION
The surrounding code was updated, making these eslint-disable comments obsolete.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
