### PR TITLE
console: improve inspectOptions validation

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -91,13 +91,15 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   if (typeof colorMode !== 'boolean' && colorMode !== 'auto')
     throw new ERR_INVALID_ARG_VALUE('colorMode', colorMode);
 
-  if (inspectOptions) {
+  if (typeof inspectOptions === 'object' && inspectOptions !== null) {
     if (inspectOptions.colors !== undefined &&
         options.colorMode !== undefined) {
       throw new ERR_INCOMPATIBLE_OPTION_PAIR(
         'inspectOptions.color', 'colorMode');
     }
     optionsMap.set(this, inspectOptions);
+  } else if (inspectOptions !== undefined) {
+    throw new ERR_INVALID_ARG_TYPE('inspectOptions', 'object', inspectOptions);
   }
 
   // Bind the prototype functions to this Console instance

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -128,3 +128,21 @@ out.write = err.write = (d) => {};
   assert.throws(() => c2.warn('foo'), /^Error: err$/);
   assert.throws(() => c2.dir('foo'), /^Error: out$/);
 }
+
+// Console constructor throws if inspectOptions is not an object.
+[null, true, false, 'foo', 5, Symbol()].forEach((inspectOptions) => {
+  assert.throws(
+    () => {
+      new Console({
+        stdout: out,
+        stderr: err,
+        inspectOptions
+      });
+    },
+    {
+      message: 'The "inspectOptions" argument must be of type object.' +
+               ` Received type ${typeof inspectOptions}`,
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});


### PR DESCRIPTION
This commit adds stricter type checking to the `inspectOptions` option to the `Console` constructor.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
