### PR TITLE
test: add missing tmpdir.refresh() in recently-added test

### DIFF
--- a/test/parallel/test-child-process-spawn-args.js
+++ b/test/parallel/test-child-process-spawn-args.js
@@ -12,6 +12,8 @@ const { spawn } = require('child_process');
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 
+tmpdir.refresh();
+
 const command = common.isWindows ? 'cd' : 'pwd';
 const options = { cwd: tmpdir.path };
 


### PR DESCRIPTION
Without `tmpdir.refresh()`, the test fails in some situations. This was
missed because using `test.py` will almost always result in a leftover
tmpdir lying around that makes the `refresh()` not needed.

Refs: https://github.com/nodejs/node/pull/24913#issuecomment-447982921

Collaborators, 👍 here to fast-track.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
