### PR TITLE
 deps: V8: fix spread operator

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/DEPS
+++ b/deps/v8/DEPS
@@ -9,6 +9,9 @@ vars = {
   'download_jsfunfuzz': False,
   'download_mips_toolchain': False,
   'check_v8_header_includes': False,
+
+  # luci-go CIPD package version.
+  'luci_go': 'git_revision:fdf05508e8a66c773a41521e0243c9d11b9a2a1c',
 }
 
 deps = {
@@ -51,7 +54,7 @@ deps = {
   'v8/third_party/markupsafe':
     Var('chromium_url') + '/chromium/src/third_party/markupsafe.git' + '@' + '8f45f5cfa0009d2a70589bcda0349b8cb2b72783',
   'v8/tools/swarming_client':
-    Var('chromium_url') + '/infra/luci/client-py.git' + '@' + '486c9b53c4d54dd4b95bb6ce0e31160e600dfc11',
+    Var('chromium_url') + '/infra/luci/client-py.git' + '@' + '0e3e1c4dc4e79f25a5b58fcbc135dc93183c0c54',
   'v8/test/benchmarks/data':
     Var('chromium_url') + '/v8/deps/third_party/benchmarks.git' + '@' + '05d7188267b4560491ff9155c5ee13e207ecd65f',
   'v8/test/mozilla/data':
@@ -82,8 +85,24 @@ deps = {
   },
   'v8/tools/clang':
     Var('chromium_url') + '/chromium/src/tools/clang.git' + '@' + '7792d28b069af6dd3a86d1ba83b7f5c4ede605dc',
-  'v8/tools/luci-go':
-    Var('chromium_url') + '/chromium/src/tools/luci-go.git' + '@' + '445d7c4b6a4f10e188edb395b132e3996b127691',
+  'v8/tools/luci-go': {
+      'packages': [
+        {
+          'package': 'infra/tools/luci/isolate/${{platform}}',
+          'version': Var('luci_go'),
+        },
+        {
+          'package': 'infra/tools/luci/isolated/${{platform}}',
+          'version': Var('luci_go'),
+        },
+        {
+          'package': 'infra/tools/luci/swarming/${{platform}}',
+          'version': Var('luci_go'),
+        },
+      ],
+      'condition': 'host_cpu != "s390"',
+      'dep_type': 'cipd',
+  },
   'v8/test/wasm-js':
     Var('chromium_url') + '/external/github.com/WebAssembly/spec.git' + '@' + 'db9cd40808a90ecc5f4a23e88fb375c8f60b8d52',
 }

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 7
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 302
-#define V8_PATCH_LEVEL 28
+#define V8_PATCH_LEVEL 33
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/builtins/array-splice.tq
+++ b/deps/v8/src/builtins/array-splice.tq
@@ -9,8 +9,12 @@ module array {
   // zero-length input FixedArray is handled here.
   macro Extract<FixedArrayType: type>(
       elements: FixedArrayBase, first: Smi, count: Smi,
-      capacity: Smi): FixedArrayType {
-    return UnsafeCast<FixedArrayType>(
+      capacity: Smi): FixedArrayType;
+
+  Extract<FixedArray>(
+      elements: FixedArrayBase, first: Smi, count: Smi,
+      capacity: Smi): FixedArray {
+    return UnsafeCast<FixedArray>(
         ExtractFixedArray(elements, first, count, capacity));
   }
 
@@ -24,60 +28,77 @@ module array {
         ExtractFixedArray(elements, first, count, capacity));
   }
 
+  macro DoMoveElements<FixedArrayType: type>(
+      elements: FixedArrayType, dstIndex: Smi, srcIndex: Smi,
+      count: Smi): void {
+    TorqueMoveElements(
+        elements, Convert<intptr>(dstIndex), Convert<intptr>(srcIndex),
+        Convert<intptr>(count));
+  }
+
+  macro StoreHoles<FixedArrayType: type>(
+      elements: FixedArrayType, holeStartIndex: Smi, holeEndIndex: Smi): void {
+    for (let i: Smi = holeStartIndex; i < holeEndIndex; i++) {
+      StoreArrayHole(elements, i);
+    }
+  }
+
+  macro DoCopyElements<FixedArrayType: type>(
+      dstElements: FixedArrayType, dstIndex: Smi, srcElements: FixedArrayType,
+      srcIndex: Smi, count: Smi): void {
+    TorqueCopyElements(
+        dstElements, Convert<intptr>(dstIndex), srcElements,
+        Convert<intptr>(srcIndex), Convert<intptr>(count));
+  }
+
   macro FastSplice<FixedArrayType: type, ElementType: type>(
       args: constexpr Arguments, a: JSArray, length: Smi, newLength: Smi,
       lengthDelta: Smi, actualStart: Smi, insertCount: Smi,
       actualDeleteCount: Smi): void
       labels Bailout {
-    const elements: FixedArrayBase = a.elements;
-    const elementsMap: Map = elements.map;
+    // Make sure elements are writable.
+    EnsureWriteableFastElements(a);
 
-    // If the spliced array is larger then the
-    // source array, then allocate a new FixedArrayType to hold the result.
-    let newElements: FixedArrayBase = elements;
-    if (elementsMap == kCOWMap || lengthDelta > 0) {
-      newElements =
-          Extract<FixedArrayType>(elements, 0, actualStart, newLength);
-      if (elementsMap == kCOWMap) {
-        newElements.map = elementsMap;
+    if (insertCount != actualDeleteCount) {
+      const elements: FixedArrayBase = a.elements;
+      const dstIndex: Smi = actualStart + insertCount;
+      const srcIndex: Smi = actualStart + actualDeleteCount;
+      const count: Smi = length - actualDeleteCount - actualStart;
+      if (insertCount < actualDeleteCount) {
+        // Shrink.
+        DoMoveElements<FixedArrayType>(
+            UnsafeCast<FixedArrayType>(elements), dstIndex, srcIndex, count);
+        StoreHoles<FixedArrayType>(
+            UnsafeCast<FixedArrayType>(elements), newLength, length);
+      } else if (insertCount > actualDeleteCount) {
+        // If the backing store is big enough, then moving elements is enough.
+        if (newLength <= elements.length) {
+          DoMoveElements<FixedArrayType>(
+              UnsafeCast<FixedArrayType>(elements), dstIndex, srcIndex, count);
+        } else {
+          // Grow.
+          let capacity: Smi = CalculateNewElementsCapacity(newLength);
+          const newElements: FixedArrayType =
+              Extract<FixedArrayType>(elements, 0, actualStart, capacity);
+          a.elements = newElements;
+          if (elements.length > 0) {
+            DoCopyElements<FixedArrayType>(
+                newElements, dstIndex, UnsafeCast<FixedArrayType>(elements),
+                srcIndex, count);
+          }
+        }
       }
-      a.elements = newElements;
     }
 
-    // Copy over inserted elements.
+    // Copy arguments.
     let k: Smi = actualStart;
     if (insertCount > 0) {
       const typedNewElements: FixedArrayType =
-          UnsafeCast<FixedArrayType>(newElements);
+          UnsafeCast<FixedArrayType>(a.elements);
       for (let e: Object of args [2: ]) {
         // The argument elements were already validated to be an appropriate
         // {ElementType} to store in {FixedArrayType}.
         typedNewElements[k++] = UnsafeCast<ElementType>(e);
-      }
-    }
-
-    // Copy over elements after deleted elements.
-    let count: Smi = length - actualStart - actualDeleteCount;
-    while (count > 0) {
-      const typedElements: FixedArrayType =
-          UnsafeCast<FixedArrayType>(elements);
-      const typedNewElements: FixedArrayType =
-          UnsafeCast<FixedArrayType>(newElements);
-      CopyArrayElement(typedElements, typedNewElements, k - lengthDelta, k);
-      k++;
-      count--;
-    }
-
-    // Fill rest of spliced FixedArray with the hole, but only if the
-    // destination FixedArray is the original array's, since otherwise the array
-    // is pre-filled with holes.
-    if (elements == newElements) {
-      const typedNewElements: FixedArrayType =
-          UnsafeCast<FixedArrayType>(newElements);
-      const limit: Smi = elements.length;
-      while (k < limit) {
-        StoreArrayHole(typedNewElements, k);
-        k++;
       }
     }
 

--- a/deps/v8/src/builtins/base.tq
+++ b/deps/v8/src/builtins/base.tq
@@ -844,6 +844,8 @@ macro AllowNonNumberElements(kind: ElementsKind): ElementsKind {
 extern macro AllocateZeroedFixedArray(intptr): FixedArray;
 extern macro AllocateZeroedFixedDoubleArray(intptr): FixedDoubleArray;
 
+extern macro CalculateNewElementsCapacity(Smi): Smi;
+
 extern macro CopyFixedArrayElements(
     constexpr ElementsKind, FixedArray, constexpr ElementsKind, FixedArray,
     intptr, intptr, intptr): void;
@@ -878,6 +880,36 @@ extern macro ExtractFixedArray(
     constexpr ExtractFixedArrayFlags): FixedArrayBase;
 
 extern builtin ExtractFastJSArray(Context, JSArray, Smi, Smi): JSArray;
+
+extern macro MoveElements(
+    constexpr ElementsKind, FixedArrayBase, intptr, intptr, intptr): void;
+macro TorqueMoveElements(
+    elements: FixedArray, dstIndex: intptr, srcIndex: intptr,
+    count: intptr): void {
+  MoveElements(HOLEY_ELEMENTS, elements, dstIndex, srcIndex, count);
+}
+macro TorqueMoveElements(
+    elements: FixedDoubleArray, dstIndex: intptr, srcIndex: intptr,
+    count: intptr): void {
+  MoveElements(HOLEY_DOUBLE_ELEMENTS, elements, dstIndex, srcIndex, count);
+}
+
+extern macro CopyElements(
+    constexpr ElementsKind, FixedArrayBase, intptr, FixedArrayBase, intptr,
+    intptr): void;
+macro TorqueCopyElements(
+    dstElements: FixedArray, dstIndex: intptr, srcElements: FixedArray,
+    srcIndex: intptr, count: intptr): void {
+  CopyElements(
+      HOLEY_ELEMENTS, dstElements, dstIndex, srcElements, srcIndex, count);
+}
+macro TorqueCopyElements(
+    dstElements: FixedDoubleArray, dstIndex: intptr,
+    srcElements: FixedDoubleArray, srcIndex: intptr, count: intptr): void {
+  CopyElements(
+      HOLEY_DOUBLE_ELEMENTS, dstElements, dstIndex, srcElements, srcIndex,
+      count);
+}
 
 macro LoadElementNoHole<T: type>(a: JSArray, index: Smi): Object
     labels IfHole;

--- a/deps/v8/src/builtins/builtins-constructor-gen.cc
+++ b/deps/v8/src/builtins/builtins-constructor-gen.cc
@@ -534,8 +534,7 @@ Node* ConstructorBuiltinsAssembler::EmitCreateShallowObjectLiteral(
     VARIABLE(offset, MachineType::PointerRepresentation(),
              IntPtrConstant(JSObject::kHeaderSize));
     // Mutable heap numbers only occur on 32-bit platforms.
-    bool may_use_mutable_heap_numbers =
-        FLAG_track_double_fields && !FLAG_unbox_double_fields;
+    bool may_use_mutable_heap_numbers = !FLAG_unbox_double_fields;
     {
       Comment("Copy in-object properties fast");
       Label continue_fast(this, &offset);

--- a/deps/v8/src/code-stub-assembler.cc
+++ b/deps/v8/src/code-stub-assembler.cc
@@ -4931,6 +4931,13 @@ void CodeStubAssembler::CopyPropertyArrayValues(Node* from_array,
   Comment("[ CopyPropertyArrayValues");
 
   bool needs_write_barrier = barrier_mode == UPDATE_WRITE_BARRIER;
+
+  if (destroy_source == DestroySource::kNo) {
+    // PropertyArray may contain MutableHeapNumbers, which will be cloned on the
+    // heap, requiring a write barrier.
+    needs_write_barrier = true;
+  }
+
   Node* start = IntPtrOrSmiConstant(0, mode);
   ElementsKind kind = PACKED_ELEMENTS;
   BuildFastFixedArrayForEach(

--- a/deps/v8/src/code-stub-assembler.h
+++ b/deps/v8/src/code-stub-assembler.h
@@ -1567,6 +1567,25 @@ class V8_EXPORT_PRIVATE CodeStubAssembler : public compiler::CodeAssembler {
                            SMI_PARAMETERS);
   }
 
+  void JumpIfPointersFromHereAreInteresting(TNode<Object> object,
+                                            Label* interesting);
+
+  // Efficiently copy elements within a single array. The regions
+  // [src_index, src_index + length) and [dst_index, dst_index + length)
+  // can be overlapping.
+  void MoveElements(ElementsKind kind, TNode<FixedArrayBase> elements,
+                    TNode<IntPtrT> dst_index, TNode<IntPtrT> src_index,
+                    TNode<IntPtrT> length);
+
+  // Efficiently copy elements from one array to another. The ElementsKind
+  // needs to be the same. Copy from src_elements at
+  // [src_index, src_index + length) to dst_elements at
+  // [dst_index, dst_index + length).
+  void CopyElements(ElementsKind kind, TNode<FixedArrayBase> dst_elements,
+                    TNode<IntPtrT> dst_index,
+                    TNode<FixedArrayBase> src_elements,
+                    TNode<IntPtrT> src_index, TNode<IntPtrT> length);
+
   TNode<FixedArray> HeapObjectToFixedArray(TNode<HeapObject> base,
                                            Label* cast_fail);
 
@@ -1739,6 +1758,10 @@ class V8_EXPORT_PRIVATE CodeStubAssembler : public compiler::CodeAssembler {
 
   Node* CalculateNewElementsCapacity(Node* old_capacity,
                                      ParameterMode mode = INTPTR_PARAMETERS);
+
+  TNode<Smi> CalculateNewElementsCapacity(TNode<Smi> old_capacity) {
+    return CAST(CalculateNewElementsCapacity(old_capacity, SMI_PARAMETERS));
+  }
 
   // Tries to grow the |elements| array of given |object| to store the |key|
   // or bails out if the growing gap is too big. Returns new elements.

--- a/deps/v8/src/compiler/representation-change.cc
+++ b/deps/v8/src/compiler/representation-change.cc
@@ -586,7 +586,7 @@ Node* RepresentationChanger::GetFloat32RepresentationFor(
   } else if (output_rep == MachineRepresentation::kFloat64) {
     op = machine()->TruncateFloat64ToFloat32();
   } else if (output_rep == MachineRepresentation::kWord64) {
-    if (output_type.Is(Type::Signed32())) {
+    if (output_type.Is(cache_.kSafeInteger)) {
       // int64 -> float64 -> float32
       op = machine()->ChangeInt64ToFloat64();
       node = jsgraph()->graph()->NewNode(op, node);

--- a/deps/v8/src/ic/accessor-assembler.cc
+++ b/deps/v8/src/ic/accessor-assembler.cc
@@ -3566,7 +3566,7 @@ void AccessorAssembler::GenerateCloneObjectIC_Slow() {
 
 void AccessorAssembler::GenerateCloneObjectIC() {
   typedef CloneObjectWithVectorDescriptor Descriptor;
-  Node* source = Parameter(Descriptor::kSource);
+  TNode<HeapObject> source = CAST(Parameter(Descriptor::kSource));
   Node* flags = Parameter(Descriptor::kFlags);
   Node* slot = Parameter(Descriptor::kSlot);
   Node* vector = Parameter(Descriptor::kVector);
@@ -3576,8 +3576,7 @@ void AccessorAssembler::GenerateCloneObjectIC() {
   Label miss(this, Label::kDeferred), try_polymorphic(this, Label::kDeferred),
       try_megamorphic(this, Label::kDeferred);
 
-  CSA_SLOW_ASSERT(this, TaggedIsNotSmi(source));
-  Node* source_map = LoadMap(UncheckedCast<HeapObject>(source));
+  TNode<Map> source_map = LoadMap(UncheckedCast<HeapObject>(source));
   GotoIf(IsDeprecatedMap(source_map), &miss);
   TNode<MaybeObject> feedback = TryMonomorphicCase(
       slot, vector, source_map, &if_handler, &var_handler, &try_polymorphic);
@@ -3598,7 +3597,7 @@ void AccessorAssembler::GenerateCloneObjectIC() {
 
     // The IC fast case should only be taken if the result map a compatible
     // elements kind with the source object.
-    TNode<FixedArrayBase> source_elements = LoadElements(source);
+    TNode<FixedArrayBase> source_elements = LoadElements(CAST(source));
 
     auto flags = ExtractFixedArrayFlag::kAllFixedArraysDontCopyCOW;
     var_elements = CAST(CloneFixedArray(source_elements, flags));
@@ -3633,22 +3632,45 @@ void AccessorAssembler::GenerateCloneObjectIC() {
     // Lastly, clone any in-object properties.
     // Determine the inobject property capacity of both objects, and copy the
     // smaller number into the resulting object.
-    Node* source_start = LoadMapInobjectPropertiesStartInWords(source_map);
-    Node* source_size = LoadMapInstanceSizeInWords(source_map);
-    Node* result_start = LoadMapInobjectPropertiesStartInWords(result_map);
-    Node* field_offset_difference =
+    TNode<IntPtrT> source_start =
+        LoadMapInobjectPropertiesStartInWords(source_map);
+    TNode<IntPtrT> source_size = LoadMapInstanceSizeInWords(source_map);
+    TNode<IntPtrT> result_start =
+        LoadMapInobjectPropertiesStartInWords(result_map);
+    TNode<IntPtrT> field_offset_difference =
         TimesPointerSize(IntPtrSub(result_start, source_start));
-    BuildFastLoop(source_start, source_size,
-                  [=](Node* field_index) {
-                    Node* field_offset = TimesPointerSize(field_index);
-                    TNode<Object> field = LoadObjectField(source, field_offset);
-                    field = CloneIfMutablePrimitive(field);
-                    Node* result_offset =
-                        IntPtrAdd(field_offset, field_offset_difference);
-                    StoreObjectFieldNoWriteBarrier(object, result_offset,
-                                                   field);
-                  },
-                  1, INTPTR_PARAMETERS, IndexAdvanceMode::kPost);
+
+    // If MutableHeapNumbers may be present in-object, allocations may occur
+    // within this loop, thus the write barrier is required.
+    //
+    // TODO(caitp): skip the write barrier until the first MutableHeapNumber
+    // field is found
+    const bool may_use_mutable_heap_numbers = !FLAG_unbox_double_fields;
+
+    BuildFastLoop(
+        source_start, source_size,
+        [=](Node* field_index) {
+          TNode<IntPtrT> field_offset =
+              TimesPointerSize(UncheckedCast<IntPtrT>(field_index));
+
+          if (may_use_mutable_heap_numbers) {
+            TNode<Object> field = LoadObjectField(source, field_offset);
+            field = CloneIfMutablePrimitive(field);
+            TNode<IntPtrT> result_offset =
+                IntPtrAdd(field_offset, field_offset_difference);
+            StoreObjectField(object, result_offset, field);
+          } else {
+            // Copy fields as raw data.
+            TNode<IntPtrT> field = UncheckedCast<IntPtrT>(
+                LoadObjectField(source, field_offset, MachineType::IntPtr()));
+            TNode<IntPtrT> result_offset =
+                IntPtrAdd(field_offset, field_offset_difference);
+            StoreObjectFieldNoWriteBarrier(
+                object, result_offset, field,
+                MachineType::IntPtr().representation());
+          }
+        },
+        1, INTPTR_PARAMETERS, IndexAdvanceMode::kPost);
     Return(object);
   }
 

--- a/deps/v8/test/mjsunit/es9/object-spread-ic.js
+++ b/deps/v8/test/mjsunit/es9/object-spread-ic.js
@@ -99,3 +99,25 @@
   // Megamorphic
   assertEquals({ boop: 1 }, f({ boop: 1 }));
 })();
+
+// There are 2 paths in CloneObjectIC's handler which need to handle double
+// fields specially --- in object properties, and copying the property array.
+function testMutableInlineProperties() {
+  function inobject() { "use strict"; this.x = 1.1; }
+  const src = new inobject();
+  const x0 = src.x;
+  const clone = { ...src, x: x0 + 1 };
+  assertEquals(x0, src.x);
+  assertEquals({ x: 2.1 }, clone);
+}
+testMutableInlineProperties()
+
+function testMutableOutOfLineProperties() {
+  const src = { a: 1, b: 2, c: 3 };
+  src.x = 2.3;
+  const x0 = src.x;
+  const clone = { ...src, x: x0 + 1 };
+  assertEquals(x0, src.x);
+  assertEquals({ a: 1, b: 2, c: 3, x: 3.3 }, clone);
+}
+testMutableOutOfLineProperties();

--- a/deps/v8/test/mjsunit/es9/regress/regress-902965.js
+++ b/deps/v8/test/mjsunit/es9/regress/regress-902965.js
@@ -1,0 +1,12 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Previously, spreading in-object properties would always treat double fields
+// as tagged, potentially dereferencing a Float64.
+function inobjectDouble() {
+  "use strict";
+  this.x = -3.9;
+}
+const instance = new inobjectDouble();
+const clone = { ...instance, };

--- a/deps/v8/test/mjsunit/es9/regress/regress-903070.js
+++ b/deps/v8/test/mjsunit/es9/regress/regress-903070.js
@@ -1,0 +1,15 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function clone(src) {
+  return { ...src };
+}
+
+function inobjectDoubles() {
+  "use strict";
+  this.p0 = -6400510997704731;
+}
+
+// Check that unboxed double is not treated as tagged
+assertEquals({ p0: -6400510997704731 }, clone(new inobjectDoubles()));

--- a/deps/v8/test/mjsunit/regress/regress-895691.js
+++ b/deps/v8/test/mjsunit/regress/regress-895691.js
@@ -1,0 +1,18 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+const n = 2**32;
+const x = new Float32Array();
+
+function f() {
+  for (var i = 96; i < 100; i += 4) {
+    x[i] = i + n;
+  }
+}
+
+f();
+%OptimizeFunctionOnNextCall(f);
+f();

--- a/deps/v8/tools/__init__.py
+++ b/deps/v8/tools/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.

--- a/deps/v8/tools/unittests/__init__.py
+++ b/deps/v8/tools/unittests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.

--- a/deps/v8/tools/unittests/v8_presubmit_test.py
+++ b/deps/v8/tools/unittests/v8_presubmit_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import sys
+import tempfile
+import unittest
+
+# Configuring the path for the v8_presubmit module
+TOOLS_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(TOOLS_ROOT)
+
+from v8_presubmit import FileContentsCache, CacheableSourceFileProcessor
+
+
+class FakeCachedProcessor(CacheableSourceFileProcessor):
+  def __init__(self, cache_file_path):
+    super(FakeCachedProcessor, self).__init__(
+      use_cache=True, cache_file_path=cache_file_path, file_type='.test')
+  def GetProcessorWorker(self):
+    return object
+  def GetProcessorScript(self):
+    return "echo", []
+  def DetectUnformattedFiles(_, cmd, worker, files):
+    raise NotImplementedError
+
+class FileContentsCacheTest(unittest.TestCase):
+  def setUp(self):
+    _, self.cache_file_path = tempfile.mkstemp()
+    cache = FileContentsCache(self.cache_file_path)
+    cache.Load()
+
+    def generate_file():
+      _, file_name = tempfile.mkstemp()
+      with open(file_name, "w") as f:
+        f.write(file_name)
+
+      return file_name
+
+    self.target_files = [generate_file() for _ in range(2)]
+    unchanged_files = cache.FilterUnchangedFiles(self.target_files)
+    self.assertEqual(len(unchanged_files), 2)
+    cache.Save()
+
+  def tearDown(self):
+    for file in [self.cache_file_path] + self.target_files:
+      os.remove(file)
+
+  def testCachesFiles(self):
+    cache = FileContentsCache(self.cache_file_path)
+    cache.Load()
+
+    changed_files = cache.FilterUnchangedFiles(self.target_files)
+    self.assertListEqual(changed_files, [])
+
+    modified_file = self.target_files[0]
+    with open(modified_file, "w") as f:
+      f.write("modification")
+
+    changed_files = cache.FilterUnchangedFiles(self.target_files)
+    self.assertListEqual(changed_files, [modified_file])
+
+  def testCacheableSourceFileProcessor(self):
+    class CachedProcessor(FakeCachedProcessor):
+      def DetectFilesToChange(_, files):
+        self.assertListEqual(files, [])
+        return []
+
+    cached_processor = CachedProcessor(cache_file_path=self.cache_file_path)
+    cached_processor.ProcessFiles(self.target_files)
+
+  def testCacheableSourceFileProcessorWithModifications(self):
+    modified_file = self.target_files[0]
+    with open(modified_file, "w") as f:
+      f.write("modification")
+
+    class CachedProcessor(FakeCachedProcessor):
+      def DetectFilesToChange(_, files):
+        self.assertListEqual(files, [modified_file])
+        return []
+
+    cached_processor = CachedProcessor(
+      cache_file_path=self.cache_file_path,
+    )
+    cached_processor.ProcessFiles(self.target_files)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
The spread operator currently mutates some input objects. This is already fixed in V8, so I just went ahead to backport these commits.

Fixes: #25089

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
