### PR TITLE
util: fixes type in argument type validation error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -317,7 +317,7 @@ function inherits(ctor, superCtor) {
 
   if (superCtor.prototype === undefined) {
     throw new ERR_INVALID_ARG_TYPE('superCtor.prototype',
-                                   'Function', superCtor.prototype);
+                                   'Object', superCtor.prototype);
   }
   Object.defineProperty(ctor, 'super_', {
     value: superCtor,

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -88,7 +88,7 @@ common.expectsError(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor.prototype" property must be of type Function. ' +
+  message: 'The "superCtor.prototype" property must be of type Object. ' +
            'Received type undefined'
 });
 


### PR DESCRIPTION
The argument validation for `superCtor` should not output that `superCtor.prototype`
must be a Function, but rather it must be an Object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
