### PR TITLE
lib: switch to object spread where possible

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,4 +1,5 @@
 rules:
+  prefer-object-spread: error
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -291,7 +291,7 @@ function initRead(tls, wrapped) {
  */
 
 function TLSSocket(socket, opts) {
-  const tlsOptions = Object.assign({}, opts);
+  const tlsOptions = { ...opts };
 
   if (tlsOptions.ALPNProtocols)
     tls.convertALPNProtocols(tlsOptions.ALPNProtocols, tlsOptions);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -136,7 +136,7 @@ function normalizeExecArgs(command, options, callback) {
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
+  options = { ...options };
   options.shell = typeof options.shell === 'string' ? options.shell : true;
 
   return {
@@ -470,7 +470,7 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
-  options = Object.assign({}, options);
+  options = { ...options };
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -636,7 +636,7 @@ function setupChannel(target, channel) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
 
-    options = Object.assign({ swallowErrors: false }, options);
+    options = { swallowErrors: false, ...options };
 
     if (this.connected) {
       return this._send(message, handle, options, callback);

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -292,10 +292,11 @@ Console.prototype.warn = function warn(...args) {
 Console.prototype.error = Console.prototype.warn;
 
 Console.prototype.dir = function dir(object, options) {
-  options = Object.assign({
-    customInspect: false
-  }, this[kGetInspectOptions](this._stdout), options);
-  this[kWriteToConsole](kUseStdout, util.inspect(object, options));
+  this[kWriteToConsole](kUseStdout, util.inspect(object, {
+    customInspect: false,
+    ...this[kGetInspectOptions](this._stdout),
+    ...options
+  }));
 };
 
 Console.prototype.time = function time(label = 'default') {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -512,7 +512,7 @@ class Http2ServerResponse extends Stream {
   }
 
   getHeaders() {
-    return Object.assign({}, this[kHeaders]);
+    return { ...this[kHeaders] };
   }
 
   hasHeader(name) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -790,7 +790,7 @@ function pingCallback(cb) {
 // 6. enablePush must be a boolean
 // All settings are optional and may be left undefined
 function validateSettings(settings) {
-  settings = Object.assign({}, settings);
+  settings = { ...settings };
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
                     0, kMaxInt);
@@ -1443,7 +1443,7 @@ class ClientHttp2Session extends Http2Session {
     assertIsObject(options, 'options');
 
     headers = Object.assign(Object.create(null), headers);
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
@@ -1848,7 +1848,7 @@ class Http2Stream extends Duplex {
       throw new ERR_HTTP2_INVALID_STREAM();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
     validatePriorityOptions(options);
 
     const priorityFn = submitPriority.bind(this, options);
@@ -2257,7 +2257,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new ERR_INVALID_CALLBACK();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
     options.endStream = !!options.endStream;
 
     assertIsObject(headers, 'headers');
@@ -2322,7 +2322,7 @@ class ServerHttp2Stream extends Http2Stream {
     const state = this[kState];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +
@@ -2378,7 +2378,7 @@ class ServerHttp2Stream extends Http2Stream {
     const session = this[kSession];
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
@@ -2441,7 +2441,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new ERR_HTTP2_HEADERS_SENT();
 
     assertIsObject(options, 'options');
-    options = Object.assign({}, options);
+    options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
       throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
@@ -2667,10 +2667,10 @@ function connectionListener(socket) {
 
 function initializeOptions(options) {
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = { ...options };
   options.allowHalfOpen = true;
   assertIsObject(options.settings, 'options.settings');
-  options.settings = Object.assign({}, options.settings);
+  options.settings = { ...options.settings };
 
   // Used only with allowHTTP1
   options.Http1IncomingMessage = options.Http1IncomingMessage ||
@@ -2775,7 +2775,7 @@ function connect(authority, options, listener) {
   }
 
   assertIsObject(options, 'options');
-  options = Object.assign({}, options);
+  options = { ...options };
 
   if (typeof authority === 'string')
     authority = new URL(authority);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -129,8 +129,7 @@ function hasOwnProperty(obj, prop) {
 // and it can be overridden by custom print functions, such as `probe` or
 // `eyes.js`.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
-writer.options =
-    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
+writer.options = { ...util.inspect.defaultOptions, showProxy: true };
 
 exports._builtinLibs = builtinLibs;
 
@@ -509,7 +508,7 @@ function REPLServer(prompt,
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = Object.assign({}, writer.options, { colors: true });
+    self.writer.options = { ...writer.options, colors: true };
   }
 
   function filterInternalStackFrames(structuredStack) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -270,9 +270,13 @@ class SecurePair extends EventEmitter {
     this.credentials = secureContext;
 
     this.encrypted = socket1;
-    this.cleartext = new exports.TLSSocket(socket2, Object.assign({
-      secureContext, isServer, requestCert, rejectUnauthorized
-    }, options));
+    this.cleartext = new exports.TLSSocket(socket2, {
+      secureContext,
+      isServer,
+      requestCert,
+      rejectUnauthorized,
+      ...options
+    });
     this.cleartext.once('secure', () => this.emit('secure'));
   }
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -292,9 +292,7 @@ function runInContext(code, contextifiedSandbox, options) {
       [kParsingContext]: contextifiedSandbox
     };
   } else {
-    options = Object.assign({}, options, {
-      [kParsingContext]: contextifiedSandbox
-    });
+    options = { ...options, [kParsingContext]: contextifiedSandbox };
   }
   return createScript(code, options)
     .runInContext(contextifiedSandbox, options);
@@ -305,9 +303,7 @@ function runInNewContext(code, sandbox, options) {
     options = { filename: options };
   }
   sandbox = createContext(sandbox, getContextOptions(options));
-  options = Object.assign({}, options, {
-    [kParsingContext]: sandbox
-  });
+  options = { ...options, [kParsingContext]: sandbox };
   return createScript(code, options).runInNewContext(sandbox, options);
 }
 


### PR DESCRIPTION
Use the object spread notation instead of using Object.assign.
It is not only easier to read it is also faster as of V8 6.8.

Benchmark with 11.4:

```
// node benchmark/es/spread-assign.js 
es/spread-assign.js n=1000000 count=5 method="spread": 36,495,416.66835458
es/spread-assign.js n=1000000 count=10 method="spread": 31,889,730.923060697
es/spread-assign.js n=1000000 count=20 method="spread": 151,930.52448171392
es/spread-assign.js n=1000000 count=5 method="assign": 9,476,496.804852217
es/spread-assign.js n=1000000 count=10 method="assign": 4,704,920.0252048215
es/spread-assign.js n=1000000 count=20 method="assign": 123,309.56193177585
es/spread-assign.js n=1000000 count=5 method="_extend": 5,076,862.324845331
es/spread-assign.js n=1000000 count=10 method="_extend": 2,359,288.3170930305
es/spread-assign.js n=1000000 count=20 method="_extend": 382,746.2281006062
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
