### PR TITLE
src: port GetLoadedLibraries for freebsd

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -30,9 +30,9 @@
 
 #endif  // __POSIX__
 
-#if defined(__linux__) || defined(__sun)
+#if defined(__linux__) || defined(__sun) || defined(__FreeBSD__)
 #include <link.h>
-#endif  // (__linux__) || defined(__sun)
+#endif  // (__linux__) || defined(__sun) || defined(__FreeBSD__)
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>  // _dyld_get_image_name()
@@ -322,7 +322,7 @@ void CheckedUvLoopClose(uv_loop_t* loop) {
 
 std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
   std::vector<std::string> list;
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
   dl_iterate_phdr(
       [](struct dl_phdr_info* info, size_t size, void* data) {
         auto list = static_cast<std::vector<std::string>*>(data);


### PR DESCRIPTION
[came to know this recently, when I got access to a freebsd box]

the `dl_iterate_phdr` and its associated data structure in Linux are fully available in freebsd as well, so opening it up for freebsd means just opening up the platform specific identifiers.

Refs: https://github.com/nodejs/node/pull/24825

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
