### PR TITLE
win, build: fix building addons on Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -446,8 +446,8 @@ if errorlevel 1 goto exit
 
 
 :install-doctools
-REM only install if building doc OR testing doctool
-if not defined doc (
+REM only install if building doc OR testing doctool OR building addons
+if not defined doc if not defined build_addons (
   echo.%test_args% | findstr doctool 1>nul
   if errorlevel 1 goto :skip-install-doctools
 )


### PR DESCRIPTION
Building addons would fail because addon-verify.js dependencies from
tools\doc where not installed. This fixes this issue by installing
those dependencies if addons are to be built.

Fixes: https://github.com/nodejs/node/issues/25096

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
