### PR TITLE
src: move more version computation code into node_metadata.cc

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -38,8 +38,6 @@ function startup() {
   // Do this good and early, since it handles errors.
   setupProcessFatal();
 
-  setupProcessICUVersions();
-
   setupGlobalVariables();
 
   // Bootstrappers for all threads, including worker threads and main thread
@@ -636,25 +634,6 @@ function setupProcessFatal() {
 
     return true;
   };
-}
-
-function setupProcessICUVersions() {
-  const icu = internalBinding('config').hasIntl ?
-    internalBinding('icu') : undefined;
-  if (!icu) return;  // no Intl/ICU: nothing to add here.
-  // With no argument, getVersion() returns a comma separated list
-  // of possible types.
-  const versionTypes = icu.getVersion().split(',');
-
-  for (var n = 0; n < versionTypes.length; n++) {
-    const name = versionTypes[n];
-    const version = icu.getVersion(name);
-    Object.defineProperty(process.versions, name, {
-      writable: false,
-      enumerable: true,
-      value: version
-    });
-  }
 }
 
 function wrapForBreakOnFirstLine(source) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -877,7 +877,10 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(process, "versions", versions);
 
 #define V(key)                                                                 \
-  READONLY_STRING_PROPERTY(versions, #key, per_process::metadata.versions.key);
+  if (!per_process::metadata.versions.key.empty()) {                           \
+    READONLY_STRING_PROPERTY(                                                  \
+        versions, #key, per_process::metadata.versions.key);                   \
+  }
   NODE_VERSIONS_KEYS(V)
 #undef V
 
@@ -1664,6 +1667,7 @@ void Init(std::vector<std::string>* argv,
             argv->at(0).c_str());
     exit(9);
   }
+  per_process::metadata.versions.InitializeIntlVersions();
 #endif
 
   // We should set node_is_initialized here instead of in node::Start,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5842,21 +5842,6 @@ void Initialize(Local<Object> target,
 #endif  // OPENSSL_NO_SCRYPT
 }
 
-constexpr int search(const char* s, int n, int c) {
-  return *s == c ? n : search(s + 1, n + 1, c);
-}
-
-std::string GetOpenSSLVersion() {
-  // sample openssl version string format
-  // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
-  char buf[128];
-  const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
-  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ');
-  const int len = end - start;
-  snprintf(buf, sizeof(buf), "%.*s", len, &OPENSSL_VERSION_TEXT[start]);
-  return std::string(buf);
-}
-
 }  // namespace crypto
 }  // namespace node
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -94,7 +94,6 @@ extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 extern void UseExtraCaCerts(const std::string& file);
 
 void InitCryptoOnce();
-std::string GetOpenSSLVersion();
 
 class SecureContext : public BaseObject {
  public:

--- a/src/node_http_parser_llhttp.cc
+++ b/src/node_http_parser_llhttp.cc
@@ -1,16 +1,18 @@
 #define NODE_EXPERIMENTAL_HTTP 1
 
 #include "node_http_parser_impl.h"
+#include "node_metadata.h"
 
 namespace node {
 
+namespace per_process {
 const char* const llhttp_version =
     NODE_STRINGIFY(LLHTTP_VERSION_MAJOR)
     "."
     NODE_STRINGIFY(LLHTTP_VERSION_MINOR)
     "."
     NODE_STRINGIFY(LLHTTP_VERSION_PATCH);
-
+}  // namespace per_process
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(http_parser_llhttp,

--- a/src/node_http_parser_traditional.cc
+++ b/src/node_http_parser_traditional.cc
@@ -3,16 +3,17 @@
 #endif
 
 #include "node_http_parser_impl.h"
+#include "node_metadata.h"
 
 namespace node {
-
+namespace per_process {
 const char* const http_parser_version =
   NODE_STRINGIFY(HTTP_PARSER_VERSION_MAJOR)
   "."
   NODE_STRINGIFY(HTTP_PARSER_VERSION_MINOR)
   "."
   NODE_STRINGIFY(HTTP_PARSER_VERSION_PATCH);
-
+}  // namespace per_process
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(http_parser, node::InitializeHttpParser)

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -698,9 +698,6 @@ static inline const char* errno_string(int errorno) {
 
 extern double prog_start_time;
 
-extern const char* const llhttp_version;
-extern const char* const http_parser_version;
-
 void Abort(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Chdir(const v8::FunctionCallbackInfo<v8::Value>& args);
 void CPUUsage(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -11,6 +11,13 @@
 #include <openssl/opensslv.h>
 #endif  // HAVE_OPENSSL
 
+#ifdef NODE_HAVE_I18N_SUPPORT
+#include <unicode/timezone.h>
+#include <unicode/ulocdata.h>
+#include <unicode/uvernum.h>
+#include <unicode/uversion.h>
+#endif  // NODE_HAVE_I18N_SUPPORT
+
 namespace node {
 
 namespace per_process {
@@ -34,6 +41,25 @@ std::string GetOpenSSLVersion() {
 }
 #endif  // HAVE_OPENSSL
 
+#ifdef NODE_HAVE_I18N_SUPPORT
+void Metadata::Versions::InitializeIntlVersions() {
+  UErrorCode status = U_ZERO_ERROR;
+
+  const char* tz_version = icu::TimeZone::getTZDataVersion(status);
+  if (U_SUCCESS(status)) {
+    tz = tz_version;
+  }
+
+  char buf[U_MAX_VERSION_STRING_LENGTH];
+  UVersionInfo versionArray;
+  ulocdata_getCLDRVersion(versionArray, &status);
+  if (U_SUCCESS(status)) {
+    u_versionToString(versionArray, buf);
+    cldr = buf;
+  }
+}
+#endif  // NODE_HAVE_I18N_SUPPORT
+
 Metadata::Versions::Versions() {
   node = NODE_VERSION_STRING;
   v8 = v8::V8::GetVersion();
@@ -49,6 +75,11 @@ Metadata::Versions::Versions() {
 #if HAVE_OPENSSL
   openssl = GetOpenSSLVersion();
 #endif
+
+#ifdef NODE_HAVE_I18N_SUPPORT
+  icu = U_ICU_VERSION;
+  unicode = U_UNICODE_VERSION;
+#endif  // NODE_HAVE_I18N_SUPPORT
 }
 
 }  // namespace node

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -2,7 +2,6 @@
 #include "ares.h"
 #include "nghttp2/nghttp2ver.h"
 #include "node.h"
-#include "node_internals.h"
 #include "util.h"
 #include "uv.h"
 #include "v8.h"
@@ -44,8 +43,8 @@ Metadata::Versions::Versions() {
   modules = NODE_STRINGIFY(NODE_MODULE_VERSION);
   nghttp2 = NGHTTP2_VERSION;
   napi = NODE_STRINGIFY(NAPI_VERSION);
-  llhttp = llhttp_version;
-  http_parser = http_parser_version;
+  llhttp = per_process::llhttp_version;
+  http_parser = per_process::http_parser_version;
 
 #if HAVE_OPENSSL
   openssl = GetOpenSSLVersion();

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -9,14 +9,31 @@
 #include "zlib.h"
 
 #if HAVE_OPENSSL
-#include "node_crypto.h"
-#endif
+#include <openssl/opensslv.h>
+#endif  // HAVE_OPENSSL
 
 namespace node {
 
 namespace per_process {
 Metadata metadata;
 }
+
+#if HAVE_OPENSSL
+constexpr int search(const char* s, int n, int c) {
+  return *s == c ? n : search(s + 1, n + 1, c);
+}
+
+std::string GetOpenSSLVersion() {
+  // sample openssl version string format
+  // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
+  char buf[128];
+  const int start = search(OPENSSL_VERSION_TEXT, 0, ' ') + 1;
+  const int end = search(OPENSSL_VERSION_TEXT + start, start, ' ');
+  const int len = end - start;
+  snprintf(buf, sizeof(buf), "%.*s", len, &OPENSSL_VERSION_TEXT[start]);
+  return std::string(buf);
+}
+#endif  // HAVE_OPENSSL
 
 Metadata::Versions::Versions() {
   node = NODE_VERSION_STRING;
@@ -31,7 +48,7 @@ Metadata::Versions::Versions() {
   http_parser = http_parser_version;
 
 #if HAVE_OPENSSL
-  openssl = crypto::GetOpenSSLVersion();
+  openssl = GetOpenSSLVersion();
 #endif
 }
 

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -44,6 +44,8 @@ class Metadata {
 // Per-process global
 namespace per_process {
 extern Metadata metadata;
+extern const char* const llhttp_version;
+extern const char* const http_parser_version;
 }
 
 }  // namespace node

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -25,14 +25,38 @@ namespace node {
 #define NODE_VERSIONS_KEY_CRYPTO(V)
 #endif
 
+#ifdef NODE_HAVE_I18N_SUPPORT
+#define NODE_VERSIONS_KEY_INTL(V)                                              \
+  V(cldr)                                                                      \
+  V(icu)                                                                       \
+  V(tz)                                                                        \
+  V(unicode)
+#else
+#define NODE_VERSIONS_KEY_INTL(V)
+#endif  // NODE_HAVE_I18N_SUPPORT
+
 #define NODE_VERSIONS_KEYS(V)                                                  \
   NODE_VERSIONS_KEYS_BASE(V)                                                   \
-  NODE_VERSIONS_KEY_CRYPTO(V)
+  NODE_VERSIONS_KEY_CRYPTO(V)                                                  \
+  NODE_VERSIONS_KEY_INTL(V)
 
 class Metadata {
  public:
+  Metadata() = default;
+  Metadata(Metadata&) = delete;
+  Metadata(Metadata&&) = delete;
+  Metadata operator=(Metadata&) = delete;
+  Metadata operator=(Metadata&&) = delete;
+
   struct Versions {
     Versions();
+
+#ifdef NODE_HAVE_I18N_SUPPORT
+    // Must be called on the main thread after
+    // i18n::InitializeICUDirectory()
+    void InitializeIntlVersions();
+#endif  // NODE_HAVE_I18N_SUPPORT
+
 #define V(key) std::string key;
     NODE_VERSIONS_KEYS(V)
 #undef V


### PR DESCRIPTION
#### src: move the declaration of http parser versions into node_metadata.h

Instead of putting them in node_internals.h.

#### src: move GetOpenSSLVersion into node_metadata.cc

Instead of implementing it in node_crypto.cc even though the only
place that needs it is the `Metadata::Versions` constructor.

#### src: initialize ICU version in per_process::metadata.versions

Instead of

- Initialize the ICU versions in JS land after consulting
  internalBinding('config').hasIntl
- Joining the version keys in C++
- Splitting the keys in JS and call into C++ again to get the value for
  each of the keys

Do:

- Guard the initialization code behind `NODE_HAVE_I18N_SUPPORT`
- Do the initialization in C++ right after ICU data is loaded
- Initialize each version directly using ICU functions/constants,
  and put them in per_process::metadata.versions. These will be
  copied into `process.versions` naturally later.
  This way, the initialization of the versions won't be called
  in worker threads again.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
