### PR TITLE
Update v8.x docs for http request set timeout

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -625,8 +625,9 @@ added: v0.5.9
 * `timeout` {number} Milliseconds before a request times out.
 * `callback` {Function} Optional function to be called when a timeout occurs. Same as binding to the `timeout` event.
 
-Once a socket is assigned to this request and is connected
-[`socket.setTimeout()`][] will be called.
+Once a socket is assigned to this request [`socket.setTimeout()`][] will be called.
+
+Note that this behaviour changes in Node.js version 9 and higher.
 
 Returns `request`.
 


### PR DESCRIPTION
When upgrading from Node.js 8 to 10 I hit the behaviour change in #8895. This documentation update would have helped me find the problem faster :)

Also see #25121 for an update to the docs on master.

Thanks :)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
