### PR TITLE
[v8.x] update the http.request.setTimeout docs to be accurate

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 2
 #define V8_BUILD_NUMBER 414
-#define V8_PATCH_LEVEL 75
+#define V8_PATCH_LEVEL 76
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/profiler/cpu-profiler.cc
+++ b/deps/v8/src/profiler/cpu-profiler.cc
@@ -326,8 +326,11 @@ void CpuProfiler::StartProcessorIfNotStarted() {
   // Disable logging when using the new implementation.
   saved_is_logging_ = logger->is_logging_;
   logger->is_logging_ = false;
+
+  bool codemap_needs_initialization = false;
   if (!generator_) {
     generator_.reset(new ProfileGenerator(profiles_.get()));
+    codemap_needs_initialization = true;
     CreateEntriesForRuntimeCallStats();
   }
   processor_.reset(new ProfilerEventsProcessor(isolate_, generator_.get(),
@@ -341,12 +344,14 @@ void CpuProfiler::StartProcessorIfNotStarted() {
   isolate_->set_is_profiling(true);
   // Enumerate stuff we already have in the heap.
   DCHECK(isolate_->heap()->HasBeenSetUp());
-  if (!FLAG_prof_browser_mode) {
-    logger->LogCodeObjects();
+  if (codemap_needs_initialization) {
+    if (!FLAG_prof_browser_mode) {
+      logger->LogCodeObjects();
+    }
+    logger->LogCompiledFunctions();
+    logger->LogAccessorCallbacks();
+    LogBuiltins();
   }
-  logger->LogCompiledFunctions();
-  logger->LogAccessorCallbacks();
-  LogBuiltins();
   // Enable stack sampling.
   processor_->AddCurrentStack(isolate_);
   processor_->StartSynchronously();

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -625,8 +625,9 @@ added: v0.5.9
 * `timeout` {number} Milliseconds before a request times out.
 * `callback` {Function} Optional function to be called when a timeout occurs. Same as binding to the `timeout` event.
 
-Once a socket is assigned to this request and is connected
-[`socket.setTimeout()`][] will be called.
+If no socket is assigned to this request then [`socket.setTimeout()`][] will be
+called immediately. Otherwise [`socket.setTimeout()`][] will be called after the
+assigned socket is connected.
 
 Returns `request`.
 


### PR DESCRIPTION
When upgrading from Node.js 8 to 10 I hit the behaviour change in #8895. This documentation update would have helped me find the problem faster :)

Also see #25121 for an update to the docs on master.

Thanks :)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
