### PR TITLE
lib: make internal API warning more direct

### DIFF
--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -1,8 +1,7 @@
 'use strict';
 
 process.emitWarning(
-  'These APIs are exposed only for testing and are not ' +
-  'tracked by any versioning system or deprecation process.',
+  'These APIs are for internal testing only. Do not use them.',
   'internal/test/binding');
 
 module.exports = { internalBinding };

--- a/lib/internal/test/heap.js
+++ b/lib/internal/test/heap.js
@@ -1,8 +1,7 @@
 'use strict';
 
 process.emitWarning(
-  'These APIs are exposed only for testing and are not ' +
-  'tracked by any versioning system or deprecation process.',
+  'These APIs are for internal testing only. Do not use them.',
   'internal/test/heap');
 
 const { createHeapDump, buildEmbedderGraph } = internalBinding('heap_utils');

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -24,8 +24,7 @@ cares.getaddrinfo = () => internalBinding('uv').UV_ENOENT;
 common.expectWarning({
   // For 'internal/test/binding' module.
   'internal/test/binding': [
-    'These APIs are exposed only for testing and are not ' +
-    'tracked by any versioning system or deprecation process.'
+    'These APIs are for internal testing only. Do not use them.'
   ],
   // For dns.promises.
   'ExperimentalWarning': [

--- a/test/parallel/test-fs-filehandle.js
+++ b/test/parallel/test-fs-filehandle.js
@@ -21,8 +21,7 @@ let fdnum;
 
 common.expectWarning({
   'internal/test/binding': [
-    'These APIs are exposed only for testing ' +
-    'and are not tracked by any versioning system or deprecation process.',
+    'These APIs are for internal testing only. Do not use them.',
     common.noWarnCode
   ],
   'Warning': [


### PR DESCRIPTION
Before:
These APIs are exposed only for testing and are not tracked by any
versioning system or deprecation process.

After:
These APIs are for internal testing only. Do not use them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
