### PR TITLE
test: mark sequential/test-inspector-debug-end and parallel/test-child-process-execfile as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -32,3 +32,5 @@ test-cli-node-options: PASS,FLAKY
 [$system==freebsd]
 
 [$system==aix]
+# https://github.com/nodejs/node/issues/25029
+test-child-process-execfile: PASS,FLAKY

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -28,5 +28,7 @@ test-http2-large-file: PASS, FLAKY
 [$system==aix]
 # https://github.com/nodejs/node/issues/24921
 test-child-process-execsync: PASS, FLAKY
+# https://github.com/nodejs/node/issues/25047
+test-inspector-debug-end: PASS, FLAKY
 
 [$arch==arm]


### PR DESCRIPTION
Off late this has been failing in AIX. Debugging core dump
suggested that this is a side effect of exit-race that is
described in https://github.com/nodejs/node/issues/25007
Mart it as flaky in AIX until that is resolved.

Refs: https://github.com/nodejs/node/issues/25047

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
