### PR TITLE
src: move more process methods initialization in bootstrap/node.js

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -20,11 +20,7 @@
 const {
   _setupTraceCategoryState,
   _setupNextTick,
-  _setupPromises, _chdir, _cpuUsage,
-  _hrtime, _hrtimeBigInt,
-  _memoryUsage, _rawDebug,
-  _umask,
-  _shouldAbortOnUncaughtToggle
+  _setupPromises
 } = bootstrappers;
 const { internalBinding, NativeModule } = loaderExports;
 
@@ -56,15 +52,57 @@ function startup() {
     );
   }
 
-  perThreadSetup.setupAssert();
-  perThreadSetup.setupConfig();
+  // process.config is serialized config.gypi
+  process.config = JSON.parse(internalBinding('native_module').config);
 
+  const rawMethods = internalBinding('process_methods');
+  // Set up methods and events on the process object for the main thread
   if (isMainThread) {
+    // This depends on process being an event emitter
     mainThreadSetup.setupSignalHandlers(internalBinding);
+
+    process.abort = rawMethods.abort;
+    const wrapped = mainThreadSetup.wrapProcessMethods(rawMethods);
+    process.umask = wrapped.umask;
+    process.chdir = wrapped.chdir;
+
+    // TODO(joyeecheung): deprecate and remove these underscore methods
+    process._debugProcess = rawMethods._debugProcess;
+    process._debugEnd = rawMethods._debugEnd;
+    process._startProfilerIdleNotifier =
+      rawMethods._startProfilerIdleNotifier;
+    process._stopProfilerIdleNotifier = rawMethods._stopProfilerIdleNotifier;
   }
 
-  perThreadSetup.setupUncaughtExceptionCapture(exceptionHandlerState,
-                                               _shouldAbortOnUncaughtToggle);
+  // Set up methods on the process object for all threads
+  {
+    process.cwd = rawMethods.cwd;
+    process.dlopen = rawMethods.dlopen;
+    process.uptime = rawMethods.uptime;
+
+    // TODO(joyeecheung): either remove them or make them public
+    process._getActiveRequests = rawMethods._getActiveRequests;
+    process._getActiveHandles = rawMethods._getActiveHandles;
+
+    // TODO(joyeecheung): remove these
+    process.reallyExit = rawMethods.reallyExit;
+    process._kill = rawMethods._kill;
+
+    const wrapped = perThreadSetup.wrapProcessMethods(
+      rawMethods, exceptionHandlerState
+    );
+    process._rawDebug = wrapped._rawDebug;
+    process.hrtime = wrapped.hrtime;
+    process.hrtime.bigint = wrapped.hrtimeBigInt;
+    process.cpuUsage = wrapped.cpuUsage;
+    process.memoryUsage = wrapped.memoryUsage;
+    process.kill = wrapped.kill;
+    process.exit = wrapped.exit;
+    process.setUncaughtExceptionCaptureCallback =
+      wrapped.setUncaughtExceptionCaptureCallback;
+    process.hasUncaughtExceptionCaptureCallback =
+      wrapped.hasUncaughtExceptionCaptureCallback;
+  }
 
   NativeModule.require('internal/process/warning').setup();
   NativeModule.require('internal/process/next_tick').setup(_setupNextTick,
@@ -90,21 +128,9 @@ function startup() {
 
   if (isMainThread) {
     mainThreadSetup.setupStdio();
-    mainThreadSetup.setupProcessMethods(_chdir, _umask);
   } else {
     workerThreadSetup.setupStdio();
   }
-
-  const perf = internalBinding('performance');
-  const {
-    NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE,
-  } = perf.constants;
-
-  perThreadSetup.setupRawDebug(_rawDebug);
-  perThreadSetup.setupHrtime(_hrtime, _hrtimeBigInt);
-  perThreadSetup.setupCpuUsage(_cpuUsage);
-  perThreadSetup.setupMemoryUsage(_memoryUsage);
-  perThreadSetup.setupKillAndExit();
 
   if (global.__coverage__)
     NativeModule.require('internal/process/write-coverage').setup();
@@ -208,9 +234,37 @@ function startup() {
     }
   }
 
-  perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
+  // process.allowedNodeEnvironmentFlags
+  Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
+    get() {
+      const flags = perThreadSetup.buildAllowedFlags();
+      process.allowedNodeEnvironmentFlags = flags;
+      return process.allowedNodeEnvironmentFlags;
+    },
+    // If the user tries to set this to another value, override
+    // this completely to that value.
+    set(value) {
+      Object.defineProperty(this, 'allowedNodeEnvironmentFlags', {
+        value,
+        configurable: true,
+        enumerable: true,
+        writable: true
+      });
+    },
+    enumerable: true,
+    configurable: true
+  });
+  // process.assert
+  process.assert = deprecate(
+    perThreadSetup.assert,
+    'process.assert() is deprecated. Please use the `assert` module instead.',
+    'DEP0100');
 
-  perThreadSetup.setupAllowedFlags();
+  const perf = internalBinding('performance');
+  const {
+    NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE,
+  } = perf.constants;
+  perf.markMilestone(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
 
   startExecution();
 }

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -27,21 +27,25 @@ function setupStdio() {
   setupProcessStdio(getMainThreadStdio());
 }
 
-// Non-POSIX platforms like Windows don't have certain methods.
-// Workers also lack these methods since they change process-global state.
-function setupProcessMethods(_chdir, _umask) {
-  process.chdir = function chdir(directory) {
+// The execution of this function itself should not cause any side effects.
+function wrapProcessMethods(binding) {
+  function chdir(directory) {
     validateString(directory, 'directory');
-    return _chdir(directory);
-  };
+    return binding.chdir(directory);
+  }
 
-  process.umask = function umask(mask) {
+  function umask(mask) {
     if (mask === undefined) {
       // Get the mask
-      return _umask(mask);
+      return binding.umask(mask);
     }
     mask = validateMode(mask, 'mask');
-    return _umask(mask);
+    return binding.umask(mask);
+  }
+
+  return {
+    chdir,
+    umask
   };
 }
 
@@ -175,7 +179,7 @@ function setupChildProcessIpcChannel() {
 
 module.exports = {
   setupStdio,
-  setupProcessMethods,
+  wrapProcessMethods,
   setupSignalHandlers,
   setupChildProcessIpcChannel,
   wrapPosixCredentialSetters

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -18,25 +18,30 @@ const {
 } = require('internal/errors');
 const util = require('util');
 const constants = internalBinding('constants').os.signals;
-const { deprecate } = require('internal/util');
 
-function setupAssert() {
-  process.assert = deprecate(
-    function(x, msg) {
-      if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
-    },
-    'process.assert() is deprecated. Please use the `assert` module instead.',
-    'DEP0100');
+function assert(x, msg) {
+  if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
 }
 
-// Set up the process.cpuUsage() function.
-function setupCpuUsage(_cpuUsage) {
+// The execution of this function itself should not cause any side effects.
+function wrapProcessMethods(binding, exceptionHandlerState) {
+  const {
+    hrtime: _hrtime,
+    hrtimeBigInt: _hrtimeBigInt,
+    cpuUsage: _cpuUsage,
+    memoryUsage: _memoryUsage
+  } = binding;
+
+  function _rawDebug(...args) {
+    binding._rawDebug(util.format.apply(null, args));
+  }
+
   // Create the argument array that will be passed to the native function.
   const cpuValues = new Float64Array(2);
 
   // Replace the native function with the JS version that calls the native
   // function.
-  process.cpuUsage = function cpuUsage(prevValue) {
+  function cpuUsage(prevValue) {
     // If a previous value was passed in, ensure it has the correct shape.
     if (prevValue) {
       if (!previousValueIsValid(prevValue.user)) {
@@ -80,7 +85,7 @@ function setupCpuUsage(_cpuUsage) {
       user: cpuValues[0],
       system: cpuValues[1]
     };
-  };
+  }
 
   // Ensure that a previously passed in value is valid. Currently, the native
   // implementation always returns numbers <= Number.MAX_SAFE_INTEGER.
@@ -89,15 +94,13 @@ function setupCpuUsage(_cpuUsage) {
         num <= Number.MAX_SAFE_INTEGER &&
         num >= 0;
   }
-}
 
-// The 3 entries filled in by the original process.hrtime contains
-// the upper/lower 32 bits of the second part of the value,
-// and the remaining nanoseconds of the value.
-function setupHrtime(_hrtime, _hrtimeBigInt) {
+  // The 3 entries filled in by the original process.hrtime contains
+  // the upper/lower 32 bits of the second part of the value,
+  // and the remaining nanoseconds of the value.
   const hrValues = new Uint32Array(3);
 
-  process.hrtime = function hrtime(time) {
+  function hrtime(time) {
     _hrtime(hrValues);
 
     if (time !== undefined) {
@@ -118,21 +121,18 @@ function setupHrtime(_hrtime, _hrtimeBigInt) {
       hrValues[0] * 0x100000000 + hrValues[1],
       hrValues[2]
     ];
-  };
+  }
 
   // Use a BigUint64Array in the closure because V8 does not have an API for
   // creating a BigInt out of a uint64_t yet.
   const hrBigintValues = new BigUint64Array(1);
-  process.hrtime.bigint = function() {
+  function hrtimeBigInt() {
     _hrtimeBigInt(hrBigintValues);
     return hrBigintValues[0];
-  };
-}
+  }
 
-function setupMemoryUsage(_memoryUsage) {
   const memValues = new Float64Array(4);
-
-  process.memoryUsage = function memoryUsage() {
+  function memoryUsage() {
     _memoryUsage(memValues);
     return {
       rss: memValues[0],
@@ -140,18 +140,9 @@ function setupMemoryUsage(_memoryUsage) {
       heapUsed: memValues[2],
       external: memValues[3]
     };
-  };
-}
+  }
 
-function setupConfig() {
-  // Serialized config.gypi
-  process.config = JSON.parse(internalBinding('native_module').config);
-}
-
-
-function setupKillAndExit() {
-
-  process.exit = function(code) {
+  function exit(code) {
     if (code || code === 0)
       process.exitCode = code;
 
@@ -159,10 +150,10 @@ function setupKillAndExit() {
       process._exiting = true;
       process.emit('exit', process.exitCode || 0);
     }
-    process.reallyExit(process.exitCode || 0);
-  };
+    binding.reallyExit(process.exitCode || 0);
+  }
 
-  process.kill = function(pid, sig) {
+  function kill(pid, sig) {
     var err;
     if (process.env.NODE_V8_COVERAGE) {
       const { writeCoverage } = require('internal/process/coverage');
@@ -176,6 +167,8 @@ function setupKillAndExit() {
 
     // preserve null signal
     if (sig === (sig | 0)) {
+      // XXX(joyeecheung): we have to use process._kill here because
+      // it's monkey-patched by tests.
       err = process._kill(pid, sig);
     } else {
       sig = sig || 'SIGTERM';
@@ -190,22 +183,13 @@ function setupKillAndExit() {
       throw errnoException(err, 'kill');
 
     return true;
-  };
-}
+  }
 
-function setupRawDebug(_rawDebug) {
-  process._rawDebug = function() {
-    _rawDebug(util.format.apply(null, arguments));
-  };
-}
-
-
-function setupUncaughtExceptionCapture(exceptionHandlerState,
-                                       shouldAbortOnUncaughtToggle) {
   // shouldAbortOnUncaughtToggle is a typed array for faster
   // communication with JS.
+  const { shouldAbortOnUncaughtToggle } = binding;
 
-  process.setUncaughtExceptionCaptureCallback = function(fn) {
+  function setUncaughtExceptionCaptureCallback(fn) {
     if (fn === null) {
       exceptionHandlerState.captureFn = fn;
       shouldAbortOnUncaughtToggle[0] = 1;
@@ -219,10 +203,22 @@ function setupUncaughtExceptionCapture(exceptionHandlerState,
     }
     exceptionHandlerState.captureFn = fn;
     shouldAbortOnUncaughtToggle[0] = 0;
-  };
+  }
 
-  process.hasUncaughtExceptionCaptureCallback = function() {
+  function hasUncaughtExceptionCaptureCallback() {
     return exceptionHandlerState.captureFn !== null;
+  }
+
+  return {
+    _rawDebug,
+    hrtime,
+    hrtimeBigInt,
+    cpuUsage,
+    memoryUsage,
+    kill,
+    exit,
+    setUncaughtExceptionCaptureCallback,
+    hasUncaughtExceptionCaptureCallback
   };
 }
 
@@ -326,38 +322,13 @@ function buildAllowedFlags() {
   Object.freeze(NodeEnvironmentFlagsSet.prototype.constructor);
   Object.freeze(NodeEnvironmentFlagsSet.prototype);
 
-  return process.allowedNodeEnvironmentFlags = Object.freeze(
-    new NodeEnvironmentFlagsSet(
-      allowedNodeEnvironmentFlags
-    ));
-}
-
-function setupAllowedFlags() {
-  Object.defineProperty(process, 'allowedNodeEnvironmentFlags', {
-    get: buildAllowedFlags,
-    set(value) {
-      // If the user tries to set this to another value, override
-      // this completely to that value.
-      Object.defineProperty(this, 'allowedNodeEnvironmentFlags', {
-        value,
-        configurable: true,
-        enumerable: true,
-        writable: true
-      });
-    },
-    enumerable: true,
-    configurable: true
-  });
+  return Object.freeze(new NodeEnvironmentFlagsSet(
+    allowedNodeEnvironmentFlags
+  ));
 }
 
 module.exports = {
-  setupAllowedFlags,
-  setupAssert,
-  setupCpuUsage,
-  setupHrtime,
-  setupMemoryUsage,
-  setupConfig,
-  setupKillAndExit,
-  setupRawDebug,
-  setupUncaughtExceptionCapture
+  assert,
+  buildAllowedFlags,
+  wrapProcessMethods
 };

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -139,20 +139,6 @@ void SetupBootstrapObject(Environment* env,
   BOOTSTRAP_METHOD(_setupTraceCategoryState, SetupTraceCategoryState);
   BOOTSTRAP_METHOD(_setupNextTick, SetupNextTick);
   BOOTSTRAP_METHOD(_setupPromises, SetupPromises);
-  BOOTSTRAP_METHOD(_chdir, Chdir);
-  BOOTSTRAP_METHOD(_cpuUsage, CPUUsage);
-  BOOTSTRAP_METHOD(_hrtime, Hrtime);
-  BOOTSTRAP_METHOD(_hrtimeBigInt, HrtimeBigInt);
-  BOOTSTRAP_METHOD(_memoryUsage, MemoryUsage);
-  BOOTSTRAP_METHOD(_rawDebug, RawDebug);
-  BOOTSTRAP_METHOD(_umask, Umask);
-
-  Local<String> should_abort_on_uncaught_toggle =
-      FIXED_ONE_BYTE_STRING(env->isolate(), "_shouldAbortOnUncaughtToggle");
-  CHECK(bootstrapper->Set(env->context(),
-                       should_abort_on_uncaught_toggle,
-                       env->should_abort_on_uncaught_toggle().GetJSArray())
-                           .FromJust());
 }
 #undef BOOTSTRAP_METHOD
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -95,8 +95,6 @@
 #if defined(_MSC_VER)
 #include <direct.h>
 #include <io.h>
-#define umask _umask
-typedef int mode_t;
 #else
 #include <pthread.h>
 #include <sys/resource.h>  // getrlimit, setrlimit
@@ -689,8 +687,7 @@ static void WaitForInspectorDisconnect(Environment* env) {
 #endif
 }
 
-
-static void Exit(const FunctionCallbackInfo<Value>& args) {
+void Exit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   WaitForInspectorDisconnect(env);
   v8_platform.StopTracingAgent();
@@ -1109,29 +1106,6 @@ void SetupProcessObject(Environment* env,
                              DebugPortGetter,
                              env->is_main_thread() ? DebugPortSetter : nullptr,
                              env->as_external()).FromJust());
-
-  // define various internal methods
-  if (env->is_main_thread()) {
-    env->SetMethod(process, "_debugProcess", DebugProcess);
-    env->SetMethod(process, "_debugEnd", DebugEnd);
-    env->SetMethod(process,
-                   "_startProfilerIdleNotifier",
-                   StartProfilerIdleNotifier);
-    env->SetMethod(process,
-                   "_stopProfilerIdleNotifier",
-                   StopProfilerIdleNotifier);
-    env->SetMethod(process, "abort", Abort);
-    env->SetMethod(process, "chdir", Chdir);
-    env->SetMethod(process, "umask", Umask);
-  }
-  env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
-  env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
-  env->SetMethod(process, "_kill", Kill);
-
-  env->SetMethodNoSideEffect(process, "cwd", Cwd);
-  env->SetMethod(process, "dlopen", binding::DLOpen);
-  env->SetMethod(process, "reallyExit", Exit);
-  env->SetMethodNoSideEffect(process, "uptime", Uptime);
 }
 
 
@@ -1273,134 +1247,7 @@ void RegisterSignalHandler(int signal,
   CHECK_EQ(sigaction(signal, &sa, nullptr), 0);
 }
 
-
-void DebugProcess(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  if (args.Length() != 1) {
-    return env->ThrowError("Invalid number of arguments.");
-  }
-
-  CHECK(args[0]->IsNumber());
-  pid_t pid = args[0].As<Integer>()->Value();
-  int r = kill(pid, SIGUSR1);
-
-  if (r != 0) {
-    return env->ThrowErrnoException(errno, "kill");
-  }
-}
 #endif  // __POSIX__
-
-
-#ifdef _WIN32
-static int GetDebugSignalHandlerMappingName(DWORD pid, wchar_t* buf,
-    size_t buf_len) {
-  return _snwprintf(buf, buf_len, L"node-debug-handler-%u", pid);
-}
-
-
-static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = args.GetIsolate();
-
-  if (args.Length() != 1) {
-    env->ThrowError("Invalid number of arguments.");
-    return;
-  }
-
-  HANDLE process = nullptr;
-  HANDLE thread = nullptr;
-  HANDLE mapping = nullptr;
-  wchar_t mapping_name[32];
-  LPTHREAD_START_ROUTINE* handler = nullptr;
-  DWORD pid = 0;
-
-  OnScopeLeave cleanup([&]() {
-    if (process != nullptr)
-      CloseHandle(process);
-    if (thread != nullptr)
-      CloseHandle(thread);
-    if (handler != nullptr)
-      UnmapViewOfFile(handler);
-    if (mapping != nullptr)
-      CloseHandle(mapping);
-  });
-
-  CHECK(args[0]->IsNumber());
-  pid = args[0].As<Integer>()->Value();
-
-  process = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
-                            PROCESS_VM_OPERATION | PROCESS_VM_WRITE |
-                            PROCESS_VM_READ,
-                        FALSE,
-                        pid);
-  if (process == nullptr) {
-    isolate->ThrowException(
-        WinapiErrnoException(isolate, GetLastError(), "OpenProcess"));
-    return;
-  }
-
-  if (GetDebugSignalHandlerMappingName(pid,
-                                       mapping_name,
-                                       arraysize(mapping_name)) < 0) {
-    env->ThrowErrnoException(errno, "sprintf");
-    return;
-  }
-
-  mapping = OpenFileMappingW(FILE_MAP_READ, FALSE, mapping_name);
-  if (mapping == nullptr) {
-    isolate->ThrowException(WinapiErrnoException(isolate,
-                                             GetLastError(),
-                                             "OpenFileMappingW"));
-    return;
-  }
-
-  handler = reinterpret_cast<LPTHREAD_START_ROUTINE*>(
-      MapViewOfFile(mapping,
-                    FILE_MAP_READ,
-                    0,
-                    0,
-                    sizeof *handler));
-  if (handler == nullptr || *handler == nullptr) {
-    isolate->ThrowException(
-        WinapiErrnoException(isolate, GetLastError(), "MapViewOfFile"));
-    return;
-  }
-
-  thread = CreateRemoteThread(process,
-                              nullptr,
-                              0,
-                              *handler,
-                              nullptr,
-                              0,
-                              nullptr);
-  if (thread == nullptr) {
-    isolate->ThrowException(WinapiErrnoException(isolate,
-                                                 GetLastError(),
-                                                 "CreateRemoteThread"));
-    return;
-  }
-
-  // Wait for the thread to terminate
-  if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
-    isolate->ThrowException(WinapiErrnoException(isolate,
-                                                 GetLastError(),
-                                                 "WaitForSingleObject"));
-    return;
-  }
-}
-#endif  // _WIN32
-
-
-static void DebugEnd(const FunctionCallbackInfo<Value>& args) {
-#if HAVE_INSPECTOR
-  Environment* env = Environment::GetCurrent(args);
-  if (env->inspector_agent()->IsListening()) {
-    env->inspector_agent()->Stop();
-  }
-#endif
-}
-
 
 inline void PlatformInit() {
 #ifdef __POSIX__

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -44,6 +44,7 @@
   V(performance)                                                               \
   V(pipe_wrap)                                                                 \
   V(process_wrap)                                                              \
+  V(process_methods)                                                           \
   V(serdes)                                                                    \
   V(signal_wrap)                                                               \
   V(spawn_sync)                                                                \

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -119,6 +119,7 @@ void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
+void Exit(const v8::FunctionCallbackInfo<v8::Value>& args);
 void SignalExit(int signo);
 #ifdef __POSIX__
 void RegisterSignalHandler(int signal,
@@ -698,21 +699,7 @@ static inline const char* errno_string(int errorno) {
 
 extern double prog_start_time;
 
-void Abort(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Chdir(const v8::FunctionCallbackInfo<v8::Value>& args);
-void CPUUsage(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Cwd(const v8::FunctionCallbackInfo<v8::Value>& args);
-void GetActiveHandles(const v8::FunctionCallbackInfo<v8::Value>& args);
-void GetActiveRequests(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Hrtime(const v8::FunctionCallbackInfo<v8::Value>& args);
-void HrtimeBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Kill(const v8::FunctionCallbackInfo<v8::Value>& args);
-void MemoryUsage(const v8::FunctionCallbackInfo<v8::Value>& args);
 void RawDebug(const v8::FunctionCallbackInfo<v8::Value>& args);
-void StartProfilerIdleNotifier(const v8::FunctionCallbackInfo<v8::Value>& args);
-void StopProfilerIdleNotifier(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Umask(const v8::FunctionCallbackInfo<v8::Value>& args);
-void Uptime(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 void DebugPortGetter(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value>& info);

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const isMainThread = common.isMainThread;
-const kMaxModuleCount = isMainThread ? 60 : 82;
+const kMaxModuleCount = isMainThread ? 61 : 83;
 
 assert(list.length <= kMaxModuleCount,
        `Total length: ${list.length}\n` + list.join('\n')


### PR DESCRIPTION
Instead of:

- Writing methods onto the process directly in C++ during
  `SetupProcessObject()` and overwrite with argument checks later
- Or, wrapping and writing them in `internal/process/*.js`

Do:

- Move the C++ implementations in node_process.cc and mark them static
  wherever possible
- Expose the C++ methods through a new
  `internalBinding('process_methods')`
- Wrap the methods in `internal/process/*.js` in a
  side-effect-free manner and return them back to
  `internal/bootstrap/node.js`
- Centralize the write to the process object based on conditions
  in `bootstrap/node.js`

So it's easier to see what methods are attached to the process object
during bootstrap under what condition and in what order.

The eventual goal is to figure out the dependency of process methods
and the write/read access to the process object during bootstrap, group
these access properly and remove the process properties that should not
be exposed to users this way.

Also correct the NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE milestone
which should be marked before code execution.

Refs: https://github.com/nodejs/node/issues/24961

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
