### PR TITLE
trace_events: move SetupTraceCategoryState into node_trace_events.cc

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -18,7 +18,6 @@
 /* global isMainThread */
 
 const {
-  _setupTraceCategoryState,
   _setupNextTick,
   _setupPromises, _chdir, _cpuUsage,
   _hrtime, _hrtimeBigInt,
@@ -384,7 +383,10 @@ function readAndExecuteStdin() {
 }
 
 function setupTraceCategoryState() {
-  const { traceCategoryState } = internalBinding('trace_events');
+  const {
+    traceCategoryState,
+    setupTraceCategoryState
+  } = internalBinding('trace_events');
   const kCategoryAsyncHooks = 0;
   let traceEventsAsyncHook;
 
@@ -406,7 +408,7 @@ function setupTraceCategoryState() {
   }
 
   toggleTraceCategoryState();
-  _setupTraceCategoryState(toggleTraceCategoryState);
+  setupTraceCategoryState(toggleTraceCategoryState);
 }
 
 function setupProcessObject() {

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -30,12 +30,6 @@ void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {
   args.GetIsolate()->RunMicrotasks();
 }
 
-void SetupTraceCategoryState(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  CHECK(args[0]->IsFunction());
-  env->set_trace_category_state_function(args[0].As<Function>());
-}
-
 void SetupNextTick(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -136,7 +130,6 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 // completes so that it can be gc'd as soon as possible.
 void SetupBootstrapObject(Environment* env,
                           Local<Object> bootstrapper) {
-  BOOTSTRAP_METHOD(_setupTraceCategoryState, SetupTraceCategoryState);
   BOOTSTRAP_METHOD(_setupNextTick, SetupNextTick);
   BOOTSTRAP_METHOD(_setupPromises, SetupPromises);
   BOOTSTRAP_METHOD(_chdir, Chdir);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -11,6 +11,7 @@ namespace node {
 
 using v8::Array;
 using v8::Context;
+using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Local;
@@ -102,6 +103,12 @@ void GetEnabledCategories(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static void SetupTraceCategoryState(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsFunction());
+  env->set_trace_category_state_function(args[0].As<Function>());
+}
+
 void NodeCategorySet::Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -109,6 +116,7 @@ void NodeCategorySet::Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "getEnabledCategories", GetEnabledCategories);
+  env->SetMethod(target, "setupTraceCategoryState", SetupTraceCategoryState);
 
   Local<FunctionTemplate> category_set =
       env->NewFunctionTemplate(NodeCategorySet::New);


### PR DESCRIPTION
It makes more sense to put it in `internalBinding('trace_events')`
instead of in the bootstrapper object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
