### PR TITLE
src: only expose per-isolate symbols wherever necessary

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -12,11 +12,12 @@ const {
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
 
-const { MessagePort, MessageChannel } = internalBinding('messaging');
 const {
-  handle_onclose: handleOnCloseSymbol,
-  oninit: onInitSymbol
-} = internalBinding('symbols');
+  MessagePort,
+  MessageChannel,
+  handleOnCloseSymbol,
+  onInitSymbol
+} = internalBinding('messaging');
 const { clearAsyncIdStack } = require('internal/async_hooks');
 const { serializeError, deserializeError } = require('internal/error-serdes');
 const { pathToFileURL } = require('url');

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -156,22 +156,4 @@ void SetupBootstrapObject(Environment* env,
 }
 #undef BOOTSTRAP_METHOD
 
-namespace symbols {
-
-void Initialize(Local<Object> target,
-                Local<Value> unused,
-                Local<Context> context,
-                void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-#define V(PropertyName, StringValue)                                        \
-    target->Set(env->context(),                                             \
-               env->PropertyName()->Name(),                                 \
-               env->PropertyName()).FromJust();
-  PER_ISOLATE_SYMBOL_PROPERTIES(V)
-#undef V
-}
-
-}  // namespace symbols
 }  // namespace node
-
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(symbols, node::symbols::Initialize)

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -54,7 +54,6 @@
   V(stream_pipe)                                                               \
   V(stream_wrap)                                                               \
   V(string_decoder)                                                            \
-  V(symbols)                                                                   \
   V(tcp_wrap)                                                                  \
   V(timers)                                                                    \
   V(trace_events)                                                              \

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -784,6 +784,18 @@ static void InitMessaging(Local<Object> target,
                   .FromJust();
 
   env->SetMethod(target, "registerDOMException", RegisterDOMException);
+
+  // Used to add methods to MessagePort.prototype
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "handleOnCloseSymbol"),
+            env->handle_onclose_symbol())
+      .FromJust();
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "onInitSymbol"),
+            env->oninit_symbol())
+      .FromJust();
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Currently the all-in-one `internalBinding('symbols')`
is only used in the MessagePort prototype setup.
Until we actually need to share these symbols across multiple files,
only expose them wherever necessary and make them as local as
possible.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
