### PR TITLE
test: add hasCrypto check to common flags check

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -36,6 +36,8 @@ const {
 
 const noop = () => {};
 
+const hasCrypto = Boolean(process.versions.openssl);
+
 const isMainThread = (() => {
   try {
     return require('worker_threads').isMainThread;
@@ -73,6 +75,9 @@ if (process.argv.length === 2 &&
     const args = process.execArgv.map((arg) => arg.replace(/_/g, '-'));
     for (const flag of flags) {
       if (!args.includes(flag) &&
+          // If the binary was built without-ssl then the crypto flags are
+          // invalid (bad option). The test itself should handle this case.
+          hasCrypto &&
           // If the binary is build without `intl` the inspect option is
           // invalid. The test itself should handle this case.
           (process.config.variables.v8_enable_inspector !== 0 ||
@@ -105,7 +110,6 @@ const rootDir = isWindows ? 'c:\\' : '/';
 
 const buildType = process.config.target_defaults.default_configuration;
 
-const hasCrypto = Boolean(process.versions.openssl);
 
 // If env var is set then enable async_hook hooks for all tests.
 if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {


### PR DESCRIPTION
Currently, if node is configured `--without-ssl` there will be a number of
test errors related to crypto flags:
```console
Error: Test has to be started with the flag: '--tls-v1.1'
```
This commit adds a hasCrypto check to the flags checking similar to what
is done for `--without-intl`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
