### PR TITLE
v8: fix call of its own deprecated API

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.7',
+    'v8_embedder_string': '-node.8',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2631,8 +2631,7 @@ class V8_EXPORT String : public Name {
    public:
     virtual ~ExternalStringResourceBase() = default;
 
-    V8_DEPRECATE_SOON("Use IsCacheable().",
-                      virtual bool IsCompressible() const) {
+    V8_DEPRECATED("Use IsCacheable().", virtual bool IsCompressible() const) {
       return false;
     }
 
@@ -2641,16 +2640,7 @@ class V8_EXPORT String : public Name {
      * ExternalStringResource::data() may be cached, otherwise it is not
      * expected to be stable beyond the current top-level task.
      */
-    virtual bool IsCacheable() const {
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-      return !IsCompressible();
-#if __clang__
-#pragma clang diagnostic pop
-#endif
-    }
+    virtual bool IsCacheable() const { return true; }
 
    protected:
     ExternalStringResourceBase() = default;


### PR DESCRIPTION
   v8.h contains calls to the deprecated IsCompressible() API causing a
    deprecated warning for every include of v8.h. The warning is disabled
    for clang, but GNU compiler chains. Developer builds and ci build logs
    are filled with pages and pages of warnings at the moment.

@targos @ofrobots  @nodejs/v8  can any of you upstream this? The procedure to do so is complex for me, technically and legally. I can do it, but if its trivial for you it would be great if this could be fixed.

Btw, I don't have clang, but I suspect that it may support `GCC` pragmas, in which case the easier fix would to be to just change `#pragma clang` to `#pragma GCC` instead of a new if block for `GCC`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
