### PR TITLE
buffer: inspect extra properties

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -39,6 +39,13 @@ const {
 } = internalBinding('buffer');
 const { isAnyArrayBuffer } = internalBinding('types');
 const {
+  getOwnNonIndexProperties,
+  propertyFilter: {
+    ALL_PROPERTIES,
+    ONLY_ENUMERABLE
+  }
+} = internalBinding('util');
+const {
   customInspectSymbol,
   isInsideNodeModules,
   normalizeEncoding,
@@ -48,6 +55,10 @@ const {
   isArrayBufferView,
   isUint8Array
 } = require('internal/util/types');
+const {
+  formatProperty,
+  kObjectType
+} = require('internal/util/inspect');
 
 const {
   ERR_BUFFER_OUT_OF_BOUNDS,
@@ -671,10 +682,20 @@ Buffer.prototype.equals = function equals(otherBuffer) {
 Buffer.prototype[customInspectSymbol] = function inspect(recurseTimes, ctx) {
   const max = exports.INSPECT_MAX_BYTES;
   const actualMax = Math.min(max, this.length);
-  let str = this.hexSlice(0, actualMax).replace(/(.{2})/g, '$1 ').trim();
   const remaining = this.length - max;
+  let str = this.hexSlice(0, actualMax).replace(/(.{2})/g, '$1 ').trim();
   if (remaining > 0)
     str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
+  // Inspect special properties as well, if possible.
+  if (ctx) {
+    const filter = ctx.showHidden ? ALL_PROPERTIES : ONLY_ENUMERABLE;
+    str += getOwnNonIndexProperties(this, filter).reduce((str, key) => {
+      // Using `formatProperty()` expects an indentationLvl to be set.
+      ctx.indentationLvl = 0;
+      str += `, ${formatProperty(ctx, this, recurseTimes, key, kObjectType)}`;
+      return str;
+    }, '');
+  }
   return `<${this.constructor.name} ${str}>`;
 };
 Buffer.prototype.inspect = Buffer.prototype[customInspectSymbol];

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1214,5 +1214,7 @@ function reduceToSingleString(ctx, output, base, braces) {
 }
 
 module.exports = {
-  inspect
+  inspect,
+  formatProperty,
+  kObjectType
 };

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -55,4 +55,4 @@ assert.strictEqual(util.inspect(b), expected);
 assert.strictEqual(util.inspect(s), expected);
 
 b.inspect = undefined;
-assert.strictEqual(util.inspect(b), expected);
+assert.strictEqual(util.inspect(b), '<Buffer 31 32, inspect: undefined>');


### PR DESCRIPTION
This makes sure extra properties on buffers are not ignored anymore
when inspecting the buffer.

I am not sure about this either being a patch or semver-major. We mainly consider changes to `util.inspect` as patch, so I guess this could be considered a similar thing.

The implementation uses some internal knowledge and it would require more overhead otherwise but this seemed the most straight forward way to do this.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
