### PR TITLE
buffer: set toStringTag to buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -68,6 +68,13 @@ const { setupBufferJS } = internalBuffer;
 const bindingObj = {};
 
 class FastBuffer extends Uint8Array {}
+// Make a Buffer look like such for a `Object.prototype.toString.call()`.
+Object.defineProperty(FastBuffer.prototype, Symbol.toStringTag, {
+  value: 'Buffer',
+  configurable: true,
+  writable: true,
+  enumerable: false
+});
 FastBuffer.prototype.constructor = Buffer;
 internalBuffer.FastBuffer = FastBuffer;
 

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -53,7 +53,7 @@ assert.throws(
     code: 'ERR_ASSERTION',
     message: `${defaultMsgStartFull} ... Lines skipped\n\n` +
              '+ Uint8Array [\n' +
-             '- Buffer [Uint8Array] [\n    120,\n...\n    10\n  ]'
+             '- Buffer [\n    120,\n...\n    10\n  ]'
   }
 );
 assert.deepEqual(arr, buf);
@@ -67,7 +67,7 @@ assert.deepEqual(arr, buf);
     {
       code: 'ERR_ASSERTION',
       message: `${defaultMsgStartFull} ... Lines skipped\n\n` +
-               '  Buffer [Uint8Array] [\n' +
+               '  Buffer [\n' +
                '    120,\n' +
                '...\n' +
                '    10,\n' +

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -56,3 +56,5 @@ assert.strictEqual(util.inspect(s), expected);
 
 b.inspect = undefined;
 assert.strictEqual(util.inspect(b), expected);
+
+assert.strictEqual(Object.prototype.toString.call(b), '[object Buffer]');


### PR DESCRIPTION
This makes sure using `Object.prototype.toString.call()` on a
buffer does not return `[object Uint8Array]` but `[object Buffer]`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
