### PR TITLE
buffer: fix crash for invalid index types

### DIFF
--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -26,6 +26,17 @@ let cntr = 0;
 }
 
 {
+  // Current behavior is to coerce values to integers.
+  b.fill(++cntr);
+  c.fill(++cntr);
+  const copied = b.copy(c, '0', '0', '512');
+  assert.strictEqual(copied, 512);
+  for (let i = 0; i < c.length; i++) {
+    assert.strictEqual(c[i], b[i]);
+  }
+}
+
+{
   // copy c into b, without specifying sourceEnd
   b.fill(++cntr);
   c.fill(++cntr);
@@ -151,4 +162,19 @@ assert.strictEqual(b.copy(c, 512, 0, 10), 0);
   for (let i = 0; i < c.length; i++) {
     assert.strictEqual(c[i], e[i]);
   }
+}
+
+// https://github.com/nodejs/node/issues/23668: Do not crash for invalid input.
+c.fill('c');
+b.copy(c, 'not a valid offset');
+// Make sure this acted like a regular copy with `0` offset.
+assert.deepStrictEqual(c, b.slice(0, c.length));
+
+{
+  c.fill('C');
+  assert.throws(() => {
+    b.copy(c, { [Symbol.toPrimitive]() { throw new Error('foo'); } });
+  }, /foo/);
+  // No copying took place:
+  assert.deepStrictEqual(c.toString(), 'C'.repeat(c.length));
 }


### PR DESCRIPTION
This is a forward-port of v10.x’s https://github.com/nodejs/node/pull/23795, which was originally targeting master, to fix https://github.com/nodejs/node/issues/23668.

As part of the discussion back then, we wanted to explore a “fix” for v11.x and master that involved introducing typechecking along the lines of https://github.com/nodejs/node/pull/23840, but since that hasn’t happened, it seems like a good idea to apply this on all affected branches, in order to make sure the bug is fixed everywhere.

This does *not* keep https://github.com/nodejs/node/pull/23840 from happening in any way (except that this makes it a semver-major PR).

---

2555cb4a4049dc4c41d8a2f4ce50909cc0a12a4a introduced a crash
when a non-number value was passed to `ParseArrayIndex()`.

We do not always have JS typechecking for that in place, though.
This returns back to the previous behavior of coercing values
to integers, which is certainly questionable.

Refs: https://github.com/nodejs/node/pull/22129
Fixes: https://github.com/nodejs/node/issues/23668

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
