### PR TITLE
fs: reduce redundant callback check

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1571,7 +1571,7 @@ realpathSync.native = (path, options) => {
 
 
 function realpath(p, options, callback) {
-  callback = maybeCallback(typeof options === 'function' ? options : callback);
+  callback = typeof options === 'function' ? options : maybeCallback(callback);
   if (!options)
     options = emptyObj;
   else


### PR DESCRIPTION
If `options` is a function, we don't need to call `maybeCallback` to check it again.
https://github.com/nodejs/node/blob/4ac170251bc44563755576d8dea1f46c715bac8d/lib/fs.js#L130-L135
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
