### PR TITLE
fs: remove use less internalFS

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -52,7 +52,6 @@ const {
 } = errors.codes;
 
 const { FSReqCallback, statValues } = binding;
-const internalFS = require('internal/fs/utils');
 const { toPathIfFileURL } = require('internal/url');
 const internalUtil = require('internal/util');
 const {
@@ -72,7 +71,7 @@ const {
   validateOffsetLengthRead,
   validateOffsetLengthWrite,
   validatePath
-} = internalFS;
+} = require('internal/fs/utils');
 const {
   CHAR_FORWARD_SLASH,
   CHAR_BACKWARD_SLASH,


### PR DESCRIPTION
`internalFS` is just used once in the whole `fs.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
