### PR TITLE
util: simplify code

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -267,10 +267,9 @@ function promisify(original) {
     if (typeof fn !== 'function') {
       throw new ERR_INVALID_ARG_TYPE('util.promisify.custom', 'Function', fn);
     }
-    Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+    return Object.defineProperty(fn, kCustomPromisifiedSymbol, {
       value: fn, enumerable: false, writable: false, configurable: true
     });
-    return fn;
   }
 
   // Names to create an object from in case the callback receives multiple


### PR DESCRIPTION
Simplify code by using return value of Object.defineProperty directly.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
