### PR TITLE
src: set up process.nextTick and promise handlers with internalBinding('task_queue')

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -14,13 +14,9 @@
 
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::LoadEnvironment()
-/* global process, bootstrappers, loaderExports, triggerFatalException */
+/* global process, loaderExports, triggerFatalException */
 /* global isMainThread */
 
-const {
-  _setupNextTick,
-  _setupPromises
-} = bootstrappers;
 const { internalBinding, NativeModule } = loaderExports;
 
 const exceptionHandlerState = { captureFn: null };
@@ -105,8 +101,18 @@ function startup() {
   }
 
   NativeModule.require('internal/process/warning').setup();
-  NativeModule.require('internal/process/next_tick').setup(_setupNextTick,
-                                                           _setupPromises);
+  const {
+    nextTick,
+    runNextTicks
+  } = NativeModule.require('internal/process/next_tick').setup();
+
+  process.nextTick = nextTick;
+  // Used to emulate a tick manually in the JS land.
+  // A better name for this function would be `runNextTicks` but
+  // it has been exposed to the process object so we keep this legacy name
+  // TODO(joyeecheung): either remove it or make it public
+  process._tickCallback = runNextTicks;
+
   const credentials = internalBinding('credentials');
   if (credentials.implementsPosixCredentials) {
     process.getuid = credentials.getuid;

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -1,128 +1,138 @@
 'use strict';
 
-exports.setup = setupNextTick;
+const {
+  // For easy access to the nextTick state in the C++ land,
+  // and to avoid unnecessary calls into JS land.
+  tickInfo,
+  // Used to run V8's micro task queue.
+  runMicrotasks,
+  setTickCallback,
+  initializePromiseRejectCallback
+} = internalBinding('task_queue');
 
-function setupNextTick(_setupNextTick, _setupPromises) {
-  const {
-    getDefaultTriggerAsyncId,
-    newAsyncId,
-    initHooksExist,
-    destroyHooksExist,
-    emitInit,
-    emitBefore,
-    emitAfter,
-    emitDestroy,
-    symbols: { async_id_symbol, trigger_async_id_symbol }
-  } = require('internal/async_hooks');
-  const emitPromiseRejectionWarnings =
-    require('internal/process/promises').setup(_setupPromises);
-  const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
-  const FixedQueue = require('internal/fixed_queue');
+const {
+  promiseRejectHandler,
+  emitPromiseRejectionWarnings
+} = require('internal/process/promises');
 
-  // tickInfo is used so that the C++ code in src/node.cc can
-  // have easy access to our nextTick state, and avoid unnecessary
-  // calls into JS land.
-  // runMicrotasks is used to run V8's micro task queue.
-  const [
-    tickInfo,
-    runMicrotasks
-  ] = _setupNextTick(internalTickCallback);
+const {
+  getDefaultTriggerAsyncId,
+  newAsyncId,
+  initHooksExist,
+  destroyHooksExist,
+  emitInit,
+  emitBefore,
+  emitAfter,
+  emitDestroy,
+  symbols: { async_id_symbol, trigger_async_id_symbol }
+} = require('internal/async_hooks');
+const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
+const FixedQueue = require('internal/fixed_queue');
 
-  // *Must* match Environment::TickInfo::Fields in src/env.h.
-  const kHasScheduled = 0;
-  const kHasPromiseRejections = 1;
+// *Must* match Environment::TickInfo::Fields in src/env.h.
+const kHasScheduled = 0;
+const kHasPromiseRejections = 1;
 
-  const queue = new FixedQueue();
+const queue = new FixedQueue();
 
-  process.nextTick = nextTick;
-  // Needs to be accessible from beyond this scope.
-  process._tickCallback = _tickCallback;
+function runNextTicks() {
+  if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
+    runMicrotasks();
+  if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
+    return;
 
-  function _tickCallback() {
-    if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
-      runMicrotasks();
-    if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
-      return;
+  internalTickCallback();
+}
 
-    internalTickCallback();
-  }
+function internalTickCallback() {
+  let tock;
+  do {
+    while (tock = queue.shift()) {
+      const asyncId = tock[async_id_symbol];
+      emitBefore(asyncId, tock[trigger_async_id_symbol]);
+      // emitDestroy() places the async_id_symbol into an asynchronous queue
+      // that calls the destroy callback in the future. It's called before
+      // calling tock.callback so destroy will be called even if the callback
+      // throws an exception that is handled by 'uncaughtException' or a
+      // domain.
+      // TODO(trevnorris): This is a bit of a hack. It relies on the fact
+      // that nextTick() doesn't allow the event loop to proceed, but if
+      // any async hooks are enabled during the callback's execution then
+      // this tock's after hook will be called, but not its destroy hook.
+      if (destroyHooksExist())
+        emitDestroy(asyncId);
 
-  function internalTickCallback() {
-    let tock;
-    do {
-      while (tock = queue.shift()) {
-        const asyncId = tock[async_id_symbol];
-        emitBefore(asyncId, tock[trigger_async_id_symbol]);
-        // emitDestroy() places the async_id_symbol into an asynchronous queue
-        // that calls the destroy callback in the future. It's called before
-        // calling tock.callback so destroy will be called even if the callback
-        // throws an exception that is handled by 'uncaughtException' or a
-        // domain.
-        // TODO(trevnorris): This is a bit of a hack. It relies on the fact
-        // that nextTick() doesn't allow the event loop to proceed, but if
-        // any async hooks are enabled during the callback's execution then
-        // this tock's after hook will be called, but not its destroy hook.
-        if (destroyHooksExist())
-          emitDestroy(asyncId);
+      const callback = tock.callback;
+      if (tock.args === undefined)
+        callback();
+      else
+        Reflect.apply(callback, undefined, tock.args);
 
-        const callback = tock.callback;
-        if (tock.args === undefined)
-          callback();
-        else
-          Reflect.apply(callback, undefined, tock.args);
-
-        emitAfter(asyncId);
-      }
-      tickInfo[kHasScheduled] = 0;
-      runMicrotasks();
-    } while (!queue.isEmpty() || emitPromiseRejectionWarnings());
-    tickInfo[kHasPromiseRejections] = 0;
-  }
-
-  class TickObject {
-    constructor(callback, args, triggerAsyncId) {
-      // This must be set to null first to avoid function tracking
-      // on the hidden class, revisit in V8 versions after 6.2
-      this.callback = null;
-      this.callback = callback;
-      this.args = args;
-
-      const asyncId = newAsyncId();
-      this[async_id_symbol] = asyncId;
-      this[trigger_async_id_symbol] = triggerAsyncId;
-
-      if (initHooksExist()) {
-        emitInit(asyncId,
-                 'TickObject',
-                 triggerAsyncId,
-                 this);
-      }
+      emitAfter(asyncId);
     }
-  }
+    tickInfo[kHasScheduled] = 0;
+    runMicrotasks();
+  } while (!queue.isEmpty() || emitPromiseRejectionWarnings());
+  tickInfo[kHasPromiseRejections] = 0;
+}
 
-  // `nextTick()` will not enqueue any callback when the process is about to
-  // exit since the callback would not have a chance to be executed.
-  function nextTick(callback) {
-    if (typeof callback !== 'function')
-      throw new ERR_INVALID_CALLBACK();
+class TickObject {
+  constructor(callback, args, triggerAsyncId) {
+    // This must be set to null first to avoid function tracking
+    // on the hidden class, revisit in V8 versions after 6.2
+    this.callback = null;
+    this.callback = callback;
+    this.args = args;
 
-    if (process._exiting)
-      return;
+    const asyncId = newAsyncId();
+    this[async_id_symbol] = asyncId;
+    this[trigger_async_id_symbol] = triggerAsyncId;
 
-    var args;
-    switch (arguments.length) {
-      case 1: break;
-      case 2: args = [arguments[1]]; break;
-      case 3: args = [arguments[1], arguments[2]]; break;
-      case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
-      default:
-        args = new Array(arguments.length - 1);
-        for (var i = 1; i < arguments.length; i++)
-          args[i - 1] = arguments[i];
+    if (initHooksExist()) {
+      emitInit(asyncId,
+               'TickObject',
+               triggerAsyncId,
+               this);
     }
-
-    if (queue.isEmpty())
-      tickInfo[kHasScheduled] = 1;
-    queue.push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
   }
 }
+
+// `nextTick()` will not enqueue any callback when the process is about to
+// exit since the callback would not have a chance to be executed.
+function nextTick(callback) {
+  if (typeof callback !== 'function')
+    throw new ERR_INVALID_CALLBACK();
+
+  if (process._exiting)
+    return;
+
+  var args;
+  switch (arguments.length) {
+    case 1: break;
+    case 2: args = [arguments[1]]; break;
+    case 3: args = [arguments[1], arguments[2]]; break;
+    case 4: args = [arguments[1], arguments[2], arguments[3]]; break;
+    default:
+      args = new Array(arguments.length - 1);
+      for (var i = 1; i < arguments.length; i++)
+        args[i - 1] = arguments[i];
+  }
+
+  if (queue.isEmpty())
+    tickInfo[kHasScheduled] = 1;
+  queue.push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
+}
+
+// TODO(joyeecheung): make this a factory class so that node.js can
+// control the side effects caused by the initializers.
+exports.setup = function() {
+  // Initializes the per-isolate promise rejection callback which
+  // will call the handler being passed into this function.
+  initializePromiseRejectCallback(promiseRejectHandler);
+  // Sets the callback to be run in every tick.
+  setTickCallback(internalTickCallback);
+  return {
+    nextTick,
+    runNextTicks
+  };
+};

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -1,21 +1,16 @@
 'use strict';
 
 const { safeToString } = internalBinding('util');
+const {
+  promiseRejectEvents
+} = internalBinding('task_queue');
 
 const maybeUnhandledPromises = new WeakMap();
 const pendingUnhandledRejections = [];
 const asyncHandledRejections = [];
-const promiseRejectEvents = {};
 let lastPromiseId = 0;
 
-exports.setup = setupPromises;
-
-function setupPromises(_setupPromises) {
-  _setupPromises(handler, promiseRejectEvents);
-  return emitPromiseRejectionWarnings;
-}
-
-function handler(type, promise, reason) {
+function promiseRejectHandler(type, promise, reason) {
   switch (type) {
     case promiseRejectEvents.kPromiseRejectWithNoHandler:
       return unhandledRejection(promise, reason);
@@ -124,3 +119,8 @@ function emitPromiseRejectionWarnings() {
   }
   return maybeScheduledTicks || pendingUnhandledRejections.length !== 0;
 }
+
+module.exports = {
+  promiseRejectHandler,
+  emitPromiseRejectionWarnings
+};

--- a/node.gyp
+++ b/node.gyp
@@ -325,7 +325,6 @@
 
       'sources': [
         'src/async_wrap.cc',
-        'src/bootstrapper.cc',
         'src/callback_scope.cc',
         'src/cares_wrap.cc',
         'src/connect_wrap.cc',
@@ -372,6 +371,7 @@
         'src/node_serdes.cc',
         'src/node_stat_watcher.cc',
         'src/node_symbols.cc',
+        'src/node_task_queue.cc',
         'src/node_trace_events.cc',
         'src/node_types.cc',
         'src/node_url.cc',

--- a/node.gyp
+++ b/node.gyp
@@ -371,6 +371,7 @@
         'src/node_process.cc',
         'src/node_serdes.cc',
         'src/node_stat_watcher.cc',
+        'src/node_symbols.cc',
         'src/node_trace_events.cc',
         'src/node_types.cc',
         'src/node_url.cc',

--- a/src/bootstrapper.cc
+++ b/src/bootstrapper.cc
@@ -135,22 +135,4 @@ void SetupBootstrapObject(Environment* env,
 }
 #undef BOOTSTRAP_METHOD
 
-namespace symbols {
-
-void Initialize(Local<Object> target,
-                Local<Value> unused,
-                Local<Context> context,
-                void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-#define V(PropertyName, StringValue)                                        \
-    target->Set(env->context(),                                             \
-               env->PropertyName()->Name(),                                 \
-               env->PropertyName()).FromJust();
-  PER_ISOLATE_SYMBOL_PROPERTIES(V)
-#undef V
-}
-
-}  // namespace symbols
 }  // namespace node
-
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(symbols, node::symbols::Initialize)

--- a/src/env.h
+++ b/src/env.h
@@ -358,7 +358,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(performance_entry_template, v8::Function)                                  \
   V(pipe_constructor_template, v8::FunctionTemplate)                           \
   V(process_object, v8::Object)                                                \
-  V(promise_handler_function, v8::Function)                                    \
+  V(promise_reject_callback, v8::Function)                                     \
   V(promise_wrap_template, v8::ObjectTemplate)                                 \
   V(sab_lifetimepartner_constructor_template, v8::FunctionTemplate)            \
   V(script_context_constructor_template, v8::FunctionTemplate)                 \
@@ -373,7 +373,7 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(tty_constructor_template, v8::FunctionTemplate)                            \
   V(udp_constructor_function, v8::Function)                                    \
   V(url_constructor_function, v8::Function)                                    \
-  V(write_wrap_template, v8::ObjectTemplate)                                   \
+  V(write_wrap_template, v8::ObjectTemplate)
 
 class Environment;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1200,20 +1200,14 @@ void LoadEnvironment(Environment* env) {
     return;
   }
 
-  // Bootstrap Node.js
-  Local<Object> bootstrapper = Object::New(env->isolate());
-  SetupBootstrapObject(env, bootstrapper);
-
   // process, bootstrappers, loaderExports, triggerFatalException
   std::vector<Local<String>> node_params = {
       env->process_string(),
-      FIXED_ONE_BYTE_STRING(isolate, "bootstrappers"),
       FIXED_ONE_BYTE_STRING(isolate, "loaderExports"),
       FIXED_ONE_BYTE_STRING(isolate, "triggerFatalException"),
       FIXED_ONE_BYTE_STRING(isolate, "isMainThread")};
   std::vector<Local<Value>> node_args = {
       process,
-      bootstrapper,
       loader_exports.ToLocalChecked(),
       env->NewFunctionTemplate(FatalException)
           ->GetFunction(context)

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -52,6 +52,7 @@
   V(stream_wrap)                                                               \
   V(string_decoder)                                                            \
   V(symbols)                                                                   \
+  V(task_queue)                                                                \
   V(tcp_wrap)                                                                  \
   V(timers)                                                                    \
   V(trace_events)                                                              \

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -185,8 +185,6 @@ v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
                                               const char* warning,
                                               const char* deprecation_code);
 
-void SetupBootstrapObject(Environment* env,
-                          v8::Local<v8::Object> bootstrapper);
 void SetupProcessObject(Environment* env,
                         const std::vector<std::string>& args,
                         const std::vector<std::string>& exec_args);

--- a/src/node_symbols.cc
+++ b/src/node_symbols.cc
@@ -1,0 +1,29 @@
+#include "env-inl.h"
+#include "node_binding.h"
+
+namespace node {
+
+using v8::Context;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+namespace symbols {
+
+static void Initialize(Local<Object> target,
+                       Local<Value> unused,
+                       Local<Context> context,
+                       void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+#define V(PropertyName, StringValue)                                           \
+  target                                                                       \
+      ->Set(env->context(), env->PropertyName()->Name(), env->PropertyName())  \
+      .FromJust();
+  PER_ISOLATE_SYMBOL_PROPERTIES(V)
+#undef V
+}
+
+}  // namespace symbols
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(symbols, node::symbols::Initialize)

--- a/test/message/events_unhandled_error_nexttick.out
+++ b/test/message/events_unhandled_error_nexttick.out
@@ -16,7 +16,7 @@ Error
 Emitted 'error' event at:
     at process.nextTick (*events_unhandled_error_nexttick.js:*:*)
     at internalTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at process.runNextTicks [as _tickCallback] (internal/process/next_tick.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -5,7 +5,7 @@
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
     at internalTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at process.runNextTicks [as _tickCallback] (internal/process/next_tick.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)
     at startExecution (internal/bootstrap/node.js:*:*)

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -42,7 +42,7 @@
     at *
 (node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
     at handledRejection (internal/process/promises.js:*)
-    at handler (internal/process/promises.js:*)
+    at promiseRejectHandler (internal/process/promises.js:*)
     at Promise.then *
     at Promise.catch *
     at Immediate.setImmediate (*test*message*unhandled_promise_trace_warnings.js:*)

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const isMainThread = common.isMainThread;
-const kMaxModuleCount = isMainThread ? 62 : 83;
+const kMaxModuleCount = isMainThread ? 62 : 84;
 
 assert(list.length <= kMaxModuleCount,
        `Total length: ${list.length}\n` + list.join('\n')

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const isMainThread = common.isMainThread;
-const kMaxModuleCount = isMainThread ? 61 : 83;
+const kMaxModuleCount = isMainThread ? 62 : 83;
 
 assert(list.length <= kMaxModuleCount,
        `Total length: ${list.length}\n` + list.join('\n')


### PR DESCRIPTION
Please use https://github.com/nodejs/node/pull/25163/files?w=1 to skip indentation changes

#### src: move symbols binding into node_symbols.cc

#### src: move process.nextTick and promise setup into node_task_queue.cc

This patch:

- Moves the process.nextTick and promise setup C++ code into
  node_task_queue.cc which is exposed as
  `internalBinding('task_queue')`
- Makes `lib/internal/process/promises.js` and
  `lib/internal/process/next_tick.js` as side-effect-free
  as possible
- Removes the bootstrapper object being passed into
  `bootstrap/node.js`, let `next_tick.js` and `promises.js`
  load whatever they need from `internalBinding('task_queue')`
  instead.
- Rename `process._tickCallback` to `runNextTicks` internally
  for clarity but still expose it as `process._tickCallback`.

Refs: https://github.com/nodejs/node/issues/24961

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
