### PR TITLE
src: fix compiler warnings

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -841,9 +841,6 @@ static Local<Object> GetFeatures(Environment* env) {
   return scope.Escape(obj);
 }
 
-static void DebugProcess(const FunctionCallbackInfo<Value>& args);
-static void DebugEnd(const FunctionCallbackInfo<Value>& args);
-
 void SetupProcessObject(Environment* env,
                         const std::vector<std::string>& args,
                         const std::vector<std::string>& exec_args) {


### PR DESCRIPTION
The warnings in question are:

```
../src/node.cc:844:13: warning: unused function 'DebugProcess' [-Wunused-function]
static void DebugProcess(const FunctionCallbackInfo<Value>& args);
            ^
../src/node.cc:845:13: warning: unused function 'DebugEnd' [-Wunused-function]
static void DebugEnd(const FunctionCallbackInfo<Value>& args);
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
