### PR TITLE
build: fix Windows shared lib build

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -878,7 +878,7 @@
                 '<(PRODUCT_DIR)/<(node_core_target_name).exe',
               ],
               'action': [
-                'mv', '<@(_inputs)', '<@(_outputs)',
+                'move', '<@(_inputs)', '<@(_outputs)',
               ],
             },
           ],


### PR DESCRIPTION
Fixes the following error running `vcbuild.bat dll release openssl-no-asm`:
```
...
  Finished generating code
  node.vcxproj -> C:\work\node\github\node\Release\\node-win.exe
  rename_node_bin_win
  'mv' is not recognized as an internal or external command,
  operable program or batch file.
C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\VC\VCTargets\Microsoft.CppCommon.targets(209,5): error MSB6006: "cmd.exe" exited with code 1. [C:\work\node\github\node\rename_node_bin_win.vcxproj]
```
[Full build log](https://gist.github.com/richardlau/5347274123e92a6cecd0bd536fa9d935).

cc @BethGriggs @rubys 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
