### PR TITLE
test: refactor stdio handling in test-esm-cjs-main

### DIFF
--- a/test/es-module/test-esm-cjs-main.js
+++ b/test/es-module/test-esm-cjs-main.js
@@ -8,21 +8,20 @@ const assert = require('assert');
 const entry = fixtures.path('/es-modules/cjs.js');
 
 const child = spawn(process.execPath, ['--experimental-modules', entry]);
-let experimentalWarning = false;
-let validatedExecution = false;
+let stderr = '';
+child.stderr.setEncoding('utf8');
 child.stderr.on('data', (data) => {
-  if (!experimentalWarning) {
-    experimentalWarning = true;
-    return;
-  }
-  throw new Error(data.toString());
+  stderr += data;
 });
+let stdout = '';
+child.stdout.setEncoding('utf8');
 child.stdout.on('data', (data) => {
-  assert.strictEqual(data.toString(), 'executed\n');
-  validatedExecution = true;
+  stdout += data;
 });
 child.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(validatedExecution, true);
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
+  assert.strictEqual(stdout, 'executed\n');
+  assert.strictEqual(stderr, `(node:${child.pid}) ` +
+      'ExperimentalWarning: The ESM module loader is experimental.\n');
 }));


### PR DESCRIPTION
Set encoding on the stderr/stdout streams instead of calling
data.toString(). Don't assume the complete expected messages arrive in
a single event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
