### PR TITLE
 lib: support overriding http\s.globalAgent

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const { Agent, globalAgent } = require('_http_agent');
+const httpAgent = require('_http_agent');
 const { ClientRequest } = require('_http_client');
 const { methods } = require('_http_common');
 const { IncomingMessage } = require('_http_incoming');
@@ -52,9 +52,8 @@ module.exports = {
   _connectionListener,
   METHODS: methods.slice().sort(),
   STATUS_CODES,
-  Agent,
+  Agent: httpAgent.Agent,
   ClientRequest,
-  globalAgent,
   IncomingMessage,
   OutgoingMessage,
   Server,
@@ -74,5 +73,16 @@ Object.defineProperty(module.exports, 'maxHeaderSize', {
     }
 
     return maxHeaderSize;
+  }
+});
+
+Object.defineProperty(module.exports, 'globalAgent', {
+  configurable: true,
+  enumerable: true,
+  get() {
+    return httpAgent.globalAgent;
+  },
+  set(value) {
+    httpAgent.globalAgent = value;
   }
 });

--- a/lib/https.js
+++ b/lib/https.js
@@ -296,7 +296,7 @@ function request(...args) {
     Object.assign(options, args.shift());
   }
 
-  options._defaultAgent = globalAgent;
+  options._defaultAgent = module.exports.globalAgent;
   args.unshift(options);
 
   return new ClientRequest(...args);

--- a/test/parallel/test-http-client-override-global-agent.js
+++ b/test/parallel/test-http-client-override-global-agent.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.Server(common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.end('Hello, World!');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent();
+  const name = agent.getName({ port: server.address().port });
+  http.globalAgent = agent;
+
+  makeRequest();
+  assert(agent.sockets.hasOwnProperty(name)); // agent has indeed been used
+}));
+
+function makeRequest() {
+  const req = http.get({
+    port: server.address().port
+  });
+  req.on('close', () =>
+    server.close());
+}

--- a/test/parallel/test-https-client-override-global-agent.js
+++ b/test/parallel/test-https-client-override-global-agent.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const https = require('https');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+const server = https.Server(options, common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.end('Hello, World!');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const agent = new https.Agent();
+  const name = agent.getName({ port: server.address().port });
+  https.globalAgent = agent;
+
+  makeRequest();
+  assert(agent.sockets.hasOwnProperty(name)); // agent has indeed been used
+}));
+
+function makeRequest() {
+  const req = https.get({
+    port: server.address().port
+  });
+  req.on('close', () =>
+    server.close());
+}


### PR DESCRIPTION
Overriding `require('http').globalAgent` and `require('https').globalAgent` is now respected by consequent requests.

In order to achieve that, the following changes were made:
1. `http`: `module.exports.globalAgent` is now defined through `Object.defineProperty`. Its getter and setter return \ set `require('_http_agent').globalAgent`.
2. `https`: the https `globalAgent` is not the same as `_http_agent`, and is defined in `https` module itself. Therefore, the fix here was to simply use `module.exports.globalAgent` to support mutation.
3. `test/parallel`: according tests were added for both `http` and `https`, where in both we create a server, set the default agent to a newly created instance and make a request to that server. We then assert that the given instance was actually used by inspecting its sockets property.

Fixes: https://github.com/nodejs/node/issues/23281

On a side note, this is my first contribution to the project. Would appreciate feedback :)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
