### PR TITLE
test: remove Files: comment processing from Python test runner

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -38,7 +38,6 @@ except NameError:
 
 
 FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
-FILES_PATTERN = re.compile(r"//\s+Files:(.*)")
 
 
 class SimpleTestCase(test.TestCase):
@@ -87,12 +86,6 @@ class SimpleTestCase(test.TestCase):
         print(': Skipping as node was compiled without crypto support')
       else:
         result += flags
-    files_match = FILES_PATTERN.search(source);
-    additional_files = []
-    if files_match:
-      additional_files += files_match.group(1).strip().split()
-    for a_file in additional_files:
-      result.append(join(dirname(self.config.root), '..', a_file))
 
     if self.additional_flags:
       result += self.additional_flags


### PR DESCRIPTION
We don't use any Files: comments in our tests so remove the Python code
for it from test/testpy/__init__.py.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
