### PR TITLE
src, lib: use internal/options for indicating breakFirstLine

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -83,6 +83,16 @@ function startup() {
     process._stopProfilerIdleNotifier = rawMethods._stopProfilerIdleNotifier;
   }
 
+  // Set up debugger related options
+  {
+    process._breakFirstLine = getOptionValue('--inspect-brk');
+    process._breakNodeFirstLine = getOptionValue('--inspect-brk-node');
+    process._deprecatedDebugBrk = getOptionValue('--debug-brk') &&
+        process._breakFirstLine;
+    process._invalidDebug = getOptionValue('--debug') ||
+      getOptionValue('--debug-brk');
+  }
+
   // Set up methods on the process object for all threads
   {
     process.cwd = rawMethods.cwd;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -712,18 +712,12 @@ bool Agent::Start(const std::string& path,
     return false;
   }
 
-  // TODO(joyeecheung): we should not be using process as a global object
-  // to transport --inspect-brk. Instead, the JS land can get this through
-  // require('internal/options') since it should be set once CLI parsing
-  // is done.
   if (wait_for_connect) {
-    HandleScope scope(parent_env_->isolate());
-    parent_env_->process_object()->DefineOwnProperty(
-        parent_env_->context(),
-        FIXED_ONE_BYTE_STRING(parent_env_->isolate(), "_breakFirstLine"),
-        True(parent_env_->isolate()),
-        static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontEnum))
-        .FromJust();
+    // TODO(GauthamBanasandra): set this in another property
+    // of Environment and make it available to JS via
+    // an internal mechanism instead of proxying the state by
+    // fixing up the parsed CLI option
+    parent_env_->options()->get_debug_options()->break_first_line = true;
     client_->waitForFrontend();
   }
   return true;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1009,30 +1009,6 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
   }
 
-  // TODO(refack): move the following 4 to `node_config`
-  // --inspect-brk
-  if (env->options()->debug_options().wait_for_connect()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_breakFirstLine", True(env->isolate()));
-  }
-
-  if (env->options()->debug_options().break_node_first_line) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_breakNodeFirstLine", True(env->isolate()));
-  }
-
-  // --inspect --debug-brk
-  if (env->options()->debug_options().deprecated_invocation()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_deprecatedDebugBrk", True(env->isolate()));
-  }
-
-  // --debug or, --debug-brk without --inspect
-  if (env->options()->debug_options().invalid_invocation()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_invalidDebug", True(env->isolate()));
-  }
-
   // --security-revert flags
 #define V(code, _, __)                                                        \
   do {                                                                        \


### PR DESCRIPTION
Before:
_breakFirstLine was set onto process object.

After:
This is now indicated by --inspect-brk option, which can
be obtained from internal/options.

This commit resolves the following TODO -
https://github.com/nodejs/node/blob/master/src/inspector_agent.cc#L715-L718

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
