### PR TITLE
dns: fix TTL value for AAAA replies to `resolveAny()`

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1265,6 +1265,7 @@ class QueryAnyWrap: public QueryWrap {
     }
 
     CHECK_EQ(aaaa_count, naddr6ttls);
+    CHECK_EQ(ret->Length(), a_count + aaaa_count);
     for (uint32_t i = a_count; i < ret->Length(); i++) {
       Local<Object> obj = Object::New(env()->isolate());
       obj->Set(context,
@@ -1272,7 +1273,8 @@ class QueryAnyWrap: public QueryWrap {
                ret->Get(context, i).ToLocalChecked()).FromJust();
       obj->Set(context,
                env()->ttl_string(),
-               Integer::New(env()->isolate(), addr6ttls[i].ttl)).FromJust();
+               Integer::New(env()->isolate(), addr6ttls[i - a_count].ttl))
+          .FromJust();
       obj->Set(context,
                env()->type_string(),
                env()->dns_aaaa_string()).FromJust();

--- a/test/parallel/test-dns-resolveany.js
+++ b/test/parallel/test-dns-resolveany.js
@@ -53,8 +53,13 @@ server.bind(0, common.mustCall(async () => {
 }));
 
 function validateResults(res) {
-  // Compare copies with ttl removed, c-ares fiddles with that value.
-  assert.deepStrictEqual(
-    res.map((r) => Object.assign({}, r, { ttl: null })),
-    answers.map((r) => Object.assign({}, r, { ttl: null })));
+  // TTL values are only provided for A and AAAA entries.
+  assert.deepStrictEqual(res.map(maybeRedactTTL), answers.map(maybeRedactTTL));
+}
+
+function maybeRedactTTL(r) {
+  const ret = { ...r };
+  if (!['A', 'AAAA'].includes(r.type))
+    delete ret.ttl;
+  return ret;
 }


### PR DESCRIPTION
We were previously reading from the wrong offset, namely
the one into the final results array, not the one for the
AAAA results itself, which could have lead to reading
uninitialized or out-of-bounds data.

Also, adjust the test accordingly; TTL values are not
modified by c-ares, but are only exposed for a subset
of all DNS record types.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
