### PR TITLE
test: fix test-tls-session-timeout

### DIFF
--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -50,8 +50,8 @@ function doTest() {
 
   const SESSION_TIMEOUT = 1;
 
-  const key = fs.readFileSync(fixtures.path('agent.key'));
-  const cert = fs.readFileSync(fixtures.path('agent.crt'));
+  const key = fixtures.readSync('agent.key');
+  const cert = fixtures.readSync('agent.crt');
   const options = {
     key: key,
     cert: cert,

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -50,8 +50,8 @@ function doTest() {
 
   const SESSION_TIMEOUT = 1;
 
-  const key = fixtures.path('agent.key');
-  const cert = fixtures.path('agent.crt');
+  const key = fs.readFileSync(fixtures.path('agent.key'));
+  const cert = fs.readFileSync(fixtures.path('agent.crt'));
   const options = {
     key: key,
     cert: cert,


### PR DESCRIPTION
Tests in pummel seem to break often and stay broken because they don't
get run in CI. In preparation for running pummel tests in CI once a day,
this fixes test-tls-session-timeout. `key` and `cert` are now the
contents of the relevant files and not the paths.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
