### PR TITLE
process: make internal/queue_microtask.js more self-contained

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -14,8 +14,7 @@
 
 // This file is compiled as if it's wrapped in a function with arguments
 // passed by node::LoadEnvironment()
-/* global process, loaderExports, triggerFatalException */
-/* global isMainThread */
+/* global process, loaderExports, isMainThread */
 
 const { internalBinding, NativeModule } = loaderExports;
 
@@ -605,12 +604,12 @@ function setupGlobalEncoding() {
 
 function setupQueueMicrotask() {
   Object.defineProperty(global, 'queueMicrotask', {
-    get: () => {
+    get() {
       process.emitWarning('queueMicrotask() is experimental.',
                           'ExperimentalWarning');
-      const { setupQueueMicrotask } =
+      const { queueMicrotask } =
         NativeModule.require('internal/queue_microtask');
-      const queueMicrotask = setupQueueMicrotask(triggerFatalException);
+
       Object.defineProperty(global, 'queueMicrotask', {
         value: queueMicrotask,
         writable: true,
@@ -619,7 +618,7 @@ function setupQueueMicrotask() {
       });
       return queueMicrotask;
     },
-    set: (v) => {
+    set(v) {
       Object.defineProperty(global, 'queueMicrotask', {
         value: v,
         writable: true,

--- a/lib/internal/queue_microtask.js
+++ b/lib/internal/queue_microtask.js
@@ -3,37 +3,36 @@
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const { AsyncResource } = require('async_hooks');
 const { getDefaultTriggerAsyncId } = require('internal/async_hooks');
-const { enqueueMicrotask } = internalBinding('util');
+const {
+  enqueueMicrotask,
+  triggerFatalException
+} = internalBinding('util');
 
-const setupQueueMicrotask = (triggerFatalException) => {
-  const queueMicrotask = (callback) => {
-    if (typeof callback !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE('callback', 'function', callback);
-    }
+function queueMicrotask(callback) {
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE('callback', 'function', callback);
+  }
 
-    const asyncResource = new AsyncResource('Microtask', {
-      triggerAsyncId: getDefaultTriggerAsyncId(),
-      requireManualDestroy: true,
+  const asyncResource = new AsyncResource('Microtask', {
+    triggerAsyncId: getDefaultTriggerAsyncId(),
+    requireManualDestroy: true,
+  });
+
+  enqueueMicrotask(() => {
+    asyncResource.runInAsyncScope(() => {
+      try {
+        callback();
+      } catch (error) {
+        // TODO(devsnek) remove this if
+        // https://bugs.chromium.org/p/v8/issues/detail?id=8326
+        // is resolved such that V8 triggers the fatal exception
+        // handler for microtasks
+        triggerFatalException(error);
+      } finally {
+        asyncResource.emitDestroy();
+      }
     });
+  });
+}
 
-    enqueueMicrotask(() => {
-      asyncResource.runInAsyncScope(() => {
-        try {
-          callback();
-        } catch (error) {
-          // TODO(devsnek) remove this if
-          // https://bugs.chromium.org/p/v8/issues/detail?id=8326
-          // is resolved such that V8 triggers the fatal exception
-          // handler for microtasks
-          triggerFatalException(error);
-        } finally {
-          asyncResource.emitDestroy();
-        }
-      });
-    });
-  };
-
-  return queueMicrotask;
-};
-
-module.exports = { setupQueueMicrotask };
+module.exports = { queueMicrotask };

--- a/src/node.cc
+++ b/src/node.cc
@@ -1200,18 +1200,14 @@ void LoadEnvironment(Environment* env) {
     return;
   }
 
-  // process, bootstrappers, loaderExports, triggerFatalException
+  // process, loaderExports, isMainThread
   std::vector<Local<String>> node_params = {
       env->process_string(),
       FIXED_ONE_BYTE_STRING(isolate, "loaderExports"),
-      FIXED_ONE_BYTE_STRING(isolate, "triggerFatalException"),
       FIXED_ONE_BYTE_STRING(isolate, "isMainThread")};
   std::vector<Local<Value>> node_args = {
       process,
       loader_exports.ToLocalChecked(),
-      env->NewFunctionTemplate(FatalException)
-          ->GetFunction(context)
-          .ToLocalChecked(),
       Boolean::New(isolate, env->is_main_thread())};
 
   if (ExecuteBootstrapper(

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -1,4 +1,5 @@
 #include "node_internals.h"
+#include "node_errors.h"
 #include "node_watchdog.h"
 
 namespace node {
@@ -221,7 +222,7 @@ void Initialize(Local<Object> target,
                              WatchdogHasPendingSigint);
 
   env->SetMethod(target, "enqueueMicrotask", EnqueueMicrotask);
-
+  env->SetMethod(target, "triggerFatalException", FatalException);
   Local<Object> constants = Object::New(env->isolate());
   NODE_DEFINE_CONSTANT(constants, ALL_PROPERTIES);
   NODE_DEFINE_CONSTANT(constants, ONLY_WRITABLE);


### PR DESCRIPTION
- Instead of passing triggerFatalException through node.js,
  simply put it on `internalBinding('util')` which has to be
  loaded anyway.
- Expose the implementation of `queueMicrotask` directly instead
  of through an unnecessary factory function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
