### PR TITLE
child_process: simplify argument handling

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -147,8 +147,8 @@ function normalizeExecArgs(command, options, callback) {
 }
 
 
-exports.exec = function exec(/* command , options, callback */) {
-  const opts = normalizeExecArgs.apply(null, arguments);
+exports.exec = function exec(command, options, callback) {
+  const opts = normalizeExecArgs(command, options, callback);
   return exports.execFile(opts.file,
                           opts.options,
                           opts.callback);
@@ -537,11 +537,11 @@ function normalizeSpawnArguments(file, args, options) {
 }
 
 
-var spawn = exports.spawn = function spawn(/* file, args, options */) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
-  var options = opts.options;
-  var child = new ChildProcess();
+var spawn = exports.spawn = function spawn(file, args, options) {
+  const opts = normalizeSpawnArguments(file, args, options);
+  const child = new ChildProcess();
 
+  options = opts.options;
   debug('spawn', opts.args, options);
 
   child.spawn({
@@ -560,10 +560,10 @@ var spawn = exports.spawn = function spawn(/* file, args, options */) {
   return child;
 };
 
-function spawnSync(/* file, args, options */) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
+function spawnSync(file, args, options) {
+  const opts = normalizeSpawnArguments(file, args, options);
 
-  var options = opts.options;
+  options = opts.options;
 
   debug('spawnSync', opts.args, options);
 
@@ -631,8 +631,8 @@ function checkExecSyncError(ret, args, cmd) {
 }
 
 
-function execFileSync(/* command, args, options */) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
+function execFileSync(command, args, options) {
+  var opts = normalizeSpawnArguments(command, args, options);
   var inheritStderr = !opts.options.stdio;
 
   var ret = spawnSync(opts.file, opts.args.slice(1), opts.options);
@@ -650,8 +650,8 @@ function execFileSync(/* command, args, options */) {
 exports.execFileSync = execFileSync;
 
 
-function execSync(command /* , options */) {
-  var opts = normalizeExecArgs.apply(null, arguments);
+function execSync(command, options) {
+  var opts = normalizeExecArgs(command, options, null);
   var inheritStderr = !opts.options.stdio;
 
   var ret = spawnSync(opts.file, opts.options);


### PR DESCRIPTION
This commit simplifies the calling of `normalizeSpawnArguments()` and `normalizeExecArguments()`. Specifically, this commit replaces `apply()` and the use of `arguments` with a normal function call.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
