### PR TITLE
process: refactor promise rejection handling

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -6,15 +6,14 @@ const {
   tickInfo,
   // Used to run V8's micro task queue.
   runMicrotasks,
-  setTickCallback,
-  initializePromiseRejectCallback
+  setTickCallback
 } = internalBinding('task_queue');
 
 const {
   setHasRejectionToWarn,
   hasRejectionToWarn,
-  promiseRejectHandler,
-  emitPromiseRejectionWarnings
+  listenForRejections,
+  processPromiseRejections
 } = require('internal/process/promises');
 
 const {
@@ -49,10 +48,10 @@ function runNextTicks() {
   if (!hasTickScheduled() && !hasRejectionToWarn())
     return;
 
-  internalTickCallback();
+  processTicksAndRejections();
 }
 
-function internalTickCallback() {
+function processTicksAndRejections() {
   let tock;
   do {
     while (tock = queue.shift()) {
@@ -80,7 +79,7 @@ function internalTickCallback() {
     }
     setHasTickScheduled(false);
     runMicrotasks();
-  } while (!queue.isEmpty() || emitPromiseRejectionWarnings());
+  } while (!queue.isEmpty() || processPromiseRejections());
   setHasRejectionToWarn(false);
 }
 
@@ -134,11 +133,10 @@ function nextTick(callback) {
 // TODO(joyeecheung): make this a factory class so that node.js can
 // control the side effects caused by the initializers.
 exports.setup = function() {
-  // Initializes the per-isolate promise rejection callback which
-  // will call the handler being passed into this function.
-  initializePromiseRejectCallback(promiseRejectHandler);
+  // Sets the per-isolate promise rejection callback
+  listenForRejections();
   // Sets the callback to be run in every tick.
-  setTickCallback(internalTickCallback);
+  setTickCallback(processTicksAndRejections);
   return {
     nextTick,
     runNextTicks

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -11,6 +11,8 @@ const {
 } = internalBinding('task_queue');
 
 const {
+  setHasRejectionToWarn,
+  hasRejectionToWarn,
   promiseRejectHandler,
   emitPromiseRejectionWarnings
 } = require('internal/process/promises');
@@ -30,15 +32,21 @@ const { ERR_INVALID_CALLBACK } = require('internal/errors').codes;
 const FixedQueue = require('internal/fixed_queue');
 
 // *Must* match Environment::TickInfo::Fields in src/env.h.
-const kHasScheduled = 0;
-const kHasPromiseRejections = 1;
+const kHasTickScheduled = 0;
+
+function hasTickScheduled() {
+  return tickInfo[kHasTickScheduled] === 1;
+}
+function setHasTickScheduled(value) {
+  tickInfo[kHasTickScheduled] = value ? 1 : 0;
+}
 
 const queue = new FixedQueue();
 
 function runNextTicks() {
-  if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
+  if (!hasTickScheduled() && !hasRejectionToWarn())
     runMicrotasks();
-  if (tickInfo[kHasScheduled] === 0 && tickInfo[kHasPromiseRejections] === 0)
+  if (!hasTickScheduled() && !hasRejectionToWarn())
     return;
 
   internalTickCallback();
@@ -70,10 +78,10 @@ function internalTickCallback() {
 
       emitAfter(asyncId);
     }
-    tickInfo[kHasScheduled] = 0;
+    setHasTickScheduled(false);
     runMicrotasks();
   } while (!queue.isEmpty() || emitPromiseRejectionWarnings());
-  tickInfo[kHasPromiseRejections] = 0;
+  setHasRejectionToWarn(false);
 }
 
 class TickObject {
@@ -119,7 +127,7 @@ function nextTick(callback) {
   }
 
   if (queue.isEmpty())
-    tickInfo[kHasScheduled] = 1;
+    setHasTickScheduled(true);
   queue.push(new TickObject(callback, args, getDefaultTriggerAsyncId()));
 }
 

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -2,24 +2,45 @@
 
 const { safeToString } = internalBinding('util');
 const {
-  promiseRejectEvents
+  tickInfo,
+  promiseRejectEvents: {
+    kPromiseRejectWithNoHandler,
+    kPromiseHandlerAddedAfterReject,
+    kPromiseResolveAfterResolved,
+    kPromiseRejectAfterResolved
+  }
 } = internalBinding('task_queue');
+
+// *Must* match Environment::TickInfo::Fields in src/env.h.
+const kHasRejectionToWarn = 1;
 
 const maybeUnhandledPromises = new WeakMap();
 const pendingUnhandledRejections = [];
 const asyncHandledRejections = [];
 let lastPromiseId = 0;
 
+function setHasRejectionToWarn(value) {
+  tickInfo[kHasRejectionToWarn] = value ? 1 : 0;
+}
+
+function hasRejectionToWarn() {
+  return tickInfo[kHasRejectionToWarn] === 1;
+}
+
 function promiseRejectHandler(type, promise, reason) {
   switch (type) {
-    case promiseRejectEvents.kPromiseRejectWithNoHandler:
-      return unhandledRejection(promise, reason);
-    case promiseRejectEvents.kPromiseHandlerAddedAfterReject:
-      return handledRejection(promise);
-    case promiseRejectEvents.kPromiseResolveAfterResolved:
-      return resolveError('resolve', promise, reason);
-    case promiseRejectEvents.kPromiseRejectAfterResolved:
-      return resolveError('reject', promise, reason);
+    case kPromiseRejectWithNoHandler:
+      unhandledRejection(promise, reason);
+      break;
+    case kPromiseHandlerAddedAfterReject:
+      handledRejection(promise);
+      break;
+    case kPromiseResolveAfterResolved:
+      resolveError('resolve', promise, reason);
+      break;
+    case kPromiseRejectAfterResolved:
+      resolveError('reject', promise, reason);
+      break;
   }
 }
 
@@ -29,6 +50,7 @@ function resolveError(type, promise, reason) {
   process.nextTick(() => {
     process.emit('multipleResolves', type, promise, reason);
   });
+  setHasRejectionToWarn(false);
 }
 
 function unhandledRejection(promise, reason) {
@@ -38,7 +60,7 @@ function unhandledRejection(promise, reason) {
     warned: false
   });
   pendingUnhandledRejections.push(promise);
-  return true;
+  setHasRejectionToWarn(true);
 }
 
 function handledRejection(promise) {
@@ -54,10 +76,11 @@ function handledRejection(promise) {
       warning.name = 'PromiseRejectionHandledWarning';
       warning.id = uid;
       asyncHandledRejections.push({ promise, warning });
-      return true;
+      setHasRejectionToWarn(true);
+      return;
     }
   }
-  return false;
+  setHasRejectionToWarn(false);
 }
 
 const unhandledRejectionErrName = 'UnhandledPromiseRejectionWarning';
@@ -121,6 +144,8 @@ function emitPromiseRejectionWarnings() {
 }
 
 module.exports = {
+  hasRejectionToWarn,
+  setHasRejectionToWarn,
   promiseRejectHandler,
   emitPromiseRejectionWarnings
 };

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -51,7 +51,6 @@ function resolveError(type, promise, reason) {
   process.nextTick(() => {
     process.emit('multipleResolves', type, promise, reason);
   });
-  setHasRejectionToWarn(false);
 }
 
 function unhandledRejection(promise, reason) {

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -8,7 +8,8 @@ const {
     kPromiseHandlerAddedAfterReject,
     kPromiseResolveAfterResolved,
     kPromiseRejectAfterResolved
-  }
+  },
+  setPromiseRejectCallback
 } = internalBinding('task_queue');
 
 // *Must* match Environment::TickInfo::Fields in src/env.h.
@@ -118,7 +119,9 @@ function emitDeprecationWarning() {
   }
 }
 
-function emitPromiseRejectionWarnings() {
+// If this method returns true, at least one more tick need to be
+// scheduled to process any potential pending rejections
+function processPromiseRejections() {
   while (asyncHandledRejections.length > 0) {
     const { promise, warning } = asyncHandledRejections.shift();
     if (!process.emit('rejectionHandled', promise)) {
@@ -143,9 +146,13 @@ function emitPromiseRejectionWarnings() {
   return maybeScheduledTicks || pendingUnhandledRejections.length !== 0;
 }
 
+function listenForRejections() {
+  setPromiseRejectCallback(promiseRejectHandler);
+}
+
 module.exports = {
   hasRejectionToWarn,
   setHasRejectionToWarn,
-  promiseRejectHandler,
-  emitPromiseRejectionWarnings
+  listenForRejections,
+  processPromiseRejections
 };

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -5,6 +5,7 @@
 
 namespace node {
 
+using v8::Function;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -114,8 +115,13 @@ void InternalCallbackScope::Close() {
 
   if (!env_->can_call_into_js()) return;
 
-  if (env_->tick_callback_function()
-      ->Call(env_->context(), process, 0, nullptr).IsEmpty()) {
+  Local<Function> tick_callback = env_->tick_callback_function();
+
+  // The tick is triggered before JS land calls SetTickCallback
+  // to initializes the tick callback during bootstrap.
+  CHECK(!tick_callback.IsEmpty());
+
+  if (tick_callback->Call(env_->context(), process, 0, nullptr).IsEmpty()) {
     failed_ = true;
   }
 }

--- a/src/callback_scope.cc
+++ b/src/callback_scope.cc
@@ -95,7 +95,7 @@ void InternalCallbackScope::Close() {
   Environment::TickInfo* tick_info = env_->tick_info();
 
   if (!env_->can_call_into_js()) return;
-  if (!tick_info->has_scheduled()) {
+  if (!tick_info->has_tick_scheduled()) {
     env_->isolate()->RunMicrotasks();
   }
 
@@ -106,7 +106,7 @@ void InternalCallbackScope::Close() {
     CHECK_EQ(env_->trigger_async_id(), 0);
   }
 
-  if (!tick_info->has_scheduled() && !tick_info->has_promise_rejections()) {
+  if (!tick_info->has_tick_scheduled() && !tick_info->has_rejection_to_warn()) {
     return;
   }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -265,16 +265,12 @@ inline AliasedBuffer<uint8_t, v8::Uint8Array>& Environment::TickInfo::fields() {
   return fields_;
 }
 
-inline bool Environment::TickInfo::has_scheduled() const {
-  return fields_[kHasScheduled] == 1;
+inline bool Environment::TickInfo::has_tick_scheduled() const {
+  return fields_[kHasTickScheduled] == 1;
 }
 
-inline bool Environment::TickInfo::has_promise_rejections() const {
-  return fields_[kHasPromiseRejections] == 1;
-}
-
-inline void Environment::TickInfo::promise_rejections_toggle_on() {
-  fields_[kHasPromiseRejections] = 1;
+inline bool Environment::TickInfo::has_rejection_to_warn() const {
+  return fields_[kHasRejectionToWarn] == 1;
 }
 
 inline void Environment::AssignToContext(v8::Local<v8::Context> context,

--- a/src/env.cc
+++ b/src/env.cc
@@ -241,6 +241,8 @@ Environment::Environment(IsolateData* isolate_data,
   if (options_->no_force_async_hooks_checks) {
     async_hooks_.no_force_checks();
   }
+
+  isolate()->SetPromiseRejectCallback(task_queue::PromiseRejectCallback);
 }
 
 Environment::~Environment() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -242,6 +242,8 @@ Environment::Environment(IsolateData* isolate_data,
     async_hooks_.no_force_checks();
   }
 
+  // TODO(addaleax): the per-isolate state should not be controlled by
+  // a single Environment.
   isolate()->SetPromiseRejectCallback(task_queue::PromiseRejectCallback);
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -574,18 +574,16 @@ class Environment {
   class TickInfo {
    public:
     inline AliasedBuffer<uint8_t, v8::Uint8Array>& fields();
-    inline bool has_scheduled() const;
-    inline bool has_promise_rejections() const;
-
-    inline void promise_rejections_toggle_on();
+    inline bool has_tick_scheduled() const;
+    inline bool has_rejection_to_warn() const;
 
    private:
     friend class Environment;  // So we can call the constructor.
     inline explicit TickInfo(v8::Isolate* isolate);
 
     enum Fields {
-      kHasScheduled,
-      kHasPromiseRejections,
+      kHasTickScheduled = 0,
+      kHasRejectionToWarn,
       kFieldsCount
     };
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -180,6 +180,10 @@ SlicedArguments::SlicedArguments(
   size_ = size;
 }
 
+namespace task_queue {
+void PromiseRejectCallback(v8::PromiseRejectMessage message);
+}  // namespace task_queue
+
 v8::Maybe<bool> ProcessEmitWarning(Environment* env, const char* fmt, ...);
 v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
                                               const char* warning,

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -17,7 +17,6 @@ using v8::kPromiseRejectAfterResolved;
 using v8::kPromiseRejectWithNoHandler;
 using v8::kPromiseResolveAfterResolved;
 using v8::Local;
-using v8::MaybeLocal;
 using v8::Number;
 using v8::Object;
 using v8::Promise;
@@ -80,13 +79,8 @@ static void PromiseRejectCallback(PromiseRejectMessage message) {
   }
 
   Local<Value> args[] = { type, promise, value };
-  MaybeLocal<Value> ret = callback->Call(env->context(),
-                                         Undefined(isolate),
-                                         arraysize(args),
-                                         args);
-
-  if (!ret.IsEmpty() && ret.ToLocalChecked()->IsTrue())
-    env->tick_info()->promise_rejections_toggle_on();
+  USE(callback->Call(
+      env->context(), Undefined(isolate), arraysize(args), args));
 }
 
 static void InitializePromiseRejectCallback(

--- a/test/message/events_unhandled_error_nexttick.out
+++ b/test/message/events_unhandled_error_nexttick.out
@@ -15,7 +15,7 @@ Error
     at startup (internal/bootstrap/node.js:*:*)
 Emitted 'error' event at:
     at process.nextTick (*events_unhandled_error_nexttick.js:*:*)
-    at internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
     at process.runNextTicks [as _tickCallback] (internal/process/next_tick.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -4,7 +4,7 @@
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
     at process.runNextTicks [as _tickCallback] (internal/process/next_tick.js:*:*)
     at Function.Module.runMain (internal/modules/cjs/loader.js:*:*)
     at executeUserCode (internal/bootstrap/node.js:*:*)

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -12,7 +12,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Socket.process.stdin.on (internal/bootstrap/node.js:*:*)
     at Socket.emit (events.js:*:*)
     at endReadableNT (_stream_readable.js:*:*)
-    at process.internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
 42
 42
 [stdin]:1
@@ -29,7 +29,7 @@ Error: hello
     at Socket.process.stdin.on (internal/bootstrap/node.js:*:*)
     at Socket.emit (events.js:*:*)
     at endReadableNT (_stream_readable.js:*:*)
-    at process.internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
 [stdin]:1
 throw new Error("hello")
 ^
@@ -44,7 +44,7 @@ Error: hello
     at Socket.process.stdin.on (internal/bootstrap/node.js:*:*)
     at Socket.emit (events.js:*:*)
     at endReadableNT (_stream_readable.js:*:*)
-    at process.internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
 100
 [stdin]:1
 var x = 100; y = x;
@@ -60,7 +60,7 @@ ReferenceError: y is not defined
     at Socket.process.stdin.on (internal/bootstrap/node.js:*:*)
     at Socket.emit (events.js:*:*)
     at endReadableNT (_stream_readable.js:*:*)
-    at process.internalTickCallback (internal/process/next_tick.js:*:*)
+    at processTicksAndRejections (internal/process/next_tick.js:*:*)
 
 [stdin]:1
 var ______________________________________________; throw 10


### PR DESCRIPTION
It's easier to review without the indentation changes: https://github.com/nodejs/node/pull/25200/files?w=1

#### src: refactor tickInfo access

- Wrap access to tickInfo fields in functions
- Rename `kHasScheduled` to `kHasTickScheduled` and
  `kHasPromiseRejections` to `kHasRejectionToWarn` for clarity - note
  the latter will be set to false if the rejection does not lead to
  a warning so the previous description is not accurate.
- Set `kHasRejectionToWarn` in JS land of relying on C++ to use
  an implict contract (return value of the promise rejection handler)
  to set it, as the decision is made entirely in JS land.
- Destructure promise reject event constants.

#### process: make tick callback and promise rejection callback more robust

- Rename `internalTickCallback` to `processTicksAndRejections`, make
  sure it does not get called if it's not set in C++.
- Rename `emitPromiseRejectionWarnings` to `processPromiseRejections`
  since it also emit events that are not warnings.
- Sets `SetPromiseRejectCallback` in the `Environment` constructor
  to make sure it only gets called once per-isolate, and make
  sure it does not get called if it's not set in C++.
- Wrap promise rejection callback initialization into
  `listenForRejections()`.
- Add comments.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
