### PR TITLE
net: use decodeStrings public API for writable stream

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -255,6 +255,8 @@ function Socket(options) {
   options.allowHalfOpen = true;
   // For backwards compat do not emit close on destroy.
   options.emitClose = false;
+  // Handle strings directly.
+  options.decodeStrings = false;
   stream.Duplex.call(this, options);
 
   // Default to *not* allowing half open sockets.
@@ -307,9 +309,6 @@ function Socket(options) {
 
   this._pendingData = null;
   this._pendingEncoding = '';
-
-  // handle strings directly
-  this._writableState.decodeStrings = false;
 
   // If we have a handle, then start the flow of data into the
   // buffer.  if not, then this will happen when we connect


### PR DESCRIPTION
Instead of using an undocumented underscore-prefixed property to
configure the writable stream instance to not encode strings as buffers,
use the public API which is an options property passed to the
constructor.

Refs: https://github.com/nodejs/node/issues/445

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
