### PR TITLE
src: fix compiler warnings in node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3339,10 +3339,12 @@ Local<Function> KeyObject::Initialize(Environment* env, Local<Object> target) {
                                   GetAsymmetricKeyType);
   env->SetProtoMethod(t, "export", Export);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "KeyObject"),
-              t->GetFunction(env->context()).ToLocalChecked());
+  auto function = t->GetFunction(env->context()).ToLocalChecked();
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "KeyObject"),
+              function).FromJust();
 
-  return t->GetFunction();
+  return function;
 }
 
 Local<Object> KeyObject::Create(Environment* env,


### PR DESCRIPTION
During the time between https://github.com/nodejs/node/pull/24234 being opened and it landing, a V8 update occurred that deprecated several APIs. This commit fixes the following compiler warnings:

```
../src/node_crypto.cc:3342:11: warning: 'Set' is deprecated: Use maybe version

../src/node_crypto.cc:3345:13: warning: 'GetFunction' is deprecated: Use maybe version
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
