### PR TITLE
src: remove redefinition of DCHECK_LT

### DIFF
--- a/src/inspector/node_string.h
+++ b/src/inspector/node_string.h
@@ -75,6 +75,5 @@ extern size_t kNotFound;
 
 #ifndef DCHECK
   #define DCHECK CHECK
-  #define DCHECK_LT CHECK_LT
 #endif  // DCHECK
 #endif  // SRC_INSPECTOR_NODE_STRING_H_


### PR DESCRIPTION
As of 71bc7e1ce6881b4e6fe50459cc9866d47f96e4a4, the `DCHECK_LT` macro is defined unconditionally in `util.h`, making the definition in `inspector/node_string.h` generate a compiler warning. This commit removes the redefinition.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
