### PR TITLE
test: set umask explicitly

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -70,6 +70,7 @@ skip_regex = re.compile(r'# SKIP\S*\s+(.*)', re.IGNORECASE)
 
 VERBOSE = False
 
+os.umask(0o022)
 os.environ['NODE_OPTIONS'] = ''
 
 # ---------------------------------------------


### PR DESCRIPTION
Some tests which create files and check file permissions assume the
umask is compatible with 022, and break when set to something like 007.
Explicitly set umask to 022

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I'm seeing test errors

```
=== release test-fs-mkdir-mode-mask ===                                       
Path: parallel/test-fs-mkdir-mode-mask
assert.js:86
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

416 !== 420

    at test (/home/i8-pi/src/node/test/parallel/test-fs-mkdir-mode-mask.js:32:12)
    at Object.<anonymous> (/home/i8-pi/src/node/test/parallel/test-fs-mkdir-mode-mask.js:44:1)

```
when running
`umask 007; make -j4 test
`