### PR TITLE
crypto: always accept private keys as public keys

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1371,7 +1371,7 @@ added: v0.1.92
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25217
-    description: The key can now be a private key instead of a public key.
+    description: The key can now be a private key.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11705
     description: Support for RSASSA-PSS and additional options was added.

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1369,6 +1369,9 @@ This can be called many times with new data as it is streamed.
 <!-- YAML
 added: v0.1.92
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/???
+    description: The key can now be a private key instead of a public key.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11705
     description: Support for RSASSA-PSS and additional options was added.
@@ -1408,6 +1411,9 @@ string; otherwise `signature` is expected to be a [`Buffer`][],
 The `verify` object can not be used again after `verify.verify()` has been
 called. Multiple calls to `verify.verify()` will result in an error being
 thrown.
+
+Because public keys can be derived from private keys, a private key may
+be passed instead of a public key.
 
 ## `crypto` module methods and properties
 
@@ -1819,6 +1825,11 @@ must be an object with the properties described above.
 ### crypto.createPublicKey(key)
 <!-- YAML
 added: v11.6.0
+added: REPLACEME
+changes:
+  - version: REPLACEME
+    pr-url: TODO
+    description: The `key` argument can now be a private key.
 -->
 * `key` {Object | string | Buffer}
   - `key`: {string | Buffer}
@@ -1832,6 +1843,12 @@ string or `Buffer`, `format` is assumed to be `'pem'`; otherwise, `key`
 must be an object with the properties described above.
 
 If the format is `'pem'`, the `'key'` may also be an X.509 certificate.
+
+Because public keys can be derived from private keys, a private key may be
+passed instead of a public key. In that case, this function behaves as if
+[`crypto.createPrivateKey()`][] had been called, except that the type of the
+returned `KeyObject` will be `public` and that the private key cannot be
+extracted from the returned `KeyObject`.
 
 ### crypto.createSecretKey(key)
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1825,7 +1825,6 @@ must be an object with the properties described above.
 ### crypto.createPublicKey(key)
 <!-- YAML
 added: v11.6.0
-added: REPLACEME
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/25217

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1370,7 +1370,7 @@ This can be called many times with new data as it is streamed.
 added: v0.1.92
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/???
+    pr-url: https://github.com/nodejs/node/pull/25217
     description: The key can now be a private key instead of a public key.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11705
@@ -1828,7 +1828,7 @@ added: v11.6.0
 added: REPLACEME
 changes:
   - version: REPLACEME
-    pr-url: TODO
+    pr-url: https://github.com/nodejs/node/pull/25217
     description: The `key` argument can now be a private key.
 -->
 * `key` {Object | string | Buffer}

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -261,10 +261,6 @@ function prepareAsymmetricKey(key, isPublic, allowKeyObject = true) {
   }
 }
 
-function preparePublicKey(key, allowKeyObject) {
-  return prepareAsymmetricKey(key, true, allowKeyObject);
-}
-
 function preparePrivateKey(key, allowKeyObject) {
   return prepareAsymmetricKey(key, false, allowKeyObject);
 }
@@ -300,7 +296,7 @@ function createSecretKey(key) {
 }
 
 function createPublicKey(key) {
-  const { format, type, data } = preparePublicKey(key, false);
+  const { format, type, data } = preparePublicOrPrivateKey(key, false);
   const handle = new KeyObjectHandle(kKeyTypePublic);
   handle.init(data, format, type);
   return new PublicKeyObject(handle);
@@ -326,7 +322,6 @@ module.exports = {
   // These are designed for internal use only and should not be exposed.
   parsePublicKeyEncoding,
   parsePrivateKeyEncoding,
-  preparePublicKey,
   preparePrivateKey,
   preparePublicOrPrivateKey,
   prepareSecretKey,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -19,7 +19,7 @@ const {
 } = require('internal/crypto/util');
 const {
   preparePrivateKey,
-  preparePublicKey
+  preparePublicOrPrivateKey
 } = require('internal/crypto/keys');
 const { Writable } = require('stream');
 
@@ -112,8 +112,9 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   const {
     data,
     format,
-    type
-  } = preparePublicKey(options, true);
+    type,
+    passphrase
+  } = preparePublicOrPrivateKey(options, true);
 
   sigEncoding = sigEncoding || getDefaultEncoding();
 
@@ -125,7 +126,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
   signature = validateArrayBufferView(toBuf(signature, sigEncoding),
                                       'signature');
 
-  return this[kHandle].verify(data, format, type, signature,
+  return this[kHandle].verify(data, format, type, passphrase, signature,
                               rsaPadding, pssSaltLength);
 };
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -31,9 +31,11 @@ function assertApproximateSize(key, expectedSize) {
 function testEncryptDecrypt(publicKey, privateKey) {
   const message = 'Hello Node.js world!';
   const plaintext = Buffer.from(message, 'utf8');
-  const ciphertext = publicEncrypt(publicKey, plaintext);
-  const received = privateDecrypt(privateKey, ciphertext);
-  assert.strictEqual(received.toString('utf8'), message);
+  for (const key of [publicKey, privateKey]) {
+    const ciphertext = publicEncrypt(key, plaintext);
+    const received = privateDecrypt(privateKey, ciphertext);
+    assert.strictEqual(received.toString('utf8'), message);
+  }
 }
 
 // Tests that a key pair can be used for signing / verification.
@@ -41,9 +43,11 @@ function testSignVerify(publicKey, privateKey) {
   const message = 'Hello Node.js world!';
   const signature = createSign('SHA256').update(message)
                                         .sign(privateKey, 'hex');
-  const okay = createVerify('SHA256').update(message)
-                                     .verify(publicKey, signature, 'hex');
-  assert(okay);
+  for (const key of [publicKey, privateKey]) {
+    const okay = createVerify('SHA256').update(message)
+                                       .verify(key, signature, 'hex');
+    assert(okay);
+  }
 }
 
 // Constructs a regular expression for a PEM-encoded key with the given label.


### PR DESCRIPTION
Some APIs already accept private keys instead of public keys. This changes all relevant crypto APIs to do so.

As a nice side effect, this also allows to derive public keys from private keys using the new KeyObject API.

I am not 100% sure whether this is the best way to go, so I would love opinions from @nodejs/crypto or other people! Allowing private keys to be passed to `verify` makes sense in my opinion, but what if the user passes a public and a private key (both in the same PEM string) to `createPublicKey`? With this change, the public key would be used, but we should make sure to be on the same page about this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
