### PR TITLE
http: add maxHeaderSize property

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1806,6 +1806,16 @@ added: v0.5.9
 Global instance of `Agent` which is used as the default for all HTTP client
 requests.
 
+## http.maxHeaderSize
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Read-only property specifying the maximum allowed size of HTTP headers in bytes.
+Defaults to 8KB. Configurable using the [`--max-http-header-size`][] CLI option.
+
 ## http.request(options[, callback])
 <!-- YAML
 added: v0.3.6
@@ -1983,6 +1993,7 @@ will be emitted in the following order:
 Note that setting the `timeout` option or using the `setTimeout` function will
 not abort the request or do anything besides add a `timeout` event.
 
+[`--max-http-header-size`]: cli.html#cli_max_http_header_size_size
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'request'`]: #http_event_request
 [`'response'`]: #http_event_response

--- a/lib/http.js
+++ b/lib/http.js
@@ -27,6 +27,7 @@ const common = require('_http_common');
 const incoming = require('_http_incoming');
 const outgoing = require('_http_outgoing');
 const server = require('_http_server');
+let maxHeaderSize;
 
 const { Server } = server;
 
@@ -59,3 +60,15 @@ module.exports = {
   get,
   request
 };
+
+Object.defineProperty(module.exports, 'maxHeaderSize', {
+  configurable: true,
+  enumerable: true,
+  get() {
+    if (maxHeaderSize === undefined) {
+      maxHeaderSize = process.binding('config').maxHTTPHeaderSize;
+    }
+
+    return maxHeaderSize;
+  }
+});

--- a/test/parallel/test-http-max-header-size.js
+++ b/test/parallel/test-http-max-header-size.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const http = require('http');
+
+assert.strictEqual(http.maxHeaderSize, 8 * 1024);
+const child = spawnSync(process.execPath, ['--max-http-header-size=10', '-p',
+                                           'http.maxHeaderSize']);
+assert.strictEqual(+child.stdout.toString().trim(), 10);


### PR DESCRIPTION
```diff
-      const { getOptionValue } = require('internal/options');
-      maxHeaderSize = getOptionValue('--max-http-header-size');
+      maxHeaderSize = process.binding('config').maxHTTPHeaderSize;
```

`internal/options` does not exist on 8.x or 6.x. As such maxHTTPHeaderSize is exposed on `process.binding('config')`