### PR TITLE
test: make sure tmpdir is created before using it

### DIFF
--- a/test/parallel/test-child-process-spawnsync-args.js
+++ b/test/parallel/test-child-process-spawnsync-args.js
@@ -15,6 +15,8 @@ const tmpdir = require('../common/tmpdir');
 const command = common.isWindows ? 'cd' : 'pwd';
 const options = { cwd: tmpdir.path };
 
+tmpdir.refresh();
+
 if (common.isWindows) {
   // This test is not the case for Windows based systems
   // unless the `shell` options equals to `true`
@@ -31,12 +33,13 @@ const testCases = [
 const expectedResult = tmpdir.path.trim().toLowerCase();
 
 const results = testCases.map((testCase) => {
-  const { stdout, stderr } = spawnSync(
+  const { stdout, stderr, error } = spawnSync(
     command,
     testCase,
     options
   );
 
+  assert.ifError(error);
   assert.deepStrictEqual(stderr, Buffer.alloc(0));
 
   return stdout.toString().trim().toLowerCase();


### PR DESCRIPTION
Otherwise it throws ENOENT when the folder happens to be cleaned

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
