### PR TITLE
test: fix test-repl-envvars

### DIFF
--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -36,7 +36,7 @@ const tests = [
 ];
 
 function run(test) {
-  const env = Object.assign({}, process.env, test.env);
+  const env = test.env;
   const expected = test.expected;
   const opts = {
     terminal: true,


### PR DESCRIPTION
In 180f86507d496b11aa35b2df4594629a92cce329, the test was changed
so that the `env` argument of `createInternalRepl()` also contained
external environment variables, because keeping them can be necessary
for spawning processes on some systems.

However, this test does not spawn new processes, and relies on the
fact that the environment variables it tests are not already set
(and fails otherwise); therefore, reverting to the original state
should fix this.

Fixes: https://github.com/nodejs/node/issues/21451
Fixes: https://github.com/nodejs/build/issues/1377
Refs: https://github.com/nodejs/node/pull/25219

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
