### PR TITLE
test: set umask for tests

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -36,7 +36,11 @@ const {
 
 // Some tests assume a umask of 0o022 so set that up front. Tests that need a
 // different umask will set it themselves.
-process.umask(0o022);
+//
+// process.umask() is not available in workers so we need to check for its
+// existence.
+if (process.umask)
+  process.umask(0o022);
 
 const noop = () => {};
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -34,6 +34,10 @@ const {
   hasIntl
 } = process.binding('config');
 
+// Some tests assume a umask of 0o022 so set that up front. Tests that need a
+// different umask will set it themselves.
+process.umask(0o022);
+
 const noop = () => {};
 
 const hasCrypto = Boolean(process.versions.openssl);


### PR DESCRIPTION
https://github.com/nodejs/node/pull/25213 proposes setting umask in the
Python test runner to avoid spurious test failures when running from a
shell with a restrictive umask. This is a good idea, but will only fix
the issue for tests run with the Python runner. Set it in
`common/index.js` as well so that it fixes it even when tests are run
directly with a `node` binary, bypassing the Python test runner.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
