### PR TITLE
src: fix warning in cares_wrap.cc

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1212,15 +1212,15 @@ class QueryAnyWrap: public QueryWrap {
                                ret,
                                addrttls,
                                &naddrttls);
-    int a_count = ret->Length();
+    uint32_t a_count = ret->Length();
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       ParseError(status);
       return;
     }
 
     if (type == ns_t_a) {
-      CHECK_EQ(naddrttls, a_count);
-      for (int i = 0; i < a_count; i++) {
+      CHECK_EQ(static_cast<uint32_t>(naddrttls), a_count);
+      for (uint32_t i = 0; i < a_count; i++) {
         Local<Object> obj = Object::New(env()->isolate());
         obj->Set(context,
                  env()->address_string(),
@@ -1234,7 +1234,7 @@ class QueryAnyWrap: public QueryWrap {
         ret->Set(context, i, obj).FromJust();
       }
     } else {
-      for (int i = 0; i < a_count; i++) {
+      for (uint32_t i = 0; i < a_count; i++) {
         Local<Object> obj = Object::New(env()->isolate());
         obj->Set(context,
                  env()->value_string(),
@@ -1258,13 +1258,13 @@ class QueryAnyWrap: public QueryWrap {
                                ret,
                                addr6ttls,
                                &naddr6ttls);
-    int aaaa_count = ret->Length() - a_count;
+    uint32_t aaaa_count = ret->Length() - a_count;
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       ParseError(status);
       return;
     }
 
-    CHECK_EQ(aaaa_count, naddr6ttls);
+    CHECK_EQ(aaaa_count, static_cast<uint32_t>(naddr6ttls));
     CHECK_EQ(ret->Length(), a_count + aaaa_count);
     for (uint32_t i = a_count; i < ret->Length(); i++) {
       Local<Object> obj = Object::New(env()->isolate());


### PR DESCRIPTION
This commit fixes the following warning:

```
./src/cares_wrap.cc:1268:5: warning: comparison of integers of
    different signs: 'uint32_t' (aka 'unsigned int') and 'int'
    [-Wsign-compare]
    CHECK_EQ(ret->Length(), a_count + aaaa_count);
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
