### PR TITLE
deps: upgrade npm to v6.5.0

### DIFF
--- a/deps/npm/.travis.yml
+++ b/deps/npm/.travis.yml
@@ -7,7 +7,7 @@ language: node_js
 matrix:
   include:
     # LTS is our most important target
-    - node_js: "8"
+    - node_js: "10"
       # DEPLOY_VERSION is used to set the couchapp setup mode for test/tap/registry.js
       # only gather coverage info for LTS
       env: DEPLOY_VERSION=testing COVERALLS_REPO_TOKEN="$COVERALLS_OPTIONAL_TOKEN"
@@ -17,13 +17,16 @@ matrix:
     # previous LTS is next most important
     - node_js: "6"
       env: DEPLOY_VERSION=testing
-    - node_js: "10"
+    - node_js: "8"
       env: DEPLOY_VERSION=testing
     - node_js: "9"
       env: DEPLOY_VERSION=testing
+    - node_js: "11"
+      env: DEPLOY_VERSION=testing
       script:
-       - "standard"
-       - "node . run tap -- \"test/tap/*.js\" \"test/broken-under-nyc/*.js\""
+      - "npx standard"
+      - "node . run licenses"
+      - "node . run tap -- \"test/tap/*.js\" \"test/broken-under-nyc/*.js\""
 notifications:
     slack: npm-inc:kRqQjto7YbINqHPb1X6nS3g8
 cache:
@@ -33,4 +36,3 @@ install:
   - "node . install"
 script:
   - "node . run tap -- \"test/tap/*.js\" \"test/broken-under-nyc/*.js\""
-  - "node . run licenses"

--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -118,5 +118,5 @@ doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@6.5.0-next.0</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-access.html
+++ b/deps/npm/html/doc/cli/npm-access.html
@@ -85,5 +85,5 @@ with an HTTP 402 status code (logically enough), unless you use
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-access &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-access &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -78,5 +78,5 @@ username/password entry in legacy npm.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-adduser &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-audit.html
+++ b/deps/npm/html/doc/cli/npm-audit.html
@@ -81,4 +81,4 @@ different between runs.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-audit &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-audit &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-bin &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -54,5 +54,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-bugs &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -38,5 +38,5 @@ directly, run:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-build &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -31,5 +31,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-bundle &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -88,5 +88,5 @@ verify</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-cache &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-ci.html
+++ b/deps/npm/html/doc/cli/npm-ci.html
@@ -58,4 +58,4 @@ incrementally-installed local environments of most npm users.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ci &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-ci &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -42,5 +42,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-completion &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -62,5 +62,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-config &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -58,5 +58,5 @@ result in new modules being installed.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-dedupe &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -38,5 +38,5 @@ format an empty string.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-deprecate &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-dist-tag.html
+++ b/deps/npm/html/doc/cli/npm-dist-tag.html
@@ -85,5 +85,5 @@ begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dist-tag &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-dist-tag &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -55,5 +55,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-docs &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-doctor.html
+++ b/deps/npm/html/doc/cli/npm-doctor.html
@@ -102,4 +102,4 @@ cache, you should probably run <code>npm cache clean</code> and reset the cache.
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-doctor &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-doctor &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -50,5 +50,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-edit &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -47,5 +47,5 @@ Windows</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-explore &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -44,5 +44,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-help-search &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -49,5 +49,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-help &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-hook.html
+++ b/deps/npm/html/doc/cli/npm-hook.html
@@ -52,4 +52,4 @@ request came from your own configured hook.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-hook &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-hook &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -61,5 +61,5 @@ will create a scoped package.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-init &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-install-ci-test.html
+++ b/deps/npm/html/doc/cli/npm-install-ci-test.html
@@ -32,4 +32,4 @@ alias: npm cit</code></pre><h2 id="description">DESCRIPTION</h2>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install-ci-test &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-install-ci-test &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-install-test.html
+++ b/deps/npm/html/doc/cli/npm-install-test.html
@@ -41,5 +41,5 @@ takes exactly the same arguments as <code>npm install</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install-test &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-install-test &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -370,5 +370,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-install &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -71,5 +71,5 @@ include that scope, e.g.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-link &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-logout.html
+++ b/deps/npm/html/doc/cli/npm-logout.html
@@ -49,5 +49,5 @@ it takes precedence.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-logout &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-logout &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -20,7 +20,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@6.5.0-next.0 /path/to/npm
+<pre><code>npm@6.5.0 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5</code></pre><p>It will print out extraneous, missing, and invalid packages.</p>
 <p>If a project specifies git urls for dependencies these are shown
@@ -108,5 +108,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-ls &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -116,5 +116,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-outdated &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -53,5 +53,5 @@ with <code>--otp</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-owner &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -42,5 +42,5 @@ actually packing anything. Reports on what would have gone into the tarball.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-pack &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-ping.html
+++ b/deps/npm/html/doc/cli/npm-ping.html
@@ -33,5 +33,5 @@ If it works it will output something like:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-ping &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -37,5 +37,5 @@ to contain a package.json file unless <code>-g</code> is also specified.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-prefix &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-profile.html
+++ b/deps/npm/html/doc/cli/npm-profile.html
@@ -88,4 +88,4 @@ available on non npmjs.com registries.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-profile &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-profile &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -47,5 +47,5 @@ and it&#39;s up to you to run <code>npm prune</code> from time-to-time to remove
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-prune &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -87,5 +87,5 @@ included and packs them into a tarball to be uploaded to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-publish &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -34,5 +34,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-rebuild &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -40,5 +40,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-repo &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -52,5 +52,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-restart &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-root &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -79,5 +79,5 @@ without breaking the execution chain.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-run-script &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -108,5 +108,5 @@ setting.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-search &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -40,5 +40,5 @@ of package locks in npm, see <a href="../files/npm-package-locks.html">npm-packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -35,5 +35,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-star &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -35,5 +35,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-stars &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -38,5 +38,5 @@ more details.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-start &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -33,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-stop &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-team.html
+++ b/deps/npm/html/doc/cli/npm-team.html
@@ -69,5 +69,5 @@ use the <code>npm access</code> command to grant or revoke the appropriate permi
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-team &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-team &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-test &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-token.html
+++ b/deps/npm/html/doc/cli/npm-token.html
@@ -70,4 +70,4 @@ This will NOT accept the truncated token found in <code>npm token list</code> ou
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-token &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-token &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -60,5 +60,5 @@ npm uninstall lodash --no-save</code></pre><h2 id="see-also">SEE ALSO</h2>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-uninstall &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -52,5 +52,5 @@ contact <a href="mailto:support@npmjs.com">support@npmjs.com</a>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-unpublish &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -100,5 +100,5 @@ be <em>downgraded</em>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-update &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -116,5 +116,5 @@ to the same value as the current version.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-version &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -75,5 +75,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-view &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -32,5 +32,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-whoami &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -12,7 +12,7 @@
 <h1><a href="../cli/npm.html">npm</a></h1> <p>javascript package manager</p>
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]</code></pre><h2 id="version">VERSION</h2>
-<p>6.5.0-next.0</p>
+<p>6.5.0</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -130,7 +130,7 @@ reproduction to report.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="https://twitter.com/izs">@izs</a> ::
-<a href="mailto:&#x69;&#x40;&#105;&#x7a;&#115;&#46;&#109;&#101;">&#x69;&#x40;&#105;&#x7a;&#115;&#46;&#109;&#101;</a></p>
+<a href="mailto:&#x69;&#x40;&#105;&#122;&#x73;&#x2e;&#x6d;&#x65;">&#x69;&#x40;&#105;&#122;&#x73;&#x2e;&#x6d;&#x65;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html">npm-help(1)</a></li>
@@ -154,5 +154,5 @@ reproduction to report.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -179,5 +179,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-folders &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -179,5 +179,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-folders &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -574,5 +574,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@6.5.0-next.0</p>
+<p id="footer">package.json &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/files/npm-package-locks.html
+++ b/deps/npm/html/doc/files/npm-package-locks.html
@@ -154,4 +154,4 @@ pre-<code>npm@5.7.0</code> versions of npm 5, albeit a bit more noisily. Note th
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-package-locks &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-package-locks &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/files/npm-shrinkwrap.json.html
+++ b/deps/npm/html/doc/files/npm-shrinkwrap.json.html
@@ -42,4 +42,4 @@ to the manual page for <a href="../files/package-lock.json.html">package-lock.js
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap.json &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-shrinkwrap.json &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -82,5 +82,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npmrc &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/files/package-lock.json.html
+++ b/deps/npm/html/doc/files/package-lock.json.html
@@ -130,4 +130,4 @@ should match via normal matching rules a dependency either in our
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package-lock.json &mdash; npm@6.5.0-next.0</p>
+<p id="footer">package-lock.json &mdash; npm@6.5.0</p>

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -574,5 +574,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@6.5.0-next.0</p>
+<p id="footer">package.json &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -180,5 +180,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-index &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -145,5 +145,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-coding-style &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -1064,5 +1064,5 @@ exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-config &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -198,5 +198,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-developers &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -20,7 +20,7 @@ Conduct.</p>
 <h2 id="tl-dr">TL;DR</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="mailto:&#x73;&#117;&#112;&#x70;&#x6f;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#99;&#x6f;&#x6d;">&#x73;&#117;&#112;&#x70;&#x6f;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#99;&#x6f;&#x6d;</a></li>
+<li>Email the author, CC <a href="mailto:&#x73;&#117;&#112;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#x6a;&#115;&#46;&#99;&#111;&#x6d;">&#x73;&#117;&#112;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#x6a;&#115;&#46;&#99;&#111;&#x6d;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -58,13 +58,13 @@ because Yusuf&#39;s <code>foo</code> is in the way.</p>
 </li>
 <li><p>Alice emails Yusuf, explaining the situation <strong>as respectfully as possible</strong>,
 and what she would like to do with the module name. She adds the npm support
-staff <a href="mailto:&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#116;&#64;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#99;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#116;&#64;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#99;&#x6f;&#x6d;</a> to the CC list of the email. Mention in the email
+staff <a href="mailto:&#115;&#117;&#x70;&#x70;&#x6f;&#114;&#116;&#64;&#110;&#x70;&#109;&#106;&#115;&#46;&#x63;&#111;&#x6d;">&#115;&#117;&#x70;&#x70;&#x6f;&#114;&#116;&#64;&#110;&#x70;&#109;&#106;&#115;&#46;&#x63;&#111;&#x6d;</a> to the CC list of the email. Mention in the email
 that Yusuf can run npm owner <code>add alice foo</code> to add Alice as an owner of the
 foo package.</p>
 </li>
 <li><p>After a reasonable amount of time, if Yusuf has not responded, or if Yusuf
 and Alice can&#39;t come to any sort of resolution, email support
-<a href="mailto:&#115;&#x75;&#x70;&#x70;&#111;&#114;&#x74;&#64;&#110;&#112;&#109;&#106;&#115;&#46;&#99;&#111;&#x6d;">&#115;&#x75;&#x70;&#x70;&#111;&#114;&#x74;&#64;&#110;&#112;&#109;&#106;&#115;&#46;&#99;&#111;&#x6d;</a> and we&#39;ll sort it out. (&quot;Reasonable&quot; is usually at least
+<a href="mailto:&#115;&#x75;&#112;&#112;&#111;&#114;&#116;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#46;&#99;&#111;&#109;">&#115;&#x75;&#112;&#112;&#111;&#114;&#116;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#46;&#99;&#111;&#109;</a> and we&#39;ll sort it out. (&quot;Reasonable&quot; is usually at least
 4 weeks.)</p>
 </li>
 </ol>
@@ -101,12 +101,12 @@ application database or otherwise putting non-packagey things into it.</li>
 <a href="https://www.npmjs.com/policies/conduct">Code of Conduct</a> such as hateful
 language, pornographic content, or harassment.</li>
 </ol>
-<p>If you see bad behavior like this, please report it to <a href="mailto:&#x61;&#x62;&#117;&#115;&#101;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;">&#x61;&#x62;&#117;&#115;&#101;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;</a> right
+<p>If you see bad behavior like this, please report it to <a href="mailto:&#97;&#x62;&#117;&#115;&#101;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#115;&#46;&#x63;&#111;&#109;">&#97;&#x62;&#117;&#115;&#101;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#115;&#46;&#x63;&#111;&#109;</a> right
 away. <strong>You are never expected to resolve abusive behavior on your own. We are
 here to help.</strong></p>
 <h2 id="trademarks">TRADEMARKS</h2>
 <p>If you think another npm publisher is infringing your trademark, such as by
-using a confusingly similar package name, email <a href="mailto:&#97;&#98;&#x75;&#115;&#x65;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#46;&#99;&#x6f;&#x6d;">&#97;&#98;&#x75;&#115;&#x65;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#46;&#99;&#x6f;&#x6d;</a> with a link to
+using a confusingly similar package name, email <a href="mailto:&#97;&#98;&#x75;&#115;&#101;&#64;&#110;&#112;&#109;&#x6a;&#x73;&#46;&#x63;&#111;&#x6d;">&#97;&#98;&#x75;&#115;&#101;&#64;&#110;&#112;&#109;&#x6a;&#x73;&#46;&#x63;&#111;&#x6d;</a> with a link to
 the package or user account on <a href="https://www.npmjs.com/">https://www.npmjs.com/</a>.
 Attach a copy of your trademark registration certificate.</p>
 <p>If we see that the package&#39;s publisher is intentionally misleading others by
@@ -139,5 +139,5 @@ License.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-disputes &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -180,5 +180,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-index &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-orgs.html
+++ b/deps/npm/html/doc/misc/npm-orgs.html
@@ -77,5 +77,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-orgs &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-orgs &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -96,5 +96,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-registry &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-scope.html
+++ b/deps/npm/html/doc/misc/npm-scope.html
@@ -93,5 +93,5 @@ that registry instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scope &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-scope &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -234,5 +234,5 @@ scripts is for compilation which must be done on the target architecture.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@6.5.0-next.0</p>
+<p id="footer">npm-scripts &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -52,5 +52,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@6.5.0-next.0</p>
+<p id="footer">removing-npm &mdash; npm@6.5.0</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -350,5 +350,5 @@ higher value components are invalid (<code>9999999999999999.4.7.4</code> is like
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@6.5.0-next.0</p>
+<p id="footer">semver &mdash; npm@6.5.0</p>
 

--- a/deps/npm/lib/utils/unsupported.js
+++ b/deps/npm/lib/utils/unsupported.js
@@ -5,7 +5,8 @@ var supportedNode = [
   {ver: '8', min: '8.0.0'},
   {ver: '9', min: '9.0.0'},
   {ver: '10', min: '10.0.0'},
-  {ver: '11', min: '11.0.0'}
+  {ver: '11', min: '11.0.0'},
+  {ver: '12', min: '12.0.0'}
 ]
 var knownBroken = '<4.7.0'
 

--- a/deps/npm/man/man1/npm-README.1
+++ b/deps/npm/man/man1/npm-README.1
@@ -1,4 +1,4 @@
-.TH "NPM" "1" "November 2018" "" ""
+.TH "NPM" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm\fR \- a JavaScript package manager
 .P

--- a/deps/npm/man/man1/npm-access.1
+++ b/deps/npm/man/man1/npm-access.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ACCESS" "1" "November 2018" "" ""
+.TH "NPM\-ACCESS" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-access\fR \- Set access level on published packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-adduser.1
+++ b/deps/npm/man/man1/npm-adduser.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ADDUSER" "1" "November 2018" "" ""
+.TH "NPM\-ADDUSER" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-adduser\fR \- Add a registry user account
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-audit.1
+++ b/deps/npm/man/man1/npm-audit.1
@@ -1,4 +1,4 @@
-.TH "NPM\-AUDIT" "1" "November 2018" "" ""
+.TH "NPM\-AUDIT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-audit\fR \- Run a security audit
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bin.1
+++ b/deps/npm/man/man1/npm-bin.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BIN" "1" "November 2018" "" ""
+.TH "NPM\-BIN" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-bin\fR \- Display npm bin folder
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bugs.1
+++ b/deps/npm/man/man1/npm-bugs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUGS" "1" "November 2018" "" ""
+.TH "NPM\-BUGS" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-bugs\fR \- Bugs for a package in a web browser maybe
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-build.1
+++ b/deps/npm/man/man1/npm-build.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUILD" "1" "November 2018" "" ""
+.TH "NPM\-BUILD" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-build\fR \- Build a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bundle.1
+++ b/deps/npm/man/man1/npm-bundle.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUNDLE" "1" "November 2018" "" ""
+.TH "NPM\-BUNDLE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-bundle\fR \- REMOVED
 .SH DESCRIPTION

--- a/deps/npm/man/man1/npm-cache.1
+++ b/deps/npm/man/man1/npm-cache.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CACHE" "1" "November 2018" "" ""
+.TH "NPM\-CACHE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-cache\fR \- Manipulates packages cache
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-ci.1
+++ b/deps/npm/man/man1/npm-ci.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CI" "1" "November 2018" "" ""
+.TH "NPM\-CI" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-ci\fR \- Install a project with a clean slate
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-completion.1
+++ b/deps/npm/man/man1/npm-completion.1
@@ -1,4 +1,4 @@
-.TH "NPM\-COMPLETION" "1" "November 2018" "" ""
+.TH "NPM\-COMPLETION" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-completion\fR \- Tab Completion for npm
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-config.1
+++ b/deps/npm/man/man1/npm-config.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CONFIG" "1" "November 2018" "" ""
+.TH "NPM\-CONFIG" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-config\fR \- Manage the npm configuration files
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-dedupe.1
+++ b/deps/npm/man/man1/npm-dedupe.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEDUPE" "1" "November 2018" "" ""
+.TH "NPM\-DEDUPE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-dedupe\fR \- Reduce duplication
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-deprecate.1
+++ b/deps/npm/man/man1/npm-deprecate.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEPRECATE" "1" "November 2018" "" ""
+.TH "NPM\-DEPRECATE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-deprecate\fR \- Deprecate a version of a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-dist-tag.1
+++ b/deps/npm/man/man1/npm-dist-tag.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DIST\-TAG" "1" "November 2018" "" ""
+.TH "NPM\-DIST\-TAG" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-dist-tag\fR \- Modify package distribution tags
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-docs.1
+++ b/deps/npm/man/man1/npm-docs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DOCS" "1" "November 2018" "" ""
+.TH "NPM\-DOCS" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-docs\fR \- Docs for a package in a web browser maybe
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-doctor.1
+++ b/deps/npm/man/man1/npm-doctor.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DOCTOR" "1" "November 2018" "" ""
+.TH "NPM\-DOCTOR" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-doctor\fR \- Check your environments
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-edit.1
+++ b/deps/npm/man/man1/npm-edit.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EDIT" "1" "November 2018" "" ""
+.TH "NPM\-EDIT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-edit\fR \- Edit an installed package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-explore.1
+++ b/deps/npm/man/man1/npm-explore.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EXPLORE" "1" "November 2018" "" ""
+.TH "NPM\-EXPLORE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-explore\fR \- Browse an installed package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-help-search.1
+++ b/deps/npm/man/man1/npm-help-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP\-SEARCH" "1" "November 2018" "" ""
+.TH "NPM\-HELP\-SEARCH" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-help-search\fR \- Search npm help documentation
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-help.1
+++ b/deps/npm/man/man1/npm-help.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP" "1" "November 2018" "" ""
+.TH "NPM\-HELP" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-help\fR \- Get help on npm
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-hook.1
+++ b/deps/npm/man/man1/npm-hook.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HOOK" "1" "November 2018" "" ""
+.TH "NPM\-HOOK" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-hook\fR \- Manage registry hooks
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-init.1
+++ b/deps/npm/man/man1/npm-init.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INIT" "1" "November 2018" "" ""
+.TH "NPM\-INIT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-init\fR \- create a package\.json file
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-install-ci-test.1
+++ b/deps/npm/man/man1/npm-install-ci-test.1
@@ -1,4 +1,4 @@
-.TH "NPM" "" "November 2018" "" ""
+.TH "NPM" "" "December 2018" "" ""
 .SH "NAME"
 \fBnpm\fR
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-install-test.1
+++ b/deps/npm/man/man1/npm-install-test.1
@@ -1,4 +1,4 @@
-.TH "NPM" "" "November 2018" "" ""
+.TH "NPM" "" "December 2018" "" ""
 .SH "NAME"
 \fBnpm\fR
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-install.1
+++ b/deps/npm/man/man1/npm-install.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INSTALL" "1" "November 2018" "" ""
+.TH "NPM\-INSTALL" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-install\fR \- Install a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-link.1
+++ b/deps/npm/man/man1/npm-link.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LINK" "1" "November 2018" "" ""
+.TH "NPM\-LINK" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-link\fR \- Symlink a package folder
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-logout.1
+++ b/deps/npm/man/man1/npm-logout.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LOGOUT" "1" "November 2018" "" ""
+.TH "NPM\-LOGOUT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-logout\fR \- Log out of the registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LS" "1" "November 2018" "" ""
+.TH "NPM\-LS" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-ls\fR \- List installed packages
 .SH SYNOPSIS
@@ -22,7 +22,7 @@ For example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@6.5.0-next.0 /path/to/npm
+npm@6.5.0 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm-outdated.1
+++ b/deps/npm/man/man1/npm-outdated.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OUTDATED" "1" "November 2018" "" ""
+.TH "NPM\-OUTDATED" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-outdated\fR \- Check for outdated packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-owner.1
+++ b/deps/npm/man/man1/npm-owner.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OWNER" "1" "November 2018" "" ""
+.TH "NPM\-OWNER" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-owner\fR \- Manage package owners
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-pack.1
+++ b/deps/npm/man/man1/npm-pack.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PACK" "1" "November 2018" "" ""
+.TH "NPM\-PACK" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-pack\fR \- Create a tarball from a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-ping.1
+++ b/deps/npm/man/man1/npm-ping.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PING" "1" "November 2018" "" ""
+.TH "NPM\-PING" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-ping\fR \- Ping npm registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-prefix.1
+++ b/deps/npm/man/man1/npm-prefix.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PREFIX" "1" "November 2018" "" ""
+.TH "NPM\-PREFIX" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-prefix\fR \- Display prefix
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-profile.1
+++ b/deps/npm/man/man1/npm-profile.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PROFILE" "1" "November 2018" "" ""
+.TH "NPM\-PROFILE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-profile\fR \- Change settings on your registry profile
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-prune.1
+++ b/deps/npm/man/man1/npm-prune.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PRUNE" "1" "November 2018" "" ""
+.TH "NPM\-PRUNE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-prune\fR \- Remove extraneous packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-publish.1
+++ b/deps/npm/man/man1/npm-publish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PUBLISH" "1" "November 2018" "" ""
+.TH "NPM\-PUBLISH" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-publish\fR \- Publish a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-rebuild.1
+++ b/deps/npm/man/man1/npm-rebuild.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REBUILD" "1" "November 2018" "" ""
+.TH "NPM\-REBUILD" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-rebuild\fR \- Rebuild a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-repo.1
+++ b/deps/npm/man/man1/npm-repo.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REPO" "1" "November 2018" "" ""
+.TH "NPM\-REPO" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-repo\fR \- Open package repository page in the browser
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-restart.1
+++ b/deps/npm/man/man1/npm-restart.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RESTART" "1" "November 2018" "" ""
+.TH "NPM\-RESTART" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-restart\fR \- Restart a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-root.1
+++ b/deps/npm/man/man1/npm-root.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ROOT" "1" "November 2018" "" ""
+.TH "NPM\-ROOT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-root\fR \- Display npm root
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-run-script.1
+++ b/deps/npm/man/man1/npm-run-script.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RUN\-SCRIPT" "1" "November 2018" "" ""
+.TH "NPM\-RUN\-SCRIPT" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-run-script\fR \- Run arbitrary package scripts
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-search.1
+++ b/deps/npm/man/man1/npm-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SEARCH" "1" "November 2018" "" ""
+.TH "NPM\-SEARCH" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-search\fR \- Search for packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-shrinkwrap.1
+++ b/deps/npm/man/man1/npm-shrinkwrap.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SHRINKWRAP" "1" "November 2018" "" ""
+.TH "NPM\-SHRINKWRAP" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-shrinkwrap\fR \- Lock down dependency versions for publication
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-star.1
+++ b/deps/npm/man/man1/npm-star.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STAR" "1" "November 2018" "" ""
+.TH "NPM\-STAR" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-star\fR \- Mark your favorite packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-stars.1
+++ b/deps/npm/man/man1/npm-stars.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STARS" "1" "November 2018" "" ""
+.TH "NPM\-STARS" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-stars\fR \- View packages marked as favorites
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-start.1
+++ b/deps/npm/man/man1/npm-start.1
@@ -1,4 +1,4 @@
-.TH "NPM\-START" "1" "November 2018" "" ""
+.TH "NPM\-START" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-start\fR \- Start a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-stop.1
+++ b/deps/npm/man/man1/npm-stop.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STOP" "1" "November 2018" "" ""
+.TH "NPM\-STOP" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-stop\fR \- Stop a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-team.1
+++ b/deps/npm/man/man1/npm-team.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEAM" "1" "November 2018" "" ""
+.TH "NPM\-TEAM" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-team\fR \- Manage organization teams and team memberships
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-test.1
+++ b/deps/npm/man/man1/npm-test.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEST" "1" "November 2018" "" ""
+.TH "NPM\-TEST" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-test\fR \- Test a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-token.1
+++ b/deps/npm/man/man1/npm-token.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TOKEN" "1" "November 2018" "" ""
+.TH "NPM\-TOKEN" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-token\fR \- Manage your authentication tokens
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-uninstall.1
+++ b/deps/npm/man/man1/npm-uninstall.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNINSTALL" "1" "November 2018" "" ""
+.TH "NPM\-UNINSTALL" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-uninstall\fR \- Remove a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-unpublish.1
+++ b/deps/npm/man/man1/npm-unpublish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNPUBLISH" "1" "November 2018" "" ""
+.TH "NPM\-UNPUBLISH" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-unpublish\fR \- Remove a package from the registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-update.1
+++ b/deps/npm/man/man1/npm-update.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UPDATE" "1" "November 2018" "" ""
+.TH "NPM\-UPDATE" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-update\fR \- Update a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-version.1
+++ b/deps/npm/man/man1/npm-version.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VERSION" "1" "November 2018" "" ""
+.TH "NPM\-VERSION" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-version\fR \- Bump a package version
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-view.1
+++ b/deps/npm/man/man1/npm-view.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VIEW" "1" "November 2018" "" ""
+.TH "NPM\-VIEW" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-view\fR \- View registry info
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-whoami.1
+++ b/deps/npm/man/man1/npm-whoami.1
@@ -1,4 +1,4 @@
-.TH "NPM\-WHOAMI" "1" "November 2018" "" ""
+.TH "NPM\-WHOAMI" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-whoami\fR \- Display npm username
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -1,4 +1,4 @@
-.TH "NPM" "1" "November 2018" "" ""
+.TH "NPM" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm\fR \- javascript package manager
 .SH SYNOPSIS
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SH VERSION
 .P
-6.5.0-next.0
+6.5.0
 .SH DESCRIPTION
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man5/npm-folders.5
+++ b/deps/npm/man/man5/npm-folders.5
@@ -1,4 +1,4 @@
-.TH "NPM\-FOLDERS" "5" "November 2018" "" ""
+.TH "NPM\-FOLDERS" "5" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-folders\fR \- Folder Structures Used by npm
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-global.5
+++ b/deps/npm/man/man5/npm-global.5
@@ -1,4 +1,4 @@
-.TH "NPM\-FOLDERS" "5" "November 2018" "" ""
+.TH "NPM\-FOLDERS" "5" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-folders\fR \- Folder Structures Used by npm
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-json.5
+++ b/deps/npm/man/man5/npm-json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\.JSON" "5" "November 2018" "" ""
+.TH "PACKAGE\.JSON" "5" "December 2018" "" ""
 .SH "NAME"
 \fBpackage.json\fR \- Specifics of npm's package\.json handling
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-package-locks.5
+++ b/deps/npm/man/man5/npm-package-locks.5
@@ -1,4 +1,4 @@
-.TH "NPM\-PACKAGE\-LOCKS" "5" "November 2018" "" ""
+.TH "NPM\-PACKAGE\-LOCKS" "5" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-package-locks\fR \- An explanation of npm lockfiles
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-shrinkwrap.json.5
+++ b/deps/npm/man/man5/npm-shrinkwrap.json.5
@@ -1,4 +1,4 @@
-.TH "NPM\-SHRINKWRAP\.JSON" "5" "November 2018" "" ""
+.TH "NPM\-SHRINKWRAP\.JSON" "5" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-shrinkwrap.json\fR \- A publishable lockfile
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npmrc.5
+++ b/deps/npm/man/man5/npmrc.5
@@ -1,4 +1,4 @@
-.TH "NPMRC" "5" "November 2018" "" ""
+.TH "NPMRC" "5" "December 2018" "" ""
 .SH "NAME"
 \fBnpmrc\fR \- The npm config files
 .SH DESCRIPTION

--- a/deps/npm/man/man5/package-lock.json.5
+++ b/deps/npm/man/man5/package-lock.json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\-LOCK\.JSON" "5" "November 2018" "" ""
+.TH "PACKAGE\-LOCK\.JSON" "5" "December 2018" "" ""
 .SH "NAME"
 \fBpackage-lock.json\fR \- A manifestation of the manifest
 .SH DESCRIPTION

--- a/deps/npm/man/man5/package.json.5
+++ b/deps/npm/man/man5/package.json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\.JSON" "5" "November 2018" "" ""
+.TH "PACKAGE\.JSON" "5" "December 2018" "" ""
 .SH "NAME"
 \fBpackage.json\fR \- Specifics of npm's package\.json handling
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-coding-style.7
+++ b/deps/npm/man/man7/npm-coding-style.7
@@ -1,4 +1,4 @@
-.TH "NPM\-CODING\-STYLE" "7" "November 2018" "" ""
+.TH "NPM\-CODING\-STYLE" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-coding-style\fR \- npm's "funny" coding style
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-config.7
+++ b/deps/npm/man/man7/npm-config.7
@@ -1,4 +1,4 @@
-.TH "NPM\-CONFIG" "7" "November 2018" "" ""
+.TH "NPM\-CONFIG" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-config\fR \- More than you probably want to know about npm configuration
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-developers.7
+++ b/deps/npm/man/man7/npm-developers.7
@@ -1,4 +1,4 @@
-.TH "NPM\-DEVELOPERS" "7" "November 2018" "" ""
+.TH "NPM\-DEVELOPERS" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-developers\fR \- Developer Guide
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-disputes.7
+++ b/deps/npm/man/man7/npm-disputes.7
@@ -1,4 +1,4 @@
-.TH "NPM\-DISPUTES" "7" "November 2018" "" ""
+.TH "NPM\-DISPUTES" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-disputes\fR \- Handling Module Name Disputes
 .P

--- a/deps/npm/man/man7/npm-index.7
+++ b/deps/npm/man/man7/npm-index.7
@@ -1,4 +1,4 @@
-.TH "NPM\-INDEX" "7" "November 2018" "" ""
+.TH "NPM\-INDEX" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-index\fR \- Index of all npm documentation
 .SS npm help README

--- a/deps/npm/man/man7/npm-orgs.7
+++ b/deps/npm/man/man7/npm-orgs.7
@@ -1,4 +1,4 @@
-.TH "NPM\-ORGS" "7" "November 2018" "" ""
+.TH "NPM\-ORGS" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-orgs\fR \- Working with Teams & Orgs
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-registry.7
+++ b/deps/npm/man/man7/npm-registry.7
@@ -1,4 +1,4 @@
-.TH "NPM\-REGISTRY" "7" "November 2018" "" ""
+.TH "NPM\-REGISTRY" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-registry\fR \- The JavaScript Package Registry
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-scope.7
+++ b/deps/npm/man/man7/npm-scope.7
@@ -1,4 +1,4 @@
-.TH "NPM\-SCOPE" "7" "November 2018" "" ""
+.TH "NPM\-SCOPE" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-scope\fR \- Scoped packages
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-scripts.7
+++ b/deps/npm/man/man7/npm-scripts.7
@@ -1,4 +1,4 @@
-.TH "NPM\-SCRIPTS" "7" "November 2018" "" ""
+.TH "NPM\-SCRIPTS" "7" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-scripts\fR \- How npm handles the "scripts" field
 .SH DESCRIPTION

--- a/deps/npm/man/man7/removing-npm.7
+++ b/deps/npm/man/man7/removing-npm.7
@@ -1,4 +1,4 @@
-.TH "NPM\-REMOVAL" "1" "November 2018" "" ""
+.TH "NPM\-REMOVAL" "1" "December 2018" "" ""
 .SH "NAME"
 \fBnpm-removal\fR \- Cleaning the Slate
 .SH SYNOPSIS

--- a/deps/npm/man/man7/semver.7
+++ b/deps/npm/man/man7/semver.7
@@ -1,4 +1,4 @@
-.TH "SEMVER" "7" "November 2018" "" ""
+.TH "SEMVER" "7" "December 2018" "" ""
 .SH "NAME"
 \fBsemver\fR \- The semantic versioner for npm
 .SH Install

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.5.0-next.0",
+  "version": "6.5.0",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/deps/npm/test/fake-registry.js
+++ b/deps/npm/test/fake-registry.js
@@ -5,7 +5,7 @@ const log = require('npmlog')
 
 const http = require('http')
 const EventEmitter = require('events')
-// See mock-registry.md for details
+// See fake-registry.md for details
 
 class FakeRegistry extends EventEmitter {
   constructor (opts) {

--- a/deps/npm/test/tap/unsupported.js
+++ b/deps/npm/test/tap/unsupported.js
@@ -29,7 +29,8 @@ var versions = [
   ['v8.4.0', false, false],
   ['v9.3.0', false, false],
   ['v10.0.0-0', false, false],
-  ['v11.0.0-0', false, false]
+  ['v11.0.0-0', false, false],
+  ['v12.0.0-0', false, false]
 ]
 
 test('versions', function (t) {


### PR DESCRIPTION
I noticed that node v11.6 ships with an `npm` that reports a version of `v6.5.0-next.0`. This PR updates that to actual v6.5.0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] followed instructions at https://github.com/nodejs/node/blob/master/doc/guides/maintaining-npm.md
- [ ] `make test-npm` passes (running now)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)