### PR TITLE
src: trace_events: fix race with metadata events

### DIFF
--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -207,9 +207,17 @@ void Agent::AppendTraceEvent(TraceObject* trace_event) {
     id_writer.second->AppendTraceEvent(trace_event);
 }
 
+void Agent::AddMetadataEvent(std::unique_ptr<TraceObject> event) {
+  Mutex::ScopedLock lock(metadata_events_mutex_);
+  metadata_events_.push_back(std::move(event));
+}
+
 void Agent::Flush(bool blocking) {
-  for (const auto& event : metadata_events_)
-    AppendTraceEvent(event.get());
+  {
+    Mutex::ScopedLock lock(metadata_events_mutex_);
+    for (const auto& event : metadata_events_)
+      AppendTraceEvent(event.get());
+  }
 
   for (const auto& id_writer : writers_)
     id_writer.second->Flush(blocking);

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -104,9 +104,7 @@ class Agent {
   // Writes to all writers registered through AddClient().
   void AppendTraceEvent(TraceObject* trace_event);
 
-  void AddMetadataEvent(std::unique_ptr<TraceObject> event) {
-    metadata_events_.push_back(std::move(event));
-  }
+  void AddMetadataEvent(std::unique_ptr<TraceObject> event);
   // Flushes all writers registered through AddClient().
   void Flush(bool blocking);
 
@@ -145,6 +143,8 @@ class Agent {
   ConditionVariable initialize_writer_condvar_;
   uv_async_t initialize_writer_async_;
   std::set<AsyncTraceWriter*> to_be_initialized_;
+
+  Mutex metadata_events_mutex_;
   std::list<std::unique_ptr<TraceObject>> metadata_events_;
 };
 


### PR DESCRIPTION
Multiple threads may be concurrently adding to the metadata_events list.
Protect access with a mutex.

Fixes: https://github.com/nodejs/node/issues/24129

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

CI: ~~https://ci.nodejs.org/job/node-test-pull-request/19827/~~ https://ci.nodejs.org/job/node-test-pull-request/19975/