### PR TITLE
tools: update to ESLint 5.11.1 and enable no-useless-catch rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -234,6 +234,7 @@ module.exports = {
       variables: false,
     }],
     'no-useless-call': 'error',
+    'no-useless-catch': 'error',
     'no-useless-concat': 'error',
     'no-useless-constructor': 'error',
     'no-useless-escape': 'error',

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -80,7 +80,7 @@ class Script extends ContextifyScript {
     // Calling `ReThrow()` on a native TryCatch does not generate a new
     // abort-on-uncaught-exception check. A dummy try/catch in JS land
     // protects against that.
-    try {
+    try { // eslint-disable-line no-useless-catch
       super(code,
             filename,
             lineOffset,

--- a/tools/node_modules/eslint/lib/rules/no-useless-catch.js
+++ b/tools/node_modules/eslint/lib/rules/no-useless-catch.js
@@ -27,6 +27,7 @@ module.exports = {
         return {
             CatchClause(node) {
                 if (
+                    node.param &&
                     node.param.type === "Identifier" &&
                     node.body.body.length &&
                     node.body.body[0].type === "ThrowStatement" &&

--- a/tools/node_modules/eslint/package.json
+++ b/tools/node_modules/eslint/package.json
@@ -134,5 +134,5 @@
     "publish-release": "node Makefile.js publishRelease",
     "test": "node Makefile.js test"
   },
-  "version": "5.11.0"
+  "version": "5.11.1"
 }


### PR DESCRIPTION
[`no-useless-catch`](https://eslint.org/docs/rules/no-useless-catch) was introduced in ESLint 5.11.0. I tried to enable the rule then, but it had a bug. The bug is fixed in 5.11.1, which is the entirety of the ESLint update. This PR enables `no-useless-catch`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
