### PR TITLE
lib: simplify several debug() calls

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -477,8 +477,8 @@ function onOrigin(origins) {
   const session = this[kOwner];
   if (session.destroyed)
     return;
-  debug(`Http2Session ${sessionName(session[kType])}: origin received: ` +
-        `${origins.join(', ')}`);
+  debug('Http2Session %s: origin received: %j',
+        sessionName(session[kType]), origins);
   session[kUpdateTimer]();
   if (!session.encrypted || session.destroyed)
     return undefined;

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -6,9 +6,7 @@ const ArrayJoin = Function.call.bind(Array.prototype.join);
 const ArrayMap = Function.call.bind(Array.prototype.map);
 
 const createDynamicModule = (exports, url = '', evaluate) => {
-  debug(
-    `creating ESM facade for ${url} with exports: ${ArrayJoin(exports, ', ')}`
-  );
+  debug('creating ESM facade for %s with exports: %j', url, exports);
   const names = ArrayMap(exports, (name) => `${name}`);
 
   const source = `


### PR DESCRIPTION
Avoid calling `Array.prototype.join()` in `debug()` calls. These are evaluated on every call, even if the `debug()` call is a no-op. This commit replaces the `join()` calls with the `%j` placeholder.

As a general note, we should probably migrate the codebase to using `printf()` style placeholders, and avoid template strings and string concatenation in `debug()` calls. It might be a good Code and Learn activity. The http2 module is a particularly bad offender.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
