### PR TITLE
crypto: fix zero byte allocation assertion failure

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2699,7 +2699,7 @@ static bool IsSupportedAuthenticatedMode(const EVP_CIPHER_CTX* ctx) {
 template <typename T>
 static T* MallocOpenSSL(size_t count) {
   void* mem = OPENSSL_malloc(MultiplyWithOverflowCheck(count, sizeof(T)));
-  CHECK_NOT_NULL(mem);
+  CHECK_IMPLIES(mem == nullptr, count == 0);
   return static_cast<T*>(mem);
 }
 
@@ -2857,7 +2857,8 @@ static EVPKeyPointer ParsePrivateKey(const PrivateKeyEncodingConfig& config,
 
   if (config.format_ == kKeyFormatPEM) {
     BIOPointer bio(BIO_new_mem_buf(key, key_len));
-    CHECK(bio);
+    if (!bio)
+      return pkey;
 
     char* pass = const_cast<char*>(config.passphrase_.get());
     pkey.reset(PEM_read_bio_PrivateKey(bio.get(),
@@ -2872,7 +2873,8 @@ static EVPKeyPointer ParsePrivateKey(const PrivateKeyEncodingConfig& config,
       pkey.reset(d2i_PrivateKey(EVP_PKEY_RSA, nullptr, &p, key_len));
     } else if (config.type_.ToChecked() == kKeyEncodingPKCS8) {
       BIOPointer bio(BIO_new_mem_buf(key, key_len));
-      CHECK(bio);
+      if (!bio)
+        return pkey;
       char* pass = const_cast<char*>(config.passphrase_.get());
       pkey.reset(d2i_PKCS8PrivateKey_bio(bio.get(),
                                          nullptr,

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -105,3 +105,10 @@ const privatePem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
     }
   }
 }
+
+{
+  // This should not cause a crash: https://github.com/nodejs/node/issues/25247
+  assert.throws(() => {
+    createPrivateKey({ key: '' });
+  });
+}


### PR DESCRIPTION
When an empty string was passed, `malloc` might have returned a `nullptr` depending on the platform, causing an assertion failure. This change makes private key parsing behave as public key parsing does, causing a BIO error instead that can be caught in JS.

I am pre-emptively labeling this `security` due to the simplicity of causing this failure. This currently only affects the most recent release, v11.6.0, and no other release should include #24234 without this fix.

Fixes: https://github.com/nodejs/node/issues/25247

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
