### PR TITLE
assert: refactor AssertionError properties 

### DIFF
--- a/lib/internal/assert.js
+++ b/lib/internal/assert.js
@@ -390,8 +390,32 @@ class AssertionError extends Error {
     this.generatedMessage = !message;
     this.name = 'AssertionError [ERR_ASSERTION]';
     this.code = 'ERR_ASSERTION';
-    this.actual = actual;
-    this.expected = expected;
+    // This prevents inspecting the actual and expected value by default.
+    // That is logical since the summary will be printed already. Users can then
+    // explicitly access these properties in case they want to know what value
+    // was used.
+    Object.defineProperties(this, {
+      actual: {
+        get() {
+          return actual;
+        },
+        set(val) {
+          actual = val;
+        },
+        enumerable: true,
+        configurable: true
+      },
+      expected: {
+        get() {
+          return expected;
+        },
+        set(val) {
+          expected = val;
+        },
+        enumerable: true,
+        configurable: true
+      }
+    });
     this.operator = operator;
     Error.captureStackTrace(this, stackStartFn);
   }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -257,16 +257,14 @@ const circular = { y: 1 };
 circular.x = circular;
 
 function testAssertionMessage(actual, expected, msg) {
-  try {
-    assert.strictEqual(actual, '');
-  } catch (e) {
-    assert.strictEqual(
-      e.message,
-      msg || strictEqualMessageStart +
-             `+ actual - expected\n\n+ ${expected}\n- ''`
-    );
-    assert.ok(e.generatedMessage, 'Message not marked as generated');
-  }
+  assert.throws(
+    () => assert.strictEqual(actual, ''),
+    {
+      generatedMessage: true,
+      message: msg || strictEqualMessageStart +
+               `+ actual - expected\n\n+ ${expected}\n- ''`
+    }
+  );
 }
 
 function testShortAssertionMessage(actual, expected) {
@@ -280,7 +278,7 @@ testShortAssertionMessage(false, 'false');
 testShortAssertionMessage(100, '100');
 testShortAssertionMessage(NaN, 'NaN');
 testShortAssertionMessage(Infinity, 'Infinity');
-testShortAssertionMessage('', '""');
+testShortAssertionMessage('a', '"a"');
 testShortAssertionMessage('foo', '\'foo\'');
 testShortAssertionMessage(0, '0');
 testShortAssertionMessage(Symbol(), 'Symbol()');

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -308,6 +308,16 @@ try {
     `${strictEqualMessageStart}\n1 !== 2\n`
   );
   assert.ok(e.generatedMessage, 'Message not marked as generated');
+  const descriptors = Object.getOwnPropertyDescriptors(e);
+  assert.strictEqual(typeof descriptors.actual.get, 'function');
+  assert.strictEqual(typeof descriptors.expected.get, 'function');
+  const { actual, expected } = e;
+  e.actual++;
+  e.expected++;
+  assert.strictEqual(descriptors.actual.enumerable, true);
+  assert.strictEqual(descriptors.expected.enumerable, true);
+  assert.strictEqual(e.actual, actual + 1);
+  assert.strictEqual(e.expected, expected + 1);
 }
 
 try {


### PR DESCRIPTION
When inspecting an `AssertionError` the `actual` and `expected` properties would also show up inspected (due to another recent change that made sure that extra properties on errors will always be visible).

This is not really very user friendly since we already print something in the error message and showing the values again, duplicates the output. Another alternative to this would be to use a custom inspection function for `AssertionError` but I believe just moving these two properties behind getters already solved the problem well enough while keeping the other properties visible to the user.

The other commit fixes a test case.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
