### PR TITLE
util: switch to runtime deprecation for `util._extend()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1224,6 +1224,9 @@ The [`util.log()`][] API is deprecated.
 ### DEP0060: util.\_extend()
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Switched to a runtime deprecation.
   - version: v6.12.0
     pr-url: https://github.com/nodejs/node/pull/10116
     description: A deprecation code has been assigned.
@@ -1232,7 +1235,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`util._extend()`][] API is deprecated.
 
@@ -2297,7 +2300,6 @@ changes:
 Type: Runtime
 
 Please use `Server.prototype.setSecureContext()` instead.
-
 
 <a id="DEP0123"></a>
 ### DEP0123: setting the TLS ServerName to an IP address

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2244,6 +2244,6 @@ Deprecated predecessor of `console.log`.
 [default sort]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 [global symbol registry]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for
 [list of deprecated APIS]: deprecations.html#deprecations_list_of_deprecated_apis
+[object spread notation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179
 [util.inspect.custom]: #util_util_inspect_custom
-[object spread notation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1716,7 +1716,8 @@ The `util._extend()` method was never intended to be used outside of internal
 Node.js modules. The community found and used it anyway.
 
 It is deprecated and should not be used in new code. JavaScript comes with very
-similar built-in functionality through [`Object.assign()`].
+similar built-in functionality through [`Object.assign()`]. Another alternative
+that often works well is using the [object spread notation][].
 
 ### util.debug(string)
 <!-- YAML
@@ -2245,3 +2246,4 @@ Deprecated predecessor of `console.log`.
 [list of deprecated APIS]: deprecations.html#deprecations_list_of_deprecated_apis
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179
 [util.inspect.custom]: #util_util_inspect_custom
+[object spread notation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax

--- a/lib/util.js
+++ b/lib/util.js
@@ -452,8 +452,8 @@ module.exports = exports = {
   puts: deprecate(puts,
                   'util.puts is deprecated. Use console.log instead.',
                   'DEP0027'),
-  _extend: deprecate(
-    _extend,
-    'util._extend() is deprecated. Use `Object.assign()` instead.',
-    'DEP0XXX'),
+  _extend: deprecate(_extend,
+                     'util._extend() is deprecated. Use `Object.assign()` ' +
+                       'instead.',
+                     'DEP0XXX'),
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -401,7 +401,6 @@ function getSystemErrorName(err) {
 module.exports = exports = {
   _errnoException: errors.errnoException,
   _exceptionWithHostPort: errors.exceptionWithHostPort,
-  _extend,
   callbackify,
   debuglog,
   deprecate,
@@ -452,5 +451,9 @@ module.exports = exports = {
                    'DEP0026'),
   puts: deprecate(puts,
                   'util.puts is deprecated. Use console.log instead.',
-                  'DEP0027')
+                  'DEP0027'),
+  _extend: deprecate(
+    _extend,
+    'util._extend() is deprecated. Use `Object.assign()` instead.',
+    'DEP0XXX'),
 };

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -145,6 +145,7 @@ assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
 common.expectWarning('DeprecationWarning', [
+  ['util._extend() is deprecated. Use `Object.assign()` instead.', 'DEP0XXX'],
   ['util.print is deprecated. Use console.log instead.', 'DEP0026'],
   ['util.puts is deprecated. Use console.log instead.', 'DEP0027'],
   ['util.debug is deprecated. Use console.error instead.', 'DEP0028'],


### PR DESCRIPTION
This function has been deprecated for quite some while and the native
alternatives are faster than using this helper function. Therefore
it is better to warn users about using this function altogether.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
