### PR TITLE
repl: indicate if errors are thrown or not

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -435,7 +435,10 @@ function REPLServer(prompt,
     }
 
     if (errStack === '') {
-      errStack = `Thrown: ${util.inspect(e)}`;
+      errStack = `Thrown: ${util.inspect(e)}\n`;
+    } else {
+      const ln = errStack.endsWith('\n') ? '' : '\n';
+      errStack = `Thrown:\n${errStack}${ln}`;
     }
 
     if (!self.underscoreErrAssigned) {
@@ -443,7 +446,7 @@ function REPLServer(prompt,
     }
 
     const top = replMap.get(self);
-    top.outputStream.write(`${errStack}\n`);
+    top.outputStream.write(errStack);
     top.clearBufferedCommand();
     top.lines.level = [];
     top.displayPrompt();

--- a/test/parallel/test-repl-harmony.js
+++ b/test/parallel/test-repl-harmony.js
@@ -30,7 +30,7 @@ const child = spawn(process.execPath, args);
 const input = '(function(){"use strict"; const y=1;y=2})()\n';
 // This message will vary based on JavaScript engine, so don't check the message
 // contents beyond confirming that the `Error` is a `TypeError`.
-const expectOut = /^> TypeError: /;
+const expectOut = /^> Thrown:\nTypeError: /;
 
 child.stderr.setEncoding('utf8');
 child.stderr.on('data', function(c) {

--- a/test/parallel/test-repl-pretty-custom-stack.js
+++ b/test/parallel/test-repl-pretty-custom-stack.js
@@ -46,25 +46,26 @@ const tests = [
   {
     // test .load for a file that throws
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Error: Whoops!--->\nrepl:9:24--->\nd (repl:12:3)--->\nc ' +
-              '(repl:9:3)--->\nb (repl:6:3)--->\na (repl:3:3)\n'
+    expected: 'Thrown:\nError: Whoops!--->\nrepl:9:24--->\nd (repl:12:3)' +
+              '--->\nc (repl:9:3)--->\nb (repl:6:3)--->\na (repl:3:3)\n'
   },
   {
     command: 'let x y;',
-    expected: 'let x y;\n      ^\n\nSyntaxError: Unexpected identifier\n'
+    expected: 'Thrown:\n' +
+              'let x y;\n      ^\n\nSyntaxError: Unexpected identifier\n'
   },
   {
     command: 'throw new Error(\'Whoops!\')',
-    expected: 'Error: Whoops!\n'
+    expected: 'Thrown:\nError: Whoops!\n'
   },
   {
     command: 'foo = bar;',
-    expected: 'ReferenceError: bar is not defined\n'
+    expected: 'Thrown:\nReferenceError: bar is not defined\n'
   },
   // test anonymous IIFE
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Error: Whoops!--->\nrepl:1:21\n'
+    expected: 'Thrown:\nError: Whoops!--->\nrepl:1:21\n'
   }
 ];
 

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -31,25 +31,27 @@ const tests = [
   {
     // test .load for a file that throws
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Error: Whoops!\n    at repl:9:24\n    at d (repl:12:3)\n    ' +
-              'at c (repl:9:3)\n    at b (repl:6:3)\n    at a (repl:3:3)\n'
+    expected: 'Thrown:\nError: Whoops!\n    at repl:9:24\n' +
+              '    at d (repl:12:3)\n    at c (repl:9:3)\n' +
+              '    at b (repl:6:3)\n    at a (repl:3:3)\n'
   },
   {
     command: 'let x y;',
-    expected: 'let x y;\n      ^\n\nSyntaxError: Unexpected identifier\n\n'
+    expected: 'Thrown:\n' +
+              'let x y;\n      ^\n\nSyntaxError: Unexpected identifier\n'
   },
   {
     command: 'throw new Error(\'Whoops!\')',
-    expected: 'Error: Whoops!\n'
+    expected: 'Thrown:\nError: Whoops!\n'
   },
   {
     command: 'foo = bar;',
-    expected: 'ReferenceError: bar is not defined\n'
+    expected: 'Thrown:\nReferenceError: bar is not defined\n'
   },
   // test anonymous IIFE
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Error: Whoops!\n    at repl:1:21\n'
+    expected: 'Thrown:\nError: Whoops!\n    at repl:1:21\n'
   }
 ];
 

--- a/test/parallel/test-repl-tab-complete-no-warn.js
+++ b/test/parallel/test-repl-tab-complete-no-warn.js
@@ -5,8 +5,7 @@ const ArrayStream = require('../common/arraystream');
 const repl = require('repl');
 const DEFAULT_MAX_LISTENERS = require('events').defaultMaxListeners;
 
-ArrayStream.prototype.write = () => {
-};
+ArrayStream.prototype.write = () => {};
 
 const putIn = new ArrayStream();
 const testMe = repl.start('', putIn);

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -118,15 +118,15 @@ async function ordinaryTests() {
     [ 'if (await true) { function bar() {}; }', 'undefined' ],
     [ 'bar', '[Function: bar]' ],
     [ 'if (await true) { class Bar {}; }', 'undefined' ],
-    [ 'Bar', 'ReferenceError: Bar is not defined', { line: 0 } ],
+    [ 'Bar', 'ReferenceError: Bar is not defined', { line: 1 } ],
     [ 'await 0; function* gen(){}', 'undefined' ],
     [ 'for (var i = 0; i < 10; ++i) { await i; }', 'undefined' ],
     [ 'i', '10' ],
     [ 'for (let j = 0; j < 5; ++j) { await j; }', 'undefined' ],
-    [ 'j', 'ReferenceError: j is not defined', { line: 0 } ],
+    [ 'j', 'ReferenceError: j is not defined', { line: 1 } ],
     [ 'gen', '[GeneratorFunction: gen]' ],
     [ 'return 42; await 5;', 'SyntaxError: Illegal return statement',
-      { line: 3 } ],
+      { line: 4 } ],
     [ 'let o = await 1, p', 'undefined' ],
     [ 'p', 'undefined' ],
     [ 'let q = 1, s = await 2', 'undefined' ],
@@ -160,6 +160,7 @@ async function ctrlCTest() {
     { ctrl: true, name: 'c' }
   ]), [
     'await timeout(100000)\r',
+    'Thrown:',
     'Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
       'Script execution was interrupted by `SIGINT`',
     PROMPT

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -173,10 +173,12 @@ function testError() {
       'undefined',
 
       // The error, both from the original throw and the `_error` echo.
+      'Thrown:',
       'Error: foo',
       '[Error: foo]',
 
       // The sync error, with individual property echoes
+      'Thrown:',
       /^{ Error: ENOENT: no such file or directory, scandir '.*nonexistent.*'/,
       /Object\.readdirSync/,
       /^  errno: -(2|4058),$/,
@@ -191,6 +193,7 @@ function testError() {
       'undefined',
 
       // The message from the original throw
+      'Thrown:',
       'Error: baz',
       /setImmediate/,
       /^    at/,
@@ -217,6 +220,7 @@ function testError() {
       "'baz'",
       'Expression assignment to _error now disabled.',
       '0',
+      'Thrown:',
       'Error: quux',
       '0'
     ]);


### PR DESCRIPTION
Currently an error is printed identical, no matter if it is just
inspected or if the error is thrown inside of the REPL. This makes
sure we are able to distinguish these cases.

This also reduces the number of extra lines while inspecting errors in the repl in case the last line is a linebreak.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
