### PR TITLE
util: deprecate inherits

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2313,6 +2313,21 @@ Type: Runtime
 Setting the TLS ServerName to an IP address is not permitted by
 [RFC 6066][]. This will be ignored in a future version.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: util.inherits()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+`util.inherits()` is only a small abstraction over `Object.setPrototypeOf()` and
+has no real benefit over using that function directly. Use `class` with
+`extends` instead.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -317,6 +317,7 @@ fs.access('file/that/does/not/exist', (err) => {
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
+deprecated: REPLACEME
 changes:
   - version: v5.0.0
     pr-url: https://github.com/nodejs/node/pull/3455
@@ -326,9 +327,12 @@ changes:
 * `constructor` {Function}
 * `superConstructor` {Function}
 
+> Stability: 0 - Deprecated: Use `class` with [`extends`][] instead.
+
 Usage of `util.inherits()` is discouraged. Please use the ES6 `class` and
-`extends` keywords to get language level inheritance support. Also note
-that the two styles are [semantically incompatible][].
+[`extends`][] keywords to get language level inheritance support or use
+[`Object.setPrototypeOf()`]. Also note that the two styles are [semantically
+incompatible][].
 
 Inherit the prototype methods from one [constructor][] into another. The
 prototype of `constructor` will be set to a new object created from
@@ -364,7 +368,7 @@ stream.on('data', (data) => {
 stream.write('It works!'); // Received data: "It works!"
 ```
 
-ES6 example using `class` and `extends`:
+ES6 example using `class` and [`extends`][]:
 
 ```js
 const EventEmitter = require('events');
@@ -2207,6 +2211,7 @@ Deprecated predecessor of `console.log`.
 [`Int8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`Object.assign()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+[`Object.setPrototypeOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 [`Promise`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [`Proxy`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 [`Set`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
@@ -2222,6 +2227,7 @@ Deprecated predecessor of `console.log`.
 [`assert.deepStrictEqual()`]: assert.html#assert_assert_deepstrictequal_actual_expected_message
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args
+[`extends`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends
 [`util.format()`]: #util_util_format_format_args
 [`util.inspect()`]: #util_util_inspect_object_options
 [`util.promisify()`]: #util_util_promisify_original

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -309,7 +309,8 @@ function Server(options, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server, net.Server);
+Object.setPrototypeOf(Server.prototype, net.Server.prototype);
 
 
 Server.prototype.setTimeout = function setTimeout(msecs, callback) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -343,7 +343,9 @@ function TLSSocket(socket, opts) {
   // Read on next tick so the caller has a chance to setup listeners
   process.nextTick(initRead, this, socket);
 }
-util.inherits(TLSSocket, net.Socket);
+Object.setPrototypeOf(TLSSocket, net.Socket);
+Object.setPrototypeOf(TLSSocket.prototype, net.Socket.prototype);
+
 exports.TLSSocket = TLSSocket;
 
 var proxiedMethods = [
@@ -877,7 +879,9 @@ function Server(options, listener) {
   }
 }
 
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server, net.Server);
+Object.setPrototypeOf(Server.prototype, net.Server.prototype);
+
 exports.Server = Server;
 exports.createServer = function createServer(options, listener) {
   return new Server(options, listener);

--- a/lib/https.js
+++ b/lib/https.js
@@ -33,7 +33,6 @@ const {
   kServerResponse
 } = require('_http_server');
 const { ClientRequest } = require('_http_client');
-const { inherits } = util;
 const debug = util.debuglog('https');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { IncomingMessage, ServerResponse } = require('http');
@@ -76,7 +75,8 @@ function Server(opts, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-inherits(Server, tls.Server);
+Object.setPrototypeOf(Server, tls.Server);
+Object.setPrototypeOf(Server.prototype, tls.Server.prototype);
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 

--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -17,7 +17,8 @@ function LazyTransform(options) {
   this.writable = true;
   this.readable = true;
 }
-util.inherits(LazyTransform, stream.Transform);
+Object.setPrototypeOf(LazyTransform, stream.Transform);
+Object.setPrototypeOf(LazyTransform.prototype, stream.Transform.prototype);
 
 function makeGetter(name) {
   return function() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -331,7 +331,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-util.inherits(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -21,7 +21,6 @@
 
 'use strict';
 
-const { inherits } = require('util');
 const net = require('net');
 const { TTY, isTTY } = internalBinding('tty_wrap');
 const errors = require('internal/errors');
@@ -58,7 +57,8 @@ function ReadStream(fd, options) {
   this.isRaw = false;
   this.isTTY = true;
 }
-inherits(ReadStream, net.Socket);
+Object.setPrototypeOf(ReadStream, net.Socket);
+Object.setPrototypeOf(ReadStream.prototype, net.Socket.prototype);
 
 ReadStream.prototype.setRawMode = function(flag) {
   flag = !!flag;
@@ -103,7 +103,8 @@ function WriteStream(fd) {
     this.rows = winSize[1];
   }
 }
-inherits(WriteStream, net.Socket);
+Object.setPrototypeOf(WriteStream, net.Socket);
+Object.setPrototypeOf(WriteStream.prototype, net.Socket.prototype);
 
 WriteStream.prototype.isTTY = true;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -408,7 +408,11 @@ module.exports = exports = {
   format,
   formatWithOptions,
   getSystemErrorName,
-  inherits,
+  inherits: deprecate(
+    inherits,
+    'util.inherits() is deprecated. Use `class` with `extends` or ' +
+      '`Object.setPrototypeOf()` instead.',
+    'DEP0XXX'),
   inspect,
   isArray: Array.isArray,
   isBoolean,

--- a/test/parallel/test-net-access-byteswritten.js
+++ b/test/parallel/test-net-access-byteswritten.js
@@ -12,8 +12,10 @@ const tty = require('tty');
 // Check that the bytesWritten getter doesn't crash if object isn't
 // constructed.
 assert.strictEqual(net.Socket.prototype.bytesWritten, undefined);
-assert.strictEqual(tls.TLSSocket.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tls.TLSSocket).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tls.TLSSocket.prototype.bytesWritten, undefined);
-assert.strictEqual(tty.ReadStream.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tty.ReadStream).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tty.ReadStream.prototype.bytesWritten, undefined);
 assert.strictEqual(tty.WriteStream.prototype.bytesWritten, undefined);

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -108,3 +108,9 @@ common.expectsError(function() {
   type: TypeError,
   message: 'The "ctor" argument must be of type Function. Received type object'
 });
+
+common.expectWarning('DeprecationWarning', [[
+  'util.inherits() is deprecated. Use `class` with `extends` or ' +
+    '`Object.setPrototypeOf()` instead.',
+  'DEP0XXX'
+]]);


### PR DESCRIPTION
`util.inherits()` usage is already discouraged since v6.x (which is the reason why I did not use a doc-only deprecation as that's pretty much identical). Since we also removed all internal usage (besides in a few tests which is done soon) we should also suggest removing it to others.

This is currently blocked by https://github.com/nodejs/node/pull/25252 (that has to land first).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
