### PR TITLE
util: doc-deprecate inherits

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2334,6 +2334,21 @@ Type: Runtime
 Setting the TLS ServerName to an IP address is not permitted by
 [RFC 6066][]. This will be ignored in a future version.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: util.inherits()
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+`util.inherits()` is only a small abstraction over `Object.setPrototypeOf()` and
+has no real benefit over using that function directly. Use `class` with
+`extends` instead.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -317,6 +317,7 @@ fs.access('file/that/does/not/exist', (err) => {
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
+deprecated: REPLACEME
 changes:
   - version: v5.0.0
     pr-url: https://github.com/nodejs/node/pull/3455
@@ -326,13 +327,18 @@ changes:
 * `constructor` {Function}
 * `superConstructor` {Function}
 
+> Stability: 0 - Deprecated: Use `class` with [`extends`][] instead.
+
 Usage of `util.inherits()` is discouraged. Please use the ES6 `class` and
-`extends` keywords to get language level inheritance support. Also note
-that the two styles are [semantically incompatible][].
+[`extends`][] keywords to get language level inheritance support or use
+[`Object.setPrototypeOf()`].
 
 Inherit the prototype methods from one [constructor][] into another. The
 prototype of `constructor` will be set to a new object created from
-`superConstructor`.
+`superConstructor`. This is [semantically incompatible][] with the ES6
+[`extends`][] keyword as the prototype of the main class is not set to the
+inherited one and `instanceof` checks trying to verify such inheritance will
+fail. Both is the case when using ES6 classes.
 
 This mainly adds some input validation on top of
 `Object.setPrototypeOf(constructor.prototype, superConstructor.prototype)`.
@@ -364,7 +370,7 @@ stream.on('data', (data) => {
 stream.write('It works!'); // Received data: "It works!"
 ```
 
-ES6 example using `class` and `extends`:
+ES6 example using `class` and [`extends`][]:
 
 ```js
 const EventEmitter = require('events');
@@ -2159,6 +2165,7 @@ util.log('Timestamped message.');
 [`Int8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`Object.assign()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+[`Object.setPrototypeOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 [`Promise`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [`Proxy`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 [`Set`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
@@ -2173,6 +2180,8 @@ util.log('Timestamped message.');
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.html#assert_assert_deepstrictequal_actual_expected_message
 [`console.error()`]: console.html#console_console_error_data_args
+[`console.log()`]: console.html#console_console_log_data_args
+[`extends`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Terminology
 [`util.format()`]: #util_util_format_format_args
 [`util.inspect()`]: #util_util_inspect_object_options

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -21,7 +21,6 @@
 
 'use strict';
 
-const util = require('util');
 const net = require('net');
 const assert = require('assert').ok;
 const {
@@ -309,7 +308,8 @@ function Server(options, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server, net.Server);
+Object.setPrototypeOf(Server.prototype, net.Server.prototype);
 
 
 Server.prototype.setTimeout = function setTimeout(msecs, callback) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -347,7 +347,9 @@ function TLSSocket(socket, opts) {
   // Read on next tick so the caller has a chance to setup listeners
   process.nextTick(initRead, this, socket);
 }
-util.inherits(TLSSocket, net.Socket);
+Object.setPrototypeOf(TLSSocket, net.Socket);
+Object.setPrototypeOf(TLSSocket.prototype, net.Socket.prototype);
+
 exports.TLSSocket = TLSSocket;
 
 var proxiedMethods = [
@@ -881,7 +883,9 @@ function Server(options, listener) {
   }
 }
 
-util.inherits(Server, net.Server);
+Object.setPrototypeOf(Server, net.Server);
+Object.setPrototypeOf(Server.prototype, net.Server.prototype);
+
 exports.Server = Server;
 exports.createServer = function createServer(options, listener) {
   return new Server(options, listener);

--- a/lib/https.js
+++ b/lib/https.js
@@ -33,7 +33,6 @@ const {
   kServerResponse
 } = require('_http_server');
 const { ClientRequest } = require('_http_client');
-const { inherits } = util;
 const debug = util.debuglog('https');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { IncomingMessage, ServerResponse } = require('http');
@@ -76,7 +75,8 @@ function Server(opts, requestListener) {
   this.maxHeadersCount = null;
   this.headersTimeout = 40 * 1000; // 40 seconds
 }
-inherits(Server, tls.Server);
+Object.setPrototypeOf(Server, tls.Server);
+Object.setPrototypeOf(Server.prototype, tls.Server.prototype);
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 

--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const stream = require('stream');
-const util = require('util');
 
 const {
   getDefaultEncoding
@@ -17,7 +16,8 @@ function LazyTransform(options) {
   this.writable = true;
   this.readable = true;
 }
-util.inherits(LazyTransform, stream.Transform);
+Object.setPrototypeOf(LazyTransform, stream.Transform);
+Object.setPrototypeOf(LazyTransform.prototype, stream.Transform.prototype);
 
 function makeGetter(name) {
   return function() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -331,7 +331,8 @@ function Socket(options) {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
 }
-util.inherits(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket, stream.Duplex);
+Object.setPrototypeOf(Socket.prototype, stream.Duplex.prototype);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -21,7 +21,6 @@
 
 'use strict';
 
-const { inherits } = require('util');
 const net = require('net');
 const { TTY, isTTY } = internalBinding('tty_wrap');
 const errors = require('internal/errors');
@@ -58,7 +57,8 @@ function ReadStream(fd, options) {
   this.isRaw = false;
   this.isTTY = true;
 }
-inherits(ReadStream, net.Socket);
+Object.setPrototypeOf(ReadStream, net.Socket);
+Object.setPrototypeOf(ReadStream.prototype, net.Socket.prototype);
 
 ReadStream.prototype.setRawMode = function(flag) {
   flag = !!flag;
@@ -103,7 +103,8 @@ function WriteStream(fd) {
     this.rows = winSize[1];
   }
 }
-inherits(WriteStream, net.Socket);
+Object.setPrototypeOf(WriteStream, net.Socket);
+Object.setPrototypeOf(WriteStream.prototype, net.Socket.prototype);
 
 WriteStream.prototype.isTTY = true;
 

--- a/test/parallel/test-net-access-byteswritten.js
+++ b/test/parallel/test-net-access-byteswritten.js
@@ -12,8 +12,10 @@ const tty = require('tty');
 // Check that the bytesWritten getter doesn't crash if object isn't
 // constructed.
 assert.strictEqual(net.Socket.prototype.bytesWritten, undefined);
-assert.strictEqual(tls.TLSSocket.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tls.TLSSocket).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tls.TLSSocket.prototype.bytesWritten, undefined);
-assert.strictEqual(tty.ReadStream.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(Object.getPrototypeOf(tty.ReadStream).prototype.bytesWritten,
+                   undefined);
 assert.strictEqual(tty.ReadStream.prototype.bytesWritten, undefined);
 assert.strictEqual(tty.WriteStream.prototype.bytesWritten, undefined);


### PR DESCRIPTION
This is an alternative to #25254.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
