### PR TITLE
process: move --help and --bash-completeion handling to startExecution

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -20,7 +20,8 @@
 const { internalBinding, NativeModule } = loaderExports;
 
 const exceptionHandlerState = { captureFn: null };
-let getOptionValue;
+const { getOptionValue } = NativeModule.require('internal/options');
+
 
 function startup() {
   setupTraceCategoryState();
@@ -147,18 +148,6 @@ function startup() {
 
   if (process.config.variables.v8_enable_inspector) {
     NativeModule.require('internal/inspector_async_hook').setup();
-  }
-
-  getOptionValue = NativeModule.require('internal/options').getOptionValue;
-
-  if (getOptionValue('--help')) {
-    NativeModule.require('internal/print_help').print(process.stdout);
-    return;
-  }
-
-  if (getOptionValue('--completion-bash')) {
-    NativeModule.require('internal/bash_completion').print(process.stdout);
-    return;
   }
 
   // If the process is spawned with env NODE_CHANNEL_FD, it's probably
@@ -314,6 +303,18 @@ function startExecution() {
     process.nextTick(() => {
       NativeModule.require('internal/deps/node-inspect/lib/_inspect').start();
     });
+    return;
+  }
+
+  // node --help
+  if (getOptionValue('--help')) {
+    NativeModule.require('internal/print_help').print(process.stdout);
+    return;
+  }
+
+  // e.g. node --completion-bash >> ~/.bashrc
+  if (getOptionValue('--completion-bash')) {
+    NativeModule.require('internal/bash_completion').print(process.stdout);
     return;
   }
 


### PR DESCRIPTION
Because they are similar to `--prof-process` and are part of
the execution instead of initialization.
Also move the `getOptionValue` initialization to top scope and add
comments about the flags.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
