### PR TITLE
fs: extract start and end check into checkPosition

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -36,6 +36,19 @@ function allocNewPool(poolSize) {
   pool.used = 0;
 }
 
+// Check the `this.start` and `this.end` of stream.
+function checkPosition(pos, name) {
+  if (!Number.isSafeInteger(pos)) {
+    validateNumber(pos, name);
+    if (!Number.isInteger(pos))
+      throw new ERR_OUT_OF_RANGE(name, 'an integer', pos);
+    throw new ERR_OUT_OF_RANGE(name, '>= 0 and <= 2 ** 53 - 1', pos);
+  }
+  if (pos < 0) {
+    throw new ERR_OUT_OF_RANGE(name, '>= 0 and <= 2 ** 53 - 1', pos);
+  }
+}
+
 function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
@@ -64,23 +77,7 @@ function ReadStream(path, options) {
   this.closed = false;
 
   if (this.start !== undefined) {
-    if (!Number.isSafeInteger(this.start)) {
-      validateNumber(this.start, 'start');
-      if (!Number.isInteger(this.start))
-        throw new ERR_OUT_OF_RANGE('start', 'an integer', this.start);
-      throw new ERR_OUT_OF_RANGE(
-        'start',
-        '>= 0 and <= 2 ** 53 - 1',
-        this.start
-      );
-    }
-    if (this.start < 0) {
-      throw new ERR_OUT_OF_RANGE(
-        'start',
-        '>= 0 and <= 2 ** 53 - 1',
-        this.start
-      );
-    }
+    checkPosition(this.start, 'start');
 
     this.pos = this.start;
   }
@@ -88,17 +85,7 @@ function ReadStream(path, options) {
   if (this.end === undefined) {
     this.end = Infinity;
   } else if (this.end !== Infinity) {
-    if (!Number.isSafeInteger(this.end)) {
-      if (typeof this.end !== 'number')
-        throw new ERR_INVALID_ARG_TYPE('end', 'number', this.end);
-      if (!Number.isInteger(this.end))
-        throw new ERR_OUT_OF_RANGE('end', 'an integer', this.end);
-      throw new ERR_OUT_OF_RANGE('end', '>= 0 and <= 2 ** 53 - 1', this.end);
-    }
-
-    if (this.end < 0) {
-      throw new ERR_OUT_OF_RANGE('end', '>= 0 and <= 2 ** 53 - 1', this.end);
-    }
+    checkPosition(this.end, 'end');
 
     if (this.start !== undefined && this.start > this.end) {
       throw new ERR_OUT_OF_RANGE(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
`this.start` and `this.end` in `ReadStream` meet the same conditions, extract their check into `checkPosition` function.

Maybe we can use it to check `this.start` in `WriteStream` too(but may need to do other works).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
