### PR TITLE
lib/buffer: change checks for SlowBuffer creation

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -309,8 +309,6 @@ Buffer.allocUnsafeSlow = function allocUnsafeSlow(size) {
 function SlowBuffer(length) {
   if (typeof length !== 'number')
     length = +length;
-  if (isNaN(length))
-    length = 0;
   assertSize(length);
   return createUnsafeBuffer(length);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -102,7 +102,7 @@ const constants = Object.defineProperties({}, {
 });
 
 Buffer.poolSize = 8 * 1024;
-var poolSize, poolOffset, allocPool;
+let poolSize, poolOffset, allocPool;
 
 setupBufferJS(Buffer.prototype, bindingObj);
 
@@ -221,7 +221,7 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   if (valueOf !== null && valueOf !== undefined && valueOf !== value)
     return Buffer.from(valueOf, encodingOrOffset, length);
 
-  var b = fromObject(value);
+  const b = fromObject(value);
   if (b)
     return b;
 
@@ -307,13 +307,12 @@ Buffer.allocUnsafeSlow = function allocUnsafeSlow(size) {
 // If --zero-fill-buffers command line argument is set, a zero-filled
 // buffer is returned.
 function SlowBuffer(length) {
-  const len = +length;
-  // eslint-disable-next-line eqeqeq
-  if (len != length)
+  if (typeof length !== 'number')
+    length = +length;
+  if (isNaN(length))
     length = 0;
-  else
-    assertSize(len);
-  return createUnsafeBuffer(len);
+  assertSize(length);
+  return createUnsafeBuffer(length);
 }
 
 Object.setPrototypeOf(SlowBuffer.prototype, Uint8Array.prototype);
@@ -326,7 +325,7 @@ function allocate(size) {
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))
       createPool();
-    var b = new FastBuffer(allocPool, poolOffset, size);
+    const b = new FastBuffer(allocPool, poolOffset, size);
     poolOffset += size;
     alignPool();
     return b;
@@ -335,7 +334,7 @@ function allocate(size) {
 }
 
 function fromString(string, encoding) {
-  var length;
+  let length;
   if (typeof encoding !== 'string' || encoding.length === 0) {
     if (string.length === 0)
       return new FastBuffer();
@@ -354,7 +353,7 @@ function fromString(string, encoding) {
 
   if (length > (poolSize - poolOffset))
     createPool();
-  var b = new FastBuffer(allocPool, poolOffset, length);
+  let b = new FastBuffer(allocPool, poolOffset, length);
   const actual = b.write(string, encoding);
   if (actual !== length) {
     // byteLength() may overestimate. That's a rare case, though.
@@ -456,7 +455,7 @@ Buffer.isEncoding = function isEncoding(encoding) {
 Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 
 Buffer.concat = function concat(list, length) {
-  var i;
+  let i;
   if (!Array.isArray(list)) {
     throw new ERR_INVALID_ARG_TYPE(
       'list', ['Array', 'Buffer', 'Uint8Array'], list);
@@ -473,10 +472,10 @@ Buffer.concat = function concat(list, length) {
     length = length >>> 0;
   }
 
-  var buffer = Buffer.allocUnsafe(length);
-  var pos = 0;
+  const buffer = Buffer.allocUnsafe(length);
+  let pos = 0;
   for (i = 0; i < list.length; i++) {
-    var buf = list[i];
+    const buf = list[i];
     if (!isUint8Array(buf)) {
       // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
       // Instead, find the proper error code for this.
@@ -791,7 +790,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
 }
 
 function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
-  var loweredCase = false;
+  let loweredCase = false;
   for (;;) {
     switch (encoding) {
       case 'utf8':
@@ -926,7 +925,7 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
       length = undefined;
     }
 
-    var remaining = this.length - offset;
+    const remaining = this.length - offset;
     if (length === undefined || length > remaining)
       length = remaining;
 


### PR DESCRIPTION
lib/buffer: fix unused variable initialization in SlowBuffer method
lib/buffer: change var to let/const variables initialization

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows